### PR TITLE
Catch all types of exception thrown by ReadAllText

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Mail;
+using System.Security;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -2791,7 +2792,7 @@ namespace GitCommands
 
                 headFileContents = File.ReadAllText(headFileName, SystemEncoding);
             }
-            catch (IOException)
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is SecurityException)
             {
                 // ignore inaccessible file
                 return string.Empty;


### PR DESCRIPTION
Fixes #8074

## Proposed changes

- Ignore all types of exception which can be thrown by `File.ReadAllText` in `GetSelectedBranchFast`

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build c06c3ae32425747f74329068433189e56cdf79cd
- Git 2.26.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4121.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).