### PR TITLE
Introduce a new console styles settings page under Appearance

### DIFF
--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -127,12 +127,14 @@ namespace GitUI.CommandsDialogs
 
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<GeneralSettingsPage>(this), gitExtPageRef, Images.GeneralSettings);
 
+            // >> Appearance
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<AppearanceSettingsPage>(this), gitExtPageRef, Images.Appearance);
             var appearanceSettingsPage = AppearanceSettingsPage.GetPageReference();
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ColorsSettingsPage>(this), appearanceSettingsPage, Images.Colors);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<AppearanceFontsSettingsPage>(this), appearanceSettingsPage, Images.Font.AdaptLightness());
-
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ConsoleStyleSettingsPage>(this), appearanceSettingsPage, Images.Console);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<RevisionLinksSettingsPage>(this), gitExtPageRef, Images.Link.AdaptLightness());
+
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<BuildServerIntegrationSettingsPage>(this), gitExtPageRef, Images.Integration);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ScriptsSettingsPage>(this), gitExtPageRef, Images.Console);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<HotkeysSettingsPage>(this), gitExtPageRef, Images.Hotkey);
@@ -142,10 +144,12 @@ namespace GitUI.CommandsDialogs
                 settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ShellExtensionSettingsPage>(this), gitExtPageRef, Images.ShellExtensions);
             }
 
+            // >> Advanced
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<AdvancedSettingsPage>(this), gitExtPageRef, Images.AdvancedSettings);
             SettingsPageReference advancedPageRef = AdvancedSettingsPage.GetPageReference();
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ConfirmationsSettingsPage>(this), advancedPageRef, Images.BisectGood);
 
+            // >> Detailed
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<DetailedSettingsPage>(this), gitExtPageRef, Images.Settings);
             var detailedSettingsPage = DetailedSettingsPage.GetPageReference();
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<FormBrowseRepoSettingsPage>(this), detailedSettingsPage, Images.BranchFolder);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.Designer.cs
@@ -1,0 +1,158 @@
+﻿namespace GitUI.CommandsDialogs.SettingsDialog.Pages
+{
+    partial class ConsoleStyleSettingsPage
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.groupBoxConsoleSettings = new System.Windows.Forms.GroupBox();
+            this.label3 = new System.Windows.Forms.Label();
+            this.cboFontSize = new System.Windows.Forms.ComboBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_cboStyle = new System.Windows.Forms.ComboBox();
+            this.groupBoxConsoleSettings.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // groupBoxConsoleSettings
+            // 
+            this.groupBoxConsoleSettings.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBoxConsoleSettings.AutoSize = true;
+            this.groupBoxConsoleSettings.Controls.Add(this.label3);
+            this.groupBoxConsoleSettings.Controls.Add(this.cboFontSize);
+            this.groupBoxConsoleSettings.Controls.Add(this.label1);
+            this.groupBoxConsoleSettings.Controls.Add(this._NO_TRANSLATE_cboStyle);
+            this.groupBoxConsoleSettings.Location = new System.Drawing.Point(8, 10);
+            this.groupBoxConsoleSettings.Margin = new System.Windows.Forms.Padding(17, 2, 3, 2);
+            this.groupBoxConsoleSettings.Name = "groupBoxConsoleSettings";
+            this.groupBoxConsoleSettings.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.groupBoxConsoleSettings.Size = new System.Drawing.Size(1653, 89);
+            this.groupBoxConsoleSettings.TabIndex = 1;
+            this.groupBoxConsoleSettings.TabStop = false;
+            this.groupBoxConsoleSettings.Text = "Console settings (restart required)";
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(6, 54);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(49, 13);
+            this.label3.TabIndex = 4;
+            this.label3.Text = "Font size";
+            // 
+            // cboFontSize
+            // 
+            this.cboFontSize.FormattingEnabled = true;
+            this.cboFontSize.Items.AddRange(new object[] {
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "16",
+            "18",
+            "19",
+            "20",
+            "24"});
+            this.cboFontSize.Location = new System.Drawing.Point(118, 51);
+            this.cboFontSize.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.cboFontSize.Name = "cboFontSize";
+            this.cboFontSize.Size = new System.Drawing.Size(262, 21);
+            this.cboFontSize.TabIndex = 5;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(5, 28);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(69, 13);
+            this.label1.TabIndex = 2;
+            this.label1.Text = "Console style";
+            // 
+            // _NO_TRANSLATE_cboStyle
+            // 
+            this._NO_TRANSLATE_cboStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this._NO_TRANSLATE_cboStyle.FormattingEnabled = true;
+            this._NO_TRANSLATE_cboStyle.Items.AddRange(new object[] {
+            "Default",
+            "<Default Windows scheme>",
+            "<Base16>",
+            "<Cobalt2>",
+            "<ConEmu>",
+            "<Gamma 1>",
+            "<Monokai>",
+            "<Murena scheme>",
+            "<PowerShell>",
+            "<Solarized>",
+            "<Solarized Git>",
+            "<Solarized (Luke Maciak)>",
+            "<Solarized (John Doe)>",
+            "<Solarized Light>",
+            "<SolarMe>",
+            "<Standard VGA>",
+            "<tc-maxx>",
+            "<Terminal.app>",
+            "<Tomorrow>",
+            "<Tomorrow Night>",
+            "<Tomorrow Night Blue>",
+            "<Tomorrow Night Bright>",
+            "<Tomorrow Night Eighties>",
+            "<Twilight>",
+            "<Ubuntu>",
+            "<xterm>",
+            "<Zenburn>"});
+            this._NO_TRANSLATE_cboStyle.Location = new System.Drawing.Point(118, 26);
+            this._NO_TRANSLATE_cboStyle.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this._NO_TRANSLATE_cboStyle.Name = "_NO_TRANSLATE_cboStyle";
+            this._NO_TRANSLATE_cboStyle.Size = new System.Drawing.Size(262, 21);
+            this._NO_TRANSLATE_cboStyle.TabIndex = 3;
+            // 
+            // ConsoleStyleSettingsPage
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.Controls.Add(this.groupBoxConsoleSettings);
+            this.Name = "ConsoleStyleSettingsPage";
+            this.Padding = new System.Windows.Forms.Padding(8);
+            this.Size = new System.Drawing.Size(1711, 555);
+            this.groupBoxConsoleSettings.ResumeLayout(false);
+            this.groupBoxConsoleSettings.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.GroupBox groupBoxConsoleSettings;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.ComboBox cboFontSize;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.ComboBox _NO_TRANSLATE_cboStyle;
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.cs
@@ -1,0 +1,29 @@
+﻿using System.Windows.Forms;
+using GitCommands;
+
+namespace GitUI.CommandsDialogs.SettingsDialog.Pages
+{
+    public partial class ConsoleStyleSettingsPage : SettingsPageWithHeader
+    {
+        public ConsoleStyleSettingsPage()
+        {
+            InitializeComponent();
+            Text = "Console style";
+            InitializeComplete();
+        }
+
+        protected override void Init(ISettingsPageHost pageHost)
+        {
+            base.Init(pageHost);
+
+            // Bind settings with controls
+            AddSettingBinding(AppSettings.ConEmuStyle, _NO_TRANSLATE_cboStyle);
+            AddSettingBinding(AppSettings.ConEmuFontSize, cboFontSize);
+        }
+
+        public static SettingsPageReference GetPageReference()
+        {
+            return new SettingsPageReferenceByType(typeof(ConsoleStyleSettingsPage));
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.resx
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
@@ -28,245 +28,105 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.chkShowGpgInformation = new System.Windows.Forms.CheckBox();
-            this.ConEmuGB = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-            this.groupBoxConsoleSettings = new System.Windows.Forms.GroupBox();
-            this.label3 = new System.Windows.Forms.Label();
-            this.cboFontSize = new System.Windows.Forms.ComboBox();
-            this.label2 = new System.Windows.Forms.Label();
-            this.label1 = new System.Windows.Forms.Label();
-            this.cboTerminal = new System.Windows.Forms.ComboBox();
-            this._NO_TRANSLATE_cboStyle = new System.Windows.Forms.ComboBox();
             this.chkChowConsoleTab = new System.Windows.Forms.CheckBox();
-            this.tableLayoutPanel2.SuspendLayout();
-            this.ConEmuGB.SuspendLayout();
-            this.tableLayoutPanel3.SuspendLayout();
-            this.groupBoxConsoleSettings.SuspendLayout();
+            this.cboTerminal = new System.Windows.Forms.ComboBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.gbGeneral = new System.Windows.Forms.GroupBox();
+            this.gbTabs = new System.Windows.Forms.GroupBox();
+            this.gbGeneral.SuspendLayout();
+            this.gbTabs.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // tableLayoutPanel2
-            // 
-            this.tableLayoutPanel2.AutoSize = true;
-            this.tableLayoutPanel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tableLayoutPanel2.ColumnCount = 1;
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel2.Controls.Add(this.chkShowGpgInformation, 0, 1);
-            this.tableLayoutPanel2.Controls.Add(this.ConEmuGB, 0, 0);
-            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 2;
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(1020, 1447);
-            this.tableLayoutPanel2.TabIndex = 3;
             // 
             // chkShowGpgInformation
             // 
             this.chkShowGpgInformation.AutoSize = true;
-            this.chkShowGpgInformation.Location = new System.Drawing.Point(3, 198);
+            this.chkShowGpgInformation.Location = new System.Drawing.Point(9, 48);
             this.chkShowGpgInformation.Name = "chkShowGpgInformation";
-            this.chkShowGpgInformation.Size = new System.Drawing.Size(132, 17);
-            this.chkShowGpgInformation.TabIndex = 7;
-            this.chkShowGpgInformation.Text = "Show GPG information (a restart is needed to take effect)";
+            this.chkShowGpgInformation.Size = new System.Drawing.Size(212, 17);
+            this.chkShowGpgInformation.TabIndex = 6;
+            this.chkShowGpgInformation.Text = "Show GPG information";
             this.chkShowGpgInformation.UseVisualStyleBackColor = true;
             // 
-            // ConEmuGB
+            // chkChowConsoleTab
             // 
-            this.ConEmuGB.AutoSize = true;
-            this.ConEmuGB.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.ConEmuGB.Controls.Add(this.tableLayoutPanel3);
-            this.ConEmuGB.Dock = System.Windows.Forms.DockStyle.Top;
-            this.ConEmuGB.Location = new System.Drawing.Point(3, 3);
-            this.ConEmuGB.Name = "ConEmuGB";
-            this.ConEmuGB.Padding = new System.Windows.Forms.Padding(8);
-            this.ConEmuGB.Size = new System.Drawing.Size(1014, 189);
-            this.ConEmuGB.TabIndex = 0;
-            this.ConEmuGB.TabStop = false;
-            this.ConEmuGB.Text = "Console emulator";
-            // 
-            // tableLayoutPanel3
-            // 
-            this.tableLayoutPanel3.AutoSize = true;
-            this.tableLayoutPanel3.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tableLayoutPanel3.ColumnCount = 1;
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.Controls.Add(this.groupBoxConsoleSettings, 0, 1);
-            this.tableLayoutPanel3.Controls.Add(this.chkChowConsoleTab, 0, 0);
-            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(8, 22);
-            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.RowCount = 2;
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(998, 159);
-            this.tableLayoutPanel3.TabIndex = 1;
-            // 
-            // groupBoxConsoleSettings
-            // 
-            this.groupBoxConsoleSettings.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBoxConsoleSettings.AutoSize = true;
-            this.groupBoxConsoleSettings.Controls.Add(this.label3);
-            this.groupBoxConsoleSettings.Controls.Add(this.cboFontSize);
-            this.groupBoxConsoleSettings.Controls.Add(this.label2);
-            this.groupBoxConsoleSettings.Controls.Add(this.label1);
-            this.groupBoxConsoleSettings.Controls.Add(this.cboTerminal);
-            this.groupBoxConsoleSettings.Controls.Add(this._NO_TRANSLATE_cboStyle);
-            this.groupBoxConsoleSettings.Location = new System.Drawing.Point(17, 25);
-            this.groupBoxConsoleSettings.Margin = new System.Windows.Forms.Padding(17, 2, 3, 2);
-            this.groupBoxConsoleSettings.Name = "groupBoxConsoleSettings";
-            this.groupBoxConsoleSettings.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.groupBoxConsoleSettings.Size = new System.Drawing.Size(978, 132);
-            this.groupBoxConsoleSettings.TabIndex = 3;
-            this.groupBoxConsoleSettings.TabStop = false;
-            this.groupBoxConsoleSettings.Text = "Console settings (a restart is needed to take effect)";
-            // 
-            // label3
-            // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(5, 93);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(50, 13);
-            this.label3.TabIndex = 7;
-            this.label3.Text = "Font size";
-            // 
-            // cboFontSize
-            // 
-            this.cboFontSize.FormattingEnabled = true;
-            this.cboFontSize.Items.AddRange(new object[] {
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "16",
-            "18",
-            "19",
-            "20",
-            "24"});
-            this.cboFontSize.Location = new System.Drawing.Point(118, 93);
-            this.cboFontSize.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.cboFontSize.Name = "cboFontSize";
-            this.cboFontSize.Size = new System.Drawing.Size(262, 21);
-            this.cboFontSize.TabIndex = 6;
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(5, 59);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(61, 13);
-            this.label2.TabIndex = 5;
-            this.label2.Text = "Shell to run";
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(5, 28);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(71, 13);
-            this.label1.TabIndex = 5;
-            this.label1.Text = "Console style";
+            this.chkChowConsoleTab.AutoSize = true;
+            this.chkChowConsoleTab.Location = new System.Drawing.Point(9, 25);
+            this.chkChowConsoleTab.Name = "chkChowConsoleTab";
+            this.chkChowConsoleTab.Size = new System.Drawing.Size(209, 17);
+            this.chkChowConsoleTab.TabIndex = 5;
+            this.chkChowConsoleTab.Text = "Show the Console tab";
+            this.chkChowConsoleTab.UseVisualStyleBackColor = true;
             // 
             // cboTerminal
             // 
             this.cboTerminal.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboTerminal.FormattingEnabled = true;
-            this.cboTerminal.Location = new System.Drawing.Point(118, 59);
+            this.cboTerminal.Location = new System.Drawing.Point(146, 22);
             this.cboTerminal.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cboTerminal.Name = "cboTerminal";
             this.cboTerminal.Size = new System.Drawing.Size(262, 21);
-            this.cboTerminal.TabIndex = 4;
-            this.cboTerminal.SelectionChangeCommitted += new System.EventHandler(this.cboTerminal_SelectionChangeCommitted);
-            this.cboTerminal.Enter += new System.EventHandler(this.cboTerminal_Enter);
+            this.cboTerminal.TabIndex = 3;
             // 
-            // _NO_TRANSLATE_cboStyle
+            // label2
             // 
-            this._NO_TRANSLATE_cboStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this._NO_TRANSLATE_cboStyle.FormattingEnabled = true;
-            this._NO_TRANSLATE_cboStyle.Items.AddRange(new object[] {
-            "Default",
-            "<Default Windows scheme>",
-            "<Base16>",
-            "<Cobalt2>",
-            "<ConEmu>",
-            "<Gamma 1>",
-            "<Monokai>",
-            "<Murena scheme>",
-            "<PowerShell>",
-            "<Solarized>",
-            "<Solarized Git>",
-            "<Solarized (Luke Maciak)>",
-            "<Solarized (John Doe)>",
-            "<Solarized Light>",
-            "<SolarMe>",
-            "<Standard VGA>",
-            "<tc-maxx>",
-            "<Terminal.app>",
-            "<Tomorrow>",
-            "<Tomorrow Night>",
-            "<Tomorrow Night Blue>",
-            "<Tomorrow Night Bright>",
-            "<Tomorrow Night Eighties>",
-            "<Twilight>",
-            "<Ubuntu>",
-            "<xterm>",
-            "<Zenburn>"});
-            this._NO_TRANSLATE_cboStyle.Location = new System.Drawing.Point(118, 26);
-            this._NO_TRANSLATE_cboStyle.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this._NO_TRANSLATE_cboStyle.Name = "_NO_TRANSLATE_cboStyle";
-            this._NO_TRANSLATE_cboStyle.Size = new System.Drawing.Size(262, 21);
-            this._NO_TRANSLATE_cboStyle.TabIndex = 3;
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(6, 25);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(65, 13);
+            this.label2.TabIndex = 2;
+            this.label2.Text = "Default shell";
             // 
-            // chkChowConsoleTab
+            // gbGeneral
             // 
-            this.chkChowConsoleTab.AutoSize = true;
-            this.chkChowConsoleTab.Location = new System.Drawing.Point(3, 3);
-            this.chkChowConsoleTab.Name = "chkChowConsoleTab";
-            this.chkChowConsoleTab.Size = new System.Drawing.Size(131, 17);
-            this.chkChowConsoleTab.TabIndex = 0;
-            this.chkChowConsoleTab.Text = "Show the Console tab (restart required)";
-            this.chkChowConsoleTab.UseVisualStyleBackColor = true;
-            this.chkChowConsoleTab.CheckedChanged += new System.EventHandler(this.chkChowConsoleTab_CheckedChanged);
+            this.gbGeneral.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.gbGeneral.Controls.Add(this.cboTerminal);
+            this.gbGeneral.Controls.Add(this.label2);
+            this.gbGeneral.Location = new System.Drawing.Point(11, 11);
+            this.gbGeneral.Name = "gbGeneral";
+            this.gbGeneral.Size = new System.Drawing.Size(1487, 56);
+            this.gbGeneral.TabIndex = 1;
+            this.gbGeneral.TabStop = false;
+            this.gbGeneral.Text = "General";
+            // 
+            // gbTabs
+            // 
+            this.gbTabs.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.gbTabs.Controls.Add(this.chkShowGpgInformation);
+            this.gbTabs.Controls.Add(this.chkChowConsoleTab);
+            this.gbTabs.Location = new System.Drawing.Point(11, 86);
+            this.gbTabs.Name = "gbTabs";
+            this.gbTabs.Size = new System.Drawing.Size(1487, 82);
+            this.gbTabs.TabIndex = 4;
+            this.gbTabs.TabStop = false;
+            this.gbTabs.Text = "Tabs (restart required)";
             // 
             // FormBrowseRepoSettingsPage
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.Controls.Add(this.tableLayoutPanel2);
+            this.Controls.Add(this.gbTabs);
+            this.Controls.Add(this.gbGeneral);
             this.Name = "FormBrowseRepoSettingsPage";
-            this.Size = new System.Drawing.Size(1020, 1447);
-            this.tableLayoutPanel2.ResumeLayout(false);
-            this.tableLayoutPanel2.PerformLayout();
-            this.ConEmuGB.ResumeLayout(false);
-            this.ConEmuGB.PerformLayout();
-            this.tableLayoutPanel3.ResumeLayout(false);
-            this.tableLayoutPanel3.PerformLayout();
-            this.groupBoxConsoleSettings.ResumeLayout(false);
-            this.groupBoxConsoleSettings.PerformLayout();
+            this.Padding = new System.Windows.Forms.Padding(8);
+            this.Size = new System.Drawing.Size(1509, 596);
+            this.gbGeneral.ResumeLayout(false);
+            this.gbGeneral.PerformLayout();
+            this.gbTabs.ResumeLayout(false);
+            this.gbTabs.PerformLayout();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
         #endregion
 
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
-        private System.Windows.Forms.GroupBox ConEmuGB;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
-        private System.Windows.Forms.GroupBox groupBoxConsoleSettings;
-        private System.Windows.Forms.Label label3;
-        private System.Windows.Forms.ComboBox cboFontSize;
-        private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.ComboBox cboTerminal;
-        private System.Windows.Forms.ComboBox _NO_TRANSLATE_cboStyle;
-        private System.Windows.Forms.CheckBox chkChowConsoleTab;
         private System.Windows.Forms.CheckBox chkShowGpgInformation;
+        private System.Windows.Forms.CheckBox chkChowConsoleTab;
+        private System.Windows.Forms.ComboBox cboTerminal;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.GroupBox gbGeneral;
+        private System.Windows.Forms.GroupBox gbTabs;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
@@ -23,8 +23,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             // Bind settings with controls
             AddSettingBinding(AppSettings.ShowConEmuTab, chkChowConsoleTab);
-            AddSettingBinding(AppSettings.ConEmuStyle, _NO_TRANSLATE_cboStyle);
-            AddSettingBinding(AppSettings.ConEmuFontSize, cboFontSize);
             AddSettingBinding(AppSettings.ShowGpgInformation, chkShowGpgInformation);
         }
 
@@ -47,11 +45,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
 
             base.SettingsToPage();
-        }
-
-        private void chkChowConsoleTab_CheckedChanged(object sender, EventArgs e)
-        {
-            groupBoxConsoleSettings.Enabled = chkChowConsoleTab.Checked;
         }
 
         public static SettingsPageReference GetPageReference()

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -970,6 +970,26 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
       </trans-unit>
     </body>
   </file>
+  <file datatype="plaintext" original="ConsoleStyleSettingsPage" source-language="en">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Console style</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="groupBoxConsoleSettings.Text">
+        <source>Console settings (restart required)</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="label1.Text">
+        <source>Console style</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="label3.Text">
+        <source>Font size</source>
+        <target />
+      </trans-unit>
+    </body>
+  </file>
   <file datatype="plaintext" original="ControlHotkeys" source-language="en">
     <body>
       <trans-unit id="bApply.Text">
@@ -2607,32 +2627,24 @@ Do you want to continue?</source>
         <source>Browse repository window</source>
         <target />
       </trans-unit>
-      <trans-unit id="ConEmuGB.Text">
-        <source>Console emulator</source>
-        <target />
-      </trans-unit>
       <trans-unit id="chkChowConsoleTab.Text">
-        <source>Show the Console tab (restart required)</source>
+        <source>Show the Console tab</source>
         <target />
       </trans-unit>
       <trans-unit id="chkShowGpgInformation.Text">
-        <source>Show GPG information (a restart is needed to take effect)</source>
+        <source>Show GPG information</source>
         <target />
       </trans-unit>
-      <trans-unit id="groupBoxConsoleSettings.Text">
-        <source>Console settings (a restart is needed to take effect)</source>
+      <trans-unit id="gbGeneral.Text">
+        <source>General</source>
         <target />
       </trans-unit>
-      <trans-unit id="label1.Text">
-        <source>Console style</source>
+      <trans-unit id="gbTabs.Text">
+        <source>Tabs (restart required)</source>
         <target />
       </trans-unit>
       <trans-unit id="label2.Text">
-        <source>Shell to run</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="label3.Text">
-        <source>Font size</source>
+        <source>Default shell</source>
         <target />
       </trans-unit>
     </body>

--- a/contributors.txt
+++ b/contributors.txt
@@ -137,3 +137,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/07/07, bstecisa, Borja Serrano, borjaserrano(at)gmail.com
 2020/08/02, FodderMK, Kevin Yockey, gitex{at]foddermk.com
 2020/09/13, hoborm, Mihaly Hobor, mail{{at]]hobor.xyz
+2020/07/11, blitzmann, Ryan Holmes, holmes.ryan.90(at)gmail.com


### PR DESCRIPTION
Fixes #8306


## Proposed changes

- Remove Console style and font controls from Detailed > Browse Repository Window
- Add new Settings page under Appearance > Console Styles, and add the removed controls to this


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/3904767/87232230-4ee93c00-c38b-11ea-8edc-857d0ee4eedc.png)

### After

#### > Console Styles page

![image](https://user-images.githubusercontent.com/3904767/87232313-dd5dbd80-c38b-11ea-8332-e785a6466f18.png)

#### > Browse Repo Page

![image](https://user-images.githubusercontent.com/3904767/87232316-ecdd0680-c38b-11ea-8bf4-8fbae2d7a9e9.png)


## Test methodology <!-- How did you ensure quality? -->

- Purely a UI thing, no real logic was changed.
- After moving the controls to another page, ensures that changing the values saved properly and were loaded at next restart
- Also ensured that the style and font settings actually got applied to ComEmu
- Other than the designer page to remove the controls, no code was touched for the Browse Repository Window page

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 10
- English. Where possible I kept text  the same so as to avoid re-translations. I haven't tested with non-English locale

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
