### PR TITLE
Improve CommandLog

### DIFF
--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -111,9 +111,17 @@ namespace GitCommands
                     // if the Process is disposed then reading ExitCode will throw.
                     if (!_disposed)
                     {
-                        var exitCode = _process.ExitCode;
-                        _logOperation.LogProcessEnd(exitCode);
-                        _exitTaskCompletionSource.TrySetResult(exitCode);
+                        try
+                        {
+                            var exitCode = _process.ExitCode;
+                            _logOperation.LogProcessEnd(exitCode);
+                            _exitTaskCompletionSource.TrySetResult(exitCode);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logOperation.LogProcessEnd(ex);
+                            _exitTaskCompletionSource.TrySetException(ex);
+                        }
                     }
                 }
             }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.Designer.cs
@@ -102,7 +102,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             // 
             this.splitContainer2.Panel2.Controls.Add(this.LogOutput);
             this.splitContainer2.Size = new System.Drawing.Size(655, 419);
-            this.splitContainer2.SplitterDistance = 337;
+            this.splitContainer2.SplitterDistance = 280;
             this.splitContainer2.TabIndex = 1;
             // 
             // LogItems
@@ -114,7 +114,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             this.LogItems.Location = new System.Drawing.Point(0, 0);
             this.LogItems.Margin = new System.Windows.Forms.Padding(0);
             this.LogItems.Name = "LogItems";
-            this.LogItems.Size = new System.Drawing.Size(655, 337);
+            this.LogItems.Size = new System.Drawing.Size(655, 280);
             this.LogItems.TabIndex = 0;
             this.LogItems.SelectedIndexChanged += new System.EventHandler(this.LogItems_SelectedIndexChanged);
             // 
@@ -150,7 +150,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             this.LogOutput.Location = new System.Drawing.Point(0, 0);
             this.LogOutput.Margin = new System.Windows.Forms.Padding(0);
             this.LogOutput.Name = "LogOutput";
-            this.LogOutput.Size = new System.Drawing.Size(655, 78);
+            this.LogOutput.Size = new System.Drawing.Size(655, 135);
             this.LogOutput.TabIndex = 0;
             this.LogOutput.Text = "";
             // 

--- a/GitUI/Script/PowerShellHelper.cs
+++ b/GitUI/Script/PowerShellHelper.cs
@@ -1,6 +1,5 @@
-﻿using System.Diagnostics;
-using GitCommands;
-using GitCommands.Logging;
+﻿using GitCommands;
+using GitUIPluginInterfaces;
 
 namespace GitUI.Script
 {
@@ -12,18 +11,8 @@ namespace GitUI.Script
             var arguments = (runInBackground ? "" : "-NoExit") + " -ExecutionPolicy Unrestricted -Command \"" + command + " " + argument + "\"";
             EnvironmentConfiguration.SetEnvironmentVariables();
 
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = filename,
-                Arguments = arguments,
-                WorkingDirectory = workingDir,
-                UseShellExecute = false
-            };
-
-            var operation = CommandLog.LogProcessStart(filename, arguments, workingDir);
-            var process = Process.Start(startInfo);
-            operation.SetProcessId(process.Id);
-            process.Exited += (s, e) => operation.LogProcessEnd();
+            IExecutable executable = new Executable(filename, workingDir);
+            executable.Start(arguments);
         }
     }
 }

--- a/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -96,6 +96,8 @@ namespace GitUI.UserControls
 
         public override void StartProcess(string command, string arguments, string workDir, Dictionary<string, string> envVariables)
         {
+            ProcessOperation operation = CommandLog.LogProcessStart(command, arguments, workDir);
+
             try
             {
                 EnvironmentConfiguration.SetEnvironmentVariables();
@@ -110,7 +112,7 @@ namespace GitUI.UserControls
                 {
                     UseShellExecute = false,
                     ErrorDialog = false,
-                    CreateNoWindow = true,
+                    CreateNoWindow = !ssh && !AppSettings.ShowGitCommandLine,
                     RedirectStandardInput = true,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
@@ -120,7 +122,6 @@ namespace GitUI.UserControls
                     Arguments = arguments,
                     WorkingDirectory = workDir
                 };
-                startInfo.CreateNoWindow = !ssh && !AppSettings.ShowGitCommandLine;
 
                 foreach (var (name, value) in envVariables)
                 {
@@ -129,19 +130,16 @@ namespace GitUI.UserControls
 
                 var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
 
-                var operation = CommandLog.LogProcessStart(command, arguments, workDir);
-
                 process.OutputDataReceived += (sender, args) => FireDataReceived(new TextEventArgs((args.Data ?? "") + '\n'));
                 process.ErrorDataReceived += (sender, args) => FireDataReceived(new TextEventArgs((args.Data ?? "") + '\n'));
                 process.Exited += delegate
                 {
-                    operation.LogProcessEnd();
-
                     this.InvokeAsync(
                         () =>
                         {
                             if (_process == null)
                             {
+                                operation.LogProcessEnd(new Exception("Process instance is null in Exited event"));
                                 return;
                             }
 
@@ -153,12 +151,13 @@ namespace GitUI.UserControls
                             {
                                 _process.WaitForExit();
                             }
-                            catch
+                            catch (Exception ex)
                             {
-                                // NOP
+                                operation.LogProcessEnd(ex);
                             }
 
                             _exitcode = _process.ExitCode;
+                            operation.LogProcessEnd(_exitcode);
                             _process = null;
                             _outputThrottle?.FlushOutput();
                             FireProcessExited();
@@ -174,6 +173,7 @@ namespace GitUI.UserControls
             }
             catch (Exception ex)
             {
+                operation.LogProcessEnd(ex);
                 ex.Data.Add("command", command);
                 ex.Data.Add("arguments", arguments);
                 throw;


### PR DESCRIPTION
Inspired by https://github.com/gitextensions/gitextensions/pull/8278#discussion_r449728071

## Proposed changes

- log exceptions thrown while attempting to start a process in the `CommandLog`
- improve `CommandLog` output formatting:
  - was 2 digits for exit code ("128" happens often)
  - was "Call stack: not captured"
- catch and log exception handling `ExitCode` in `Executable.OnProcessExit`
- `PowerShellHelper.RunPowerShell`: use `Executable` & `ProcessWrapper` in order to call `LogProcessEnd` correctly
- log exceptions from `ConsoleEmulatorOutputControl.StartProcess` and `EditboxBasedConsoleOutputControl.StartProcess`
- `EditboxBasedConsoleOutputControl.StartProcess`: correctly call `LogProcessEnd`
- fit footer size of `FormGitCommandLog` to usual content, i.e. 9 lines

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/86540096-a22e3b00-bf02-11ea-8e56-3872e7dc7f6f.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/86540457-b7589900-bf05-11ea-93ec-bcb524fd5a3d.png)

![grafik](https://user-images.githubusercontent.com/36601201/86844169-edce1980-c0a7-11ea-8e2e-385ba68eed0c.png)

saved log
```
2020-07-07T23:11:10.1553204+02:00	174	16404	UI	0	git	remote	F:\Build\gitextensions3_dev\
2020-07-07T23:11:10.4071289+02:00	106	16560	UI	1	git		
2020-07-07T23:11:10.6608885+02:00	275		UI	exc	cmdx	/k echo mstv~https://github.com/mstv/gitextensions.git~/mstv/gitextensions	F:\Build\gitextensions3_dev\
System.Exception: outer ---> System.ComponentModel.Win32Exception: Das System kann die angegebene Datei nicht finden
   bei System.Diagnostics.Process.StartWithCreateProcess(ProcessStartInfo startInfo)
   bei System.Diagnostics.Process.Start()
   bei GitUI.UserControls.EditboxBasedConsoleOutputControl.StartProcess(String command, String arguments, String workDir, Dictionary`2 envVariables)
   --- Ende der internen Ausnahmestapelüberwachung ---
   bei GitUI.UserControls.EditboxBasedConsoleOutputControl.StartProcess(String command, String arguments, String workDir, Dictionary`2 envVariables)
   bei GitUI.FormProcess.ProcessStart(FormStatus form)
2020-07-07T23:11:13.3177835+02:00	131	15808	UI	0	git	ls-files -z --unmerged	F:\Build\gitextensions3_dev\
```

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 662ae11be2cac2cefbef1b967c15aaf5b6ab8680
- Git 2.27.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
