### PR TITLE
Fix ssh not found

### DIFF
--- a/GitCommands/SshPathLocator.cs
+++ b/GitCommands/SshPathLocator.cs
@@ -54,7 +54,10 @@ namespace GitCommands
 
             try
             {
-                var gitDirInfo = _fileSystem.Directory.GetParent(gitBinDirectory);
+                // gitBinDirectory will normally end with a directory separator
+                // (at least this is what AppSettings.GitBinDir ensures),
+                // but then GetParent() returns the same directory, only without the trailing separator
+                var gitDirInfo = _fileSystem.Directory.GetParent(gitBinDirectory.RemoveTrailingPathSeparator());
                 if (gitDirInfo == null)
                 {
                     return null;


### PR DESCRIPTION
When `ssh.exe` is not in the path, the attempt to find it in git
directory will fail, resulting in a nasty crash of the whole
GitExtensions process if it is needed (an example is when
downloading a patchset in Gerrit plugin).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
