### PR TITLE
Merge combined conflict set to IsConflict

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -4061,7 +4061,6 @@ namespace GitCommands
                 file => new GitItemStatus
                 {
                     IsChanged = true,
-                    IsConflict = true,
                     IsTracked = true,
                     IsDeleted = false,
                     IsNew = false,


### PR DESCRIPTION
Followup to #7922 

## Proposed changes

#7922 added conflict icons to files in conflict, which should be set on files in index/worktree where merge conflicts have not been resolved.
Example where branch_x is merged to branch_y
![image](https://user-images.githubusercontent.com/6248932/78477977-2545c680-7745-11ea-8228-f8a237a22db3.png)

However, the status was incorrectly set for files in the merge 'combined commit' too, changing the icon
(previously it was 'file modified' for all conflicts, including submodules).

## Screenshots 

See 81f72a7fdc43bc15c6d8737e65cc513a302769e8
### Before

![image](https://user-images.githubusercontent.com/6248932/78473690-e7e03980-7742-11ea-8860-65b39ccf4243.png)

### After

![image](https://user-images.githubusercontent.com/6248932/78473704-fe869080-7742-11ea-8a2a-fee90cf1213e.png)

## Test methodology

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
