### PR TITLE
Wrap and popup exceptions from Executable

### DIFF
--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -20,11 +20,6 @@ namespace GitCommands
         private readonly Func<string> _fileNameProvider;
         private readonly string _workingDir;
 
-        public Executable([NotNull] string fileName, [NotNull] string workingDir = "")
-            : this(() => fileName, workingDir)
-        {
-        }
-
         public Executable([NotNull] Func<string> fileNameProvider,
             [NotNull] string workingDir = "",
             ExternalOperationExceptionFactory.Handling exceptionHandling = ExternalOperationExceptionFactory.Handling.OptionalBugReport,

--- a/GitCommands/Git/ExecutableFactory.cs
+++ b/GitCommands/Git/ExecutableFactory.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using GitUIPluginInterfaces;
+using JetBrains.Annotations;
+
+namespace GitCommands
+{
+    public class ExecutableFactory
+    {
+        /// <summary>
+        /// Singleton accessor.
+        /// </summary>
+        public static ExecutableFactory Default { get; } = new ExecutableFactory();
+
+        public IExecutable Create([NotNull] Func<string> fileNameProvider,
+            [NotNull] string workingDir = "",
+            ExternalOperationExceptionFactory.Handling exceptionHandling = ExternalOperationExceptionFactory.Handling.OptionalBugReport,
+            [CanBeNull] string context = null)
+            => new Executable(fileNameProvider, workingDir, exceptionHandling, context);
+
+        public IExecutable Create([NotNull] string fileName,
+            [NotNull] string workingDir = "",
+            ExternalOperationExceptionFactory.Handling exceptionHandling = ExternalOperationExceptionFactory.Handling.OptionalBugReport,
+            [CanBeNull] string context = null)
+            => Create(() => fileName, workingDir, exceptionHandling, context);
+    }
+}

--- a/GitCommands/Git/ExecutableFactory.cs
+++ b/GitCommands/Git/ExecutableFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Windows.Forms;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 
@@ -22,5 +23,8 @@ namespace GitCommands
             ExternalOperationExceptionFactory.Handling exceptionHandling = ExternalOperationExceptionFactory.Handling.OptionalBugReport,
             [CanBeNull] string context = null)
             => Create(() => fileName, workingDir, exceptionHandling, context);
+
+        public IProcess Spawn(string arguments, [NotNull] string workingDir = "")
+            => Create(Application.ExecutablePath, workingDir, ExternalOperationExceptionFactory.Handling.OptionalBugReport).Start(arguments);
     }
 }

--- a/GitCommands/Git/ExternalOperationException.cs
+++ b/GitCommands/Git/ExternalOperationException.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace GitCommands
+{
+    /// <summary>
+    /// Exception class for failures of external operations,
+    /// e.g. file access or start of other executables, which always can fail due to removed or locked files.
+    /// </summary>
+    public class ExternalOperationException : Exception
+    {
+        public ExternalOperationException(string context, string command, string workingDirectory, Exception inner)
+            : base(inner?.Message, inner)
+        {
+            Context = context;
+            Command = command;
+            WorkingDirectory = workingDirectory;
+        }
+
+        public string Context { get; }
+        public string Command { get; }
+        public string WorkingDirectory { get; }
+
+        /// <summary>
+        /// Flag whether this exception has already been handled, e.g. shown to the user,
+        /// and shall not be reported as a bug.
+        /// </summary>
+        public bool Handled { get; set; } = false;
+    }
+}

--- a/GitCommands/Git/ExternalOperationExceptionFactory.cs
+++ b/GitCommands/Git/ExternalOperationExceptionFactory.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace GitCommands
+{
+    public class ExternalOperationExceptionFactory
+    {
+        public enum Handling
+        {
+            OptionalBugReport,
+            Show,
+            None
+        }
+
+        /// <summary>
+        /// Singleton accessor.
+        /// </summary>
+        public static ExternalOperationExceptionFactory Default { get; } = new ExternalOperationExceptionFactory();
+
+        public event Action<ExternalOperationException, Handling> OnException;
+
+        public ExternalOperationException Create(string context, string command, string workingDirectory, Exception inner, Handling handling = Handling.OptionalBugReport)
+        {
+            ExternalOperationException ex = new ExternalOperationException(context, command, workingDirectory, inner);
+            OnException?.Invoke(ex, handling);
+            return ex;
+        }
+    }
+}

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -51,7 +51,7 @@ namespace GitCommands
             WorkingDirGitDir = GitDirectoryResolverInstance.Resolve(WorkingDir);
             _indexLockManager = new IndexLockManager(this);
             _commitDataManager = new CommitDataManager(() => this);
-            _gitExecutable = new Executable(() => AppSettings.GitCommand, WorkingDir);
+            _gitExecutable = ExecutableFactory.Default.Create(() => AppSettings.GitCommand, WorkingDir);
             _gitCommandRunner = new GitCommandRunner(_gitExecutable, () => SystemEncoding);
             _getAllChangedFilesOutputParser = new GetAllChangedFilesOutputParser(() => this);
 
@@ -859,7 +859,7 @@ namespace GitCommands
         {
             if (EnvUtils.RunningOnUnix())
             {
-                new Executable("gitk", WorkingDir).Start(createWindow: true);
+                ExecutableFactory.Default.Create("gitk", WorkingDir).Start(createWindow: true);
             }
             else
             {
@@ -870,7 +870,7 @@ namespace GitCommands
                     .Replace("git.exe", "gitk")
                     .Replace("git.cmd", "gitk");
 
-                new Executable("cmd.exe", WorkingDir).Start($"/c \"\"{cmd}\" --branches --tags --remotes\"");
+                ExecutableFactory.Default.Create("cmd.exe", WorkingDir).Start($"/c \"\"{cmd}\" --branches --tags --remotes\"");
             }
         }
 
@@ -890,7 +890,7 @@ namespace GitCommands
                     $"\"{AppSettings.GitCommand.QuoteNE()}",
                     "gui\""
                 };
-                new Executable("cmd.exe", WorkingDir).Start(args);
+                ExecutableFactory.Default.Create("cmd.exe", WorkingDir).Start(args);
             }
         }
 
@@ -1415,7 +1415,7 @@ namespace GitCommands
 
         public static void StartPageantWithKey(string sshKeyFile)
         {
-            var pageantExecutable = new Executable(AppSettings.Pageant);
+            var pageantExecutable = ExecutableFactory.Default.Create(AppSettings.Pageant);
 
             // ensure pageant is loaded, so we can wait for loading a key in the next command
             // otherwise we'll stuck there waiting until pageant exits
@@ -3861,7 +3861,7 @@ namespace GitCommands
 
             // Get processes by "ps" command.
             var cmd = Path.Combine(AppSettings.GitBinDir, "ps");
-            var lines = new Executable(cmd).GetOutput("x").Split('\n');
+            var lines = ExecutableFactory.Default.Create(cmd).GetOutput("x").Split('\n');
 
             if (lines.Length <= 2)
             {

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using GitCommands.Git;
 
 namespace GitCommands
 {
@@ -34,7 +35,7 @@ namespace GitCommands
             {
                 if (_current == null || _current.IsUnknown)
                 {
-                    var output = new Executable(AppSettings.GitCommand).GetOutput("--version");
+                    var output = ExecutableFactory.Default.Create(AppSettings.GitCommand).GetOutput("--version");
                     _current = new GitVersion(output);
                 }
 

--- a/GitCommands/Plink.cs
+++ b/GitCommands/Plink.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Text;
 using System.Threading.Tasks;
+using GitCommands.Git;
 using GitUI;
+using GitUIPluginInterfaces;
 
 namespace GitCommands
 {
@@ -57,11 +59,11 @@ namespace GitCommands
          *   -shareexists
          *             test whether a connection-sharing upstream exists
          */
-        private readonly Executable _executable;
+        private readonly IExecutable _executable;
 
-        public Plink(Executable executable = null)
+        public Plink(IExecutable executable = null)
         {
-            _executable = executable ?? new Executable("cmd.exe");
+            _executable = executable ?? ExecutableFactory.Default.Create("cmd.exe");
         }
 
         public bool Connect(string host)

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -348,7 +348,7 @@ namespace GitExtensions
 
                 case 1:
                     {
-                        Process.Start(@"https://github.com/gitextensions/gitextensions/wiki/Application-Dependencies#git");
+                        OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/Application-Dependencies#git");
                         return false;
                     }
 

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -29,6 +29,8 @@ namespace GitExtensions
         [STAThread]
         private static void Main()
         {
+            ExternalOperationExceptionFactory.Default.OnException += (ex, handling) => MessageBoxes.Show(owner: null, ex, handling);
+
             if (Environment.OSVersion.Version.Major >= 6)
             {
                 SetProcessDPIAware();
@@ -359,6 +361,11 @@ namespace GitExtensions
 
         private static void ReportBug(Exception ex)
         {
+            if ((ex as ExternalOperationException)?.Handled == true)
+            {
+                return;
+            }
+
             // if the error happens before we had a chance to init the environment information
             // the call to GetInformation() will fail. A double Initialise() call is safe.
             UserEnvironmentInformation.Initialise(ThisAssembly.Git.Sha, ThisAssembly.Git.IsDirty);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -310,7 +310,7 @@ namespace GitUI.BranchTreePanel
                     return;
                 }
 
-                Process.Start(_remote.FetchUrl);
+                OsShellUtil.OpenUrlInDefaultBrowser(_remote.FetchUrl);
             }
 
             public bool IsRemoteUrlUsingHttp => _remote.FetchUrl.IsUrlUsingHttp();

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
@@ -212,18 +211,18 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private static void TranslateItem_Click(object sender, EventArgs e)
         {
-            Process.Start("https://github.com/gitextensions/gitextensions/wiki/Translations");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/Translations");
         }
 
         private static void GitHubItem_Click(object sender, EventArgs e)
         {
-            Process.Start(@"https://github.com/gitextensions/gitextensions");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions");
         }
 
         private static void IssuesItem_Click(object sender, EventArgs e)
         {
             UserEnvironmentInformation.CopyInformation();
-            Process.Start(@"https://github.com/gitextensions/gitextensions/issues");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/issues");
         }
 
         private void openItem_Click(object sender, EventArgs e)
@@ -247,7 +246,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private static void DonateItem_Click(object sender, EventArgs e)
         {
-            Process.Start(FormDonate.DonationUrl);
+            OsShellUtil.OpenUrlInDefaultBrowser(FormDonate.DonationUrl);
         }
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -731,16 +730,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         }
 
         private void tsmiOpenFolder_Click(object sender, EventArgs e)
-        {
-            try
-            {
-                RepositoryContextAction(sender as ToolStripMenuItem, selectedRepositoryItem => Process.Start(selectedRepositoryItem.Repository.Path));
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(this, ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-        }
+            => RepositoryContextAction(sender as ToolStripMenuItem, selectedRepositoryItem => OsShellUtil.OpenWithFileExplorer(selectedRepositoryItem.Repository.Path));
 
         private void tsmiRemoveFromList_Click(object sender, EventArgs e)
         {

--- a/GitUI/CommandsDialogs/BrowseDialog/FormDonate.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormDonate.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Drawing;
 using ResourceManager;
 
@@ -27,7 +26,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void PictureBox1Click(object sender, EventArgs e)
         {
-            Process.Start(DonationUrl);
+            OsShellUtil.OpenUrlInDefaultBrowser(DonationUrl);
         }
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -71,7 +70,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void linkGitRevParse_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://git-scm.com/docs/git-rev-parse#_specifying_revisions");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://git-scm.com/docs/git-rev-parse#_specifying_revisions");
         }
 
         private Task LoadTagsAsync()

--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -165,10 +165,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             switch (launchType)
             {
                 case LaunchType.ChangeLog:
-                    Process.Start("https://github.com/gitextensions/gitextensions/blob/master/GitUI/Resources/ChangeLog.md");
+                    OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/blob/master/GitUI/Resources/ChangeLog.md");
                     break;
                 case LaunchType.DirectDownload:
-                    Process.Start(UpdateUrl);
+                    OsShellUtil.OpenUrlInDefaultBrowser(UpdateUrl);
                     break;
             }
         }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using Git.hub;
 using GitCommands;
 using GitCommands.Config;
+using GitCommands.Git;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using ResourceManager;
@@ -203,18 +204,16 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
                 try
                 {
-                    Process process = new Process();
-                    process.StartInfo.UseShellExecute = false;
-                    process.StartInfo.FileName = "msiexec.exe";
-                    process.StartInfo.Arguments = string.Format("/i \"{0}\\{1}\" /qb LAUNCH=1", Environment.GetEnvironmentVariable("TEMP"), fileName);
-                    process.Start();
+                    string arguments = string.Format("/i \"{0}\\{1}\" /qb LAUNCH=1", Environment.GetEnvironmentVariable("TEMP"), fileName);
+                    ExecutableFactory.Default.Create("msiexec.exe", exceptionHandling: ExternalOperationExceptionFactory.Handling.Show).Start(arguments);
 
                     progressBar1.Visible = false;
                     Close();
                     Application.Exit();
                 }
-                catch (Win32Exception)
+                catch (ExternalOperationException)
                 {
+                    // ignore because already shown to the user
                 }
             }).FileAndForget();
         }

--- a/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
+++ b/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -39,7 +38,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (!string.IsNullOrWhiteSpace(_url))
                 {
-                    Process.Start(_url);
+                    OsShellUtil.OpenUrlInDefaultBrowser(_url);
                 }
             };
             _openReportLink.Font = new Font(_openReportLink.Font.Name, 16F);

--- a/GitUI/CommandsDialogs/FormAbout.cs
+++ b/GitUI/CommandsDialogs/FormAbout.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using GitCommands;
@@ -30,10 +29,10 @@ namespace GitUI.CommandsDialogs
             linkLabelIcons.LinkColor = clrLink;
 
             // Click handlers
-            _NO_TRANSLATE_labelProductName.LinkClicked += delegate { Process.Start("https://github.com/gitextensions/gitextensions"); };
+            _NO_TRANSLATE_labelProductName.LinkClicked += delegate { OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions"); };
             _NO_TRANSLATE_ThanksTo.LinkClicked += delegate { ShowContributorsForm(); };
-            pictureDonate.Click += delegate { Process.Start(FormDonate.DonationUrl); };
-            linkLabelIcons.LinkClicked += delegate { Process.Start("http://p.yusukekamiyamane.com/"); };
+            pictureDonate.Click += delegate { OsShellUtil.OpenUrlInDefaultBrowser(FormDonate.DonationUrl); };
+            linkLabelIcons.LinkClicked += delegate { OsShellUtil.OpenUrlInDefaultBrowser(@"http://p.yusukekamiyamane.com/"); };
 
             var contributorsList = GetContributorList();
             var thanksToContributorsText = string.Format(_thanksToContributors.Text, contributorsList.Count);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1452,12 +1452,12 @@ namespace GitUI.CommandsDialogs
 
             try
             {
-                var executable = new Executable(shell.ExecutablePath, Module.WorkingDir);
-                executable.Start(createWindow: true);
+                string context = $"shell {shell.Name.Quote()}";
+                ExecutableFactory.Default.Create(shell.ExecutablePath, Module.WorkingDir, ExternalOperationExceptionFactory.Handling.Show, context).Start(createWindow: true);
             }
-            catch (Exception exception)
+            catch (Exception)
             {
-                MessageBoxes.FailedToRunShell(this, shell.Name, exception);
+                // ignore because already shown to the user
             }
         }
 
@@ -1674,12 +1674,12 @@ namespace GitUI.CommandsDialogs
 
         private void StartAuthenticationAgentToolStripMenuItemClick(object sender, EventArgs e)
         {
-            new Executable(AppSettings.Pageant, Module.WorkingDir).Start();
+            ExecutableFactory.Default.Create(AppSettings.Pageant, Module.WorkingDir).Start();
         }
 
         private void GenerateOrImportKeyToolStripMenuItemClick(object sender, EventArgs e)
         {
-            new Executable(AppSettings.Puttygen, Module.WorkingDir).Start();
+            ExecutableFactory.Default.Create(AppSettings.Puttygen, Module.WorkingDir).Start();
         }
 
         private void CommitInfoTabControl_SelectedIndexChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1822,7 +1822,7 @@ namespace GitUI.CommandsDialogs
             try
             {
                 // Point to the default documentation, will work also if the old doc version is removed
-                Process.Start("https://git-extensions-documentation.readthedocs.org");
+                OsShellUtil.OpenUrlInDefaultBrowser(@"https://git-extensions-documentation.readthedocs.org");
             }
             catch (Win32Exception)
             {
@@ -1980,19 +1980,12 @@ namespace GitUI.CommandsDialogs
 
         private void TranslateToolStripMenuItemClick(object sender, EventArgs e)
         {
-            Process.Start("https://github.com/gitextensions/gitextensions/wiki/Translations");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/Translations");
         }
 
         private void FileExplorerToolStripMenuItemClick(object sender, EventArgs e)
         {
-            try
-            {
-                Process.Start("explorer.exe", Module.WorkingDir);
-            }
-            catch (Exception ex)
-            {
-                MessageBoxes.ShowError(this, ex.Message);
-            }
+            OsShellUtil.OpenWithFileExplorer(Module.WorkingDir);
         }
 
         private void CreateBranchToolStripMenuItemClick(object sender, EventArgs e)
@@ -2870,7 +2863,7 @@ namespace GitUI.CommandsDialogs
         private void reportAnIssueToolStripMenuItem_Click(object sender, EventArgs e)
         {
             UserEnvironmentInformation.CopyInformation();
-            Process.Start(@"https://github.com/gitextensions/gitextensions/issues");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/issues");
         }
 
         private void checkForUpdatesToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormBrowseController.cs
+++ b/GitUI/CommandsDialogs/FormBrowseController.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
@@ -107,17 +106,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var process = new Process
-            {
-                StartInfo =
-                {
-                    FileName = AppSettings.GetGitExtensionsFullPath(),
-                    Arguments = "browse",
-                    WorkingDirectory = repoPath,
-                    UseShellExecute = false
-                }
-            };
-            process.Start();
+            ExecutableFactory.Default.Spawn("browse", repoPath);
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -22,6 +22,7 @@ using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using GitUI.AutoCompletion;
+using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.CommandsDialogs.CommitDialog;
 using GitUI.Editor;
 using GitUI.HelperDialogs;
@@ -2564,15 +2565,7 @@ namespace GitUI.CommandsDialogs
 
             var fileName = list.SelectedGitItem.Name;
             var path = _fullPathResolver.Resolve(fileName).ToNativePath();
-
-            try
-            {
-                Process.Start(path);
-            }
-            catch (System.ComponentModel.Win32Exception)
-            {
-                OsShellUtil.OpenAs(path);
-            }
+            OsShellUtil.Open(path);
         }
 
         private void OpenWithToolStripMenuItemClick(object sender, EventArgs e)
@@ -3184,14 +3177,8 @@ namespace GitUI.CommandsDialogs
         {
             foreach (var item in list.SelectedItems)
             {
-                var fileNames = new StringBuilder();
-                fileNames.Append(_fullPathResolver.Resolve(item.Item.Name).ToNativePath());
-
-                string filePath = fileNames.ToString();
-                if (File.Exists(filePath))
-                {
-                    OsShellUtil.SelectPathInFileExplorer(filePath);
-                }
+                string filePath = _fullPathResolver.Resolve(item.Item.Name).ToNativePath();
+                FormBrowseUtil.ShowFileOrParentFolderInFileExplorer(filePath);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -241,12 +241,12 @@ namespace GitUI.CommandsDialogs
 
         private void lnkGitIgnorePatterns_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://github.com/github/gitignore");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/github/gitignore");
         }
 
         private void lnkGitIgnoreGenerate_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://www.gitignore.io/");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://www.gitignore.io/");
         }
 
         private void btnCancel_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormMergeSubmodule.cs
+++ b/GitUI/CommandsDialogs/FormMergeSubmodule.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Windows.Forms;
+using GitCommands;
 using GitExtUtils;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
@@ -71,19 +71,7 @@ namespace GitUI.CommandsDialogs
         }
 
         private void btOpenSubmodule_Click(object sender, EventArgs e)
-        {
-            var process = new Process
-            {
-                StartInfo =
-                {
-                    FileName = Application.ExecutablePath,
-                    Arguments = "browse",
-                    WorkingDirectory = Module.GetSubmoduleFullPath(_filename)
-                }
-            };
-
-            process.Start();
-        }
+            => ExecutableFactory.Default.Spawn("browse", Module.GetSubmoduleFullPath(_filename));
 
         private void btCheckoutBranch_Click(object sender, EventArgs e)
         {

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -1416,7 +1415,7 @@ namespace GitUI.CommandsDialogs
         private void openToolStripMenuItem_Click(object sender, EventArgs e)
         {
             string fileName = GetFileName();
-            Process.Start(_fullPathResolver.Resolve(fileName));
+            OsShellUtil.Open(_fullPathResolver.Resolve(fileName));
         }
 
         private void openWithToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -30,7 +30,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _askMergeConflictSolvedCaption = new TranslationString("Conflict solved?");
         private readonly TranslationString _noMergeTool = new TranslationString("There is no mergetool configured." + Environment.NewLine + "Please go to settings and set a mergetool!");
         private readonly TranslationString _noMergeToolConfigured = new TranslationString("The mergetool is not correctly configured." + Environment.NewLine + "Please go to settings and configure the mergetool!");
-        private readonly TranslationString _errorStartingMergetool = new TranslationString("Error starting mergetool: {0}");
         private readonly TranslationString _stageFilename = new TranslationString("Stage {0}");
 
         private readonly TranslationString _noBaseRevision = new TranslationString("There is no base revision for {0}." + Environment.NewLine + "Fall back to 2-way merge?");
@@ -362,7 +361,7 @@ namespace GitUI.CommandsDialogs
                 FixPath(baseFileName).Quote()
             };
 
-            new Executable("wscript", Module.WorkingDir).Start(args);
+            ExecutableFactory.Default.Create("wscript", Module.WorkingDir).Start(args);
 
             if (MessageBox.Show(this, string.Format(_askMergeConflictSolvedAfterCustomMergeScript.Text,
                 FixPath(_fullPathResolver.Resolve(fileName))), _askMergeConflictSolvedCaption.Text,
@@ -554,13 +553,11 @@ namespace GitUI.CommandsDialogs
                     GitUIPluginInterfaces.ExecutionResult res;
                     try
                     {
-                        res = new Executable(_mergetoolPath, Module.WorkingDir).Execute(arguments);
+                        res = ExecutableFactory.Default.Create(_mergetoolPath, Module.WorkingDir, ExternalOperationExceptionFactory.Handling.Show).Execute(arguments);
                     }
-                    catch (Exception)
+                    catch (ExternalOperationException)
                     {
-                        var text = string.Format(_errorStartingMergetool.Text, _mergetoolPath);
-                        MessageBox.Show(this, text, _noBaseFileMergeCaption.Text,
-                            MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        // ignore because already shown to the user
                         return;
                     }
 

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -340,7 +339,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             }
             else
             {
-                Process.Start(CurrentySelectedGitRepo.Homepage);
+                OsShellUtil.OpenUrlInDefaultBrowser(CurrentySelectedGitRepo.Homepage);
             }
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -759,7 +759,7 @@ namespace GitUI.CommandsDialogs
 
         private void diffOpenRevisionFileToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            SaveSelectedItemToTempFile(fileName => Process.Start(fileName));
+            SaveSelectedItemToTempFile(fileName => OsShellUtil.Open(fileName));
         }
 
         private void diffOpenRevisionFileWithToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -449,18 +448,8 @@ namespace GitUI.CommandsDialogs
                     async () =>
                     {
                         var status = await item.Item.GetSubmoduleStatusAsync().ConfigureAwait(false);
-
-                        var process = new Process
-                        {
-                            StartInfo =
-                            {
-                                FileName = Application.ExecutablePath,
-                                Arguments = "browse -commit=" + status.Commit,
-                                WorkingDirectory = _fullPathResolver.Resolve(submoduleName.EnsureTrailingPathSeparator())
-                            }
-                        };
-
-                        process.Start();
+                        string arguments = "browse -commit=" + status.Commit;
+                        ExecutableFactory.Default.Spawn(arguments, _fullPathResolver.Resolve(submoduleName.EnsureTrailingPathSeparator()));
                     });
             }
             else

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -648,17 +648,10 @@ See the changes in the commit form.");
 
         private void openFileToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            try
+            var fileName = SaveSelectedItemToTempFile();
+            if (fileName != null)
             {
-                var fileName = SaveSelectedItemToTempFile();
-                if (fileName != null)
-                {
-                    Process.Start(fileName);
-                }
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(this, ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                OsShellUtil.Open(fileName);
             }
         }
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -335,21 +334,13 @@ See the changes in the commit form.");
 
         private void SpawnCommitBrowser(GitItem item)
         {
-            var process = new Process
-            {
-                StartInfo =
-                {
-                    FileName = Application.ExecutablePath,
-                    Arguments = "browse",
-                    WorkingDirectory = _fullPathResolver.Resolve(item.FileName.EnsureTrailingPathSeparator())
-                }
-            };
+            string arguments = "browse";
             if (item.ObjectId != null)
             {
-                process.StartInfo.Arguments += " -commit=" + item.Guid;
+                arguments += " -commit=" + item.Guid;
             }
 
-            process.Start();
+            ExecutableFactory.Default.Spawn(arguments, workingDir: _fullPathResolver.Resolve(item.FileName.EnsureTrailingPathSeparator()));
         }
 
         private void tvGitTree_AfterSelect(object sender, TreeViewEventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using GitCommands;
+using GitCommands.Git;
 using GitCommands.Settings;
 using GitCommands.Utils;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;
@@ -175,7 +176,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             {
                 try
                 {
-                    string output = new Executable(command).GetOutput();
+                    string output = ExecutableFactory.Default.Create(command, exceptionHandling: ExternalOperationExceptionFactory.Handling.None).GetOutput();
                     if (!string.IsNullOrEmpty(output))
                     {
                         if (command != null)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -209,17 +208,17 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void helpTranslate_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://github.com/gitextensions/gitextensions/wiki/Translations");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/Translations");
         }
 
         private void downloadDictionary_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://github.com/gitextensions/gitextensions/wiki/Spelling");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/Spelling");
         }
 
         private void pictureAvatarHelp_Click(object sender, EventArgs e)
         {
-            Process.Start(@"http://en.gravatar.com/site/implement/images#default-image");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"http://en.gravatar.com/site/implement/images#default-image");
         }
 
         private void AvatarProvider_SelectedIndexChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -647,7 +647,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void GcmDetectedFix_Click(object sender, EventArgs e)
         {
-            Process.Start("https://github.com/gitextensions/gitextensions/wiki/How-To:-fix-GitCredentialWinStore-missing");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/How-To:-fix-GitCredentialWinStore-missing");
         }
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using GitCommands;
-using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Theming;
 using ResourceManager;
@@ -233,16 +230,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 ThemeId.Equals(other.ThemeId);
         }
 
-        private void tsmiApplicationFolder_Click(object sender, EventArgs e) => OpenFolder(_themePathProvider.AppThemesDirectory);
+        private void tsmiApplicationFolder_Click(object sender, EventArgs e)
+            => OsShellUtil.SelectPathInFileExplorer(_themePathProvider.AppThemesDirectory);
 
-        private void tsmiUserFolder_Click(object sender, EventArgs e) => OpenFolder(_themePathProvider.UserThemesDirectory);
-
-        private void OpenFolder(string folderPath)
-        {
-            if (Directory.Exists(folderPath))
-            {
-                Process.Start(folderPath);
-            }
-        }
+        private void tsmiUserFolder_Click(object sender, EventArgs e)
+            => OsShellUtil.SelectPathInFileExplorer(_themePathProvider.UserThemesDirectory);
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using GitCommands;
@@ -169,7 +168,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void LlblTelemetryPrivacyLink_LinkClicked(object sender, System.Windows.Forms.LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start("https://github.com/gitextensions/gitextensions/blob/master/PrivacyPolicy.md");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/blob/master/PrivacyPolicy.md");
         }
 
         private void lblCommitsLimit_CheckedChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Windows.Forms;
 using GitCommands;
 using ResourceManager;
@@ -86,7 +85,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void downloadGitForWindows_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://github.com/gitextensions/gitextensions/wiki/Application-Dependencies#git");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/Application-Dependencies#git");
         }
 
         private void ChangeHomeButton_Click(object sender, EventArgs e)

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -1164,17 +1163,7 @@ namespace GitUI
         public void StartFileHistoryDialog(IWin32Window owner, string fileName, GitRevision revision = null, bool filterByRevision = false, bool showBlame = false)
         {
             string arguments = $"{(showBlame ? BlameHistoryCommand : FileHistoryCommand)} {fileName.Quote()} {revision?.ObjectId} {(filterByRevision ? FilterByRevisionArg : string.Empty)}";
-            var process = new Process
-            {
-                StartInfo =
-                {
-                    FileName = Application.ExecutablePath,
-                    Arguments = arguments,
-                    WorkingDirectory = Module.WorkingDir
-                }
-            };
-
-            process.Start();
+            ExecutableFactory.Default.Spawn(arguments, Module.WorkingDir);
         }
 
         public void OpenWithDifftool(IWin32Window owner, IReadOnlyList<GitRevision> revisions, string fileName, string oldFileName, RevisionDiffKind diffKind, bool isTracked, string customTool = null)

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git.Commands;
@@ -147,7 +146,7 @@ namespace GitUI.HelperDialogs
                 helpSection = "--hard";
             }
 
-            Process.Start($"https://git-scm.com/docs/git-reset#Documentation/git-reset.txt-{helpSection}");
+            OsShellUtil.OpenUrlInDefaultBrowser(@$"https://git-scm.com/docs/git-reset#Documentation/git-reset.txt-{helpSection}");
         }
     }
 }

--- a/GitUI/MessageBoxes.cs
+++ b/GitUI/MessageBoxes.cs
@@ -22,8 +22,6 @@ namespace GitUI
 
         private readonly TranslationString _failedToExecute = new TranslationString("Failed to execute");
 
-        private readonly TranslationString _failedToRunShell = new TranslationString("Failed to run shell");
-
         private readonly TranslationString _notValidGitDirectory = new TranslationString("The current directory is not a valid git repository.");
 
         private readonly TranslationString _unresolvedMergeConflictsCaption = new TranslationString("Merge conflicts");
@@ -68,10 +66,6 @@ namespace GitUI
 
         public static void FailedToExecute(IWin32Window owner, string executable, Exception ex)
             => ShowError(owner, $"{Instance._failedToExecute.Text} {executable}.{Environment.NewLine}"
-                                + $"{Instance._reason.Text}: {Instance.GetText(ex)}");
-
-        public static void FailedToRunShell(IWin32Window owner, string shell, Exception ex)
-            => ShowError(owner, $"{Instance._failedToRunShell.Text} {shell.Quote()}.{Environment.NewLine}"
                                 + $"{Instance._reason.Text}: {Instance.GetText(ex)}");
 
         public static void NotValidGitDirectory([CanBeNull] IWin32Window owner)

--- a/GitUI/NBugReports/BugReportForm.cs
+++ b/GitUI/NBugReports/BugReportForm.cs
@@ -8,7 +8,6 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
-using System.Diagnostics;
 using System.Drawing;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
@@ -138,7 +137,7 @@ Send report anyway?");
             }
 
             string url = UrlBuilder.Build("https://github.com/gitextensions/gitextensions/issues/new", _lastException.OriginalException, _environmentInfo, descriptionTextBox.Text);
-            Process.Start(url);
+            OsShellUtil.OpenUrlInDefaultBrowser(url);
 
             DialogResult = DialogResult.Abort;
             Close();

--- a/GitUI/OsShellUtil.cs
+++ b/GitUI/OsShellUtil.cs
@@ -1,29 +1,57 @@
 ﻿using System.Diagnostics;
 using System.Windows.Forms;
+using GitCommands;
 using Microsoft.WindowsAPICodePack.Dialogs;
 namespace GitUI
 {
     public static class OsShellUtil
     {
-        public static void OpenAs(string file)
+        public static void Open(string filePath)
         {
-            Process.Start(new ProcessStartInfo
+            try
             {
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                FileName = "rundll32.exe",
-                Arguments = "shell32.dll,OpenAs_RunDLL " + file
-            });
+                ExecutableFactory.Default.Create(filePath, exceptionHandling: ExternalOperationExceptionFactory.Handling.None).Start();
+            }
+            catch (ExternalOperationException)
+            {
+                OpenAs(filePath);
+            }
+        }
+
+        public static void OpenAs(string filePath)
+        {
+            try
+            {
+                ExecutableFactory.Default.Create("rundll32.exe", exceptionHandling: ExternalOperationExceptionFactory.Handling.Show).Start("shell32.dll,OpenAs_RunDLL " + filePath);
+            }
+            catch (ExternalOperationException)
+            {
+                // ignore because already shown to the user
+            }
         }
 
         public static void SelectPathInFileExplorer(string filePath)
         {
-            Process.Start("explorer.exe", "/select, " + filePath);
+            try
+            {
+                ExecutableFactory.Default.Create("explorer.exe", exceptionHandling: ExternalOperationExceptionFactory.Handling.Show).Start("/select, " + filePath);
+            }
+            catch (ExternalOperationException)
+            {
+                // ignore because already shown to the user
+            }
         }
 
         public static void OpenWithFileExplorer(string filePath)
         {
-            Process.Start("explorer.exe", filePath);
+            try
+            {
+                ExecutableFactory.Default.Create("explorer.exe", exceptionHandling: ExternalOperationExceptionFactory.Handling.Show).Start(filePath);
+            }
+            catch (ExternalOperationException)
+            {
+                // ignore because already shown to the user
+            }
         }
 
         /// <summary>
@@ -33,7 +61,14 @@ namespace GitUI
         {
             if (!string.IsNullOrWhiteSpace(url))
             {
-                Process.Start(url);
+                try
+                {
+                    ExecutableFactory.Default.Create(url, exceptionHandling: ExternalOperationExceptionFactory.Handling.Show).Start(useShellExecute: true);
+                }
+                catch (ExternalOperationException)
+                {
+                    // ignore because already shown to the user
+                }
             }
         }
 

--- a/GitUI/Script/PowerShellHelper.cs
+++ b/GitUI/Script/PowerShellHelper.cs
@@ -1,4 +1,5 @@
 ﻿using GitCommands;
+using GitCommands.Git;
 using GitUIPluginInterfaces;
 
 namespace GitUI.Script
@@ -10,9 +11,7 @@ namespace GitUI.Script
             const string filename = "powershell.exe";
             var arguments = (runInBackground ? "" : "-NoExit") + " -ExecutionPolicy Unrestricted -Command \"" + command + " " + argument + "\"";
             EnvironmentConfiguration.SetEnvironmentVariables();
-
-            IExecutable executable = new Executable(filename, workingDir);
-            executable.Start(arguments);
+            ExecutableFactory.Default.Create(filename, workingDir).Start(arguments);
         }
     }
 }

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -72,6 +72,8 @@ namespace GitUI
         private readonly TranslationString _diffRange = new TranslationString("Range diff");
         private readonly TranslationString _combinedDiff = new TranslationString("Combined diff");
 
+        private readonly TranslationString _script = new TranslationString("script");
+
         private readonly TranslationString _showDiffForAllParentsText = new TranslationString("Show file differences for all parents in browse dialog");
         private readonly TranslationString _showDiffForAllParentsTooltip = new TranslationString(@"Show all differences between the selected commits, not limiting to only one difference.
 
@@ -173,6 +175,7 @@ namespace GitUI
         public static string DiffCommonBase => _instance.Value._diffCommonBase.Text;
         public static string DiffRange => _instance.Value._diffRange.Text;
         public static string CombinedDiff => _instance.Value._combinedDiff.Text;
+        public static string Script => _instance.Value._script.Text;
         public static string ShowDiffForAllParentsText => _instance.Value._showDiffForAllParentsText.Text;
         public static string ShowDiffForAllParentsTooltip => _instance.Value._showDiffForAllParentsTooltip.Text;
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6364,10 +6364,6 @@ Is the merge conflict solved?</source>
         <source>deleted</source>
         <target />
       </trans-unit>
-      <trans-unit id="_errorStartingMergetool.Text">
-        <source>Error starting mergetool: {0}</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_failureWhileOpenFile.Text">
         <source>Open temporary file failed.</source>
         <target />
@@ -7765,10 +7761,6 @@ help</source>
       </trans-unit>
       <trans-unit id="_failedToExecute.Text">
         <source>Failed to execute</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_failedToRunShell.Text">
-        <source>Failed to run shell</source>
         <target />
       </trans-unit>
       <trans-unit id="_middleOfPatchApply.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7751,8 +7751,20 @@ help</source>
         <source>Archive revision</source>
         <target />
       </trans-unit>
-      <trans-unit id="_failedToExecuteScript.Text">
-        <source>Failed to execute script</source>
+      <trans-unit id="_context.Text">
+        <source>Context</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_externalOperationFailure.Text">
+        <source>External operation failure</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_externalOperationFailureHint.Text">
+        <source>If you think this was caused by Git Extensions, you can report a bug, or just ignore and continue.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_failedToExecute.Text">
+        <source>Failed to execute</source>
         <target />
       </trans-unit>
       <trans-unit id="_failedToRunShell.Text">
@@ -7833,6 +7845,10 @@ Do you want to trust this host key and then try again?</source>
         <source>Since this repository has submodules, it's necessary to update them on every checkout.
 
 This will just checkout on the submodule the commit determined by the superproject.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_workingDirectory.Text">
+        <source>Working directory</source>
         <target />
       </trans-unit>
     </body>
@@ -9495,6 +9511,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_rotInactive.Text">
         <source>[ Inactive ]</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_script.Text">
+        <source>script</source>
         <target />
       </trans-unit>
       <trans-unit id="_searchingFor.Text">

--- a/GitUI/UserControls/AvatarControl.cs
+++ b/GitUI/UserControls/AvatarControl.cs
@@ -179,14 +179,7 @@ namespace GitUI
 
         private void OnRegisterGravatarClick(object sender, EventArgs e)
         {
-            try
-            {
-                Process.Start("https://www.gravatar.com");
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(this, ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://www.gravatar.com");
         }
 
         private void OnDefaultImageDropDownOpening(object sender, EventArgs e)

--- a/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.Text;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Git;
 using GitCommands.Git.Extensions;
 using GitCommands.Logging;
 using JetBrains.Annotations;
@@ -174,10 +175,13 @@ namespace GitUI.UserControls
             }
             catch (Exception ex)
             {
-                operation.LogProcessEnd(ex);
                 ex.Data.Add("command", command);
                 ex.Data.Add("arguments", arguments);
-                throw;
+                operation.LogProcessEnd(ex);
+                throw ExternalOperationExceptionFactory.Default.Create(context: null,
+                    command: $"{_process.StartInfo.FileName} {_process.StartInfo.Arguments}",
+                    _process.StartInfo.WorkingDirectory,
+                    inner: ex);
             }
         }
 

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -793,20 +793,9 @@ namespace GitUI
         private async Task OpenSubmoduleAsync()
         {
             var submoduleName = SelectedItem.Item.Name;
-
             var status = await SelectedItem.Item.GetSubmoduleStatusAsync().ConfigureAwait(false);
-
-            var process = new Process
-            {
-                StartInfo =
-                {
-                    FileName = Application.ExecutablePath,
-                    Arguments = "browse -commit=" + status.Commit,
-                    WorkingDirectory = _fullPathResolver.Resolve(submoduleName.EnsureTrailingPathSeparator())
-                }
-            };
-
-            process.Start();
+            string arguments = "browse -commit=" + status.Commit;
+            ExecutableFactory.Default.Spawn(arguments, _fullPathResolver.Resolve(submoduleName.EnsureTrailingPathSeparator()));
         }
 
         private void SelectItems(Func<ListViewItem, bool> predicate)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Reactive.Concurrency;
@@ -2592,7 +2591,7 @@ namespace GitUI
 
             if (revision != null && !string.IsNullOrWhiteSpace(revision.BuildStatus?.Url))
             {
-                Process.Start(revision.BuildStatus.Url);
+                OsShellUtil.OpenUrlInDefaultBrowser(revision.BuildStatus.Url);
             }
         }
 
@@ -2602,7 +2601,7 @@ namespace GitUI
 
             if (revision != null && !string.IsNullOrWhiteSpace(revision.BuildStatus?.PullRequestUrl))
             {
-                Process.Start(revision.BuildStatus.PullRequestUrl);
+                OsShellUtil.OpenUrlInDefaultBrowser(revision.BuildStatus.PullRequestUrl);
             }
         }
 

--- a/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using ApprovalTests.Utilities;
 using CommonTestUtils;
 using FluentAssertions;
 using GitCommands;

--- a/IntegrationTests/UI.IntegrationTests/Script/ScriptRunnerTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/Script/ScriptRunnerTests.cs
@@ -85,7 +85,7 @@ namespace GitExtensions.UITests.Script
             var result = ExecuteRunScript(null, _module, invalidScriptKey, uiCommands: null, revisionGrid: null, error => errorMessage = error);
 
             result.Executed.Should().BeFalse();
-            errorMessage.Should().Be("Cannot find script: " + invalidScriptKey);
+            errorMessage.Should().Be($"Cannot find script \"{invalidScriptKey}\"");
         }
 
         [Test]

--- a/Plugins/GitUIPluginInterfaces/IExecutable.cs
+++ b/Plugins/GitUIPluginInterfaces/IExecutable.cs
@@ -25,7 +25,7 @@ namespace GitUIPluginInterfaces
         /// <returns>The started process.</returns>
         [NotNull]
         [MustUseReturnValue]
-        IProcess Start(ArgumentString arguments = default, bool createWindow = false, bool redirectInput = false, bool redirectOutput = false, [CanBeNull] Encoding outputEncoding = null);
+        IProcess Start(ArgumentString arguments = default, bool createWindow = false, bool redirectInput = false, bool redirectOutput = false, [CanBeNull] Encoding outputEncoding = null, bool useShellExecute = false);
 
         /// <summary>
         /// Launches a process for the executable and returns its output.

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -73,7 +73,7 @@ namespace CommonTestUtils
             }
         }
 
-        public IProcess Start(ArgumentString arguments, bool createWindow, bool redirectInput, bool redirectOutput, Encoding outputEncoding)
+        public IProcess Start(ArgumentString arguments, bool createWindow, bool redirectInput, bool redirectOutput, Encoding outputEncoding, bool useShellExecute = false)
         {
             if (_outputStackByArguments.TryRemove(arguments, out var queue) && queue.TryPop(out var item))
             {

--- a/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
@@ -17,7 +17,7 @@ namespace GitCommandsTests.Git
     public sealed class ExecutableExtensionsTests
     {
         private MockExecutable _executable;
-        private Executable _gitExecutable;
+        private IExecutable _gitExecutable;
         private string _appPath;
 
         [SetUp]
@@ -37,7 +37,7 @@ namespace GitCommandsTests.Git
             // git always return non-zero exit code when run git reset outside of git repository
             // NUnit working directory always default to MS test host
             var workingDir = Path.GetDirectoryName(Assembly.GetAssembly(typeof(ExecutableExtensionsTests)).Location);
-            _gitExecutable = new Executable(_appPath, workingDir);
+            _gitExecutable = ExecutableFactory.Default.Create(_appPath, workingDir);
         }
 
         [TearDown]

--- a/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Reflection;
 using System.Text;
 using CommonTestUtils;
+using FluentAssertions;
 using GitCommands;
 using GitCommands.Settings;
 using GitExtUtils;
@@ -128,7 +129,8 @@ namespace GitCommandsTests.Git
                     GenerateStringByLength(Math.Max(1, arg2Len - _appPath.Length - 4))
                 }, _appPath.Length + 3, maxLength);
 
-            Assert.Throws(typeof(Win32Exception), () => _gitExecutable.RunBatchCommand(args));
+            ExternalOperationException ex = Assert.Throws<ExternalOperationException>(() => _gitExecutable.RunBatchCommand(args));
+            ex.InnerException.Should().BeOfType<Win32Exception>();
         }
 
         private string GenerateStringByLength(int length)

--- a/UnitTests/GitCommands.Tests/Git/ExecutableTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ExecutableTests.cs
@@ -31,7 +31,7 @@ namespace GitCommandsTests.Git
         [Test]
         public void StartNonexisting()
         {
-            IExecutable executable = new Executable(_invalidExe);
+            IExecutable executable = ExecutableFactory.Default.Create(_invalidExe);
 
             ExternalOperationException ex = Assert.Throws<ExternalOperationException>(() => executable.Start());
 
@@ -42,7 +42,7 @@ namespace GitCommandsTests.Git
         [Test]
         public void GetOutputNonexisting()
         {
-            IExecutable executable = new Executable(_invalidExe);
+            IExecutable executable = ExecutableFactory.Default.Create(_invalidExe);
 
             ExternalOperationException ex = Assert.Throws<ExternalOperationException>(() => executable.GetOutput(""));
 
@@ -55,7 +55,7 @@ namespace GitCommandsTests.Git
         {
             string executableName = "cmd.exe";
             string workingDirectory = @"C:\nonexistent-dir";
-            IExecutable executable = new Executable(executableName, workingDirectory);
+            IExecutable executable = ExecutableFactory.Default.Create(executableName, workingDirectory);
 
             ExternalOperationException ex = Assert.Throws<ExternalOperationException>(() => executable.Start());
 

--- a/UnitTests/GitCommands.Tests/Git/ExecutableTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ExecutableTests.cs
@@ -1,0 +1,67 @@
+﻿using FluentAssertions;
+using GitCommands;
+using GitUIPluginInterfaces;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Git
+{
+    [TestFixture]
+    public sealed class ExecutableTests
+    {
+        private const string _invalidExe = "invalid.exe";
+
+        private ExternalOperationException _externalOperationException;
+
+        private void RecordExecutableException(ExternalOperationException ex, ExternalOperationExceptionFactory.Handling exceptionHandling)
+            => _externalOperationException = ex as ExternalOperationException;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _externalOperationException = null;
+            ExternalOperationExceptionFactory.Default.OnException += RecordExecutableException;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            ExternalOperationExceptionFactory.Default.OnException -= RecordExecutableException;
+        }
+
+        [Test]
+        public void StartNonexisting()
+        {
+            IExecutable executable = new Executable(_invalidExe);
+
+            ExternalOperationException ex = Assert.Throws<ExternalOperationException>(() => executable.Start());
+
+            ex.Command.Should().StartWith(_invalidExe);
+            ex.Should().BeSameAs(_externalOperationException);
+        }
+
+        [Test]
+        public void GetOutputNonexisting()
+        {
+            IExecutable executable = new Executable(_invalidExe);
+
+            ExternalOperationException ex = Assert.Throws<ExternalOperationException>(() => executable.GetOutput(""));
+
+            ex.Command.Should().StartWith(_invalidExe);
+            ex.Should().BeSameAs(_externalOperationException);
+        }
+
+        [Test]
+        public void StartExistingInInvalidDir()
+        {
+            string executableName = "cmd.exe";
+            string workingDirectory = @"C:\nonexistent-dir";
+            IExecutable executable = new Executable(executableName, workingDirectory);
+
+            ExternalOperationException ex = Assert.Throws<ExternalOperationException>(() => executable.Start());
+
+            ex.Command.Should().StartWith(executableName);
+            ex.WorkingDirectory.Should().Be(workingDirectory);
+            ex.Should().BeSameAs(_externalOperationException);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #7795

## Proposed changes

- wrap any exception from starting an external process into the new `ExternalOperationException`,
- show any `ExternalOperationException` to the user when it is created in order to avoid silent errors eaten by too generic `catch`
- let the user decide whether the `ExternalOperationException` shall be reported as a bug anyways if unhandled
- adapt the process creation and the exception handling in the `ScriptRunner`
- refactor and extend `MessageBoxes`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/85960429-9f33c780-b9a3-11ea-94fd-6a75ba5a7b8d.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/97794891-ec4cd200-1bff-11eb-8a98-9320c44a6a54.png)

![grafik](https://user-images.githubusercontent.com/36601201/97794954-bb20d180-1c00-11eb-9b61-dff7b6fa3deb.png)

## Test methodology <!-- How did you ensure quality? -->

- add NUnit tests
- manual with User Scripts

## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 33.33.33
- Build f33a5b45015f282bbc024605917b72a37972b015
- Git 2.27.0.windows.1 (recommended: 2.28.0 or later)
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4250.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
