### PR TITLE
RevDiff: Add hotkeys to stage/unstage/reset

### DIFF
--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -364,7 +364,10 @@ namespace GitUI.Hotkey
                     Hk(RevisionDiffControl.Command.OpenWithDifftool, OpenWithDifftoolHotkey),
                     Hk(RevisionDiffControl.Command.OpenWithDifftoolFirstToLocal, OpenWithDifftoolFirstToLocalHotkey),
                     Hk(RevisionDiffControl.Command.OpenWithDifftoolSelectedToLocal, OpenWithDifftoolSelectedToLocalHotkey),
-                    Hk(RevisionDiffControl.Command.ShowHistory, ShowHistoryHotkey)),
+                    Hk(RevisionDiffControl.Command.ShowHistory, ShowHistoryHotkey),
+                    Hk(RevisionDiffControl.Command.ResetSelectedFiles, Keys.R),
+                    Hk(RevisionDiffControl.Command.StageSelectedFile, Keys.S),
+                    Hk(RevisionDiffControl.Command.UnStageSelectedFile, Keys.U)),
                 new HotkeySettings(
                     RevisionFileTreeControl.HotkeySettingsName,
                     Hk(RevisionFileTreeControl.Command.Blame, BlameHotkey),

--- a/GitUI/MessageBoxes.cs
+++ b/GitUI/MessageBoxes.cs
@@ -45,6 +45,7 @@ namespace GitUI
 
         private readonly TranslationString _shellNotFoundCaption = new TranslationString("Shell not found");
         private readonly TranslationString _shellNotFound = new TranslationString("The selected shell is not installed, or is not on your path.");
+        private readonly TranslationString _resetChangesCaption = new TranslationString("Reset changes");
 
         // internal for FormTranslate
         internal MessageBoxes()
@@ -137,5 +138,8 @@ namespace GitUI
 
         public static void ShowError([CanBeNull] IWin32Window owner, string text, string caption = null)
             => MessageBox.Show(owner, text, caption ?? Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+
+        public static bool ResetSelectedFiles(IWin32Window owner, string text)
+            => MessageBox.Show(owner, text, Instance._resetChangesCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7726,6 +7726,10 @@ help</source>
         <source>Remember choice</source>
         <target />
       </trans-unit>
+      <trans-unit id="_resetChangesCaption.Text">
+        <source>Reset changes</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_selectOnlyOneOrTwoRevisions.Text">
         <source>Select only one or two revisions. Abort.</source>
         <target />
@@ -8085,6 +8089,10 @@ To show all branches, right click the revision grid, select 'view' and then the 
       </trans-unit>
       <trans-unit id="_multipleDescription.Text">
         <source>&lt;multiple&gt;</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_resetSelectedChangesText.Text">
+        <source>Are you sure you want to reset all selected files to {0}?</source>
         <target />
       </trans-unit>
       <trans-unit id="_saveFileFilterAllFiles.Text">


### PR DESCRIPTION
Separating hotkey handling in RevDiff file status list from #7825 

No longer based on #8193 (some conflicts)

## Proposed changes

Add hotkeys to stage/unstage/reset in RevDiff
Checks that the status list is in focus (if the viewer is in focus in #7825, lines will be changed instead).


## Screenshots <!-- Remove this section if PR does not change UI -->

### After

![image](https://user-images.githubusercontent.com/6248932/84868761-79422500-b07d-11ea-96e6-89fdd21b5335.png)

![image](https://user-images.githubusercontent.com/6248932/84868884-a0005b80-b07d-11ea-862c-7ed46c4017e1.png)

![image](https://user-images.githubusercontent.com/6248932/85204808-503cc100-b317-11ea-84a3-67be2df429a7.png)


## Test methodology 

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
