### PR TITLE
RevDiff: FirstRevision is null for the initial commit

### DIFF
--- a/GitCommands/CommitData.cs
+++ b/GitCommands/CommitData.cs
@@ -10,7 +10,7 @@ namespace GitCommands
         public CommitData(
             ObjectId objectId,
             ObjectId treeGuid,
-            IReadOnlyList<ObjectId> parentGuids,
+            IReadOnlyList<ObjectId> parentIds,
             string author,
             DateTime authorDate,
             string committer,
@@ -19,7 +19,7 @@ namespace GitCommands
         {
             ObjectId = objectId;
             TreeGuid = treeGuid;
-            ParentGuids = parentGuids;
+            ParentIds = parentIds;
             Author = author;
             AuthorDate = authorDate.ToDateTimeOffset();
             Committer = committer;
@@ -29,7 +29,7 @@ namespace GitCommands
 
         public ObjectId ObjectId { get; }
         public ObjectId TreeGuid { get; }
-        public IReadOnlyList<ObjectId> ParentGuids { get; }
+        public IReadOnlyList<ObjectId> ParentIds { get; }
         public string Author { get; }
         public DateTimeOffset AuthorDate { get; }
         public string Committer { get; }

--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -141,7 +141,7 @@ namespace GitCommands
             var treeGuid = ObjectId.Parse(lines[1]);
 
             // TODO: we can use this to add more relationship info like gitk does if wanted
-            var parentGuids = lines[2].Split(' ').Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => ObjectId.Parse(id)).ToList();
+            var parentIds = lines[2].Split(' ').Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => ObjectId.Parse(id)).ToList();
             var author = module.ReEncodeStringFromLossless(lines[3]);
             var authorDate = DateTimeUtils.ParseUnixTime(lines[4]);
             var committer = module.ReEncodeStringFromLossless(lines[5]);
@@ -152,7 +152,7 @@ namespace GitCommands
             // commit message is not re-encoded by git when format is given
             var body = module.ReEncodeCommitMessage(message, commitEncoding);
 
-            return new CommitData(guid, treeGuid, parentGuids, author, authorDate, committer, commitDate, body);
+            return new CommitData(guid, treeGuid, parentIds, author, authorDate, committer, commitDate, body);
         }
 
         /// <inheritdoc />

--- a/GitCommands/Git/GitRevision.cs
+++ b/GitCommands/Git/GitRevision.cs
@@ -99,7 +99,7 @@ namespace GitCommands
         public bool HasParent => ParentIds?.Count > 0;
 
         [CanBeNull]
-        public ObjectId FirstParentGuid => ParentIds?.FirstOrDefault();
+        public ObjectId FirstParentId => ParentIds?.FirstOrDefault();
 
         #region INotifyPropertyChanged
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1631,7 +1631,7 @@ namespace GitUI.CommandsDialogs
             ClearDiffViewIfNoFilesLeft();
             Staged.ClearSelected();
 
-            _currentSelection = Unstaged.SelectedGitItems.ToList();
+            _currentSelection = Unstaged.SelectedItems.Items().ToList();
             FileStatusItem item = Unstaged.SelectedItem;
             ShowChanges(item, false);
 
@@ -1698,8 +1698,8 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            // Staged.SelectedGitItems is needed only once, so we can safely convert to list here
-            var allFiles = Staged.SelectedGitItems.ToList();
+            // Staged.SelectedItems.Items() is needed only once, so we can safely convert to list here
+            var allFiles = Staged.SelectedItems.Items().ToList();
             if (allFiles.Count == 0)
             {
                 return;
@@ -1844,7 +1844,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            Stage(Unstaged.SelectedGitItems.Where(s => !s.IsAssumeUnchanged && !s.IsSkipWorktree).ToList());
+            Stage(Unstaged.SelectedItems.Items().Where(s => !s.IsAssumeUnchanged && !s.IsSkipWorktree).ToList());
             if (Unstaged.IsEmpty)
             {
                 Message.Focus();
@@ -1854,7 +1854,7 @@ namespace GitUI.CommandsDialogs
         private void Unstaged_DoubleClick(object sender, EventArgs e)
         {
             _currentFilesList = Unstaged;
-            Stage(Unstaged.SelectedGitItems.ToList());
+            Stage(Unstaged.SelectedItems.Items().ToList());
             if (Unstaged.IsEmpty)
             {
                 Message.Focus();
@@ -1890,7 +1890,7 @@ namespace GitUI.CommandsDialogs
             ClearDiffViewIfNoFilesLeft();
 
             Unstaged.ClearSelected();
-            _currentSelection = Staged.SelectedGitItems.ToList();
+            _currentSelection = Staged.SelectedItems.Items().ToList();
             var item = Staged.SelectedItem;
             ShowChanges(item, true);
         }
@@ -2054,7 +2054,7 @@ namespace GitUI.CommandsDialogs
                 }
 
                 // Unstage file first, then reset
-                var selectedFiles = Staged.SelectedGitItems.ToList();
+                var selectedFiles = Staged.SelectedItems.Items().ToList();
                 toolStripProgressBar1.Visible = true;
                 toolStripProgressBar1.Maximum = selectedFiles.Count;
                 toolStripProgressBar1.Value = 0;
@@ -2449,7 +2449,7 @@ namespace GitUI.CommandsDialogs
 
             SelectedDiff.Clear();
 
-            Module.AssumeUnchangedFiles(Unstaged.SelectedGitItems.ToList(), true, out _);
+            Module.AssumeUnchangedFiles(Unstaged.SelectedItems.Items().ToList(), true, out _);
 
             Initialize();
         }
@@ -2463,7 +2463,7 @@ namespace GitUI.CommandsDialogs
 
             SelectedDiff.Clear();
 
-            Module.AssumeUnchangedFiles(Unstaged.SelectedGitItems.ToList(), false, out _);
+            Module.AssumeUnchangedFiles(Unstaged.SelectedItems.Items().ToList(), false, out _);
 
             Initialize();
         }
@@ -2477,7 +2477,7 @@ namespace GitUI.CommandsDialogs
 
             SelectedDiff.Clear();
 
-            Module.SkipWorktreeFiles(Unstaged.SelectedGitItems.ToList(), true);
+            Module.SkipWorktreeFiles(Unstaged.SelectedItems.Items().ToList(), true);
 
             Initialize();
         }
@@ -2491,7 +2491,7 @@ namespace GitUI.CommandsDialogs
 
             SelectedDiff.Clear();
 
-            Module.SkipWorktreeFiles(Unstaged.SelectedGitItems.ToList(), false);
+            Module.SkipWorktreeFiles(Unstaged.SelectedItems.Items().ToList(), false);
 
             Initialize();
         }
@@ -2576,7 +2576,7 @@ namespace GitUI.CommandsDialogs
 
         private void OpenWithDifftoolToolStripMenuItemClick(object sender, EventArgs e)
         {
-            OpenFilesWithDiffTool(Unstaged.SelectedGitItems, GitRevision.IndexGuid, GitRevision.WorkTreeGuid);
+            OpenFilesWithDiffTool(Unstaged.SelectedItems.Items(), GitRevision.IndexGuid, GitRevision.WorkTreeGuid);
         }
 
         private void OpenWithDiffTool()
@@ -2586,7 +2586,7 @@ namespace GitUI.CommandsDialogs
 
         private void ResetPartOfFileToolStripMenuItemClick(object sender, EventArgs e)
         {
-            var items = Unstaged.SelectedGitItems.ToList();
+            var items = Unstaged.SelectedItems.Items().ToList();
 
             if (items.Count != 1)
             {
@@ -2979,7 +2979,7 @@ namespace GitUI.CommandsDialogs
 
         private void resetSubmoduleChanges_Click(object sender, EventArgs e)
         {
-            var unstagedFiles = Unstaged.SelectedGitItems.ToList();
+            var unstagedFiles = Unstaged.SelectedItems.Items().ToList();
             if (unstagedFiles.Count == 0)
             {
                 return;
@@ -3011,7 +3011,7 @@ namespace GitUI.CommandsDialogs
 
         private void updateSubmoduleMenuItem_Click(object sender, EventArgs e)
         {
-            var unstagedFiles = Unstaged.SelectedGitItems.ToList();
+            var unstagedFiles = Unstaged.SelectedItems.Items().ToList();
             if (unstagedFiles.Count == 0)
             {
                 return;
@@ -3027,7 +3027,7 @@ namespace GitUI.CommandsDialogs
 
         private void stashSubmoduleChangesToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var unstagedFiles = Unstaged.SelectedGitItems.ToList();
+            var unstagedFiles = Unstaged.SelectedItems.Items().ToList();
             if (unstagedFiles.Count == 0)
             {
                 return;
@@ -3148,7 +3148,7 @@ namespace GitUI.CommandsDialogs
 
         private void stagedOpenDifftoolToolStripMenuItem9_Click(object sender, EventArgs e)
         {
-            OpenFilesWithDiffTool(Staged.SelectedGitItems, "HEAD", GitRevision.IndexGuid);
+            OpenFilesWithDiffTool(Staged.SelectedItems.Items(), "HEAD", GitRevision.IndexGuid);
         }
 
         private void openFolderToolStripMenuItem10_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -8,6 +8,7 @@ using GitCommands.Git;
 using GitExtUtils.GitUI.Theming;
 using GitUI.HelperDialogs;
 using GitUI.Theming;
+using GitUI.UserControls;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using ResourceManager;
@@ -285,11 +286,7 @@ namespace GitUI.CommandsDialogs
 
         private ContextMenuDiffToolInfo GetContextMenuDiffToolInfo()
         {
-            var parentIds = DiffFiles.SelectedItems
-                .Where(i => i.FirstRevision != null)
-                .Select(i => i.FirstRevision.ObjectId)
-                .Distinct()
-                .ToList();
+            var parentIds = DiffFiles.SelectedItems.FirstIds().ToList();
             bool firstIsParent = _revisionTester.AllFirstAreParentsToSelected(parentIds, _headRevision);
             bool localExists = _revisionTester.AnyLocalFileExists(DiffFiles.SelectedItems.Select(i => i.Item));
 

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -152,6 +152,11 @@ namespace GitUI.CommandsDialogs
 
             foreach (var item in DiffFiles.SelectedItems)
             {
+                if (item.FirstRevision?.ObjectId == ObjectId.CombinedDiffId)
+                {
+                    continue;
+                }
+
                 var revs = new[] { item.SecondRevision, item.FirstRevision };
                 UICommands.OpenWithDifftool(this, revs, item.Item.Name, item.Item.OldName, diffKind, item.Item.IsTracked);
             }
@@ -280,7 +285,11 @@ namespace GitUI.CommandsDialogs
 
         private ContextMenuDiffToolInfo GetContextMenuDiffToolInfo()
         {
-            var parentIds = DiffFiles.SelectedItems.Select(i => i.FirstRevision.ObjectId).Distinct().ToList();
+            var parentIds = DiffFiles.SelectedItems
+                .Where(i => i.FirstRevision != null)
+                .Select(i => i.FirstRevision.ObjectId)
+                .Distinct()
+                .ToList();
             bool firstIsParent = _revisionTester.AllFirstAreParentsToSelected(parentIds, _headRevision);
             bool localExists = _revisionTester.AnyLocalFileExists(DiffFiles.SelectedItems.Select(i => i.Item));
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -280,15 +280,11 @@ namespace GitUI.CommandsDialogs
             var selectedItems = DiffFiles.SelectedItems.ToList();
 
             // Some items are not supported if more than one revision is selected
-            var revisions = selectedItems.Select(item => item.SecondRevision).Distinct().ToList();
+            var revisions = selectedItems.SecondRevs().ToList();
             var selectedRev = revisions.Count() != 1 ? null : revisions.FirstOrDefault();
 
             // First (A) is parent if one revision selected or if parent, then selected
-            var parentIds = selectedItems
-                .Where(i => i.FirstRevision != null)
-                .Select(i => i.FirstRevision.ObjectId)
-                .Distinct()
-                .ToList();
+            var parentIds = selectedItems.FirstIds().ToList();
 
             // Combined diff is a display only diff, no manipulations
             bool isAnyCombinedDiff = parentIds.Contains(ObjectId.CombinedDiffId);
@@ -353,7 +349,7 @@ namespace GitUI.CommandsDialogs
                     .Select(item => item.Item.Name).ToList();
                 Module.RemoveFiles(deletedItems, false);
 
-                foreach (var childId in selectedItems.Select(i => i.SecondRevision.ObjectId).Distinct())
+                foreach (var childId in selectedItems.SecondIds())
                 {
                     var itemsToCheckout = selectedItems
                         .Where(item => !item.Item.IsDeleted && item.SecondRevision.ObjectId == childId)
@@ -370,10 +366,7 @@ namespace GitUI.CommandsDialogs
                     .Select(item => item.Item.Name).ToList();
                 Module.RemoveFiles(addedItems, false);
 
-                foreach (var parentId in selectedItems
-                    .Where(i => i.FirstRevision != null)
-                    .Select(i => i.FirstRevision.ObjectId)
-                    .Distinct())
+                foreach (var parentId in selectedItems.FirstIds())
                 {
                     var itemsToCheckout = selectedItems
                         .Where(item => !item.Item.IsNew && item.FirstRevision?.ObjectId == parentId)
@@ -696,14 +689,10 @@ namespace GitUI.CommandsDialogs
         private ContextMenuDiffToolInfo GetContextMenuDiffToolInfo()
         {
             // Some items are not supported if more than one revision is selected
-            var revisions = DiffFiles.SelectedItems.Select(item => item.SecondRevision).Distinct().ToList();
+            var revisions = DiffFiles.SelectedItems.SecondRevs().ToList();
             var selectedRev = revisions.Count() != 1 ? null : revisions.FirstOrDefault();
 
-            var parentIds = DiffFiles.SelectedItems
-                .Where(i => i.FirstRevision != null)
-                .Select(i => i.FirstRevision.ObjectId)
-                .Distinct()
-                .ToList();
+            var parentIds = DiffFiles.SelectedItems.FirstIds().ToList();
             bool firstIsParent = _gitRevisionTester.AllFirstAreParentsToSelected(parentIds, selectedRev);
             bool localExists = _gitRevisionTester.AnyLocalFileExists(DiffFiles.SelectedItems.Select(i => i.Item));
 
@@ -732,7 +721,7 @@ namespace GitUI.CommandsDialogs
                 MenuUtil.SetAsCaptionMenuItem(selectedDiffCaptionMenuItem, DiffContextMenu);
 
                 firstDiffCaptionMenuItem.Text = _firstRevision.Text +
-                                                (DescribeRevision(DiffFiles.SelectedItems.Select(i => i.FirstRevision).Distinct().ToList()) ?? string.Empty);
+                                                (DescribeRevision(DiffFiles.SelectedItems.FirstRevs().ToList()) ?? string.Empty);
                 firstDiffCaptionMenuItem.Visible = true;
                 MenuUtil.SetAsCaptionMenuItem(firstDiffCaptionMenuItem, DiffContextMenu);
             }
@@ -771,7 +760,7 @@ namespace GitUI.CommandsDialogs
         private void resetFileToToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
         {
             var items = DiffFiles.SelectedItems;
-            var selectedIds = items.Select(it => it.SecondRevision.ObjectId).Distinct().ToList();
+            var selectedIds = items.SecondIds().ToList();
             if (selectedIds.Count == 0)
             {
                 resetFileToSelectedToolStripMenuItem.Visible = false;
@@ -790,11 +779,7 @@ namespace GitUI.CommandsDialogs
                     _selectedRevision + DescribeRevision(selectedIds.FirstOrDefault(), 50);
             }
 
-            var parentIds = DiffFiles.SelectedItems
-                .Where(i => i.FirstRevision != null)
-                .Select(i => i.FirstRevision.ObjectId)
-                .Distinct()
-                .ToList();
+            var parentIds = DiffFiles.SelectedItems.FirstIds().ToList();
             if (parentIds.Count != 1 || !CanResetToRevision(parentIds.FirstOrDefault()))
             {
                 resetFileToParentToolStripMenuItem.Visible = false;

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -65,7 +65,7 @@ namespace GitUI
                 return Task.CompletedTask;
             }
 
-            var firstId = item.FirstRevision?.ObjectId ?? item.SecondRevision.FirstParentGuid;
+            var firstId = item.FirstRevision?.ObjectId ?? item.SecondRevision.FirstParentId;
 
             openWithDiffTool ??= OpenWithDiffTool;
 

--- a/GitUI/RevisionDiffInfoProvider.cs
+++ b/GitUI/RevisionDiffInfoProvider.cs
@@ -47,7 +47,7 @@ namespace GitUI
                 return false;
             }
 
-            if (revisions[0] == null || (revisions.Count == 2 && revisions[1] == null))
+            if (revisions[0] == null)
             {
                 error = "Unexpected single null argument to difftool";
                 firstRevision = null;
@@ -55,11 +55,20 @@ namespace GitUI
                 return false;
             }
 
+            if (revisions.Count == 2 && revisions[1] == null && (diffKind == RevisionDiffKind.DiffBLocal || diffKind == RevisionDiffKind.DiffBParentLocal))
+            {
+                error = "Unexpected second null argument to difftool for DiffB";
+                firstRevision = null;
+                secondRevision = null;
+                return false;
+            }
+
             if (diffKind == RevisionDiffKind.DiffAB)
             {
+                // If revisions[1]?.Guid is null, the "commit before the initial" is used as firstRev
                 firstRevision = revisions.Count == 1
                     ? GetParentRef(revisions[0])
-                    : revisions[1].Guid;
+                    : revisions[1]?.Guid ?? "--root";
                 secondRevision = revisions[0].Guid;
             }
             else
@@ -94,11 +103,11 @@ namespace GitUI
                 }
                 else if (diffKind == RevisionDiffKind.DiffALocal)
                 {
-                    firstRevision = revisions[1].Guid;
+                    firstRevision = revisions[1]?.Guid ?? "--root";
                 }
                 else if (diffKind == RevisionDiffKind.DiffAParentLocal)
                 {
-                    firstRevision = GetParentRef(revisions[1]);
+                    firstRevision = revisions[1] == null ? "--root" : GetParentRef(revisions[1]);
                 }
                 else
                 {
@@ -111,7 +120,7 @@ namespace GitUI
             error = null;
             return true;
 
-            string GetParentRef(GitRevision revision)
+            static string GetParentRef(GitRevision revision)
             {
                 return revision.FirstParentId?.ToString() ?? revision.Guid + '^';
             }

--- a/GitUI/RevisionDiffInfoProvider.cs
+++ b/GitUI/RevisionDiffInfoProvider.cs
@@ -113,7 +113,7 @@ namespace GitUI
 
             string GetParentRef(GitRevision revision)
             {
-                return revision.FirstParentGuid?.ToString() ?? revision.Guid + '^';
+                return revision.FirstParentId?.ToString() ?? revision.Guid + '^';
             }
         }
     }

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -598,7 +598,7 @@ namespace GitUI.Blame
                 return;
             }
 
-            BlameRevision(selectedRevision.FirstParentGuid);
+            BlameRevision(selectedRevision.FirstParentId);
         }
 
         private void BlameRevision(ObjectId revisionId)

--- a/GitUI/UserControls/FileStatusItemExtensions.cs
+++ b/GitUI/UserControls/FileStatusItemExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using GitCommands;
+using GitUIPluginInterfaces;
+
+namespace GitUI.UserControls
+{
+    public static class FileStatusItemExtensions
+    {
+        public static IEnumerable<GitRevision> FirstRevs(this IEnumerable<FileStatusItem> l)
+        {
+            return l.Where(i => i.FirstRevision != null)
+                .Select(i => i.FirstRevision)
+                .Distinct();
+        }
+
+        public static IEnumerable<ObjectId> FirstIds(this IEnumerable<FileStatusItem> l)
+        {
+            return l.Where(i => i.FirstRevision != null)
+                .Select(i => i.FirstRevision.ObjectId)
+                .Distinct();
+        }
+
+        public static IEnumerable<GitRevision> SecondRevs(this IEnumerable<FileStatusItem> l)
+        {
+            return l.Select(i => i.SecondRevision)
+                .Distinct();
+        }
+
+        public static IEnumerable<ObjectId> SecondIds(this IEnumerable<FileStatusItem> l)
+        {
+            return l.Select(i => i.SecondRevision.ObjectId)
+                .Distinct();
+        }
+
+        public static IEnumerable<GitItemStatus> Items(this IEnumerable<FileStatusItem> l)
+        {
+            return l.Select(i => i.Item);
+        }
+    }
+}

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -265,7 +265,7 @@ namespace GitUI
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [Browsable(false)]
-        public IReadOnlyList<GitItemStatus> GitItemFilteredStatuses => AllItems.Select(i => i.Item).AsReadOnlyList();
+        public IReadOnlyList<GitItemStatus> GitItemFilteredStatuses => AllItems.Items().AsReadOnlyList();
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [Browsable(false)]
@@ -364,7 +364,6 @@ namespace GitUI
         [Browsable(false)]
         public IEnumerable<GitItemStatus> SelectedGitItems
         {
-            get => SelectedItems.Select(i => i.Item);
             set
             {
                 if (value == null)

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -662,7 +662,7 @@ namespace GitUI
                             ((GitRevision, GitRevision, string, IReadOnlyList<GitItemStatus>))(new GitRevision(parentId),
                                 selectedRev,
                                 _diffWithParent.Text + GetDescriptionForRevision(parentId),
-                                Module.GetDiffFilesWithSubmodulesStatus(parentId, selectedRev.ObjectId, selectedRev.FirstParentGuid))));
+                                Module.GetDiffFilesWithSubmodulesStatus(parentId, selectedRev.ObjectId, selectedRev.FirstParentId))));
                 }
 
                 // Show combined (merge conflicts) when a single merge commit is selected
@@ -690,7 +690,7 @@ namespace GitUI
                         (firstRev,
                             selectedRev,
                             _diffWithParent.Text + GetDescriptionForRevision(firstRev.ObjectId),
-                            Module.GetDiffFilesWithSubmodulesStatus(firstRev.ObjectId, selectedRev.ObjectId, selectedRev.FirstParentGuid))));
+                            Module.GetDiffFilesWithSubmodulesStatus(firstRev.ObjectId, selectedRev.ObjectId, selectedRev.FirstParentId))));
 
                 if (AppSettings.ShowDiffForAllParents && revisions.Count == 2)
                 {
@@ -699,7 +699,7 @@ namespace GitUI
 
                     // Get base commit, add as parent if unique
                     Lazy<ObjectId> head = getRevision != null
-                        ? new Lazy<ObjectId>(() => getRevision(ObjectId.IndexId).FirstParentGuid)
+                        ? new Lazy<ObjectId>(() => getRevision(ObjectId.IndexId).FirstParentId)
                         : new Lazy<ObjectId>(() => Module.RevParse("HEAD"));
                     var baseRevGuid = Module.GetMergeBase(GetRevisionOrHead(firstRev, head),
                         GetRevisionOrHead(selectedRev, head));
@@ -713,8 +713,8 @@ namespace GitUI
                         // For the following diff:  A->B a,c,d; BASE->B a,b,c; BASE->A a,b,d
                         // (the file a has unique changes, b has the same change and c,d is changed in one of the branches)
                         // The following groups will be shown: A->B a,c,d; BASE->B a,c; BASE->A a,d; Common BASE b
-                        var allBaseToB = Module.GetDiffFilesWithSubmodulesStatus(baseRevGuid, selectedRev.ObjectId, selectedRev.FirstParentGuid);
-                        var allBaseToA = Module.GetDiffFilesWithSubmodulesStatus(baseRevGuid, firstRev.ObjectId, firstRev.FirstParentGuid);
+                        var allBaseToB = Module.GetDiffFilesWithSubmodulesStatus(baseRevGuid, selectedRev.ObjectId, selectedRev.FirstParentId);
+                        var allBaseToA = Module.GetDiffFilesWithSubmodulesStatus(baseRevGuid, firstRev.ObjectId, firstRev.FirstParentId);
 
                         var comparer = new GitItemStatusNameEqualityComparer();
                         var commonBaseToAandB = allBaseToB.Intersect(allBaseToA, comparer).Except(allAToB, comparer).ToList();

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -726,7 +726,7 @@ namespace GitUI
         {
             var revisions = GetSelectedRevisions();
             var selectedRev = revisions?.FirstOrDefault();
-            var firstId = revisions != null && revisions.Count > 1 ? revisions.LastOrDefault().ObjectId : selectedRev?.FirstParentGuid;
+            var firstId = revisions != null && revisions.Count > 1 ? revisions.LastOrDefault().ObjectId : selectedRev?.FirstParentId;
 
             return (firstId, selectedRev);
         }
@@ -2325,7 +2325,7 @@ namespace GitUI
                 }
                 else if (r.HasParent)
                 {
-                    _parentChildNavigationHistory.NavigateToParent(r.ObjectId, r.FirstParentGuid);
+                    _parentChildNavigationHistory.NavigateToParent(r.ObjectId, r.FirstParentId);
                 }
             }
         }
@@ -2572,7 +2572,7 @@ namespace GitUI
             }
 
             string rebaseCmd = GitCommandHelpers.RebaseCmd(
-                LatestSelectedRevision.FirstParentGuid?.ToString(),
+                LatestSelectedRevision.FirstParentId?.ToString(),
                 interactive: true, preserveMerges: false, autosquash: false, autoStash: true);
 
             using (var formProcess = new FormProcess(null, rebaseCmd, Module.WorkingDir, null, true))

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FileStatusListTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FileStatusListTests.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using System.Threading;
 using System.Windows.Forms;
 using FluentAssertions;
 using GitCommands;
 using GitUI;
+using GitUI.UserControls;
 using GitUIPluginInterfaces;
 using NUnit.Framework;
 
@@ -57,10 +57,10 @@ namespace GitExtensions.UITests.CommandsDialogs
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
             _fileStatusList.SelectedIndex.Should().Be(0);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt0);
-            _fileStatusList.SelectedGitItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0 });
+            _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0 });
 
             _fileStatusList.SelectedGitItem.Should().BeSameAs(_fileStatusList.SelectedItem.Item);
-            _fileStatusList.SelectedGitItems.Should().BeEquivalentTo(_fileStatusList.SelectedItems.Select(i => i.Item));
+            _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(_fileStatusList.SelectedItems.Items());
 
             // SelectedIndex
 
@@ -69,14 +69,14 @@ namespace GitExtensions.UITests.CommandsDialogs
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
             _fileStatusList.SelectedIndex.Should().Be(1);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt1);
-            _fileStatusList.SelectedGitItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
+            _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
 
             _fileStatusList.SelectedIndex = -1;
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1); // unchanged
             _fileStatusList.SelectedIndex.Should().Be(-1);
             _fileStatusList.SelectedGitItem.Should().BeNull();
-            _fileStatusList.SelectedGitItems.Should().BeEmpty();
+            _fileStatusList.SelectedItems.Items().Should().BeEmpty();
 
             _fileStatusList.SelectedIndex = 2;
             _fileStatusList.SelectedIndex = 42; // clears the selection
@@ -84,14 +84,14 @@ namespace GitExtensions.UITests.CommandsDialogs
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(2); // unchanged
             _fileStatusList.SelectedIndex.Should().Be(-1);
             _fileStatusList.SelectedGitItem.Should().BeNull();
-            _fileStatusList.SelectedGitItems.Should().BeEmpty();
+            _fileStatusList.SelectedItems.Items().Should().BeEmpty();
 
             _fileStatusList.SelectedIndex = 1;
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
             _fileStatusList.SelectedIndex.Should().Be(1);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt1);
-            _fileStatusList.SelectedGitItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
+            _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
 
             // SelectedGitItem
 
@@ -100,14 +100,14 @@ namespace GitExtensions.UITests.CommandsDialogs
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
             _fileStatusList.SelectedIndex.Should().Be(1);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt1);
-            _fileStatusList.SelectedGitItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
+            _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
 
             _fileStatusList.SelectedGitItem = null;
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1); // unchanged
             _fileStatusList.SelectedIndex.Should().Be(-1);
             _fileStatusList.SelectedGitItem.Should().BeNull();
-            _fileStatusList.SelectedGitItems.Should().BeEmpty();
+            _fileStatusList.SelectedItems.Items().Should().BeEmpty();
 
             _fileStatusList.SelectedGitItem = itemAt2;
             _fileStatusList.SelectedGitItem = itemNotInList; // clears the selection
@@ -115,37 +115,37 @@ namespace GitExtensions.UITests.CommandsDialogs
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(2); // unchanged
             _fileStatusList.SelectedIndex.Should().Be(-1);
             _fileStatusList.SelectedGitItem.Should().BeNull();
-            _fileStatusList.SelectedGitItems.Should().BeEmpty();
+            _fileStatusList.SelectedItems.Items().Should().BeEmpty();
 
             _fileStatusList.SelectedGitItem = itemAt1;
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
             _fileStatusList.SelectedIndex.Should().Be(1);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt1);
-            _fileStatusList.SelectedGitItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
+            _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
 
-            // SelectedGitItems (up to one item)
+            // SelectedItems.Items() (up to one item)
 
             _fileStatusList.SelectedGitItems = new List<GitItemStatus> { itemAt1 };
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
             _fileStatusList.SelectedIndex.Should().Be(1);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt1);
-            _fileStatusList.SelectedGitItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
+            _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
 
-            _fileStatusList.SelectedGitItems = null;
+            _fileStatusList.SelectedItems = null;
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1); // unchanged
             _fileStatusList.SelectedIndex.Should().Be(-1);
             _fileStatusList.SelectedGitItem.Should().BeNull();
-            _fileStatusList.SelectedGitItems.Should().BeEmpty();
+            _fileStatusList.SelectedItems.Items().Should().BeEmpty();
 
             _fileStatusList.SelectedGitItems = new List<GitItemStatus> { };
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1); // unchanged
             _fileStatusList.SelectedIndex.Should().Be(-1);
             _fileStatusList.SelectedGitItem.Should().BeNull();
-            _fileStatusList.SelectedGitItems.Should().BeEmpty();
+            _fileStatusList.SelectedItems.Items().Should().BeEmpty();
 
             _fileStatusList.SelectedGitItems = new List<GitItemStatus> { itemAt2 };
             _fileStatusList.SelectedGitItems = new List<GitItemStatus> { itemNotInList }; // clears the selection
@@ -153,16 +153,16 @@ namespace GitExtensions.UITests.CommandsDialogs
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(2); // unchanged
             _fileStatusList.SelectedIndex.Should().Be(-1);
             _fileStatusList.SelectedGitItem.Should().BeNull();
-            _fileStatusList.SelectedGitItems.Should().BeEmpty();
+            _fileStatusList.SelectedItems.Items().Should().BeEmpty();
 
             _fileStatusList.SelectedGitItems = new List<GitItemStatus> { itemAt1 };
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
             _fileStatusList.SelectedIndex.Should().Be(1);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt1);
-            _fileStatusList.SelectedGitItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
+            _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1 });
 
-            // SelectedGitItems (multiple items)
+            // SelectedItems.Items() (multiple items)
 
             _fileStatusList.SelectedIndex = 2;
             _fileStatusList.SelectedGitItems = new List<GitItemStatus> { itemAt2, itemAt0, itemNotInList };
@@ -170,14 +170,14 @@ namespace GitExtensions.UITests.CommandsDialogs
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
             _fileStatusList.SelectedIndex.Should().Be(0);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt0); // focused item
-            _fileStatusList.SelectedGitItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0, itemAt2 });
+            _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0, itemAt2 });
 
             accessor.FileStatusListView.Items[1].Focused = true;
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
             _fileStatusList.SelectedIndex.Should().Be(0);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt2); // LastSelectedItem
-            _fileStatusList.SelectedGitItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0, itemAt2 });
+            _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0, itemAt2 });
 
             _fileStatusList.SelectedIndex = 2;
             _fileStatusList.SelectedGitItems = new List<GitItemStatus> { itemAt2, itemAt1, itemNotInList };
@@ -185,14 +185,14 @@ namespace GitExtensions.UITests.CommandsDialogs
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(1);
             _fileStatusList.SelectedIndex.Should().Be(1);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt1); // focused item
-            _fileStatusList.SelectedGitItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1, itemAt2 });
+            _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1, itemAt2 });
 
             accessor.FileStatusListView.Items[0].Focused = true;
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
             _fileStatusList.SelectedIndex.Should().Be(1);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt2); // LastSelectedItem
-            _fileStatusList.SelectedGitItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1, itemAt2 });
+            _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt1, itemAt2 });
 
             // SelectAll
 
@@ -207,7 +207,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
             _fileStatusList.SelectedIndex.Should().Be(0);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt0); // focused item
-            _fileStatusList.SelectedGitItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0, itemAt1, itemAt2 });
+            _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0, itemAt1, itemAt2 });
 
             // SelectFirstVisibleItem
 
@@ -217,7 +217,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);
             _fileStatusList.SelectedIndex.Should().Be(0);
             _fileStatusList.SelectedGitItem.Should().BeSameAs(itemAt0); // focused item
-            _fileStatusList.SelectedGitItems.Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0 });
+            _fileStatusList.SelectedItems.Items().Should().BeEquivalentTo(new List<GitItemStatus> { itemAt0 });
         }
 
         [Test]

--- a/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
+++ b/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
@@ -102,10 +102,10 @@ namespace ResourceManager.CommitDataRenders
                 header.AppendLine(_labelFormatter.FormatLabel(ResourceManager.Strings.GetChildren(commitData.ChildIds.Count), padding) + RenderObjectIds(commitData.ChildIds, showRevisionsAsLinks));
             }
 
-            var parentGuids = commitData.ParentGuids;
-            if (parentGuids.Count != 0)
+            var parentIds = commitData.ParentIds;
+            if (parentIds.Count != 0)
             {
-                header.AppendLine(_labelFormatter.FormatLabel(ResourceManager.Strings.GetParents(parentGuids.Count), padding) + RenderObjectIds(parentGuids, showRevisionsAsLinks));
+                header.AppendLine(_labelFormatter.FormatLabel(ResourceManager.Strings.GetParents(parentIds.Count), padding) + RenderObjectIds(parentIds, showRevisionsAsLinks));
             }
 
             // remove the trailing newline character

--- a/UnitTests/GitCommands.Tests/CommitDataManagerTest.cs
+++ b/UnitTests/GitCommands.Tests/CommitDataManagerTest.cs
@@ -49,7 +49,7 @@ namespace GitCommandsTests
             data.Author.Should().Be("John Doe (Acme Inc) <John.Doe@test.com>");
             data.Committer.Should().Be("John Doe <John.Doe@test.com>");
             data.ObjectId.Should().Be(ObjectId.Parse("37da2014bc5128ca084543423e410d81df838845"));
-            data.ParentGuids.Should().BeEquivalentTo(ObjectId.Parse("ad1ccc2ecc00865d61e74b703a260d17b4db1216"), ObjectId.Parse("a8d564d3bb8c65e88e40239937cb48dda57f01b8"), ObjectId.Parse("1711f4a6522f86c3e4e404a66a78f4586d25d89d"));
+            data.ParentIds.Should().BeEquivalentTo(ObjectId.Parse("ad1ccc2ecc00865d61e74b703a260d17b4db1216"), ObjectId.Parse("a8d564d3bb8c65e88e40239937cb48dda57f01b8"), ObjectId.Parse("1711f4a6522f86c3e4e404a66a78f4586d25d89d"));
             data.TreeGuid.Should().Be(ObjectId.Parse("a13ae23be4d207c7af2818fd7cc2caa2d0a63e47"));
 
             data.AuthorDate.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture).Should().Be("2017-10-22T12:56:12");

--- a/UnitTests/GitUI.Tests/Helpers/DiffKindRevisionTests.cs
+++ b/UnitTests/GitUI.Tests/Helpers/DiffKindRevisionTests.cs
@@ -20,6 +20,12 @@ namespace GitUITests.Helpers
 
             revisions = new List<GitRevision> { null, null };
             Assert.False(RevisionDiffInfoProvider.TryGet(revisions, RevisionDiffKind.DiffAB, out _, out _, out _, out _), "2 null rev");
+
+            var head = ObjectId.Random();
+            revisions = new List<GitRevision> { new GitRevision(head), null };
+            Assert.False(RevisionDiffInfoProvider.TryGet(revisions, RevisionDiffKind.DiffBLocal, out _, out _, out _, out _), "2nd null rev DiffBLocal");
+
+            Assert.False(RevisionDiffInfoProvider.TryGet(revisions, RevisionDiffKind.DiffBParentLocal, out _, out _, out _, out _), "2nd null rev DiffBParentLocal");
         }
 
         [Test]
@@ -51,11 +57,22 @@ namespace GitUITests.Helpers
         {
             var head = ObjectId.Random();
             var headParent = ObjectId.Random();
-            var revisions = new[] { new GitRevision(headParent), new GitRevision(head) };
+            var revisions = new[] { new GitRevision(head), new GitRevision(headParent) };
 
             Assert.True(RevisionDiffInfoProvider.TryGet(revisions, RevisionDiffKind.DiffAB, out _, out var firstRevision, out var secondRevision, out _), "null rev");
-            Assert.AreEqual(head.ToString(), firstRevision, "first");
-            Assert.AreEqual(headParent.ToString(), secondRevision, "second");
+            Assert.AreEqual(headParent.ToString(), firstRevision, "first");
+            Assert.AreEqual(head.ToString(), secondRevision, "second");
+        }
+
+        [Test]
+        public void DiffKindRevisionTests_AB_null()
+        {
+            var head = ObjectId.Random();
+            var revisions = new[] { new GitRevision(head), null };
+
+            Assert.True(RevisionDiffInfoProvider.TryGet(revisions, RevisionDiffKind.DiffAB, out _, out var firstRevision, out var secondRevision, out _), "null rev");
+            Assert.AreEqual("--root", firstRevision, "first");
+            Assert.AreEqual(head.ToString(), secondRevision, "second");
         }
 
         [Test]
@@ -74,10 +91,21 @@ namespace GitUITests.Helpers
         {
             var head = ObjectId.Random();
             var headParent = ObjectId.Random();
-            var revisions = new[] { new GitRevision(headParent), new GitRevision(head) };
+            var revisions = new[] { new GitRevision(head), new GitRevision(headParent) };
 
             Assert.True(RevisionDiffInfoProvider.TryGet(revisions, RevisionDiffKind.DiffALocal, out _, out var firstRevision, out var secondRevision, out _), "null rev");
-            Assert.AreEqual(head.ToString(), firstRevision, "first");
+            Assert.AreEqual(headParent.ToString(), firstRevision, "first");
+            Assert.AreEqual(null, secondRevision, "second");
+        }
+
+        [Test]
+        public void DiffKindRevisionTests_AL_3()
+        {
+            var head = ObjectId.Random();
+            var revisions = new[] { new GitRevision(head), null };
+
+            Assert.True(RevisionDiffInfoProvider.TryGet(revisions, RevisionDiffKind.DiffALocal, out _, out var firstRevision, out var secondRevision, out _), "null rev");
+            Assert.AreEqual("--root", firstRevision, "first");
             Assert.AreEqual(null, secondRevision, "second");
         }
 
@@ -89,6 +117,17 @@ namespace GitUITests.Helpers
 
             Assert.True(RevisionDiffInfoProvider.TryGet(revisions, RevisionDiffKind.DiffAParentLocal, out _, out var firstRevision, out var secondRevision, out _), "null rev");
             Assert.AreEqual($"{head}^^", firstRevision, "first");
+            Assert.AreEqual(null, secondRevision, "second");
+        }
+
+        [Test]
+        public void DiffKindRevisionTests_ApL_2()
+        {
+            var head = ObjectId.Random();
+            var revisions = new[] { new GitRevision(head), null };
+
+            Assert.True(RevisionDiffInfoProvider.TryGet(revisions, RevisionDiffKind.DiffAParentLocal, out _, out var firstRevision, out var secondRevision, out _), "null rev");
+            Assert.AreEqual("--root", firstRevision, "first");
             Assert.AreEqual(null, secondRevision, "second");
         }
 
@@ -108,10 +147,10 @@ namespace GitUITests.Helpers
         {
             var head = ObjectId.Random();
             var headParent = ObjectId.Random();
-            var revisions = new[] { new GitRevision(headParent), new GitRevision(head) };
+            var revisions = new[] { new GitRevision(head), new GitRevision(headParent) };
 
             Assert.True(RevisionDiffInfoProvider.TryGet(revisions, RevisionDiffKind.DiffBLocal, out _, out var firstRevision, out var secondRevision, out _), "null rev");
-            Assert.AreEqual(headParent.ToString(), firstRevision, "first");
+            Assert.AreEqual(head.ToString(), firstRevision, "first");
             Assert.AreEqual(null, secondRevision, "second");
         }
 

--- a/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererIntegrationTests.cs
+++ b/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererIntegrationTests.cs
@@ -22,14 +22,14 @@ namespace ResourceManagerTests.CommitDataRenders
         {
             var commitGuid = ObjectId.Random();
             var treeGuid = ObjectId.Random();
-            var parentGuid1 = ObjectId.Random();
-            var parentGuid2 = ObjectId.Random();
+            var parentId1 = ObjectId.Random();
+            var parentId2 = ObjectId.Random();
             var authorTime = DateTime.UtcNow.AddDays(-3);
             var commitTime = DateTime.UtcNow.AddDays(-2);
 
             _data = new CommitData(
                 commitGuid, treeGuid,
-                new[] { parentGuid1, parentGuid2 },
+                new[] { parentId1, parentId2 },
                 "John Doe (Acme Inc) <John.Doe@test.com>", authorTime,
                 "Jane Doe <Jane.Doe@test.com>", commitTime,
                 "\tI made a really neat change.\n\nNotes (p4notes):\n\tP4@547123")
@@ -59,8 +59,8 @@ namespace ResourceManagerTests.CommitDataRenders
                                    "<a href='gitext://gotocommit/" + _data.ChildIds[1] + "'>" + _data.ChildIds[1].ToShortString() + "</a> " +
                                    "<a href='gitext://gotocommit/" + _data.ChildIds[2] + "'>" + _data.ChildIds[2].ToShortString() + "</a>" + Environment.NewLine +
                                  "Parents:		" +
-                                   "<a href='gitext://gotocommit/" + _data.ParentGuids[0] + "'>" + _data.ParentGuids[0].ToShortString() + "</a> " +
-                                   "<a href='gitext://gotocommit/" + _data.ParentGuids[1] + "'>" + _data.ParentGuids[1].ToShortString() + "</a>";
+                                   "<a href='gitext://gotocommit/" + _data.ParentIds[0] + "'>" + _data.ParentIds[0].ToShortString() + "</a> " +
+                                   "<a href='gitext://gotocommit/" + _data.ParentIds[1] + "'>" + _data.ParentIds[1].ToShortString() + "</a>";
 
             var result = _rendererTabs.Render(_data, true);
 
@@ -80,8 +80,8 @@ namespace ResourceManagerTests.CommitDataRenders
                                    _data.ChildIds[1].ToShortString() + " " +
                                    _data.ChildIds[2].ToShortString() + Environment.NewLine +
                                  "Parents:		" +
-                                   _data.ParentGuids[0].ToShortString() + " " +
-                                   _data.ParentGuids[1].ToShortString();
+                                   _data.ParentIds[0].ToShortString() + " " +
+                                   _data.ParentIds[1].ToShortString();
 
             var result = _rendererTabs.Render(_data, false);
 
@@ -101,8 +101,8 @@ namespace ResourceManagerTests.CommitDataRenders
                                    "<a href='gitext://gotocommit/" + _data.ChildIds[1] + "'>" + _data.ChildIds[1].ToShortString() + "</a> " +
                                    "<a href='gitext://gotocommit/" + _data.ChildIds[2] + "'>" + _data.ChildIds[2].ToShortString() + "</a>" + Environment.NewLine +
                                  "Parents:     " +
-                                   "<a href='gitext://gotocommit/" + _data.ParentGuids[0] + "'>" + _data.ParentGuids[0].ToShortString() + "</a> " +
-                                   "<a href='gitext://gotocommit/" + _data.ParentGuids[1] + "'>" + _data.ParentGuids[1].ToShortString() + "</a>";
+                                   "<a href='gitext://gotocommit/" + _data.ParentIds[0] + "'>" + _data.ParentIds[0].ToShortString() + "</a> " +
+                                   "<a href='gitext://gotocommit/" + _data.ParentIds[1] + "'>" + _data.ParentIds[1].ToShortString() + "</a>";
 
             var result = _rendererSpaces.Render(_data, true);
 
@@ -122,8 +122,8 @@ namespace ResourceManagerTests.CommitDataRenders
                                    _data.ChildIds[1].ToShortString() + " " +
                                    _data.ChildIds[2].ToShortString() + Environment.NewLine +
                                  "Parents:     " +
-                                   _data.ParentGuids[0].ToShortString() + " " +
-                                   _data.ParentGuids[1].ToShortString();
+                                   _data.ParentIds[0].ToShortString() + " " +
+                                   _data.ParentIds[1].ToShortString();
 
             var result = _rendererSpaces.Render(_data, false);
 


### PR DESCRIPTION
Fixes #8085 

## Proposed changes

- Refactor: Align FirstParentId name
Guid suffix is quite consistently used for the string representation of the hash, while Id suffix is used for ObjectId, this was therefore switched
Some parentGuids changed too, not changing treeGuid

- Use "--root" for first revision if null
Handle GitRevision == null as the root commit, before the initial commit, i.e. compare to /dev/null
SemanticMerge and KDiff3 shows such a diff, Tortoise does not for some reason
(The alternative would be to not add null to the revisions to diff which will result in a argument popup which is OK to me.)

- RevDiff: FirstRevision is null for the initial commit
Handle that FirstRevision is not set for the initial commit
All situations changed are not causing problems, but it is easier to handle FirstRevision consistently this way.

Should be merged with these three merges, separate PR for 3.4 when approved

## Test methodology

Review if FirstRevision usage and Manual
The (meaningless) IRevisionDiffController do not cover arguments in RevisionDiffControl

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
