### PR TITLE
Make scripts execution safer

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -997,9 +997,18 @@ namespace GitUI.CommandsDialogs
 
                     button.Click += delegate
                     {
-                        if (ScriptRunner.RunScript(this, Module, script.Name, UICommands, RevisionGrid).NeedsGridRefresh)
+                        try
                         {
-                            RevisionGrid.RefreshRevisions();
+                            if (ScriptRunner.RunScript(this, Module, script.Name, UICommands, RevisionGrid).NeedsGridRefresh)
+                            {
+                                RevisionGrid.RefreshRevisions();
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            MessageBox.Show(this,
+                                $"Failed to execute '{script.Name}' script.{Environment.NewLine}Reason: {ex.Message}",
+                                Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
                     };
 

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -152,6 +152,9 @@ namespace GitUI.Script
                 }
                 else
                 {
+                    // It is totally valid to have a command without an argument, e.g.:
+                    //    Command  : myscript.cmd
+                    //    Arguments: <blank>
                     new Executable(command, module.WorkingDir).Start(argument ?? string.Empty);
                 }
             }

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -152,7 +152,7 @@ namespace GitUI.Script
                 }
                 else
                 {
-                    new Executable(command, module.WorkingDir).Start(argument);
+                    new Executable(command, module.WorkingDir).Start(argument ?? string.Empty);
                 }
             }
 


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Proposed changes

* Scripts may not have arguments, pass "" in this case instead.

* Scripts may fail during execution, show an error message instead of crashing the process.


NB: there is a new string, but I'm fine with not translating it, as the use case it likely niche.