### PR TITLE
Windows TaskBar JumpList was not initiated

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -55,6 +55,7 @@ namespace GitCommands
         // semi-constants
         public static Version AppVersion => Assembly.GetCallingAssembly().GetName().Version;
         public static string ProductVersion => Application.ProductVersion;
+        public static readonly string ApplicationId = "GitExtensions";
         public static readonly string SettingsFileName = "GitExtensions.settings";
         public static readonly string UserPluginsDirectoryName = "UserPlugins";
         private static string _applicationExecutablePath = Application.ExecutablePath;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -196,12 +196,6 @@ namespace GitUI.CommandsDialogs
             var repositoryDescriptionProvider = new RepositoryDescriptionProvider(new GitDirectoryResolver());
             _appTitleGenerator = new AppTitleGenerator(repositoryDescriptionProvider);
             _windowsJumpListManager = new WindowsJumpListManager(repositoryDescriptionProvider);
-            _windowsJumpListManager.CreateJumpList(
-                Handle,
-                new WindowsThumbnailToolbarButtons(
-                    new WindowsThumbnailToolbarButton(toolStripButtonCommit.Text, toolStripButtonCommit.Image, CommitToolStripMenuItemClick),
-                    new WindowsThumbnailToolbarButton(toolStripButtonPush.Text, toolStripButtonPush.Image, PushToolStripMenuItemClick),
-                    new WindowsThumbnailToolbarButton(toolStripButtonPull.Text, toolStripButtonPull.Image, PullToolStripMenuItemClick)));
 
             InitCountArtificial(out _gitStatusMonitor);
 
@@ -386,6 +380,10 @@ namespace GitUI.CommandsDialogs
                                     TaskbarManager.Instance.SetOverlayIcon(overlay, "");
                                 }
                             }
+
+                            var repoStateVisualiser = new RepoStateVisualiser();
+                            var (image, _) = repoStateVisualiser.Invoke(status);
+                            _windowsJumpListManager.UpdateCommitIcon(image);
                         }
 
                         if (AppSettings.ShowSubmoduleStatus)
@@ -500,6 +498,12 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnLoad(EventArgs e)
         {
+            _windowsJumpListManager.CreateJumpList(
+                Handle,
+                new WindowsThumbnailToolbarButtons(
+                    new WindowsThumbnailToolbarButton(toolStripButtonCommit.Text, toolStripButtonCommit.Image, CommitToolStripMenuItemClick),
+                    new WindowsThumbnailToolbarButton(toolStripButtonPush.Text, toolStripButtonPush.Image, PushToolStripMenuItemClick),
+                    new WindowsThumbnailToolbarButton(toolStripButtonPull.Text, toolStripButtonPull.Image, PullToolStripMenuItemClick)));
             SetSplitterPositions();
             HideVariableMainMenuItems();
             RefreshSplitViewLayout();


### PR DESCRIPTION
Fixes #7683

Regression after d072142baaec034a10bedd9fa15854eed6269222 from #7750 
The button handling has been incorrect for years

Still not fully working

## Proposed changes
Windows TaskBar JumpList was not initiated correctly

ApplicationId init too late
Windows TaskBar JumpList could be initiated without the window handle was available
JumpList buttons were never enabled when starting in Dashboard

## Test methodology 

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
