### PR TITLE
fix: New remotes not saved, if exceed limit

### DIFF
--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -17,6 +17,7 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormRemotes : GitModuleForm
     {
+        private readonly FormRemotesController _formRemotesController = new FormRemotesController();
         private IConfigFileRemoteSettingsManager _remotesManager;
         private ConfigFileRemote _selectedRemote;
         private readonly ListViewGroup _lvgEnabled;
@@ -298,39 +299,6 @@ Inactive remote is completely invisible to git.");
             }
         }
 
-        private static void RemoteDelete(IList<Repository> remotes, string oldRemoteUrl)
-        {
-            if (string.IsNullOrWhiteSpace(oldRemoteUrl))
-            {
-                return;
-            }
-
-            var oldRemote = remotes.FirstOrDefault(r => r.Path == oldRemoteUrl);
-            if (oldRemote != null)
-            {
-                remotes.Remove(oldRemote);
-            }
-        }
-
-        private static void RemoteUpdate(IList<Repository> remotes, string oldRemoteUrl, string newRemoteUrl)
-        {
-            if (string.IsNullOrWhiteSpace(newRemoteUrl))
-            {
-                return;
-            }
-
-            // if remote url was renamed - delete the old value
-            if (!string.Equals(oldRemoteUrl, newRemoteUrl, StringComparison.OrdinalIgnoreCase))
-            {
-                RemoteDelete(remotes, oldRemoteUrl);
-            }
-
-            if (remotes.All(r => r.Path != newRemoteUrl))
-            {
-                remotes.Add(new Repository(newRemoteUrl));
-            }
-        }
-
         private void application_Idle(object sender, EventArgs e)
         {
             // we need this event only once, so unwire
@@ -442,10 +410,10 @@ Inactive remote is completely invisible to git.");
                         var repositoryHistory = await RepositoryHistoryManager.Remotes.LoadRecentHistoryAsync();
 
                         await this.SwitchToMainThreadAsync();
-                        RemoteUpdate(repositoryHistory, _selectedRemote?.Url, remoteUrl);
+                        _formRemotesController.RemoteUpdate(repositoryHistory, _selectedRemote?.Url, remoteUrl);
                         if (checkBoxSepPushUrl.Checked)
                         {
-                            RemoteUpdate(repositoryHistory, _selectedRemote?.PushUrl, remotePushUrl);
+                            _formRemotesController.RemoteUpdate(repositoryHistory, _selectedRemote?.PushUrl, remotePushUrl);
                         }
 
                         await RepositoryHistoryManager.Remotes.SaveRecentHistoryAsync(repositoryHistory);

--- a/GitUI/CommandsDialogs/FormRemotesController.cs
+++ b/GitUI/CommandsDialogs/FormRemotesController.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GitCommands.UserRepositoryHistory;
+
+namespace GitUI.CommandsDialogs
+{
+    internal class FormRemotesController
+    {
+        public void RemoteDelete(IList<Repository> remotes, string oldRemoteUrl)
+        {
+            if (string.IsNullOrWhiteSpace(oldRemoteUrl))
+            {
+                return;
+            }
+
+            var oldRemote = remotes.FirstOrDefault(r => r.Path == oldRemoteUrl);
+            if (oldRemote != null)
+            {
+                remotes.Remove(oldRemote);
+            }
+        }
+
+        public void RemoteUpdate(IList<Repository> remotes, string oldRemoteUrl, string newRemoteUrl)
+        {
+            if (string.IsNullOrWhiteSpace(newRemoteUrl))
+            {
+                return;
+            }
+
+            // if remote url was renamed - delete the old value
+            if (!string.Equals(oldRemoteUrl, newRemoteUrl, StringComparison.OrdinalIgnoreCase))
+            {
+                RemoteDelete(remotes, oldRemoteUrl);
+            }
+
+            if (remotes.All(r => r.Path != newRemoteUrl))
+            {
+                remotes.Insert(0, new Repository(newRemoteUrl));
+            }
+        }
+    }
+}

--- a/UnitTests/GitUI.Tests/CommandsDialogs/FormRemotesControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/FormRemotesControllerTests.cs
@@ -1,0 +1,125 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using GitCommands.UserRepositoryHistory;
+using GitUI.CommandsDialogs;
+using NUnit.Framework;
+
+namespace GitUITests.CommandsDialogs
+{
+    [TestFixture]
+    public class FormRemotesControllerTests
+    {
+        private FormRemotesController _controller;
+
+        [SetUp]
+        public void Setup()
+        {
+            _controller = new FormRemotesController();
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("\t")]
+        public void RemoteDelete_should_not_throw_or_mutate_list_of_remotes_if_oldRemoteUrl_null_or_empty(string oldRemoteUrl)
+        {
+            var remotes = new List<Repository>
+            {
+                new Repository("a"),
+                new Repository("b")
+            };
+
+            _controller.RemoteDelete(remotes, oldRemoteUrl);
+
+            remotes.Count.Should().Be(2);
+        }
+
+        [Test]
+        public void RemoteDelete_should_not_throw_or_mutate_list_of_remotes_if_oldRemoteUrl_not_in_list()
+        {
+            var remotes = new List<Repository>
+            {
+                new Repository("a"),
+                new Repository("b")
+            };
+
+            _controller.RemoteDelete(remotes, "foo");
+
+            remotes.Count.Should().Be(2);
+        }
+
+        [Test]
+        public void RemoteDelete_should_remove_remotes_matching_oldRemoteUrl()
+        {
+            var remotes = new List<Repository>
+            {
+                new Repository("a"),
+                new Repository("b")
+            };
+
+            _controller.RemoteDelete(remotes, "b");
+
+            remotes.Count.Should().Be(1);
+            remotes[0].Path.Should().Be("a");
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("\t")]
+        public void RemoteUpdate_should_not_throw_or_mutate_list_of_remotes_if_newRemoteUrl_null_or_empty(string newRemoteUrl)
+        {
+            var remotes = new List<Repository>
+            {
+                new Repository("a"),
+                new Repository("b")
+            };
+
+            _controller.RemoteUpdate(remotes, "who cares", newRemoteUrl);
+
+            remotes.Count.Should().Be(2);
+            remotes[0].Path.Should().Be("a");
+            remotes[1].Path.Should().Be("b");
+        }
+
+        [Test]
+        public void RemoteDelete_should_replace_matching_oldRemoteUrl()
+        {
+            var remotes = new List<Repository>
+            {
+                new Repository("a"),
+                new Repository("b")
+            };
+
+            _controller.RemoteUpdate(remotes, "a", "a1");
+
+            remotes.Count.Should().Be(2);
+            remotes.Select(r => r.Path).Should().BeEquivalentTo(new[] { "a1", "b" });
+        }
+
+        [Test]
+        public void RemoteDelete_should_place_newRemoteUrl_as_first()
+        {
+            var remotes = new List<Repository>
+            {
+                new Repository("a"),
+                new Repository("b"),
+                new Repository("c")
+            };
+
+            _controller.RemoteUpdate(remotes, "c", "a1");
+
+            remotes.Count.Should().Be(3);
+            remotes[0].Path.Should().Be("a1");
+            remotes[1].Path.Should().Be("a");
+            remotes[2].Path.Should().Be("b");
+
+            _controller.RemoteUpdate(remotes, null, "q");
+
+            remotes.Count.Should().Be(4);
+            remotes[0].Path.Should().Be("q");
+            remotes[1].Path.Should().Be("a1");
+            remotes[2].Path.Should().Be("a");
+            remotes[3].Path.Should().Be("b");
+        }
+    }
+}


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->




## Proposed changes

If a user adds a new remote which index, when saved, exceeds the number of maximum recent remotes - the remote would be added to the end of the list of remotes, and trimmed off when the list of recent remotes is saved.

Fix the issue by adding the new remote to the top of the list, so it gets saved.



## Test methodology <!-- How did you ensure quality? -->

- manual
- unit tests



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
