### PR TITLE
Disable tests in DEBUG for DoAutoCRLF_should_not_unnecessarily_duplic…

### DIFF
--- a/UnitTests/GitUI.Tests/Editor/FileViewerTextTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/FileViewerTextTests.cs
@@ -36,6 +36,9 @@ namespace GitUITests.Editor
             _fileViewer.Dispose();
         }
 
+        // Temporarily disabled, see issue #8000
+        // These tests often fail on developer PCs, then ApprovalTest opens a diff viewer (where the open can fail too)
+#if !DEBUG
         [Test]
         [TestCase(AutoCRLFType.@true, "UnixLines")]
         [TestCase(AutoCRLFType.@true, "MacLines")]
@@ -76,6 +79,7 @@ namespace GitUITests.Editor
                 }
             }
         }
+#endif
 
         /// <summary>
         /// When: some text is selected in a <see cref="FileViewer"/>.


### PR DESCRIPTION
…ate_line_ending

Workaround for #8000

## Proposed changes

Disable test for DoAutoCRLF_should_not_unnecessarily_duplicate_line_ending in DEBUG
It often fails with empty output for unknown reason.
As it is an ApprovalTest, it tries to be friendly and opens a diff tool. That fails and is not easy to configure.
See discussion in #7417 

The test still runs in the build server, test kept in Release
(could be limited to the build server, but this change eliminates the annoyance for the developer in most situations as well as documents the problem.)

## Test methodology 

Disable flaky test

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
