### PR TITLE
Disable context menu items rather than hiding them

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -472,7 +472,7 @@ namespace GitUI.CommandsDialogs
             stageFileToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuStage(selectionInfo);
             unstageFileToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuUnstage(selectionInfo);
             resetFileToToolStripMenuItem.Enabled = _revisionDiffController.ShouldShowResetFileMenus(selectionInfo);
-            cherryPickSelectedDiffFileToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuCherryPick(selectionInfo);
+            cherryPickSelectedDiffFileToolStripMenuItem.Enabled = _revisionDiffController.ShouldShowMenuCherryPick(selectionInfo);
 
             diffToolStripSeparator13.Visible = _revisionDiffController.ShouldShowDifftoolMenus(selectionInfo) ||
                                                _revisionDiffController.ShouldShowMenuDeleteFile(selectionInfo) ||

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1669,13 +1669,18 @@ namespace GitUI
             }
 
             var allBranches = gitRefListsForRevision.AllBranches;
+            bool isHeadOfCurrentBranch = false;
             bool firstRemoteBranchForCheckout = false;
             foreach (var head in allBranches)
             {
                 // skip remote branches - they can not be deleted this way
                 if (!head.IsRemote)
                 {
-                    if (head.CompleteName != currentBranchRef)
+                    if (head.CompleteName == currentBranchRef)
+                    {
+                        isHeadOfCurrentBranch = true;
+                    }
+                    else
                     {
                         AddBranchMenuItem(deleteBranchDropDown, head, delegate { UICommands.StartDeleteBranchDialog(this, head.Name); });
                     }
@@ -1733,6 +1738,10 @@ namespace GitUI
 
             deleteBranchToolStripMenuItem.DropDown = deleteBranchDropDown;
             SetEnabled(deleteBranchToolStripMenuItem, deleteBranchDropDown.Items.Count > 0 && !Module.IsBareRepository());
+            if (isHeadOfCurrentBranch)
+            {
+                deleteBranchToolStripMenuItem.Visible = true;
+            }
 
             checkoutBranchToolStripMenuItem.DropDown = checkoutBranchDropDown;
             SetEnabled(checkoutBranchToolStripMenuItem, !bareRepositoryOrArtificial && HasEnabledItem(checkoutBranchDropDown) && !Module.IsBareRepository());


### PR DESCRIPTION
Fixes #8245

## Proposed changes

Disable context menu items instead of hiding them:
- `Delete branch...` for current branch in RevisionGrid
- `Cherry pick changes` for e.g. multi-selections in tab "Diff"

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/85075207-16a47280-b1be-11ea-974d-b92ff9843798.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/85074856-882ff100-b1bd-11ea-8068-0bfe1e24f77e.png)

### Before

![grafik](https://user-images.githubusercontent.com/36601201/85074920-a4339280-b1bd-11ea-9ae8-67bd902da053.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/85075059-d5ac5e00-b1bd-11ea-9a71-ac5ec8079464.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 306e547dc42e0389dfcbd5d0f394e1b2c398ec3e
- Git 2.26.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
