### PR TITLE
Tweak commit hash of portable build

### DIFF
--- a/GitExtensions/Project.Publish.targets
+++ b/GitExtensions/Project.Publish.targets
@@ -71,6 +71,7 @@
       <_PublishPortableVersionSuffix>-$(CurrentBuildVersion.ToString())</_PublishPortableVersionSuffix>
       <_PublishPortableCommitHashSuffix Condition="'$(GitCommit)' != ''">-$(GitCommit)</_PublishPortableCommitHashSuffix>
       <_PublishPortableCommitHashSuffix Condition="'$(env:APPVEYOR_REPO_COMMIT)' != ''">-$(env:APPVEYOR_REPO_COMMIT)</_PublishPortableCommitHashSuffix>
+      <_PublishPortableCommitHashSuffix Condition="'$(env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)' != ''">-$(env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)</_PublishPortableCommitHashSuffix>
       <_PublishPortableFileName>GitExtensions-Portable$(_PublishPortableVersionSuffix)$(_PublishPortableCommitHashSuffix).zip</_PublishPortableFileName>
       <_PublishPortablePath>$([MSBuild]::NormalizePath('$(ArtifactsPublishDir)', '$(_PublishPortableFileName)'))</_PublishPortablePath>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,10 @@ build:
 
 install:
 - cmd: git submodule update --init --recursive
+- cmd: echo %APPVEYOR_REPO_COMMIT%
+- cmd: echo %APPVEYOR_PULL_REQUEST_HEAD_COMMIT%
+  # if building a temporary merge with master, reset the git revision to the HEAD of the PR, keeping the files of the merge of course
+- cmd: if not "%APPVEYOR_PULL_REQUEST_HEAD_COMMIT%" == "" if not "%APPVEYOR_PULL_REQUEST_HEAD_COMMIT%" == "%APPVEYOR_REPO_COMMIT%" git reset --soft "%APPVEYOR_PULL_REQUEST_HEAD_COMMIT%" --
 - cmd: echo /logger:"%ProgramFiles%\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll">> Directory.Build.rsp
 - cmd: |-
     cd scripts


### PR DESCRIPTION
Fixes #7979

## Proposed changes

- Tweak the commit hash of portable builds both
  - in the name of zip file
  - in `ThisAssembly.Git.Sha` (by soft resetting git to the head commit of the PR)

## Screenshot

![grafik](https://user-images.githubusercontent.com/36601201/79701667-262b3c00-829f-11ea-9943-a7f4f4a0b280.png)

## Test methodology <!-- How did you ensure quality? -->

- run AppVeyor

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
