### PR TITLE
Avoid console printouts when submodule updates are throttled

### DIFF
--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -154,7 +154,7 @@ namespace GitCommands.Submodules
             TimeSpan elapsed = DateTime.Now - _previousSubmoduleUpdateTime;
             if (gitStatus == null || (!forceUpdate && elapsed.TotalSeconds <= 15))
             {
-                Console.WriteLine($"{MethodBase.GetCurrentMethod().Name} called too early again - aborting");
+                // Just drop the update in 3.4, proper delay in master
                 return;
             }
 


### PR DESCRIPTION

## Proposed changes

Annoying change in 3.4: Printouts when starting GE from commandline

git-status updates more often than 15s are dropped, to limit background refreshes of the submodule status.
The handling in 3.4 is about the same since 3.1/3.0 but improved in master (updates are throttled/delayed, not just dropped).

In 3.4 a console printout was added when an update is dropped.
Every third second or so, the following is written to the console:
```
MoveNext called too early again - aborting
```

This is very annoying if you start GE from the commandline.
Not the way I use GE (and I use master), but my coworkers are annoyed

Git alias:
```
ex = !sh -c\"\\\"C:/Program Files (x86)/GitExtensions/GitExtensions.exe\\\"browse $(git rev-parse --show-toplevel)\" &
```

A workaround is to write the printout to /dev/null

Not urgent, but should be included if there is a 3.4 release

## Test methodology

Manual, code review

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
