### PR TITLE
Fix/script without icon

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -267,7 +267,7 @@ Current Branch:
 
         private void btnArgumentsHelp_Click(object sender, EventArgs e)
         {
-            if (_argumentsCheatSheet is object)
+            if (_argumentsCheatSheet?.Visible ?? false)
             {
                 _argumentsCheatSheet.BringToFront();
                 return;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -110,7 +110,7 @@ Current Branch:
 
             propertyGrid1.SelectedGridItemChanged += (s, e) =>
             {
-                if (WatchedProxyProperties.Contains(e.OldSelection?.PropertyDescriptor.Name ?? ""))
+                if (WatchedProxyProperties.Contains(e.OldSelection?.PropertyDescriptor?.Name ?? ""))
                 {
                     BindScripts(_scripts, SelectedScript);
                     propertyGrid1.Focus();

--- a/GitUI/CommandsDialogs/UserScriptContextMenuExtensions.cs
+++ b/GitUI/CommandsDialogs/UserScriptContextMenuExtensions.cs
@@ -1,12 +1,18 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
+using GitUI.Hotkey;
 using GitUI.Script;
+using ResourceManager;
 
 namespace GitUI.CommandsDialogs
 {
     public static class UserScriptContextMenuExtensions
     {
+        private static readonly Lazy<IEnumerable<HotkeyCommand>> Hotkeys = new Lazy<IEnumerable<HotkeyCommand>>(()
+            => HotkeySettingsManager.LoadHotkeys(FormSettings.HotkeySettingsName));
+
         /// <summary>
         ///  Appends user scripts to the <paramref name="contextMenu"/>, or under <paramref name="hostMenuItem"/>,
         ///  if scripts are marked as <see cref="ScriptInfo.AddToRevisionGridContextMenu"/>.
@@ -60,7 +66,8 @@ namespace GitUI.CommandsDialogs
                     {
                         Text = script.Name,
                         Name = script.Name + "_ownScript",
-                        Image = script.GetIcon()
+                        Image = script.GetIcon(),
+                        ShortcutKeyDisplayString = Hotkeys.Value?.FirstOrDefault(h => h.Name == script.Name)?.KeyData.ToShortcutKeyDisplayString()
                     };
 
                     item.Click += (s, e) =>

--- a/GitUI/Script/ScriptInfo.cs
+++ b/GitUI/Script/ScriptInfo.cs
@@ -43,6 +43,11 @@ namespace GitUI.Script
         [CanBeNull]
         public System.Drawing.Bitmap GetIcon()
         {
+            if (string.IsNullOrWhiteSpace(Icon))
+            {
+                return null;
+            }
+
             // Get all resources
             System.Resources.ResourceManager rm
                 = new System.Resources.ResourceManager("GitUI.Properties.Images",


### PR DESCRIPTION
## Proposed changes

- It is allowed to not assign an icon to a user script.
  So avoid regarding exceptions.
- Display the shortcuts assigned to the user scripts.
- Fixup the condition for showing the user scripts arguments cheat sheet again after closing it.

### Before

NBug exceptions unless icons are defined

![grafik](https://user-images.githubusercontent.com/36601201/82077854-62a45900-96e0-11ea-9897-4ccf5c510b09.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/82074254-c75cb500-96da-11ea-8060-a63f1f4dea0d.png)
![grafik](https://user-images.githubusercontent.com/36601201/82077727-325cba80-96e0-11ea-9cd8-41525a3f6f68.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 3486ba04ff582343f82a8d2e947328ed09ba5434
- Git 2.26.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
