### PR TITLE
Tooltip for merged branches

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -138,6 +138,7 @@ namespace GitUI.BranchTreePanel
 
                     _isMerged = value;
                     ApplyStyle();
+                    TreeViewNode.ToolTipText = IsMerged ? string.Format(Strings.ContainedInCurrentCommit, Name) : string.Empty;
                 }
             }
 

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -11,6 +11,7 @@ namespace GitUI
         private readonly TranslationString _yes = new TranslationString("Yes");
         private readonly TranslationString _no = new TranslationString("No");
 
+        private readonly TranslationString _containedInCurrentCommitText = new TranslationString("'{0}' is contained in the currently selected commit");
         private readonly TranslationString _containedInBranchesText = new TranslationString("Contained in branches:");
         private readonly TranslationString _containedInNoBranchText = new TranslationString("Contained in no branch");
         private readonly TranslationString _containedInTagsText = new TranslationString("Contained in tags:");
@@ -71,6 +72,7 @@ namespace GitUI
         public static string Yes => _instance.Value._yes.Text;
         public static string No => _instance.Value._no.Text;
 
+        public static string ContainedInCurrentCommit => _instance.Value._containedInCurrentCommitText.Text;
         public static string ContainedInBranches => _instance.Value._containedInBranchesText.Text;
         public static string ContainedInNoBranch => _instance.Value._containedInNoBranchText.Text;
         public static string ContainedInTags => _instance.Value._containedInTagsText.Text;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9150,6 +9150,10 @@ Select this commit to populate the full message.</source>
         <source>Contained in branches:</source>
         <target />
       </trans-unit>
+      <trans-unit id="_containedInCurrentCommitText.Text">
+        <source>'{0}' is contained in the currently selected commit</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_containedInNoBranchText.Text">
         <source>Contained in no branch</source>
         <target />


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/pull/8139#issuecomment-634106191

## Proposed changes

- Tooltip for merged branches

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

no tooltip

### After

![grafik](https://user-images.githubusercontent.com/36601201/82949011-2bb52980-9fa3-11ea-9a99-52fe2c1bfdb4.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 581938786997c2db795eaea6460b79f90346fa5f
- Git 2.26.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).