### PR TITLE
Clean up of status reporting of failed operations

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1979,19 +1979,10 @@ namespace GitUI.CommandsDialogs
                     bool wereErrors = false;
                     if (AppSettings.ShowErrorsWhenStagingFiles)
                     {
-                        using (var form = new FormStatus(ProcessStart, _stageDetails.Text))
+                        var output = Module.StageFiles(files, out wereErrors);
+                        if (wereErrors)
                         {
-                            form.ShowDialogOnError(this);
-                        }
-
-                        void ProcessStart(FormStatus form)
-                        {
-                            form.AppendMessageCrossThread(
-                                string.Format(
-                                    _stageFiles.Text + "\n", files.Count));
-                            var output = Module.StageFiles(files, out wereErrors);
-                            form.AppendMessageCrossThread(output);
-                            form.Done(isSuccess: string.IsNullOrWhiteSpace(output));
+                            FormStatus.ShowErrorDialog(this, _stageDetails.Text, string.Format(_stageFiles.Text + "\n", files.Count), output);
                         }
                     }
                     else

--- a/GitUI/CommandsDialogs/FormMergeSubmodule.cs
+++ b/GitUI/CommandsDialogs/FormMergeSubmodule.cs
@@ -47,23 +47,20 @@ namespace GitUI.CommandsDialogs
 
         private void StageSubmodule()
         {
-            using (var form = new FormStatus(ProcessStart, string.Format(_stageFilename.Text, _filename)))
+            var args = new GitArgumentBuilder("add")
             {
-                form.ShowDialogOnError(this);
+                "--",
+                _filename.QuoteNE()
+            };
+            string output = Module.GitExecutable.GetOutput(args);
+
+            if (string.IsNullOrWhiteSpace(output))
+            {
+                return;
             }
 
-            void ProcessStart(FormStatus form)
-            {
-                form.AddMessageLine(string.Format(_stageFilename.Text, _filename));
-                var args = new GitArgumentBuilder("add")
-                {
-                    "--",
-                    _filename.QuoteNE()
-                };
-                string output = Module.GitExecutable.GetOutput(args);
-                form.AddMessageLine(output);
-                form.Done(isSuccess: string.IsNullOrWhiteSpace(output));
-            }
+            string text = string.Format(_stageFilename.Text, _filename);
+            FormStatus.ShowErrorDialog(this, text, text, output);
         }
 
         private void btStageCurrent_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1245,23 +1245,20 @@ namespace GitUI.CommandsDialogs
 
         private void StageFile(string filename)
         {
-            using (var form = new FormStatus(ProcessStart, string.Format(_stageFilename.Text, filename)))
+            var args = new GitArgumentBuilder("add")
             {
-                form.ShowDialogOnError(this);
+                "--",
+                filename.QuoteNE()
+            };
+            string output = Module.GitExecutable.GetOutput(args);
+
+            if (string.IsNullOrWhiteSpace(output))
+            {
+                return;
             }
 
-            void ProcessStart(FormStatus form)
-            {
-                form.AddMessageLine(string.Format(_stageFilename.Text, filename));
-                var args = new GitArgumentBuilder("add")
-                {
-                    "--",
-                    filename.QuoteNE()
-                };
-                string output = Module.GitExecutable.GetOutput(args);
-                form.AddMessageLine(output);
-                form.Done(isSuccess: string.IsNullOrWhiteSpace(output));
-            }
+            string text = string.Format(_stageFilename.Text, filename);
+            FormStatus.ShowErrorDialog(this, text, text, output);
         }
 
         private void merge_Click(object sender, EventArgs e)

--- a/GitUI/HelperDialogs/FormProcess.cs
+++ b/GitUI/HelperDialogs/FormProcess.cs
@@ -102,7 +102,7 @@ namespace GitUI.HelperDialogs
                 quotedProcessString = quotedProcessString.Quote();
             }
 
-            AddMessageLine(quotedProcessString + " " + ProcessArguments);
+            AppendMessage($"{quotedProcessString} {ProcessArguments}{Environment.NewLine}");
 
             try
             {
@@ -120,7 +120,7 @@ namespace GitUI.HelperDialogs
             }
             catch (Exception e)
             {
-                AddMessageLine("\n" + e.ToStringWithData());
+                AppendMessage($"{Environment.NewLine}{e.ToStringWithData()}{Environment.NewLine}");
                 OnExit(1);
             }
         }
@@ -212,7 +212,7 @@ namespace GitUI.HelperDialogs
             OutputLog.Append(line);
 
             // To the display control
-            AddMessage(line);
+            AppendMessage(line);
         }
 
         public static bool IsOperationAborted(string dialogResult)

--- a/GitUI/HelperDialogs/FormStatus.Designer.cs
+++ b/GitUI/HelperDialogs/FormStatus.Designer.cs
@@ -136,8 +136,6 @@
             this.Name = "FormStatus";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Process";
-            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.FormStatus_FormClosed);
-            this.Load += new System.EventHandler(this.FormStatus_Load);
             this.Controls.SetChildIndex(this.ProgressBar, 0);
             this.Controls.SetChildIndex(this.MainPanel, 0);
             this.MainPanel.ResumeLayout(false);

--- a/GitUI/HelperDialogs/FormStatus.cs
+++ b/GitUI/HelperDialogs/FormStatus.cs
@@ -55,9 +55,9 @@ namespace GitUI.HelperDialogs
             InitializeComplete();
         }
 
-        protected readonly ConsoleOutputControl ConsoleOutput;
-        public Action<FormStatus> ProcessCallback;
-        public Action<FormStatus> AbortCallback;
+        private protected ConsoleOutputControl ConsoleOutput { get; }
+        private protected Action<FormStatus> ProcessCallback;
+        private protected Action<FormStatus> AbortCallback;
         private bool _errorOccurred;
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace GitUI.HelperDialogs
         /// For instance, progress messages might be skipped; other messages might be added manually.
         /// </summary>
         [NotNull]
-        public readonly FormStatusOutputLog OutputLog = new FormStatusOutputLog();
+        private protected FormStatusOutputLog OutputLog { get; } = new FormStatusOutputLog();
 
         protected override CreateParams CreateParams
         {
@@ -82,7 +82,7 @@ namespace GitUI.HelperDialogs
             return _errorOccurred;
         }
 
-        public async Task SetProgressAsync(string text)
+        private protected async Task SetProgressAsync(string text)
         {
             // This has to happen on the UI thread
             await this.SwitchToMainThreadAsync();
@@ -105,12 +105,12 @@ namespace GitUI.HelperDialogs
         /// <summary>
         /// Adds a message to the console display control ONLY, <see cref="GetOutputString" /> will not list it.
         /// </summary>
-        public void AppendMessage(string text)
+        private protected void AppendMessage(string text)
         {
             ConsoleOutput.AppendMessageFreeThreaded(text);
         }
 
-        public void Done(bool isSuccess)
+        private protected void Done(bool isSuccess)
         {
             try
             {
@@ -137,7 +137,7 @@ namespace GitUI.HelperDialogs
             }
         }
 
-        public void Reset()
+        private protected void Reset()
         {
             ConsoleOutput.Reset();
             OutputLog.Clear();

--- a/GitUI/HelperDialogs/FormStatus.cs
+++ b/GitUI/HelperDialogs/FormStatus.cs
@@ -105,24 +105,16 @@ namespace GitUI.HelperDialogs
         /// <summary>
         /// Adds a message to the console display control ONLY, <see cref="GetOutputString" /> will not list it.
         /// </summary>
-        public void AddMessage(string text)
+        public void AppendMessage(string text)
         {
             ConsoleOutput.AppendMessageFreeThreaded(text);
-        }
-
-        /// <summary>
-        /// Adds a message line to the console display control ONLY, <see cref="GetOutputString" /> will not list it.
-        /// </summary>
-        public void AddMessageLine(string text)
-        {
-            AddMessage(text + Environment.NewLine);
         }
 
         public void Done(bool isSuccess)
         {
             try
             {
-                AppendMessageCrossThread("Done");
+                AppendMessage("Done");
                 ProgressBar.Visible = false;
                 Ok.Enabled = true;
                 Ok.Focus();
@@ -143,11 +135,6 @@ namespace GitUI.HelperDialogs
             {
                 // Do nothing
             }
-        }
-
-        public void AppendMessageCrossThread(string text)
-        {
-            ConsoleOutput.AppendMessageFreeThreaded(text);
         }
 
         public void Reset()
@@ -174,7 +161,7 @@ namespace GitUI.HelperDialogs
                 {
                     foreach (string line in output)
                     {
-                        form.AppendMessageCrossThread(line);
+                        form.AppendMessage(line);
                     }
                 }
 

--- a/GitUI/TaskbarProgress.cs
+++ b/GitUI/TaskbarProgress.cs
@@ -29,14 +29,14 @@ namespace GitUI
         {
             Try(taskbar =>
             {
-                taskbar.SetProgressState(TaskbarProgressBarState.Normal);
+                taskbar.SetProgressState(state);
                 taskbar.SetProgressValue(progressValue, maximumValue);
             });
         }
 
-        public static void SetIndeterminate()
+        public static void SetState(TaskbarProgressBarState state)
         {
-            Try(taskbar => taskbar.SetProgressState(TaskbarProgressBarState.Indeterminate));
+            Try(taskbar => taskbar.SetProgressState(state));
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->




## Proposed changes

Undo plumbing and infra introduced in 1572cbd7da7af53678f05b8cd4dcfcdf9e8e46d3. With that we have one less dependency on WPF stack.

There are several scenarios that involve showing `FormStatus` or its descendants.
1. Show a progress as a modal dialog (this is standard way).
2. Do not show the progress dialog, and only show it if an operation that was running failed (e.g. staging files in `FormCommit`).

The approach to showing results of failed operations appears to be unnecessary complex, that IIUC led to issues while attempting to show a dialog that was already considered opened but invisible.
And the WPF's DispatcherFrameModalController was used to deal with this. 
This also necessitated defining delegates, and required more plumbing to pass those around, validation, etc.

However it is much simpler *not* to show the dialog *until after* the operation has failed. The callsites are also much easier to read and understand.

Also some general code clean up.

⚠️ NB: best to review commit by commit. Don't squash.


## Test methodology <!-- How did you ensure quality? -->

Lots of manual tests 
- for normal operations (e.g. running `git fetch` and `git fetch -all`)
- for no-dialog operation (e.g. file staging) that were set to fail (e.g. convert EOL from `crlf` to `lf` in one of the existing files in a repo)

