### PR TITLE
Fix up splitter positions

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -532,7 +532,10 @@ namespace GitUI.CommandsDialogs
                     new WindowsThumbnailToolbarButton(toolStripButtonCommit.Text, toolStripButtonCommit.Image, CommitToolStripMenuItemClick),
                     new WindowsThumbnailToolbarButton(toolStripButtonPush.Text, toolStripButtonPush.Image, PushToolStripMenuItemClick),
                     new WindowsThumbnailToolbarButton(toolStripButtonPull.Text, toolStripButtonPull.Image, PullToolStripMenuItemClick)));
+            SetSplitterPositions();
             HideVariableMainMenuItems();
+            RefreshSplitViewLayout();
+            LayoutRevisionInfo();
             InternalInitialize(false);
 
             if (!Module.IsValidGitWorkingDir())
@@ -569,8 +572,6 @@ namespace GitUI.CommandsDialogs
 
             base.OnLoad(e);
 
-            RefreshSplitViewLayout();
-            LayoutRevisionInfo();
             SetSplitterPositions();
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8153

## Proposed changes

- Restore the call sequence of before #8124
- But keep a second call of `SetSplitterPositions` after `base.OnLoad`

## Test methodology <!-- How did you ensure quality? -->

- manual (with an without start to the Dashboard)

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build bec3e4e0e35853b95d307432a975ba860d82bb2d
- Git 2.26.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
