### PR TITLE
Avoid IEnumerable<> in test case signature

### DIFF
--- a/UnitTests/GitUI.Tests/Editor/FindAndReplaceFormTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/FindAndReplaceFormTests.cs
@@ -32,7 +32,7 @@ namespace GitUITests.Editor
             _textEditorControl.Dispose();
         }
 
-        public static IEnumerable<TestCaseData> MatchCase
+        private static IEnumerable<TestCaseData> MatchCase
         {
             get
             {
@@ -43,7 +43,7 @@ namespace GitUITests.Editor
             }
         }
 
-        [Test, TestCaseSource(nameof(MatchCase))]
+        [TestCaseSource(nameof(MatchCase))]
         public async Task FindNextAsync_match_case(string text, string searchPhrase, bool matchCase, TextRange expectedRange)
         {
             Arrange(text, searchPhrase, matchCase);
@@ -53,7 +53,7 @@ namespace GitUITests.Editor
             AssertTextRange(expectedRange, actualRange);
         }
 
-        public static IEnumerable<TestCaseData> MatchWholeWordOnly
+        private static IEnumerable<TestCaseData> MatchWholeWordOnly
         {
             get
             {
@@ -62,7 +62,7 @@ namespace GitUITests.Editor
             }
         }
 
-        [Test, TestCaseSource(nameof(MatchWholeWordOnly))]
+        [TestCaseSource(nameof(MatchWholeWordOnly))]
         public async Task FindNextAsync_match_whole_world_only(string text, string searchPhrase, TextRange expectedRange)
         {
             Arrange(text, searchPhrase, matchWholeWordOnly: true);
@@ -72,7 +72,7 @@ namespace GitUITests.Editor
             AssertTextRange(expectedRange, actualRange);
         }
 
-        public static IEnumerable<TestCaseData> LoopAround
+        private static IEnumerable<TestCaseData> LoopAround
         {
             get
             {
@@ -110,14 +110,14 @@ namespace GitUITests.Editor
             }
         }
 
-        [Test, TestCaseSource(nameof(LoopAround))]
+        [TestCaseSource(nameof(LoopAround))]
         public async Task FindNextAsync_should_make_a_loop_and_return_to_first_occurrence(
             string text,
             string searchPhrase,
             bool searchBackwards,
             TextLocation scanRegionStart,
             TextLocation scanRegionEnd,
-            IEnumerable<TextRange> expectedRanges)
+            TextRange[] expectedRanges)
         {
             Arrange(text, searchPhrase, scanRegionStart: scanRegionStart, scanRegionEnd: scanRegionEnd);
 
@@ -148,7 +148,7 @@ namespace GitUITests.Editor
             AssertTextRange(new TextRange(20, 4), actualRange);
         }
 
-        public static IEnumerable<TestCaseData> MultiFileSearch
+        private static IEnumerable<TestCaseData> MultiFileSearch
         {
             get
             {
@@ -170,13 +170,13 @@ namespace GitUITests.Editor
             }
         }
 
-        [Test, TestCaseSource(nameof(MultiFileSearch))]
+        [TestCaseSource(nameof(MultiFileSearch))]
         public async Task FindNextAsync_should_iterate_over_files(
             string[] texts,
             string searchPhrase,
             TextLocation scanRegionStart,
             TextLocation scanRegionEnd,
-            IEnumerable<TextRange> expectedRanges)
+            TextRange[] expectedRanges)
         {
             int currentIndex = 0;
 


### PR DESCRIPTION
Fixes #8300

## Proposed changes

- Avoid `IEnumerable<>` in test case signature, use arrays instead
- Declare `TestCaseSource` methods `private`
- Omit `Test` attribute where `TestCaseSource` is specified

## Test methodology <!-- How did you ensure quality? -->

- run the NUnit tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build dcea83bc1081ea9c345f19d76acb4cab542179ab
- Git 2.27.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
