### PR TITLE
FormCommit: No summary  for deleted submodules

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2397,12 +2397,14 @@ namespace GitUI.CommandsDialogs
             }
 
             Dictionary<string, string> modules = stagedFiles
-                .Where(item => item.IsSubmodule)
+                .Where(item => item.IsSubmodule
+                               && Directory.Exists(_fullPathResolver.Resolve(item.Name))
+                               && configFile.ConfigSections.FirstOrDefault(section => section.GetValue("path").Trim() == item.Name)?.SubSection != null)
                 .Select(item => item.Name)
                 .ToDictionary(localPath =>
                 {
                     var submodule = configFile.ConfigSections.FirstOrDefault(section => section.GetValue("path").Trim() == localPath);
-                    return submodule?.SubSection.Trim();
+                    return submodule?.SubSection?.Trim();
                 });
 
             if (modules.Count == 0)


### PR DESCRIPTION
Fixes #8315
Fixes #8316

## Proposed changes

Check if a submodule exists on the filesystem before trying to create a summary.
Note that deleted submodules are ignored in the summary.

## Test methodology <!-- How did you ensure quality? -->

See the issue

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
