### PR TITLE
ResetAnotherBranch: Quote path arguments

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -240,8 +240,8 @@ namespace GitCommands
         {
             return new GitArgumentBuilder("push")
             {
-                $"file://{repoPath}",
-                $"{targetId}:{gitRef}",
+                $"file://{repoPath}".RemoveTrailingPathSeparator().QuoteNE(),
+                $"{targetId}:{gitRef}".QuoteNE(),
                 { force, "--force" }
             };
         }

--- a/UnitTests/GitCommands.Tests/Git/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitCommandHelpersTest.cs
@@ -652,6 +652,14 @@ namespace GitCommandsTests.Git
                 () => GitCommandHelpers.ResetCmd(ResetMode.ResetIndex, commit: hash, file: "file.txt"));
         }
 
+        [TestCase(@"a path with spaces\", "mybranch", false, ExpectedResult = @"push ""file://a path with spaces"" ""1111111111111111111111111111111111111111:mybranch""")]
+        [TestCase(@"c:\path2\", "branch2", true, ExpectedResult = @"push ""file://c:\path2"" ""1111111111111111111111111111111111111111:branch2"" --force")]
+        [TestCase(@"/c/path3/", "branch3", true, ExpectedResult = @"push ""file:///c/path3"" ""1111111111111111111111111111111111111111:branch3"" --force")]
+        public string PushLocalCmd(string repoPath, string gitRef, bool force)
+        {
+            return GitCommandHelpers.PushLocalCmd(repoPath, gitRef, ObjectId.WorkTreeId, force).Arguments;
+        }
+
         [TestCase(ResetMode.ResetIndex, "tree-ish", null, @"reset ""tree-ish"" --")]
         [TestCase(ResetMode.ResetIndex, "tree-ish", "file.txt", @"reset ""tree-ish"" -- ""file.txt""")]
         [TestCase(ResetMode.Soft, null, null, @"reset --soft --")]


### PR DESCRIPTION
Fixes #8235


## Proposed changes

Quote path (and gitref, not strictly needed).

## Test methodology

Manual (check Git command log)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
