### PR TITLE
Fix 3954 quotes in merge commit message

### DIFF
--- a/GitCommands/CommitMessageManager.cs
+++ b/GitCommands/CommitMessageManager.cs
@@ -15,7 +15,7 @@ namespace GitCommands
         bool AmendState { get; set; }
 
         /// <summary>
-        /// The pathname of the file where a prepared (non-merge) commit message is stored.
+        /// The path of .git/COMMITMESSAGE, where a prepared (non-merge) commit message is stored.
         /// </summary>
         string CommitMessagePath { get; }
 
@@ -23,6 +23,11 @@ namespace GitCommands
         /// Returns whether .git/MERGE_MSG exists.
         /// </summary>
         bool IsMergeCommit { get; }
+
+        /// <summary>
+        /// The path of .git/MERGE_MSG, where a merge-commit message is stored.
+        /// </summary>
+        string MergeMessagePath { get; }
 
         /// <summary>
         /// Reads/stores the prepared commit message from/in .git/MERGE_MSG if it exists or else in .git/COMMITMESSAGE.
@@ -33,6 +38,16 @@ namespace GitCommands
         /// Deletes .git/COMMITMESSAGE and the file with the AmendState.
         /// </summary>
         void ResetCommitMessage();
+
+        /// <summary>
+        ///  Writes the provided commit message to .git/COMMITMESSAGE.
+        ///  The message is formatted depending whether a commit template is used or whether the 2nd line must be empty.
+        /// </summary>
+        /// <param name="commitMessage">The commit message to write out.</param>
+        /// <param name="messageType">The type of message to write out.</param>
+        /// <param name="usingCommitTemplate">The indicator whether a commit tempate is used.</param>
+        /// <param name="ensureCommitMessageSecondLineEmpty">The indicator whether empty second line is enforced.</param>
+        void WriteCommitMessageToFile(string commitMessage, CommitMessageType messageType, bool usingCommitTemplate, bool ensureCommitMessageSecondLineEmpty);
     }
 
     public sealed class CommitMessageManager : ICommitMessageManager
@@ -42,11 +57,16 @@ namespace GitCommands
         private string CannotAccessFile => "Exception: \"{0}\" when accessing {1}";
 
         private readonly string _amendSaveStatePath;
-        private readonly string _commitMessagePath;
-        private readonly string _mergeMessagePath;
 
-        private Encoding _commitEncoding;
-        private IFileSystem _fileSystem;
+        private readonly IFileSystem _fileSystem;
+
+        // Commit messages are UTF-8 by default unless otherwise in the config file.
+        // The git manual states:
+        //  git commit and git commit-tree issues a warning if the commit log message
+        //  given to it does not look like a valid UTF-8 string, unless you
+        //  explicitly say your project uses a legacy encoding. The way to say
+        //  this is to have i18n.commitencoding in .git/config file, like this:...
+        private readonly Encoding _commitEncoding;
 
         [CanBeNull]
         private string _overriddenCommitMessage;
@@ -61,11 +81,12 @@ namespace GitCommands
             _fileSystem = fileSystem;
             _commitEncoding = commitEncoding;
             _amendSaveStatePath = GetFilePath(workingDirGitDir, "GitExtensions.amend");
-            _commitMessagePath = GetFilePath(workingDirGitDir, "COMMITMESSAGE");
-            _mergeMessagePath = GetFilePath(workingDirGitDir, "MERGE_MSG");
+            CommitMessagePath = GetFilePath(workingDirGitDir, "COMMITMESSAGE");
+            MergeMessagePath = GetFilePath(workingDirGitDir, "MERGE_MSG");
             _overriddenCommitMessage = overriddenCommitMessage;
         }
 
+        /// <inheritdoc/>
         public bool AmendState
         {
             get
@@ -92,10 +113,16 @@ namespace GitCommands
             }
         }
 
-        public string CommitMessagePath => _commitMessagePath;
+        /// <inheritdoc/>
+        public string CommitMessagePath { get; }
 
-        public bool IsMergeCommit => _fileSystem.File.Exists(_mergeMessagePath);
+        /// <inheritdoc/>
+        public bool IsMergeCommit => _fileSystem.File.Exists(MergeMessagePath);
 
+        /// <inheritdoc/>
+        public string MergeMessagePath { get; }
+
+        /// <inheritdoc/>
         public string MergeOrCommitMessage
         {
             get
@@ -149,11 +176,55 @@ namespace GitCommands
             }
         }
 
+        /// <inheritdoc/>
         public void ResetCommitMessage()
         {
             _overriddenCommitMessage = null;
-            _fileSystem.File.Delete(_commitMessagePath);
+            _fileSystem.File.Delete(CommitMessagePath);
             _fileSystem.File.Delete(_amendSaveStatePath);
+        }
+
+        /// <inheritdoc/>
+        public void WriteCommitMessageToFile(string commitMessage, CommitMessageType messageType, bool usingCommitTemplate, bool ensureCommitMessageSecondLineEmpty)
+        {
+            var formattedCommitMessage = FormatCommitMessage(commitMessage, usingCommitTemplate, ensureCommitMessageSecondLineEmpty);
+
+            string path = messageType == CommitMessageType.Normal ? CommitMessagePath : MergeMessagePath;
+            File.WriteAllText(path, formattedCommitMessage, _commitEncoding);
+        }
+
+        internal static string FormatCommitMessage(string commitMessage, bool usingCommitTemplate, bool ensureCommitMessageSecondLineEmpty)
+        {
+            if (string.IsNullOrEmpty(commitMessage))
+            {
+                return string.Empty;
+            }
+
+            var formattedCommitMessage = new StringBuilder();
+
+            var lineNumber = 1;
+            foreach (var line in commitMessage.Split('\n'))
+            {
+                string nonNullLine = line ?? string.Empty;
+
+                // When a committemplate is used, skip comments and do not count them as line.
+                // otherwise: "#" is probably not used for comment but for issue number
+                if (usingCommitTemplate && nonNullLine.StartsWith("#"))
+                {
+                    continue;
+                }
+
+                if (ensureCommitMessageSecondLineEmpty && lineNumber == 2 && !string.IsNullOrEmpty(nonNullLine))
+                {
+                    formattedCommitMessage.AppendLine();
+                }
+
+                formattedCommitMessage.AppendLine(nonNullLine);
+
+                lineNumber++;
+            }
+
+            return formattedCommitMessage.ToString();
         }
 
         private string GetFilePath(string workingDirGitDir, string fileName) => _fileSystem.Path.Combine(workingDirGitDir, fileName);
@@ -162,10 +233,10 @@ namespace GitCommands
         {
             if (IsMergeCommit)
             {
-                return (_mergeMessagePath, fileExists: true);
+                return (MergeMessagePath, fileExists: true);
             }
 
-            return (_commitMessagePath, _fileSystem.File.Exists(_commitMessagePath));
+            return (CommitMessagePath, _fileSystem.File.Exists(CommitMessagePath));
         }
     }
 }

--- a/GitCommands/CommitMessageType.cs
+++ b/GitCommands/CommitMessageType.cs
@@ -1,0 +1,8 @@
+﻿namespace GitCommands
+{
+    public enum CommitMessageType
+    {
+        Normal = 0,
+        Merge
+    }
+}

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -1048,10 +1048,8 @@ namespace GitCommands
             };
         }
 
-        public static ArgumentString MergeBranchCmd(string branch, bool allowFastForward, bool squash, bool noCommit, string strategy, bool allowUnrelatedHistories, string message, int? log)
+        public static ArgumentString MergeBranchCmd(string branch, bool allowFastForward, bool squash, bool noCommit, string strategy, bool allowUnrelatedHistories, string mergeCommitFilePath, int? log)
         {
-            // TODO Quote should (optionally?) escape any " characters, at least for usages like the below
-
             return new GitArgumentBuilder("merge")
             {
                 { !allowFastForward, "--no-ff" },
@@ -1059,7 +1057,7 @@ namespace GitCommands
                 { squash, "--squash" },
                 { noCommit, "--no-commit" },
                 { allowUnrelatedHistories, "--allow-unrelated-histories" },
-                { !string.IsNullOrEmpty(message), $"-m {message.Quote()}" },
+                { !string.IsNullOrWhiteSpace(mergeCommitFilePath), $"-F \"{mergeCommitFilePath}\"" }, // let git fail, if the file doesn't exist
                 { log != null, $"--log={log}" },
                 branch
             };

--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -1058,7 +1058,7 @@ namespace GitCommands
                 { noCommit, "--no-commit" },
                 { allowUnrelatedHistories, "--allow-unrelated-histories" },
                 { !string.IsNullOrWhiteSpace(mergeCommitFilePath), $"-F \"{mergeCommitFilePath}\"" }, // let git fail, if the file doesn't exist
-                { log != null, $"--log={log}" },
+                { log != null && log.Value > 0, $"--log={log}" },
                 branch
             };
         }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -207,14 +207,6 @@ namespace GitExtensions.UITests.CommandsDialogs
             });
         }
 
-        [Test, TestCaseSource(typeof(FormatCommitMessageTestData), "TestCases")]
-        public void FormatCommitMessageFromTextBox(
-            string commitMessageText, bool usingCommitTemplate, bool ensureCommitMessageSecondLineEmpty, string expectedMessage)
-        {
-            FormCommit.TestAccessor.FormatCommitMessageFromTextBox(commitMessageText, usingCommitTemplate, ensureCommitMessageSecondLineEmpty)
-                .Should().Be(expectedMessage);
-        }
-
         [Test, TestCaseSource(typeof(CommitMessageTestData), "TestCases")]
         public void AddSelectionToCommitMessage_shall_be_ignored_unless_diff_is_focused(
             string message,
@@ -390,46 +382,6 @@ namespace GitExtensions.UITests.CommandsDialogs
                     }
                 },
                 testDriverAsync);
-        }
-    }
-
-    public class FormatCommitMessageTestData
-    {
-        private static readonly string NL = Environment.NewLine;
-
-        public static IEnumerable TestCases
-        {
-            get
-            {
-                // string commitMessageText, bool usingCommitTemplate, bool ensureCommitMessageSecondLineEmpty, string expectedMessage
-                yield return new TestCaseData(new object[] { null, false, false, "" });
-                yield return new TestCaseData(new object[] { null, true, false, "" });
-                yield return new TestCaseData(new object[] { null, false, true, "" });
-                yield return new TestCaseData(new object[] { null, true, true, "" });
-                yield return new TestCaseData(new object[] { "", false, false, NL });
-                yield return new TestCaseData(new object[] { "", true, false, NL });
-                yield return new TestCaseData(new object[] { "", false, true, NL });
-                yield return new TestCaseData(new object[] { "", true, true, NL });
-                yield return new TestCaseData(new object[] { "\n", false, false, NL + NL });
-                yield return new TestCaseData(new object[] { "\n", true, false, NL + NL });
-                yield return new TestCaseData(new object[] { "\n", false, true, NL + NL });
-                yield return new TestCaseData(new object[] { "\n", true, true, NL + NL });
-                yield return new TestCaseData(new object[] { "1", true, false, "1" + NL });
-                yield return new TestCaseData(new object[] { "#1", false, false, "#1" + NL });
-                yield return new TestCaseData(new object[] { "#1", true, false, "" });
-                yield return new TestCaseData(new object[] { "1\n\n3", false, false, "1" + NL + NL + "3" + NL });
-                yield return new TestCaseData(new object[] { "1\n\n3", false, true, "1" + NL + NL + "3" + NL });
-                yield return new TestCaseData(new object[] { "1\n2\n3", false, false, "1" + NL + "2" + NL + "3" + NL });
-                yield return new TestCaseData(new object[] { "1\n2\n3", false, true, "1" + NL + NL + "2" + NL + "3" + NL });
-                yield return new TestCaseData(new object[] { "#0\n1\n\n3", true, false, "1" + NL + NL + "3" + NL });
-                yield return new TestCaseData(new object[] { "#0\n1\n\n3", true, true, "1" + NL + NL + "3" + NL });
-                yield return new TestCaseData(new object[] { "#0\n1\n2\n3", true, false, "1" + NL + "2" + NL + "3" + NL });
-                yield return new TestCaseData(new object[] { "#0\n1\n2\n3", true, true, "1" + NL + NL + "2" + NL + "3" + NL });
-                yield return new TestCaseData(new object[] { "#0\n1\n#0\n2\n3", true, true, "1" + NL + NL + "2" + NL + "3" + NL });
-                yield return new TestCaseData(new object[] { "1\n2\n3\n4\n5\n\n7\n\n\n10", true, true, "1" + NL + NL + "2" + NL + "3" + NL + "4" + NL + "5" + NL + NL + "7" + NL + NL + NL + "10" + NL });
-                yield return new TestCaseData(new object[] { "1\n2\n3\n4\n5\n\n7\n\n\n10", false, true, "1" + NL + NL + "2" + NL + "3" + NL + "4" + NL + "5" + NL + NL + "7" + NL + NL + NL + "10" + NL });
-                yield return new TestCaseData(new object[] { "1\n2\n3\n4\n5\n\n7\n\n\n10\n", false, true, "1" + NL + NL + "2" + NL + "3" + NL + "4" + NL + "5" + NL + NL + "7" + NL + NL + NL + "10" + NL + NL });
-            }
         }
     }
 

--- a/UnitTests/GitCommands.Tests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitCommandHelpersTest.cs
@@ -705,36 +705,25 @@ namespace GitCommandsTests.Git
                 GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, IgnoreSubmodulesMode.Default, noLocks: true).Arguments);
         }
 
-        [Test]
-        public void MergeBranchCmd()
+        // Don't care about permutations because the args aren't correlated
+        [TestCase(false, false, false, null, false, null, null, "merge --no-ff branch")]
+        [TestCase(true, true, true, null, true, null, null, "merge --squash --no-commit --allow-unrelated-histories branch")]
+
+        // mergeCommitFilePath parameter
+        [TestCase(false, true, false, null, false, "", null, "merge --no-ff --squash branch")]
+        [TestCase(false, true, false, null, false, "   ", null, "merge --no-ff --squash branch")]
+        [TestCase(false, true, false, null, false, "\t", null, "merge --no-ff --squash branch")]
+        [TestCase(false, true, false, null, false, "\n", null, "merge --no-ff --squash branch")]
+        [TestCase(false, true, false, null, false, "foo", null, "merge --no-ff --squash -F \"foo\" branch")]
+        [TestCase(false, true, false, null, false, "D:\\myrepo\\.git\\file", null, "merge --no-ff --squash -F \"D:\\myrepo\\.git\\file\" branch")]
+
+        // log parameter
+        // [TestCase(true, true, false, null, false, null, -1, "merge --squash branch")]
+        // [TestCase(true, true, false, null, false, null, 0, "merge --squash branch")]
+        [TestCase(true, true, false, null, false, null, 5, "merge --squash --log=5 branch")]
+        public void MergeBranchCmd(bool allowFastForward, bool squash, bool noCommit, string strategy, bool allowUnrelatedHistories, string mergeCommitFilePath, int? log, string expected)
         {
-            Assert.AreEqual(
-                "merge branch",
-                GitCommandHelpers.MergeBranchCmd("branch", allowFastForward: true, squash: false, noCommit: false, allowUnrelatedHistories: false, message: null, log: null, strategy: null).Arguments);
-            Assert.AreEqual(
-                "merge --no-ff branch",
-                GitCommandHelpers.MergeBranchCmd("branch", allowFastForward: false, squash: false, noCommit: false, allowUnrelatedHistories: false, message: null, log: null, strategy: null).Arguments);
-            Assert.AreEqual(
-                "merge --squash branch",
-                GitCommandHelpers.MergeBranchCmd("branch", allowFastForward: true, squash: true, noCommit: false, allowUnrelatedHistories: false, message: null, log: null, strategy: null).Arguments);
-            Assert.AreEqual(
-                "merge --no-commit branch",
-                GitCommandHelpers.MergeBranchCmd("branch", allowFastForward: true, squash: false, noCommit: true, allowUnrelatedHistories: false, message: null, log: null, strategy: null).Arguments);
-            Assert.AreEqual(
-                "merge --allow-unrelated-histories branch",
-                GitCommandHelpers.MergeBranchCmd("branch", allowFastForward: true, squash: false, noCommit: false, allowUnrelatedHistories: true, message: null, log: null, strategy: null).Arguments);
-            Assert.AreEqual(
-                "merge -m \"message\" branch",
-                GitCommandHelpers.MergeBranchCmd("branch", allowFastForward: true, squash: false, noCommit: false, allowUnrelatedHistories: false, message: "message", log: null, strategy: null).Arguments);
-            Assert.AreEqual(
-                "merge --log=0 branch",
-                GitCommandHelpers.MergeBranchCmd("branch", allowFastForward: true, squash: false, noCommit: false, allowUnrelatedHistories: false, message: null, log: 0, strategy: null).Arguments);
-            Assert.AreEqual(
-                "merge --strategy=strategy branch",
-                GitCommandHelpers.MergeBranchCmd("branch", allowFastForward: true, squash: false, noCommit: false, allowUnrelatedHistories: false, message: null, log: null, strategy: "strategy").Arguments);
-            Assert.AreEqual(
-                "merge --no-ff --strategy=strategy --squash --no-commit --allow-unrelated-histories -m \"message\" --log=1 branch",
-                GitCommandHelpers.MergeBranchCmd("branch", allowFastForward: false, squash: true, noCommit: true, allowUnrelatedHistories: true, message: "message", log: 1, strategy: "strategy").Arguments);
+            Assert.AreEqual(expected, GitCommandHelpers.MergeBranchCmd("branch", allowFastForward, squash, noCommit, strategy, allowUnrelatedHistories, mergeCommitFilePath, log).Arguments);
         }
 
         [Test]

--- a/UnitTests/GitCommands.Tests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitCommandHelpersTest.cs
@@ -718,8 +718,8 @@ namespace GitCommandsTests.Git
         [TestCase(false, true, false, null, false, "D:\\myrepo\\.git\\file", null, "merge --no-ff --squash -F \"D:\\myrepo\\.git\\file\" branch")]
 
         // log parameter
-        // [TestCase(true, true, false, null, false, null, -1, "merge --squash branch")]
-        // [TestCase(true, true, false, null, false, null, 0, "merge --squash branch")]
+        [TestCase(true, true, false, null, false, null, -1, "merge --squash branch")]
+        [TestCase(true, true, false, null, false, null, 0, "merge --squash branch")]
         [TestCase(true, true, false, null, false, null, 5, "merge --squash --log=5 branch")]
         public void MergeBranchCmd(bool allowFastForward, bool squash, bool noCommit, string strategy, bool allowUnrelatedHistories, string mergeCommitFilePath, int? log, string expected)
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3954

This work is inspired by https://github.com/gitextensions/gitextensions/pull/7796 that was abandoned by its author.

## Proposed changes

- Centralise commiit message handling by moving the code from `FormCommit` that formatted and wrote a commit message into a temp file before a git command was run to `CommitMessageManager`. 
Leverage the same implementation for `FormMergeBranch` to write out merge-commit messages.
- Tighten git-merge log condition


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Merge commit message with quotes was failing the merge `test "message text" test`
![image](https://user-images.githubusercontent.com/4055444/75086597-31f1cf00-558a-11ea-891a-53ad17980a53.png)

### After
The merge succeeds.
![image](https://user-images.githubusercontent.com/4055444/75086658-d542e400-558a-11ea-8203-0031681635ee.png)
![image](https://user-images.githubusercontent.com/4055444/75086790-18ea1d80-558c-11ea-9ce1-26176c6331d6.png)


## Test methodology <!-- How did you ensure quality? -->

- manual tests
- unit tests