### PR TITLE
Restore FileStatusList focus after GoToChild/Parent

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2152,8 +2152,8 @@ namespace GitUI.CommandsDialogs
                 case Command.GoToSuperproject: toolStripButtonLevelUp_ButtonClick(null, null); break;
                 case Command.GoToSubmodule: toolStripButtonLevelUp.ShowDropDown(); break;
                 case Command.ToggleBetweenArtificialAndHeadCommits: RevisionGrid?.ExecuteCommand(RevisionGridControl.Command.ToggleBetweenArtificialAndHeadCommits); break;
-                case Command.GoToChild: RevisionGrid?.ExecuteCommand(RevisionGridControl.Command.GoToChild); break;
-                case Command.GoToParent: RevisionGrid?.ExecuteCommand(RevisionGridControl.Command.GoToParent); break;
+                case Command.GoToChild: RestoreFileStatusListFocus(() => RevisionGrid?.ExecuteCommand(RevisionGridControl.Command.GoToChild)); break;
+                case Command.GoToParent: RestoreFileStatusListFocus(() => RevisionGrid?.ExecuteCommand(RevisionGridControl.Command.GoToParent)); break;
                 default: return base.ExecuteCommand(cmd);
             }
 
@@ -2249,6 +2249,18 @@ namespace GitUI.CommandsDialogs
                 else if (fileTree.Visible)
                 {
                     fileTree.ExecuteCommand(RevisionFileTreeControl.Command.EditFile);
+                }
+            }
+
+            void RestoreFileStatusListFocus(Action action)
+            {
+                bool restoreFocus = revisionDiff.ContainsFocus;
+
+                action();
+
+                if (restoreFocus)
+                {
+                    revisionDiff.SwitchFocus(alreadyContainedFocus: false);
                 }
             }
         }


### PR DESCRIPTION
## Proposed changes

- Restore the `FileStatusList` focus after the `GoToChild`/`GoToParent` hotkeys (`Ctrl+N`, `Ctrl+P`).
  `RevisionGridControl.SetSelectedRevision` sets the focus to itself. So just restore it if the `RevisionDiffControl` was focused.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/86491180-58125180-bd6a-11ea-9ca2-b6f56fbafd64.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/86491236-842dd280-bd6a-11ea-8b60-145d1ffc351e.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build e889d7513e9bf8eb98c3d6a9b62c29c3dd8ccbc2
- Git 2.27.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
