### PR TITLE
Run FormFileHistory in a separate GE instance

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -160,7 +160,14 @@ namespace GitExtensions
             else
             {
                 // if we are here args.Length > 1
-                commands.RunCommand(args);
+
+                // Avoid replacing the ExitCode eventually set while parsing arguments,
+                // i.e. assume -1 and afterwards, only set it to 0 if no error is indicated.
+                Environment.ExitCode = -1;
+                if (commands.RunCommand(args))
+                {
+                    Environment.ExitCode = 0;
+                }
             }
 
             AppSettings.SaveSettings();

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -93,7 +93,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        public FormFileHistory(GitUICommands commands, string fileName, GitRevision revision = null, bool filterByRevision = false)
+        public FormFileHistory(GitUICommands commands, string fileName, GitRevision revision = null, bool filterByRevision = false, bool showBlame = false)
             : this(commands)
         {
             FileChanges.InitialObjectId = revision?.ObjectId;
@@ -148,6 +148,8 @@ namespace GitUI.CommandsDialogs
             {
                 _filterBranchHelper.SetBranchFilter(revision.Guid, false);
             }
+
+            tabControl1.SelectedTab = blameTabExists && showBlame ? BlameTab : DiffTab;
         }
 
         /// <summary>
@@ -170,9 +172,6 @@ namespace GitUI.CommandsDialogs
 
             base.Dispose(disposing);
         }
-
-        public void SelectBlameTab() => tabControl1.SelectedTab = BlameTab;
-        public void SelectDiffTab() => tabControl1.SelectedTab = DiffTab;
 
         protected override void OnRuntimeLoad(EventArgs e)
         {

--- a/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
@@ -300,6 +300,7 @@ namespace GitUITests.GitUICommandsTests
         public void RunCommandBasedOnArgument_searchfile()
             => RunCommandBasedOnArgument<SearchWindow<string>>(new string[] { "ge.exe", "searchfile" }, expectedResult: false);
 
+        [Ignore("FormSettings throws unhandled exceptions when opened this way, works from real command line")]
         [Test]
         public void RunCommandBasedOnArgument_settings()
             => RunCommandBasedOnArgument<FormSettings>(new string[] { "ge.exe", "settings" });

--- a/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
@@ -1,0 +1,388 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using ApprovalTests.Utilities;
+using CommonTestUtils;
+using FluentAssertions;
+using GitCommands;
+using GitExtensions.UITests;
+using GitUI;
+using GitUI.CommandsDialogs;
+using NUnit.Framework;
+
+namespace GitUITests.GitUICommandsTests
+{
+    [Apartment(ApartmentState.STA)]
+    [TestFixture]
+    public sealed class RunCommandTests
+    {
+        // Created once for the fixture
+        private ReferenceRepository _referenceRepository;
+
+        // Created once for each test
+        private GitUICommands _commands;
+
+        [SetUp]
+        public void SetUp()
+        {
+            if (_referenceRepository == null)
+            {
+                _referenceRepository = new ReferenceRepository();
+
+                string cmdPath = (Environment.GetEnvironmentVariable("COMSPEC") ?? "C:/WINDOWS/system32/cmd.exe").ToPosixPath().QuoteNE();
+                _referenceRepository.Module.GitExecutable.RunCommand($"config --local difftool.cmd.path {cmdPath}").Should().BeTrue();
+                _referenceRepository.Module.GitExecutable.RunCommand($"config --local mergetool.cmd.path {cmdPath}").Should().BeTrue();
+                _referenceRepository.Module.GitExecutable.RunCommand("config --local diff.guitool cmd").Should().BeTrue();
+                _referenceRepository.Module.GitExecutable.RunCommand("config --local merge.guitool cmd").Should().BeTrue();
+
+                AppSettings.UseConsoleEmulatorForCommands = false;
+                AppSettings.CloseProcessDialog = true;
+            }
+            else
+            {
+                _referenceRepository.Reset();
+            }
+
+            _commands = new GitUICommands(_referenceRepository.Module);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _referenceRepository.Dispose();
+        }
+
+        [Test]
+        public void RunCommandBasedOnArgument_should_throw_on_null_args()
+        {
+            ((Action)(() => _commands.GetTestAccessor().RunCommandBasedOnArgument(null)))
+                .Should().Throw<NullReferenceException>();
+        }
+
+        [Test]
+        public void RunCommandBasedOnArgument_should_throw_on_empty_args()
+        {
+            ((Action)(() => _commands.GetTestAccessor().RunCommandBasedOnArgument(new string[] { })))
+                .Should().Throw<ArgumentOutOfRangeException>();
+
+            ((Action)(() => _commands.GetTestAccessor().RunCommandBasedOnArgument(new string[] { "ge.exe" })))
+                .Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Test]
+        public void RunCommandBasedOnArgument_about()
+        {
+            UserEnvironmentInformation.Initialise("1234567", isDirty: true);
+            RunCommandBasedOnArgument<FormAbout>(new string[] { "ge.exe", "about" });
+        }
+
+        [TestCase("add")]
+        [TestCase("addfiles")]
+        public void RunCommandBasedOnArgument_add(string command)
+            => RunCommandBasedOnArgument<FormAddFiles>(new string[] { "ge.exe", command });
+
+        [TestCase("apply")]
+        [TestCase("applypatch")]
+        public void RunCommandBasedOnArgument_apply(string command)
+            => RunCommandBasedOnArgument<FormApplyPatch>(new string[] { "ge.exe", command });
+
+        [Test]
+        public void RunCommandBasedOnArgument_blame_throws()
+        {
+            ((Action)(() => _commands.GetTestAccessor().RunCommandBasedOnArgument(new string[] { "ge.exe", "blame" })))
+                .Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Test]
+        public void RunCommandBasedOnArgument_blame()
+            => RunCommandBasedOnArgument<FormBlame>(new string[] { "ge.exe", "blame", "filename" });
+
+        [Test]
+        public void RunCommandBasedOnArgument_blame_line()
+            => RunCommandBasedOnArgument<FormBlame>(new string[] { "ge.exe", "blame", "filename", "42" });
+
+        [Test]
+        public void RunCommandBasedOnArgument_branch()
+        {
+            _referenceRepository.CheckoutMaster();
+            RunCommandBasedOnArgument<FormCreateBranch>(new string[] { "ge.exe", "branch" }, runTest: form =>
+            {
+                SetText(form, "BranchNameTextBox", "branchname");
+                ClickButton(form, "Ok");
+            });
+        }
+
+        [Test]
+        public void RunCommandBasedOnArgument_browse()
+            => RunCommandBasedOnArgument<FormBrowse>(new string[] { "ge.exe", "browse" });
+
+        [TestCase("checkout")]
+        [TestCase("checkoutbranch")]
+        public void RunCommandBasedOnArgument_checkout(string command)
+            => RunCommandBasedOnArgument<FormCheckoutBranch>(new string[] { "ge.exe", command }, expectedResult: false);
+
+        [Test]
+        public void RunCommandBasedOnArgument_checkoutrevision()
+            => RunCommandBasedOnArgument<FormCheckoutRevision>(new string[] { "ge.exe", "checkoutrevision" }, expectedResult: false);
+
+        [Test]
+        public void RunCommandBasedOnArgument_cherry()
+            => RunCommandBasedOnArgument<FormCherryPick>(new string[] { "ge.exe", "cherry" }, expectedResult: false);
+
+        [Test]
+        public void RunCommandBasedOnArgument_cleanup()
+            => RunCommandBasedOnArgument<FormCleanupRepository>(new string[] { "ge.exe", "cleanup" });
+
+        [Test]
+        public void RunCommandBasedOnArgument_clone()
+            => RunCommandBasedOnArgument<FormClone>(new string[] { "ge.exe", "clone" });
+
+        [Test]
+        public void RunCommandBasedOnArgument_commit()
+            => RunCommandBasedOnArgument<FormCommit>(new string[] { "ge.exe", "commit" });
+
+        [Test]
+        public void RunCommandBasedOnArgument_difftool_throws()
+        {
+            ((Action)(() => _commands.GetTestAccessor().RunCommandBasedOnArgument(new string[] { "ge.exe", "difftool" })))
+                .Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Test]
+        public void RunCommandBasedOnArgument_difftool()
+            => _commands.GetTestAccessor().RunCommandBasedOnArgument(new string[] { "ge.exe", "difftool", "filename" }).Should().BeTrue();
+
+        [Test]
+        public void RunCommandBasedOnArgument_history_throws(
+            [Values("blamehistory", "filehistory")] string command)
+        {
+            ((Action)(() => _commands.GetTestAccessor().RunCommandBasedOnArgument(new string[] { "ge.exe", command })))
+                .Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Test]
+        public void RunCommandBasedOnArgument_history(
+            [Values("blamehistory", "filehistory")] string command,
+            [Values(false, true)] bool commit,
+            [Values(false, true)] bool filter)
+        {
+            var expectedTab = command.Contains("blame") ? "Blame" : "Diff";
+
+            var args = new System.Collections.Generic.List<string> { "ge.exe", command, "filename" };
+            if (commit)
+            {
+                args.Add(_referenceRepository.CommitHash);
+                if (filter)
+                {
+                    args.Add("--filter-by-revision");
+                }
+            }
+
+            RunCommandBasedOnArgument<FormFileHistory>(args.ToArray(),
+                runTest: form => form.FindDescendantOfType<FullBleedTabControl>(_ => true).SelectedTab.Text.Should().Be(expectedTab));
+        }
+
+        [Test]
+        public void RunCommandBasedOnArgument_history_returns_false(
+            [Values("blamehistory", "filehistory")] string command,
+            [Values(0, 1, 2, 3)] int invalidVariant)
+        {
+            const bool ignored = false;
+            (bool commitValid, bool filter, bool filterValid)[] invalidVariants =
+            {
+                (false, false, ignored),
+                (false, true, false),
+                (false, true, true),
+                (true, true, false)
+            };
+            (bool commitValid, bool filter, bool filterValid) = invalidVariants[invalidVariant];
+
+            var args = new System.Collections.Generic.List<string> { "ge.exe", command, "filename" };
+            args.Add(commitValid ? _referenceRepository.CommitHash : "no-commit");
+            if (filter)
+            {
+                args.Add(filterValid ? "--filter-by-revision" : "invalid");
+            }
+
+            _commands.GetTestAccessor().RunCommandBasedOnArgument(args.ToArray()).Should().BeFalse();
+        }
+
+        [Test]
+        public void RunCommandBasedOnArgument_fileeditor_throws()
+        {
+            ((Action)(() => _commands.GetTestAccessor().RunCommandBasedOnArgument(new string[] { "ge.exe", "fileeditor" })))
+                .Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Test]
+        public void RunCommandBasedOnArgument_fileeditor()
+            => RunCommandBasedOnArgument<FormEditor>(new string[] { "ge.exe", "fileeditor", "filename" });
+
+        [Test]
+        public void RunCommandBasedOnArgument_formatpatch()
+            => RunCommandBasedOnArgument<FormFormatPatch>(new string[] { "ge.exe", "formatpatch" });
+
+        [Test]
+        public void RunCommandBasedOnArgument_gitbash()
+        {
+            _commands.GetTestAccessor().RunCommandBasedOnArgument(new string[] { "ge.exe", "gitbash" }).Should().BeTrue();
+
+            // wait for the shell to be started
+            Thread.Sleep(5000);
+
+            // find and kill the started shell executable
+            var currentProcessId = Process.GetCurrentProcess().Id;
+            int numberOfShellChildren = KillChildProcess("git-bash") + KillChildProcess("cmd");
+            numberOfShellChildren.Should().Be(1);
+
+            return;
+
+            int KillChildProcess(string name)
+            {
+                int number = 0;
+                Process.GetProcessesByName(name)
+                    .Where(process => process.ParentProcess()?.Id == currentProcessId)
+                    .ForEach(process =>
+                    {
+                        process.TerminateTree();
+                        ++number;
+                    });
+                return number;
+            }
+        }
+
+        [Test]
+        public void RunCommandBasedOnArgument_gitignore()
+            => RunCommandBasedOnArgument<FormGitIgnore>(new string[] { "ge.exe", "gitignore" });
+
+        [Test]
+        public void RunCommandBasedOnArgument_init()
+            => RunCommandBasedOnArgument<FormInit>(new string[] { "ge.exe", "init" });
+
+        [Test]
+        public void RunCommandBasedOnArgument_merge()
+            => RunCommandBasedOnArgument<FormMergeBranch>(new string[] { "ge.exe", "merge" });
+
+        [TestCase("mergeconflicts")]
+        [TestCase("mergetool")]
+        public void RunCommandBasedOnArgument_mergeconflicts(string command)
+            => RunCommandBasedOnArgument<FormResolveConflicts>(new string[] { "ge.exe", command });
+
+        [Test]
+        public void RunCommandBasedOnArgument_openrepo()
+          => RunCommandBasedOnArgument<FormBrowse>(new string[] { "ge.exe", "openrepo" });
+
+        [Test]
+        public void RunCommandBasedOnArgument_pull()
+            => RunCommandBasedOnArgument<FormPull>(new string[] { "ge.exe", "pull" }, expectedResult: false);
+
+        [Test]
+        public void RunCommandBasedOnArgument_push()
+            => RunCommandBasedOnArgument<FormPush>(new string[] { "ge.exe", "push" }, expectedResult: false);
+
+        [Test]
+        public void RunCommandBasedOnArgument_rebase()
+            => RunCommandBasedOnArgument<FormRebase>(new string[] { "ge.exe", "rebase" });
+
+        [Test]
+        public void RunCommandBasedOnArgument_remotes()
+            => RunCommandBasedOnArgument<FormRemotes>(new string[] { "ge.exe", "remotes" });
+
+        [TestCase("revert")]
+        [TestCase("reset")]
+        public void RunCommandBasedOnArgument_reset(string command)
+            => RunCommandBasedOnArgument<FormResetChanges>(new string[] { "ge.exe", command }, expectedResult: false);
+
+        [Test]
+        public void RunCommandBasedOnArgument_searchfile()
+            => RunCommandBasedOnArgument<SearchWindow<string>>(new string[] { "ge.exe", "searchfile" }, expectedResult: false);
+
+        [Test]
+        public void RunCommandBasedOnArgument_settings()
+            => RunCommandBasedOnArgument<FormSettings>(new string[] { "ge.exe", "settings" });
+
+        [Test]
+        public void RunCommandBasedOnArgument_stash()
+            => RunCommandBasedOnArgument<FormStash>(new string[] { "ge.exe", "stash" });
+
+        [Test]
+        public void RunCommandBasedOnArgument_synchronize()
+        {
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                while (true)
+                {
+                    await UITest.WaitForIdleAsync();
+                    var formPull = Application.OpenForms.OfType<FormPull>().FirstOrDefault();
+                    if (formPull != null)
+                    {
+                        formPull.Close();
+                        break;
+                    }
+                }
+
+                while (true)
+                {
+                    await UITest.WaitForIdleAsync();
+                    var formPush = Application.OpenForms.OfType<FormPush>().FirstOrDefault();
+                    if (formPush != null)
+                    {
+                        formPush.Close();
+                        break;
+                    }
+                }
+            });
+
+            RunCommandBasedOnArgument<FormCommit>(new string[] { "ge.exe", "synchronize" }, expectedResult: false);
+        }
+
+        [Test]
+        public void RunCommandBasedOnArgument_tag()
+            => RunCommandBasedOnArgument<FormCreateTag>(new string[] { "ge.exe", "tag" }, expectedResult: false);
+
+        [Test]
+        public void RunCommandBasedOnArgument_viewdiff()
+            => RunCommandBasedOnArgument<FormLog>(new string[] { "ge.exe", "viewdiff" }, expectedResult: false);
+
+        [TestCase("git://")]
+        [TestCase("http://")]
+        [TestCase("https://")]
+        [TestCase("github-windows://openRepo/")]
+        [TestCase("github-mac://openRepo/")]
+        public void RunCommandBasedOnArgument_Url(string url)
+            => RunCommandBasedOnArgument<FormClone>(new string[] { "ge.exe", url });
+
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("help")]
+        [TestCase("nonsense")]
+        public void RunCommandBasedOnArgument_unsupported(string command)
+            => RunCommandBasedOnArgument<FormCommandlineHelp>(new string[] { "ge.exe", command });
+
+        private void RunCommandBasedOnArgument<TForm>(string[] args, bool expectedResult = true, Action<TForm> runTest = null) where TForm : Form
+        {
+            UITest.RunForm<TForm>(
+                showForm: () => _commands.GetTestAccessor().RunCommandBasedOnArgument(args).Should().Be(expectedResult),
+                runTestAsync: form =>
+                {
+                    if (runTest != null)
+                    {
+                        runTest(form);
+                    }
+
+                    return Task.CompletedTask;
+                });
+        }
+
+        private static void ClickButton(Form form, string buttonName)
+            => form.FindDescendantOfType<Button>(button => button.Name == buttonName).PerformClick();
+
+        private static void SetText(Form form, string controlName, string value)
+            => form.FindDescendantOfType<Control>(control => control.Name == controlName).Text = value;
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -30,7 +30,6 @@ namespace GitUIPluginInterfaces
         bool StartCommandLineProcessDialog(IWin32Window owner, IGitCommand command);
         void StartBatchFileProcessDialog(string batchFile);
 
-        bool StartRemotesDialog();
         bool StartSettingsDialog(IGitPlugin gitPlugin);
         void AddCommitTemplate(string key, Func<string> addingText, Image icon);
         void RemoveCommitTemplate(string key);

--- a/UnitTests/GitUI.Tests/GitUICommands/NormalizeFileNameTests.cs
+++ b/UnitTests/GitUI.Tests/GitUICommands/NormalizeFileNameTests.cs
@@ -1,0 +1,30 @@
+﻿using FluentAssertions;
+using GitCommands;
+using GitUI;
+using NUnit.Framework;
+
+namespace GitUITests.GitUICommandsTests
+{
+    [TestFixture]
+    public sealed class NormalizeFileNameTests
+    {
+        [TestCase(@"file", "file")]
+        [TestCase(@"file.ext", "file.ext")]
+        [TestCase(@"path\file.ext", "path/file.ext")]
+        [TestCase(@"path/file.ext", "path/file.ext")]
+        [TestCase(@"c:\path\file.ext", "c:/path/file.ext")]
+        [TestCase(@"c:\path/file.ext", "c:/path/file.ext")]
+        [TestCase(@"c:/path/file.ext", "c:/path/file.ext")]
+        [TestCase(@"c:\working\dir\path\file.ext", "path/file.ext")]
+        [TestCase(@"c:/working/dir/path/file.ext", "path/file.ext")]
+        [TestCase(@"C:\working\dir\path\file.ext", "C:/working/dir/path/file.ext")]
+        [TestCase(@"C:/working/dir/path/file.ext", "C:/working/dir/path/file.ext")]
+        public void NormalizeFileNameTest(string fileName, string expected)
+        {
+            var module = new GitModule(@"c:\working\dir");
+            var commands = new GitUICommands(module);
+
+            commands.GetTestAccessor().NormalizeFileName(fileName).Should().Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #7805

Reviewed best commit by commit. Do not squash.

## Proposed changes

- Run `FormFileHistory` in a separate GE instance in order:
  - to be able to use the history after opening the modal `FormCommit`,
  - to refresh `FormCommit` when switching back from `FormFileHistory`,
    which could have been used to modify the repo.
- Resolve TODOs regarding non-zero `ExitCode` on error parsing command line arguments.
- Refactor in order to let `FormFileHistory` activate the tab "Blame" itself.

## Screenshots <!-- Remove this section if PR does not change UI -->

unchanged

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 09d0a839579126488423ce6a53c3236287a00615 (Dirty)
- Git 2.26.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4121.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).