### PR TITLE
Disable Finish button while loading branches in GitFlow form.

### DIFF
--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -127,6 +127,8 @@ namespace GitFlow
         private void LoadBranches(string branchType)
         {
             cbManageType.Enabled = false;
+            btnFinish.Enabled = false;
+
             cbBranches.DataSource = new List<string> { _loading.Text };
             if (!Branches.ContainsKey(branchType))
             {
@@ -140,6 +142,8 @@ namespace GitFlow
             {
                 DisplayBranchData();
             }
+
+            btnFinish.Enabled = Branches.Any();
         }
 
         private IReadOnlyList<string> GetBranches(string typeBranch)


### PR DESCRIPTION
## Proposed changes
Disable Finish button in GitFlow form while branches are loading. Before this fix you can press Finish button while branches ComboBox displays 'Loading...', so you can finish 'Loading...' branch which doen't exists.

