### PR TITLE
Fix incorrect RestSharp bindingRedirect from 106.6.10 to 106.6.10.0

### DIFF
--- a/GitExtensions/app.config
+++ b/GitExtensions/app.config
@@ -24,7 +24,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="RestSharp" publicKeyToken="598062e77f915f75" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-106.6.10" newVersion="106.6.10" />
+        <bindingRedirect oldVersion="0.0.0.0-106.6.10.0" newVersion="106.6.10.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/contributors.txt
+++ b/contributors.txt
@@ -129,3 +129,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/04/17, miloshavlicek, Miloš Havlíček, miloshavlicek(at)gmail.com
 2020/02/01, wynnfrei, Giorgi Tsouvaltzis, giorgi.tsouvaltzis(at)doso.ge
 2020/05/04, digitalcoyote, Curtis Carter, lokiphasma(at)gmail.com
+2020/05/19, haldyr, Stanislav Řehák, haldyr(at)gmail.com


### PR DESCRIPTION
Fixes #8089


## Proposed changes

- changed wrong bindingRedirect from 106.6.10 to 106.6.10.0



## Test methodology <!-- How did you ensure quality? -->

- Manually tested by opening commit window which uses Jira Commit Hint with remote call via RestSharp. Before change it thows exception (System.IO.FileLoadException: 'Could not load file or assembly 'RestSharp, Version=106.1.0.0 ...)


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.23.0
- Windows 10 1909

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
