### PR TITLE
Prevent NRE when getting AppVeyor build duration

### DIFF
--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -434,9 +434,14 @@ namespace AppVeyorIntegration
 
         private static long GetBuildDuration(JToken buildData)
         {
-            var startTime = buildData["started"].ToObject<DateTime>();
-            var updateTime = buildData["updated"].ToObject<DateTime>();
-            return (long)(updateTime - startTime).TotalMilliseconds;
+            var startTime = (buildData["started"] ?? buildData["created"])?.ToObject<DateTime>();
+            var updateTime = buildData["updated"]?.ToObject<DateTime>();
+            if (!startTime.HasValue || !updateTime.HasValue)
+            {
+                return 0;
+            }
+
+            return (long)(updateTime.Value - startTime.Value).TotalMilliseconds;
         }
 
         private async Task<JObject> FetchBuildDetailsManagingVersionUpdateAsync(AppVeyorBuildInfo buildDetails, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes #8150

## Proposed changes

- return 0 instead of throwing an NRE

## Test methodology <!-- How did you ensure quality? -->

- None. Occured one time but difficult to reproduce.


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 0ef262dc8eddb1d6b8958d4cf7bf730c8ce28739
- Git 2.25.0.windows.1 (recommended: 2.25.1 or later)
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4180.0
- DPI 168dpi (175% scaling)

