### PR TITLE
Fix for #8030 URL in "Edit Remote Details"is case insensitive

### DIFF
--- a/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
+++ b/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
@@ -329,13 +329,13 @@ namespace GitCommands.Remotes
                 }
 
                 remoteDisabled = remote.Disabled;
-                if (!string.Equals(remote.Name, remoteName, StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(remote.Name, remoteName, StringComparison.Ordinal))
                 {
                     // the name of the remote changed - perform rename
                     output = module.RenameRemote(remote.Name, remoteName);
                 }
 
-                if (!string.Equals(remote.Url, remoteUrl, StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(remote.Url, remoteUrl, StringComparison.Ordinal))
                 {
                     // the remote url changed - we may need to update remote
                     updateRemoteRequired = true;

--- a/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -48,9 +48,9 @@ namespace GitUI.CommandsDialogs
             this.tblpnlMgtDetails = new System.Windows.Forms.TableLayoutPanel();
             this.label1 = new System.Windows.Forms.Label();
             this.folderBrowserButtonPushUrl = new GitUI.UserControls.FolderBrowserButton();
-            this.comboBoxPushUrl = new System.Windows.Forms.ComboBox();
+            this.comboBoxPushUrl = new GitUI.UserControls.CaseSensitiveComboBox();
             this.label2 = new System.Windows.Forms.Label();
-            this.Url = new System.Windows.Forms.ComboBox();
+            this.Url = new GitUI.UserControls.CaseSensitiveComboBox();
             this.labelPushUrl = new System.Windows.Forms.Label();
             this.folderBrowserButtonUrl = new GitUI.UserControls.FolderBrowserButton();
             this.checkBoxSepPushUrl = new System.Windows.Forms.CheckBox();
@@ -774,10 +774,10 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.TextBox RemoteName;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.ComboBox Url;
+        private GitUI.UserControls.CaseSensitiveComboBox Url;
         private System.Windows.Forms.CheckBox checkBoxSepPushUrl;
         private System.Windows.Forms.Label labelPushUrl;
-        private System.Windows.Forms.ComboBox comboBoxPushUrl;
+        private GitUI.UserControls.CaseSensitiveComboBox comboBoxPushUrl;
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.DataGridView RemoteBranches;

--- a/GitUI/UserControls/CaseSensitiveComboBox.cs
+++ b/GitUI/UserControls/CaseSensitiveComboBox.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows.Forms;
+
+namespace GitUI.UserControls
+{
+    public class CaseSensitiveComboBox : ComboBox
+    {
+        private const AutoCompleteMode Mode = AutoCompleteMode.SuggestAppend;
+        private string _lastTextChangedValue;
+
+        private bool SystemAutoCompleteEnabled
+        {
+            get => Mode != AutoCompleteMode.None && DropDownStyle != ComboBoxStyle.DropDownList;
+        }
+
+        protected override void OnValidating(CancelEventArgs e)
+        {
+            if (SystemAutoCompleteEnabled)
+            {
+                NotifyAutoComplete();
+            }
+        }
+
+        protected override void OnTextChanged(EventArgs e)
+        {
+            if (SystemAutoCompleteEnabled)
+            {
+                string text = Text;
+                if (text == _lastTextChangedValue)
+                {
+                    return;
+                }
+
+                _lastTextChangedValue = text;
+            }
+
+            base.OnTextChanged(e);
+        }
+
+        private int FindStringExactCase(string s)
+        {
+            for (int i = 0; i < Items.Count; i++)
+            {
+                if (GetItemText(Items[i]).Equals(s, StringComparison.Ordinal))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private void NotifyAutoComplete()
+        {
+            string text = Text;
+            bool textChanged = text != _lastTextChangedValue;
+            bool selectedIndexSet = false;
+            int index;
+            if (textChanged && text.Equals(_lastTextChangedValue, StringComparison.OrdinalIgnoreCase))
+            {
+                index = -1;
+            }
+            else
+            {
+                index = FindStringExactCase(text);
+            }
+
+            if (index != -1 && index != SelectedIndex)
+            {
+                SelectedIndex = index;
+                SelectionStart = 0;
+                SelectionLength = text.Length;
+                selectedIndexSet = true;
+            }
+
+            if (textChanged && !selectedIndexSet)
+            {
+                OnTextChanged(EventArgs.Empty);
+            }
+
+            _lastTextChangedValue = text;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8030


## Proposed changes

- Change SaveRemote to consider case when deciding if the url text has changed
- Override Autocomplete behavior in ComboBox to prevent it from resetting case-only changes

## Test methodology

- Manually tested by changing the url by 1,2 and 3 letters.
- Manually verified that autocomplete still works


## Test environment(s)

- GIT  2.26.2
- Windows 10 latest update


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
