### PR TITLE
SubmoduleStatusProvider: Set IsDirty from git-status

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2563,7 +2563,7 @@ namespace GitUI.CommandsDialogs
         private void UpdateSubmodulesStructure()
         {
             // Submodule status is updated on git-status updates. To make sure supermodule status is updated, update immediately (once)
-            var updateStatus = AppSettings.ShowSubmoduleStatus && _gitStatusMonitor.Active && (Module.SuperprojectModule != null);
+            var updateStatus = AppSettings.ShowSubmoduleStatus && _gitStatusMonitor.Active;
 
             toolStripButtonLevelUp.ToolTipText = "";
 


### PR DESCRIPTION
Backport of fixes in #8119

## Proposed changes

#8119 was opened to secure the functionality with #8049 but has cleaned up the handling some
That PR is probably too big for 3.4 right now. 
This PR cherry picks some specific limitations and bugs from that PR for 3.4

 * If not top project is current and current module has changed commits,
git-status with no dirty will not clear the current ahead/behind

 * If not top project is current and git-status is initially not dirty for super projects
but there are changed commits in superior projects, the status is now set as dirty

* If a submodule is no longer dirty, the status was no longer cleared when initiated from git-Status

* Some attempts to not refresh status twice

These are not important, but since detected, I can as well submit a PR before 3.4 is cut

## Test methodology

Tests are poor and disabled in 3.4, fixed and much expanded in #8115, tests added there

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
