### PR TITLE
Select multiple revisions using Left Panel

### DIFF
--- a/GitUI/UserControls/NativeTreeViewExplorerNavigationDecorator.cs
+++ b/GitUI/UserControls/NativeTreeViewExplorerNavigationDecorator.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
-using System.Diagnostics;
 using System.Windows.Forms;
 
 namespace GitUI.UserControls
@@ -65,7 +63,7 @@ namespace GitUI.UserControls
         private void OnAfterSelect(object sender, TreeViewEventArgs e)
         {
             // If arrow key was used to navigate to this node, don't send OnSelected
-            int delta = (int)DateTime.Now.Subtract(_lastKeyNavigateTime).TotalMilliseconds;
+            int delta = (int)_getCurrentTime().Subtract(_lastKeyNavigateTime).TotalMilliseconds;
             if (delta >= 0 && delta < 500)
             {
                 return;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -574,15 +574,11 @@ namespace GitUI
         {
             try
             {
+                _gridView.Select();
+
                 if (_gridView.Rows[index].Selected)
                 {
-                    int countVisible = _gridView.DisplayedRowCount(includePartialRow: false);
-                    int firstVisible = _gridView.FirstDisplayedScrollingRowIndex;
-                    if (index < firstVisible || firstVisible + countVisible < index)
-                    {
-                        _gridView.FirstDisplayedScrollingRowIndex = index;
-                    }
-
+                    EnsureRowVisible(_gridView, index);
                     return;
                 }
 
@@ -590,12 +586,22 @@ namespace GitUI
 
                 _gridView.Rows[index].Selected = true;
                 _gridView.CurrentCell = _gridView.Rows[index].Cells[1];
-
-                _gridView.Select();
             }
             catch (ArgumentException)
             {
                 // Ignore if selection failed. Datagridview is not threadsafe
+            }
+
+            return;
+
+            static void EnsureRowVisible(DataGridView gridView, int row)
+            {
+                int countVisible = gridView.DisplayedRowCount(includePartialRow: false);
+                int firstVisible = gridView.FirstDisplayedScrollingRowIndex;
+                if (row < firstVisible || firstVisible + countVisible <= row)
+                {
+                    gridView.FirstDisplayedScrollingRowIndex = row;
+                }
             }
         }
 
@@ -1179,6 +1185,8 @@ namespace GitUI
             {
                 SetSelectedIndex(index);
             }
+
+            return;
 
             int SearchRevision(ObjectId objectId)
             {

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1146,19 +1146,22 @@ namespace GitUI
 
         private void SelectInitialRevision()
         {
-            var selectedObjectIds = _selectedObjectIds ?? Array.Empty<ObjectId>();
+            var toBeSelectedObjectIds = _selectedObjectIds;
 
-            if (selectedObjectIds.Count == 0 && InitialObjectId != null)
+            if (toBeSelectedObjectIds == null || toBeSelectedObjectIds.Count == 0)
             {
-                selectedObjectIds = new ObjectId[] { InitialObjectId };
+                if (InitialObjectId != null)
+                {
+                    toBeSelectedObjectIds = new ObjectId[] { InitialObjectId };
+                    InitialObjectId = null;
+                }
+                else
+                {
+                    toBeSelectedObjectIds = new ObjectId[] { Module.GetCurrentCheckout() };
+                }
             }
 
-            if (selectedObjectIds.Count == 0)
-            {
-                selectedObjectIds = new ObjectId[] { Module.GetCurrentCheckout() };
-            }
-
-            _gridView.ToBeSelectedObjectIds = selectedObjectIds.ToList();
+            _gridView.ToBeSelectedObjectIds = toBeSelectedObjectIds;
             _selectedObjectIds = null;
         }
 


### PR DESCRIPTION
## Proposed changes

Improve revision selection Left Panel vs. RevisionGrid:
- Minor fixup in `NativeTreeViewExplorerNavigationDecorator`:
  Use the given lambda instead of `DateTime.Now`.
- Reset `RevisionGridControl.InitialObjectId` after use. (Might be related to #6057.)
- Fix up the check for the last visible row in `RevisionGridControl.SetSelectedIndex`:
  - factor out a new local function `EnsureRowVisible`
  - call `_gridView.Select()` first (was omitted by too early `return` from my previous PR)
- Toggle the RevisionGrid selection if `Ctrl` is pressed especially if triggered from left panel.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

result of `Ctrl+Click`

![grafik](https://user-images.githubusercontent.com/36601201/80842243-5fe63600-8c01-11ea-844a-8014f310f41d.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/80842333-9de35a00-8c01-11ea-8b62-01f8353c0b19.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build e3ee53618420676d92a77fd4ed9b6f3b16b20c07
- Git 2.26.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4121.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).