### PR TITLE
Add missing early return from OnRebaseInteractivelyClicked

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1885,6 +1885,7 @@ namespace GitUI
             if (AppSettings.DontConfirmRebase)
             {
                 UICommands.StartInteractiveRebase(this, _rebaseOnTopOf);
+                return;
             }
 
             using var dialog = new TaskDialog


### PR DESCRIPTION
Fixes #8312

## Proposed changes

- Add missing early `return` from `OnRebaseInteractivelyClicked`

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 4e89551f9cd8ee1b84443a1737551027b639a8b9
- Git 2.27.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
