### PR TITLE
Link to read-the-docs for release version

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1665,7 +1665,8 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                Process.Start("http://git-extensions-documentation.readthedocs.org/en/master/");
+                // Point to the default documentation, will work also if the old doc version is removed
+                Process.Start("https://git-extensions-documentation.readthedocs.org");
             }
             catch (Win32Exception)
             {


### PR DESCRIPTION
## Proposed changes

The GE documentation maintains several branches, currently release/3.4, release/3.3, release/2.51 and master. (I just obsoleted the _latest_ branch and retired 3.1 and 3.2 (doc remains but not listed in the list with versions).

Currently, we keep a pointer to the specific version in the link in the GE source code, in release/3.3 pointing to release/3.3. In master it has been pointing to master.
The intention was to maintain that when building releases. While this could be achieved with build scripts (not done right now, there is still a manual step when merging.

This PR changes the link to point to the main link: https://git-extensions-documentation.readthedocs.io/
that will redirect to the link that is configured as the latest.
Documentation how to configure the latest release updated in https://github.com/gitextensions/gitextensions/wiki/How-To:-update-documentation-for-the-next-release#modifying-documentation

For development builds, the _master_ build should be pointed out. This is not a high priority though, it is more important that the link do not need to changed at builds or causes merge issues.
This PR changes only DEBUG builds to use the _master_ branch. (Which is what release/3.4 points at right now, that will be incorrect if we actually start to update the documentation for 4.0.)

Note: There has been one commit for doc for 3.4 only, this release contains many great features that should be documented

Note 2: There is no user statistics for the site (unknown Google Analytical used), but there are about 30-40 searches done every day.

## Test methodology <!-- How did you ensure quality? -->

Manual build

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
