### PR TITLE
Ignore GitHub API rate limit induced errors when search for app updates

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -96,6 +96,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 // if a UI component gets disposed or the UI thread EXITs while a 'check for updates' thread
                 // is in the middle of its run... Ignore it, likely the user has closed the app
             }
+            catch (NullReferenceException)
+            {
+                // We had a number of NRE reports.
+                // Most likely scenario is that GitHub is API rate limiting unauthenticated requests that lead to failures in Git.hub library.
+                // Nothing we can do here, ignore it.
+            }
             catch (Exception ex)
             {
                 this.InvokeSync(() =>


### PR DESCRIPTION
Resolves #4469
Resolves #5928
Resolves #6070
Resolves #7413
Resolves #8023

<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Proposed changes

We had a number of NRE reports. Most likely scenario is that GitHub is API rate limiting unauthenticated requests  that lead to failures in Git.hub library.
Nothing we can do apart from ignoring these types of errors.

