### PR TITLE
FormCommit: Add context menu items Stage/Unstage

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using System.Windows.Forms;
 using GitUI.Editor;
 using GitUI.SpellChecker;
@@ -27,6 +28,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
             this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openWithToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.stageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openWithDifftoolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
             this.filenameToClipboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -52,6 +54,7 @@ namespace GitUI.CommandsDialogs
             this.stagedToolStripSeparator14 = new System.Windows.Forms.ToolStripSeparator();
             this.stagedOpenToolStripMenuItem7 = new System.Windows.Forms.ToolStripMenuItem();
             this.stagedOpenWithToolStripMenuItem8 = new System.Windows.Forms.ToolStripMenuItem();
+            this.stagedUnstageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.stagedOpenDifftoolToolStripMenuItem9 = new System.Windows.Forms.ToolStripMenuItem();
             this.stagedToolStripSeparator18 = new System.Windows.Forms.ToolStripSeparator();
             this.stagedCopyPathToolStripMenuItem14 = new System.Windows.Forms.ToolStripMenuItem();
@@ -185,6 +188,7 @@ namespace GitUI.CommandsDialogs
             // UnstagedFileContext
             //
             this.UnstagedFileContext.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.stageToolStripMenuItem,
             this.openWithDifftoolToolStripMenuItem,
             this.resetChanges,
             this.resetPartOfFileToolStripMenuItem,
@@ -244,6 +248,14 @@ namespace GitUI.CommandsDialogs
             this.openWithToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.openWithToolStripMenuItem.Text = "Open with...";
             this.openWithToolStripMenuItem.Click += new System.EventHandler(this.OpenWithToolStripMenuItemClick);
+            //
+            // stageToolStripMenuItem
+            //
+            this.stageToolStripMenuItem.Image = global::GitUI.Properties.Images.Stage;
+            this.stageToolStripMenuItem.Name = "stageToolStripMenuItem";
+            this.stageToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.stageToolStripMenuItem.Font = new Font(this.stageToolStripMenuItem.Font, FontStyle.Bold);
+            this.stageToolStripMenuItem.Click += new System.EventHandler(this.StageClick);
             //
             // openWithDifftoolToolStripMenuItem
             //
@@ -378,6 +390,7 @@ namespace GitUI.CommandsDialogs
             // StagedFileContext
             //
             this.StagedFileContext.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.stagedUnstageToolStripMenuItem,
             this.stagedOpenDifftoolToolStripMenuItem9,
             this.stagedResetChanges,
             this.stagedToolStripSeparator14,
@@ -432,6 +445,14 @@ namespace GitUI.CommandsDialogs
             this.stagedOpenWithToolStripMenuItem8.Size = new System.Drawing.Size(232, 22);
             this.stagedOpenWithToolStripMenuItem8.Text = "Open with...";
             this.stagedOpenWithToolStripMenuItem8.Click += new System.EventHandler(this.OpenWithToolStripMenuItemClick);
+            //
+            // stagedUnstageToolStripMenuItem
+            //
+            this.stagedUnstageToolStripMenuItem.Image = global::GitUI.Properties.Images.Unstage;
+            this.stagedUnstageToolStripMenuItem.Name = "stagedUnstageToolStripMenuItem";
+            this.stagedUnstageToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.stagedUnstageToolStripMenuItem.Font = new Font(this.stagedUnstageToolStripMenuItem.Font, FontStyle.Bold);
+            this.stagedUnstageToolStripMenuItem.Click += new System.EventHandler(this.UnstageFilesClick);
             //
             // stagedOpenDifftoolToolStripMenuItem9
             //
@@ -1539,6 +1560,7 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripMenuItem openWithToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem filenameToClipboardToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
+        private System.Windows.Forms.ToolStripMenuItem stageToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openWithDifftoolToolStripMenuItem;
         private System.Windows.Forms.ToolTip fileTooltip;
         private System.Windows.Forms.ToolStripMenuItem resetPartOfFileToolStripMenuItem;
@@ -1614,6 +1636,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripSeparator stagedToolStripSeparator14;
         private ToolStripMenuItem stagedOpenToolStripMenuItem7;
         private ToolStripMenuItem stagedOpenWithToolStripMenuItem8;
+        private ToolStripMenuItem stagedUnstageToolStripMenuItem;
         private ToolStripMenuItem stagedOpenDifftoolToolStripMenuItem9;
         private ToolStripMenuItem stagedOpenFolderToolStripMenuItem10;
         private ToolStripMenuItem stagedEditFileToolStripMenuItem11;

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -268,6 +268,9 @@ namespace GitUI.CommandsDialogs
             commitAuthorStatus.ToolTipText = _commitCommitterToolTip.Text;
             skipWorktreeToolStripMenuItem.ToolTipText = _skipWorktreeToolTip.Text;
             assumeUnchangedToolStripMenuItem.ToolTipText = _assumeUnchangedToolTip.Text;
+            stageToolStripMenuItem.Text = toolStageItem.Text;
+            stagedUnstageToolStripMenuItem.Text = toolUnstageItem.Text;
+
             toolAuthor.Control.PreviewKeyDown += (_, e) =>
             {
                 if (e.Alt)


### PR DESCRIPTION
Fixes #8106 


## Proposed changes

Put bold stage/unstage menu items in FileStatusList context menus

To avoid adding a translation string, the Text for the buttons are reused

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Before has #8137 applied - this PR is not necessarily an alternative to the second commit, both could be merged (even if my preference is that the second commit do not go in)

![image](https://user-images.githubusercontent.com/6248932/83461605-746c5700-a469-11ea-8c5a-1afb8c6d92ae.png)

![image](https://user-images.githubusercontent.com/6248932/83461576-5dc60000-a469-11ea-9c1c-da4b149988e1.png)

### After

![image](https://user-images.githubusercontent.com/6248932/83461497-353e0600-a469-11ea-907b-f952cfb8fe37.png)

![image](https://user-images.githubusercontent.com/6248932/83461530-4555e580-a469-11ea-823c-d71549756d84.png)

## Test methodology 

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
