### PR TITLE
Restore splitter positions

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -537,10 +537,7 @@ namespace GitUI.CommandsDialogs
                     new WindowsThumbnailToolbarButton(toolStripButtonCommit.Text, toolStripButtonCommit.Image, CommitToolStripMenuItemClick),
                     new WindowsThumbnailToolbarButton(toolStripButtonPush.Text, toolStripButtonPush.Image, PushToolStripMenuItemClick),
                     new WindowsThumbnailToolbarButton(toolStripButtonPull.Text, toolStripButtonPull.Image, PullToolStripMenuItemClick)));
-            SetSplitterPositions();
             HideVariableMainMenuItems();
-            RefreshSplitViewLayout();
-            LayoutRevisionInfo();
             InternalInitialize(false);
 
             if (!Module.IsValidGitWorkingDir())
@@ -576,6 +573,10 @@ namespace GitUI.CommandsDialogs
             _formBrowseDiagnosticsReporter.Report();
 
             base.OnLoad(e);
+
+            RefreshSplitViewLayout();
+            LayoutRevisionInfo();
+            SetSplitterPositions();
         }
 
         protected override void OnActivated(EventArgs e)


### PR DESCRIPTION
Fixes #8072

## Proposed changes

Workaround for not reliably restored splitter positions:
Restore the layout of `FormBrowse` a second time after `base.OnLoad(e)`.

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build e972d9a0a1c35a31bf0495a1536547ababc872b5
- Git 2.26.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
