### PR TITLE
Fix `FormCommit` context menu issues

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -185,11 +185,11 @@ namespace GitUI.CommandsDialogs
             // UnstagedFileContext
             //
             this.UnstagedFileContext.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.openWithDifftoolToolStripMenuItem,
             this.resetChanges,
             this.resetPartOfFileToolStripMenuItem,
             this.interactiveAddToolStripMenuItem,
             this.toolStripSeparator12,
+            this.openWithDifftoolToolStripMenuItem,
             this.editFileToolStripMenuItem,
             this.openToolStripMenuItem,
             this.openWithToolStripMenuItem,
@@ -378,9 +378,9 @@ namespace GitUI.CommandsDialogs
             // StagedFileContext
             //
             this.StagedFileContext.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.stagedOpenDifftoolToolStripMenuItem9,
             this.stagedResetChanges,
             this.stagedToolStripSeparator14,
+            this.stagedOpenDifftoolToolStripMenuItem9,
             this.stagedEditFileToolStripMenuItem11,
             this.stagedOpenToolStripMenuItem7,
             this.stagedOpenWithToolStripMenuItem8,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Move "Open with diff tool" context menu out from the top position in `FormCommit`.

   In the File Tree and Diff tabs a user would typically deal with existing commits (i.e. snapshots), and "compare" function is likely to be one of the most used (i.e. compare to the working directory).
In the Commit form the user is dealing with the working directory changes, and thus staging and reseting is likely be the primary function, then compare (which is rendered in the diff panel of the form).

   Resolves #8106

- Correct display for 'Show file differences for all parents' menu.
The context menu was shown for the first time because of the incorrect check - it assumed the item was found, whilst it wasn't.
Set visibility of the added context menu at the time of creation.

    Addendum to #8077.



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/82732143-b6e9b180-9d4e-11ea-871f-c856e0fc8dce.png)
![image](https://user-images.githubusercontent.com/4403806/82732148-c2d57380-9d4e-11ea-80d1-b5d786ff0940.png)


### After

![image](https://user-images.githubusercontent.com/4403806/82732074-55c1de00-9d4e-11ea-9670-4f8f074397b5.png)
![image](https://user-images.githubusercontent.com/4403806/82732088-6bcf9e80-9d4e-11ea-97ad-c6635c980455.png)



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
