### PR TITLE
Add 'Reset another branch to here' feature

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -228,6 +228,25 @@ namespace GitCommands
         }
 
         /// <summary>
+        /// Push a local reference to a new commit
+        /// This is similar to "git branch --force "branch" "commit", except that you get a warning if commits are lost
+        /// </summary>
+        /// <param name="repoPath">Full path to the repo</param>
+        /// <param name="gitRef">The branch to move</param>
+        /// <param name="targetId">The commit to move to</param>
+        /// <param name="force">Push the reference also if commits are lost</param>
+        /// <returns>The Git command to execute</returns>
+        public static ArgumentString PushLocalCmd(string repoPath, string gitRef, ObjectId targetId, bool force = false)
+        {
+            return new GitArgumentBuilder("push")
+            {
+                $"file://{repoPath}",
+                $"{targetId}:{gitRef}",
+                { force, "--force" }
+            };
+        }
+
+        /// <summary>
         /// Git Clone.
         /// </summary>
         /// <param name="central">Makes a bare repo.</param>

--- a/GitCommands/Git/GitRef.cs
+++ b/GitCommands/Git/GitRef.cs
@@ -124,6 +124,8 @@ namespace GitCommands
 
         public bool IsDereference { get; }
 
+        public bool IsOther => !IsHead && !IsRemote && !IsTag;
+
         public string LocalName => IsRemote ? Name.Substring(Remote.Length + 1) : Name;
 
         public string Remote { get; }

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -155,10 +155,8 @@ namespace GitUI.CommandsDialogs
             var resetType = _isDirtyDir ? FormResetCurrentBranch.ResetType.Soft : FormResetCurrentBranch.ResetType.Hard;
             UICommands.DoActionOnRepo(() =>
             {
-                using (var form = new FormResetCurrentBranch(UICommands, gitRevision, resetType))
-                {
-                    return form.ShowDialog(this) == DialogResult.OK;
-                }
+                using var form = FormResetCurrentBranch.Create(UICommands, gitRevision, resetType);
+                return form.ShowDialog(this) == DialogResult.OK;
             });
         }
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -184,10 +184,8 @@ namespace GitUI
                 return false;
             }
 
-            using (var form = new FormResetCurrentBranch(this, Module.GetRevision(objectId)))
-            {
-                return form.ShowDialog(owner) == DialogResult.OK;
-            }
+            using var form = FormResetCurrentBranch.Create(this, Module.GetRevision(objectId));
+            return form.ShowDialog(owner) == DialogResult.OK;
         }
 
         public bool StashSave(IWin32Window owner, bool includeUntrackedFiles, bool keepIndex = false, string message = "", IReadOnlyList<string> selectedFiles = null)

--- a/GitUI/HelperDialogs/FormResetAnotherBranch.Designer.cs
+++ b/GitUI/HelperDialogs/FormResetAnotherBranch.Designer.cs
@@ -1,0 +1,241 @@
+﻿namespace GitUI.HelperDialogs
+{
+    partial class FormResetAnotherBranch
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.BranchInfo = new System.Windows.Forms.Label();
+            this.Ok = new System.Windows.Forms.Button();
+            this.Cancel = new System.Windows.Forms.Button();
+            this.commitSummaryUserControl = new GitUI.UserControls.CommitSummaryUserControl();
+            this.ForceReset = new System.Windows.Forms.CheckBox();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.labelResetBranchWarning = new System.Windows.Forms.Label();
+            this.Branches = new System.Windows.Forms.ComboBox();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.tlpnlWarning = new System.Windows.Forms.TableLayoutPanel();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
+            this.tlpnlWarning.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // BranchInfo
+            // 
+            this.BranchInfo.AutoSize = true;
+            this.BranchInfo.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.BranchInfo.Location = new System.Drawing.Point(6, 39);
+            this.BranchInfo.Name = "BranchInfo";
+            this.BranchInfo.Size = new System.Drawing.Size(509, 13);
+            this.BranchInfo.TabIndex = 0;
+            this.BranchInfo.Text = "Reset local &branch:";
+            // 
+            // Ok
+            // 
+            this.Ok.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.Ok.Location = new System.Drawing.Point(320, 3);
+            this.Ok.Name = "Ok";
+            this.Ok.Size = new System.Drawing.Size(91, 25);
+            this.Ok.TabIndex = 3;
+            this.Ok.Text = "OK";
+            this.Ok.UseVisualStyleBackColor = true;
+            this.Ok.Click += new System.EventHandler(this.Ok_Click);
+            // 
+            // Cancel
+            // 
+            this.Cancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.Cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.Cancel.Location = new System.Drawing.Point(417, 3);
+            this.Cancel.Name = "Cancel";
+            this.Cancel.Size = new System.Drawing.Size(91, 25);
+            this.Cancel.TabIndex = 4;
+            this.Cancel.Text = "Cancel";
+            this.Cancel.UseVisualStyleBackColor = true;
+            this.Cancel.Click += new System.EventHandler(this.Cancel_Click);
+            // 
+            // commitSummaryUserControl
+            // 
+            this.commitSummaryUserControl.AutoSize = true;
+            this.commitSummaryUserControl.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.commitSummaryUserControl.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.commitSummaryUserControl.Location = new System.Drawing.Point(4, 80);
+            this.commitSummaryUserControl.Margin = new System.Windows.Forms.Padding(1);
+            this.commitSummaryUserControl.MinimumSize = new System.Drawing.Size(493, 150);
+            this.commitSummaryUserControl.Name = "commitSummaryUserControl";
+            this.commitSummaryUserControl.Revision = null;
+            this.commitSummaryUserControl.Size = new System.Drawing.Size(513, 150);
+            this.commitSummaryUserControl.TabIndex = 0;
+            // 
+            // ForceReset
+            // 
+            this.ForceReset.AutoSize = true;
+            this.ForceReset.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ForceReset.Location = new System.Drawing.Point(6, 234);
+            this.ForceReset.Name = "ForceReset";
+            this.ForceReset.Size = new System.Drawing.Size(509, 17);
+            this.ForceReset.TabIndex = 2;
+            this.ForceReset.Text = "&Force reset for a non-fast-forward reset";
+            this.ForceReset.UseVisualStyleBackColor = true;
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pictureBox1.Image = global::GitUI.Properties.Images.Warning;
+            this.pictureBox1.InitialImage = global::GitUI.Properties.Images.Warning;
+            this.pictureBox1.Location = new System.Drawing.Point(3, 3);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(16, 16);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
+            this.pictureBox1.TabIndex = 11;
+            this.pictureBox1.TabStop = false;
+            // 
+            // labelResetBranchWarning
+            // 
+            this.labelResetBranchWarning.ForeColor = System.Drawing.Color.Black;
+            this.labelResetBranchWarning.Location = new System.Drawing.Point(25, 0);
+            this.labelResetBranchWarning.Name = "labelResetBranchWarning";
+            this.labelResetBranchWarning.Size = new System.Drawing.Size(250, 20);
+            this.labelResetBranchWarning.TabIndex = 0;
+            this.labelResetBranchWarning.Text = "You can only reset a branch safely if there is a direct path from it to selected " +
+    "revision.\r\nForcing a branch to reset if it has not been merged might leave some " +
+    "commits unreachable.";
+            // 
+            // Branches
+            // 
+            this.Branches.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.Branches.Location = new System.Drawing.Point(11, 55);
+            this.Branches.Margin = new System.Windows.Forms.Padding(8, 3, 8, 3);
+            this.Branches.Name = "Branches";
+            this.Branches.Size = new System.Drawing.Size(499, 21);
+            this.Branches.TabIndex = 1;
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.AutoSize = true;
+            this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel1.ColumnCount = 1;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.Controls.Add(this.BranchInfo, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.Branches, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.ForceReset, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.commitSummaryUserControl, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.tlpnlWarning, 0, 0);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Top;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(8, 8);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.Padding = new System.Windows.Forms.Padding(3);
+            this.tableLayoutPanel1.RowCount = 7;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 10F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(519, 292);
+            this.tableLayoutPanel1.TabIndex = 12;
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.AutoSize = true;
+            this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.flowLayoutPanel1.Controls.Add(this.Cancel);
+            this.flowLayoutPanel1.Controls.Add(this.Ok);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(5, 256);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(511, 31);
+            this.flowLayoutPanel1.TabIndex = 3;
+            // 
+            // tlpnlWarning
+            // 
+            this.tlpnlWarning.AutoSize = true;
+            this.tlpnlWarning.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tlpnlWarning.ColumnCount = 2;
+            this.tlpnlWarning.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tlpnlWarning.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tlpnlWarning.Controls.Add(this.pictureBox1, 0, 0);
+            this.tlpnlWarning.Controls.Add(this.labelResetBranchWarning, 1, 0);
+            this.tlpnlWarning.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tlpnlWarning.Location = new System.Drawing.Point(5, 5);
+            this.tlpnlWarning.Margin = new System.Windows.Forms.Padding(2);
+            this.tlpnlWarning.Name = "tlpnlWarning";
+            this.tlpnlWarning.RowCount = 1;
+            this.tlpnlWarning.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlWarning.Size = new System.Drawing.Size(511, 22);
+            this.tlpnlWarning.TabIndex = 4;
+            // 
+            // FormResetAnotherBranch
+            // 
+            this.AcceptButton = this.Ok;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.AutoSize = true;
+            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.CancelButton = this.Cancel;
+            this.ClientSize = new System.Drawing.Size(535, 381);
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "FormResetAnotherBranch";
+            this.Padding = new System.Windows.Forms.Padding(8);
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Reset branch";
+            this.Load += new System.EventHandler(this.FormResetAnotherBranch_Load);
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.tlpnlWarning.ResumeLayout(false);
+            this.tlpnlWarning.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label BranchInfo;
+        private System.Windows.Forms.Button Ok;
+        private System.Windows.Forms.Button Cancel;
+        private UserControls.CommitSummaryUserControl commitSummaryUserControl;
+        private System.Windows.Forms.CheckBox ForceReset;
+        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.Label labelResetBranchWarning;
+        private System.Windows.Forms.ComboBox Branches;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private System.Windows.Forms.TableLayoutPanel tlpnlWarning;
+    }
+}

--- a/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+using GitCommands;
+using GitCommands.Git;
+using GitExtUtils.GitUI;
+using GitExtUtils.GitUI.Theming;
+using GitUIPluginInterfaces;
+using ResourceManager;
+
+namespace GitUI.HelperDialogs
+{
+    public partial class FormResetAnotherBranch : GitModuleForm
+    {
+        private IGitRef[] _localGitRefs;
+        private readonly GitRevision _revision;
+        private readonly TranslationString _localRefInvalid = new TranslationString("The entered value '{0}' is not the name of an existing local branch.");
+
+        public static FormResetAnotherBranch Create(GitUICommands gitUiCommands, GitRevision revision)
+            => new FormResetAnotherBranch(gitUiCommands, revision ?? throw new NotSupportedException(Strings.NoRevision));
+
+        [Obsolete("For VS designer and translation test only. Do not remove.")]
+        private FormResetAnotherBranch()
+        {
+            InitializeComponent();
+        }
+
+        private FormResetAnotherBranch(GitUICommands gitUiCommands, GitRevision revision)
+            : base(gitUiCommands)
+        {
+            _revision = revision;
+
+            InitializeComponent();
+
+            pictureBox1.Image = DpiUtil.Scale(pictureBox1.Image);
+            labelResetBranchWarning.AutoSize = true;
+            labelResetBranchWarning.Dock = DockStyle.Fill;
+
+            Height = tableLayoutPanel1.Height + tableLayoutPanel1.Top;
+            tableLayoutPanel1.Dock = DockStyle.Fill;
+
+            InitializeComplete();
+
+            labelResetBranchWarning.SetForeColorForBackColor();
+        }
+
+        private void Application_Idle(object sender, EventArgs e)
+        {
+            Application.Idle -= Application_Idle;
+
+            if (Branches.Text.Length == 0)
+            {
+                Branches.DroppedDown = true;
+            }
+        }
+
+        private IGitRef[] GetLocalBranchesWithoutCurrent()
+        {
+            var currentBranch = Module.GetSelectedBranch();
+            var isDetachedHead = currentBranch == DetachedHeadParser.DetachedBranch;
+
+            return Module.GetRefs(false)
+                .Where(r => r.IsHead && (isDetachedHead || r.LocalName != currentBranch))
+                .ToArray();
+        }
+
+        private void FormResetAnotherBranch_Load(object sender, EventArgs e)
+        {
+            _localGitRefs = GetLocalBranchesWithoutCurrent();
+
+            Branches.DisplayMember = nameof(IGitRef.Name);
+            Branches.Items.AddRange(_localGitRefs);
+
+            commitSummaryUserControl.Revision = _revision;
+
+            Application.Idle += Application_Idle;
+        }
+
+        private void Ok_Click(object sender, EventArgs e)
+        {
+            var gitRefToReset = _localGitRefs.FirstOrDefault(b => b.Name == Branches.Text);
+            if (gitRefToReset == null)
+            {
+                MessageBox.Show(string.Format(_localRefInvalid.Text, Branches.Text), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            var repoPath = Path.GetFullPath(Module.WorkingDir);
+            var args = GitCommandHelpers.PushLocalCmd(repoPath, gitRefToReset.CompleteName, _revision.ObjectId, ForceReset.Checked);
+            var isSuccess = FormProcess.ShowDialog(this, args);
+
+            if (isSuccess)
+            {
+                UICommands.RepoChangedNotifier.Notify();
+                Close();
+            }
+        }
+
+        private void Cancel_Click(object sender, EventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/GitUI/HelperDialogs/FormResetAnotherBranch.resx
+++ b/GitUI/HelperDialogs/FormResetAnotherBranch.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -22,13 +22,16 @@ namespace GitUI.HelperDialogs
             Hard
         }
 
+        public static FormResetCurrentBranch Create(GitUICommands commands, GitRevision revision, ResetType resetType = ResetType.Mixed)
+            => new FormResetCurrentBranch(commands, revision ?? throw new NotSupportedException(Strings.NoRevision), resetType);
+
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormResetCurrentBranch()
         {
             InitializeComponent();
         }
 
-        public FormResetCurrentBranch(GitUICommands commands, GitRevision revision, ResetType resetType = ResetType.Mixed)
+        private FormResetCurrentBranch(GitUICommands commands, GitRevision revision, ResetType resetType)
             : base(commands)
         {
             Revision = revision;
@@ -65,11 +68,6 @@ namespace GitUI.HelperDialogs
 
         private void FormResetCurrentBranch_Load(object sender, EventArgs e)
         {
-            if (Revision == null)
-            {
-                throw new Exception("No revision");
-            }
-
             _NO_TRANSLATE_BranchInfo.Text = string.Format(_branchInfo.Text, Module.GetSelectedBranch());
             commitSummaryUserControl1.Revision = Revision;
         }

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -10,6 +10,8 @@ namespace GitUI
         private readonly TranslationString _warning = new TranslationString("Warning");
         private readonly TranslationString _yes = new TranslationString("Yes");
         private readonly TranslationString _no = new TranslationString("No");
+        private readonly TranslationString _okText = new TranslationString("OK");
+        private readonly TranslationString _cancelText = new TranslationString("Cancel");
 
         private readonly TranslationString _containedInBranchesText = new TranslationString("Contained in branches:");
         private readonly TranslationString _containedInNoBranchText = new TranslationString("Contained in no branch");
@@ -34,6 +36,7 @@ namespace GitUI
         private readonly TranslationString _remote = new TranslationString("Remote");
         private readonly TranslationString _openWithGitExtensions = new TranslationString("Open with Git Extensions");
         private readonly TranslationString _contScrollToNextFileOnlyWithAlt = new TranslationString("Enable automatic continuous scroll (without ALT button)");
+        private readonly TranslationString _noRevision = new TranslationString("No revision");
 
         private readonly TranslationString _authored = new TranslationString("authored");
         private readonly TranslationString _committed = new TranslationString("committed");
@@ -82,6 +85,8 @@ namespace GitUI
         public static string Warning => _instance.Value._warning.Text;
         public static string Yes => _instance.Value._yes.Text;
         public static string No => _instance.Value._no.Text;
+        public static string OK => _instance.Value._okText.Text;
+        public static string Cancel => _instance.Value._cancelText.Text;
 
         public static string ContainedInBranches => _instance.Value._containedInBranchesText.Text;
         public static string ContainedInNoBranch => _instance.Value._containedInNoBranchText.Text;
@@ -109,6 +114,7 @@ namespace GitUI
         public static string Remote => _instance.Value._remote.Text;
         public static string OpenWithGitExtensions => _instance.Value._openWithGitExtensions.Text;
         public static string ContScrollToNextFileOnlyWithAlt => _instance.Value._contScrollToNextFileOnlyWithAlt.Text;
+        public static string NoRevision => _instance.Value._noRevision.Text;
 
         public static string OpenReport => _instance.Value._openReport.Text;
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6039,6 +6039,39 @@ Value has been reset to empty value.</source>
       </trans-unit>
     </body>
   </file>
+  <file datatype="plaintext" original="FormResetAnotherBranch" source-language="en">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Reset branch</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="BranchInfo.Text">
+        <source>Reset local &amp;branch:</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="Cancel.Text">
+        <source>Cancel</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="ForceReset.Text">
+        <source>&amp;Force reset for a non-fast-forward reset</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="Ok.Text">
+        <source>OK</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_localRefInvalid.Text">
+        <source>The entered value '{0}' is not the name of an existing local branch.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="labelResetBranchWarning.Text">
+        <source>You can only reset a branch safely if there is a direct path from it to selected revision.
+Forcing a branch to reset if it has not been merged might leave some commits unreachable.</source>
+        <target />
+      </trans-unit>
+    </body>
+  </file>
   <file datatype="plaintext" original="FormResetChanges" source-language="en">
     <body>
       <trans-unit id="$this.Text">
@@ -8676,6 +8709,10 @@ See the changes in the commit form.</source>
         <source>Rename branch...</source>
         <target />
       </trans-unit>
+      <trans-unit id="resetAnotherBranchToHereToolStripMenuItem.Text">
+        <source>Reset another branch to here...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="resetCurrentBranchToHereToolStripMenuItem.Text">
         <source>Reset current branch to here...</source>
         <target />
@@ -9105,6 +9142,10 @@ Select this commit to populate the full message.</source>
         <source>Branches</source>
         <target />
       </trans-unit>
+      <trans-unit id="_cancelText.Text">
+        <source>Cancel</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_childrenText.Text">
         <source>{0:Child|Children}</source>
         <target />
@@ -9247,6 +9288,14 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_noResultsFound.Text">
         <source>&lt;No results found&gt;</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_noRevision.Text">
+        <source>No revision</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_okText.Text">
+        <source>OK</source>
         <target />
       </trans-unit>
       <trans-unit id="_open.Text">

--- a/GitUI/UserControls/RevisionGrid/GitRefListsForRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/GitRefListsForRevision.cs
@@ -35,6 +35,8 @@ namespace GitUI.UserControls.RevisionGrid
             _tags = revision.Refs.Where(h => h.IsTag).ToArray();
         }
 
+        public IReadOnlyList<IGitRef> LocalBranches => _localBranches;
+
         public IReadOnlyList<IGitRef> AllBranches => _allBranches;
 
         public IReadOnlyList<IGitRef> AllTags => _tags;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -33,6 +33,7 @@ namespace GitUI
             this.checkoutBranchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mergeBranchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resetCurrentBranchToHereToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resetAnotherBranchToHereToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.rebaseOnToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.createNewBranchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -124,6 +125,7 @@ namespace GitUI
             this.mergeBranchToolStripMenuItem,
             this.rebaseOnToolStripMenuItem,
             this.resetCurrentBranchToHereToolStripMenuItem,
+            this.resetAnotherBranchToHereToolStripMenuItem,
             this.toolStripSeparator3,
             this.createNewBranchToolStripMenuItem,
             this.renameBranchToolStripMenuItem,
@@ -227,6 +229,14 @@ namespace GitUI
             this.resetCurrentBranchToHereToolStripMenuItem.Size = new System.Drawing.Size(223, 22);
             this.resetCurrentBranchToHereToolStripMenuItem.Text = "Reset current branch to here...";
             this.resetCurrentBranchToHereToolStripMenuItem.Click += new System.EventHandler(this.ResetCurrentBranchToHereToolStripMenuItemClick);
+            // 
+            // resetAnotherBranchToHereToolStripMenuItem
+            // 
+            this.resetAnotherBranchToHereToolStripMenuItem.Image = global::GitUI.Properties.Images.ResetCurrentBranchToHere;
+            this.resetAnotherBranchToHereToolStripMenuItem.Name = "resetAnotherBranchToHereToolStripMenuItem";
+            this.resetAnotherBranchToHereToolStripMenuItem.Size = new System.Drawing.Size(223, 22);
+            this.resetAnotherBranchToHereToolStripMenuItem.Text = "Reset another branch to here...";
+            this.resetAnotherBranchToHereToolStripMenuItem.Click += new System.EventHandler(this.ResetAnotherBranchToHereToolStripMenuItemClick);
             // 
             // toolStripSeparator3
             // 
@@ -571,6 +581,7 @@ namespace GitUI
         private System.Windows.Forms.ToolStripMenuItem createTagToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem createNewBranchToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem resetCurrentBranchToHereToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem resetAnotherBranchToHereToolStripMenuItem;
         private GitUI.UserControls.RevisionGrid.CopyContextMenuItem copyToClipboardToolStripMenuItem;
 
         private System.Windows.Forms.ToolStripSeparator bisectSeparator;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1474,12 +1474,10 @@ namespace GitUI
             var revision = LatestSelectedRevision;
 
             UICommands.DoActionOnRepo(() =>
-                {
-                    using (var frm = new FormCreateTag(UICommands, revision?.ObjectId))
-                    {
-                        return frm.ShowDialog(this) == DialogResult.OK;
-                    }
-                });
+            {
+                using var form = new FormCreateTag(UICommands, revision?.ObjectId);
+                return form.ShowDialog(this) == DialogResult.OK;
+            });
         }
 
         private void ResetCurrentBranchToHereToolStripMenuItemClick(object sender, EventArgs e)
@@ -1489,8 +1487,25 @@ namespace GitUI
                 return;
             }
 
-            var frm = new FormResetCurrentBranch(UICommands, LatestSelectedRevision);
-            frm.ShowDialog(this);
+            UICommands.DoActionOnRepo(() =>
+            {
+                using var form = FormResetCurrentBranch.Create(UICommands, LatestSelectedRevision);
+                return form.ShowDialog(this) == DialogResult.OK;
+            });
+        }
+
+        private void ResetAnotherBranchToHereToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            if (LatestSelectedRevision == null)
+            {
+                return;
+            }
+
+            UICommands.DoActionOnRepo(() =>
+            {
+                using var form = FormResetAnotherBranch.Create(UICommands, LatestSelectedRevision);
+                return form.ShowDialog(this) == DialogResult.OK;
+            });
         }
 
         private void CreateNewBranchToolStripMenuItemClick(object sender, EventArgs e)
@@ -1498,11 +1513,10 @@ namespace GitUI
             var revision = LatestSelectedRevision;
 
             UICommands.DoActionOnRepo(() =>
-                {
-                    var frm = new FormCreateBranch(UICommands, revision?.ObjectId);
-
-                    return frm.ShowDialog(this) == DialogResult.OK;
-                });
+            {
+                using var form = new FormCreateBranch(UICommands, revision?.ObjectId);
+                return form.ShowDialog(this) == DialogResult.OK;
+            });
         }
 
         internal void ShowCurrentBranchOnly()
@@ -1739,6 +1753,7 @@ namespace GitUI
             SetEnabled(copyToClipboardToolStripMenuItem, !revision.IsArtificial);
             SetEnabled(createNewBranchToolStripMenuItem, !bareRepositoryOrArtificial);
             SetEnabled(resetCurrentBranchToHereToolStripMenuItem, !bareRepositoryOrArtificial);
+            SetEnabled(resetAnotherBranchToHereToolStripMenuItem, !bareRepositoryOrArtificial);
             SetEnabled(archiveRevisionToolStripMenuItem, !revision.IsArtificial);
             SetEnabled(createTagToolStripMenuItem, !revision.IsArtificial);
 


### PR DESCRIPTION
Fixes #2876 (Superseding #8026 )
Implementation initially based on @mdonatas

## Proposed changes

- In the revision gird, being able to reset any branch (not only the one checked out) to the selected commit, using "git reset --force"

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/79908466-91018200-841b-11ea-9d5b-7131346912ec.png)

### After

![image](https://user-images.githubusercontent.com/6248932/80648730-f505f500-8a70-11ea-9e1f-688ec2c5a427.png)

The initial view when opening
![image](https://user-images.githubusercontent.com/6248932/80648803-1c5cc200-8a71-11ea-89ca-16164e5fdf53.png)

The new reset form for "other branches"
![image](https://user-images.githubusercontent.com/460196/82740433-e2699d80-9d48-11ea-8977-cd21db529af6.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 0a69f31ca246ebe13a212db80476180c4ac662d8
- Git 2.25.0.windows.1 (recommended: 2.25.1 or later)
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4150.0
- DPI 192dpi (200% scaling)


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
