### PR TITLE
Track theme colors via Telemetry

### DIFF
--- a/GitUI/Infrastructure/Telemetry/DiagnosticsClient.cs
+++ b/GitUI/Infrastructure/Telemetry/DiagnosticsClient.cs
@@ -22,6 +22,7 @@ namespace GitUI.Infrastructure.Telemetry
             TelemetryConfiguration.Active.TelemetryInitializers.Add(new AppEnvironmentTelemetryInitializer());
             TelemetryConfiguration.Active.TelemetryInitializers.Add(new AppInfoTelemetryInitializer(isDirty));
             TelemetryConfiguration.Active.TelemetryInitializers.Add(new MonitorsTelemetryInitializer());
+            TelemetryConfiguration.Active.TelemetryInitializers.Add(new ThemingTelemetryInitializer());
 
             _initialized = true;
 

--- a/GitUI/Infrastructure/Telemetry/ThemingTelemetryInitializer.cs
+++ b/GitUI/Infrastructure/Telemetry/ThemingTelemetryInitializer.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Drawing;
+using GitExtUtils.GitUI.Theming;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace GitUI.Infrastructure.Telemetry
+{
+    internal class ThemingTelemetryInitializer : ITelemetryInitializer
+    {
+        public void Initialize(ITelemetry telemetry)
+        {
+            var properties = telemetry.Context.GlobalProperties;
+            ThemeId themeId = Theming.ThemeModule.Settings.Theme.Id;
+            properties["Theme name"] = themeId.Name;
+            properties["Theme is builtin"] = themeId.IsBuiltin.ToString();
+            properties["Theme use system visual style"] = Theming.ThemeModule.Settings.UseSystemVisualStyle.ToString();
+
+            if (Theming.ThemeModule.Settings.Theme != Theme.Default)
+            {
+                foreach ((AppColor appColor, Color color) in Theming.ThemeModule.Settings.Theme.AppColorValues)
+                {
+                    properties[$"Theme application color {appColor}"] = Format(color);
+                }
+
+                foreach ((KnownColor sysColor, Color color) in Theming.ThemeModule.Settings.Theme.SysColorValues)
+                {
+                    properties[$"Theme system color {sysColor}"] = Format(color);
+                }
+            }
+
+            return;
+
+            static string Format(Color c) =>
+                c.ToArgb().ToString("x8");
+        }
+    }
+}

--- a/GitUI/Infrastructure/Telemetry/ThemingTelemetryInitializer.cs
+++ b/GitUI/Infrastructure/Telemetry/ThemingTelemetryInitializer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Drawing;
-using GitExtUtils.GitUI.Theming;
+﻿using GitExtUtils.GitUI.Theming;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
 
@@ -15,24 +13,6 @@ namespace GitUI.Infrastructure.Telemetry
             properties["Theme name"] = themeId.Name;
             properties["Theme is builtin"] = themeId.IsBuiltin.ToString();
             properties["Theme use system visual style"] = Theming.ThemeModule.Settings.UseSystemVisualStyle.ToString();
-
-            if (Theming.ThemeModule.Settings.Theme != Theme.Default)
-            {
-                foreach ((AppColor appColor, Color color) in Theming.ThemeModule.Settings.Theme.AppColorValues)
-                {
-                    properties[$"Theme application color {appColor}"] = Format(color);
-                }
-
-                foreach ((KnownColor sysColor, Color color) in Theming.ThemeModule.Settings.Theme.SysColorValues)
-                {
-                    properties[$"Theme system color {sysColor}"] = Format(color);
-                }
-            }
-
-            return;
-
-            static string Format(Color c) =>
-                c.ToArgb().ToString("x8");
         }
     }
 }

--- a/GitUI/Infrastructure/Telemetry/ThemingTelemetryInitializer.cs
+++ b/GitUI/Infrastructure/Telemetry/ThemingTelemetryInitializer.cs
@@ -10,9 +10,12 @@ namespace GitUI.Infrastructure.Telemetry
         {
             var properties = telemetry.Context.GlobalProperties;
             var themeSettings = Theming.ThemeModule.Settings;
-            properties["Theme dark"] = themeSettings.Theme.Id.Name == "dark" ? 1 : 0;
-            properties["Theme builtin"] = themeSettings.Theme.Id.IsBuiltin ? 1 : 0;
-            properties["Theme systemstyles"] = themeSettings.UseSystemVisualStyle ? 1 : 0;
+            properties["Theme dark"] = FlagString(themeSettings.Theme.Id.Name == "dark");
+            properties["Theme builtin"] = FlagString(themeSettings.Theme.Id.IsBuiltin);
+            properties["Theme systemstyles"] = FlagString(themeSettings.UseSystemVisualStyle);
         }
+
+        private static string FlagString(bool value) =>
+            value ? "1" : "0";
     }
 }

--- a/GitUI/Infrastructure/Telemetry/ThemingTelemetryInitializer.cs
+++ b/GitUI/Infrastructure/Telemetry/ThemingTelemetryInitializer.cs
@@ -9,10 +9,10 @@ namespace GitUI.Infrastructure.Telemetry
         public void Initialize(ITelemetry telemetry)
         {
             var properties = telemetry.Context.GlobalProperties;
-            ThemeId themeId = Theming.ThemeModule.Settings.Theme.Id;
-            properties["Theme name"] = themeId.Name;
-            properties["Theme is builtin"] = themeId.IsBuiltin.ToString();
-            properties["Theme use system visual style"] = Theming.ThemeModule.Settings.UseSystemVisualStyle.ToString();
+            var themeSettings = Theming.ThemeModule.Settings;
+            properties["Theme dark"] = themeSettings.Theme.Id.Name == "dark" ? 1 : 0;
+            properties["Theme builtin"] = themeSettings.Theme.Id.IsBuiltin ? 1 : 0;
+            properties["Theme systemstyles"] = themeSettings.UseSystemVisualStyle ? 1 : 0;
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

Track theme color and other settings

## Test methodology

Manual. What did I actually check:
- Theme properties were written to `telemetry.Context.GlobalProperties`.
- DiagnosticsClient calls OnExit, which calls _client.Flush() without exceptions.

## Test environment(s)

- Windows10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
