### PR TITLE
Avoid invalid path exception on invalidated Module.WorkingDir

### DIFF
--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -141,7 +141,7 @@ namespace GitCommands
             var treeGuid = ObjectId.Parse(lines[1]);
 
             // TODO: we can use this to add more relationship info like gitk does if wanted
-            var parentGuids = lines[2].Split(' ').Where(id => id.IsNotNullOrWhitespace()).Select(id => ObjectId.Parse(id)).ToList();
+            var parentGuids = lines[2].Split(' ').Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => ObjectId.Parse(id)).ToList();
             var author = module.ReEncodeStringFromLossless(lines[3]);
             var authorDate = DateTimeUtils.ParseUnixTime(lines[4]);
             var committer = module.ReEncodeStringFromLossless(lines[5]);

--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -309,7 +309,7 @@ namespace GitCommands.Config
 
                 string value = _token.ToString();
 
-                if (_key.IsNullOrEmpty())
+                if (string.IsNullOrEmpty(_key))
                 {
                     throw new Exception($"Value {value} for empty key in config file {FileName}.");
                 }

--- a/GitCommands/Config/ConfigSection.cs
+++ b/GitCommands/Config/ConfigSection.cs
@@ -117,7 +117,7 @@ namespace GitCommands.Config
         public override string ToString()
         {
             string result = "[" + SectionName;
-            if (!SubSection.IsNullOrEmpty())
+            if (!string.IsNullOrEmpty(SubSection))
             {
                 var escSubSection = SubSection.Replace("\"", "\\\"");
                 escSubSection = escSubSection.Replace("\\", "\\\\");

--- a/GitCommands/DiffMergeTools/DiffMergeToolConfigurationManager.cs
+++ b/GitCommands/DiffMergeTools/DiffMergeToolConfigurationManager.cs
@@ -43,7 +43,7 @@ namespace GitCommands.DiffMergeTools
                 }
 
                 // Fallback and older Git
-                if (mergetool.IsNullOrEmpty())
+                if (string.IsNullOrEmpty(mergetool))
                 {
                     mergetool = _getFileSettings()?.GetValue(SettingKeyString.MergeToolNoGuiKey);
                 }

--- a/GitCommands/ExternalLinks/ExternalLinkDefinition.cs
+++ b/GitCommands/ExternalLinks/ExternalLinkDefinition.cs
@@ -167,7 +167,7 @@ namespace GitCommands.ExternalLinks
 
         public void RemoveEmptyFormats()
         {
-            var toRemove = LinkFormats.Where(f => f.Caption.IsNullOrWhiteSpace() && f.Format.IsNullOrWhiteSpace()).ToArray();
+            var toRemove = LinkFormats.Where(f => string.IsNullOrWhiteSpace(f.Caption) && string.IsNullOrWhiteSpace(f.Format)).ToArray();
 
             foreach (var format in toRemove)
             {

--- a/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
+++ b/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
@@ -123,7 +123,7 @@ namespace GitCommands.ExternalLinks
 
         private static IEnumerable<ExternalLink> ParseRevisionPart(GitRevision revision, ExternalLinkDefinition definition, Match remoteMatch, string part)
         {
-            if (definition.SearchPattern.IsNullOrEmpty() || definition.SearchPatternRegex.Value == null || part == null)
+            if (string.IsNullOrEmpty(definition.SearchPattern) || definition.SearchPatternRegex.Value == null || part == null)
             {
                 yield break;
             }
@@ -136,7 +136,7 @@ namespace GitCommands.ExternalLinks
                 var match = matches[i];
                 if (match.Success)
                 {
-                    if (definition.NestedSearchPattern.IsNullOrEmpty())
+                    if (string.IsNullOrEmpty(definition.NestedSearchPattern))
                     {
                         allMatches.Add(match);
                     }

--- a/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
+++ b/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
@@ -28,7 +28,7 @@ namespace GitCommands.ExternalLinks
 
         private static IEnumerable<ConfigFileRemote> GetMatchingRemotes(ExternalLinkDefinition definition, IEnumerable<ConfigFileRemote> remotes)
         {
-            if (definition.UseRemotesPattern.IsNullOrWhiteSpace() || definition.UseRemotesRegex.Value == null)
+            if (string.IsNullOrWhiteSpace(definition.UseRemotesPattern) || definition.UseRemotesRegex.Value == null)
             {
                 return remotes;
             }
@@ -47,7 +47,7 @@ namespace GitCommands.ExternalLinks
         {
             var allMatches = new List<Match>();
 
-            if (definition.RemoteSearchPattern.IsNullOrWhiteSpace() || definition.RemoteSearchPatternRegex.Value == null)
+            if (string.IsNullOrWhiteSpace(definition.RemoteSearchPattern) || definition.RemoteSearchPatternRegex.Value == null)
             {
                 allMatches.Add(null);
                 return allMatches;

--- a/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
+++ b/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
@@ -62,7 +62,7 @@ namespace GitCommands.ExternalLinks
             {
                 if (definition.RemoteSearchInParts.Contains(ExternalLinkDefinition.RemotePart.URL))
                 {
-                    if (remote.Url.IsNotNullOrWhitespace())
+                    if (!string.IsNullOrWhiteSpace(remote.Url))
                     {
                         remoteUrls.Add(remote.Url);
                     }
@@ -70,7 +70,7 @@ namespace GitCommands.ExternalLinks
 
                 if (definition.RemoteSearchInParts.Contains(ExternalLinkDefinition.RemotePart.PushURL))
                 {
-                    if (remote.PushUrl.IsNotNullOrWhitespace())
+                    if (!string.IsNullOrWhiteSpace(remote.PushUrl))
                     {
                         remoteUrls.Add(remote.PushUrl);
                     }

--- a/GitCommands/FileHelper.cs
+++ b/GitCommands/FileHelper.cs
@@ -57,7 +57,7 @@ namespace GitCommands
 
         public static bool IsBinaryFileName(GitModule module, string fileName)
         {
-            return fileName.IsNotNullOrWhitespace()
+            return !string.IsNullOrWhiteSpace(fileName)
                    && (IsBinaryAccordingToGitAttributes(module, fileName)
                        ?? HasMatchingExtension(BinaryExtensions, fileName));
         }

--- a/GitCommands/FullPathResolver.cs
+++ b/GitCommands/FullPathResolver.cs
@@ -49,7 +49,13 @@ namespace GitCommands
                 return path;
             }
 
-            var basePath = Path.GetFullPath(_getWorkingDir() ?? Environment.CurrentDirectory);
+            var workingDir = _getWorkingDir();
+            if (string.IsNullOrWhiteSpace(workingDir))
+            {
+                workingDir = Environment.CurrentDirectory;
+            }
+
+            var basePath = Path.GetFullPath(workingDir);
             if (!basePath.EndsWith(Path.DirectorySeparatorChar.ToString())
                 && !basePath.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
             {

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -216,7 +216,7 @@ namespace GitCommands
         /// <returns>Argument string</returns>
         public static ArgumentString ResetCmd(ResetMode mode, string commit = null, string file = null)
         {
-            if (mode == ResetMode.ResetIndex && commit.IsNullOrWhiteSpace())
+            if (mode == ResetMode.ResetIndex && string.IsNullOrWhiteSpace(commit))
             {
                 throw new ArgumentException("reset to index requires a tree-ish parameter");
             }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3152,7 +3152,7 @@ namespace GitCommands
         public IReadOnlyList<string> GetIgnoredFiles(IEnumerable<string> ignorePatterns)
         {
             var notEmptyPatterns = ignorePatterns
-                .Where(pattern => !pattern.IsNullOrWhiteSpace())
+                .Where(pattern => !string.IsNullOrWhiteSpace(pattern))
                 .ToList();
 
             if (notEmptyPatterns.Count != 0)
@@ -3713,7 +3713,7 @@ namespace GitCommands
                 throw new ArgumentNullException(nameof(branchName));
             }
 
-            if (branchName.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(branchName))
             {
                 return false;
             }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -521,7 +521,7 @@ namespace GitCommands
             };
             var output = _gitExecutable.GetOutput(args);
 
-            if (!output.IsNullOrEmpty())
+            if (!string.IsNullOrEmpty(output))
             {
                 return false;
             }
@@ -532,7 +532,7 @@ namespace GitCommands
                 fileName.ToPosixPath().QuoteNE()
             };
             output = _gitExecutable.GetOutput(args);
-            return output.IsNullOrEmpty();
+            return string.IsNullOrEmpty(output);
         }
 
         public bool HandleConflictsSaveSide(string fileName, string saveAsFileName, string side)
@@ -548,7 +548,7 @@ namespace GitCommands
             };
             var output = _gitExecutable.GetOutput(args);
 
-            if (output.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(output))
             {
                 return false;
             }
@@ -1199,7 +1199,7 @@ namespace GitCommands
 
         public bool ExistsMergeCommit(string startRev, string endRev)
         {
-            if (startRev.IsNullOrEmpty() || endRev.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(startRev) || string.IsNullOrEmpty(endRev))
             {
                 return false;
             }
@@ -2366,8 +2366,8 @@ namespace GitCommands
             };
 
             var cache = cacheResult &&
-                        !secondRevision.IsNullOrEmpty() &&
-                        !firstRevision.IsNullOrEmpty() &&
+                        !string.IsNullOrEmpty(secondRevision) &&
+                        !string.IsNullOrEmpty(firstRevision) &&
                         !secondRevision.IsArtificial() &&
                         !firstRevision.IsArtificial()
                 ? GitCommandCache
@@ -3941,7 +3941,7 @@ namespace GitCommands
 
             if (isABug)
             {
-                if (encodingName.IsNullOrEmpty())
+                if (string.IsNullOrEmpty(encodingName))
                 {
                     return Encoding.UTF8;
                 }
@@ -3976,7 +3976,7 @@ namespace GitCommands
         [ContractAnnotation("s:notnull=>notnull")]
         public string ReEncodeShowString(string s)
         {
-            if (s.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(s))
             {
                 return s;
             }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -711,7 +711,7 @@ namespace GitCommands
             {
                 "-z",
                 "--unmerged",
-                { filename.IsNotNullOrWhitespace(), "--" },
+                { !string.IsNullOrWhiteSpace(filename), "--" },
                 filename.QuoteNE()
             };
 
@@ -812,7 +812,7 @@ namespace GitCommands
             var args = new GitArgumentBuilder("ls-tree")
             {
                 refName,
-                { filename.IsNotNullOrWhitespace(), "--" },
+                { !string.IsNullOrWhiteSpace(filename), "--" },
                 filename.QuoteNE()
             };
             var output = _gitExecutable.GetOutput(args);
@@ -902,7 +902,7 @@ namespace GitCommands
             var args = new GitArgumentBuilder("mergetool")
             {
                 { GitVersion.Current.SupportGuiMergeTool, "--gui" },
-                { fileName.IsNotNullOrWhitespace(), "--" },
+                { !string.IsNullOrWhiteSpace(fileName), "--" },
                 fileName.ToPosixPath().QuoteNE()
             };
             using (var process = _gitExecutable.Start(args, createWindow: true))
@@ -3479,7 +3479,7 @@ namespace GitCommands
                 var args = new GitArgumentBuilder("ls-files")
                 {
                     "-s",
-                    { fileName.IsNotNullOrWhitespace(), "--" },
+                    { !string.IsNullOrWhiteSpace(fileName), "--" },
                     fileName.QuoteNE()
                 };
 
@@ -3497,7 +3497,7 @@ namespace GitCommands
                 {
                     "-r",
                     objectId,
-                    { fileName.IsNotNullOrWhitespace(), "--" },
+                    { !string.IsNullOrWhiteSpace(fileName), "--" },
                     fileName.QuoteNE()
                 };
                 var lines = _gitExecutable.GetOutput(args).Split(' ', '\t');

--- a/GitCommands/Git/GitPushAction.cs
+++ b/GitCommands/Git/GitPushAction.cs
@@ -114,7 +114,7 @@ namespace GitCommands
         /// <summary>Creates the push action command part.</summary>
         public override string ToString()
         {
-            if (_localBranch.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(_localBranch))
             {
                 return $":{_remoteBranch}";
             }

--- a/GitCommands/Git/GitRef.cs
+++ b/GitCommands/Git/GitRef.cs
@@ -40,7 +40,7 @@ namespace GitCommands
 
             var name = ParseName();
 
-            Name = name.IsNullOrWhiteSpace() ? CompleteName : name;
+            Name = string.IsNullOrWhiteSpace(name) ? CompleteName : name;
 
             _remoteSettingName = $"branch.{Name}.remote";
             _mergeSettingName = $"branch.{Name}.merge";

--- a/GitCommands/Git/RevisionDiffProvider.cs
+++ b/GitCommands/Git/RevisionDiffProvider.cs
@@ -100,7 +100,7 @@ namespace GitCommands.Git
                 secondRevision = "";
             }
 
-            if (fileName.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(fileName))
             {
                 extra.Add(firstRevision);
                 extra.Add(secondRevision);

--- a/GitCommands/Git/RevisionDiffProvider.cs
+++ b/GitCommands/Git/RevisionDiffProvider.cs
@@ -74,21 +74,21 @@ namespace GitCommands.Git
             // Note: As artificial are options, diff unstage..unstage and
             // stage..stage will show output, different from e.g. HEAD..HEAD
             // Diff-to-itself is not always disabled or is transient why this is not handled as error in release builds
-            Debug.Assert(!(firstRevision == secondRevision && (firstRevision.IsNullOrEmpty() || firstRevision == StagedOpt)),
+            Debug.Assert(!(firstRevision == secondRevision && (string.IsNullOrEmpty(firstRevision) || firstRevision == StagedOpt)),
                 "Unexpectedly two identical artificial revisions to diff: " + firstRevision +
                 ". This will be displayed as diff to HEAD, not an identical diff.");
 
             // As empty (unstaged) and --cached (staged) are options (not revisions),
             // order must be preserved with -R
-            if (firstRevision != secondRevision && (firstRevision.IsNullOrEmpty() ||
-                               (firstRevision == StagedOpt && !secondRevision.IsNullOrEmpty())))
+            if (firstRevision != secondRevision && (string.IsNullOrEmpty(firstRevision) ||
+                               (firstRevision == StagedOpt && !string.IsNullOrEmpty(secondRevision))))
             {
                 extra.Add("-R");
             }
 
             // Special case: Remove options comparing worktree-index
-            if ((firstRevision.IsNullOrEmpty() && secondRevision == StagedOpt) ||
-                (firstRevision == StagedOpt && secondRevision.IsNullOrEmpty()))
+            if ((string.IsNullOrEmpty(firstRevision) && secondRevision == StagedOpt) ||
+                (firstRevision == StagedOpt && string.IsNullOrEmpty(secondRevision)))
             {
                 firstRevision = secondRevision = "";
             }

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -91,7 +91,7 @@ namespace GitCommands
 
         public static bool CanBeGitURL(string url)
         {
-            if (url.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(url))
             {
                 return false;
             }

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -56,7 +56,7 @@ namespace GitCommands
         [ContractAnnotation("dirPath:notnull=>notnull")]
         public static string EnsureTrailingPathSeparator([CanBeNull] this string dirPath)
         {
-            if (!dirPath.IsNullOrEmpty() &&
+            if (!string.IsNullOrEmpty(dirPath) &&
                 dirPath[dirPath.Length - 1] != NativeDirectorySeparatorChar &&
                 dirPath[dirPath.Length - 1] != PosixDirectorySeparatorChar)
             {

--- a/GitCommands/Remotes/RepoNameExtractor.cs
+++ b/GitCommands/Remotes/RepoNameExtractor.cs
@@ -38,7 +38,7 @@ namespace GitCommands.Remotes
             // Extract "name of repo" from remote url
             var remoteName = module.GetCurrentRemote();
 
-            if (remoteName.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(remoteName))
             {
                 // No remote for the branch, for instance a submodule. Use first remote.
                 var remotes = module.GetRemoteNames();

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -187,7 +187,7 @@ namespace GitCommands
                             {
                                 {
                                     refFilterOptions.HasFlag(RefFilterOptions.Branches) &&
-                                    !branchFilter.IsNullOrWhiteSpace() && branchFilter.IndexOfAny(new[] { '?', '*', '[' }) != -1,
+                                    !string.IsNullOrWhiteSpace(branchFilter) && branchFilter.IndexOfAny(new[] { '?', '*', '[' }) != -1,
                                     "--branches=" + branchFilter
                                 },
                                 { refFilterOptions.HasFlag(RefFilterOptions.Remotes), "--remotes" },

--- a/GitCommands/Settings/ConfigFileSettings.cs
+++ b/GitCommands/Settings/ConfigFileSettings.cs
@@ -86,7 +86,7 @@ namespace GitCommands.Settings
 
         public void SetValue(string setting, [CanBeNull] string value)
         {
-            if (value.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(value))
             {
                 // to remove setting
                 value = null;

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -237,14 +237,6 @@ namespace System
             return string.IsNullOrWhiteSpace(value);
         }
 
-        /// <summary>Indicates whether the specified string is neither null, nor empty, nor has only whitespace.</summary>
-        [Pure]
-        [ContractAnnotation("value:null=>false")]
-        public static bool IsNotNullOrWhitespace([CanBeNull] this string value)
-        {
-            return !string.IsNullOrWhiteSpace(value);
-        }
-
         /// <summary>
         /// Determines whether the beginning of this instance matches any of the specified strings.
         /// </summary>

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -140,7 +140,7 @@ namespace System
         [NotNull]
         public static string CommonPrefix([CanBeNull] this string s, [CanBeNull] string other)
         {
-            if (s.IsNullOrEmpty() || other.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(s) || string.IsNullOrEmpty(other))
             {
                 return string.Empty;
             }
@@ -161,21 +161,14 @@ namespace System
         }
 
         [Pure]
-        [ContractAnnotation("s:null=>true")]
-        public static bool IsNullOrEmpty([CanBeNull] this string s)
-        {
-            return string.IsNullOrEmpty(s);
-        }
-
-        [Pure]
         [CanBeNull]
         public static string Combine([CanBeNull] this string left, [NotNull] string sep, [CanBeNull] string right)
         {
-            if (left.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(left))
             {
                 return right;
             }
-            else if (right.IsNullOrEmpty())
+            else if (string.IsNullOrEmpty(right))
             {
                 return left;
             }
@@ -207,7 +200,7 @@ namespace System
         [ContractAnnotation("s:null=>null")]
         public static string QuoteNE([CanBeNull] this string s)
         {
-            return s.IsNullOrEmpty() ? s : s.Quote();
+            return string.IsNullOrEmpty(s) ? s : s.Quote();
         }
 
         /// <summary>
@@ -217,7 +210,7 @@ namespace System
         [ContractAnnotation("s:null=>null")]
         public static string AddParenthesesNE([CanBeNull] this string s)
         {
-            return s.IsNullOrEmpty() ? s : "(" + s + ")";
+            return string.IsNullOrEmpty(s) ? s : "(" + s + ")";
         }
 
         /// <summary>
@@ -236,7 +229,7 @@ namespace System
         [ContractAnnotation("value:null=>null")]
         public static string RemoveLines([CanBeNull] this string value, [NotNull] Func<string, bool> shouldRemoveLine)
         {
-            if (value.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(value))
             {
                 return value;
             }
@@ -276,7 +269,7 @@ namespace System
         [NotNull]
         public static string ShortenTo([CanBeNull] this string str, int maxLength)
         {
-            if (str.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(str))
             {
                 return string.Empty;
             }

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -221,23 +221,6 @@ namespace System
         }
 
         /// <summary>
-        /// Indicates whether a specified string is null, empty, or consists only of white-space characters.
-        /// </summary>
-        /// <param name="value">The string to test.</param>
-        /// <remarks>
-        /// This method is copied from .Net Framework 4.0 and should be deleted after leaving 3.5.
-        /// </remarks>
-        /// <returns>
-        /// true if the value parameter is null or <see cref="string.Empty"/>, or if value consists exclusively of white-space characters.
-        /// </returns>
-        [Pure]
-        [ContractAnnotation("value:null=>true")]
-        public static bool IsNullOrWhiteSpace([CanBeNull] this string value)
-        {
-            return string.IsNullOrWhiteSpace(value);
-        }
-
-        /// <summary>
         /// Determines whether the beginning of this instance matches any of the specified strings.
         /// </summary>
         /// <param name="starts">array of strings to compare</param>

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -387,7 +387,7 @@ namespace GitCommands.Submodules
         /// <returns>the task</returns>
         private async Task GetSubmoduleDetailedStatusAsync(GitModule superModule, string submoduleName, CancellationToken cancelToken)
         {
-            if (superModule == null || submoduleName.IsNullOrWhiteSpace())
+            if (superModule == null || string.IsNullOrWhiteSpace(submoduleName))
             {
                 return;
             }

--- a/GitCommands/UserRepositoryHistory/RecentRepoInfo.cs
+++ b/GitCommands/UserRepositoryHistory/RecentRepoInfo.cs
@@ -163,14 +163,14 @@ namespace GitCommands.UserRepositoryHistory
             if (shortenPath && repoInfo.DirInfo != null)
             {
                 string s = repoInfo.DirName.Substring(repoInfo.DirInfo.FullName.Length);
-                if (!s.IsNullOrEmpty())
+                if (!string.IsNullOrEmpty(s))
                 {
                     s = s.Trim(Path.DirectorySeparatorChar);
                 }
 
                 // candidate for short name
                 repoInfo.Caption = repoInfo.ShortName;
-                if (!s.IsNullOrEmpty())
+                if (!string.IsNullOrEmpty(s))
                 {
                     repoInfo.Caption += " (" + s + ")";
                 }

--- a/GitCommands/Utils/EnvUtils.cs
+++ b/GitCommands/Utils/EnvUtils.cs
@@ -107,7 +107,7 @@ namespace GitCommands.Utils
 
         public static string ReplaceLinuxNewLinesDependingOnPlatform(string s)
         {
-            if (s.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(s))
             {
                 return s;
             }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -353,7 +353,7 @@ namespace GitUI.BranchTreePanel
 
             if (_searchResult == null || !_searchResult.Any())
             {
-                if (_txtBranchCriterion.Text.IsNotNullOrWhitespace())
+                if (!string.IsNullOrWhiteSpace(_txtBranchCriterion.Text))
                 {
                     _searchResult = SearchTree(_txtBranchCriterion.Text, treeMain.Nodes.Cast<TreeNode>());
                 }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -344,7 +344,7 @@ namespace GitUI.BranchTreePanel
                 }
 
                 _searchResult = null;
-                if (_txtBranchCriterion.Text.IsNullOrWhiteSpace())
+                if (string.IsNullOrWhiteSpace(_txtBranchCriterion.Text))
                 {
                     _txtBranchCriterion.Focus();
                     return;

--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -325,7 +325,7 @@ namespace GitUI.BuildServerIntegration
                 try
                 {
                     var canBeLoaded = export.Metadata.CanBeLoaded;
-                    if (!canBeLoaded.IsNullOrEmpty())
+                    if (!string.IsNullOrEmpty(canBeLoaded))
                     {
                         Debug.Write(export.Metadata.BuildServerType + " adapter could not be loaded: " + canBeLoaded);
                         return null;

--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -231,12 +231,12 @@ namespace GitUI.BuildServerIntegration
         {
             var (repoProject, repoName) = _repoNameExtractor.Get();
 
-            if (repoProject.IsNotNullOrWhitespace())
+            if (!string.IsNullOrWhiteSpace(repoProject))
             {
                 projectNames = projectNames.Replace("{cRepoProject}", repoProject);
             }
 
-            if (repoName.IsNotNullOrWhitespace())
+            if (!string.IsNullOrWhiteSpace(repoName))
             {
                 projectNames = projectNames.Replace("{cRepoShortName}", repoName);
             }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -200,7 +200,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         private void SetCommitExpressionFromClipboard()
         {
             string text = Clipboard.GetText().Trim();
-            if (text.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(text))
             {
                 return;
             }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
@@ -48,7 +48,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             var directories = new List<string>();
 
-            if (AppSettings.DefaultCloneDestinationPath.IsNotNullOrWhitespace())
+            if (!string.IsNullOrWhiteSpace(AppSettings.DefaultCloneDestinationPath))
             {
                 directories.Add(AppSettings.DefaultCloneDestinationPath.EnsureTrailingPathSeparator());
             }
@@ -66,13 +66,13 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             if (directories.Count == 0)
             {
-                if (AppSettings.RecentWorkingDir.IsNotNullOrWhitespace())
+                if (!string.IsNullOrWhiteSpace(AppSettings.RecentWorkingDir))
                 {
                     directories.Add(AppSettings.RecentWorkingDir.EnsureTrailingPathSeparator());
                 }
 
                 string homeDir = EnvironmentConfiguration.GetHomeDir();
-                if (homeDir.IsNotNullOrWhitespace())
+                if (!string.IsNullOrWhiteSpace(homeDir))
                 {
                     directories.Add(homeDir.EnsureTrailingPathSeparator());
                 }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
@@ -116,7 +116,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         private void folderBrowserButton_Click(object sender, EventArgs e)
         {
             string userSelectedPath = OsShellUtil.PickFolder(this, _NO_TRANSLATE_Directory.Text);
-            if (!userSelectedPath.IsNullOrEmpty())
+            if (!string.IsNullOrEmpty(userSelectedPath))
             {
                 _NO_TRANSLATE_Directory.Text = userSelectedPath;
                 Load.PerformClick();

--- a/GitUI/CommandsDialogs/CommitDialog/FormCommitTemplateSettings.cs
+++ b/GitUI/CommandsDialogs/CommitDialog/FormCommitTemplateSettings.cs
@@ -100,7 +100,7 @@ namespace GitUI.CommandsDialogs.CommitDialog
         {
             string comboBoxText;
 
-            if (!_commitTemplates[line].Name.IsNullOrEmpty())
+            if (!string.IsNullOrEmpty(_commitTemplates[line].Name))
             {
                 comboBoxText = _commitTemplates[line].Name.ShortenTo(_maxShownCharsForName);
             }

--- a/GitUI/CommandsDialogs/FormArchive.cs
+++ b/GitUI/CommandsDialogs/FormArchive.cs
@@ -67,7 +67,7 @@ namespace GitUI.CommandsDialogs
 
         public void SetPathArgument(string path)
         {
-            if (path.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(path))
             {
                 checkBoxPathFilter.Checked = false;
                 textBoxPaths.Text = "";

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -228,7 +228,7 @@ namespace GitUI.CommandsDialogs
                 branchNames = GetContainsRevisionBranches();
             }
 
-            Branches.Items.AddRange(branchNames.Where(name => name.IsNotNullOrWhitespace()).ToArray<object>());
+            Branches.Items.AddRange(branchNames.Where(name => !string.IsNullOrWhiteSpace(name)).ToArray<object>());
 
             if (_containRevisions != null && Branches.Items.Count == 1)
             {

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -164,7 +164,7 @@ namespace GitUI.CommandsDialogs
 
         public DialogResult DoDefaultActionOrShow(IWin32Window owner)
         {
-            bool localBranchSelected = !Branches.Text.IsNullOrWhiteSpace() && !Remotebranch.Checked;
+            bool localBranchSelected = !string.IsNullOrWhiteSpace(Branches.Text) && !Remotebranch.Checked;
             if (!AppSettings.AlwaysShowCheckoutBranchDlg && localBranchSelected &&
                 (!HasUncommittedChanges || AppSettings.UseDefaultCheckoutBranchAction))
             {
@@ -292,7 +292,7 @@ namespace GitUI.CommandsDialogs
                 {
                     newBranchName = txtCustomBranchName.Text.Trim();
                     newBranchMode = CheckoutNewBranchMode.Create;
-                    if (newBranchName.IsNullOrWhiteSpace())
+                    if (string.IsNullOrWhiteSpace(newBranchName))
                     {
                         MessageBox.Show(_customBranchNameIsEmpty.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         DialogResult = DialogResult.None;
@@ -462,7 +462,7 @@ namespace GitUI.CommandsDialogs
             lbChanges.Text = "";
 
             var branch = Branches.Text;
-            if (branch.IsNullOrWhiteSpace() || !Remotebranch.Checked)
+            if (string.IsNullOrWhiteSpace(branch) || !Remotebranch.Checked)
             {
                 _remoteName = string.Empty;
                 _localBranchName = string.Empty;
@@ -488,7 +488,7 @@ namespace GitUI.CommandsDialogs
             branchName.Text = "'" + _localBranchName + "'";
             txtCustomBranchName.Text = _newLocalBranchName;
 
-            if (branch.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(branch))
             {
                 lbChanges.Text = "";
             }

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -33,7 +33,7 @@ namespace GitUI.CommandsDialogs
 
         public void SetPathArgument(string path)
         {
-            if (path.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(path))
             {
                 checkBoxPathFilter.Checked = false;
                 textBoxPaths.Text = "";
@@ -93,7 +93,7 @@ namespace GitUI.CommandsDialogs
             // 1. get all lines from text box which are not empty
             // 2. wrap lines with ""
             // 3. join together with space as separator
-            return string.Join(" ", textBoxPaths.Lines.Where(a => !a.IsNullOrEmpty()).Select(a => string.Format("\"{0}\"", a)));
+            return string.Join(" ", textBoxPaths.Lines.Where(a => !string.IsNullOrEmpty(a)).Select(a => string.Format("\"{0}\"", a)));
         }
 
         private void Cancel_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -114,7 +114,7 @@ namespace GitUI.CommandsDialogs
 
                 // if the From field is empty, then fill it with the current repository remote URL in hope
                 // that the cloned repository is hosted on the same server
-                if (_NO_TRANSLATE_From.Text.IsNullOrWhiteSpace())
+                if (string.IsNullOrWhiteSpace(_NO_TRANSLATE_From.Text))
                 {
                     var currentBranchRemote = Module.GetSetting(string.Format(SettingKeyString.BranchRemote, Module.GetSelectedBranch()));
                     if (currentBranchRemote.IsNullOrEmpty())
@@ -142,7 +142,7 @@ namespace GitUI.CommandsDialogs
                     try
                     {
                         // If the from directory is filled with the pushUrl from current working directory, set the destination directory to the parent
-                        if (!string.IsNullOrWhiteSpace(pushUrl) && _NO_TRANSLATE_To.Text.IsNullOrWhiteSpace() && !string.IsNullOrWhiteSpace(Module.WorkingDir))
+                        if (!string.IsNullOrWhiteSpace(pushUrl) && string.IsNullOrWhiteSpace(_NO_TRANSLATE_To.Text) && !string.IsNullOrWhiteSpace(Module.WorkingDir))
                         {
                             _NO_TRANSLATE_To.Text = Path.GetDirectoryName(Module.WorkingDir.TrimEnd(Path.DirectorySeparatorChar));
                         }
@@ -156,7 +156,7 @@ namespace GitUI.CommandsDialogs
 
             // if there is no destination directory, then use the parent of the current working directory
             // this would clone the new repo at the same level as the current one by default
-            if (_NO_TRANSLATE_To.Text.IsNullOrWhiteSpace() && !string.IsNullOrWhiteSpace(Module.WorkingDir))
+            if (string.IsNullOrWhiteSpace(_NO_TRANSLATE_To.Text) && !string.IsNullOrWhiteSpace(Module.WorkingDir))
             {
                 if (Module.IsValidGitWorkingDir())
                 {

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -117,7 +117,7 @@ namespace GitUI.CommandsDialogs
                 if (string.IsNullOrWhiteSpace(_NO_TRANSLATE_From.Text))
                 {
                     var currentBranchRemote = Module.GetSetting(string.Format(SettingKeyString.BranchRemote, Module.GetSelectedBranch()));
-                    if (currentBranchRemote.IsNullOrEmpty())
+                    if (string.IsNullOrEmpty(currentBranchRemote))
                     {
                         var remotes = Module.GetRemoteNames();
 
@@ -132,7 +132,7 @@ namespace GitUI.CommandsDialogs
                     }
 
                     string pushUrl = Module.GetSetting(string.Format(SettingKeyString.RemotePushUrl, currentBranchRemote));
-                    if (pushUrl.IsNullOrEmpty())
+                    if (string.IsNullOrEmpty(pushUrl))
                     {
                         pushUrl = Module.GetSetting(string.Format(SettingKeyString.RemoteUrl, currentBranchRemote));
                     }

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -142,7 +142,7 @@ namespace GitUI.CommandsDialogs
                     try
                     {
                         // If the from directory is filled with the pushUrl from current working directory, set the destination directory to the parent
-                        if (pushUrl.IsNotNullOrWhitespace() && _NO_TRANSLATE_To.Text.IsNullOrWhiteSpace() && Module.WorkingDir.IsNotNullOrWhitespace())
+                        if (!string.IsNullOrWhiteSpace(pushUrl) && _NO_TRANSLATE_To.Text.IsNullOrWhiteSpace() && !string.IsNullOrWhiteSpace(Module.WorkingDir))
                         {
                             _NO_TRANSLATE_To.Text = Path.GetDirectoryName(Module.WorkingDir.TrimEnd(Path.DirectorySeparatorChar));
                         }
@@ -156,7 +156,7 @@ namespace GitUI.CommandsDialogs
 
             // if there is no destination directory, then use the parent of the current working directory
             // this would clone the new repo at the same level as the current one by default
-            if (_NO_TRANSLATE_To.Text.IsNullOrWhiteSpace() && Module.WorkingDir.IsNotNullOrWhitespace())
+            if (_NO_TRANSLATE_To.Text.IsNullOrWhiteSpace() && !string.IsNullOrWhiteSpace(Module.WorkingDir))
             {
                 if (Module.IsValidGitWorkingDir())
                 {

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1514,7 +1514,7 @@ namespace GitUI.CommandsDialogs
                         }
                     }
 
-                    if (!AppSettings.CommitValidationRegEx.IsNullOrEmpty())
+                    if (!string.IsNullOrEmpty(AppSettings.CommitValidationRegEx))
                     {
                         try
                         {

--- a/GitUI/CommandsDialogs/FormCompareToBranch.cs
+++ b/GitUI/CommandsDialogs/FormCompareToBranch.cs
@@ -36,7 +36,7 @@ namespace GitUI.CommandsDialogs
 
         private void btnCompare_Click(object sender, EventArgs e)
         {
-            if (branchSelector.SelectedBranchName.IsNotNullOrWhitespace())
+            if (!string.IsNullOrWhiteSpace(branchSelector.SelectedBranchName))
             {
                 BranchName = branchSelector.SelectedBranchName;
                 DialogResult = DialogResult.OK;

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -45,7 +45,7 @@ namespace GitUI.CommandsDialogs
             {
                 commitPickerSmallControl1.SetSelectedCommitHash(objectId.ToString());
 
-                if (newBranchNamePrefix.IsNullOrWhiteSpace())
+                if (string.IsNullOrWhiteSpace(newBranchNamePrefix))
                 {
                     var refs = Module.GetRevision(objectId, shortFormat: true, loadRefs: true).Refs;
                     IGitRef firstRef = refs.FirstOrDefault(r => !r.IsTag) ?? refs.FirstOrDefault(r => r.IsTag);
@@ -103,7 +103,7 @@ namespace GitUI.CommandsDialogs
             }
 
             var branchName = BranchNameTextBox.Text.Trim();
-            if (branchName.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(branchName))
             {
                 MessageBox.Show(_branchNameIsEmpty.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 DialogResult = DialogResult.None;

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -53,7 +53,7 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            if (newBranchNamePrefix.IsNotNullOrWhitespace())
+            if (!string.IsNullOrWhiteSpace(newBranchNamePrefix))
             {
                 BranchNameTextBox.Text = newBranchNamePrefix;
             }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -293,7 +293,7 @@ namespace GitUI.CommandsDialogs
                 .Append("File History - ")
                 .Append(FileName);
 
-            if (!alternativeFileName.IsNullOrEmpty() && alternativeFileName != FileName)
+            if (!string.IsNullOrEmpty(alternativeFileName) && alternativeFileName != FileName)
             {
                 str.Append(" (").Append(alternativeFileName).Append(')');
             }

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -159,7 +159,7 @@ namespace GitUI.CommandsDialogs
                 case AppSettings.PullAction.FetchPruneAll:
                     Fetch.Checked = true;
                     Prune.Checked = true;
-                    if (defaultRemote.IsNullOrEmpty())
+                    if (string.IsNullOrEmpty(defaultRemote))
                     {
                         _NO_TRANSLATE_Remotes.Text = AllRemotes;
                     }
@@ -206,7 +206,7 @@ namespace GitUI.CommandsDialogs
             _NO_TRANSLATE_Remotes.SelectedIndex = -1;
             _NO_TRANSLATE_Remotes.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
 
-            if (selectedRemoteName.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(selectedRemoteName))
             {
                 selectedRemoteName = Module.GetSetting(string.Format(SettingKeyString.BranchRemote, _branch));
             }
@@ -235,7 +235,7 @@ namespace GitUI.CommandsDialogs
             if (pullAction == AppSettings.PullAction.FetchPruneAll)
             {
                 string messageBoxTitle = null;
-                if (remote.IsNullOrEmpty())
+                if (string.IsNullOrEmpty(remote))
                 {
                     messageBoxTitle = string.Format(_pruneFromCaption.Text, AllRemotes);
                 }
@@ -717,9 +717,9 @@ namespace GitUI.CommandsDialogs
 
             if (_branch == localBranch.Text)
             {
-                if (remote == currentBranchRemote.Value || currentBranchRemote.Value.IsNullOrEmpty())
+                if (remote == currentBranchRemote.Value || string.IsNullOrEmpty(currentBranchRemote.Value))
                 {
-                    curLocalBranch = Branches.Text.IsNullOrEmpty() ? null : _branch;
+                    curLocalBranch = string.IsNullOrEmpty(Branches.Text) ? null : _branch;
                 }
                 else
                 {
@@ -731,7 +731,7 @@ namespace GitUI.CommandsDialogs
                 curLocalBranch = localBranch.Text;
             }
 
-            if (Branches.Text.IsNullOrEmpty() && !curLocalBranch.IsNullOrEmpty()
+            if (string.IsNullOrEmpty(Branches.Text) && !string.IsNullOrEmpty(curLocalBranch)
                 && remote != currentBranchRemote.Value && !Fetch.Checked)
             {
                 int idx = PSTaskDialog.cTaskDialog.ShowCommandBox(this,
@@ -750,7 +750,7 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            if (Branches.Text.IsNullOrEmpty() && !curLocalBranch.IsNullOrEmpty()
+            if (string.IsNullOrEmpty(Branches.Text) && !string.IsNullOrEmpty(curLocalBranch)
                 && Fetch.Checked)
             {
                 // if local branch eq to current branch and remote branch is not specified
@@ -788,7 +788,7 @@ namespace GitUI.CommandsDialogs
         private string CalculateRemoteBranchName()
         {
             string remoteBranchName = CalculateRemoteBranchNameBasedOnBranchesText();
-            if (remoteBranchName.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(remoteBranchName))
             {
                 return remoteBranchName;
             }
@@ -800,13 +800,13 @@ namespace GitUI.CommandsDialogs
 
         private string CalculateRemoteBranchNameBasedOnBranchesText()
         {
-            if (!Branches.Text.IsNullOrEmpty())
+            if (!string.IsNullOrEmpty(Branches.Text))
             {
                 return Branches.Text;
             }
 
             string remoteBranchName = Module.GetSetting(string.Format("branch.{0}.merge", _branch));
-            if (!remoteBranchName.IsNullOrEmpty())
+            if (!string.IsNullOrEmpty(remoteBranchName))
             {
                 var args = new GitArgumentBuilder("name-rev")
                 {

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -363,7 +363,7 @@ namespace GitUI.CommandsDialogs
                 return dr;
             }
 
-            if (!Fetch.Checked && Branches.Text.IsNullOrWhiteSpace() && Module.IsDetachedHead())
+            if (!Fetch.Checked && string.IsNullOrWhiteSpace(Branches.Text) && Module.IsDetachedHead())
             {
                 int idx = PSTaskDialog.cTaskDialog.ShowCommandBox(
                     owner,
@@ -864,13 +864,13 @@ namespace GitUI.CommandsDialogs
                 {
                     foreach (var remote in (IEnumerable<ConfigFileRemote>)_NO_TRANSLATE_Remotes.DataSource)
                     {
-                        if (!remote.Name.IsNullOrWhiteSpace() && remote.Name != AllRemotes)
+                        if (!string.IsNullOrWhiteSpace(remote.Name) && remote.Name != AllRemotes)
                         {
                             yield return remote.Name;
                         }
                     }
                 }
-                else if (!_NO_TRANSLATE_Remotes.Text.IsNullOrWhiteSpace())
+                else if (!string.IsNullOrWhiteSpace(_NO_TRANSLATE_Remotes.Text))
                 {
                     yield return _NO_TRANSLATE_Remotes.Text;
                 }
@@ -1066,7 +1066,7 @@ namespace GitUI.CommandsDialogs
 
         private void localBranch_Leave(object sender, EventArgs e)
         {
-            if (_branch != localBranch.Text.Trim() && Branches.Text.IsNullOrWhiteSpace())
+            if (_branch != localBranch.Text.Trim() && string.IsNullOrWhiteSpace(Branches.Text))
             {
                 Branches.Text = localBranch.Text;
             }

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -334,7 +334,7 @@ namespace GitUI.CommandsDialogs
                     track = selectedLocalBranch != null && string.IsNullOrEmpty(selectedLocalBranch.TrackingRemote) &&
                             !UserGitRemotes.Any(x => _NO_TRANSLATE_Branch.Text.StartsWith(x.Name, StringComparison.OrdinalIgnoreCase));
                     var autoSetupMerge = Module.EffectiveConfigFile.GetValue("branch.autoSetupMerge");
-                    if (autoSetupMerge.IsNotNullOrWhitespace() && autoSetupMerge.ToLowerInvariant() == "false")
+                    if (!string.IsNullOrWhiteSpace(autoSetupMerge) && autoSetupMerge.ToLowerInvariant() == "false")
                     {
                         track = false;
                     }
@@ -831,7 +831,7 @@ namespace GitUI.CommandsDialogs
 
         private void EnableLoadSshButton()
         {
-            LoadSSHKey.Visible = _selectedRemote?.PuttySshKey.IsNotNullOrWhitespace() ?? false;
+            LoadSSHKey.Visible = !string.IsNullOrWhiteSpace(_selectedRemote?.PuttySshKey);
         }
 
         private void LoadSshKeyClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -216,7 +216,7 @@ namespace GitUI.CommandsDialogs
             _NO_TRANSLATE_Remotes.SelectedIndexChanged += RemotesUpdated;
             _NO_TRANSLATE_Remotes.TextUpdate += RemotesUpdated;
 
-            if (selectedRemoteName.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(selectedRemoteName))
             {
                 selectedRemoteName = Module.GetSetting(string.Format(SettingKeyString.BranchRemote, _currentBranchName));
             }
@@ -727,7 +727,7 @@ namespace GitUI.CommandsDialogs
                         {
                             string defaultRemote = _remotesManager.GetDefaultPushRemote(_selectedRemote,
                                 branch.Name);
-                            if (!defaultRemote.IsNullOrEmpty())
+                            if (!string.IsNullOrEmpty(defaultRemote))
                             {
                                 RemoteBranch.Text = defaultRemote;
                                 return;
@@ -809,7 +809,7 @@ namespace GitUI.CommandsDialogs
 
             // update the text box of the Remote Url combobox to show the URL of selected remote
             string pushUrl = _selectedRemote.PushUrl;
-            if (pushUrl.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(pushUrl))
             {
                 pushUrl = _selectedRemote.Url;
             }

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1213,19 +1213,19 @@ namespace GitUI.CommandsDialogs
         {
             var conflictedFileNames = ThreadHelper.JoinableTaskFactory.Run(() =>
                 Module.GetConflictAsync(fileName));
-            if (conflictedFileNames.Local.Filename.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(conflictedFileNames.Local.Filename))
             {
                 ContextSaveLocalAs.Enabled = false;
                 ContextOpenLocalWith.Enabled = false;
             }
 
-            if (conflictedFileNames.Remote.Filename.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(conflictedFileNames.Remote.Filename))
             {
                 ContextSaveRemoteAs.Enabled = false;
                 ContextOpenRemoteWith.Enabled = false;
             }
 
-            if (conflictedFileNames.Base.Filename.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(conflictedFileNames.Base.Filename))
             {
                 ContextSaveBaseAs.Enabled = false;
                 ContextOpenBaseWith.Enabled = false;

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
@@ -223,7 +223,7 @@ namespace GitUI.CommandsDialogs
             }
 
             // Now check the rules, the well-known recommendation is to have the single "/*" rule active
-            List<string> rulelines = RulesText.SplitLines().Select(l => l.Trim()).Where(l => (!l.IsNullOrEmpty()) && (l[0] != '#')).ToList(); // All nonempty and non-comment lines
+            List<string> rulelines = RulesText.SplitLines().Select(l => l.Trim()).Where(l => (!string.IsNullOrEmpty(l)) && (l[0] != '#')).ToList(); // All nonempty and non-comment lines
             if (rulelines.All(l => l == "/*"))
             {
                 return; // Rules OK for turning off

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -163,7 +163,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
         private void _yourBranchCB_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (_prevTitle == _titleTB.Text && !_yourBranchesCB.Text.IsNullOrWhiteSpace() && MyRemote != null)
+            if (_prevTitle == _titleTB.Text && !string.IsNullOrWhiteSpace(_yourBranchesCB.Text) && MyRemote != null)
             {
                 var lastMsg = Module.GetPreviousCommitMessages(1, MyRemote.Name.Combine("/", _yourBranchesCB.Text)).FirstOrDefault();
                 _titleTB.Text = lastMsg?.SubstringUntil('\n');

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -675,7 +675,7 @@ namespace GitUI.CommandsDialogs
 
                 firstDiffCaptionMenuItem.Text = _firstRevision.Text;
                 var parentDesc = DescribeRevision(DiffFiles.SelectedItemParents.ToList());
-                if (parentDesc.IsNotNullOrWhitespace())
+                if (!string.IsNullOrWhiteSpace(parentDesc))
                 {
                     firstDiffCaptionMenuItem.Text += parentDesc;
                 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -490,7 +490,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
 
             string cmd = _diffMergeToolConfigurationManager.GetToolCommand(diffTool, DiffMergeToolType.Diff);
-            if (cmd.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(cmd))
             {
                 RenderSettingUnset(DiffTool, DiffTool_Fix, _adviceDiffToolConfiguration.Text);
                 return false;
@@ -511,7 +511,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
 
             string cmd = _diffMergeToolConfigurationManager.GetToolCommand(mergeTool, DiffMergeToolType.Merge);
-            if (cmd.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(cmd))
             {
                 RenderSettingUnset(MergeTool, MergeTool_Fix, string.Format(_mergeToolXConfiguredNeedsCmd.Text, mergeTool));
                 return false;

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
@@ -123,7 +123,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         {
             _nodesFoundByTextBox = new List<TreeNode>();
 
-            if (textBoxFind.Text.IsNullOrEmpty() || textBoxFind.Text == FindPrompt)
+            if (string.IsNullOrEmpty(textBoxFind.Text) || textBoxFind.Text == FindPrompt)
             {
                 ResetAllNodeHighlighting();
                 return;

--- a/GitUI/CommitInfo/RefsFormatter.cs
+++ b/GitUI/CommitInfo/RefsFormatter.cs
@@ -128,7 +128,7 @@ namespace GitUI.CommitInfo
         private string ToString(IEnumerable<string> formattedRefs, string prefix, string textIfEmpty, string refsType, bool truncated)
         {
             string linksJoined = formattedRefs?.Join(Environment.NewLine);
-            if (linksJoined.IsNullOrEmpty())
+            if (string.IsNullOrEmpty(linksJoined))
             {
                 return WebUtility.HtmlEncode(textIfEmpty);
             }

--- a/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
+++ b/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
@@ -25,7 +25,7 @@ namespace GitUI.Editor.Diff
             for (int i = 0; i < lines.Length; i++)
             {
                 string line = lines[i];
-                if (i == lines.Length - 1 && line.IsNullOrEmpty())
+                if (i == lines.Length - 1 && string.IsNullOrEmpty(line))
                 {
                     break;
                 }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1190,7 +1190,7 @@ namespace GitUI.Editor
 
             var text = internalFileViewer.GetText();
 
-            if (!text.IsNullOrEmpty())
+            if (!string.IsNullOrEmpty(text))
             {
                 ClipboardUtil.TrySetText(text);
             }

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -116,7 +116,7 @@ namespace GitUI.Editor
         [NotNull]
         private IList<TextMarker> GetTextMarkersMatchingWord(string word)
         {
-            if (word.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(word))
             {
                 return Array.Empty<TextMarker>();
             }

--- a/GitUI/FormRemoteProcess.cs
+++ b/GitUI/FormRemoteProcess.cs
@@ -150,7 +150,7 @@ Do you want to register the host's fingerprint and restart the process?");
 
         public static bool AskForCacheHostkey(IWin32Window owner, GitModule module, string remoteUrl)
         {
-            if (!remoteUrl.IsNullOrEmpty() && MessageBoxes.CacheHostkey(owner))
+            if (!string.IsNullOrEmpty(remoteUrl) && MessageBoxes.CacheHostkey(owner))
             {
                 return new Plink().Connect(remoteUrl);
             }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1719,7 +1719,7 @@ namespace GitUI
                 fileHistoryFileName = exactFileName.Substring(Module.WorkingDir.Length);
             }
 
-            if (fileHistoryFileName.IsNotNullOrWhitespace())
+            if (!string.IsNullOrWhiteSpace(fileHistoryFileName))
             {
                 StartFileHistoryDialog(null, fileHistoryFileName);
             }

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -53,7 +53,7 @@ namespace GitUI
         {
             if (file == null || selectedRev?.ObjectId == null)
             {
-                if (defaultText.IsNotNullOrWhitespace())
+                if (!string.IsNullOrWhiteSpace(defaultText))
                 {
                     return fileViewer.ViewTextAsync(file?.Name, defaultText, openWithDiffTool);
                 }

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -382,7 +382,7 @@ namespace GitUI.Hotkey
                  */
                 return ScriptManager
                     .GetScripts()
-                    .Where(s => !s.Name.IsNullOrEmpty())
+                    .Where(s => !string.IsNullOrEmpty(s.Name))
                     .Select(s => new HotkeyCommand(s.HotkeyCommandIdentifier, s.Name) { KeyData = Keys.None })
                     .ToArray();
             }

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -127,7 +127,7 @@ namespace GitUI.Script
                 }
 
                 command = command.Replace(NavigateToPrefix, string.Empty);
-                if (!command.IsNullOrEmpty())
+                if (!string.IsNullOrEmpty(command))
                 {
                     var revisionRef = new Executable(command, module.WorkingDir).GetOutputLines(argument).FirstOrDefault();
 

--- a/GitUI/UserControls/BranchSelector.cs
+++ b/GitUI/UserControls/BranchSelector.cs
@@ -117,7 +117,7 @@ namespace GitUI.UserControls
             lbChanges.Text = "";
             FireSelectionChangedEvent(sender, e);
 
-            if (SelectedBranchName.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(SelectedBranchName))
             {
                 lbChanges.Text = "";
             }

--- a/GitUI/UserControls/CommitPickerSmallControl.cs
+++ b/GitUI/UserControls/CommitPickerSmallControl.cs
@@ -32,7 +32,7 @@ namespace GitUI.UserControls
 
             SelectedObjectId = Module.RevParse(commitHash);
 
-            if (SelectedObjectId == null && !commitHash.IsNullOrWhiteSpace())
+            if (SelectedObjectId == null && !string.IsNullOrWhiteSpace(commitHash))
             {
                 SelectedObjectId = oldCommitHash;
                 MessageBox.Show("The given commit hash is not valid for this repository and was therefore discarded.", Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
+++ b/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
@@ -178,7 +178,7 @@ namespace GitUI.UserControls
 
             string[] outputLines = Regex.Split(output, @"(?<=[\n\r])");
             int lineCount = outputLines.Length;
-            if (outputLines[lineCount - 1].IsNullOrEmpty())
+            if (string.IsNullOrEmpty(outputLines[lineCount - 1]))
             {
                 lineCount--;
             }

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -943,7 +943,7 @@ namespace GitUI
 
         private void SetDeleteFilterButtonVisibility()
         {
-            DeleteFilterButton.Visible = FilterVisibleInternal && !FilterComboBox.Text.IsNullOrEmpty();
+            DeleteFilterButton.Visible = FilterVisibleInternal && !string.IsNullOrEmpty(FilterComboBox.Text);
         }
 
         private void SetFilterWatermarkLabelVisibility()

--- a/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
@@ -43,10 +43,10 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 laneInfoText.AppendLine(node.GitRevision.Guid);
 
                 var branch = new BranchFinder(node);
-                if (branch.CommittedTo.IsNotNullOrWhitespace())
+                if (!string.IsNullOrWhiteSpace(branch.CommittedTo))
                 {
                     laneInfoText.AppendFormat("\n{0}: {1}", Strings.Branch, branch.CommittedTo);
-                    if (branch.MergedWith.IsNotNullOrWhitespace())
+                    if (!string.IsNullOrWhiteSpace(branch.MergedWith))
                     {
                         laneInfoText.AppendFormat(MergedWithText.Text, branch.MergedWith);
                     }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -461,7 +461,7 @@ namespace GitUI
                     }
                 }
 
-                if (filterCommitter && !filter.IsNullOrWhiteSpace())
+                if (filterCommitter && !string.IsNullOrWhiteSpace(filter))
                 {
                     if (cmdLineSafe)
                     {
@@ -473,7 +473,7 @@ namespace GitUI
                     }
                 }
 
-                if (filterAuthor && !filter.IsNullOrWhiteSpace())
+                if (filterAuthor && !string.IsNullOrWhiteSpace(filter))
                 {
                     if (cmdLineSafe)
                     {
@@ -2439,7 +2439,7 @@ namespace GitUI
         private void CompareWithCurrentBranchToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var headBranch = Module.GetSelectedBranch(setDefaultIfEmpty: false);
-            if (headBranch.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(headBranch))
             {
                 MessageBox.Show(this, "No branch is currently selected", Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1248,7 +1248,7 @@ namespace GitUI
             var (first, selected) = getFirstAndSelected();
 
             compareToWorkingDirectoryMenuItem.Enabled = selected != null && selected.ObjectId != ObjectId.WorkTreeId;
-            compareWithCurrentBranchToolStripMenuItem.Enabled = Module.GetSelectedBranch(setDefaultIfEmpty: false).IsNotNullOrWhitespace();
+            compareWithCurrentBranchToolStripMenuItem.Enabled = !string.IsNullOrWhiteSpace(Module.GetSelectedBranch(setDefaultIfEmpty: false));
             compareSelectedCommitsMenuItem.Enabled = first != null && selected != null;
             openCommitsWithDiffToolMenuItem.Enabled = first != null && selected != null;
 

--- a/GitUI/UserManual/SingleHtmlUserManual.cs
+++ b/GitUI/UserManual/SingleHtmlUserManual.cs
@@ -32,7 +32,7 @@ namespace GitUI.UserManual
         public string GetUrl()
         {
             return string.Format("{0}/index.html{1}{2}",
-                                 Location, _anchorName.IsNullOrEmpty() ? "" : "#", _anchorName);
+                                 Location, string.IsNullOrEmpty(_anchorName) ? "" : "#", _anchorName);
         }
     }
 }

--- a/GitUI/UserManual/StandardHtmlUserManual.cs
+++ b/GitUI/UserManual/StandardHtmlUserManual.cs
@@ -17,7 +17,7 @@ namespace GitUI.UserManual
 
         public string GetUrl()
         {
-            var subFolder = _subFolder.IsNullOrEmpty() ? string.Empty : _subFolder + ".html";
+            var subFolder = string.IsNullOrEmpty(_subFolder) ? string.Empty : _subFolder + ".html";
 
             return (_location + subFolder).Combine("#", _anchorName);
         }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -109,7 +109,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                 var remoteNameLabelStatus = form.GetTestAccessor().RemoteNameLabelStatus;
 
                 // For a yet unknown cause randomly, the wait in UITest.RunForm does not suffice.
-                if (!remoteNameLabelStatus.Text.IsNullOrEmpty())
+                if (!string.IsNullOrEmpty(remoteNameLabelStatus.Text))
                 {
                     Console.WriteLine($"{nameof(Should_display_detached_head_info_in_statusbar)} waits again");
                     await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -53,7 +53,7 @@ namespace Bitbucket
                 var branch = GitCommands.GitRefName.GetFullBranchName(module.GetSelectedBranch());
 
                 _NO_TRANSLATE_lblLinkCreatePull.Text = repoUrl +
-                    ((branch.IsNullOrEmpty() || branch.Equals(DetachedHeadParser.DetachedBranch)) ?
+                    ((string.IsNullOrEmpty(branch) || branch.Equals(DetachedHeadParser.DetachedBranch)) ?
                     _NO_TRANSLATE_LinkCreatePullNoBranch :
                     string.Format(_NO_TRANSLATE_LinkCreatePull, branch));
                 toolTipLink.SetToolTip(_NO_TRANSLATE_lblLinkCreatePull, _linkLabelToolTip.Text);

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -172,7 +172,7 @@ namespace AppVeyorIntegration
                 Timeout = TimeSpan.FromMinutes(2),
                 BaseAddress = new Uri(baseUrl, UriKind.Absolute),
             };
-            if (accountToken.IsNotNullOrWhitespace())
+            if (!string.IsNullOrWhiteSpace(accountToken))
             {
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accountToken);
             }

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -77,7 +77,7 @@ namespace AppVeyorIntegration
             var accountName = config.GetString("AppVeyorAccountName", null);
             _accountToken = config.GetString("AppVeyorAccountToken", null);
             var projectNamesSetting = config.GetString("AppVeyorProjectName", null);
-            if (accountName.IsNullOrWhiteSpace() && projectNamesSetting.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(accountName) && string.IsNullOrWhiteSpace(projectNamesSetting))
             {
                 return;
             }
@@ -100,13 +100,13 @@ namespace AppVeyorIntegration
                 (!useAllProjects && Projects.Keys.Intersect(projectNames).Count() != projectNames.Length))
             {
                 Projects.Clear();
-                if (_accountToken.IsNullOrWhiteSpace())
+                if (string.IsNullOrWhiteSpace(_accountToken))
                 {
                     FillProjectsFromSettings(accountName, projectNames);
                 }
                 else
                 {
-                    if (accountName.IsNullOrWhiteSpace())
+                    if (string.IsNullOrWhiteSpace(accountName))
                     {
                         return;
                     }
@@ -116,7 +116,7 @@ namespace AppVeyorIntegration
                         {
                             var result = await GetResponseAsync(_httpClientAppVeyor, ApiBaseUrl, CancellationToken.None).ConfigureAwait(false);
 
-                            if (result.IsNullOrWhiteSpace())
+                            if (string.IsNullOrWhiteSpace(result))
                             {
                                 return;
                             }

--- a/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
+++ b/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
@@ -98,7 +98,7 @@ namespace JenkinsIntegration
             }
 
             var ignoreBuilds = config.GetString("IgnoreBuildBranch", string.Empty);
-            _ignoreBuilds = ignoreBuilds.IsNotNullOrWhitespace() ? new Regex(ignoreBuilds) : null;
+            _ignoreBuilds = !string.IsNullOrWhiteSpace(ignoreBuilds) ? new Regex(ignoreBuilds) : null;
         }
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace JenkinsIntegration
                 t = null;
             }
 
-            if (t.IsNotNullOrWhitespace() && !cancellationToken.IsCancellationRequested)
+            if (!string.IsNullOrWhiteSpace(t) && !cancellationToken.IsCancellationRequested)
             {
                 JObject jobDescription = JObject.Parse(t);
                 if (jobDescription["builds"] != null)
@@ -350,7 +350,7 @@ namespace JenkinsIntegration
                             if (name != null)
                             {
                                 var name2 = name.ToObject<string>();
-                                if (name2.IsNotNullOrWhitespace() && _ignoreBuilds.IsMatch(name2))
+                                if (!string.IsNullOrWhiteSpace(name2) && _ignoreBuilds.IsMatch(name2))
                                 {
                                     return null;
                                 }

--- a/UnitTests/GitCommands.Tests/FullPathResolverTests.cs
+++ b/UnitTests/GitCommands.Tests/FullPathResolverTests.cs
@@ -63,5 +63,14 @@ namespace GitCommandsTests
             var resolver = new FullPathResolver(() => workingDir);
             resolver.Resolve("file.txt").Should().Be(Path.Combine(workingDir, "file.txt").Replace("/", "\\"));
         }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void Resolve_does_not_throw_on_invalid_workingDir(string workingDir)
+        {
+            var resolver = new FullPathResolver(() => workingDir);
+            resolver.Resolve("file.txt").Should().Be(Path.Combine(Environment.CurrentDirectory, "file.txt").Replace("/", "\\"));
+        }
     }
 }


### PR DESCRIPTION
Fixes #7958

## Proposed changes

- handle empty `WorkingDir` the same way as if it was `null` in `FullPathResolver.Resolve`
- remove the string extension methods `IsNotNullOrWhitespace`, `IsNullOrWhiteSpace` and `IsNullOrEmpty`

## Test methodology <!-- How did you ensure quality? -->

- added NUnit test

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 61acf3fb39e6063f3b705dca6f5b1772f2f370e4
- Git 2.24.1.windows.2 (recommended: 2.25.1 or later)
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4121.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
