### PR TITLE
Apply dark theme for check boxes in NativeListView

### DIFF
--- a/GitUI/Interops/DTBGOPTS.cs
+++ b/GitUI/Interops/DTBGOPTS.cs
@@ -7,8 +7,8 @@ namespace System
         [StructLayout(LayoutKind.Sequential)]
         public struct DTBGOPTS
         {
-            public int dwSize;
-            public int dwFlags;
+            public uint dwSize;
+            public uint dwFlags;
             public RECT rcClip;
         }
     }

--- a/GitUI/Interops/DTBGOPTS.cs
+++ b/GitUI/Interops/DTBGOPTS.cs
@@ -1,0 +1,15 @@
+﻿using System.Runtime.InteropServices;
+
+namespace System
+{
+    internal static partial class NativeMethods
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        public struct DTBGOPTS
+        {
+            public int dwSize;
+            public int dwFlags;
+            public RECT rcClip;
+        }
+    }
+}

--- a/GitUI/Theming/Renderers/ListViewRenderer.cs
+++ b/GitUI/Theming/Renderers/ListViewRenderer.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Drawing;
+using System.Windows.Forms;
+using System.Windows.Forms.VisualStyles;
 using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 
@@ -59,6 +61,44 @@ namespace GitUI.Theming
                     default:
                         return Unhandled;
                 }
+            }
+        }
+
+        public override int RenderBackgroundEx(
+            IntPtr htheme, IntPtr hdc,
+            int partid, int stateid,
+            NativeMethods.RECTCLS prect, ref NativeMethods.DTBGOPTS poptions)
+        {
+            switch ((Parts)partid)
+            {
+                case Parts.LVP_LISTDETAIL:
+                    CheckBoxState state;
+                    switch ((State.ListItem)stateid)
+                    {
+                        case State.ListItem.LISS_NORMAL:
+                            state = CheckBoxState.UncheckedNormal;
+                            break;
+
+                        case State.ListItem.LISS_SELECTEDNOTFOCUS:
+                            state = CheckBoxState.CheckedNormal;
+                            break;
+
+                        default:
+                            return Unhandled;
+                    }
+
+                    using (var ctx = CreateRenderContext(hdc, clip: null))
+                    {
+                        CheckBoxRenderer.DrawCheckBox(
+                            ctx.Graphics,
+                            new Point(prect.Left, prect.Top),
+                            state);
+                    }
+
+                    return Handled;
+
+                default:
+                    return Unhandled;
             }
         }
 

--- a/GitUI/Theming/Renderers/ThemeRenderer.cs
+++ b/GitUI/Theming/Renderers/ThemeRenderer.cs
@@ -16,12 +16,12 @@ namespace GitUI.Theming
         /// Result code indicating theming method's task was not achieved.
         /// In this case original win32 theming api method is applied by <see cref="Win32ThemeHooks"/>
         /// </summary>
-        protected const int Unhandled = 1;
+        public const int Unhandled = 1;
 
         /// <summary>
         /// Result code indicating successful completion of theming method's task
         /// </summary>
-        protected const int Handled = 0;
+        public const int Handled = 0;
 
         private readonly HashSet<IntPtr> _themeDataHandles = new HashSet<IntPtr>();
 
@@ -36,6 +36,14 @@ namespace GitUI.Theming
 
         public virtual int RenderBackground(IntPtr hdc, int partid, int stateid, Rectangle prect,
             NativeMethods.RECTCLS pcliprect)
+        {
+            return Unhandled;
+        }
+
+        public virtual int RenderBackgroundEx(
+            IntPtr htheme, IntPtr hdc,
+            int partid, int stateid,
+            NativeMethods.RECTCLS prect, ref NativeMethods.DTBGOPTS poptions)
         {
             return Unhandled;
         }

--- a/GitUI/Theming/Win32ThemeDelegates.cs
+++ b/GitUI/Theming/Win32ThemeDelegates.cs
@@ -15,6 +15,11 @@ namespace GitUI.Theming
         int partId, int stateId,
         NativeMethods.RECTCLS prect, NativeMethods.RECTCLS pcliprect);
 
+    [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true, CharSet = CharSet.Unicode)]
+    internal delegate int DrawThemeBackgroundExDelegate(
+        IntPtr htheme, IntPtr hdc, int partId, int stateId,
+        NativeMethods.RECTCLS prect, ref NativeMethods.DTBGOPTS poptions);
+
     [UnmanagedFunctionPointer(CallingConvention.StdCall, SetLastError = true)]
     internal delegate int GetThemeColorDelegate(
         IntPtr htheme, int ipartid, int istateid, int ipropid, out int pcolor);

--- a/GitUI/UserControls/NativeListView.cs
+++ b/GitUI/UserControls/NativeListView.cs
@@ -4,10 +4,15 @@ namespace GitUI.UserControls
 {
     public class NativeListView : System.Windows.Forms.ListView
     {
+        internal static event EventHandler BeginCreateHandle;
+        internal static event EventHandler EndCreateHandle;
+
         protected override void CreateHandle()
         {
+            BeginCreateHandle?.Invoke(this, EventArgs.Empty);
             base.CreateHandle();
             NativeMethods.SetWindowTheme(Handle, "explorer", null);
+            EndCreateHandle?.Invoke(this, EventArgs.Empty);
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

The solution used to detect when check boxes are painted is dirty.

The check boxes are painted by windows once, when ListView control is created.

Theming hook method, the one that desides whether rendering shoud be overriden, receives `IntPtr hTheme` - a handle of theme data. It's always a pain to find out which type of control is being painted, because AFAIK there is no API to infer it from `hTheme`.

One workaround that worked in all previous cases, was to exploit the fact that `OpenThemeData(control.Handle, partName)` returns the same `hTheme`  until `CloseThemeData` is called with same `control.Handle` and `partName` values.

`hTheme` depends only on 2 parameters - the window class of the control, and `partName`.

So I would normally `OpenThemeData(listView.Handle, "ListView")`, remember which `hTheme` was returned and then any ListView rendereng in application lifetime would happen with this known `hTheme` value.

In this PR however I was out of luck finding which window class + part name are used by Windows when rendering the checkBoxes. A brute force search failed. 

So eventually I used a workaround: I know that that CheckBoxes are painted when NativeListView is initializing. So if the hooked `DrawThemeBackgroundEx` is called while a NativeListView with checkboxes is being initialized, the theming override is applied.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/12046452/79698135-7ef2d880-828f-11ea-863f-94b2d528f3af.png)

### After

![image](https://user-images.githubusercontent.com/12046452/80269003-ae9d4880-86b4-11ea-8cf6-36164d53e825.png)

## Test methodology

manually

## Test environment(s)

Windows 10, default dpi (96)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).