### PR TITLE
Fix error during Publish build.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -125,3 +125,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/03/22, joergpichler, Jörg Pichler, joerg.pichler(at)gmail.com
 2020/03/27, cado1982, Chris Oliver, cado82(at)gmail.com
 2020/04/02, NoahLerner, Noah Lerner, noahlerner94(at)gmail.com
+2020/04/07, dimfish, Dmitry I, dimfish(at)gmail.com

--- a/scripts/tools/Publish.targets
+++ b/scripts/tools/Publish.targets
@@ -21,7 +21,7 @@
             .Where(proj => proj.ProjectType == SolutionProjectType.KnownToBeMSBuildFormat)
             .SelectMany(proj => 
                         {
-                            var project = new Project(proj.AbsolutePath);
+                            var project = new Project(proj.AbsolutePath, null, null, new ProjectCollection());
                             project.SetGlobalProperty("Configuration", BuildConfiguration);
                             project.SetGlobalProperty("ContinuousIntegrationBuild", IsContinuousIntegrationBuild);
                             project.ReevaluateIfNecessary();


### PR DESCRIPTION
Fix "An equivalent project (a project with the same global properties and tools version is already present in the project collection)" error during Publish build.