### PR TITLE
Fix incorrect location of tests

### DIFF
--- a/IntegrationTests/Directory.Build.props
+++ b/IntegrationTests/Directory.Build.props
@@ -17,7 +17,7 @@
       Direct integration test artifacts to be placed under tests/IntegrationTests folder
     -->
   <PropertyGroup>
-    <BaseOutputPath>$([System.IO.Path]::GetFullPath('$(ArtifactsBinDir)tests\IntegrationTests\$(OutDirName)'))</BaseOutputPath>
+    <BaseOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsIntegrationTestsDir)', '$(OutDirName)'))</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)</OutputPath>
   </PropertyGroup>
 

--- a/UnitTests/Directory.Build.props
+++ b/UnitTests/Directory.Build.props
@@ -17,7 +17,7 @@
       Direct unit test artifacts to be placed under tests/UnitTests folder
     -->
   <PropertyGroup>
-    <BaseOutputPath>$([System.IO.Path]::GetFullPath('$(ArtifactsBinDir)tests\UnitTests\$(OutDirName)'))</BaseOutputPath>
+    <BaseOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsUnitTestsDir)', '$(OutDirName)'))</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)</OutputPath>
   </PropertyGroup>
 

--- a/scripts/tools/RepoLayout.props
+++ b/scripts/tools/RepoLayout.props
@@ -29,10 +29,13 @@
     <ArtifactsToolsetDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'toolset'))</ArtifactsToolsetDir>
     <ArtifactsObjDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'obj'))</ArtifactsObjDir>
     <ArtifactsBinDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'bin'))</ArtifactsBinDir>
+    <ArtifactsTestsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'tests'))</ArtifactsTestsDir>
     <ArtifactsLogDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'log', '$(Configuration)'))</ArtifactsLogDir>
     <ArtifactsTmpDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'tmp', '$(Configuration)'))</ArtifactsTmpDir>
     <ArtifactsTestResultsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'TestResults', '$(Configuration)'))</ArtifactsTestResultsDir>
     <ArtifactsPackagesDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'packages', '$(Configuration)'))</ArtifactsPackagesDir>
+    <ArtifactsUnitTestsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsTestsDir)', '$(Configuration)', 'UnitTests'))</ArtifactsUnitTestsDir>
+    <ArtifactsIntegrationTestsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsTestsDir)', '$(Configuration)', 'IntegrationTests'))</ArtifactsIntegrationTestsDir>
 
     <ArtifactsPublishDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'publish'))</ArtifactsPublishDir>
     <AppPublishDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsPublishDir)', '$(Configuration)', 'GitExtensions'))</AppPublishDir>


### PR DESCRIPTION
Resolves #7969

Tests are now written under `.\gitextensions\artifacts\tests\$(Condition)\[UnitTests|IntegrationTests]`

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
