### PR TITLE
Fix #7937 Reflog form : index was out of range.

### DIFF
--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -125,9 +125,17 @@ namespace GitUI.CommandsDialogs
 
             DataGridViewRow GetSelectedRow()
             {
-                return gridReflog.SelectedRows.Count > 0
-                    ? gridReflog.SelectedRows[0]
-                    : gridReflog.Rows[gridReflog.SelectedCells[0].RowIndex];
+                if (gridReflog.SelectedRows.Count > 0)
+                {
+                    return gridReflog.SelectedRows[0];
+                }
+
+                if (gridReflog.SelectedCells.Count > 0)
+                {
+                    return gridReflog.Rows[gridReflog.SelectedCells[0].RowIndex];
+                }
+
+                return gridReflog.CurrentRow;
             }
         }
 


### PR DESCRIPTION
Fixes #7937 

## Proposed changes

In the Reflog form, when the popup are shown, if no row or cell are selected, use the current row.

### Before

An exception are shown.

### After

Use the commit in the current row.

## Test methodology <!-- How did you ensure quality? -->

I tried to copy a SHA with a line deselected. It crashes without my patch. It works with my patch.

## Test environment(s)

- Git Extensions 3.3.1.7897
- Git 2.25.1.windows.1
- Microsoft Windows NT 10.0.18363.0
- .NET Framework 4.8.4150.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
