### PR TITLE
Fixup regression introduced by ROT multiselect

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -106,7 +106,7 @@ namespace GitUI.BranchTreePanel
             {
                 TreeViewNode.TreeView.BeginInvoke(new Action(() =>
                 {
-                    UICommands.BrowseGoToRef(FullPath, showNoRevisionMsg: true);
+                    UICommands.BrowseGoToRef(FullPath, showNoRevisionMsg: true, toggleSelection: ModifierKeys.HasFlag(Keys.Control));
                     TreeViewNode.TreeView?.Focus();
                 }));
             }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2448,7 +2448,7 @@ namespace GitUI.CommandsDialogs
                     CommitData commit = _commitDataManager.GetCommitData(e.Data, out _);
                     if (commit != null)
                     {
-                        RevisionGrid.SetSelectedRevision(new GitRevision(commit.ObjectId));
+                        RevisionGrid.SetSelectedRevision(commit.ObjectId);
                     }
 
                     break;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -663,11 +663,11 @@ namespace GitUI.CommandsDialogs
 
         #region IBrowseRepo
 
-        public void GoToRef(string refName, bool showNoRevisionMsg)
+        public void GoToRef(string refName, bool showNoRevisionMsg, bool toggleSelection = false)
         {
             using (WaitCursorScope.Enter())
             {
-                RevisionGrid.GoToRef(refName, showNoRevisionMsg);
+                RevisionGrid.GoToRef(refName, showNoRevisionMsg, toggleSelection);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -582,7 +582,7 @@ namespace GitUI.CommandsDialogs
                 CommitData commit = _commitDataManager.GetCommitData(e.Data, out _);
                 if (commit != null)
                 {
-                    FileChanges.SetSelectedRevision(new GitRevision(commit.ObjectId));
+                    FileChanges.SetSelectedRevision(commit.ObjectId);
                 }
             }
             else if (e.Command == "navigatebackward")

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1864,9 +1864,9 @@ namespace GitUI
             InvokeEvent(owner, PostRegisterPlugin);
         }
 
-        public void BrowseGoToRef(string refName, bool showNoRevisionMsg)
+        public void BrowseGoToRef(string refName, bool showNoRevisionMsg, bool toggleSelection = false)
         {
-            BrowseRepo?.GoToRef(refName, showNoRevisionMsg);
+            BrowseRepo?.GoToRef(refName, showNoRevisionMsg, toggleSelection);
         }
 
         public void BrowseSetWorkingDir(string path)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -673,11 +673,6 @@ namespace GitUI
             return _gridView.GetRevision(objectId);
         }
 
-        public bool SetSelectedRevision([CanBeNull] GitRevision revision)
-        {
-            return SetSelectedRevision(revision?.ObjectId);
-        }
-
         private void HighlightBranch(ObjectId id)
         {
             _revisionGraphColumnProvider.RevisionGraphDrawStyle = RevisionGraphDrawStyleEnum.HighlightSelected;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -570,9 +570,7 @@ namespace GitUI
             ForceRefreshRevisions();
         }
 
-        private void SetSelectedIndex(int index) => SetSelectedIndex(index, toggleSelection: ModifierKeys.HasFlag(Keys.Control));
-
-        private void SetSelectedIndex(int index, bool toggleSelection)
+        private void SetSelectedIndex(int index, bool toggleSelection = false)
         {
             try
             {
@@ -651,13 +649,13 @@ namespace GitUI
         /// </summary>
         /// <param name="objectId">Id of the revision to select.</param>
         /// <returns><c>true</c> if the required revision was found and selected, otherwise <c>false</c>.</returns>
-        public bool SetSelectedRevision([CanBeNull] ObjectId objectId)
+        public bool SetSelectedRevision([CanBeNull] ObjectId objectId, bool toggleSelection = false)
         {
             var index = FindRevisionIndex(objectId);
 
             if (index >= 0 && index < _gridView.RowCount)
             {
-                SetSelectedIndex(index);
+                SetSelectedIndex(index, toggleSelection);
                 _navigationHistory.Push(objectId);
                 return true;
             }
@@ -2380,7 +2378,7 @@ namespace GitUI
             }
         }
 
-        public void GoToRef(string refName, bool showNoRevisionMsg)
+        public void GoToRef(string refName, bool showNoRevisionMsg, bool toggleSelection = false)
         {
             if (string.IsNullOrEmpty(refName))
             {
@@ -2395,7 +2393,7 @@ namespace GitUI
             var revisionGuid = Module.RevParse(refName);
             if (revisionGuid != null)
             {
-                if (_isReadingRevisions || !SetSelectedRevision(revisionGuid))
+                if (_isReadingRevisions || !SetSelectedRevision(revisionGuid, toggleSelection))
                 {
                     InitialObjectId = revisionGuid;
                     _selectedObjectIds = null;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -423,7 +423,7 @@ namespace GitUI.UserControls.RevisionGrid
 
                 if (objectId != null)
                 {
-                    _revisionGrid.SetSelectedRevision(new GitRevision(objectId));
+                    _revisionGrid.SetSelectedRevision(objectId);
                 }
                 else
                 {

--- a/Plugins/GitUIPluginInterfaces/IBrowseRepo.cs
+++ b/Plugins/GitUIPluginInterfaces/IBrowseRepo.cs
@@ -2,7 +2,7 @@
 {
     public interface IBrowseRepo
     {
-        void GoToRef(string refName, bool showNoRevisionMsg);
+        void GoToRef(string refName, bool showNoRevisionMsg, bool toggleSelection = false);
         void SetWorkingDir(string path);
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes regression https://github.com/gitextensions/gitextensions/pull/8056#issuecomment-623719356


## Proposed changes

- Make shortcuts with `Ctrl` select single revisions again
  by toggling the selection from Left Panel only
- Avoid pointless `new GitRevision` for `RevisionGridControl.SetSelectedRevision(GitRevision)` by calling the `ObjectId` overload directly

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build Toggle selection from Left Panel only
- Git 2.26.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4121.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
