### PR TITLE
Do not use Cursor.Position in Mouse event handlers

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -607,11 +607,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             }
             else if (e.Button == MouseButtons.Right)
             {
-                // translate the mouse position from screen coordinates to
-                // client coordinates within the given ListView
-                Point localPoint = listView1.PointToClient(Cursor.Position);
-                _rightClickedItem = listView1.GetItemAt(localPoint.X, localPoint.Y);
-
+                _rightClickedItem = listView1.GetItemAt(e.X, e.Y);
                 if (_rightClickedItem != null)
                 {
                     _rightClickedItem.Selected = true;

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1117,8 +1117,7 @@ namespace GitUI.CommandsDialogs
                     return;
                 }
 
-                System.Drawing.Point pt = ConflictedFiles.PointToClient(Cursor.Position);
-                DataGridView.HitTestInfo hti = ConflictedFiles.HitTest(pt.X, pt.Y);
+                DataGridView.HitTestInfo hti = ConflictedFiles.HitTest(e.X, e.Y);
                 int lastRow = hti.RowIndex;
                 ConflictedFiles.ClearSelection();
                 if (lastRow >= 0 && ConflictedFiles.Rows.Count > lastRow)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1418,8 +1418,7 @@ namespace GitUI
 
         private void OnGridViewMouseClick(object sender, MouseEventArgs e)
         {
-            var pt = _gridView.PointToClient(Cursor.Position);
-            var hti = _gridView.HitTest(pt.X, pt.Y);
+            var hti = _gridView.HitTest(e.X, e.Y);
             _latestSelectedRowIndex = hti.RowIndex;
         }
 
@@ -1430,8 +1429,7 @@ namespace GitUI
                 return;
             }
 
-            var pt = _gridView.PointToClient(Cursor.Position);
-            var hti = _gridView.HitTest(pt.X, pt.Y);
+            var hti = _gridView.HitTest(e.X, e.Y);
 
             if (_latestSelectedRowIndex == hti.RowIndex
                 && _latestSelectedRowIndex < _gridView.Rows.Count


### PR DESCRIPTION
Fixes: `RevisionGridControl._latestSelectedRowIndex` can be `-1`.
Then `LatestSelectedRevision` yields `null`.

## Proposed changes

Do not use `Cursor.Position` in Mouse event handlers!
Use `MouseEventArgs.Location` instead. It contains the clicked position. `Cursor.Position` can be quite different, e.g. if the main thread is busy updating and the mouse is moved away.

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 4.0.0
- Build 9a8bb6d6fcfd531aeb1dcf4254d22df71287c86a
- Git 2.26.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).