### PR TITLE
RevFile: Diff any two files

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -31,7 +31,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _multipleDescription = new TranslationString("<multiple>");
         private readonly TranslationString _selectedRevision = new TranslationString("Second: b/");
         private readonly TranslationString _firstRevision = new TranslationString("First: a/");
-        private readonly TranslationString _diffSelectedWithRememberedFile = new TranslationString("Diff with \"{0}\"");
 
         private RevisionGridControl _revisionGrid;
         private RevisionFileTreeControl _revisionFileTree;
@@ -40,7 +39,8 @@ namespace GitUI.CommandsDialogs
         private readonly IFullPathResolver _fullPathResolver;
         private readonly IFindFilePredicateProvider _findFilePredicateProvider;
         private readonly IGitRevisionTester _gitRevisionTester;
-        private readonly RememberFileContextMenuController _rememberFileContextMenuController;
+        private readonly RememberFileContextMenuController _rememberFileContextMenuController
+            = RememberFileContextMenuController.Default;
 
         public RevisionDiffControl()
         {
@@ -52,7 +52,6 @@ namespace GitUI.CommandsDialogs
             _findFilePredicateProvider = new FindFilePredicateProvider();
             _gitRevisionTester = new GitRevisionTester(_fullPathResolver);
             _revisionDiffContextMenuController = new FileStatusListContextMenuController();
-            _rememberFileContextMenuController = new RememberFileContextMenuController();
             DiffText.TopScrollReached += FileViewer_TopScrollReached;
             DiffText.BottomScrollReached += FileViewer_BottomScrollReached;
         }
@@ -828,7 +827,7 @@ namespace GitUI.CommandsDialogs
                 && _rememberFileContextMenuController.ShouldEnableSecondItemDiff(diffFiles[0]);
             diffWithRememberedDifftoolToolStripMenuItem.Text =
                 _rememberFileContextMenuController.RememberedDiffFileItem != null
-                    ? string.Format(_diffSelectedWithRememberedFile.Text, _rememberFileContextMenuController.RememberedDiffFileItem.Item.Name)
+                    ? string.Format(Strings.DiffSelectedWithRememberedFile, _rememberFileContextMenuController.RememberedDiffFileItem.Item.Name)
                     : string.Empty;
 
             rememberSecondRevDiffToolStripMenuItem.Visible = diffFiles.Count == 1;

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
@@ -33,6 +33,8 @@
             this.tvGitTree = new GitUI.UserControls.NativeTreeView();
             this.FileTreeContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.openWithDifftoolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.diffWithRememberedFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.rememberFileStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resetToThisRevisionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparatorFileSystemActions = new System.Windows.Forms.ToolStripSeparator();
@@ -110,6 +112,8 @@
             this.resetToThisRevisionToolStripMenuItem,
             this.toolStripSeparatorTopActions,
             this.openWithDifftoolToolStripMenuItem,
+            this.diffWithRememberedFileToolStripMenuItem,
+            this.rememberFileStripMenuItem,
             this.openWithToolStripMenuItem,
             this.openFileToolStripMenuItem,
             this.openFileWithToolStripMenuItem,
@@ -142,6 +146,19 @@
             this.openWithDifftoolToolStripMenuItem.Size = new System.Drawing.Size(325, 22);
             this.openWithDifftoolToolStripMenuItem.Text = "Open with difftool";
             this.openWithDifftoolToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
+            // 
+            // diffWithRememberedFileToolStripMenuItem
+            // 
+            this.diffWithRememberedFileToolStripMenuItem.Name = "diffWithRememberedFileToolStripMenuItem";
+            this.diffWithRememberedFileToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.diffWithRememberedFileToolStripMenuItem.Click += new System.EventHandler(this.diffWithRememberedFileToolStripMenuItem_Click);
+            // 
+            // rememberFileStripMenuItem
+            // 
+            this.rememberFileStripMenuItem.Name = "rememberFileStripMenuItem";
+            this.rememberFileStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.rememberFileStripMenuItem.Text = "Remember file for diff";
+            this.rememberFileStripMenuItem.Click += new System.EventHandler(this.rememberFileToolStripMenuItem_Click);
             // 
             // saveAsToolStripMenuItem
             // 
@@ -355,6 +372,8 @@
         private Editor.FileViewer FileText;
         private System.Windows.Forms.ContextMenuStrip FileTreeContextMenu;
         private System.Windows.Forms.ToolStripMenuItem openWithDifftoolToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem diffWithRememberedFileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem rememberFileStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveAsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem resetToThisRevisionToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparatorFileSystemActions;

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -664,7 +664,7 @@ See the changes in the commit form.");
         {
             if (tvGitTree.SelectedNode?.Tag is GitItem gitItem)
             {
-                Module.OpenWithDifftool(gitItem.Name, firstRevision: _revision?.ObjectId?.ToString());
+                Module.OpenWithDifftool(gitItem.FileName, firstRevision: _revision?.ObjectId?.ToString());
             }
         }
 

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -54,6 +54,7 @@ namespace GitUI
         private readonly TranslationString _open = new TranslationString("Open");
         private readonly TranslationString _directoryIsNotAValidRepository = new TranslationString("The selected item is not a valid git repository.");
 
+        private readonly TranslationString _diffSelectedWithRememberedFile = new TranslationString("Diff with \"{0}\"");
         private readonly TranslationString _showDiffForAllParentsText = new TranslationString("Show file differences for all parents in browse dialog");
         private readonly TranslationString _showDiffForAllParentsTooltip = new TranslationString(@"Show all differences between the selected commits, not limiting to only one difference.
 
@@ -136,6 +137,7 @@ namespace GitUI
         public static string Open => _instance.Value._open.Text;
         public static string DirectoryInvalidRepository => _instance.Value._directoryIsNotAValidRepository.Text;
 
+        public static string DiffSelectedWithRememberedFile => _instance.Value._diffSelectedWithRememberedFile.Text;
         public static string ShowDiffForAllParentsText => _instance.Value._showDiffForAllParentsText.Text;
         public static string ShowDiffForAllParentsTooltip => _instance.Value._showDiffForAllParentsTooltip.Text;
     }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8071,10 +8071,6 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <source>Delete</source>
         <target />
       </trans-unit>
-      <trans-unit id="_diffSelectedWithRememberedFile.Text">
-        <source>Diff with "{0}"</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_firstRevision.Text">
         <source>First: a/</source>
         <target />
@@ -8351,6 +8347,10 @@ See the changes in the commit form.</source>
       </trans-unit>
       <trans-unit id="openWithToolStripMenuItem.Text">
         <source>Open working directory file with...</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="rememberFileStripMenuItem.Text">
+        <source>Remember file for diff</source>
         <target />
       </trans-unit>
       <trans-unit id="resetToThisRevisionToolStripMenuItem.Text">
@@ -9224,6 +9224,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_deleteFile.Text">
         <source>{0:Delete file|Delete files}</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_diffSelectedWithRememberedFile.Text">
+        <source>Diff with "{0}"</source>
         <target />
       </trans-unit>
       <trans-unit id="_directoryIsNotAValidRepository.Text">


### PR DESCRIPTION
Based on #8193, for RevisionFileHistory

## Proposed changes

Add _Remember file for diff_ for RevisionFileHistory similar to RevDiff in #8193 The context is shared between the tabs 

## Screenshots 

### Before

![image](https://user-images.githubusercontent.com/6248932/85932888-b5bd1e80-b8d0-11ea-974b-52341ff2017d.png)

### After

![image](https://user-images.githubusercontent.com/6248932/85932914-324ffd00-b8d1-11ea-847a-ec801b24e8cd.png)

## Test methodology 

Tests added for RevisionDiff

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
