### PR TITLE
GitStatusMonitor: Avoid background updates if GUI is not visible

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Utils;
 using GitUIPluginInterfaces;
 
 namespace GitUI.CommandsDialogs.BrowseDialog
@@ -309,16 +311,29 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             }
         }
 
+        private static bool IsMinimized()
+        {
+            if (!EnvUtils.RunningOnWindows())
+            {
+                return false;
+            }
+
+            var currentProcess = Process.GetCurrentProcess();
+            if (currentProcess is null)
+            {
+                return false;
+            }
+
+            return NativeMethods.IsIconic(currentProcess.MainWindowHandle).IsTrue();
+        }
+
         private void Update()
         {
             ThreadHelper.AssertOnUIThread();
 
-            if (CurrentStatus != GitStatusMonitorState.Running)
-            {
-                return;
-            }
-
-            if (_nextUpdateTime - Environment.TickCount > 0)
+            if (CurrentStatus != GitStatusMonitorState.Running
+                || _nextUpdateTime - Environment.TickCount > 0
+                || IsMinimized())
             {
                 return;
             }

--- a/GitUI/Interops/User32/IsIconic.cs
+++ b/GitUI/Interops/User32/IsIconic.cs
@@ -1,0 +1,11 @@
+using System.Runtime.InteropServices;
+using static System.Interop;
+
+namespace System
+{
+    internal static partial class NativeMethods
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern BOOL IsIconic(IntPtr hWnd);
+    }
+}


### PR DESCRIPTION
Part of #6521

## Proposed changes

Avoid running git-status when GE Browse is minimized

## Test methodology
Check Git Command Log

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
