### PR TITLE
Git: Set recommended version to 2.25.1

### DIFF
--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -23,7 +23,7 @@ namespace GitCommands
         private static readonly GitVersion v2_20_0 = new GitVersion("2.20.0");
 
         public static readonly GitVersion LastSupportedVersion = v2_11_0;
-        public static readonly GitVersion LastRecommendedVersion = new GitVersion("2.23.0");
+        public static readonly GitVersion LastRecommendedVersion = new GitVersion("2.25.1");
 
         private static GitVersion _current;
 


### PR DESCRIPTION
## Proposed changes

Update recommended Git version to 2.25.1 (released Feb 19, 2.25.0 released Jan 13)
Latest is Git 2.26, released on Mar 23, maybe to new to set as default (I have been running the RC a little longer without issues, but nothing I know is important)

## Test methodology 

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
