### PR TITLE
Submodule status: Throttle instead of drop frequent updates

### DIFF
--- a/GitCommands/Submodules/SubmoduleInfoResult.cs
+++ b/GitCommands/Submodules/SubmoduleInfoResult.cs
@@ -16,8 +16,7 @@ namespace GitCommands.Submodules
         public IList<SubmoduleInfo> OurSubmodules { get; } = new List<SubmoduleInfo>();
 
         // List of SubmoduleInfo for all submodules under TopProject.
-        // Only populated if current module is a submodule (i.e. is not TopProject)
-        public IList<SubmoduleInfo> SuperSubmodules { get; } = new List<SubmoduleInfo>();
+        public IList<SubmoduleInfo> AllSubmodules { get; } = new List<SubmoduleInfo>();
 
         // Always set to the top-most module.
         [NotNull]

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -262,17 +262,8 @@ namespace GitUI.BranchTreePanel
 
                 var submoduleNodes = new List<SubmoduleNode>();
 
-                // We always want to display submodules rooted from the top project. If the currently open project is the top project,
-                // OurSubmodules contains all child submodules recursively; otherwise, if we're currently in a submodule, SuperSubmodules
-                // contains all submodule info relative to the top project.
-                if (result.SuperSubmodules?.Count > 0)
-                {
-                    CreateSubmoduleNodes(result.SuperSubmodules, threadModule, ref submoduleNodes);
-                }
-                else
-                {
-                    CreateSubmoduleNodes(result.OurSubmodules, threadModule, ref submoduleNodes);
-                }
+                // We always want to display submodules rooted from the top project.
+                CreateSubmoduleNodes(result.AllSubmodules, threadModule, ref submoduleNodes);
 
                 var nodes = new Nodes(this);
                 AddNodesToTree(ref nodes, submoduleNodes, threadModule, result.TopProject);
@@ -281,7 +272,7 @@ namespace GitUI.BranchTreePanel
 
             private void CreateSubmoduleNodes(IEnumerable<SubmoduleInfo> submodules, GitModule threadModule, ref List<SubmoduleNode> nodes)
             {
-                // result.OurSubmodules/SuperSubmodules contain a recursive list of submodules, but don't provide info about the super
+                // result.OurSubmodules/AllSubmodules contain a recursive list of submodules, but don't provide info about the super
                 // project path. So we deduce these by substring matching paths against an ordered list of all paths.
                 var modulePaths = submodules.Select(info => info.Path).ToList();
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2638,7 +2638,7 @@ namespace GitUI.CommandsDialogs
                 }
 
                 newItems.Add(CreateSubmoduleMenuItem(cancelToken, result.SuperProject, _superprojectModuleFormat.Text));
-                newItems.AddRange(result.SuperSubmodules.Select(submodule => CreateSubmoduleMenuItem(cancelToken, submodule)));
+                newItems.AddRange(result.AllSubmodules.Select(submodule => CreateSubmoduleMenuItem(cancelToken, submodule)));
                 toolStripButtonLevelUp.ToolTipText = _goToSuperProject.Text;
             }
 

--- a/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
+++ b/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
@@ -30,10 +30,7 @@ namespace CommonTestUtils
             Module = module;
 
             // Don't assume global user/email
-            Module.LocalConfigFile.SetString(SettingKeyString.UserName, "author");
-            Module.LocalConfigFile.SetString(SettingKeyString.UserEmail, "author@mail.com");
-            Module.LocalConfigFile.FilesEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-            Module.LocalConfigFile.Save();
+            SetDummyUserEmail(module);
 
             return;
 
@@ -111,20 +108,29 @@ namespace CommonTestUtils
         }
 
         /// <summary>
-        /// Adds 'helper' as a submodule of the current helper.
+        /// Set dummy user and email locally for the module, no global setting in AppVeyor
+        /// Must also be set on the submodule, local settings are not included when adding it
         /// </summary>
-        /// <param name="helper">GitModuleTestHelper to add as a submodule of this.</param>
+        private void SetDummyUserEmail(GitModule module)
+        {
+            module.LocalConfigFile.SetString(SettingKeyString.UserName, "author");
+            module.LocalConfigFile.SetString(SettingKeyString.UserEmail, "author@mail.com");
+            module.LocalConfigFile.FilesEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+            module.LocalConfigFile.Save();
+        }
+
+        /// <summary>
+        /// Adds 'subModuleHelper' as a submodule of the current subModuleHelper.
+        /// </summary>
+        /// <param name="subModuleHelper">GitModuleTestHelper to add as a submodule of this.</param>
         /// <param name="path">Relative submodule path.</param>
-        /// <returns>Module of added submodule</returns>
-        public GitModule AddSubmodule(GitModuleTestHelper helper, string path)
+        public void AddSubmodule(GitModuleTestHelper subModuleHelper, string path)
         {
             // Submodules require at least one commit
-            helper.Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Empty commit""");
+            subModuleHelper.Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Initial empty commit""");
 
-            Module.GitExecutable.GetOutput(GitCommandHelpers.AddSubmoduleCmd(helper.Module.WorkingDir.ToPosixPath(), path, null, true));
+            Module.GitExecutable.GetOutput(GitCommandHelpers.AddSubmoduleCmd(subModuleHelper.Module.WorkingDir.ToPosixPath(), path, null, true));
             Module.GitExecutable.GetOutput(@"commit -am ""Add submodule""");
-
-            return new GitModule(Path.Combine(Module.WorkingDir, path).ToPosixPath());
         }
 
         /// <summary>
@@ -135,7 +141,12 @@ namespace CommonTestUtils
         {
             Module.GitExecutable.GetOutput(@"submodule update --init --recursive");
             var paths = Module.GetSubmodulesLocalPaths(recursive: true);
-            return paths.Select(path => new GitModule(Path.Combine(Module.WorkingDir, path).ToNativePath()));
+            return paths.Select(path =>
+            {
+                var module = new GitModule(Path.Combine(Module.WorkingDir, path).ToNativePath());
+                SetDummyUserEmail(module);
+                return module;
+            });
         }
 
         public void Dispose()

--- a/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
+++ b/UnitTests/CommonTestUtils/SubmoduleTestHelpers.cs
@@ -7,7 +7,7 @@ namespace CommonTestUtils
 {
     public class SubmoduleTestHelpers
     {
-        public static async Task<SubmoduleInfoResult> UpdateSubmoduleStructureAndWaitForResultAsync(ISubmoduleStatusProvider provider, GitModule module, bool updateStatus = false)
+        public static async Task<SubmoduleInfoResult> UpdateSubmoduleStructureAndWaitForResultAsync(ISubmoduleStatusProvider provider, GitModule module, bool updateStatus = true)
         {
             SubmoduleInfoResult result = null;
             provider.StatusUpdated += ProviderStatusUpdated;
@@ -33,14 +33,14 @@ namespace CommonTestUtils
             }
         }
 
-        public static async Task UpdateSubmoduleStatusAndWaitForResultAsync(ISubmoduleStatusProvider provider, GitModule module, IReadOnlyList<GitItemStatus> gitStatus)
+        public static async Task UpdateSubmoduleStatusAndWaitForResultAsync(ISubmoduleStatusProvider provider, GitModule module, IReadOnlyList<GitItemStatus> gitStatus, bool forceUpdate = true)
         {
             provider.StatusUpdated += Provider_StatusUpdated;
 
             await provider.UpdateSubmodulesStatusAsync(
                     workingDirectory: module.WorkingDir,
                     gitStatus: gitStatus,
-                    forceUpdate: true);
+                    forceUpdate: forceUpdate);
 
             await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
 

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -705,19 +705,9 @@ namespace GitCommandsTests
             using (CommonTestUtils.GitModuleTestHelper moduleTestHelperSuper = new CommonTestUtils.GitModuleTestHelper("super repo"),
                                                        moduleTestHelperSub = new CommonTestUtils.GitModuleTestHelper("sub repo"))
             {
-                // Inital commit in super project
-                moduleTestHelperSuper.Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Initial commit""");
-
-                // Submodules require at least one commit
-                moduleTestHelperSub.Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Empty commit""");
-
-                // Add submodule
-                moduleTestHelperSuper.Module.GitExecutable.GetOutput(GitCommandHelpers.AddSubmoduleCmd(moduleTestHelperSub.Module.WorkingDir.ToPosixPath(), "sub repo", null, true));
-                moduleTestHelperSuper.Module.GitExecutable.GetOutput(@"commit -am ""Add submodule""");
-                GitModule moduleSub = new GitModule(Path.Combine(moduleTestHelperSuper.Module.WorkingDir, "sub repo").ToPosixPath());
-
-                // Init submodule
-                moduleTestHelperSuper.Module.GitExecutable.GetOutput(@"submodule update --init --recursive");
+                // Add and init the submodule
+                moduleTestHelperSuper.AddSubmodule(moduleTestHelperSub, "sub repo");
+                var moduleSub = moduleTestHelperSuper.GetSubmodulesRecursive().ElementAt(0);
 
                 // Commit in submodule
                 moduleSub.GitExecutable.GetOutput(@"commit --allow-empty -am ""First commit""");

--- a/UnitTests/GitCommands.Tests/Submodules/SubmoduleStatusProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/Submodules/SubmoduleStatusProviderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -5,9 +6,9 @@ using System.Threading.Tasks;
 using CommonTestUtils;
 using FluentAssertions;
 using GitCommands;
+using GitCommands.Git;
 using GitCommands.Submodules;
 using GitUIPluginInterfaces;
-using Microsoft.VisualStudio.Threading;
 using NUnit.Framework;
 
 namespace GitCommandsTests.Submodules
@@ -22,7 +23,7 @@ namespace GitCommandsTests.Submodules
         private GitModuleTestHelper _repo3;
 
         // Note that _repo2Module and _repo3Module point to the submodules under _repo1Module,
-        // not _repo2.Module and _repo3.Module respectively. In general, the tests should here
+        // not the 'origin' _repo2.Module and _repo3.Module respectively. In general, the tests should here
         // should interact with these modules, not with _repo2 and _repo3.
         private GitModule _repo1Module;
         private GitModule _repo2Module;
@@ -66,41 +67,42 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
             result.SuperProject.Should().Be(null);
             result.CurrentSubmoduleName.Should().Be(null);
-            result.OurSubmodules.Select(info => info.Path).Should().Contain(_repo2Module.WorkingDir, _repo3Module.WorkingDir);
-            result.SuperSubmodules.Should().BeEmpty();
-            result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.AllSubmodules.Select(info => info.Path).Should().Contain(_repo2Module.WorkingDir, _repo3Module.WorkingDir);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
         }
 
         [Test]
         public async Task UpdateSubmoduleStructure_valid_result_for_first_nested_submodule()
         {
-            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo2Module, true);
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo2Module);
 
             result.Should().NotBeNull();
             result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
             result.SuperProject.Should().Be(result.TopProject);
             result.CurrentSubmoduleName.Should().Be("repo2");
+            result.AllSubmodules.Select(info => info.Path).Should().Contain(_repo2Module.WorkingDir, _repo3Module.WorkingDir);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules[0].Should().BeEquivalentTo(result.AllSubmodules[1]);
             result.OurSubmodules.Select(info => info.Path).Should().ContainSingle(_repo3Module.WorkingDir);
-            result.SuperSubmodules.Select(info => info.Path).Should().Contain(_repo2Module.WorkingDir, _repo3Module.WorkingDir);
-            result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
         }
 
         [Test]
         public async Task UpdateSubmoduleStructure_valid_result_for_second_nested_submodule()
         {
-            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo3Module, true);
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo3Module);
 
             result.Should().NotBeNull();
             result.TopProject.Path.Should().Be(_repo1Module.WorkingDir);
             result.SuperProject.Path.Should().Be(_repo2Module.WorkingDir);
             result.CurrentSubmoduleName.Should().Be("repo3");
+            result.AllSubmodules.Select(info => info.Path).Should().Contain(_repo2Module.WorkingDir, _repo3Module.WorkingDir);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
             result.OurSubmodules.Select(info => info.Path).Should().BeEmpty();
-            result.SuperSubmodules.Select(info => info.Path).Should().Contain(_repo2Module.WorkingDir, _repo3Module.WorkingDir);
-            result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
         }
 
         [Test]
-        public async Task Submodule_status_changes_for_top_module()
+        public async Task Submodule_status_changes_for_top_module_with_first_nested_module_change()
         {
             var currentModule = _repo1Module;
             var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
@@ -111,27 +113,313 @@ namespace GitCommandsTests.Submodules
             var changedFiles = GetStatusChangedFiles(currentModule);
             changedFiles.Should().HaveCount(0);
             await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
-            result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
 
             // Make a change in repo2
             _repo1.CreateFile(_repo2Module.WorkingDir, "test.txt", "test");
             changedFiles = GetStatusChangedFiles(currentModule);
             changedFiles.Should().HaveCount(1);
             await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
-
-            result.OurSubmodules[0].Detailed.IsDirty.Should().BeTrue();
-            result.OurSubmodules[1].Detailed.Should().BeNull();
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[1].Detailed.Should().BeNull();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+            result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
 
             // Revert the change
             File.Delete(Path.Combine(_repo2Module.WorkingDir, "test.txt"));
             changedFiles = GetStatusChangedFiles(currentModule);
             changedFiles.Should().HaveCount(0);
             await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
-            result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
         }
 
         [Test]
-        public async Task Submodule_status_changes_for_first_nested_module()
+        public async Task Submodule_status_changes_for_top_module_with_first_nested_module_commit()
+        {
+            var currentModule = _repo1Module;
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            // No changes in repo
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+
+            // Update commit in repo2
+            _repo2Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Dummy commit""");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(1);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeFalse();
+            result.AllSubmodules[0].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.FastForward);
+            result.AllSubmodules[1].Detailed.Should().BeNull();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+            result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+
+            // Revert the change
+            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_top_module_with_first_nested_module_change_commit()
+        {
+            var currentModule = _repo1Module;
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            // No changes in repo
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+
+            // Make a change and update commit in repo2
+            _repo1.CreateFile(_repo2Module.WorkingDir, "test.txt", "test");
+            _repo2Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Dummy commit""");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(1);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[0].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.FastForward);
+            result.AllSubmodules[1].Detailed.Should().BeNull();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+            result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+
+            // Revert the change
+            File.Delete(Path.Combine(_repo2Module.WorkingDir, "test.txt"));
+            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_top_module_with_second_nested_module_change()
+        {
+            var currentModule = _repo1Module;
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            // No changes in repo
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+
+            // Make a change in repo3
+            _repo1.CreateFile(_repo3Module.WorkingDir, "test.txt", "test");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(1);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[0].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+            result.AllSubmodules[1].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[1].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+            result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+
+            // Revert the change
+            File.Delete(Path.Combine(_repo3Module.WorkingDir, "test.txt"));
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_top_module_with_first_nested_module_commit_second_nested_module_change()
+        {
+            var currentModule = _repo1Module;
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            // No changes in repo
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+
+            // Make a change in repo3
+            _repo1.CreateFile(_repo3Module.WorkingDir, "test.txt", "test");
+            _repo2Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Dummy commit""");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(1);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[0].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.FastForward);
+            result.AllSubmodules[1].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[1].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+            result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+
+            // Revert the change for repo3
+            File.Delete(Path.Combine(_repo3Module.WorkingDir, "test.txt"));
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(1);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeFalse();
+            result.AllSubmodules[0].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.FastForward);
+            result.AllSubmodules[1].Detailed.Should().BeNull();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+            result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+
+            // Revert the change
+            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_top_module_with_second_nested_module_commit()
+        {
+            var currentModule = _repo1Module;
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            // No changes in repo
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+
+            // Update commit in repo3
+            _repo3Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Dummy commit""");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(1);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[0].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+            result.AllSubmodules[1].Detailed.IsDirty.Should().BeFalse();
+            result.AllSubmodules[1].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.FastForward);
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+            result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+
+            // Revert the change
+            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_top_module_with_top_module_change()
+        {
+            var currentModule = _repo1Module;
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            // No changes in repo
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+
+            // Make a change in repo1
+            _repo1.CreateFile(_repo1Module.WorkingDir, "test.txt", "test");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(1);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules[0].Detailed.Should().BeNull();
+            result.AllSubmodules[1].Detailed.Should().BeNull();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+            result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+
+            // Revert the change
+            File.Delete(Path.Combine(_repo1Module.WorkingDir, "test.txt"));
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_top_module_top_module_commit()
+        {
+            var currentModule = _repo1Module;
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            // No changes in repo
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+
+            // Update commit in topmodule
+            currentModule.GitExecutable.GetOutput(@"commit --allow-empty -m ""Dummy commit""");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+
+            // Revert the change
+            _repo1Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_first_nested_module_with_top_module_changes()
         {
             var currentModule = _repo2Module;
             var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
@@ -142,37 +430,376 @@ namespace GitCommandsTests.Submodules
             var changedFiles = GetStatusChangedFiles(currentModule);
             changedFiles.Should().HaveCount(0);
             await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
-            result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules[0].Should().BeEquivalentTo(result.AllSubmodules[1]);
+            result.TopProject.Detailed.Should().BeNull();
 
             // Make a change in repo1
             _repo1.CreateFile(_repo1Module.WorkingDir, "test.txt", "test");
             changedFiles = GetStatusChangedFiles(currentModule);
             changedFiles.Should().HaveCount(0);
             await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
-            result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules[0].Should().BeEquivalentTo(result.AllSubmodules[1]);
+            result.TopProject.Detailed.Should().BeNull();
 
             // Revert the change
             File.Delete(Path.Combine(_repo1Module.WorkingDir, "test.txt"));
             changedFiles = GetStatusChangedFiles(currentModule);
             changedFiles.Should().HaveCount(0);
             await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
-            result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules[0].Should().BeEquivalentTo(result.AllSubmodules[1]);
+            result.TopProject.Detailed.Should().BeNull();
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_first_nested_module_with_second_nested_module_changes()
+        {
+            var currentModule = _repo2Module;
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            // No changes in repo
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules[0].Should().BeEquivalentTo(result.AllSubmodules[1]);
+            result.TopProject.Detailed.Should().BeNull();
 
             // Make a change in repo3
             _repo1.CreateFile(_repo3Module.WorkingDir, "test.txt", "test");
             changedFiles = GetStatusChangedFiles(currentModule);
             changedFiles.Should().HaveCount(1);
             await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
-
-            // Fails, for same reason as previous test
-            ////result.OurSubmodules[0].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[0].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+            result.AllSubmodules[1].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[1].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+            result.OurSubmodules[0].Should().BeEquivalentTo(result.AllSubmodules[1]);
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
 
             // Revert the change
             File.Delete(Path.Combine(_repo3Module.WorkingDir, "test.txt"));
             changedFiles = GetStatusChangedFiles(currentModule);
             changedFiles.Should().HaveCount(0);
             await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
-            result.OurSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules[0].Should().BeEquivalentTo(result.AllSubmodules[1]);
+
+            // Revert manually - not changed back automatically
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+            result.TopProject.Detailed = null;
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_first_nested_module_with_second_nested_module_commit()
+        {
+            var currentModule = _repo2Module;
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            // No changes in repo
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules[0].Should().BeEquivalentTo(result.AllSubmodules[1]);
+            result.TopProject.Detailed.Should().BeNull();
+
+            // Update commit in repo3
+            _repo3Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Dummy commit""");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(1);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[0].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+            result.AllSubmodules[1].Detailed.IsDirty.Should().BeFalse();
+            result.AllSubmodules[1].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.FastForward);
+            result.OurSubmodules[0].Should().BeEquivalentTo(result.AllSubmodules[1]);
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+
+            // Revert the change
+            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules[0].Should().BeEquivalentTo(result.AllSubmodules[1]);
+
+            // Revert manually
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+            result.TopProject.Detailed = null;
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_second_nested_module_with_second_nested_module_changes()
+        {
+            var currentModule = _repo3Module;
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            // No changes in repo
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.TopProject.Detailed.Should().BeNull();
+
+            // Make a change in repo3
+            _repo1.CreateFile(_repo3Module.WorkingDir, "test.txt", "test");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(1);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[0].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+            result.AllSubmodules[1].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[1].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+
+            // Revert the change
+            File.Delete(Path.Combine(_repo3Module.WorkingDir, "test.txt"));
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules[1].Detailed.Should().BeNull();
+
+            // Revert manually
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[0].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+            result.TopProject.Detailed = null;
+            result.AllSubmodules[0].Detailed = null;
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_second_nested_module_with_second_nested_module_commit()
+        {
+            var currentModule = _repo3Module;
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            // No changes in repo
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.TopProject.Detailed.Should().BeNull();
+
+            // Update commit in repo3
+            _repo3Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Dummy commit""");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.TopProject.Detailed.Should().BeNull();
+
+            // Revert the change
+            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.TopProject.Detailed.Should().BeNull();
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_second_nested_module_with_first_nested_module_commit()
+        {
+            var currentModule = _repo3Module;
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            // No changes in repo
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.TopProject.Detailed.Should().BeNull();
+
+            // Update commit in repo2
+            _repo2Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Dummy commit""");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.TopProject.Detailed.Should().BeNull();
+
+            // Revert the change
+            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.TopProject.Detailed.Should().BeNull();
+        }
+
+        [Ignore("Delays tests with 15s without much value in the test")]
+        [Test]
+        public async Task Submodule_status_changes_for_top_module_with_no_forced_changes()
+        {
+            var currentModule = _repo1Module;
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            // No changes in repo
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+
+            // Make a change in repo1 without force update, should take 15s
+            DateTime statusStart = DateTime.Now;
+            _repo1.CreateFile(_repo1Module.WorkingDir, "test.txt", "test");
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(1);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles, false);
+            result.AllSubmodules[0].Detailed.Should().BeNull();
+            result.AllSubmodules[1].Detailed.Should().BeNull();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+            result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+            (DateTime.Now - statusStart).TotalSeconds.Should().BeGreaterOrEqualTo(14);
+
+            // Revert the change
+            File.Delete(Path.Combine(_repo1Module.WorkingDir, "test.txt"));
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_top_module_with_top_module_changes()
+        {
+            var currentModule = _repo1Module;
+            _repo1.CreateFile(_repo1Module.WorkingDir, "test.txt", "test");
+
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            // When top module is current, only structure is updated and no changes seen until explicit git-status
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(1);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+            result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+
+            // Revert the change
+            File.Delete(Path.Combine(_repo1Module.WorkingDir, "test.txt"));
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.OurSubmodules.Should().BeEquivalentTo(result.AllSubmodules);
+            result.TopProject.Detailed.Should().BeNull();
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_second_nested_module_with_first_nested_module_prechanges()
+        {
+            var currentModule = _repo3Module;
+
+            // Update commit in repo2, will check status
+            _repo2Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Dummy commit""");
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            result.AllSubmodules[0].Detailed.Should().NotBeNull();
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeFalse();
+            result.AllSubmodules[0].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.FastForward);
+            result.AllSubmodules[1].Detailed.Should().BeNull();
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+
+            // Revert the change, top and first level status is not reverted
+            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeFalse();
+            result.AllSubmodules[0].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.FastForward);
+            result.AllSubmodules[1].Detailed.Should().BeNull();
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_second_nested_module_with_prechanges_noupdate()
+        {
+            var currentModule = _repo3Module;
+
+            // Update repos
+            _repo1.CreateFile(_repo1Module.WorkingDir, "test.txt", "test");
+            _repo1Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Dummy commit""");
+            _repo1.CreateFile(_repo2Module.WorkingDir, "test.txt", "test");
+            _repo2Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Dummy commit""");
+            _repo1.CreateFile(_repo3Module.WorkingDir, "test.txt", "test");
+            _repo3Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Dummy commit""");
+
+            // Update requires: AppSettings.ShowSubmoduleStatus && (AppSettings.ShowGitStatusInBrowseToolbar || (AppSettings.ShowGitStatusForArtificialCommits && AppSettings.RevisionGraphShowWorkingDirChanges))
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule, false);
+
+            result.Should().NotBeNull();
+
+            result.AllSubmodules.All(i => i.Detailed == null).Should().BeTrue();
+            result.TopProject.Detailed.Should().BeNull();
+        }
+
+        [Test]
+        public async Task Submodule_status_changes_for_second_nested_module_with_first_nested_module_precommit()
+        {
+            var currentModule = _repo3Module;
+
+            // Update commit in repo2, will check status
+            _repo2Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Dummy commit""");
+            var result = await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, currentModule);
+
+            result.Should().NotBeNull();
+
+            result.AllSubmodules[0].Detailed.Should().NotBeNull();
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeFalse();
+            result.AllSubmodules[0].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.FastForward);
+            result.AllSubmodules[1].Detailed.Should().BeNull();
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+
+            // Make a change in repo3, still not changing
+            _repo1.CreateFile(_repo3Module.WorkingDir, "test.txt", "test");
+            var changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(1);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[0].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.FastForward);
+            result.AllSubmodules[1].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[1].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
+
+            // Revert the change
+            File.Delete(Path.Combine(_repo3Module.WorkingDir, "test.txt"));
+            changedFiles = GetStatusChangedFiles(currentModule);
+            changedFiles.Should().HaveCount(0);
+            await SubmoduleTestHelpers.UpdateSubmoduleStatusAndWaitForResultAsync(_provider, currentModule, changedFiles);
+            result.AllSubmodules[0].Detailed.IsDirty.Should().BeTrue();
+            result.AllSubmodules[0].Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.FastForward);
+            result.AllSubmodules[1].Detailed.Should().BeNull();
+            result.TopProject.Detailed.IsDirty.Should().BeTrue();
         }
 
         private static IReadOnlyList<GitItemStatus> GetStatusChangedFiles(IGitModule module)


### PR DESCRIPTION
I believe this is ready, but did not plan to include it in 3.4
Submitting now for discussion of #8049 

## Proposed changes

SubmoduleStatusProvider will not update the status more often than every 15th second to limit load.
This was added before the status update was fully async and before updates were pruned (latest change in #8116).
The status should not be noticable (at least comparable to git-status, that can take a long time in big repos with many submodules).

The update limitation remains with this PR, but instead of dropping frequent updates, the handling is throttled to update no more often than every 15th second.
The handling has also been simplified.

A change to specific mention is that previously, if not the top module was selected, the complete structure including the current submodule was updated. The current submodule was then updated a second time. (There was a comment that the update not triggered by git-status would skip this, but that was incorrect.)
This will maybe be noticeable on a deep tree where a module below submodule is updated. (but very minor effect)

## Test methodology <!-- How did you ensure quality? -->

Tests exists, a test is disabled for the same reason as before.
Can maybe be improved.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
