### PR TITLE
Uplift script handling

### DIFF
--- a/GitUI/CommandsDialogs/UserScriptContextMenuExtensions.cs
+++ b/GitUI/CommandsDialogs/UserScriptContextMenuExtensions.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Linq;
+using System.Windows.Forms;
+using GitUI.Script;
+
+namespace GitUI.CommandsDialogs
+{
+    public static class UserScriptContextMenuExtensions
+    {
+        /// <summary>
+        ///  Appends user scripts to the <paramref name="contextMenu"/>, or under <paramref name="hostMenuItem"/>,
+        ///  if scripts are marked as <see cref="ScriptInfo.AddToRevisionGridContextMenu"/>.
+        /// </summary>
+        /// <param name="contextMenu">The context menu to add user scripts too.</param>
+        /// <param name="hostMenuItem">The menu item to which to add user scripts marked as <see cref="ScriptInfo.AddToRevisionGridContextMenu"/>.</param>
+        /// <param name="scriptInvoker">The handler that handles user script invocation.</param>
+        public static void AppendUserScripts(this ContextMenuStrip contextMenu, ToolStripMenuItem hostMenuItem, EventHandler scriptInvoker)
+        {
+            contextMenu = contextMenu ?? throw new ArgumentNullException(nameof(contextMenu));
+            hostMenuItem = hostMenuItem ?? throw new ArgumentNullException(nameof(hostMenuItem));
+            scriptInvoker = scriptInvoker ?? throw new ArgumentNullException(nameof(scriptInvoker));
+
+            RemoveOwnScripts();
+            AddOwnScripts();
+            return;
+
+            void RemoveOwnScripts()
+            {
+                hostMenuItem.DropDown.Items.Clear();
+
+                var list = contextMenu.Items.Cast<ToolStripItem>().ToList();
+
+                foreach (var item in list)
+                {
+                    if (item.Name.Contains("_ownScript"))
+                    {
+                        contextMenu.Items.RemoveByKey(item.Name);
+                    }
+                }
+
+                if (contextMenu.Items[contextMenu.Items.Count - 1] is ToolStripSeparator)
+                {
+                    contextMenu.Items.RemoveAt(contextMenu.Items.Count - 1);
+                }
+            }
+
+            void AddOwnScripts()
+            {
+                var lastIndex = contextMenu.Items.Count;
+
+                var scripts = ScriptManager.GetScripts();
+                foreach (var script in scripts)
+                {
+                    if (!script.Enabled)
+                    {
+                        continue;
+                    }
+
+                    var item = new ToolStripMenuItem
+                    {
+                        Text = script.Name,
+                        Name = script.Name + "_ownScript",
+                        Image = script.GetIcon()
+                    };
+                    item.Click += scriptInvoker;
+
+                    if (script.AddToRevisionGridContextMenu)
+                    {
+                        contextMenu.Items.Add(item);
+                    }
+                    else
+                    {
+                        hostMenuItem.DropDown.Items.Add(item);
+                    }
+                }
+
+                if (lastIndex != contextMenu.Items.Count)
+                {
+                    contextMenu.Items.Insert(lastIndex, new ToolStripSeparator());
+                }
+
+                bool showScriptsMenu = hostMenuItem.DropDown.Items.Count > 0;
+                hostMenuItem.Visible = showScriptsMenu;
+            }
+        }
+    }
+}

--- a/GitUI/Script/IScriptHostControl.cs
+++ b/GitUI/Script/IScriptHostControl.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using GitCommands;
+
+namespace GitUI.Script
+{
+    public interface IScriptHostControl
+    {
+        GitRevision GetCurrentRevision();
+        GitRevision GetLatestSelectedRevision();
+        IReadOnlyList<GitRevision> GetSelectedRevisions();
+        Point GetQuickItemSelectorLocation();
+    }
+}

--- a/GitUI/Script/ScriptOptionsParser.cs
+++ b/GitUI/Script/ScriptOptionsParser.cs
@@ -128,7 +128,7 @@ namespace GitUI.Script
                 }
                 else if (selectedRevision == null && scriptHostControl != null && DependsOnSelectedRevision(option))
                 {
-                    allSelectedRevisions = scriptHostControl.GetSelectedRevisions();
+                    allSelectedRevisions = scriptHostControl.GetSelectedRevisions() ?? Array.Empty<GitRevision>();
                     selectedRevision = CalculateSelectedRevision(scriptHostControl, selectedRemoteBranches, selectedRemotes, selectedLocalBranches, selectedBranches, selectedTags);
                     if (selectedRevision == null)
                     {
@@ -172,7 +172,7 @@ namespace GitUI.Script
             List<string> selectedRemotes, List<IGitRef> selectedLocalBranches,
             List<IGitRef> selectedBranches, List<IGitRef> selectedTags)
         {
-            GitRevision selectedRevision = scriptHostControl.GetLatestSelectedRevision();
+            GitRevision selectedRevision = scriptHostControl?.GetLatestSelectedRevision();
             if (selectedRevision == null)
             {
                 return null;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Commands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Commands.cs
@@ -1,0 +1,42 @@
+﻿namespace GitUI
+{
+    public sealed partial class RevisionGridControl
+    {
+        internal enum Commands
+        {
+            ToggleRevisionGraph = 0,
+            RevisionFilter = 1,
+            ToggleAuthorDateCommitDate = 2,
+            ToggleOrderRevisionsByDate = 3,
+            ToggleShowRelativeDate = 4,
+            ToggleDrawNonRelativesGray = 5,
+            ToggleShowGitNotes = 6,
+            //// <snip>
+            ToggleShowMergeCommits = 8,
+            ShowAllBranches = 9,
+            ShowCurrentBranchOnly = 10,
+            ShowFilteredBranches = 11,
+            ShowRemoteBranches = 12,
+            ShowFirstParent = 13,
+            GoToParent = 14,
+            GoToChild = 15,
+            ToggleHighlightSelectedBranch = 16,
+            NextQuickSearch = 17,
+            PrevQuickSearch = 18,
+            SelectCurrentRevision = 19,
+            GoToCommit = 20,
+            NavigateBackward = 21,
+            NavigateForward = 22,
+            SelectAsBaseToCompare = 23,
+            CompareToBase = 24,
+            CreateFixupCommit = 25,
+            ToggleShowTags = 26,
+            CompareToWorkingDirectory = 27,
+            CompareToCurrentBranch = 28,
+            CompareToBranch = 29,
+            CompareSelectedCommits = 30,
+            GoToMergeBaseCommit = 31,
+            OpenCommitsWithDifftool = 32
+        }
+    }
+}

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.RevisionGridInMemFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.RevisionGridInMemFilter.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using GitCommands;
+using GitUIPluginInterfaces;
+using JetBrains.Annotations;
+
+namespace GitUI
+{
+    public sealed partial class RevisionGridControl
+    {
+        private sealed class RevisionGridInMemFilter
+        {
+            private readonly string _authorFilter;
+            private readonly Regex _authorFilterRegex;
+            private readonly string _committerFilter;
+            private readonly Regex _committerFilterRegex;
+            private readonly string _messageFilter;
+            private readonly Regex _messageFilterRegex;
+            private readonly string _shaFilter;
+            private readonly Regex _shaFilterRegex;
+
+            private RevisionGridInMemFilter(string authorFilter, string committerFilter, string messageFilter, bool ignoreCase)
+            {
+                (_authorFilter, _authorFilterRegex) = SetUpVars(authorFilter, ignoreCase);
+                (_committerFilter, _committerFilterRegex) = SetUpVars(committerFilter, ignoreCase);
+                (_messageFilter, _messageFilterRegex) = SetUpVars(messageFilter, ignoreCase);
+
+                if (!string.IsNullOrEmpty(_messageFilter) && ObjectId.IsValidPartial(_messageFilter, minLength: 5))
+                {
+                    (_shaFilter, _shaFilterRegex) = SetUpVars(messageFilter, false);
+                }
+
+                (string filterStr, Regex filterRegex) SetUpVars(string filterValue, bool ignoreKase)
+                {
+                    var filterStr = filterValue?.Trim() ?? string.Empty;
+
+                    try
+                    {
+                        var options = ignoreKase ? RegexOptions.IgnoreCase : RegexOptions.None;
+                        return (filterStr, new Regex(filterStr, options));
+                    }
+                    catch (ArgumentException)
+                    {
+                        return (filterStr, null);
+                    }
+                }
+            }
+
+            public bool Predicate(GitRevision rev)
+            {
+                return CheckCondition(_authorFilter, _authorFilterRegex, rev.Author) &&
+                       CheckCondition(_committerFilter, _committerFilterRegex, rev.Committer) &&
+                       (CheckCondition(_messageFilter, _messageFilterRegex, rev.Body) ||
+                        (_shaFilter != null && CheckCondition(_shaFilter, _shaFilterRegex, rev.Guid)));
+
+                bool CheckCondition(string filter, Regex regex, string value)
+                {
+                    return string.IsNullOrEmpty(filter) ||
+                           (regex != null && value != null && regex.IsMatch(value));
+                }
+            }
+
+            [CanBeNull]
+            public static RevisionGridInMemFilter CreateIfNeeded([CanBeNull] string authorFilter,
+                [CanBeNull] string committerFilter,
+                [CanBeNull] string messageFilter,
+                bool ignoreCase)
+            {
+                if (string.IsNullOrEmpty(authorFilter) &&
+                    string.IsNullOrEmpty(committerFilter) &&
+                    string.IsNullOrEmpty(messageFilter) &&
+                    !ObjectId.IsValidPartial(messageFilter, minLength: 5))
+                {
+                    return null;
+                }
+
+                return new RevisionGridInMemFilter(
+                    authorFilter,
+                    committerFilter,
+                    messageFilter,
+                    ignoreCase);
+            }
+        }
+    }
+}

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
@@ -55,7 +54,7 @@ namespace GitUI
     }
 
     [DefaultEvent("DoubleClick")]
-    public sealed partial class RevisionGridControl : GitModuleControl
+    public sealed partial class RevisionGridControl : GitModuleControl, IScriptHostControl
     {
         public event EventHandler<DoubleClickRevisionEventArgs> DoubleClickRevision;
         public event EventHandler<EventArgs> ShowFirstParentsToggled;
@@ -2575,88 +2574,6 @@ namespace GitUI
             RefreshRevisions();
         }
 
-        #region Nested type: RevisionGridInMemFilter
-
-        private sealed class RevisionGridInMemFilter
-        {
-            private readonly string _authorFilter;
-            private readonly Regex _authorFilterRegex;
-            private readonly string _committerFilter;
-            private readonly Regex _committerFilterRegex;
-            private readonly string _messageFilter;
-            private readonly Regex _messageFilterRegex;
-            private readonly string _shaFilter;
-            private readonly Regex _shaFilterRegex;
-
-            private RevisionGridInMemFilter(string authorFilter, string committerFilter, string messageFilter, bool ignoreCase)
-            {
-                (_authorFilter, _authorFilterRegex) = SetUpVars(authorFilter, ignoreCase);
-                (_committerFilter, _committerFilterRegex) = SetUpVars(committerFilter, ignoreCase);
-                (_messageFilter, _messageFilterRegex) = SetUpVars(messageFilter, ignoreCase);
-
-                if (!string.IsNullOrEmpty(_messageFilter) && ObjectId.IsValidPartial(_messageFilter, minLength: 5))
-                {
-                    (_shaFilter, _shaFilterRegex) = SetUpVars(messageFilter, false);
-                }
-
-                (string filterStr, Regex filterRegex) SetUpVars(string filterValue, bool ignoreKase)
-                {
-                    var filterStr = filterValue?.Trim() ?? string.Empty;
-
-                    try
-                    {
-                        var options = ignoreKase ? RegexOptions.IgnoreCase : RegexOptions.None;
-                        return (filterStr, new Regex(filterStr, options));
-                    }
-                    catch (ArgumentException)
-                    {
-                        return (filterStr, null);
-                    }
-                }
-            }
-
-            public bool Predicate(GitRevision rev)
-            {
-                return CheckCondition(_authorFilter, _authorFilterRegex, rev.Author) &&
-                       CheckCondition(_committerFilter, _committerFilterRegex, rev.Committer) &&
-                       (CheckCondition(_messageFilter, _messageFilterRegex, rev.Body) ||
-                        (_shaFilter != null && CheckCondition(_shaFilter, _shaFilterRegex, rev.Guid)));
-
-                bool CheckCondition(string filter, Regex regex, string value)
-                {
-                    return string.IsNullOrEmpty(filter) ||
-                           (regex != null && value != null && regex.IsMatch(value));
-                }
-            }
-
-            [CanBeNull]
-            public static RevisionGridInMemFilter CreateIfNeeded([CanBeNull] string authorFilter,
-                [CanBeNull] string committerFilter,
-                [CanBeNull] string messageFilter,
-                bool ignoreCase)
-            {
-                if (string.IsNullOrEmpty(authorFilter) &&
-                    string.IsNullOrEmpty(committerFilter) &&
-                    string.IsNullOrEmpty(messageFilter) &&
-                    !ObjectId.IsValidPartial(messageFilter, minLength: 5))
-                {
-                    return null;
-                }
-
-                return new RevisionGridInMemFilter(
-                    authorFilter,
-                    committerFilter,
-                    messageFilter,
-                    ignoreCase);
-            }
-        }
-
-        #endregion
-
-        #region Nested type: SuperProjectInfo
-
-        #endregion
-
         #region Drag/drop patch files on revision grid
 
         private void OnGridViewDragDrop(object sender, DragEventArgs e)
@@ -2705,46 +2622,10 @@ namespace GitUI
                 }
             }
         }
+
         #endregion
 
         #region Hotkey commands
-
-        internal enum Commands
-        {
-            ToggleRevisionGraph = 0,
-            RevisionFilter = 1,
-            ToggleAuthorDateCommitDate = 2,
-            ToggleOrderRevisionsByDate = 3,
-            ToggleShowRelativeDate = 4,
-            ToggleDrawNonRelativesGray = 5,
-            ToggleShowGitNotes = 6,
-            //// <snip>
-            ToggleShowMergeCommits = 8,
-            ShowAllBranches = 9,
-            ShowCurrentBranchOnly = 10,
-            ShowFilteredBranches = 11,
-            ShowRemoteBranches = 12,
-            ShowFirstParent = 13,
-            GoToParent = 14,
-            GoToChild = 15,
-            ToggleHighlightSelectedBranch = 16,
-            NextQuickSearch = 17,
-            PrevQuickSearch = 18,
-            SelectCurrentRevision = 19,
-            GoToCommit = 20,
-            NavigateBackward = 21,
-            NavigateForward = 22,
-            SelectAsBaseToCompare = 23,
-            CompareToBase = 24,
-            CreateFixupCommit = 25,
-            ToggleShowTags = 26,
-            CompareToWorkingDirectory = 27,
-            CompareToCurrentBranch = 28,
-            CompareToBranch = 29,
-            CompareSelectedCommits = 30,
-            GoToMergeBaseCommit = 31,
-            OpenCommitsWithDifftool = 32
-        }
 
         protected override CommandStatus ExecuteCommand(int cmd)
         {
@@ -2801,6 +2682,21 @@ namespace GitUI
 
             return true;
         }
+        #endregion
+
+        #region IScriptHostControl
+
+        GitRevision IScriptHostControl.GetCurrentRevision()
+            => GetCurrentRevision();
+
+        GitRevision IScriptHostControl.GetLatestSelectedRevision()
+            => LatestSelectedRevision;
+
+        IReadOnlyList<GitRevision> IScriptHostControl.GetSelectedRevisions()
+            => GetSelectedRevisions();
+
+        Point IScriptHostControl.GetQuickItemSelectorLocation()
+            => GetQuickItemSelectorLocation();
 
         #endregion
     }

--- a/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
+++ b/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using GitCommands;
 using GitCommands.Config;
@@ -9,19 +10,169 @@ using NUnit.Framework;
 
 namespace GitUITests.Script
 {
+    [SetCulture("en-US")]
+    [SetUICulture("en-US")]
     [TestFixture]
     public class ScriptOptionsParserTests
     {
         private IGitModule _module;
+        private IScriptHostControl _scriptHostControl;
 
         [SetUp]
         public void Setup()
         {
             _module = Substitute.For<IGitModule>();
+            _scriptHostControl = Substitute.For<IScriptHostControl>();
         }
 
         [Test]
-        public void ScriptOptionsParser_resolve_cDefaultRemotePathFromUrl_currentRemote_unset()
+        public void Contains_should_throw_if_arguments_null()
+        {
+            ((Action)(() => ScriptOptionsParser.Contains(null, null))).Should()
+                .Throw<ArgumentNullException>()
+                .WithMessage("Value cannot be null.\r\nParameter name: arguments");
+        }
+
+        [Test]
+        public void Contains_should_throw_if_option_null()
+        {
+            ((Action)(() => ScriptOptionsParser.Contains("", null))).Should()
+                .Throw<ArgumentNullException>()
+                .WithMessage("Value cannot be null.\r\nParameter name: option");
+        }
+
+        [TestCase("", "", true)]
+        [TestCase("", " ", true)]
+        [TestCase(" ", "", true)]
+        [TestCase(" ", " ", true)]
+        [TestCase("{openUrl} https://gitlab.com{cDefaultRemotePathFromUrl}/tree/{sBranch}", "sBranch", true)]
+        [TestCase("{openUrl} https://gitlab.com{cDefaultRemotePathFromUrl}/tree/{sBranch}", "zeBranch", false)]
+        public void Contains_should_return_expected(string arguments, string option, bool expected)
+        {
+            ScriptOptionsParser.Contains(arguments, option).Should().Be(expected);
+        }
+
+        [Test]
+        public void DependsOnSelectedRevision_should_throw_if_option_null()
+        {
+            ((Action)(() => ScriptOptionsParser.DependsOnSelectedRevision(null))).Should()
+                .Throw<ArgumentNullException>()
+                .WithMessage("Value cannot be null.\r\nParameter name: option");
+        }
+
+        [TestCase("", false)]
+        [TestCase(" ", false)]
+        [TestCase("\t", false)]
+        [TestCase("s", true)]
+        [TestCase("sBranch", true)]
+        [TestCase("zeBranch", false)]
+        public void DependsOnSelectedRevision_should_return_expected(string option, bool expected)
+        {
+            ScriptOptionsParser.DependsOnSelectedRevision(option).Should().Be(expected);
+        }
+
+        [TestCase("", false, "")]
+        [TestCase("", true, "")]
+        [TestCase(" ", false, "")]
+        [TestCase(" ", true, "")]
+        [TestCase("\t", false, "")]
+        [TestCase("\t", true, "")]
+        [TestCase("a", false, "{a}")]
+        [TestCase("a", true, "{{a}}")]
+        [TestCase(" a", false, "{a}")]
+        [TestCase(" a", true, "{{a}}")]
+        [TestCase("a ", false, "{a}")]
+        [TestCase("a ", true, "{{a}}")]
+        [TestCase(" a ", false, "{a}")]
+        [TestCase(" a ", true, "{{a}}")]
+        [TestCase(" a\ta ", false, "{a\ta}")]
+        [TestCase(" a\ta ", true, "{{a\ta}}")]
+        [TestCase(" a\ta ", false, "{a\ta}")]
+        [TestCase(" a\ta ", true, "{{a\ta}}")]
+        public void CreateOption_returns_expected(string option, bool quoted, string expected)
+        {
+            ScriptOptionsParser.GetTestAccessor().CreateOption(option, quoted).Should().Be(expected);
+        }
+
+        [Test]
+        public void GetCurrentRevision_should_return_null_if_scriptHostControl_unset_bare_or_empty_repo()
+        {
+            // bare repo has no current checkout, empty repo has no commits
+            _module.GetCurrentCheckout().Returns(x => null);
+
+            var result = ScriptOptionsParser.GetTestAccessor()
+                .GetCurrentRevision(module: _module, scriptHostControl: null, currentTags: null, currentLocalBranches: null, currentRemoteBranches: null, currentBranches: null);
+
+            result.Should().Be(null);
+        }
+
+        [Test]
+        public void GetCurrentRevision_should_return_expected_if_scriptHostControl_unset_unmatched_ref()
+        {
+            _module.GetCurrentCheckout().Returns(x => ObjectId.IndexId);
+
+            var result = ScriptOptionsParser.GetTestAccessor()
+                .GetCurrentRevision(module: _module, scriptHostControl: null, currentTags: null, currentLocalBranches: null, currentRemoteBranches: null, currentBranches: null);
+
+            result.ObjectId.Should().Be(ObjectId.IndexId);
+        }
+
+        [Test]
+        public void GetCurrentRevision_should_return_null_if_scriptHostControl_set_current_revision_null()
+        {
+            _scriptHostControl.GetCurrentRevision().Returns(x => null);
+
+            var result = ScriptOptionsParser.GetTestAccessor()
+                .GetCurrentRevision(module: _module, scriptHostControl: _scriptHostControl, currentTags: null, currentLocalBranches: null, currentRemoteBranches: null, currentBranches: null);
+
+            result.Should().Be(null);
+        }
+
+        [Test]
+        public void GetCurrentRevision_should_return_expected_if_scriptHostControl_set_current_revision_has_no_refs()
+        {
+            var revision = new GitRevision(ObjectId.IndexId);
+            _scriptHostControl.GetCurrentRevision().Returns(x => revision);
+
+            var result = ScriptOptionsParser.GetTestAccessor()
+                .GetCurrentRevision(module: _module, scriptHostControl: _scriptHostControl, currentTags: null, currentLocalBranches: null, currentRemoteBranches: null, currentBranches: null);
+
+            result.Should().Be(revision);
+        }
+
+        [Test]
+        public void Parse_should_throw_if_module_null()
+        {
+            ((Action)(() => ScriptOptionsParser.Parse(arguments: "bla", module: null, owner: null, scriptHostControl: null))).Should()
+                .Throw<ArgumentNullException>()
+                .WithMessage("Value cannot be null.\r\nParameter name: module");
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("\t")]
+        public void Parse_should_return_without_process_if_arguments_unset(string arguments)
+        {
+            var result = ScriptOptionsParser.Parse(arguments, module: null, owner: null, scriptHostControl: null);
+
+            result.arguments.Should().Be(arguments);
+            result.abort.Should().Be(false);
+        }
+
+        [Test]
+        public void Parse_should_return_unmodified_arguments_if_no_options_matched()
+        {
+            const string arguments = "{openUrl} https://gitlab.com{zeDefaultRemotePathFromUrl}/tree/{zeBranch}";
+
+            var result = ScriptOptionsParser.Parse(arguments: arguments, module: _module, owner: null, scriptHostControl: null);
+
+            result.arguments.Should().Be(arguments);
+            result.abort.Should().Be(false);
+        }
+
+        [Test]
+        public void ParseScriptArguments_resolves_cDefaultRemotePathFromUrl_currentRemote_unset()
         {
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{openUrl} https://gitlab.com{cDefaultRemotePathFromUrl}/tree/{sBranch}", option: "cDefaultRemotePathFromUrl",
@@ -34,7 +185,7 @@ namespace GitUITests.Script
         }
 
         [Test]
-        public void ScriptOptionsParser_resolve_cDefaultRemotePathFromUrl_currentRemote_set()
+        public void ParseScriptArguments_resolve_cDefaultRemotePathFromUrl_currentRemote_set()
         {
             var currentRemote = "myRemote";
             _module.GetSetting(string.Format(SettingKeyString.RemoteUrl, currentRemote)).Returns("https://gitlab.com/gitlabhq/gitlabhq.git");
@@ -50,7 +201,7 @@ namespace GitUITests.Script
         }
 
         [Test]
-        public void ScriptOptionsParser_resolve_sRemotePathFromUrl_selectedRemotes_empty()
+        public void ParseScriptArguments_resolve_sRemotePathFromUrl_selectedRemotes_empty()
         {
             var noSelectedRemotes = new List<string>();
 
@@ -65,7 +216,7 @@ namespace GitUITests.Script
         }
 
         [Test]
-        public void ScriptOptionsParser_resolve_sRemotePathFromUrl_currentRemote_set()
+        public void ParseScriptArguments_resolve_sRemotePathFromUrl_currentRemote_set()
         {
             var currentRemote = "myRemote";
             var selectedRemotes = new List<string>() { currentRemote };
@@ -82,7 +233,7 @@ namespace GitUITests.Script
         }
 
         [Test]
-        public void ScriptOptionsParser_resolve_sRemoteBranch(
+        public void ParseScriptArguments_resolve_sRemoteBranch(
             [Values("", "origin", "upstream", "remote")] string remoteName,
             [Values("", "branch", "feature/branch")] string branchName)
         {
@@ -101,7 +252,7 @@ namespace GitUITests.Script
         }
 
         [Test]
-        public void ScriptOptionsParser_resolve_sRemoteBranchName(
+        public void ParseScriptArguments_resolve_sRemoteBranchName(
             [Values("", "origin", "upstream", "remote")] string remoteName,
             [Values("", "branch", "feature/branch")] string branchName)
         {
@@ -120,7 +271,7 @@ namespace GitUITests.Script
         }
 
         [Test]
-        public void ScriptOptionsParser_resolve_cRemoteBranch(
+        public void ParseScriptArguments_resolve_cRemoteBranch(
             [Values("", "origin", "upstream", "remote")] string remoteName,
             [Values("", "branch", "feature/branch")] string branchName)
         {
@@ -139,7 +290,7 @@ namespace GitUITests.Script
         }
 
         [Test]
-        public void ScriptOptionsParser_resolve_cRemoteBranchName(
+        public void ParseScriptArguments_resolve_cRemoteBranchName(
             [Values("", "origin", "upstream", "remote")] string remoteName,
             [Values("", "branch", "feature/branch")] string branchName)
         {
@@ -158,7 +309,7 @@ namespace GitUITests.Script
         }
 
         [Test]
-        public void ScriptOptionsParser_resolve_RepoName_null()
+        public void ParseScriptArguments_resolve_RepoName_null()
         {
             var option = "RepoName";
 
@@ -173,7 +324,7 @@ namespace GitUITests.Script
         }
 
         [Test]
-        public void ScriptOptionsParser_resolve_RepoName()
+        public void ParseScriptArguments_resolve_RepoName()
         {
             var option = "RepoName";
             var dirName = "Windows"; // chose one which will never contain a repo
@@ -190,7 +341,7 @@ namespace GitUITests.Script
         }
 
         [Test]
-        public void ScriptOptionsParser_resolve_QuotedWithBackslashAtEnd()
+        public void ParseScriptArguments_resolve_QuotedWithBackslashAtEnd()
         {
             _module.WorkingDir.Returns("C:\\test path with whitespaces\\");
 
@@ -200,7 +351,7 @@ namespace GitUITests.Script
         }
 
         [Test]
-        public void ScriptOptionsParser_resolve_StringWithDoubleQuotes()
+        public void ParseScriptArguments_resolve_StringWithDoubleQuotes()
         {
             GitRevision gitRevision = new GitRevision(ObjectId.Random());
             gitRevision.Subject = "test string with \"double qoutes\" and escaped \\\"double qoutes\\\"";

--- a/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
+++ b/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
@@ -25,7 +25,7 @@ namespace GitUITests.Script
         {
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{openUrl} https://gitlab.com{cDefaultRemotePathFromUrl}/tree/{sBranch}", option: "cDefaultRemotePathFromUrl",
-                owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptHostControl: null, module: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
@@ -41,7 +41,7 @@ namespace GitUITests.Script
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{openUrl} https://gitlab.com{cDefaultRemotePathFromUrl}/tree/{sBranch}", option: "cDefaultRemotePathFromUrl",
-                owner: null, revisionGrid: null, _module, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptHostControl: null, _module, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote);
@@ -56,7 +56,7 @@ namespace GitUITests.Script
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{openUrl} https://gitlab.com{sRemotePathFromUrl}/tree/{sBranch}", option: "sRemotePathFromUrl",
-                owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptHostControl: null, module: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, noSelectedRemotes, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
@@ -73,7 +73,7 @@ namespace GitUITests.Script
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{openUrl} https://gitlab.com{sRemotePathFromUrl}/tree/{sBranch}", option: "sRemotePathFromUrl",
-                owner: null, revisionGrid: null, _module, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptHostControl: null, _module, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
@@ -92,7 +92,7 @@ namespace GitUITests.Script
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
-                owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptHostControl: null, module: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: remoteBranches, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
@@ -111,7 +111,7 @@ namespace GitUITests.Script
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
-                owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptHostControl: null, module: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: remoteBranches, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
@@ -130,7 +130,7 @@ namespace GitUITests.Script
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
-                owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptHostControl: null, module: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: remoteBranches, currentRevision: null, currentRemote: null);
@@ -149,7 +149,7 @@ namespace GitUITests.Script
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
-                owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptHostControl: null, module: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: remoteBranches, currentRevision: null, currentRemote: null);
@@ -164,7 +164,7 @@ namespace GitUITests.Script
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
-                owner: null, revisionGrid: null, module: null, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptHostControl: null, module: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
@@ -181,7 +181,7 @@ namespace GitUITests.Script
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
-                owner: null, revisionGrid: null, _module, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptHostControl: null, _module, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Proposed changes

- Decouple script parsing from the revision grid. This will allow easier and simpler integration of other controls with the script manager (e.g. the left panel or the file tree)
- Extract user script binding to a context menu to an extension method. This will allow re-use of the functionality in other parts of the app (e.g. the left panel or the file tree). This is small step in the same direction as #6348 proposed by @ivangrek. Sadly we stalled on this work.
- Review the code and add multiple validations and add tests.

This work is foundational to allow re-use of user scripts in other parts of the app (e.g. the left panel or the file tree). Specifically I want to allow users to run custom scripts for files in the working tree, e.g. to achieve what was proposed in #6135, or open a file and/or folder in VS Code, or launch a project in a VS.

![image](https://user-images.githubusercontent.com/4403806/78473813-ce60e100-7786-11ea-813a-2c3f552b6854.png)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
