### PR TITLE
Cleanup git status before calling TranslationApp

### DIFF
--- a/GitExtensions/Project.Publish.targets
+++ b/GitExtensions/Project.Publish.targets
@@ -148,6 +148,7 @@
       <_PublishMsiVersionSuffix>-$(CurrentBuildVersion.ToString())</_PublishMsiVersionSuffix>
       <_PublishMsiCommitHashSuffix Condition="'$(GitCommit)' != ''">-$(GitCommit)</_PublishMsiCommitHashSuffix>
       <_PublishMsiCommitHashSuffix Condition="'$(env:APPVEYOR_REPO_COMMIT)' != ''">-$(env:APPVEYOR_REPO_COMMIT)</_PublishMsiCommitHashSuffix>
+      <_PublishMsiCommitHashSuffix Condition="'$(env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)' != ''">-$(env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)</_PublishMsiCommitHashSuffix>
       <_PublishMsiFileName>GitExtensions$(_PublishPortableVersionSuffix)$(_PublishPortableCommitHashSuffix)</_PublishMsiFileName>
       <_PublishMsiPath>$([MSBuild]::NormalizePath('$(ArtifactsPublishDir)'))</_PublishMsiPath>
     </PropertyGroup>

--- a/appveyor.experimental.yml
+++ b/appveyor.experimental.yml
@@ -60,7 +60,7 @@ build_script:
       & .\scripts\Mark-RepoClean.ps1
     }
 
-    # if building a temporary merge with master, reset the git revision to the HEAD of the PR, keeping the files of the merge of course
+    # if building a temporary merge with master, soft reset to the PR commit so the build contains the PR's hash instead of the merge-commit's hash
     if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and ($env:APPVEYOR_REPO_COMMIT -ne $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT))
     {
       git reset --soft "$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT" --
@@ -70,8 +70,7 @@ build_script:
     & .\cibuild.cmd -restore -build -buildNative -logFileName build.binlog
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 
-    # for pull-requests we get merge-commits, and we reset to the actual PR commit, for the build contains the correct hash
-    # to verify the localisation was done correctly we don't need the original hash, so reset it back
+    # if we have reset above we need to reset English xlfs, otherwise the loc verification step will fail
     # refer to https://github.com/gitextensions/gitextensions/issues/7979
     if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT) {
       git reset $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT --quiet -- "GitUI/Translation/English.xlf" "GitUI/Translation/English.Plugins.xlf"
@@ -107,8 +106,8 @@ test_script:
         Write-Host ""
         Write-Host "[INFO]: Test Run ${testRun}/${testRunCount}${failedBefore}"
 
-        if ($runUnitTests        -ne 0) { & .\cibuild.cmd -test            -logFileName UnitTest.binlog        /p:NoBuild=true }
-        if ($runIntegrationTests -ne 0) { & .\cibuild.cmd -integrationTest -logFileName IntegrationTest.binlog /p:NoBuild=true }
+        if ($runUnitTests        -ne 0) { & .\cibuild.cmd /p:NoBuild=true -test            -logFileName UnitTest.binlog        }
+        if ($runIntegrationTests -ne 0) { & .\cibuild.cmd /p:NoBuild=true -integrationTest -logFileName IntegrationTest.binlog }
 
         Get-ChildItem -recurse artifacts\tests\TestResult.xml -ErrorAction SilentlyContinue `
         | ForEach-Object {

--- a/appveyor.experimental.yml
+++ b/appveyor.experimental.yml
@@ -42,6 +42,8 @@ build:
   verbosity: minimal
 
 install:
+- cmd: echo %APPVEYOR_REPO_COMMIT%
+- cmd: echo %APPVEYOR_PULL_REQUEST_HEAD_COMMIT%
 - cmd: git submodule update --init --recursive
 - cmd: echo /logger:"%ProgramFiles%\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll">> Directory.Build.rsp
 - cmd: |-
@@ -58,9 +60,29 @@ build_script:
       & .\scripts\Mark-RepoClean.ps1
     }
 
+    # if building a temporary merge with master, reset the git revision to the HEAD of the PR, keeping the files of the merge of course
+    if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and ($env:APPVEYOR_REPO_COMMIT -ne $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT))
+    {
+      git reset --soft "$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT" --
+    }
+
     # build
-    & .\cibuild.cmd -restore -build -buildNative
+    & .\cibuild.cmd -restore -build -buildNative -logFileName build.binlog
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+
+    # for pull-requests we get merge-commits, and we reset to the actual PR commit, for the build contains the correct hash
+    # to verify the localisation was done correctly we don't need the original hash, so reset it back
+    # refer to https://github.com/gitextensions/gitextensions/issues/7979
+    if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT) {
+      git reset $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT --quiet -- "GitUI/Translation/English.xlf" "GitUI/Translation/English.Plugins.xlf"
+      git checkout                                     --force -- "GitUI/Translation/English.xlf" "GitUI/Translation/English.Plugins.xlf"
+    }
+
+    # it would be nice to run '.\cibuild.cmd -loc -logFileName localise.binlog /p:NoBuild=true' but it doesn't work without `-build` switch :\
+    Push-Location .\GitExtensions
+    msbuild /p:Configuration=Release /t:_UpdateEnglishTranslations /p:RunTranslationApp=true /p:ContinuousIntegrationBuild=true /v:m /bl:..\artifacts\log\localise.binlog
+    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+    Pop-Location
 
 
 # to run your custom scripts instead of automatic tests
@@ -85,8 +107,8 @@ test_script:
         Write-Host ""
         Write-Host "[INFO]: Test Run ${testRun}/${testRunCount}${failedBefore}"
 
-        if ($runUnitTests        -ne 0) { & .\cibuild.cmd -test }
-        if ($runIntegrationTests -ne 0) { & .\cibuild.cmd -integrationTest }
+        if ($runUnitTests        -ne 0) { & .\cibuild.cmd -test            -logFileName UnitTest.binlog        /p:NoBuild=true }
+        if ($runIntegrationTests -ne 0) { & .\cibuild.cmd -integrationTest -logFileName IntegrationTest.binlog /p:NoBuild=true }
 
         Get-ChildItem -recurse artifacts\tests\TestResult.xml -ErrorAction SilentlyContinue `
         | ForEach-Object {
@@ -119,7 +141,7 @@ test_script:
 after_test:
 - ps: |
     Write-Host "Preparing build artifacts..."
-    & .\cibuild.cmd -publish
+    & .\cibuild.cmd -publish -logFileName publish.binlog
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 
 
@@ -129,3 +151,12 @@ artifacts:
 
 #on_finish:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+
+# on build failure
+on_failure:
+- ps: |
+    Get-ChildItem -recurse artifacts\log\*.binlog -ErrorAction SilentlyContinue `
+    | ForEach-Object {
+        Push-AppveyorArtifact "$_"
+    }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,10 +25,6 @@ build:
 
 install:
 - cmd: git submodule update --init --recursive
-- cmd: echo %APPVEYOR_REPO_COMMIT%
-- cmd: echo %APPVEYOR_PULL_REQUEST_HEAD_COMMIT%
-  # if building a temporary merge with master, reset the git revision to the HEAD of the PR, keeping the files of the merge of course
-- cmd: if not "%APPVEYOR_PULL_REQUEST_HEAD_COMMIT%" == "" if not "%APPVEYOR_PULL_REQUEST_HEAD_COMMIT%" == "%APPVEYOR_REPO_COMMIT%" git reset --soft "%APPVEYOR_PULL_REQUEST_HEAD_COMMIT%" --
 - cmd: echo /logger:"%ProgramFiles%\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll">> Directory.Build.rsp
 - cmd: |-
     cd scripts
@@ -44,17 +40,37 @@ build_script:
       & .\scripts\Mark-RepoClean.ps1
     }
 
+    # if building a temporary merge with master, reset the git revision to the HEAD of the PR, keeping the files of the merge of course
+    if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and ($env:APPVEYOR_REPO_COMMIT -ne $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT))
+    {
+      git reset --soft "$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT" --
+    }
+
     # build
-    & .\cibuild.cmd -restore -build -buildNative -loc
+    & .\cibuild.cmd -restore -build -buildNative -logFileName build.binlog
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+
+    # for pull-requests we get merge-commits, and we reset to the actual PR commit, for the build contains the correct hash
+    # to verify the localisation was done correctly we don't need the original hash, so reset it back
+    # refer to https://github.com/gitextensions/gitextensions/issues/7979
+    if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT) {
+      git reset $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT --quiet -- "GitUI/Translation/English.xlf" "GitUI/Translation/English.Plugins.xlf"
+      git checkout                                     --force -- "GitUI/Translation/English.xlf" "GitUI/Translation/English.Plugins.xlf"
+    }
+
+    # it would be nice to run '.\cibuild.cmd -loc -logFileName localise.binlog /p:NoBuild=true' but it doesn't work without `-build` switch :\
+    Push-Location .\GitExtensions
+    msbuild /p:Configuration=Release /t:_UpdateEnglishTranslations /p:RunTranslationApp=true /p:ContinuousIntegrationBuild=true /v:m /bl:..\artifacts\log\localise.binlog
+    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+    Pop-Location
 
 
 # to run your custom scripts instead of automatic tests
 test_script:
 - ps: |
-    & .\cibuild.cmd -test
-    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode);  }
-    & .\cibuild.cmd -integrationTest
+    & .\cibuild.cmd -test            -logFileName UnitTest.binlog        /p:NoBuild=true
+    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+    & .\cibuild.cmd -integrationTest -logFileName IntegrationTest.binlog /p:NoBuild=true
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 
 
@@ -62,7 +78,7 @@ test_script:
 after_test:
 - ps: |
     Write-Host "Preparing build artifacts..."
-    & .\cibuild.cmd -publish
+    & .\cibuild.cmd -publish -logFileName publish.binlog
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 
 
@@ -73,8 +89,14 @@ artifacts:
 #on_finish:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
+
 # on build failure
 on_failure:
+- ps: |
+    Get-ChildItem -recurse artifacts\log\*.binlog -ErrorAction SilentlyContinue `
+    | ForEach-Object {
+        Push-AppveyorArtifact "$_"
+    }
 - ps: |
     Get-ChildItem -recurse artifacts\tests\TestResult.xml -ErrorAction SilentlyContinue `
     | ForEach-Object {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ build_script:
       & .\scripts\Mark-RepoClean.ps1
     }
 
-    # if building a temporary merge with master, reset the git revision to the HEAD of the PR, keeping the files of the merge of course
+    # if building a temporary merge with master, soft reset to the PR commit so the build contains the PR's hash instead of the merge-commit's hash
     if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and ($env:APPVEYOR_REPO_COMMIT -ne $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT))
     {
       git reset --soft "$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT" --
@@ -50,8 +50,7 @@ build_script:
     & .\cibuild.cmd -restore -build -buildNative -logFileName build.binlog
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 
-    # for pull-requests we get merge-commits, and we reset to the actual PR commit, for the build contains the correct hash
-    # to verify the localisation was done correctly we don't need the original hash, so reset it back
+    # if we have reset above we need to reset English xlfs, otherwise the loc verification step will fail
     # refer to https://github.com/gitextensions/gitextensions/issues/7979
     if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT) {
       git reset $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT --quiet -- "GitUI/Translation/English.xlf" "GitUI/Translation/English.Plugins.xlf"
@@ -68,9 +67,9 @@ build_script:
 # to run your custom scripts instead of automatic tests
 test_script:
 - ps: |
-    & .\cibuild.cmd -test            -logFileName UnitTest.binlog        /p:NoBuild=true
+    & .\cibuild.cmd /p:NoBuild=true -test -logFileName UnitTest.binlog
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
-    & .\cibuild.cmd -integrationTest -logFileName IntegrationTest.binlog /p:NoBuild=true
+    & .\cibuild.cmd /p:NoBuild=true -integrationTest -logFileName IntegrationTest.binlog
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,6 +1,7 @@
 [CmdletBinding(PositionalBinding=$false)]
 Param(
   [string] $version,
+  [string] $logFileName = "build.binlog",
   [string][Alias('c')] $configuration = "Debug",
   [string][Alias('v')] $verbosity = "minimal",
   [switch] $restore,
@@ -69,7 +70,7 @@ function Build {
   }
 
   # build the solution
-  $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "build.binlog") } else { "" }
+  $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir $logFileName) } else { "" }
   $platformArg = if ($platform) { "/p:Platform=$platform" } else { "" }
 
   MSBuild $toolsetBuildProj `


### PR DESCRIPTION
Fixes #7979


## Proposed changes

- Cleanup the git status of `English.xlf` and `English.Plugins.xlf` before calling the `TranslationApp` if a `git reset --soft` was done in order to tweak the commit hash
  which is done only if the env var `"APPVEYOR_PULL_REQUEST_HEAD_COMMIT` is set
- Use the same commit hash for the `.msi`
- Keep the `.binlog` files on failure, too

## Test methodology <!-- How did you ensure quality? -->

- CI build
  - with and without correct `English.xlf`
  - with PR branch based on current and on earlier master

## Test environment(s) <!-- Remove any that don't apply -->

- AppVeyor
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
