### PR TITLE
Fix up show all branches / tags in history

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -785,7 +785,7 @@ namespace GitUI.CommandsDialogs
             this.RevisionInfo.ShowBranchesAsLinks = true;
             this.RevisionInfo.Size = new System.Drawing.Size(646, 264);
             this.RevisionInfo.TabIndex = 0;
-            this.RevisionInfo.CommandClicked += new System.EventHandler<GitUI.CommitInfo.CommandEventArgs>(this.RevisionInfo_CommandClicked);
+            this.RevisionInfo.CommandClicked += new System.EventHandler<ResourceManager.CommandEventArgs>(this.RevisionInfo_CommandClicked);
             // 
             // TreeTabPage
             // 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2410,7 +2410,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void RevisionInfo_CommandClicked(object sender, CommitInfo.CommandEventArgs e)
+        private void RevisionInfo_CommandClicked(object sender, ResourceManager.CommandEventArgs e)
         {
             // TODO this code duplicated in FormFileHistory.Blame_CommandClick
             switch (e.Command)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2448,9 +2448,8 @@ namespace GitUI.CommandsDialogs
                 case "navigateforward":
                     RevisionGrid.NavigateForward();
                     break;
-                case "showall":
-                    RevisionInfo.ShowAll(e.Data);
-                    break;
+                default:
+                    throw new InvalidOperationException($"unexpected internal link: {e.Command}/{e.Data}");
             }
         }
 

--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -328,7 +328,7 @@ namespace GitUI.CommandsDialogs
             this.Blame.Name = "Blame";
             this.Blame.Size = new System.Drawing.Size(744, 291);
             this.Blame.TabIndex = 0;
-            this.Blame.CommandClick += new System.EventHandler<GitUI.CommitInfo.CommandEventArgs>(this.Blame_CommandClick);
+            this.Blame.CommandClick += new System.EventHandler<ResourceManager.CommandEventArgs>(this.Blame_CommandClick);
             // 
             // ToolStrip
             // 

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -569,7 +569,7 @@ namespace GitUI.CommandsDialogs
             loadBlameOnShowToolStripMenuItem.Checked = AppSettings.LoadBlameOnShow;
         }
 
-        private void Blame_CommandClick(object sender, CommitInfo.CommandEventArgs e)
+        private void Blame_CommandClick(object sender, ResourceManager.CommandEventArgs e)
         {
             if (e.Command == "gotocommit")
             {

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -164,25 +164,23 @@ namespace GitUI.CommitInfo
 
         private void RevisionInfoLinkClicked(object sender, LinkClickedEventArgs e)
         {
-            if (!_linkFactory.ParseLink(e.LinkText, out var result))
+            if (!_linkFactory.ParseLink(e.LinkText, out var uri))
             {
                 return;
             }
 
-            if (result.Scheme == "gitext")
+            if (_linkFactory.ParseInternalScheme(uri, out var commandEventArgs))
             {
-                CommandClickedEvent?.Invoke(sender, new CommandEventArgs(result.Host, result.AbsolutePath.TrimStart('/')));
+                CommandClickedEvent?.Invoke(sender, commandEventArgs);
                 return;
             }
 
-            using (var process = new Process
+            using var process = new Process
             {
                 EnableRaisingEvents = false,
-                StartInfo = { FileName = result.AbsoluteUri }
-            })
-            {
-                process.Start();
-            }
+                StartInfo = { FileName = uri.AbsoluteUri }
+            };
+            process.Start();
         }
 
         public void SetRevisionWithChildren(GitRevision revision, IReadOnlyList<ObjectId> children)

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -164,23 +164,14 @@ namespace GitUI.CommitInfo
 
         private void RevisionInfoLinkClicked(object sender, LinkClickedEventArgs e)
         {
-            if (!_linkFactory.ParseLink(e.LinkText, out var uri))
+            try
             {
-                return;
+                _linkFactory.ExecuteLink(e.LinkText, commandEventArgs => CommandClickedEvent?.Invoke(sender, commandEventArgs), ShowAll);
             }
-
-            if (_linkFactory.ParseInternalScheme(uri, out var commandEventArgs))
+            catch (Exception ex)
             {
-                CommandClickedEvent?.Invoke(sender, commandEventArgs);
-                return;
+                MessageBox.Show(this, ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
-
-            using var process = new Process
-            {
-                EnableRaisingEvents = false,
-                StartInfo = { FileName = uri.AbsoluteUri }
-            };
-            process.Start();
         }
 
         public void SetRevisionWithChildren(GitRevision revision, IReadOnlyList<ObjectId> children)
@@ -199,7 +190,7 @@ namespace GitUI.CommitInfo
             ReloadCommitInfo();
         }
 
-        public void ShowAll(string what)
+        private void ShowAll(string what)
         {
             switch (what)
             {

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -164,29 +164,24 @@ namespace GitUI.CommitInfo
 
         private void RevisionInfoLinkClicked(object sender, LinkClickedEventArgs e)
         {
-            var link = _linkFactory.ParseLink(e.LinkText);
-
-            try
+            if (!_linkFactory.ParseLink(e.LinkText, out var result))
             {
-                var result = new Uri(link);
-                if (result.Scheme == "gitext")
-                {
-                    CommandClickedEvent?.Invoke(sender, new CommandEventArgs(result.Host, result.AbsolutePath.TrimStart('/')));
-                }
-                else
-                {
-                    using (var process = new Process
-                    {
-                        EnableRaisingEvents = false,
-                        StartInfo = { FileName = result.AbsoluteUri }
-                    })
-                    {
-                        process.Start();
-                    }
-                }
+                return;
             }
-            catch (UriFormatException)
+
+            if (result.Scheme == "gitext")
             {
+                CommandClickedEvent?.Invoke(sender, new CommandEventArgs(result.Host, result.AbsolutePath.TrimStart('/')));
+                return;
+            }
+
+            using (var process = new Process
+            {
+                EnableRaisingEvents = false,
+                StartInfo = { FileName = result.AbsoluteUri }
+            })
+            {
+                process.Start();
             }
         }
 

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -127,9 +127,9 @@ namespace GitUI.CommitInfo
                 return;
             }
 
-            if (uri.Scheme == "gitext")
+            if (_linkFactory.ParseInternalScheme(uri, out var commandEventArgs))
             {
-                CommandClicked?.Invoke(sender, new CommandEventArgs(uri.Host, uri.AbsolutePath.TrimStart('/')));
+                CommandClicked?.Invoke(sender, commandEventArgs);
                 return;
             }
 

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -122,9 +122,7 @@ namespace GitUI.CommitInfo
 
         private void rtbRevisionHeader_LinkClicked(object sender, LinkClickedEventArgs e)
         {
-            var link = _linkFactory.ParseLink(e.LinkText);
-
-            if (!Uri.TryCreate(link, UriKind.Absolute, out var uri))
+            if (!_linkFactory.ParseLink(e.LinkText, out var uri))
             {
                 return;
             }

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -122,25 +122,9 @@ namespace GitUI.CommitInfo
 
         private void rtbRevisionHeader_LinkClicked(object sender, LinkClickedEventArgs e)
         {
-            if (!_linkFactory.ParseLink(e.LinkText, out var uri))
-            {
-                return;
-            }
-
-            if (_linkFactory.ParseInternalScheme(uri, out var commandEventArgs))
-            {
-                CommandClicked?.Invoke(sender, commandEventArgs);
-                return;
-            }
-
             try
             {
-                using var process = new Process
-                {
-                    EnableRaisingEvents = false,
-                    StartInfo = { FileName = uri.AbsoluteUri }
-                };
-                process.Start();
+                _linkFactory.ExecuteLink(e.LinkText, commandEventArgs => CommandClicked?.Invoke(sender, commandEventArgs));
             }
             catch (Exception ex)
             {

--- a/ResourceManager/CommandEventArgs.cs
+++ b/ResourceManager/CommandEventArgs.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace GitUI.CommitInfo
+namespace ResourceManager
 {
     public class CommandEventArgs : EventArgs
     {

--- a/UnitTests/ResourceManager.Tests/LinkFactoryFixture.cs
+++ b/UnitTests/ResourceManager.Tests/LinkFactoryFixture.cs
@@ -6,14 +6,25 @@ namespace ResourceManagerTests
     [TestFixture]
     internal class LinkFactoryFixture
     {
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("no link")]
+        public void ParseInvalidLink(string link)
+        {
+            var linkFactory = new LinkFactory();
+            Assert.False(linkFactory.ParseLink(link, out var actualUri));
+            Assert.That(actualUri, Is.Null);
+        }
+
         [Test]
         public void ParseGoToBranchLink()
         {
             var linkFactory = new LinkFactory();
             linkFactory.CreateBranchLink("master");
             string expected = "gitext://gotobranch/master";
-            string actual = linkFactory.ParseLink("master#gitext://gotobranch/master");
-            Assert.That(actual, Is.EqualTo(expected));
+            Assert.True(linkFactory.ParseLink("master#gitext://gotobranch/master", out var actualUri));
+            Assert.That(actualUri.AbsoluteUri, Is.EqualTo(expected));
         }
 
         [Test]
@@ -22,17 +33,17 @@ namespace ResourceManagerTests
             var linkFactory = new LinkFactory();
             linkFactory.CreateBranchLink("PR#23");
             string expected = "gitext://gotobranch/PR#23";
-            string actual = linkFactory.ParseLink("PR#23#gitext://gotobranch/PR#23");
-            Assert.That(actual, Is.EqualTo(expected));
+            Assert.True(linkFactory.ParseLink("PR#23#gitext://gotobranch/PR#23", out var actualUri));
+            Assert.That(actualUri.AbsoluteUri, Is.EqualTo(expected));
         }
 
         private static void TestCreateLink(string caption, string uri)
         {
             var linkFactory = new LinkFactory();
             linkFactory.CreateLink(caption, uri);
-            string actual = linkFactory.ParseLink(caption + "#" + uri);
             string expected = uri;
-            Assert.That(actual, Is.EqualTo(expected));
+            Assert.True(linkFactory.ParseLink(caption + "#" + uri, out var actualUri));
+            Assert.That(actualUri.AbsoluteUri, Is.EqualTo(expected));
         }
 
         [Test]
@@ -53,8 +64,8 @@ namespace ResourceManagerTests
             var linkFactory = new LinkFactory();
 
             string expected = "https://github.com/gitextensions/gitextensions/pull/3471#end";
-            string actual = linkFactory.ParseLink("https://github.com/gitextensions/gitextensions/pull/3471#end");
-            Assert.That(actual, Is.EqualTo(expected));
+            Assert.True(linkFactory.ParseLink("https://github.com/gitextensions/gitextensions/pull/3471#end", out var actualUri));
+            Assert.That(actualUri.AbsoluteUri, Is.EqualTo(expected));
         }
 
         [Test]

--- a/UnitTests/ResourceManager.Tests/LinkFactoryFixture.cs
+++ b/UnitTests/ResourceManager.Tests/LinkFactoryFixture.cs
@@ -111,5 +111,50 @@ namespace ResourceManagerTests
             Assert.That(actualCommandEventArgs.Command, Is.EqualTo(expectedCommand));
             Assert.That(actualCommandEventArgs.Data, Is.EqualTo(expectedData));
         }
+
+        [TestCase("gitext://command/data", "command", "data", null, "", false, true)]
+        [TestCase("gitext://command/data", "command", "data", null, "", false, false)]
+        [TestCase("gitext://showall/what", null, null, "what", "", true, false)]
+        [TestCase("gitext://showall/what", null, null, "what", "", false, false)]
+        [TestCase("gitext://command/data", null, null, null, "unexpected internal link: gitext://command/data", true, false)]
+        [TestCase("gitext://showall/what", null, null, null, "unexpected internal link: gitext://showall/what", false, true)]
+        public void ExecuteLink(string link,
+            string expectedCommand,
+            string expectedData,
+            string expectedShowAll,
+            string expectedException,
+            bool omitHandler,
+            bool omitShowAll)
+        {
+            var linkFactory = new LinkFactory();
+            CommandEventArgs actualCommandEventArgs = null;
+            string actualShowAll = null;
+            string actualException = "";
+            Action<CommandEventArgs> handleInternalLink = commandEventArgs => actualCommandEventArgs = commandEventArgs;
+            Action<string> showAll = what => actualShowAll = what;
+            if (omitHandler)
+            {
+                handleInternalLink = null;
+            }
+
+            if (omitShowAll)
+            {
+                showAll = null;
+            }
+
+            try
+            {
+                linkFactory.ExecuteLink(link, handleInternalLink, showAll);
+            }
+            catch (InvalidOperationException ex)
+            {
+                actualException = ex.Message;
+            }
+
+            Assert.That(actualCommandEventArgs?.Command, Is.EqualTo(expectedCommand));
+            Assert.That(actualCommandEventArgs?.Data, Is.EqualTo(expectedData));
+            Assert.That(actualShowAll, Is.EqualTo(expectedShowAll));
+            Assert.That(actualException, Is.EqualTo(expectedException));
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7582

## Proposed changes

- Handle `showall` links in `CommitInfo` directly
- Pop up exception on link execution in `CommitInfo`, too
- Factor out `ILinkFactory.ExecuteLink`
- Factor out `ILinkFactory.ParseInternalScheme`
- Refactor `ILinkFactory.ParseLink to yield Uri`

## Test methodology <!-- How did you ensure quality? -->

- added NUnit tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build pop up link exception in CommitInfo, too
- Git 2.26.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4121.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
