### PR TITLE
Deleted files presented as Unkown

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1091,7 +1091,7 @@ namespace GitUI
 
             static string GetItemImageKey(GitItemStatus gitItemStatus)
             {
-                if (!gitItemStatus.IsNew && !gitItemStatus.IsTracked)
+                if (!gitItemStatus.IsNew && !gitItemStatus.IsDeleted && !gitItemStatus.IsTracked)
                 {
                     // Illegal combinations, no flags set?
                     return nameof(Images.FileStatusUnknown);


### PR DESCRIPTION
## Proposed changes

Follow up from #7922 
When comparing new files from WorkTree -> commit, the files were presented with the Unknown icon instead of deleted.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/79080895-08972900-7d19-11ea-8734-d9efdf5510e7.png)

### After

![image](https://user-images.githubusercontent.com/6248932/79080928-3c724e80-7d19-11ea-81ca-71ba0c5e756d.png)

## Test methodology 
Manual
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
