### PR TITLE
Align context menu order for FileStatusList

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -33,7 +33,6 @@ namespace GitUI.CommandsDialogs
             this.openContainingFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
             this.viewFileHistoryToolStripItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
             this.editFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.deleteFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
@@ -43,13 +42,13 @@ namespace GitUI.CommandsDialogs
             this.doNotSkipWorktreeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.assumeUnchangedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.doNotAssumeUnchangedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.interactiveAddToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fileTooltip = new System.Windows.Forms.ToolTip(this.components);
             this.StageInSuperproject = new System.Windows.Forms.CheckBox();
             this.StagedFileContext = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.stagedResetChanges = new System.Windows.Forms.ToolStripMenuItem();
             this.stagedFileHistoryToolStripMenuItem6 = new System.Windows.Forms.ToolStripMenuItem();
+            this.stagedFileHistoryToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.stagedToolStripSeparator14 = new System.Windows.Forms.ToolStripSeparator();
             this.stagedOpenToolStripMenuItem7 = new System.Windows.Forms.ToolStripMenuItem();
             this.stagedOpenWithToolStripMenuItem8 = new System.Windows.Forms.ToolStripMenuItem();
@@ -57,7 +56,6 @@ namespace GitUI.CommandsDialogs
             this.stagedToolStripSeparator18 = new System.Windows.Forms.ToolStripSeparator();
             this.stagedCopyPathToolStripMenuItem14 = new System.Windows.Forms.ToolStripMenuItem();
             this.stagedOpenFolderToolStripMenuItem10 = new System.Windows.Forms.ToolStripMenuItem();
-            this.stagedToolStripSeparator17 = new System.Windows.Forms.ToolStripSeparator();
             this.stagedEditFileToolStripMenuItem11 = new System.Windows.Forms.ToolStripMenuItem();
             this.UnstagedSubmoduleContext = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.commitSubmoduleChanges = new System.Windows.Forms.ToolStripMenuItem();
@@ -65,10 +63,8 @@ namespace GitUI.CommandsDialogs
             this.stashSubmoduleChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.updateSubmoduleMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
-            this.submoduleSummaryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.viewHistoryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
-            this.openSubmoduleMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openFolderMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openDiffMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator16 = new System.Windows.Forms.ToolStripSeparator();
@@ -189,20 +185,20 @@ namespace GitUI.CommandsDialogs
             // UnstagedFileContext
             //
             this.UnstagedFileContext.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.openWithDifftoolToolStripMenuItem,
             this.resetChanges,
             this.resetPartOfFileToolStripMenuItem,
+            this.interactiveAddToolStripMenuItem,
             this.toolStripSeparator12,
+            this.editFileToolStripMenuItem,
             this.openToolStripMenuItem,
             this.openWithToolStripMenuItem,
-            this.openWithDifftoolToolStripMenuItem,
+            this.deleteFileToolStripMenuItem,
             this.toolStripSeparator9,
             this.filenameToClipboardToolStripMenuItem,
             this.openContainingFolderToolStripMenuItem,
             this.toolStripSeparator8,
             this.viewFileHistoryToolStripItem,
-            this.toolStripSeparator7,
-            this.editFileToolStripMenuItem,
-            this.deleteFileToolStripMenuItem,
             this.toolStripSeparator5,
             this.addFileToGitIgnoreToolStripMenuItem,
             this.addFileToGitInfoExcludeLocallyToolStripMenuItem,
@@ -210,9 +206,7 @@ namespace GitUI.CommandsDialogs
             this.skipWorktreeToolStripMenuItem,
             this.doNotSkipWorktreeToolStripMenuItem,
             this.assumeUnchangedToolStripMenuItem,
-            this.doNotAssumeUnchangedToolStripMenuItem,
-            this.toolStripSeparator4,
-            this.interactiveAddToolStripMenuItem});
+            this.doNotAssumeUnchangedToolStripMenuItem});
             this.UnstagedFileContext.Name = "UnstagedFileContext";
             this.UnstagedFileContext.Size = new System.Drawing.Size(233, 414);
             this.UnstagedFileContext.Opening += UnstagedFileContext_Opening;
@@ -294,11 +288,6 @@ namespace GitUI.CommandsDialogs
             this.viewFileHistoryToolStripItem.Text = "View file history";
             this.viewFileHistoryToolStripItem.Click += new System.EventHandler(this.ViewFileHistoryMenuItem_Click);
             //
-            // toolStripSeparator7
-            //
-            this.toolStripSeparator7.Name = "toolStripSeparator7";
-            this.toolStripSeparator7.Size = new System.Drawing.Size(229, 6);
-            //
             // editFileToolStripMenuItem
             //
             this.editFileToolStripMenuItem.Image = global::GitUI.Properties.Images.EditFile;
@@ -366,11 +355,6 @@ namespace GitUI.CommandsDialogs
             this.doNotAssumeUnchangedToolStripMenuItem.Visible = false;
             this.doNotAssumeUnchangedToolStripMenuItem.Click += new System.EventHandler(this.DoNotAssumeUnchangedToolStripMenuItemClick);
             //
-            // toolStripSeparator4
-            //
-            this.toolStripSeparator4.Name = "toolStripSeparator4";
-            this.toolStripSeparator4.Size = new System.Drawing.Size(229, 6);
-            //
             // interactiveAddToolStripMenuItem
             //
             this.interactiveAddToolStripMenuItem.Name = "interactiveAddToolStripMenuItem";
@@ -394,17 +378,17 @@ namespace GitUI.CommandsDialogs
             // StagedFileContext
             //
             this.StagedFileContext.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.stagedOpenDifftoolToolStripMenuItem9,
             this.stagedResetChanges,
-            this.stagedFileHistoryToolStripMenuItem6,
             this.stagedToolStripSeparator14,
+            this.stagedEditFileToolStripMenuItem11,
             this.stagedOpenToolStripMenuItem7,
             this.stagedOpenWithToolStripMenuItem8,
-            this.stagedOpenDifftoolToolStripMenuItem9,
             this.stagedToolStripSeparator18,
             this.stagedCopyPathToolStripMenuItem14,
             this.stagedOpenFolderToolStripMenuItem10,
-            this.stagedToolStripSeparator17,
-            this.stagedEditFileToolStripMenuItem11});
+            this.stagedFileHistoryToolStripSeparator,
+            this.stagedFileHistoryToolStripMenuItem6});
             this.StagedFileContext.Name = "StagedFileContext";
             this.StagedFileContext.Size = new System.Drawing.Size(233, 198);
             this.StagedFileContext.Opening += StagedFileContext_Opening;
@@ -425,6 +409,11 @@ namespace GitUI.CommandsDialogs
             this.stagedFileHistoryToolStripMenuItem6.Text = "View file history";
             this.stagedFileHistoryToolStripMenuItem6.Click += new System.EventHandler(this.ViewFileHistoryMenuItem_Click);
             //
+            // stagedFileHistoryToolStripSeparator
+            // 
+            this.stagedFileHistoryToolStripSeparator.Name = "stagedFileHistoryToolStripSeparator";
+            this.stagedFileHistoryToolStripSeparator.Size = new System.Drawing.Size(229, 6);
+            // 
             // stagedToolStripSeparator14
             //
             this.stagedToolStripSeparator14.Name = "stagedToolStripSeparator14";
@@ -474,11 +463,6 @@ namespace GitUI.CommandsDialogs
             this.stagedOpenFolderToolStripMenuItem10.Text = "Show in folder";
             this.stagedOpenFolderToolStripMenuItem10.Click += new System.EventHandler(this.openFolderToolStripMenuItem10_Click);
             //
-            // stagedToolStripSeparator17
-            //
-            this.stagedToolStripSeparator17.Name = "stagedToolStripSeparator17";
-            this.stagedToolStripSeparator17.Size = new System.Drawing.Size(229, 6);
-            //
             // stagedEditFileToolStripMenuItem11
             //
             this.stagedEditFileToolStripMenuItem11.Image = global::GitUI.Properties.Images.EditFile;
@@ -490,19 +474,17 @@ namespace GitUI.CommandsDialogs
             // UnstagedSubmoduleContext
             //
             this.UnstagedSubmoduleContext.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.commitSubmoduleChanges,
+            this.updateSubmoduleMenuItem,
             this.resetSubmoduleChanges,
             this.stashSubmoduleChangesToolStripMenuItem,
-            this.updateSubmoduleMenuItem,
-            this.toolStripSeparator13,
-            this.submoduleSummaryMenuItem,
-            this.viewHistoryMenuItem,
+            this.commitSubmoduleChanges,
             this.toolStripSeparator15,
-            this.openSubmoduleMenuItem,
-            this.openFolderMenuItem,
             this.openDiffMenuItem,
             this.toolStripSeparator16,
-            this.copyFolderNameMenuItem});
+            this.openFolderMenuItem,
+            this.copyFolderNameMenuItem,
+            this.toolStripSeparator13,
+            this.viewHistoryMenuItem});
             this.UnstagedSubmoduleContext.Name = "UnstagedSubmoduleContext";
             this.UnstagedSubmoduleContext.Size = new System.Drawing.Size(229, 242);
             //
@@ -545,13 +527,6 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator13.Size = new System.Drawing.Size(225, 6);
             this.toolStripSeparator13.Tag = "1";
             //
-            // submoduleSummaryMenuItem
-            //
-            this.submoduleSummaryMenuItem.Name = "submoduleSummaryMenuItem";
-            this.submoduleSummaryMenuItem.Size = new System.Drawing.Size(228, 22);
-            this.submoduleSummaryMenuItem.Text = "View summary";
-            this.submoduleSummaryMenuItem.Click += new System.EventHandler(this.submoduleSummaryMenuItem_Click);
-            //
             // viewHistoryMenuItem
             //
             this.viewHistoryMenuItem.Image = global::GitUI.Properties.Images.FileHistory;
@@ -564,15 +539,6 @@ namespace GitUI.CommandsDialogs
             //
             this.toolStripSeparator15.Name = "toolStripSeparator15";
             this.toolStripSeparator15.Size = new System.Drawing.Size(225, 6);
-            //
-            // openSubmoduleMenuItem
-            //
-            this.openSubmoduleMenuItem.Image = global::GitUI.Properties.Images.GitExtensionsLogo16;
-            this.openSubmoduleMenuItem.Name = "openSubmoduleMenuItem";
-            this.openSubmoduleMenuItem.Size = new System.Drawing.Size(228, 22);
-            this.openSubmoduleMenuItem.Tag = "1";
-            this.openSubmoduleMenuItem.Text = "Open with Git Extensions";
-            this.openSubmoduleMenuItem.Click += new System.EventHandler(this.openSubmoduleMenuItem_Click);
             //
             // openFolderMenuItem
             //
@@ -1569,7 +1535,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripMenuItem doNotAssumeUnchangedToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem skipWorktreeToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem doNotSkipWorktreeToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
         private System.Windows.Forms.ToolStripMenuItem openToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openWithToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem filenameToClipboardToolStripMenuItem;
@@ -1610,7 +1575,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripButton toolRefreshItem;
         private ToolStripSeparator toolStripSeparator6;
         private ToolStripSeparator toolStripSeparator8;
-        private ToolStripSeparator toolStripSeparator7;
         private ToolStripSeparator toolStripSeparator9;
         private ToolStripButton toolStageAllItem;
         private ToolStripSeparator toolStripSeparator10;
@@ -1627,7 +1591,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripComboBox selectionFilter;
         private ToolStripMenuItem selectionFilterToolStripMenuItem;
         private ContextMenuStrip UnstagedSubmoduleContext;
-        private ToolStripMenuItem openSubmoduleMenuItem;
         private ToolStripMenuItem updateSubmoduleMenuItem;
         private ToolStripSeparator toolStripSeparator13;
         private ToolStripMenuItem viewHistoryMenuItem;
@@ -1636,7 +1599,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem openDiffMenuItem;
         private ToolStripSeparator toolStripSeparator16;
         private ToolStripMenuItem copyFolderNameMenuItem;
-        private ToolStripMenuItem submoduleSummaryMenuItem;
         private ToolStripMenuItem resetSubmoduleChanges;
         private ToolStripMenuItem commitSubmoduleChanges;
         private ToolStripMenuItem stashSubmoduleChangesToolStripMenuItem;
@@ -1648,12 +1610,12 @@ namespace GitUI.CommandsDialogs
         private ContextMenuStrip StagedFileContext;
         private ToolStripMenuItem stagedResetChanges;
         private ToolStripMenuItem stagedFileHistoryToolStripMenuItem6;
+        private ToolStripSeparator stagedFileHistoryToolStripSeparator;
         private ToolStripSeparator stagedToolStripSeparator14;
         private ToolStripMenuItem stagedOpenToolStripMenuItem7;
         private ToolStripMenuItem stagedOpenWithToolStripMenuItem8;
         private ToolStripMenuItem stagedOpenDifftoolToolStripMenuItem9;
         private ToolStripMenuItem stagedOpenFolderToolStripMenuItem10;
-        private ToolStripSeparator stagedToolStripSeparator17;
         private ToolStripMenuItem stagedEditFileToolStripMenuItem11;
         private ToolStripSeparator stagedToolStripSeparator18;
         private ToolStripMenuItem stagedCopyPathToolStripMenuItem14;

--- a/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
@@ -59,7 +59,7 @@ namespace GitUI.CommandsDialogs
             this.diffResetSubmoduleChanges = new System.Windows.Forms.ToolStripMenuItem();
             this.diffStashSubmoduleChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.diffUpdateSubmoduleMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.diffSubmoduleSummaryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.submoduleStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.diffToolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
             this.copyFilenameToClipboardToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.openContainingFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -115,23 +115,23 @@ namespace GitUI.CommandsDialogs
             // DiffContextMenu
             // 
             this.DiffContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.diffUpdateSubmoduleMenuItem,
+            this.diffResetSubmoduleChanges,
+            this.diffStashSubmoduleChangesToolStripMenuItem,
+            this.diffCommitSubmoduleChanges,
+            this.submoduleStripSeparator,
             this.openWithDifftoolToolStripMenuItem,
-            this.saveAsToolStripMenuItem1,
             this.resetFileToToolStripMenuItem,
             this.stageFileToolStripMenuItem,
             this.unstageFileToolStripMenuItem,
             this.cherryPickSelectedDiffFileToolStripMenuItem,
             this.toolStripSeparator32,
+            this.saveAsToolStripMenuItem1,
             this.diffEditWorkingDirectoryFileToolStripMenuItem,
             this.diffOpenWorkingDirectoryFileWithToolStripMenuItem,
             this.diffOpenRevisionFileToolStripMenuItem,
             this.diffOpenRevisionFileWithToolStripMenuItem,
             this.diffDeleteFileToolStripMenuItem,
-            this.diffCommitSubmoduleChanges,
-            this.diffResetSubmoduleChanges,
-            this.diffStashSubmoduleChangesToolStripMenuItem,
-            this.diffUpdateSubmoduleMenuItem,
-            this.diffSubmoduleSummaryMenuItem,
             this.diffToolStripSeparator13,
             this.copyFilenameToClipboardToolStripMenuItem1,
             this.openContainingFolderToolStripMenuItem,
@@ -342,12 +342,11 @@ namespace GitUI.CommandsDialogs
             this.diffUpdateSubmoduleMenuItem.Text = "Update submodule";
             this.diffUpdateSubmoduleMenuItem.Click += new System.EventHandler(this.diffUpdateSubmoduleMenuItem_Click);
             // 
-            // diffSubmoduleSummaryMenuItem
+            // submoduleStripSeparator
             // 
-            this.diffSubmoduleSummaryMenuItem.Name = "diffSubmoduleSummaryMenuItem";
-            this.diffSubmoduleSummaryMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.diffSubmoduleSummaryMenuItem.Text = "View summary";
-            this.diffSubmoduleSummaryMenuItem.Click += new System.EventHandler(this.diffSubmoduleSummaryMenuItem_Click);
+            this.submoduleStripSeparator.Name = "submoduleStripSeparator";
+            this.submoduleStripSeparator.Size = new System.Drawing.Size(293, 6);
+            this.submoduleStripSeparator.Tag = "1";
             // 
             // diffToolStripSeparator13
             // 
@@ -467,10 +466,10 @@ namespace GitUI.CommandsDialogs
         private ToolStripSeparator toolStripSeparator32;
         private ToolStripMenuItem diffDeleteFileToolStripMenuItem;
         private ToolStripMenuItem diffUpdateSubmoduleMenuItem;
-        private ToolStripMenuItem diffSubmoduleSummaryMenuItem;
         private ToolStripMenuItem diffResetSubmoduleChanges;
         private ToolStripMenuItem diffCommitSubmoduleChanges;
         private ToolStripMenuItem diffStashSubmoduleChangesToolStripMenuItem;
+        private ToolStripSeparator submoduleStripSeparator;
         private ToolStripSeparator diffToolStripSeparator13;
         private ToolStripMenuItem resetFileToToolStripMenuItem;
         private ToolStripMenuItem saveAsToolStripMenuItem1;

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -423,14 +423,13 @@ namespace GitUI.CommandsDialogs
             diffOpenRevisionFileToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuOpenRevision(selectionInfo);
             diffOpenRevisionFileWithToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuOpenRevision(selectionInfo);
 
-            diffCommitSubmoduleChanges.Visible =
+            diffUpdateSubmoduleMenuItem.Visible =
                 diffResetSubmoduleChanges.Visible =
                 diffStashSubmoduleChangesToolStripMenuItem.Visible =
-                diffSubmoduleSummaryMenuItem.Visible =
-                diffUpdateSubmoduleMenuItem.Visible = _revisionDiffController.ShouldShowSubmoduleMenus(selectionInfo);
+                diffCommitSubmoduleChanges.Visible =
+                submoduleStripSeparator.Visible = _revisionDiffController.ShouldShowSubmoduleMenus(selectionInfo);
 
             diffToolStripSeparator13.Visible = _revisionDiffController.ShouldShowMenuDeleteFile(selectionInfo) ||
-                                               _revisionDiffController.ShouldShowSubmoduleMenus(selectionInfo) ||
                                                _revisionDiffController.ShouldShowMenuEditWorkingDirectoryFile(selectionInfo) ||
                                                _revisionDiffController.ShouldShowMenuOpenRevision(selectionInfo);
 
@@ -876,22 +875,6 @@ namespace GitUI.CommandsDialogs
             }
 
             RefreshArtificial();
-        }
-
-        private void diffSubmoduleSummaryMenuItem_Click(object sender, EventArgs e)
-        {
-            var submodules = DiffFiles.SelectedItems.Where(it => it.IsSubmodule).Select(it => it.Name).Distinct().ToList();
-
-            string summary = "";
-            foreach (var name in submodules)
-            {
-                summary += Module.GetSubmoduleSummary(name);
-            }
-
-            using (var frm = new FormEdit(UICommands, summary))
-            {
-                frm.ShowDialog(this);
-            }
         }
 
         public void SwitchFocus(bool alreadyContainedFocus)

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
@@ -106,23 +106,23 @@
             // FileTreeContextMenu
             // 
             this.FileTreeContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.openWithDifftoolToolStripMenuItem,
-            this.saveAsToolStripMenuItem,
-            this.resetToThisRevisionToolStripMenuItem,
-            this.toolStripSeparatorFileSystemActions,
             this.openSubmoduleMenuItem,
-            this.copyFilenameToClipboardToolStripMenuItem,
-            this.fileTreeOpenContainingFolderToolStripMenuItem,
-            this.fileTreeArchiveToolStripMenuItem,
-            this.fileTreeCleanWorkingTreeToolStripMenuItem,
-            this.toolStripSeparatorGitHistoryActions,
-            this.fileHistoryToolStripMenuItem,
-            this.blameToolStripMenuItem1,
+            this.openWithDifftoolToolStripMenuItem,
+            this.resetToThisRevisionToolStripMenuItem,
             this.toolStripSeparatorEditFileActions,
+            this.saveAsToolStripMenuItem,
             this.editCheckedOutFileToolStripMenuItem,
             this.openWithToolStripMenuItem,
             this.openFileToolStripMenuItem,
             this.openFileWithToolStripMenuItem,
+            this.toolStripSeparatorFileSystemActions,
+            this.copyFilenameToClipboardToolStripMenuItem,
+            this.fileTreeOpenContainingFolderToolStripMenuItem,
+            this.toolStripSeparatorGitHistoryActions,
+            this.fileHistoryToolStripMenuItem,
+            this.blameToolStripMenuItem1,
+            this.fileTreeArchiveToolStripMenuItem,
+            this.fileTreeCleanWorkingTreeToolStripMenuItem,
             this.toolStripSeparatorGitActions,
             this.stopTrackingThisFileToolStripMenuItem,
             this.assumeUnchangedTheFileToolStripMenuItem,
@@ -169,7 +169,7 @@
             this.openSubmoduleMenuItem.Image = global::GitUI.Properties.Images.GitExtensionsLogo16;
             this.openSubmoduleMenuItem.Name = "openSubmoduleMenuItem";
             this.openSubmoduleMenuItem.Size = new System.Drawing.Size(325, 22);
-            this.openSubmoduleMenuItem.Text = "Open with Git Extensions";
+            this.openSubmoduleMenuItem.Text = Strings.OpenWithGitExtensions;
             this.openSubmoduleMenuItem.Click += new System.EventHandler(this.openSubmoduleMenuItem_Click);
             // 
             // copyFilenameToClipboardToolStripMenuItem

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -32,6 +32,7 @@ namespace GitUI
         private readonly TranslationString _local = new TranslationString("Local");
         private readonly TranslationString _tag = new TranslationString("Tag");
         private readonly TranslationString _remote = new TranslationString("Remote");
+        private readonly TranslationString _openWithGitExtensions = new TranslationString("Open with Git Extensions");
 
         private readonly TranslationString _authored = new TranslationString("authored");
         private readonly TranslationString _committed = new TranslationString("committed");
@@ -87,6 +88,7 @@ namespace GitUI
         public static string Local => _instance.Value._local.Text;
         public static string Tag => _instance.Value._tag.Text;
         public static string Remote => _instance.Value._remote.Text;
+        public static string OpenWithGitExtensions => _instance.Value._openWithGitExtensions.Text;
 
         public static string OpenReport => _instance.Value._openReport.Text;
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3500,10 +3500,6 @@ You can unset the template:
         <source>Show in folder</source>
         <target />
       </trans-unit>
-      <trans-unit id="openSubmoduleMenuItem.Text">
-        <source>Open with Git Extensions</source>
-        <target />
-      </trans-unit>
       <trans-unit id="openToolStripMenuItem.Text">
         <source>Open</source>
         <target />
@@ -3614,10 +3610,6 @@ You can unset the template:
       </trans-unit>
       <trans-unit id="stopTrackingThisFileToolStripMenuItem.Text">
         <source>Stop tracking this file</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="submoduleSummaryMenuItem.Text">
-        <source>View summary</source>
         <target />
       </trans-unit>
       <trans-unit id="toolAuthorLabelItem.Text">
@@ -8134,10 +8126,6 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <source>Stash submodule changes</source>
         <target />
       </trans-unit>
-      <trans-unit id="diffSubmoduleSummaryMenuItem.Text">
-        <source>View summary</source>
-        <target />
-      </trans-unit>
       <trans-unit id="diffUpdateSubmoduleMenuItem.Text">
         <source>Update submodule</source>
         <target />
@@ -9319,6 +9307,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_openReport.Text">
         <source>Open report</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_openWithGitExtensions.Text">
+        <source>Open with Git Extensions</source>
         <target />
       </trans-unit>
       <trans-unit id="_parentsText.Text">

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -56,6 +56,11 @@ namespace GitUI
         public new event EventHandler DoubleClick;
         public new event KeyEventHandler KeyDown;
         public new event EnterEventHandler Enter;
+
+        [Description("Disable showing open submodule menu items as bold")]
+        [DefaultValue(false)]
+        public bool DisableSubmoduleMenuItemBold { get; set; }
+
         private Dictionary<string, int> _stateImageIndexDict;
 
         public FileStatusList()
@@ -868,7 +873,7 @@ namespace GitUI
             {
                 Name = "openSubmoduleMenuItem",
                 Tag = "1",
-                Text = "Open with Git Extensions",
+                Text = Strings.OpenWithGitExtensions,
                 Image = Images.GitExtensionsLogo16
             };
             _openSubmoduleMenuItem.Click += (s, ea) => { ThreadHelper.JoinableTaskFactory.RunAsync(() => OpenSubmoduleAsync()); };
@@ -1187,20 +1192,23 @@ namespace GitUI
         {
             var cm = (ContextMenuStrip)sender;
 
+            // TODO The handling of _openSubmoduleMenuItem need to be revised
+            // This code handles the 'bold' in the menu for submodules. Other default actions are not set to bold.
+            // The actual implementation of the default handling with doubleclick is in each form,
+            // separate from this menu item
+
             if (!cm.Items.Find(_openSubmoduleMenuItem.Name, true).Any())
             {
-                cm.Items.Insert(1, _openSubmoduleMenuItem);
+                cm.Items.Insert(0, _openSubmoduleMenuItem);
             }
 
             bool isSubmoduleSelected = SelectedItem != null && SelectedItem.IsSubmodule;
-
             _openSubmoduleMenuItem.Visible = isSubmoduleSelected;
-
-            if (isSubmoduleSelected)
+            if (isSubmoduleSelected && !DisableSubmoduleMenuItemBold)
             {
-                _openSubmoduleMenuItem.Font = AppSettings.OpenSubmoduleDiffInSeparateWindow ?
-                    new Font(_openSubmoduleMenuItem.Font, FontStyle.Bold) :
-                    new Font(_openSubmoduleMenuItem.Font, FontStyle.Regular);
+                _openSubmoduleMenuItem.Font = AppSettings.OpenSubmoduleDiffInSeparateWindow
+                    ? new Font(_openSubmoduleMenuItem.Font, FontStyle.Bold)
+                    : new Font(_openSubmoduleMenuItem.Font, FontStyle.Regular);
             }
 
             if (!cm.Items.Find(_sortByContextMenu.Name, true).Any())


### PR DESCRIPTION
## Proposed changes 

See the commits for detailed explanations, this is a summary of changes.

The context menus are not aligned much, neither contents nor order.
This PR tries to align the options in a x more consistent way, grouping similar functionality and aligning RevisionDiff, RevisionFile and FormCommit.
The order can be discussed, but I doubt I will update the screen shots.

The convention in menus is that the first item should be the default 'double-clicked' action and that it should be default.
This PR makes sure that items are bot bold if they are not the default and sets submodule "Open with Git Extensions" as bold.
To change the default file action to open the history in RevDiff/RevFile, some deeper changes are required. If so, the History/Blame should probably be handled by FileStatusList as OpenWithGE is now. Just setting bold should be eenough, setting order will be a little complex -  I want DiffTool as default in RevDiff anyway

One functional change (not counting the setting to bold), Edit File was not blocked for FormCommit Edit file.

Some code removed too.

A squash is planned before merge, probably just one commit.

Note: This should be merged before 4.0, all screenshots in the documentation need to be updated anyway...

## Screenshots
### Before
(Shortcut for Stage/Unstage from #7825, not in master)
![pre-revdiff-file-worktree](https://user-images.githubusercontent.com/6248932/78803756-aad4ab00-79bf-11ea-9326-3a00407302d0.JPG)
![pre-revdiff-subm-worktree](https://user-images.githubusercontent.com/6248932/78803763-ac9e6e80-79bf-11ea-85ff-2299fb2fd529.JPG)

![pre-revdiff-file-index](https://user-images.githubusercontent.com/6248932/78803770-af00c880-79bf-11ea-9f0c-c3bfffc2f9e8.JPG)
![pre-revdiff-subm-index](https://user-images.githubusercontent.com/6248932/78803774-b031f580-79bf-11ea-8198-4c31acd75186.JPG)

![pre-revdiff-file-commit](https://user-images.githubusercontent.com/6248932/78803779-b1fbb900-79bf-11ea-8391-324e12d925be.JPG)
![pre-revdiff-subm-commit](https://user-images.githubusercontent.com/6248932/78803786-b45e1300-79bf-11ea-80ce-6090464f8075.JPG)

![pre-revfile-subm](https://user-images.githubusercontent.com/6248932/78803788-b627d680-79bf-11ea-9a67-fd14be448da6.JPG)
![pre-revfile-file](https://user-images.githubusercontent.com/6248932/78803791-b7590380-79bf-11ea-89f9-c0026e4e3c97.JPG)

![pre-commit-file-worktree](https://user-images.githubusercontent.com/6248932/78803808-b9bb5d80-79bf-11ea-93cd-6a699a089681.JPG)
![pre-commit-subm-worktree](https://user-images.githubusercontent.com/6248932/78803811-baec8a80-79bf-11ea-8048-6d0fc4dbfe57.JPG)

![pre-commit-file-index](https://user-images.githubusercontent.com/6248932/78803817-bcb64e00-79bf-11ea-9101-c6f46416ee46.JPG)
![pre-commit-subm-index](https://user-images.githubusercontent.com/6248932/78803823-be801180-79bf-11ea-8859-f0ec700436bd.JPG)

Removed
![pre-commit-subm-summary](https://user-images.githubusercontent.com/6248932/78803828-c049d500-79bf-11ea-8c68-5958efef51d2.JPG)
![pre-revdiff-subm-summary](https://user-images.githubusercontent.com/6248932/78803869-cd66c400-79bf-11ea-8085-8bed15c06eb7.JPG)


### After

![post-revdiff-file-worktree](https://user-images.githubusercontent.com/6248932/78803875-ce97f100-79bf-11ea-86fa-e6159d272533.JPG)
![post-revdiff-subm-worktree](https://user-images.githubusercontent.com/6248932/78803882-d061b480-79bf-11ea-8bde-b25413df4f43.JPG)

![post-revdiff-file-index](https://user-images.githubusercontent.com/6248932/78803886-d192e180-79bf-11ea-9e34-c3f6a422025b.JPG)
![post-revdiff-subm-index](https://user-images.githubusercontent.com/6248932/78803891-d35ca500-79bf-11ea-9d8b-e9eb6804c95c.JPG)

![post-revdiff-file-commit](https://user-images.githubusercontent.com/6248932/78803895-d48dd200-79bf-11ea-867c-0eb222402deb.JPG)
![post-revdiff-subm-commit](https://user-images.githubusercontent.com/6248932/78803900-d5beff00-79bf-11ea-90b4-6bdcaa05f6ae.JPG)

![post-revfile-file](https://user-images.githubusercontent.com/6248932/78803903-d788c280-79bf-11ea-867b-36907deba4f9.JPG)
![post-revfile-subm](https://user-images.githubusercontent.com/6248932/78803915-d9eb1c80-79bf-11ea-9fff-3166cde55f4f.JPG)

![post-commit-file-worktree](https://user-images.githubusercontent.com/6248932/78803918-db1c4980-79bf-11ea-8fab-2ebb79eb98ee.JPG)
![post-commit-subm-worktree](https://user-images.githubusercontent.com/6248932/78803926-db1c4980-79bf-11ea-84d3-0ab2f54728d5.JPG)

![post-commit-file-index](https://user-images.githubusercontent.com/6248932/78803935-dd7ea380-79bf-11ea-8dd9-fc055a400fed.JPG)
![post-commit-subm-index](https://user-images.githubusercontent.com/6248932/78803946-e2435780-79bf-11ea-97e7-bb186aae2d26.JPG)

## Test methodology 
Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
