### PR TITLE
Unneeded rev-list for submodule status

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -609,9 +609,17 @@ namespace GitCommands
 
             if (oldCommitId != null && commitId != null)
             {
-                var submodule = module.GetSubmodule(fileName);
-                addedCommits = submodule.GetCommitCount(commitId.ToString(), oldCommitId.ToString());
-                removedCommits = submodule.GetCommitCount(oldCommitId.ToString(), commitId.ToString());
+                if (oldCommitId == commitId)
+                {
+                    addedCommits = 0;
+                    removedCommits = 0;
+                }
+                else
+                {
+                    var submodule = module.GetSubmodule(fileName);
+                    addedCommits = submodule.GetCommitCount(commitId.ToString(), oldCommitId.ToString());
+                    removedCommits = submodule.GetCommitCount(oldCommitId.ToString(), commitId.ToString());
+                }
             }
 
             return new GitSubmoduleStatus(name, oldName, isDirty, commitId, oldCommitId, addedCommits, removedCommits);


### PR DESCRIPTION
Seen with #8049, but has occurred since the before/after feature was added 2013 or so

## Proposed changes

GE tries to get how many commits that a changed submodule is before/after the intended commit, using git-rev-list
This check is done also if the submodule only is dirty, i.e. commit is unchanged, there cannot be any commit changes.
For instance listing the submodule status in the sidepanel could take twice the time needed.

This is normally not a big problem as only changed submodules are queried.

## Screenshots 

Excerpts from logs after refresh, starting with git-status (the response triggers the status update of submodules with changes).
All GE submodules are dirty (in this case a new files added to the worktree).

### Before

```
2020-04-29T21:44:11.8426454+02:00	145	21304	UI	0	git	--no-optional-locks -c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files	F:\dev\gc\gitextensions_4\
2020-04-29T21:44:11.8966576+02:00	41	21296	UI	0	git	-c log.showSignature=false log -1 --pretty="format:%H%n%e%n%B%nNotes:%n%-N" 5be5391af1b8b1a8b7889962eac5e7da9a85fc77	F:\dev\gc\gitextensions_4\
2020-04-29T21:44:11.9386669+02:00	111	17464		0	git	branch -a --contains 5be5391af1b8b1a8b7889962eac5e7da9a85fc77	F:\dev\gc\gitextensions_4\
2020-04-29T21:44:12.0166836+02:00	55	3872		0	git	--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color --histogram -- "Externals/EasyHook"	F:\dev\gc\gitextensions_4\
2020-04-29T21:44:12.0566937+02:00	44	20748		0	git	tag --contains 5be5391af1b8b1a8b7889962eac5e7da9a85fc77	F:\dev\gc\gitextensions_4\
2020-04-29T21:44:12.0726969+02:00	35	20760		0	git	rev-parse --git-common-dir	F:\dev\gc\gitextensions_4\
2020-04-29T21:44:12.1037039+02:00	74	9392		0	git	describe --tags --first-parent --abbrev=40 5be5391af1b8b1a8b7889962eac5e7da9a85fc77	F:\dev\gc\gitextensions_4\
2020-04-29T21:44:12.1077038+02:00	36	7560		0	git	rev-list 0296f95158a7da669b44aaa264d8793c478ef648 ^0296f95158a7da669b44aaa264d8793c478ef648 --count	F:\dev\gc\gitextensions_4\Externals\EasyHook\
2020-04-29T21:44:12.1447123+02:00	36	9920		0	git	rev-list 0296f95158a7da669b44aaa264d8793c478ef648 ^0296f95158a7da669b44aaa264d8793c478ef648 --count	F:\dev\gc\gitextensions_4\Externals\EasyHook\
2020-04-29T21:44:12.1817212+02:00	53	17932		0	git	--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color --histogram -- "Externals/Git.hub"	F:\dev\gc\gitextensions_4\
2020-04-29T21:44:12.2357416+02:00	34	5712		0	git	rev-list 8098defa53ece8a8e747a9231ff12ffd224a5b32 ^8098defa53ece8a8e747a9231ff12ffd224a5b32 --count	F:\dev\gc\gitextensions_4\Externals\Git.hub\
2020-04-29T21:44:12.2697406+02:00	34	18756		0	git	rev-list 8098defa53ece8a8e747a9231ff12ffd224a5b32 ^8098defa53ece8a8e747a9231ff12ffd224a5b32 --count	F:\dev\gc\gitextensions_4\Externals\Git.hub\
2020-04-29T21:44:12.3047495+02:00	54	3268		0	git	--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color --histogram -- "Externals/ICSharpCode.TextEditor"	F:\dev\gc\gitextensions_4\
2020-04-29T21:44:12.3597612+02:00	40	20568		0	git	rev-list 1f1906ed0a4f02ae81646dd24caabec42ca730ec ^1f1906ed0a4f02ae81646dd24caabec42ca730ec --count	F:\dev\gc\gitextensions_4\Externals\ICSharpCode.TextEditor\
2020-04-29T21:44:12.3997707+02:00	36	21368		0	git	rev-list 1f1906ed0a4f02ae81646dd24caabec42ca730ec ^1f1906ed0a4f02ae81646dd24caabec42ca730ec --count	F:\dev\gc\gitextensions_4\Externals\ICSharpCode.TextEditor\
2020-04-29T21:44:12.4367790+02:00	54	13668		0	git	--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color --histogram -- "Externals/conemu-inside"	F:\dev\gc\gitextensions_4\
2020-04-29T21:44:12.4917904+02:00	36	1532		0	git	rev-list d56573bf41259c9334a8826ba3a2e618e06ec909 ^d56573bf41259c9334a8826ba3a2e618e06ec909 --count	F:\dev\gc\gitextensions_4\Externals\conemu-inside\
2020-04-29T21:44:12.5277992+02:00	34	14964		0	git	rev-list d56573bf41259c9334a8826ba3a2e618e06ec909 ^d56573bf41259c9334a8826ba3a2e618e06ec909 --count	F:\dev\gc\gitextensions_4\Externals\conemu-inside\
2020-04-29T21:44:12.5628070+02:00	55	8564		0	git	--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color --histogram -- "GitExtensionsDoc"	F:\dev\gc\gitextensions_4\
2020-04-29T21:44:12.6188198+02:00	34	15776		0	git	rev-list fc710667b29a528e3da475dd108dc066d00d4c7d ^fc710667b29a528e3da475dd108dc066d00d4c7d --count	F:\dev\gc\gitextensions_4\GitExtensionsDoc\
2020-04-29T21:44:12.6528270+02:00	34	6060		0	git	rev-list fc710667b29a528e3da475dd108dc066d00d4c7d ^fc710667b29a528e3da475dd108dc066d00d4c7d --count	F:\dev\gc\gitextensions_4\GitExtensionsDoc\
```

### After

```
2020-04-29T21:42:56.0375896+02:00	154	16428	UI	0	git	--no-optional-locks -c diff.ignoreSubmodules=none status --porcelain=2 -z --untracked-files	F:\dev\gc\gitextensions_4\
2020-04-29T21:42:56.1066048+02:00	43	14420	UI	0	git	-c log.showSignature=false log -1 --pretty="format:%H%n%e%n%B%nNotes:%n%-N" 5be5391af1b8b1a8b7889962eac5e7da9a85fc77	F:\dev\gc\gitextensions_4\
2020-04-29T21:42:56.1816222+02:00	114	8328		0	git	branch -a --contains 5be5391af1b8b1a8b7889962eac5e7da9a85fc77	F:\dev\gc\gitextensions_4\
2020-04-29T21:42:56.2766442+02:00	59	20080		0	git	--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color --histogram -- "Externals/EasyHook"	F:\dev\gc\gitextensions_4\
2020-04-29T21:42:56.3386626+02:00	36	21024		0	git	rev-parse --git-common-dir	F:\dev\gc\gitextensions_4\
2020-04-29T21:42:56.3796723+02:00	62	6328		0	git	--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color --histogram -- "Externals/Git.hub"	F:\dev\gc\gitextensions_4\
2020-04-29T21:42:56.3956756+02:00	54	19716		0	git	tag --contains 5be5391af1b8b1a8b7889962eac5e7da9a85fc77	F:\dev\gc\gitextensions_4\
2020-04-29T21:42:56.4456874+02:00	61	8224		0	git	--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color --histogram -- "Externals/ICSharpCode.TextEditor"	F:\dev\gc\gitextensions_4\
2020-04-29T21:42:56.5097016+02:00	59	14752		0	git	--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color --histogram -- "Externals/conemu-inside"	F:\dev\gc\gitextensions_4\
2020-04-29T21:42:56.5347059+02:00	73	1740		0	git	describe --tags --first-parent --abbrev=40 5be5391af1b8b1a8b7889962eac5e7da9a85fc77	F:\dev\gc\gitextensions_4\
2020-04-29T21:42:56.5707154+02:00	60	14652		0	git	--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color --histogram -- "GitExtensionsDoc"	F:\dev\gc\gitextensions_4\
```


## Test methodology 

Dirty submodules to see the change (for instance just touching files in them)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
