### PR TITLE
Submodule status: Present dirty submodules

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3667,7 +3667,7 @@ namespace GitCommands
 
         public SubmoduleStatus CheckSubmoduleStatus([CanBeNull] ObjectId commit, [CanBeNull] ObjectId oldCommit, CommitData data, CommitData oldData, bool loadData = false)
         {
-            // TODO File access for Git revision access
+            // Submodule directory must exist to run commands, unknown otherwise
             if (!IsValidGitWorkingDir() || oldCommit == null)
             {
                 return SubmoduleStatus.NewSubmodule;

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -370,7 +370,7 @@ See the changes in the commit form.");
                         var file = new GitItemStatus
                         {
                             IsTracked = true,
-                            Name = gitItem.Name,
+                            Name = gitItem.FileName,
                             TreeGuid = gitItem.ObjectId,
                             IsSubmodule = gitItem.ObjectType == GitObjectType.Commit
                         };


### PR DESCRIPTION
## Proposed changes

- Present submodule changes where commit is unchanged without the duplicated info
- Set status as Dirty if no commit changes

- RevFileTree: Minimal info for submodules if path contained a folder as the file name was used instead of the path
Normal files were OK as the blob was used rather than the filename (except for binary files)


## Screenshots 

Text examples from FileViewer

### Before

```
Submodule subtest/s002 Change

From:	68c11dc3b22c1e1476f03c0a6cc65591a4ccc95e
					2 years ago (2018-11-09 21:57:35)
		Merge pull request #5729 from gerhardol/bugfix/transifex-notranslate
		
		Remove untranslatable strings

To:		68c11dc3b22c1e1476f03c0a6cc65591a4ccc95e (dirty)
					2 years ago (2018-11-09 21:57:35)
		Merge pull request #5729 from gerhardol/bugfix/transifex-notranslate
		
		Remove untranslatable strings

Type: Unknown

Status:
?? t.t
```

```
Submodule s002

Commit hash:	68c11dc3b22c1e1476f03c0a6cc65591a4ccc95e
```

```
Binary file:

PSTaskDialog.dll

58 820 bytes:

0000    4D 5A 3F 00 03 00 00 00  04 00 00 00 3F 3F 00 00    MZ?..... ....??..
```

### After

RevDiff, Commit
```
Submodule subtest/s002 Change

Commit:	68c11dc3b22c1e1476f03c0a6cc65591a4ccc95e (dirty)
					2 years ago (2018-11-09 21:57:35)
		Merge pull request #5729 from gerhardol/bugfix/transifex-notranslate
		
		Remove untranslatable strings

Type: Dirty

Status:
?? t.t
```

RevFileTree
```
Submodule subtest\s002

Author:      RussKie <RussKie@users.noreply.github.com>
Date:        2 years ago (2018-11-09 21:57:35)
Committer:   GitHub <noreply@github.com>
Commit hash: 68c11dc3b22c1e1476f03c0a6cc65591a4ccc95e

Merge pull request #5729 from gerhardol/bugfix/transifex-notranslate

Remove untranslatable strings
```

RevFileTree
```
Binary file:

Bin\PSTaskDialog.dll

58 820 bytes:

0000    4D 5A 3F 00 03 00 00 00  04 00 00 00 3F 3F 00 00    MZ?..... ....??..
```

## Test methodology 

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
