### PR TITLE
Update artificial commit diff

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -637,7 +637,7 @@ namespace GitCommands
             set => SetBool("closecommitdialogafterlastcommit", value);
         }
 
-        public static bool RefreshCommitDialogOnFormFocus
+        public static bool RefreshArtificialCommitOnApplicationActivated
         {
             get => GetBool("refreshcommitdialogonformfocus", false);
             set => SetBool("refreshcommitdialogonformfocus", value);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -506,6 +506,16 @@ namespace GitUI.CommandsDialogs
             base.Dispose(disposing);
         }
 
+        protected override void OnApplicationActivated()
+        {
+            if (AppSettings.RefreshCommitDialogOnFormFocus && CommitInfoTabControl.SelectedTab == DiffTabPage)
+            {
+                revisionDiff.RefreshArtificial();
+            }
+
+            base.OnApplicationActivated();
+        }
+
         protected override void OnLoad(EventArgs e)
         {
             _windowsJumpListManager.CreateJumpList(

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -508,7 +508,7 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnApplicationActivated()
         {
-            if (AppSettings.RefreshCommitDialogOnFormFocus && CommitInfoTabControl.SelectedTab == DiffTabPage)
+            if (AppSettings.RefreshArtificialCommitOnApplicationActivated && CommitInfoTabControl.SelectedTab == DiffTabPage)
             {
                 revisionDiff.RefreshArtificial();
             }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -232,7 +232,7 @@ namespace GitUI.CommandsDialogs
             StageInSuperproject.Checked = AppSettings.StageInSuperprojectAfterCommit;
             closeDialogAfterEachCommitToolStripMenuItem.Checked = AppSettings.CloseCommitDialogAfterCommit;
             closeDialogAfterAllFilesCommittedToolStripMenuItem.Checked = AppSettings.CloseCommitDialogAfterLastCommit;
-            refreshDialogOnFormFocusToolStripMenuItem.Checked = AppSettings.RefreshCommitDialogOnFormFocus;
+            refreshDialogOnFormFocusToolStripMenuItem.Checked = AppSettings.RefreshArtificialCommitOnApplicationActivated;
             ShowOnlyMyMessagesToolStripMenuItem.Checked = AppSettings.CommitDialogShowOnlyMyMessages;
 
             Unstaged.SetNoFilesText(_noUnstagedChanges.Text);
@@ -404,7 +404,7 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnApplicationActivated()
         {
-            if (!_bypassActivatedEventHandler && AppSettings.RefreshCommitDialogOnFormFocus)
+            if (!_bypassActivatedEventHandler && AppSettings.RefreshArtificialCommitOnApplicationActivated)
             {
                 RescanChanges();
             }
@@ -2977,7 +2977,7 @@ namespace GitUI.CommandsDialogs
         private void refreshDialogOnFormFocusToolStripMenuItem_Click(object sender, EventArgs e)
         {
             refreshDialogOnFormFocusToolStripMenuItem.Checked = !refreshDialogOnFormFocusToolStripMenuItem.Checked;
-            AppSettings.RefreshCommitDialogOnFormFocus = refreshDialogOnFormFocusToolStripMenuItem.Checked;
+            AppSettings.RefreshArtificialCommitOnApplicationActivated = refreshDialogOnFormFocusToolStripMenuItem.Checked;
         }
 
         private void signOffToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7875

## Proposed changes

- Update artificial commit in FormBrowse on `WM_ACTIVATEAPP`
  in dependency on the regarding setting used in FormCommit
- Rename `AppSettings.RefreshCommitDialogOnFormFocus`to `RefreshArtificialCommitOnApplicationActivated`

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 8a24eb00c4b3f4b457d1cff5845637989bb23c1b
- Git 2.26.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4121.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
