### PR TITLE
WIP Parse dereferenced tags

### DIFF
--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -752,7 +752,7 @@ namespace GitCommandsTests
         }
 
         [TestCase(@"show-ref --dereference", true, true, false)]
-        [TestCase(@"show-ref --tags", true, false, false)]
+        [TestCase(@"show-ref --tags --dereference", true, false, false)]
         [TestCase(@"for-each-ref --sort=-committerdate refs/heads/ --format=""%(objectname) %(refname)""", false, true, false)]
         [TestCase(@"--no-optional-locks for-each-ref --sort=-committerdate refs/heads/ --format=""%(objectname) %(refname)""", false, true, true)]
         public void GetRefsCmd(string expected, bool tags, bool branches, bool noLocks)


### PR DESCRIPTION
Fixes #8301

## Proposed changes

- get tags using `git show-ref --tags --dereference`
- parse dereferenced tags

## Test methodology <!-- How did you ensure quality? -->

- select `refs/tags/v2.48` in `GoToCommitForm`
- TODO: add NUnit test

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 850153e311703ab052bc9ee076fab650e5b97542
- Git 2.27.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
