### PR TITLE
Bugfix/i8115 submodule gitstatus

### DIFF
--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -475,6 +475,12 @@ namespace GitCommands.Submodules
                 SetModuleAsDirtyUpwards(superModule.GetTopModule());
             }
 
+            if (submoduleStatus == null || !submoduleStatus.IsDirty)
+            {
+                // no changes to submodules
+                return;
+            }
+
             // Recursively update submodules
             var module = new GitModule(path);
             await GetSubmoduleDetailedStatusAsync(module, cancelToken);


### PR DESCRIPTION
Fixes #8115

## Proposed changes

First commit:
- SubmoduleStatus: Check that a path exist before updating
- Set status as non dirty if git-status has no status also for other than top module
- Improve comments about the handling

The first commit prepares for two improvements to limit the commands run by the git status provider.
No major improvement, they could be separated to a separate commit too
- SubmoduleStatus: Use all info about submodules info from git-status
- SubmoduleStatus: Prune recursive calls when module is not dirty


## Test methodology <!-- How did you ensure quality? -->

Manual
There are some tests for SubmoduleStatusProvider.cs that are revised in #8049 
They do not have complex enough test cases to test this

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
