### PR TITLE
Refactor MessageBoxes

### DIFF
--- a/GitUI/CommandsDialogs/MergeConflictHandler.cs
+++ b/GitUI/CommandsDialogs/MergeConflictHandler.cs
@@ -9,7 +9,7 @@ namespace GitUI.CommandsDialogs
         {
             if (commands.Module.InTheMiddleOfConflictedMerge())
             {
-                if (AppSettings.DontConfirmResolveConflicts || MessageBoxes.UnresolvedMergeConflicts(owner))
+                if (AppSettings.DontConfirmResolveConflicts || MessageBoxes.ConfirmResolveMergeConflicts(owner))
                 {
                     SolveMergeConflicts(commands, owner, offerCommit);
                 }

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -1115,7 +1115,7 @@ namespace GitUI.CommandsDialogs
 
             var rev = _firstRevision.Text + (DescribeRevision(DiffFiles.SelectedItems.FirstRevs().ToList()) ?? string.Empty);
             var text = string.Format(_resetSelectedChangesText.Text, rev);
-            if (!MessageBoxes.ResetSelectedFiles(this, text))
+            if (!MessageBoxes.ConfirmResetSelectedFiles(this, text))
             {
                 return true;
             }

--- a/GitUI/MessageBoxes.cs
+++ b/GitUI/MessageBoxes.cs
@@ -37,7 +37,6 @@ namespace GitUI
         private readonly TranslationString _theRepositorySubmodules = new TranslationString("Update submodules on checkout?");
         private readonly TranslationString _updateSubmodulesToo = new TranslationString("Since this repository has submodules, it's necessary to update them on every checkout.\r\n\r\nThis will just checkout on the submodule the commit determined by the superproject.");
         private readonly TranslationString _rememberChoice = new TranslationString("Remember choice");
-        private readonly TranslationString _confirmDeleteRemoteBranch = new TranslationString("Do you want to delete the branch {0} from {1}?");
 
         private readonly TranslationString _reason = new TranslationString("Reason");
 
@@ -69,27 +68,18 @@ namespace GitUI
             => ShowError(owner, Instance._notValidGitDirectory.Text);
 
         public static void ShowGitConfigurationExceptionMessage(IWin32Window owner, GitConfigurationException exception)
-        {
-            MessageBox.Show(owner,
-                string.Format(ResourceManager.Strings.GeneralGitConfigExceptionMessage, exception.ConfigPath, Environment.NewLine, (exception.InnerException ?? exception).Message),
-                ResourceManager.Strings.GeneralGitConfigExceptionCaption,
-                MessageBoxButtons.OK, MessageBoxIcon.Warning);
-        }
-
-        public static bool UnresolvedMergeConflicts(IWin32Window owner)
-        {
-            return MessageBox.Show(owner, Instance._unresolvedMergeConflicts.Text, Instance._unresolvedMergeConflictsCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
-        }
+            => Show(owner,
+                    string.Format(ResourceManager.Strings.GeneralGitConfigExceptionMessage,
+                                  exception.ConfigPath, Environment.NewLine, (exception.InnerException ?? exception).Message),
+                    ResourceManager.Strings.GeneralGitConfigExceptionCaption,
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
 
         public static bool MiddleOfRebase(IWin32Window owner)
-        {
-            return MessageBox.Show(owner, Instance._middleOfRebase.Text, Instance._middleOfRebaseCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
-        }
+            => Confirm(owner, Instance._middleOfRebase.Text, Instance._middleOfRebaseCaption.Text);
 
         public static bool MiddleOfPatchApply(IWin32Window owner)
-        {
-            return MessageBox.Show(owner, Instance._middleOfPatchApply.Text, Instance._middleOfPatchApplyCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
-        }
+            => Confirm(owner, Instance._middleOfPatchApply.Text, Instance._middleOfPatchApplyCaption.Text);
 
         public static void PAgentNotFound(IWin32Window owner)
             => ShowError(owner, Instance._pageantNotFound.Text, _putty);
@@ -98,9 +88,13 @@ namespace GitUI
             => ShowError(owner, Instance._selectOnlyOneOrTwoRevisions.Text, Instance._archiveRevisionCaption.Text);
 
         public static bool CacheHostkey(IWin32Window owner)
-        {
-            return MessageBox.Show(owner, Instance._serverHostkeyNotCachedText.Text, "SSH", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
-        }
+            => Confirm(owner, Instance._serverHostkeyNotCachedText.Text, "SSH");
+
+        public static bool ConfirmResetSelectedFiles(IWin32Window owner, string text)
+            => Confirm(owner, text, Instance._resetChangesCaption.Text);
+
+        public static bool ConfirmResolveMergeConflicts(IWin32Window owner)
+            => Confirm(owner, Instance._unresolvedMergeConflicts.Text, Instance._unresolvedMergeConflictsCaption.Text);
 
         public static bool ConfirmUpdateSubmodules(IWin32Window win)
         {
@@ -127,19 +121,16 @@ namespace GitUI
             return result;
         }
 
-        public static bool ConfirmDeleteRemoteBranch(IWin32Window owner, string branchName, string remote)
-        {
-            return MessageBox.Show(owner, string.Format(Instance._confirmDeleteRemoteBranch.Text, branchName, remote),
-                "", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
-        }
-
         public static void ShellNotFound([CanBeNull] IWin32Window owner)
             => ShowError(owner, Instance._shellNotFound.Text, Instance._shellNotFoundCaption.Text);
 
         public static void ShowError([CanBeNull] IWin32Window owner, string text, string caption = null)
-            => MessageBox.Show(owner, text, caption ?? Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            => Show(owner, text, caption ?? Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
 
-        public static bool ResetSelectedFiles(IWin32Window owner, string text)
-            => MessageBox.Show(owner, text, Instance._resetChangesCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
+        private static bool Confirm([CanBeNull] IWin32Window owner, string text, string caption)
+            => Show(owner, text, caption, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;
+
+        private static DialogResult Show([CanBeNull] IWin32Window owner, string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon)
+            => MessageBox.Show(owner, text, caption, buttons, icon);
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7670,10 +7670,6 @@ help</source>
         <source>Archive revision</source>
         <target />
       </trans-unit>
-      <trans-unit id="_confirmDeleteRemoteBranch.Text">
-        <source>Do you want to delete the branch {0} from {1}?</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_failedToExecuteScript.Text">
         <source>Failed to execute script</source>
         <target />


### PR DESCRIPTION
## Proposed changes

- Factor out a common function `Show` to call `MessageBox.Show` in a single place in `MessageBoxes`
  in order to prepare for easy replacement / extension, e.g. for
  - mock-up in NUnit tests
  - switching to the UI thread in order to show errors of external operations when they occur
- Factor out a common function `Confirm`
- Remove unreferenced `_confirmDeleteRemoteBranch` and `ConfirmDeleteRemoteBranch`

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build b6a6047
- Git 2.27.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
