### PR TITLE
Fix up restoring the selection of revisions on reload

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -990,7 +990,7 @@ namespace GitUI
                     AppSettings.RevisionGraphShowWorkingDirChanges &&
                     !Module.IsBareRepository())
                 {
-                    CheckUncommittedChanged(revision.ObjectId);
+                    AddArtificialRevisions(revision.ObjectId);
                 }
 
                 var flags = RevisionNodeFlags.None;
@@ -1014,7 +1014,7 @@ namespace GitUI
 
                 return;
 
-                void CheckUncommittedChanged(ObjectId filteredCurrentCheckout)
+                void AddArtificialRevisions(ObjectId filteredCurrentCheckout)
                 {
                     _indexChangeCount = new ChangeCount();
                     _workTreeChangeCount = new ChangeCount();


### PR DESCRIPTION
Fixes #6057

## Proposed changes

- get the row index from the correct source when it is stable
- clear ToBeSelectedObjectIds again when done

corrects the wrong assumption the revisions were loaded in order
fixes multi-selections not being restored anymore

## Screenshots <!-- Remove this section if PR does not change UI -->

see issue

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 71ee25272ff39bcc59dedca0a4d8fc956cb68971
- Git 2.26.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
