### PR TITLE
Support 0 options in ScriptOptionsParser.AskToSpecify

### DIFF
--- a/GitUI/Script/ScriptOptionsParser.cs
+++ b/GitUI/Script/ScriptOptionsParser.cs
@@ -156,10 +156,16 @@ namespace GitUI.Script
 
         private static string AskToSpecify(IEnumerable<IGitRef> options, IScriptHostControl scriptHostControl)
         {
+            var items = options.ToList();
+            if (items.Count == 0)
+            {
+                return string.Empty;
+            }
+
             using (var f = new FormQuickGitRefSelector())
             {
                 f.Location = scriptHostControl?.GetQuickItemSelectorLocation() ?? new System.Drawing.Point();
-                f.Init(FormQuickGitRefSelector.Action.Select, options.ToList());
+                f.Init(FormQuickGitRefSelector.Action.Select, items);
                 f.ShowDialog();
                 return f.SelectedRef.Name;
             }


### PR DESCRIPTION
Fixes #8128

## Proposed changes

`ScriptOptionsParser.AskToSpecify` shall return `string.Empty` in case there are no options to select
in order to avoid unhandled `ObjectDisposedException`,
e.g. when determining the current remote while parsing script arguments starting with "c"

## Test methodology <!-- How did you ensure quality? -->

- manual similar to the description in the bug report

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 51e71c23c32b22963250eb3a1dd7e3053a5d58df
- Git 2.26.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
