### PR TITLE
Draw current commit message bold in detached-head mode

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -50,7 +50,6 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             var superprojectRefs = new List<IGitRef>();
             var offset = ColumnLeftMargin;
             var normalFont = style.NormalFont;
-            var hasSelectedRef = false;
 
             #region Draw super project references (for submodules)
 
@@ -118,11 +117,6 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                             DrawImage(_bisectBadImage);
                             continue;
                         }
-                    }
-
-                    if (gitRef.IsSelected)
-                    {
-                        hasSelectedRef = true;
                     }
 
                     var headColor = RevisionGridRefRenderer.GetHeadColor(gitRef);
@@ -208,7 +202,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
                 // Draw the summary text
                 var bounds = messageBounds.ReduceLeft(offset);
-                _grid.DrawColumnText(e, text, hasSelectedRef ? style.BoldFont : normalFont, style.ForeColor, bounds);
+                _grid.DrawColumnText(e, text, revision.ObjectId == _grid.CurrentCheckout ? style.BoldFont : normalFont, style.ForeColor, bounds);
 
                 // Draw the multi-line indicator
                 indicator.Render();


### PR DESCRIPTION
Fixes #8099
and part of #5767

## Proposed changes

- draw the message of the `RevisionGrid.CurrentCheckout` with bold font

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/85183348-b419a800-b28b-11ea-867d-1bdf62b2cb6e.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/85183379-cd225900-b28b-11ea-8498-5892ba099d47.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.3.0
- Build 83f645ee6e38a2d35869bf6f371c75e57f864ad4
- Git 2.26.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
