### PR TITLE
Use DataGridViewCellMouseEventArgs.RowIndex

### DIFF
--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1117,8 +1117,7 @@ namespace GitUI.CommandsDialogs
                     return;
                 }
 
-                DataGridView.HitTestInfo hti = ConflictedFiles.HitTest(e.X, e.Y);
-                int lastRow = hti.RowIndex;
+                int lastRow = e.RowIndex;
                 ConflictedFiles.ClearSelection();
                 if (lastRow >= 0 && ConflictedFiles.Rows.Count > lastRow)
                 {

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1429,16 +1429,14 @@ namespace GitUI
                 return;
             }
 
-            var hti = _gridView.HitTest(e.X, e.Y);
-
-            if (_latestSelectedRowIndex == hti.RowIndex
+            if (_latestSelectedRowIndex == e.RowIndex
                 && _latestSelectedRowIndex < _gridView.Rows.Count
                 && _gridView.Rows[_latestSelectedRowIndex].Selected)
             {
                 return;
             }
 
-            _latestSelectedRowIndex = hti.RowIndex;
+            _latestSelectedRowIndex = e.RowIndex;
             _gridView.ClearSelection();
 
             if (IsValidRevisionIndex(_latestSelectedRowIndex))


### PR DESCRIPTION
Fixes part of #8195, which broke the right click / context menu

## Proposed changes

In case of `DataGridViewCellMouseEvent`, the base class `MouseEventArgs.Location` contains the mouse position relative to the selected cell not to the `Control`.
And it already contains the `RowIndex`.
So use it instead of `HitTest(e.X, e.Y)`.

## Test methodology <!-- How did you ensure quality? -->

- manual (more complete this time, sorry)

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build d60ed2270cde53b15fc84b353e77a78cf98acae3
- Git 2.26.0.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
