### PR TITLE
Ignore inaccessible file in GetSelectedBranchFast

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2778,15 +2778,24 @@ namespace GitCommands
                 return string.Empty;
             }
 
-            // eg. "/path/to/repo/.git/HEAD"
-            var headFileName = Path.Combine(GetGitDirectory(repositoryPath), "HEAD");
-
-            if (!File.Exists(headFileName))
+            string headFileContents;
+            try
             {
+                // eg. "/path/to/repo/.git/HEAD"
+                var headFileName = Path.Combine(GetGitDirectory(repositoryPath), "HEAD");
+
+                if (!File.Exists(headFileName))
+                {
+                    return string.Empty;
+                }
+
+                headFileContents = File.ReadAllText(headFileName, SystemEncoding);
+            }
+            catch (IOException)
+            {
+                // ignore inaccessible file
                 return string.Empty;
             }
-
-            var headFileContents = File.ReadAllText(headFileName, SystemEncoding);
 
             // eg. "ref: refs/heads/master"
             //     "9601551c564b48208bccd50b705264e9bd68140d"


### PR DESCRIPTION
Fixes #8057

## Proposed changes

- Catch and ignore `IOException` in `GetSelectedBranchFast` the same way as if the file did not exist

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build d58beb57a9b070c9b00d33a6a51518423bc25f1b
- Git 2.26.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4121.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).