### PR TITLE
Redesign script config

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
@@ -37,7 +37,6 @@
             this.chdrNames = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.chdrEvents = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.chdrCommand = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chdrArguments = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.panelButtons = new System.Windows.Forms.FlowLayoutPanel();
             this.btnAdd = new System.Windows.Forms.Button();
             this.btnDelete = new System.Windows.Forms.Button();
@@ -107,8 +106,7 @@
             this.lvScripts.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.chdrNames,
             this.chdrEvents,
-            this.chdrCommand,
-            this.chdrArguments});
+            this.chdrCommand});
             this.lvScripts.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lvScripts.FullRowSelect = true;
             this.lvScripts.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
@@ -132,17 +130,12 @@
             // chdrEvents
             // 
             this.chdrEvents.Text = "Event";
-            this.chdrEvents.Width = 100;
+            this.chdrEvents.Width = 130;
             // 
             // chdrCommand
             // 
             this.chdrCommand.Text = "Command";
-            this.chdrCommand.Width = 100;
-            // 
-            // chdrArguments
-            // 
-            this.chdrArguments.Text = "Arguments";
-            this.chdrArguments.Width = 200;
+            this.chdrCommand.Width = 330;
             // 
             // panelButtons
             // 
@@ -228,6 +221,5 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.ColumnHeader chdrEvents;
         private System.Windows.Forms.ColumnHeader chdrCommand;
-        private System.Windows.Forms.ColumnHeader chdrArguments;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
@@ -84,6 +84,7 @@
             // 
             this.propertyGrid1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.propertyGrid1.Location = new System.Drawing.Point(3, 276);
+            this.propertyGrid1.Margin = new System.Windows.Forms.Padding(3, 3, 40, 3);
             this.propertyGrid1.Name = "propertyGrid1";
             this.propertyGrid1.Size = new System.Drawing.Size(394, 259);
             this.propertyGrid1.TabIndex = 2;
@@ -96,7 +97,7 @@
             this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel2.Location = new System.Drawing.Point(3, 3);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(394, 259);
+            this.panel2.Size = new System.Drawing.Size(431, 259);
             this.panel2.TabIndex = 3;
             // 
             // lvScripts
@@ -113,10 +114,11 @@
             this.lvScripts.HideSelection = false;
             this.lvScripts.LabelWrap = false;
             this.lvScripts.Location = new System.Drawing.Point(0, 0);
+            this.lvScripts.Margin = new System.Windows.Forms.Padding(0);
             this.lvScripts.MultiSelect = false;
             this.lvScripts.Name = "lvScripts";
             this.lvScripts.ShowItemToolTips = true;
-            this.lvScripts.Size = new System.Drawing.Size(358, 259);
+            this.lvScripts.Size = new System.Drawing.Size(395, 259);
             this.lvScripts.TabIndex = 1;
             this.lvScripts.TileSize = new System.Drawing.Size(136, 18);
             this.lvScripts.UseCompatibleStateImageBehavior = false;
@@ -147,7 +149,7 @@
             this.panelButtons.Controls.Add(this.btnArgumentsHelp);
             this.panelButtons.Dock = System.Windows.Forms.DockStyle.Right;
             this.panelButtons.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.panelButtons.Location = new System.Drawing.Point(358, 0);
+            this.panelButtons.Location = new System.Drawing.Point(395, 0);
             this.panelButtons.Margin = new System.Windows.Forms.Padding(8);
             this.panelButtons.Name = "panelButtons";
             this.panelButtons.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
@@ -188,7 +190,7 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 8F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(400, 538);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(437, 538);
             this.tableLayoutPanel1.TabIndex = 4;
             // 
             // ScriptsSettingsPage

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
@@ -28,457 +28,175 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
+            this.btnMoveUp = new System.Windows.Forms.Button();
+            this.btnMoveDown = new System.Windows.Forms.Button();
+            this.btnArgumentsHelp = new System.Windows.Forms.Button();
+            this.propertyGrid1 = new System.Windows.Forms.PropertyGrid();
+            this.panel2 = new System.Windows.Forms.Panel();
+            this.lvScripts = new GitUI.UserControls.NativeListView();
+            this.chdrNames = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chdrEvents = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chdrCommand = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chdrArguments = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.panelButtons = new System.Windows.Forms.FlowLayoutPanel();
+            this.btnAdd = new System.Windows.Forms.Button();
+            this.btnDelete = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.ScriptList = new System.Windows.Forms.DataGridView();
-            this.HotkeyCommandIdentifier = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.EnabledColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.OnEvent = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.AskConfirmation = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.panel1 = new System.Windows.Forms.Panel();
-            this.addScriptButton = new System.Windows.Forms.Button();
-            this.moveUpButton = new System.Windows.Forms.Button();
-            this.removeScriptButton = new System.Windows.Forms.Button();
-            this.moveDownButton = new System.Windows.Forms.Button();
-            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this.flowLayoutPanel3 = new System.Windows.Forms.FlowLayoutPanel();
-            this.scriptEvent = new System.Windows.Forms.ComboBox();
-            this.lbl_icon = new System.Windows.Forms.Label();
-            this.sbtn_icon = new GitUI.Script.SplitButton();
-            this.contextMenuStrip_SplitButton = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.nameLabel = new System.Windows.Forms.Label();
-            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.nameTextBox = new System.Windows.Forms.TextBox();
-            this.scriptEnabled = new System.Windows.Forms.CheckBox();
-            this.scriptNeedsConfirmation = new System.Windows.Forms.CheckBox();
-            this.commandLabel = new System.Windows.Forms.Label();
-            this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
-            this.commandTextBox = new System.Windows.Forms.TextBox();
-            this.browseScriptButton = new System.Windows.Forms.Button();
-            this.argumentsTextBox = new System.Windows.Forms.RichTextBox();
-            this.labelOnEvent = new System.Windows.Forms.Label();
-            this.flowLayoutPanel4 = new System.Windows.Forms.FlowLayoutPanel();
-            this.argumentsLabel = new System.Windows.Forms.Label();
-            this.buttonShowArgumentsHelp = new System.Windows.Forms.Button();
-            this.flowLayoutPanel5 = new System.Windows.Forms.FlowLayoutPanel();
-            this.scriptRunInBackground = new System.Windows.Forms.CheckBox();
-            this.inMenuCheckBox = new System.Windows.Forms.CheckBox();
-            this.scriptIsPowerShell = new System.Windows.Forms.CheckBox();
+            this.panel2.SuspendLayout();
+            this.panelButtons.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.ScriptList)).BeginInit();
-            this.panel1.SuspendLayout();
-            this.tableLayoutPanel2.SuspendLayout();
-            this.flowLayoutPanel3.SuspendLayout();
-            this.flowLayoutPanel1.SuspendLayout();
-            this.flowLayoutPanel2.SuspendLayout();
-            this.flowLayoutPanel4.SuspendLayout();
-            this.flowLayoutPanel5.SuspendLayout();
             this.SuspendLayout();
+            // 
+            // btnMoveUp
+            // 
+            this.btnMoveUp.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnMoveUp.Enabled = false;
+            this.btnMoveUp.Image = global::GitUI.Properties.Images.ArrowUp;
+            this.btnMoveUp.Location = new System.Drawing.Point(7, 67);
+            this.btnMoveUp.Name = "btnMoveUp";
+            this.btnMoveUp.Size = new System.Drawing.Size(26, 26);
+            this.btnMoveUp.TabIndex = 0;
+            this.btnMoveUp.UseVisualStyleBackColor = true;
+            this.btnMoveUp.Click += new System.EventHandler(this.btnMoveUp_Click);
+            // 
+            // btnMoveDown
+            // 
+            this.btnMoveDown.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnMoveDown.Enabled = false;
+            this.btnMoveDown.Image = global::GitUI.Properties.Images.ArrowDown;
+            this.btnMoveDown.Location = new System.Drawing.Point(7, 99);
+            this.btnMoveDown.Name = "btnMoveDown";
+            this.btnMoveDown.Size = new System.Drawing.Size(26, 26);
+            this.btnMoveDown.TabIndex = 3;
+            this.btnMoveDown.UseVisualStyleBackColor = true;
+            this.btnMoveDown.Click += new System.EventHandler(this.btnMoveDown_Click);
+            // 
+            // btnArgumentsHelp
+            // 
+            this.btnArgumentsHelp.Location = new System.Drawing.Point(7, 131);
+            this.btnArgumentsHelp.Name = "btnArgumentsHelp";
+            this.btnArgumentsHelp.Size = new System.Drawing.Size(26, 26);
+            this.btnArgumentsHelp.TabIndex = 13;
+            this.btnArgumentsHelp.Text = "?";
+            this.btnArgumentsHelp.UseVisualStyleBackColor = true;
+            this.btnArgumentsHelp.Click += new System.EventHandler(this.btnArgumentsHelp_Click);
+            // 
+            // propertyGrid1
+            // 
+            this.propertyGrid1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.propertyGrid1.Location = new System.Drawing.Point(3, 276);
+            this.propertyGrid1.Name = "propertyGrid1";
+            this.propertyGrid1.Size = new System.Drawing.Size(394, 259);
+            this.propertyGrid1.TabIndex = 2;
+            this.propertyGrid1.ToolbarVisible = false;
+            // 
+            // panel2
+            // 
+            this.panel2.Controls.Add(this.lvScripts);
+            this.panel2.Controls.Add(this.panelButtons);
+            this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel2.Location = new System.Drawing.Point(3, 3);
+            this.panel2.Name = "panel2";
+            this.panel2.Size = new System.Drawing.Size(394, 259);
+            this.panel2.TabIndex = 3;
+            // 
+            // lvScripts
+            // 
+            this.lvScripts.Activation = System.Windows.Forms.ItemActivation.OneClick;
+            this.lvScripts.CheckBoxes = true;
+            this.lvScripts.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.chdrNames,
+            this.chdrEvents,
+            this.chdrCommand,
+            this.chdrArguments});
+            this.lvScripts.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lvScripts.FullRowSelect = true;
+            this.lvScripts.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.lvScripts.HideSelection = false;
+            this.lvScripts.LabelWrap = false;
+            this.lvScripts.Location = new System.Drawing.Point(0, 0);
+            this.lvScripts.MultiSelect = false;
+            this.lvScripts.Name = "lvScripts";
+            this.lvScripts.ShowItemToolTips = true;
+            this.lvScripts.Size = new System.Drawing.Size(358, 259);
+            this.lvScripts.TabIndex = 1;
+            this.lvScripts.TileSize = new System.Drawing.Size(136, 18);
+            this.lvScripts.UseCompatibleStateImageBehavior = false;
+            this.lvScripts.View = System.Windows.Forms.View.Details;
+            // 
+            // chdrNames
+            // 
+            this.chdrNames.Text = "Name";
+            this.chdrNames.Width = 200;
+            // 
+            // chdrEvents
+            // 
+            this.chdrEvents.Text = "Event";
+            this.chdrEvents.Width = 100;
+            // 
+            // chdrCommand
+            // 
+            this.chdrCommand.Text = "Command";
+            this.chdrCommand.Width = 100;
+            // 
+            // chdrArguments
+            // 
+            this.chdrArguments.Text = "Arguments";
+            this.chdrArguments.Width = 200;
+            // 
+            // panelButtons
+            // 
+            this.panelButtons.AutoSize = true;
+            this.panelButtons.Controls.Add(this.btnAdd);
+            this.panelButtons.Controls.Add(this.btnDelete);
+            this.panelButtons.Controls.Add(this.btnMoveUp);
+            this.panelButtons.Controls.Add(this.btnMoveDown);
+            this.panelButtons.Controls.Add(this.btnArgumentsHelp);
+            this.panelButtons.Dock = System.Windows.Forms.DockStyle.Right;
+            this.panelButtons.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.panelButtons.Location = new System.Drawing.Point(358, 0);
+            this.panelButtons.Margin = new System.Windows.Forms.Padding(8);
+            this.panelButtons.Name = "panelButtons";
+            this.panelButtons.Padding = new System.Windows.Forms.Padding(4, 0, 0, 0);
+            this.panelButtons.Size = new System.Drawing.Size(36, 259);
+            this.panelButtons.TabIndex = 1;
+            // 
+            // btnAdd
+            // 
+            this.btnAdd.Image = global::GitUI.Properties.Images.RemoteAdd;
+            this.btnAdd.Location = new System.Drawing.Point(7, 3);
+            this.btnAdd.Name = "btnAdd";
+            this.btnAdd.Size = new System.Drawing.Size(26, 26);
+            this.btnAdd.TabIndex = 0;
+            this.btnAdd.UseVisualStyleBackColor = true;
+            this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
+            // 
+            // btnDelete
+            // 
+            this.btnDelete.Image = global::GitUI.Properties.Images.RemoteDelete;
+            this.btnDelete.Location = new System.Drawing.Point(7, 35);
+            this.btnDelete.Name = "btnDelete";
+            this.btnDelete.Size = new System.Drawing.Size(26, 26);
+            this.btnDelete.TabIndex = 1;
+            this.btnDelete.UseVisualStyleBackColor = true;
+            this.btnDelete.Click += new System.EventHandler(this.btnDelete_Click);
             // 
             // tableLayoutPanel1
             // 
-            this.tableLayoutPanel1.ColumnCount = 2;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.AutoSize = true;
+            this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel1.ColumnCount = 1;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel1.Controls.Add(this.ScriptList, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.panel1, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 0, 1);
-            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Controls.Add(this.panel2, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.propertyGrid1, 0, 2);
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 3;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 230F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1153, 462);
-            this.tableLayoutPanel1.TabIndex = 0;
-            // 
-            // ScriptList
-            // 
-            this.ScriptList.AllowUserToAddRows = false;
-            this.ScriptList.AllowUserToDeleteRows = false;
-            this.ScriptList.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.ScriptList.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.HotkeyCommandIdentifier,
-            this.EnabledColumn,
-            this.OnEvent,
-            this.AskConfirmation});
-            this.ScriptList.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ScriptList.GridColor = System.Drawing.SystemColors.ActiveBorder;
-            this.ScriptList.Location = new System.Drawing.Point(3, 3);
-            this.ScriptList.Name = "ScriptList";
-            this.ScriptList.ReadOnly = true;
-            this.ScriptList.RowHeadersVisible = false;
-            this.ScriptList.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.ScriptList.ShowCellErrors = false;
-            this.ScriptList.Size = new System.Drawing.Size(1031, 224);
-            this.ScriptList.TabIndex = 0;
-            this.ScriptList.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.ScriptList_CellClick);
-            this.ScriptList.SelectionChanged += new System.EventHandler(this.ScriptList_SelectionChanged);
-            // 
-            // HotkeyCommandIdentifier
-            // 
-            this.HotkeyCommandIdentifier.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.HotkeyCommandIdentifier.HeaderText = "#";
-            this.HotkeyCommandIdentifier.Name = "HotkeyCommandIdentifier";
-            this.HotkeyCommandIdentifier.ReadOnly = true;
-            // 
-            // EnabledColumn
-            // 
-            this.EnabledColumn.HeaderText = "Enabled";
-            this.EnabledColumn.Name = "EnabledColumn";
-            this.EnabledColumn.ReadOnly = true;
-            // 
-            // OnEvent
-            // 
-            this.OnEvent.HeaderText = "OnEvent";
-            this.OnEvent.Name = "OnEvent";
-            this.OnEvent.ReadOnly = true;
-            // 
-            // AskConfirmation
-            // 
-            this.AskConfirmation.HeaderText = "Confirmation";
-            this.AskConfirmation.Name = "AskConfirmation";
-            this.AskConfirmation.ReadOnly = true;
-            // 
-            // panel1
-            // 
-            this.panel1.Controls.Add(this.addScriptButton);
-            this.panel1.Controls.Add(this.moveUpButton);
-            this.panel1.Controls.Add(this.removeScriptButton);
-            this.panel1.Controls.Add(this.moveDownButton);
-            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel1.Location = new System.Drawing.Point(1040, 3);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(110, 224);
-            this.panel1.TabIndex = 1;
-            // 
-            // addScriptButton
-            // 
-            this.addScriptButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.addScriptButton.Location = new System.Drawing.Point(3, 86);
-            this.addScriptButton.Name = "addScriptButton";
-            this.addScriptButton.Size = new System.Drawing.Size(104, 25);
-            this.addScriptButton.TabIndex = 1;
-            this.addScriptButton.Text = "Add";
-            this.addScriptButton.UseVisualStyleBackColor = true;
-            this.addScriptButton.Click += new System.EventHandler(this.addScriptButton_Click);
-            // 
-            // moveUpButton
-            // 
-            this.moveUpButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.moveUpButton.Enabled = false;
-            this.moveUpButton.Image = global::GitUI.Properties.Images.ArrowUp;
-            this.moveUpButton.Location = new System.Drawing.Point(42, 57);
-            this.moveUpButton.Name = "moveUpButton";
-            this.moveUpButton.Size = new System.Drawing.Size(26, 23);
-            this.moveUpButton.TabIndex = 0;
-            this.moveUpButton.UseVisualStyleBackColor = true;
-            this.moveUpButton.Click += new System.EventHandler(this.moveUpButton_Click);
-            // 
-            // removeScriptButton
-            // 
-            this.removeScriptButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.removeScriptButton.Enabled = false;
-            this.removeScriptButton.Location = new System.Drawing.Point(3, 117);
-            this.removeScriptButton.Name = "removeScriptButton";
-            this.removeScriptButton.Size = new System.Drawing.Size(104, 25);
-            this.removeScriptButton.TabIndex = 2;
-            this.removeScriptButton.Text = "Remove";
-            this.removeScriptButton.UseVisualStyleBackColor = true;
-            this.removeScriptButton.Click += new System.EventHandler(this.removeScriptButton_Click);
-            // 
-            // moveDownButton
-            // 
-            this.moveDownButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.moveDownButton.Enabled = false;
-            this.moveDownButton.Image = global::GitUI.Properties.Images.ArrowDown;
-            this.moveDownButton.Location = new System.Drawing.Point(42, 148);
-            this.moveDownButton.Name = "moveDownButton";
-            this.moveDownButton.Size = new System.Drawing.Size(26, 23);
-            this.moveDownButton.TabIndex = 3;
-            this.moveDownButton.UseVisualStyleBackColor = true;
-            this.moveDownButton.Click += new System.EventHandler(this.moveDownButton_Click);
-            // 
-            // tableLayoutPanel2
-            // 
-            this.tableLayoutPanel2.ColumnCount = 2;
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel3, 1, 4);
-            this.tableLayoutPanel2.Controls.Add(this.nameLabel, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel1, 1, 0);
-            this.tableLayoutPanel2.Controls.Add(this.commandLabel, 0, 2);
-            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel2, 1, 2);
-            this.tableLayoutPanel2.Controls.Add(this.argumentsTextBox, 1, 3);
-            this.tableLayoutPanel2.Controls.Add(this.labelOnEvent, 0, 4);
-            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel4, 0, 3);
-            this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel5, 1, 1);
-            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 233);
-            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 5;
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(1031, 206);
-            this.tableLayoutPanel2.TabIndex = 2;
-            // 
-            // flowLayoutPanel3
-            // 
-            this.flowLayoutPanel3.AutoSize = true;
-            this.flowLayoutPanel3.Controls.Add(this.scriptEvent);
-            this.flowLayoutPanel3.Controls.Add(this.lbl_icon);
-            this.flowLayoutPanel3.Controls.Add(this.sbtn_icon);
-            this.flowLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel3.Location = new System.Drawing.Point(90, 172);
-            this.flowLayoutPanel3.Name = "flowLayoutPanel3";
-            this.flowLayoutPanel3.Size = new System.Drawing.Size(938, 31);
-            this.flowLayoutPanel3.TabIndex = 4;
-            // 
-            // scriptEvent
-            // 
-            this.scriptEvent.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.scriptEvent.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.scriptEvent.FormattingEnabled = true;
-            this.scriptEvent.Location = new System.Drawing.Point(3, 4);
-            this.scriptEvent.Name = "scriptEvent";
-            this.scriptEvent.Size = new System.Drawing.Size(208, 23);
-            this.scriptEvent.TabIndex = 15;
-            this.scriptEvent.SelectedIndexChanged += new System.EventHandler(this.scriptEvent_SelectedIndexChanged);
-            this.scriptEvent.Validating += new System.ComponentModel.CancelEventHandler(this.ScriptInfoEdit_Validating);
-            // 
-            // lbl_icon
-            // 
-            this.lbl_icon.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.lbl_icon.AutoSize = true;
-            this.lbl_icon.Location = new System.Drawing.Point(217, 8);
-            this.lbl_icon.Name = "lbl_icon";
-            this.lbl_icon.Size = new System.Drawing.Size(33, 15);
-            this.lbl_icon.TabIndex = 22;
-            this.lbl_icon.Text = "Icon:";
-            this.lbl_icon.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.lbl_icon.Visible = false;
-            // 
-            // sbtn_icon
-            // 
-            this.sbtn_icon.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.sbtn_icon.AutoSize = true;
-            this.sbtn_icon.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.sbtn_icon.ContextMenuStrip = this.contextMenuStrip_SplitButton;
-            this.sbtn_icon.Location = new System.Drawing.Point(256, 3);
-            this.sbtn_icon.Name = "sbtn_icon";
-            this.sbtn_icon.Size = new System.Drawing.Size(92, 25);
-            this.sbtn_icon.SplitMenuStrip = this.contextMenuStrip_SplitButton;
-            this.sbtn_icon.TabIndex = 16;
-            this.sbtn_icon.Text = "Select icon";
-            this.sbtn_icon.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.sbtn_icon.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
-            this.sbtn_icon.UseVisualStyleBackColor = true;
-            this.sbtn_icon.Visible = false;
-            this.sbtn_icon.WholeButtonDropdown = true;
-            // 
-            // contextMenuStrip_SplitButton
-            // 
-            this.contextMenuStrip_SplitButton.Name = "contextMenuStrip1";
-            this.contextMenuStrip_SplitButton.Size = new System.Drawing.Size(61, 4);
-            // 
-            // nameLabel
-            // 
-            this.nameLabel.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.nameLabel.AutoSize = true;
-            this.nameLabel.Location = new System.Drawing.Point(3, 12);
-            this.nameLabel.Name = "nameLabel";
-            this.nameLabel.Size = new System.Drawing.Size(42, 15);
-            this.nameLabel.TabIndex = 4;
-            this.nameLabel.Text = "Name:";
-            // 
-            // flowLayoutPanel1
-            // 
-            this.flowLayoutPanel1.Controls.Add(this.nameTextBox);
-            this.flowLayoutPanel1.Controls.Add(this.scriptEnabled);
-            this.flowLayoutPanel1.Controls.Add(this.scriptNeedsConfirmation);
-            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(90, 3);
-            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(938, 34);
-            this.flowLayoutPanel1.TabIndex = 0;
-            this.flowLayoutPanel1.WrapContents = false;
-            // 
-            // nameTextBox
-            // 
-            this.nameTextBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.nameTextBox.Location = new System.Drawing.Point(3, 3);
-            this.nameTextBox.Name = "nameTextBox";
-            this.nameTextBox.Size = new System.Drawing.Size(251, 23);
-            this.nameTextBox.TabIndex = 5;
-            this.nameTextBox.Validating += new System.ComponentModel.CancelEventHandler(this.ScriptInfoEdit_Validating);
-            // 
-            // scriptEnabled
-            // 
-            this.scriptEnabled.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.scriptEnabled.AutoSize = true;
-            this.scriptEnabled.Location = new System.Drawing.Point(260, 7);
-            this.scriptEnabled.Name = "scriptEnabled";
-            this.scriptEnabled.Size = new System.Drawing.Size(68, 19);
-            this.scriptEnabled.TabIndex = 6;
-            this.scriptEnabled.Text = "Enabled";
-            this.scriptEnabled.UseVisualStyleBackColor = true;
-            this.scriptEnabled.Validating += new System.ComponentModel.CancelEventHandler(this.ScriptInfoEdit_Validating);
-            // 
-            // scriptNeedsConfirmation
-            // 
-            this.scriptNeedsConfirmation.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.scriptNeedsConfirmation.AutoSize = true;
-            this.scriptNeedsConfirmation.Location = new System.Drawing.Point(334, 7);
-            this.scriptNeedsConfirmation.Name = "scriptNeedsConfirmation";
-            this.scriptNeedsConfirmation.Size = new System.Drawing.Size(135, 19);
-            this.scriptNeedsConfirmation.TabIndex = 7;
-            this.scriptNeedsConfirmation.Text = "Ask for confirmation";
-            this.scriptNeedsConfirmation.UseVisualStyleBackColor = true;
-            this.scriptNeedsConfirmation.Validating += new System.ComponentModel.CancelEventHandler(this.ScriptInfoEdit_Validating);
-            // 
-            // commandLabel
-            // 
-            this.commandLabel.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.commandLabel.AutoSize = true;
-            this.commandLabel.Location = new System.Drawing.Point(3, 83);
-            this.commandLabel.Name = "commandLabel";
-            this.commandLabel.Size = new System.Drawing.Size(67, 15);
-            this.commandLabel.TabIndex = 10;
-            this.commandLabel.Text = "Command:";
-            // 
-            // flowLayoutPanel2
-            // 
-            this.flowLayoutPanel2.Controls.Add(this.commandTextBox);
-            this.flowLayoutPanel2.Controls.Add(this.browseScriptButton);
-            this.flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel2.Location = new System.Drawing.Point(90, 74);
-            this.flowLayoutPanel2.Name = "flowLayoutPanel2";
-            this.flowLayoutPanel2.Size = new System.Drawing.Size(938, 34);
-            this.flowLayoutPanel2.TabIndex = 2;
-            // 
-            // commandTextBox
-            // 
-            this.commandTextBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.commandTextBox.Location = new System.Drawing.Point(3, 4);
-            this.commandTextBox.Name = "commandTextBox";
-            this.commandTextBox.Size = new System.Drawing.Size(388, 23);
-            this.commandTextBox.TabIndex = 11;
-            this.commandTextBox.Validating += new System.ComponentModel.CancelEventHandler(this.ScriptInfoEdit_Validating);
-            // 
-            // browseScriptButton
-            // 
-            this.browseScriptButton.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.browseScriptButton.Location = new System.Drawing.Point(397, 3);
-            this.browseScriptButton.Name = "browseScriptButton";
-            this.browseScriptButton.Size = new System.Drawing.Size(107, 25);
-            this.browseScriptButton.TabIndex = 12;
-            this.browseScriptButton.Text = "Browse";
-            this.browseScriptButton.UseVisualStyleBackColor = true;
-            this.browseScriptButton.Click += new System.EventHandler(this.browseScriptButton_Click);
-            // 
-            // argumentsTextBox
-            // 
-            this.argumentsTextBox.DetectUrls = false;
-            this.argumentsTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.argumentsTextBox.Location = new System.Drawing.Point(90, 114);
-            this.argumentsTextBox.Name = "argumentsTextBox";
-            this.argumentsTextBox.Size = new System.Drawing.Size(938, 52);
-            this.argumentsTextBox.TabIndex = 14;
-            this.argumentsTextBox.Text = "";
-            this.argumentsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.argumentsTextBox_KeyDown);
-            this.argumentsTextBox.Validating += new System.ComponentModel.CancelEventHandler(this.ScriptInfoEdit_Validating);
-            // 
-            // labelOnEvent
-            // 
-            this.labelOnEvent.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.labelOnEvent.AutoSize = true;
-            this.labelOnEvent.Location = new System.Drawing.Point(3, 180);
-            this.labelOnEvent.Name = "labelOnEvent";
-            this.labelOnEvent.Size = new System.Drawing.Size(58, 15);
-            this.labelOnEvent.Text = "On event:";
-            // 
-            // flowLayoutPanel4
-            // 
-            this.flowLayoutPanel4.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.flowLayoutPanel4.AutoSize = true;
-            this.flowLayoutPanel4.Controls.Add(this.argumentsLabel);
-            this.flowLayoutPanel4.Controls.Add(this.buttonShowArgumentsHelp);
-            this.flowLayoutPanel4.Location = new System.Drawing.Point(3, 118);
-            this.flowLayoutPanel4.Name = "flowLayoutPanel4";
-            this.flowLayoutPanel4.Size = new System.Drawing.Size(81, 44);
-            this.flowLayoutPanel4.TabIndex = 27;
-            // 
-            // argumentsLabel
-            // 
-            this.argumentsLabel.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.argumentsLabel.AutoSize = true;
-            this.argumentsLabel.Location = new System.Drawing.Point(3, 0);
-            this.argumentsLabel.Name = "argumentsLabel";
-            this.argumentsLabel.Size = new System.Drawing.Size(69, 15);
-            this.argumentsLabel.Text = "Arguments:";
-            // 
-            // buttonShowArgumentsHelp
-            // 
-            this.buttonShowArgumentsHelp.Location = new System.Drawing.Point(3, 18);
-            this.buttonShowArgumentsHelp.Name = "buttonShowArgumentsHelp";
-            this.buttonShowArgumentsHelp.Size = new System.Drawing.Size(75, 23);
-            this.buttonShowArgumentsHelp.TabIndex = 13;
-            this.buttonShowArgumentsHelp.Text = "Help";
-            this.buttonShowArgumentsHelp.UseVisualStyleBackColor = true;
-            this.buttonShowArgumentsHelp.Click += new System.EventHandler(this.buttonShowArgumentsHelp_Click);
-            // 
-            // flowLayoutPanel5
-            // 
-            this.flowLayoutPanel5.AutoSize = true;
-            this.flowLayoutPanel5.Controls.Add(this.scriptRunInBackground);
-            this.flowLayoutPanel5.Controls.Add(this.inMenuCheckBox);
-            this.flowLayoutPanel5.Controls.Add(this.scriptIsPowerShell);
-            this.flowLayoutPanel5.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel5.Location = new System.Drawing.Point(90, 43);
-            this.flowLayoutPanel5.Name = "flowLayoutPanel5";
-            this.flowLayoutPanel5.Size = new System.Drawing.Size(938, 25);
-            this.flowLayoutPanel5.TabIndex = 1;
-            // 
-            // scriptRunInBackground
-            // 
-            this.scriptRunInBackground.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.scriptRunInBackground.AutoSize = true;
-            this.scriptRunInBackground.Location = new System.Drawing.Point(3, 3);
-            this.scriptRunInBackground.Name = "scriptRunInBackground";
-            this.scriptRunInBackground.Size = new System.Drawing.Size(127, 19);
-            this.scriptRunInBackground.TabIndex = 8;
-            this.scriptRunInBackground.Text = "Run in background";
-            this.scriptRunInBackground.UseVisualStyleBackColor = true;
-            this.scriptRunInBackground.Validating += new System.ComponentModel.CancelEventHandler(this.ScriptInfoEdit_Validating);
-            // 
-            // inMenuCheckBox
-            // 
-            this.inMenuCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.inMenuCheckBox.AutoSize = true;
-            this.inMenuCheckBox.Location = new System.Drawing.Point(136, 3);
-            this.inMenuCheckBox.Name = "inMenuCheckBox";
-            this.inMenuCheckBox.Size = new System.Drawing.Size(206, 19);
-            this.inMenuCheckBox.TabIndex = 9;
-            this.inMenuCheckBox.Text = "Add to revision grid context menu";
-            this.inMenuCheckBox.UseVisualStyleBackColor = true;
-            this.inMenuCheckBox.CheckedChanged += new System.EventHandler( this.inMenuCheckBox_CheckedChanged );
-            this.inMenuCheckBox.Validating += new System.ComponentModel.CancelEventHandler(this.ScriptInfoEdit_Validating);
-            // 
-            // scriptIsPowerShell
-            // 
-            this.scriptIsPowerShell.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.scriptIsPowerShell.AutoSize = true;
-            this.scriptIsPowerShell.Location = new System.Drawing.Point(348, 3);
-            this.scriptIsPowerShell.Name = "scriptIsPowerShell";
-            this.scriptIsPowerShell.Size = new System.Drawing.Size(95, 19);
-            this.scriptIsPowerShell.TabIndex = 10;
-            this.scriptIsPowerShell.Text = "Is PowerShell";
-            this.scriptIsPowerShell.UseVisualStyleBackColor = true;
-            this.scriptIsPowerShell.Validating += new System.ComponentModel.CancelEventHandler(this.ScriptInfoEdit_Validating);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 8F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(400, 538);
+            this.tableLayoutPanel1.TabIndex = 4;
             // 
             // ScriptsSettingsPage
             // 
@@ -486,62 +204,30 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "ScriptsSettingsPage";
-            this.Size = new System.Drawing.Size(1153, 462);
+            this.Size = new System.Drawing.Size(1335, 885);
+            this.panel2.ResumeLayout(false);
+            this.panel2.PerformLayout();
+            this.panelButtons.ResumeLayout(false);
             this.tableLayoutPanel1.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.ScriptList)).EndInit();
-            this.panel1.ResumeLayout(false);
-            this.tableLayoutPanel2.ResumeLayout(false);
-            this.tableLayoutPanel2.PerformLayout();
-            this.flowLayoutPanel3.ResumeLayout(false);
-            this.flowLayoutPanel3.PerformLayout();
-            this.flowLayoutPanel1.ResumeLayout(false);
-            this.flowLayoutPanel1.PerformLayout();
-            this.flowLayoutPanel2.ResumeLayout(false);
-            this.flowLayoutPanel2.PerformLayout();
-            this.flowLayoutPanel4.ResumeLayout(false);
-            this.flowLayoutPanel4.PerformLayout();
-            this.flowLayoutPanel5.ResumeLayout(false);
-            this.flowLayoutPanel5.PerformLayout();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
         #endregion
-
+        private System.Windows.Forms.Button btnMoveUp;
+        private System.Windows.Forms.Button btnMoveDown;
+        private System.Windows.Forms.Button btnArgumentsHelp;
+        private System.Windows.Forms.PropertyGrid propertyGrid1;
+        private System.Windows.Forms.Panel panel2;
+        private UserControls.NativeListView lvScripts;
+        private System.Windows.Forms.FlowLayoutPanel panelButtons;
+        private System.Windows.Forms.Button btnAdd;
+        private System.Windows.Forms.Button btnDelete;
+        private System.Windows.Forms.ColumnHeader chdrNames;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.DataGridView ScriptList;
-        private System.Windows.Forms.DataGridViewTextBoxColumn HotkeyCommandIdentifier;
-        private System.Windows.Forms.DataGridViewCheckBoxColumn EnabledColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn OnEvent;
-        private System.Windows.Forms.DataGridViewCheckBoxColumn AskConfirmation;
-        private System.Windows.Forms.Panel panel1;
-        private System.Windows.Forms.Button addScriptButton;
-        private System.Windows.Forms.Button moveUpButton;
-        private System.Windows.Forms.Button removeScriptButton;
-        private System.Windows.Forms.Button moveDownButton;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel3;
-        private System.Windows.Forms.ComboBox scriptEvent;
-        private System.Windows.Forms.Label lbl_icon;
-        private Script.SplitButton sbtn_icon;
-        private System.Windows.Forms.Label nameLabel;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
-        private System.Windows.Forms.TextBox nameTextBox;
-        private System.Windows.Forms.CheckBox scriptEnabled;
-        private System.Windows.Forms.CheckBox scriptNeedsConfirmation;
-        private System.Windows.Forms.CheckBox inMenuCheckBox;
-        private System.Windows.Forms.Label commandLabel;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel2;
-        private System.Windows.Forms.TextBox commandTextBox;
-        private System.Windows.Forms.Button browseScriptButton;
-        private System.Windows.Forms.Label argumentsLabel;
-        private System.Windows.Forms.RichTextBox argumentsTextBox;
-        private System.Windows.Forms.Label labelOnEvent;
-        private System.Windows.Forms.ContextMenuStrip contextMenuStrip_SplitButton;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel4;
-        private System.Windows.Forms.Button buttonShowArgumentsHelp;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel5;
-        private System.Windows.Forms.CheckBox scriptRunInBackground;
-        private System.Windows.Forms.CheckBox scriptIsPowerShell;
+        private System.Windows.Forms.ColumnHeader chdrEvents;
+        private System.Windows.Forms.ColumnHeader chdrCommand;
+        private System.Windows.Forms.ColumnHeader chdrArguments;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.ScriptInfoProxy.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.ScriptInfoProxy.cs
@@ -1,0 +1,129 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.Design;
+using System.Drawing.Design;
+using System.Windows.Forms;
+using GitUI.Design;
+using GitUI.Script;
+
+namespace GitUI.CommandsDialogs.SettingsDialog.Pages
+{
+    partial class ScriptsSettingsPage
+    {
+        [TypeConverter(typeof(PropertySorter))]
+        private class ScriptInfoProxy
+        {
+            private const string ScriptCategory = "Script";
+            private const string ScriptBehaviourCategory = "Script Behaviour";
+            private const string ScriptContextCategory = "Script Context";
+
+            // Needed for the ImageKeyConverter to work
+            [Browsable(false)]
+            public ImageList ImageList { get; set; }
+
+            [Browsable(false)]
+            public int HotkeyCommandIdentifier { get; set; }
+
+            [Category(ScriptCategory)]
+            [PropertyOrder(0)]
+            public string Name { get; set; }
+
+            [Category(ScriptCategory)]
+            [DefaultValue(true)]
+            [PropertyOrder(1)]
+            public bool Enabled { get; set; }
+
+            [Category(ScriptCategory)]
+            [PropertyOrder(2)]
+            [Editor(typeof(ExecutableFileNameEditor), typeof(UITypeEditor))]
+            public string Command { get; set; }
+
+            [Category(ScriptCategory)]
+            [PropertyOrder(3)]
+            [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
+            public string Arguments { get; set; }
+
+            [Category(ScriptCategory)]
+            [PropertyOrder(4)]
+            [DisplayName("Execute on event")]
+            [DefaultValue(ScriptEvent.None)]
+            public ScriptEvent OnEvent { get; set; }
+
+            [TypeConverter(typeof(ImageKeyConverter))]
+            [Editor("System.Windows.Forms.Design.ImageIndexEditor, System.Design", typeof(UITypeEditor))]
+            [Category(ScriptCategory)]
+            [PropertyOrder(4)]
+            public string Icon { get; set; }
+
+            [Category(ScriptBehaviourCategory)]
+            [DisplayName("Ask confirmation")]
+            [DefaultValue(false)]
+            public bool AskConfirmation { get; set; }
+
+            [Category(ScriptBehaviourCategory)]
+            [DefaultValue(false)]
+            [DisplayName("Run in background")]
+            public bool RunInBackground { get; set; }
+
+            [Category(ScriptBehaviourCategory)]
+            [DefaultValue(false)]
+            [DisplayName("Is PowerShell script")]
+            public bool IsPowerShell { get; set; }
+
+            [Category(ScriptContextCategory)]
+            [DefaultValue(false)]
+            [DisplayName("Show in RevisionGrid")]
+            public bool AddToRevisionGridContextMenu { get; set; }
+
+            internal void SetImages(ImageList images)
+            {
+                ImageList = images;
+            }
+
+            public static implicit operator ScriptInfoProxy(ScriptInfo script)
+            {
+                if (script == null)
+                {
+                    return null;
+                }
+
+                return new ScriptInfoProxy
+                {
+                    Enabled = script.Enabled,
+                    HotkeyCommandIdentifier = script.HotkeyCommandIdentifier,
+                    Name = script.Name,
+                    Command = script.Command,
+                    Arguments = script.Arguments,
+                    AskConfirmation = script.AskConfirmation,
+                    IsPowerShell = script.IsPowerShell,
+                    OnEvent = script.OnEvent,
+                    AddToRevisionGridContextMenu = script.AddToRevisionGridContextMenu,
+                    RunInBackground = script.RunInBackground,
+                    Icon = script.Icon
+                };
+            }
+
+            public static implicit operator ScriptInfo(ScriptInfoProxy proxy)
+            {
+                if (proxy == null)
+                {
+                    return null;
+                }
+
+                return new ScriptInfo
+                {
+                    Enabled = proxy.Enabled,
+                    HotkeyCommandIdentifier = proxy.HotkeyCommandIdentifier,
+                    Name = proxy.Name,
+                    Command = proxy.Command,
+                    Arguments = proxy.Arguments,
+                    AskConfirmation = proxy.AskConfirmation,
+                    IsPowerShell = proxy.IsPowerShell,
+                    OnEvent = proxy.OnEvent,
+                    AddToRevisionGridContextMenu = proxy.AddToRevisionGridContextMenu,
+                    RunInBackground = proxy.RunInBackground,
+                    Icon = proxy.Icon
+                };
+            }
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Utils;
 using GitExtUtils.GitUI;
+using GitExtUtils.GitUI.Theming;
 using GitUI.Script;
 using JetBrains.Annotations;
 using ResourceManager;
@@ -143,7 +144,7 @@ Current Branch:
             {
                 if (icon.Value is Bitmap bitmap)
                 {
-                    EmbeddedIcons.Images.Add(icon.Key.ToString(), bitmap);
+                    EmbeddedIcons.Images.Add(icon.Key.ToString(), bitmap.AdaptLightness());
                 }
             }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -216,8 +216,7 @@ Current Branch:
                     lvScripts.Items.Add(lvitem);
 
                     lvitem.SubItems.Add(script.OnEvent.ToString());
-                    lvitem.SubItems.Add(script.Command);
-                    lvitem.SubItems.Add(script.Arguments);
+                    lvitem.SubItems.Add(string.Concat(script.Command, " ", script.Arguments));
                 }
 
                 lvScripts.SelectedIndexChanged += lvScripts_SelectedIndexChanged;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -101,6 +101,8 @@ Current Branch:
             }
 
             tableLayoutPanel1.Dock = DockStyle.Fill;
+            var margin = propertyGrid1.Margin.Left;
+            propertyGrid1.Margin = new Padding(margin, margin, panelButtons.Width, margin);
 
             propertyGrid1.SelectedGridItemChanged += (s, e) =>
             {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -102,11 +102,12 @@ Current Branch:
 
             tableLayoutPanel1.Dock = DockStyle.Fill;
 
-            propertyGrid1.PropertyValueChanged += (s, e) =>
+            propertyGrid1.SelectedGridItemChanged += (s, e) =>
             {
-                if (WatchedProxyProperties.Contains(e.ChangedItem.PropertyDescriptor.Name))
+                if (WatchedProxyProperties.Contains(e.OldSelection.PropertyDescriptor.Name))
                 {
                     BindScripts(_scripts, SelectedScript);
+                    propertyGrid1.Focus();
                 }
             };
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -106,7 +106,7 @@ Current Branch:
 
             propertyGrid1.SelectedGridItemChanged += (s, e) =>
             {
-                if (WatchedProxyProperties.Contains(e.OldSelection.PropertyDescriptor.Name))
+                if (WatchedProxyProperties.Contains(e.OldSelection?.PropertyDescriptor.Name ?? ""))
                 {
                     BindScripts(_scripts, SelectedScript);
                     propertyGrid1.Focus();

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -77,7 +77,10 @@ Current Branch:
             nameof(ScriptInfoProxy.Command),
             nameof(ScriptInfoProxy.Arguments),
         };
-        private static ImageList EmbeddedIcons = new ImageList();
+        private static ImageList EmbeddedIcons = new ImageList
+        {
+            ColorDepth = ColorDepth.Depth32Bit
+        };
         private BindingList<ScriptInfoProxy> _scripts;
         private SimpleHelpDisplayDialog _argumentsCheatSheet;
         private bool _handlingCheck;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
+using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Utils;
@@ -14,8 +18,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class ScriptsSettingsPage : SettingsPageWithHeader
     {
-        #region translation
-
         private readonly TranslationString _scriptSettingsPageHelpDisplayArgumentsHelp = new TranslationString("Arguments help");
         private readonly TranslationString _scriptSettingsPageHelpDisplayContent = new TranslationString(@"Use {option} for normal replacement.
 Use {{option}} for quoted replacement.
@@ -65,323 +67,287 @@ Current Branch:
 {cDefaultRemoteUrl}
 {cDefaultRemotePathFromUrl}");
 
-        #endregion
+        private static readonly string[] WatchedProxyProperties = new string[]
+        {
+            nameof(ScriptInfoProxy.Name),
+            nameof(ScriptInfoProxy.Enabled),
+            nameof(ScriptInfoProxy.Icon),
+            nameof(ScriptInfoProxy.OnEvent),
+            nameof(ScriptInfoProxy.Command),
+            nameof(ScriptInfoProxy.Arguments),
+        };
+        private static ImageList EmbeddedIcons = new ImageList();
+        private BindingList<ScriptInfoProxy> _scripts;
+        private SimpleHelpDisplayDialog _argumentsCheatSheet;
+        private bool _handlingCheck;
 
-        private string _iconName = "bug";
+        // settings maybe loaded before page is shwon or after
+        // we need to track that so we load images before we bind the list
+        private bool _imagsLoaded;
 
         public ScriptsSettingsPage()
         {
             InitializeComponent();
-            HotkeyCommandIdentifier.Width = DpiUtil.Scale(39);
             Text = "Scripts";
+
+            // stop the localisation of the propertygrid
+            propertyGrid1.Text = string.Empty;
+
             InitializeComplete();
 
-            HotkeyCommandIdentifier.DataPropertyName = nameof(ScriptInfo.HotkeyCommandIdentifier);
-            EnabledColumn.DataPropertyName = nameof(ScriptInfo.Enabled);
-            OnEvent.DataPropertyName = nameof(ScriptInfo.OnEvent);
-            AskConfirmation.DataPropertyName = nameof(ScriptInfo.AskConfirmation);
+            foreach (ColumnHeader column in lvScripts.Columns)
+            {
+                column.Width = DpiUtil.Scale(column.Width);
+            }
+
+            tableLayoutPanel1.Dock = DockStyle.Fill;
+
+            propertyGrid1.PropertyValueChanged += (s, e) =>
+            {
+                if (WatchedProxyProperties.Contains(e.ChangedItem.PropertyDescriptor.Name))
+                {
+                    BindScripts(_scripts, SelectedScript);
+                }
+            };
         }
 
-        public override bool IsInstantSavePage => true;
+        private ScriptInfoProxy SelectedScript { get; set; }
+
+        protected override void OnParentChanged(EventArgs e)
+        {
+            base.OnParentChanged(e);
+
+            if (Parent is null && _argumentsCheatSheet is object)
+            {
+                _argumentsCheatSheet.Close();
+            }
+        }
 
         public override void OnPageShown()
         {
-            if (EnvUtils.RunningOnWindows())
+            if (!EnvUtils.RunningOnWindows())
             {
-                System.Resources.ResourceManager rm =
-                    new System.Resources.ResourceManager("GitUI.Properties.Images",
-                                System.Reflection.Assembly.GetExecutingAssembly());
+                return;
+            }
 
-                // dummy request; for some strange reason the ResourceSets are not loaded untill after the first object request... bug?
-                rm.GetObject("dummy");
+            var rm = new System.Resources.ResourceManager("GitUI.Properties.Images", Assembly.GetExecutingAssembly());
 
-                System.Resources.ResourceSet resourceSet = rm.GetResourceSet(System.Globalization.CultureInfo.CurrentUICulture, true, true);
+            // dummy request; for some strange reason the ResourceSets are not loaded untill after the first object request... bug?
+            rm.GetObject("dummy");
 
-                contextMenuStrip_SplitButton.Items.Clear();
-
-                var iconItems = new List<ToolStripItem>();
-                foreach (System.Collections.DictionaryEntry icon in resourceSet)
+            using System.Resources.ResourceSet resourceSet = rm.GetResourceSet(CultureInfo.CurrentUICulture, true, true);
+            foreach (DictionaryEntry icon in resourceSet.Cast<DictionaryEntry>().OrderBy(icon => icon.Key))
+            {
+                if (icon.Value is Bitmap bitmap)
                 {
-                    // add entry to toolstrip
-                    if (icon.Value is Icon)
-                    {
-                        ////contextMenuStrip_SplitButton.Items.Add(icon.Key.ToString(), (Image)((Icon)icon.Value).ToBitmap(), SplitButtonMenuItem_Click);
-                    }
-                    else if (icon.Value is Bitmap bitmap)
-                    {
-                        iconItems.Add(new ToolStripMenuItem(icon.Key.ToString(), bitmap, SplitButtonMenuItem_Click));
-                    }
+                    EmbeddedIcons.Images.Add(icon.Key.ToString(), bitmap);
                 }
+            }
 
-                contextMenuStrip_SplitButton.Items.AddRange(iconItems.OrderBy(i => i.Text).ToArray());
+            resourceSet.Close();
+            rm.ReleaseAllResources();
 
-                resourceSet.Close();
-                rm.ReleaseAllResources();
+            lvScripts.LargeImageList =
+                lvScripts.SmallImageList = EmbeddedIcons;
+            _imagsLoaded = true;
+
+            if (_scripts is object)
+            {
+                BindScripts(_scripts, null);
             }
         }
 
         protected override void SettingsToPage()
         {
-            scriptEvent.DataSource = Enum.GetValues(typeof(ScriptEvent));
-            LoadScripts();
+            _scripts = new BindingList<ScriptInfoProxy>();
+            foreach (var script in ScriptManager.GetScripts())
+            {
+                _scripts.Add(script);
+            }
+
+            if (_imagsLoaded)
+            {
+                BindScripts(_scripts, null);
+            }
         }
 
         protected override void PageToSettings()
         {
-            SaveScripts();
-        }
+            // TODO: this is an abomination, the whole script persistence must be scorched and rewritten
 
-        private static void SaveScripts()
-        {
+            BindingList<ScriptInfo> scripts = ScriptManager.GetScripts();
+            scripts.Clear();
+
+            foreach (ScriptInfoProxy proxy in _scripts)
+            {
+                scripts.Add(proxy);
+            }
+
             AppSettings.OwnScripts = ScriptManager.SerializeIntoXml();
         }
 
-        private void LoadScripts()
+        private void BindScripts(IList<ScriptInfoProxy> scripts, ScriptInfoProxy selectedScript)
         {
-            ScriptList.DataSource = ScriptManager.GetScripts();
-        }
-
-        private void ClearScriptDetails()
-        {
-            nameTextBox.Clear();
-            commandTextBox.Clear();
-            argumentsTextBox.Clear();
-            inMenuCheckBox.Checked = false;
-        }
-
-        private void RefreshScriptDetails()
-        {
-            if (ScriptList.SelectedRows.Count == 0)
+            try
             {
+                lvScripts.BeginUpdate();
+                lvScripts.SelectedIndexChanged -= lvScripts_SelectedIndexChanged;
+                lvScripts.ItemChecked -= lvScripts_ItemChecked;
+                lvScripts.Items.Clear();
+
+                if (scripts.Count < 1)
+                {
+                    btnAdd.Focus();
+                    return;
+                }
+
+                foreach (ScriptInfoProxy script in scripts)
+                {
+                    var color = !script.Enabled ? SystemColors.GrayText : SystemColors.WindowText;
+
+                    ListViewItem lvitem = new ListViewItem(script.Name)
+                    {
+                        ToolTipText = $"{script.Command} {script.Arguments}",
+                        Tag = script,
+                        ForeColor = color,
+                        ImageKey = script.Icon,
+                        Checked = script.Enabled
+                    };
+                    lvScripts.Items.Add(lvitem);
+
+                    lvitem.SubItems.Add(script.OnEvent.ToString());
+                    lvitem.SubItems.Add(script.Command);
+                    lvitem.SubItems.Add(script.Arguments);
+                }
+
+                lvScripts.SelectedIndexChanged += lvScripts_SelectedIndexChanged;
+                lvScripts.ItemChecked += lvScripts_ItemChecked;
+                lvScripts.SelectedIndices.Clear();
+
+                SelectedScript = selectedScript;
+
+                if (selectedScript is object)
+                {
+                    ListViewItem lvi = lvScripts.Items.Cast<ListViewItem>().FirstOrDefault(x => x.Tag == selectedScript);
+                    if (lvi != null)
+                    {
+                        lvi.Selected = true;
+                        lvScripts.FocusedItem = lvi;
+                    }
+                }
+
+                if (lvScripts.FocusedItem is null)
+                {
+                    lvScripts.Items[0].Selected = true;
+                    lvScripts.FocusedItem = lvScripts.Items[0];
+                }
+
+                lvScripts.Select();
+            }
+            finally
+            {
+                lvScripts.EndUpdate();
+            }
+        }
+
+        private void btnAdd_Click(object sender, EventArgs e)
+        {
+            ScriptInfoProxy script = _scripts.AddNew();
+            script.HotkeyCommandIdentifier = Math.Max(ScriptManager.MinimumUserScriptID, _scripts.Max(s => s.HotkeyCommandIdentifier)) + 1;
+            script.Name = "<New Script>";
+
+            BindScripts(_scripts, script);
+        }
+
+        private void btnArgumentsHelp_Click(object sender, EventArgs e)
+        {
+            if (_argumentsCheatSheet is object)
+            {
+                _argumentsCheatSheet.BringToFront();
                 return;
             }
 
-            var scriptInfo = (ScriptInfo)ScriptList.SelectedRows[0].DataBoundItem;
-
-            nameTextBox.Text = scriptInfo.Name;
-            commandTextBox.Text = scriptInfo.Command;
-            argumentsTextBox.Text = scriptInfo.Arguments;
-            scriptRunInBackground.Checked = scriptInfo.RunInBackground;
-            scriptIsPowerShell.Checked = scriptInfo.IsPowerShell;
-            inMenuCheckBox.Checked = scriptInfo.AddToRevisionGridContextMenu;
-            scriptEnabled.Checked = scriptInfo.Enabled;
-            scriptNeedsConfirmation.Checked = scriptInfo.AskConfirmation;
-            scriptEvent.SelectedItem = scriptInfo.OnEvent;
-            sbtn_icon.Image = ResizeForSplitButton(scriptInfo.GetIcon());
-            _iconName = scriptInfo.Icon;
-
-            foreach (ToolStripItem item in contextMenuStrip_SplitButton.Items)
-            {
-                if (item.ToString() == _iconName)
-                {
-                    item.Font = new Font(item.Font, FontStyle.Bold);
-                }
-            }
-        }
-
-        private void addScriptButton_Click(object sender, EventArgs e)
-        {
-            ScriptList.ClearSelection();
-            ScriptInfo script = ScriptManager.GetScripts().AddNew();
-            script.HotkeyCommandIdentifier = ScriptManager.NextHotkeyCommandIdentifier();
-            ScriptList.Rows[ScriptList.RowCount - 1].Selected = true;
-            ScriptList_SelectionChanged(null, null); // needed for linux
-        }
-
-        private void removeScriptButton_Click(object sender, EventArgs e)
-        {
-            if (ScriptList.SelectedRows.Count > 0)
-            {
-                ScriptManager.GetScripts().Remove(ScriptList.SelectedRows[0].DataBoundItem as ScriptInfo);
-
-                ClearScriptDetails();
-            }
-        }
-
-        private void ScriptInfoFromEdits()
-        {
-            if (ScriptList.SelectedRows.Count > 0)
-            {
-                var selectedScriptInfo = (ScriptInfo)ScriptList.SelectedRows[0].DataBoundItem;
-
-                selectedScriptInfo.Name = nameTextBox.Text;
-                selectedScriptInfo.Command = commandTextBox.Text;
-                selectedScriptInfo.Arguments = argumentsTextBox.Text;
-                selectedScriptInfo.AddToRevisionGridContextMenu = inMenuCheckBox.Checked;
-                selectedScriptInfo.Enabled = scriptEnabled.Checked;
-                selectedScriptInfo.RunInBackground = scriptRunInBackground.Checked;
-                selectedScriptInfo.IsPowerShell = scriptIsPowerShell.Checked;
-                selectedScriptInfo.AskConfirmation = scriptNeedsConfirmation.Checked;
-                selectedScriptInfo.OnEvent = (ScriptEvent)scriptEvent.SelectedItem;
-                selectedScriptInfo.Icon = _iconName;
-            }
-        }
-
-        private void moveUpButton_Click(object sender, EventArgs e)
-        {
-            if (ScriptList.SelectedRows.Count > 0)
-            {
-                ScriptInfo scriptInfo = ScriptList.SelectedRows[0].DataBoundItem as ScriptInfo;
-                int index = ScriptManager.GetScripts().IndexOf(scriptInfo);
-                ScriptManager.GetScripts().Remove(scriptInfo);
-                ScriptManager.GetScripts().Insert(Math.Max(index - 1, 0), scriptInfo);
-
-                ScriptList.ClearSelection();
-                ScriptList.Rows[Math.Max(index - 1, 0)].Selected = true;
-                ScriptList.Focus();
-            }
-        }
-
-        private void moveDownButton_Click(object sender, EventArgs e)
-        {
-            if (ScriptList.SelectedRows.Count > 0)
-            {
-                ScriptInfo scriptInfo = ScriptList.SelectedRows[0].DataBoundItem as ScriptInfo;
-                int index = ScriptManager.GetScripts().IndexOf(scriptInfo);
-                ScriptManager.GetScripts().Remove(scriptInfo);
-                ScriptManager.GetScripts().Insert(Math.Min(index + 1, ScriptManager.GetScripts().Count), scriptInfo);
-
-                ScriptList.ClearSelection();
-                ScriptList.Rows[Math.Max(index + 1, 0)].Selected = true;
-                ScriptList.Focus();
-            }
-        }
-
-        private void browseScriptButton_Click(object sender, EventArgs e)
-        {
-            using (var ofd = new OpenFileDialog
-            {
-                InitialDirectory = "c:\\",
-                Filter = "Executable files (*.exe)|*.exe|All files (*.*)|*.*",
-                RestoreDirectory = true
-            })
-            {
-                if (ofd.ShowDialog(this) == DialogResult.OK)
-                {
-                    commandTextBox.Text = ofd.FileName;
-                }
-            }
-        }
-
-        private void ScriptList_SelectionChanged(object sender, EventArgs e)
-        {
-            if (ScriptList.SelectedRows.Count > 0)
-            {
-                RefreshScriptDetails();
-
-                removeScriptButton.Enabled = true;
-                moveDownButton.Enabled = moveUpButton.Enabled = false;
-                if (ScriptList.SelectedRows[0].Index > 0)
-                {
-                    moveUpButton.Enabled = true;
-                }
-
-                if (ScriptList.SelectedRows[0].Index < ScriptList.RowCount - 1)
-                {
-                    moveDownButton.Enabled = true;
-                }
-            }
-            else
-            {
-                removeScriptButton.Enabled = false;
-                moveUpButton.Enabled = false;
-                moveDownButton.Enabled = false;
-                ClearScriptDetails();
-            }
-
-            UpdateIconVisibility();
-        }
-
-        private void ScriptInfoEdit_Validating(object sender, System.ComponentModel.CancelEventArgs e)
-        {
-            ScriptInfoFromEdits();
-            ScriptList.Refresh();
-        }
-
-        private void ScriptList_CellClick(object sender, DataGridViewCellEventArgs e)
-        {
-            ScriptList_SelectionChanged(null, null); // needed for linux
-        }
-
-        private void SplitButtonMenuItem_Click(object sender, EventArgs e)
-        {
-            // reset bold item to regular
-            var item = contextMenuStrip_SplitButton.Items.OfType<ToolStripMenuItem>().FirstOrDefault(s => s.Font.Bold);
-            if (item != null)
-            {
-                item.Font = new Font(contextMenuStrip_SplitButton.Font, FontStyle.Regular);
-            }
-
-            // make new item bold
-            ((ToolStripMenuItem)sender).Font = new Font(((ToolStripMenuItem)sender).Font, FontStyle.Bold);
-
-            // set new image on button
-            sbtn_icon.Image = ResizeForSplitButton((Bitmap)((ToolStripMenuItem)sender).Image);
-
-            _iconName = ((ToolStripMenuItem)sender).Text;
-
-            // store variables
-            ScriptInfoEdit_Validating(sender, new System.ComponentModel.CancelEventArgs());
-        }
-
-        private Bitmap ResizeForSplitButton(Bitmap b)
-        {
-            return ResizeBitmap(b, 12, 12);
-        }
-
-        [CanBeNull]
-        public Bitmap ResizeBitmap(Bitmap b, int width, int height)
-        {
-            if (b == null)
-            {
-                return null;
-            }
-
-            var result = new Bitmap(width, height);
-            using (Graphics g = Graphics.FromImage(result))
-            {
-                g.DrawImage(b, 0, 0, width, height);
-            }
-
-            return result;
-        }
-
-        private void scriptEvent_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            UpdateIconVisibility();
-        }
-
-        private void UpdateIconVisibility()
-        {
-            bool showIcon = scriptEvent.Text == ScriptEvent.ShowInUserMenuBar.ToString() || inMenuCheckBox.Checked;
-
-            sbtn_icon.Visible = showIcon;
-            lbl_icon.Visible = showIcon;
-        }
-
-        private void buttonShowArgumentsHelp_Click(object sender, EventArgs e)
-        {
-            var helpDisplayDialog = new SimpleHelpDisplayDialog
+            _argumentsCheatSheet = new SimpleHelpDisplayDialog
             {
                 DialogTitle = _scriptSettingsPageHelpDisplayArgumentsHelp.Text,
                 ContentText = _scriptSettingsPageHelpDisplayContent.Text.Replace("\n", Environment.NewLine)
             };
 
-            helpDisplayDialog.ShowDialog();
+            _argumentsCheatSheet.Show(this);
         }
 
-        private void argumentsTextBox_KeyDown(object sender, KeyEventArgs e)
+        private void btnDelete_Click(object sender, EventArgs e)
         {
-            if ((e.Control && e.KeyCode == Keys.V) || (e.Shift && e.KeyCode == Keys.Insert))
+            if (SelectedScript is null)
             {
-                ((RichTextBox)sender).Paste(DataFormats.GetFormat(DataFormats.UnicodeText));
-                e.Handled = true;
+                return;
             }
+
+            _scripts.Remove(SelectedScript);
+            BindScripts(_scripts, null);
         }
 
-        private void inMenuCheckBox_CheckedChanged(object sender, EventArgs e)
+        private void btnMoveDown_Click(object sender, EventArgs e)
         {
-            UpdateIconVisibility();
+            if (SelectedScript is null)
+            {
+                return;
+            }
+
+            ScriptInfoProxy script = SelectedScript;
+
+            int index = _scripts.IndexOf(script);
+            _scripts.Remove(script);
+            _scripts.Insert(Math.Min(index + 1, _scripts.Count), script);
+
+            BindScripts(_scripts, script);
+        }
+
+        private void btnMoveUp_Click(object sender, EventArgs e)
+        {
+            if (SelectedScript is null)
+            {
+                return;
+            }
+
+            ScriptInfoProxy script = SelectedScript;
+
+            int index = _scripts.IndexOf(script);
+            _scripts.Remove(script);
+            _scripts.Insert(Math.Max(index - 1, 0), script);
+
+            BindScripts(_scripts, script);
+        }
+
+        private void lvScripts_ItemChecked(object sender, ItemCheckedEventArgs e)
+        {
+            if (_handlingCheck)
+            {
+                return;
+            }
+
+            _handlingCheck = true;
+            e.Item.Selected = true;
+            e.Item.Checked = !e.Item.Checked;
+            _handlingCheck = false;
+        }
+
+        private void lvScripts_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (lvScripts.SelectedItems.Count < 1 || !(lvScripts.SelectedItems[0].Tag is ScriptInfoProxy script))
+            {
+                propertyGrid1.SelectedObject = null;
+                return;
+            }
+
+            SelectedScript = script;
+            script.SetImages(EmbeddedIcons);
+
+            propertyGrid1.SelectedObject = script;
+
+            int index = _scripts.IndexOf(script);
+            btnMoveUp.Enabled = index > 0;
+            btnMoveDown.Enabled = index < _scripts.Count - 1;
         }
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.resx
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.resx
@@ -117,19 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="HotkeyCommandIdentifier.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="EnabledColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="OnEvent.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="AskConfirmation.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="contextMenuStrip_SplitButton.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>104</value>
   </metadata>
 </root>

--- a/GitUI/Design/ExecutableFileNameEditor.cs
+++ b/GitUI/Design/ExecutableFileNameEditor.cs
@@ -1,0 +1,14 @@
+﻿using System.Windows.Forms;
+using System.Windows.Forms.Design;
+
+namespace GitUI.Design
+{
+    internal class ExecutableFileNameEditor : FileNameEditor
+    {
+        protected override void InitializeDialog(OpenFileDialog openFileDialog)
+        {
+            base.InitializeDialog(openFileDialog);
+            openFileDialog.Filter = "Executable file (*.exe;*.cmd;*.bat)|*.exe;*.cmd;*.bat|All files (*.*)|*.*";
+        }
+    }
+}

--- a/GitUI/Design/PropertyOrderAttribute.cs
+++ b/GitUI/Design/PropertyOrderAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace GitUI.Design
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    internal class PropertyOrderAttribute : Attribute
+    {
+        public PropertyOrderAttribute(int order)
+        {
+            Order = order;
+        }
+
+        public int Order { get; }
+    }
+}

--- a/GitUI/Design/PropertySorter.cs
+++ b/GitUI/Design/PropertySorter.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace GitUI.Design
+{
+    internal class PropertySorter : ExpandableObjectConverter
+    {
+        public override bool GetPropertiesSupported(ITypeDescriptorContext context)
+        {
+            return true;
+        }
+
+        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
+        {
+            PropertyDescriptorCollection pdc = TypeDescriptor.GetProperties(value, attributes);
+            var orderedProperties = new List<(string, int)>();
+            foreach (PropertyDescriptor pd in pdc)
+            {
+                Attribute attribute = pd.Attributes[typeof(PropertyOrderAttribute)];
+                if (attribute != null)
+                {
+                    PropertyOrderAttribute poa = (PropertyOrderAttribute)attribute;
+                    orderedProperties.Add((pd.Name, poa.Order));
+                }
+                else
+                {
+                    orderedProperties.Add((pd.Name, 100));
+                }
+            }
+
+            return pdc.Sort(orderedProperties.OrderBy(p => p.Item2).Select(p => p.Item1).ToArray());
+        }
+    }
+}

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -16,7 +16,9 @@
       <HintPath>..\Bin\PSTaskDialog.dll</HintPath>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.Design" />
     <Reference Include="System.DirectoryServices" />
+    <Reference Include="System.Drawing.Design" />
     <Reference Include="System.Management" />
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceModel" />

--- a/GitUI/Script/ScriptEvent.cs
+++ b/GitUI/Script/ScriptEvent.cs
@@ -1,0 +1,20 @@
+﻿namespace GitUI.Script
+{
+    public enum ScriptEvent
+    {
+        None,
+        BeforeCommit,
+        AfterCommit,
+        BeforePull,
+        AfterPull,
+        BeforePush,
+        AfterPush,
+        ShowInUserMenuBar,
+        BeforeCheckout,
+        AfterCheckout,
+        BeforeMerge,
+        AfterMerge,
+        BeforeFetch,
+        AfterFetch
+    }
+}

--- a/GitUI/Script/ScriptInfo.cs
+++ b/GitUI/Script/ScriptInfo.cs
@@ -2,24 +2,7 @@
 
 namespace GitUI.Script
 {
-    public enum ScriptEvent
-    {
-        None,
-        BeforeCommit,
-        AfterCommit,
-        BeforePull,
-        AfterPull,
-        BeforePush,
-        AfterPush,
-        ShowInUserMenuBar,
-        BeforeCheckout,
-        AfterCheckout,
-        BeforeMerge,
-        AfterMerge,
-        BeforeFetch,
-        AfterFetch
-    }
-
+    // WARNING: This class is serialized to XML!
     public class ScriptInfo
     {
         public ScriptInfo()

--- a/GitUI/Script/ScriptManager.cs
+++ b/GitUI/Script/ScriptManager.cs
@@ -13,6 +13,7 @@ namespace GitUI.Script
 {
     public static class ScriptManager
     {
+        internal const int MinimumUserScriptID = 9000;
         private static readonly XmlSerializer _serializer = new XmlSerializer(typeof(BindingList<ScriptInfo>));
         private static BindingList<ScriptInfo> _scripts;
 

--- a/GitUI/Themes/dark.css
+++ b/GitUI/Themes/dark.css
@@ -13,7 +13,7 @@
 .Highlight { color: #6290e6 }
 .HighlightText { color: #000000 }
 .HotTrack { color: #98b7ef }
-.InactiveBorder { color: #808080 }
+.InactiveBorder { color: #4c4d4d }
 .InactiveCaption { color: #3c3f41 }
 .InactiveCaptionText { color: #afb1b3 }
 .Info { color: #373832 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8872,10 +8872,6 @@ Current Branch:
 {cDefaultRemotePathFromUrl}</source>
         <target />
       </trans-unit>
-      <trans-unit id="chdrArguments.Text">
-        <source>Arguments</source>
-        <target />
-      </trans-unit>
       <trans-unit id="chdrCommand.Text">
         <source>Command</source>
         <target />

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8818,18 +8818,6 @@ See the changes in the commit form.</source>
         <source>Scripts</source>
         <target />
       </trans-unit>
-      <trans-unit id="AskConfirmation.HeaderText">
-        <source>Confirmation</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="EnabledColumn.HeaderText">
-        <source>Enabled</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="OnEvent.HeaderText">
-        <source>OnEvent</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_scriptSettingsPageHelpDisplayArgumentsHelp.Text">
         <source>Arguments help</source>
         <target />
@@ -8884,64 +8872,20 @@ Current Branch:
 {cDefaultRemotePathFromUrl}</source>
         <target />
       </trans-unit>
-      <trans-unit id="addScriptButton.Text">
-        <source>Add</source>
+      <trans-unit id="chdrArguments.Text">
+        <source>Arguments</source>
         <target />
       </trans-unit>
-      <trans-unit id="argumentsLabel.Text">
-        <source>Arguments:</source>
+      <trans-unit id="chdrCommand.Text">
+        <source>Command</source>
         <target />
       </trans-unit>
-      <trans-unit id="browseScriptButton.Text">
-        <source>Browse</source>
+      <trans-unit id="chdrEvents.Text">
+        <source>Event</source>
         <target />
       </trans-unit>
-      <trans-unit id="buttonShowArgumentsHelp.Text">
-        <source>Help</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="commandLabel.Text">
-        <source>Command:</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="inMenuCheckBox.Text">
-        <source>Add to revision grid context menu</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="labelOnEvent.Text">
-        <source>On event:</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="lbl_icon.Text">
-        <source>Icon:</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="nameLabel.Text">
-        <source>Name:</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="removeScriptButton.Text">
-        <source>Remove</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="sbtn_icon.Text">
-        <source>Select icon</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="scriptEnabled.Text">
-        <source>Enabled</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="scriptIsPowerShell.Text">
-        <source>Is PowerShell</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="scriptNeedsConfirmation.Text">
-        <source>Ask for confirmation</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="scriptRunInBackground.Text">
-        <source>Run in background</source>
+      <trans-unit id="chdrNames.Text">
+        <source>Name</source>
         <target />
       </trans-unit>
     </body>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

- Redesign script configuration settings
- One of a key change is that script modifications are no longer "destructive" _until_ the settings are accepted via [OK] or [Apply] buttons. 
The race condition where a user has multiple instances of the app open and modifies scripts in several instances at once still remains, and it completely outside the scope of this PR. 
The last instance of the app to accept changes to scripts will overwrite all other changes may have been made in other instances. 



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/79067954-a2090f80-7d06-11ea-8394-5af77dd93829.png)


### After

![image](https://user-images.githubusercontent.com/4403806/79564660-7022ef00-80f2-11ea-9721-e9d9242aefa5.png)
![image](https://user-images.githubusercontent.com/4403806/79564475-13bfcf80-80f2-11ea-8383-ece6d3469de6.png)



## Test methodology <!-- How did you ensure quality? -->

- manual
- I may look at adding tests, but may do that at a later stage.


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
