### PR TITLE
git-diff override  diff.mnemonicprefix=true

### DIFF
--- a/GitExtUtils/GitCommandConfiguration.cs
+++ b/GitExtUtils/GitCommandConfiguration.cs
@@ -24,6 +24,7 @@ namespace GitCommands
 
             Default.Add(new GitConfigItem("diff.submodule", "short"), "diff");
             Default.Add(new GitConfigItem("diff.noprefix", "false"), "diff");
+            Default.Add(new GitConfigItem("diff.mnemonicprefix", "false"), "diff");
             Default.Add(new GitConfigItem("diff.ignoreSubmodules", "none"), "diff", "status");
         }
 

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -744,9 +744,9 @@ namespace GitCommandsTests
             Assert.AreEqual(expected, _gitModule.GetStashesCmd(noLocks).ToString());
         }
 
-        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", false)]
-        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color extra -- ""new""", "new", "old", false, "extra", false)]
-        [TestCase(@"--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.ignoreSubmodules=none diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", true)]
+        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", false)]
+        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none diff --no-color extra -- ""new""", "new", "old", false, "extra", false)]
+        [TestCase(@"--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", true)]
         public void GetCurrentChangesCmd(string expected, string fileName, [CanBeNull] string oldFileName, bool staged,
             string extraDiffArguments, bool noLocks)
         {


### PR DESCRIPTION
Fixes #7570 
Replaces #8046 

## Proposed changes

Override diff.mnemonicprefix=true, reverse diffs cannot be parsed

## Test methodology <!-- How did you ensure quality? -->

Adopted the test

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
