### PR TITLE
fix: Locate diff tools in C:\Program Files\ folder

### DIFF
--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -306,6 +306,12 @@ namespace GitCommands
                     return fullName;
                 }
 
+                fullName = FindFileInEnvVarFolder("ProgramW6432", location, fileName);
+                if (fullName != null)
+                {
+                    return fullName;
+                }
+
                 if (IntPtr.Size == 8 || (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("PROCESSOR_ARCHITEW6432"))))
                 {
                     fullName = FindFileInEnvVarFolder("ProgramFiles(x86)", location, fileName);


### PR DESCRIPTION
Resolves #7947

<!-- Please read CONTRIBUTING.md before submitting a pull request -->




## Proposed changes

- Correctly locate tools under `C:\Program Files` using `env.var["ProgramW6432"]`.



## Test methodology <!-- How did you ensure quality? -->

- manual


## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
