### PR TITLE
Remove debugging code

### DIFF
--- a/GitUI/Theming/Win32ThemeHooks.cs
+++ b/GitUI/Theming/Win32ThemeHooks.cs
@@ -234,7 +234,6 @@ namespace GitUI.Theming
             int partid, int stateid,
             NativeMethods.RECTCLS prect, ref NativeMethods.DTBGOPTS poptions)
         {
-            Debug.WriteLine($"DrawThemeBackgroundEx {htheme} part {partid} state {stateid}");
             if (!BypassThemeRenderers)
             {
                 var renderer = _renderers.FirstOrDefault(_ => _.Supports(htheme));


### PR DESCRIPTION
A `Debug.WriteLine()` call slipped into my previous PR, only noticed it now.