### PR TITLE
Make WindowsJumpListManager calls safer

### DIFF
--- a/GitUI/WindowsJumpListManager.cs
+++ b/GitUI/WindowsJumpListManager.cs
@@ -108,7 +108,7 @@ namespace GitUI
                 _commitButton.Enabled = true;
                 _pushButton.Enabled = true;
                 _pullButton.Enabled = true;
-            }, "AddToRecent");
+            }, nameof(AddToRecent));
         }
 
         public void UpdateCommitIcon(Image image)
@@ -119,7 +119,7 @@ namespace GitUI
                 {
                     _commitButton.Icon = MakeIcon(image, 48, true);
                 }
-            }, "UpdateJumplist");
+            }, nameof(UpdateCommitIcon));
         }
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace GitUI
                 jumpList.Refresh();
 
                 CreateTaskbarButtons(windowHandle, buttons);
-            }, "CreateJumpList");
+            }, nameof(CreateJumpList));
 
             return;
 
@@ -179,7 +179,7 @@ namespace GitUI
                 _commitButton.Enabled = false;
                 _pushButton.Enabled = false;
                 _pullButton.Enabled = false;
-            }, "DisableThumbnailToolbar");
+            }, nameof(DisableThumbnailToolbar));
         }
 
         /// <summary>

--- a/GitUI/WindowsJumpListManager.cs
+++ b/GitUI/WindowsJumpListManager.cs
@@ -137,20 +137,16 @@ namespace GitUI
 
             SafeInvoke(() =>
             {
-                CreateJumpList();
-                CreateTaskbarButtons(windowHandle, buttons);
-            }, "CreateJumpList");
-
-            return;
-
-            void CreateJumpList()
-            {
                 // One ApplicationId, so all windows must share the same jumplist
                 var jumpList = JumpList.CreateJumpList();
                 jumpList.ClearAllUserTasks();
                 jumpList.KnownCategoryToDisplay = JumpListKnownCategoryType.Recent;
                 jumpList.Refresh();
-            }
+
+                CreateTaskbarButtons(windowHandle, buttons);
+            }, "CreateJumpList");
+
+            return;
 
             void CreateTaskbarButtons(IntPtr handle, WindowsThumbnailToolbarButtons thumbButtons)
             {
@@ -264,7 +260,10 @@ namespace GitUI
 
                     // reported in https://github.com/gitextensions/gitextensions/issues/4549
                     // looks like a regression in Windows 10.0.16299 (1709)
-                    ex is IOException)
+                    ex is IOException ||
+
+                    // observed during integration tests: A valid active Window is needed to update the Taskbar.
+                    ex is InvalidOperationException)
             {
                 Trace.WriteLine(ex.Message, callerName);
             }


### PR DESCRIPTION
Wrap WindowsJumpListManager calls in try..catch.
Resolves #8234
