### PR TITLE
Align folder/copy for submodule

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -481,8 +481,8 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator15,
             this.openDiffMenuItem,
             this.toolStripSeparator16,
-            this.openFolderMenuItem,
             this.copyFolderNameMenuItem,
+            this.openFolderMenuItem,
             this.toolStripSeparator13,
             this.viewHistoryMenuItem});
             this.UnstagedSubmoduleContext.Name = "UnstagedSubmoduleContext";


### PR DESCRIPTION
Follow up to #7961 

## Proposed changes
For submodule in FormCommit, open folder is before copy path, this aligns with other menus

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/81018327-9374ca80-8e64-11ea-8156-ff9ca5f8f5ee.png)

### After

![image](https://user-images.githubusercontent.com/6248932/81018387-adaea880-8e64-11ea-96ce-d2923b18e8f6.png)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
