### PR TITLE
Apply also font size setting to the ConEmu popup

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2797,28 +2797,7 @@ namespace GitUI.CommandsDialogs
                     WhenConsoleProcessExits = WhenConsoleProcessExits.CloseConsoleEmulator
                 };
 
-                var startInfoBaseConfiguration = startInfo.BaseConfiguration;
-                if (!string.IsNullOrWhiteSpace(AppSettings.ConEmuFontSize.ValueOrDefault))
-                {
-                    if (int.TryParse(AppSettings.ConEmuFontSize.ValueOrDefault, out var fontSize))
-                    {
-                        var nodeFontSize =
-                            startInfoBaseConfiguration.SelectSingleNode("/key/key/key/value[@name='FontSize']");
-
-                        if (nodeFontSize?.Attributes != null)
-                        {
-                            nodeFontSize.Attributes["data"].Value = fontSize.ToString("X8");
-                        }
-                    }
-                }
-
-                startInfo.BaseConfiguration = startInfoBaseConfiguration;
                 startInfo.ConsoleProcessCommandLine = ShellHelper.GetCommandLineForCurrentShell();
-
-                if (AppSettings.ConEmuStyle.ValueOrDefault != "Default")
-                {
-                    startInfo.ConsoleProcessExtraArgs = " -new_console:P:\"" + AppSettings.ConEmuStyle.ValueOrDefault + "\"";
-                }
 
                 // Set path to git in this window (actually, effective with CMD only)
                 if (!string.IsNullOrEmpty(AppSettings.GitCommandValue))
@@ -2832,7 +2811,7 @@ namespace GitUI.CommandsDialogs
 
                 try
                 {
-                    _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory);
+                    _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, AppSettings.ConEmuStyle.ValueOrDefault, AppSettings.ConEmuFontSize.ValueOrDefault);
                 }
                 catch (InvalidOperationException)
                 {

--- a/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
+++ b/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
@@ -95,11 +95,6 @@ namespace GitUI.UserControls
                 StartupDirectory = workDir
             };
 
-            if (AppSettings.ConEmuStyle.ValueOrDefault != "Default")
-            {
-                startInfo.ConsoleProcessExtraArgs = " -new_console:P:\"" + AppSettings.ConEmuStyle.ValueOrDefault + "\"";
-            }
-
             foreach (var (name, value) in envVariables)
             {
                 startInfo.SetEnv(name, value);
@@ -123,7 +118,7 @@ namespace GitUI.UserControls
                 }
             };
 
-            _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory);
+            _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, AppSettings.ConEmuStyle.ValueOrDefault, AppSettings.ConEmuFontSize.ValueOrDefault);
         }
     }
 


### PR DESCRIPTION
## Proposed changes

- Apply also the Conemu font configuration to the ConEmu popup (because that's strange to apply only just one setting, the console style and not the other)


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/84518607-3ecd3680-acd1-11ea-9c4a-0b0b207a6ea8.png)


### After

That's bigger (even if we don't really see it due to how GitHub handle images. Compare text size inside the console with the one of the button or with the icon size)

![image](https://user-images.githubusercontent.com/460196/84518828-910e5780-acd1-11ea-8f82-5f3f4f1f78ec.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build f544aba2e27d05647ec1f7d122cbf3bea744dca7 (Dirty)
- Git 2.25.0.windows.1 (recommended: 2.25.1 or later)
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.8.4180.0
- DPI 168dpi (175% scaling)
