### PR TITLE
fix hidden toolStripRevisionFilterTextBox in Linux

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -14,6 +14,7 @@ using GitCommands.Git;
 using GitCommands.Gpg;
 using GitCommands.Repository;
 using GitCommands.Utils;
+using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.CommandsDialogs.BrowseDialog.DashboardControl;
 using GitUI.CommandsDialogs.WorktreeDialog;
@@ -156,6 +157,9 @@ namespace GitUI.CommandsDialogs
             //Save value for commit info panel, may be changed
             _showRevisionInfoNextToRevisionGrid = AppSettings.ShowRevisionInfoNextToRevisionGrid;
             InitializeComponent();
+
+            Layout += formBrowse_layout;
+            toolStripRevisionFilterTextBox.TextBox.MinimumSize = DpiUtil.Scale(new Size(97, 25));
 
             // set tab page images
             {
@@ -2810,6 +2814,11 @@ namespace GitUI.CommandsDialogs
         private void toolStripBranchFilterComboBox_Click(object sender, EventArgs e)
         {
             toolStripBranchFilterComboBox.DroppedDown = true;
+        }
+
+        private void formBrowse_layout(object sender, LayoutEventArgs e)
+        {
+            ToolStrip.MinimumSize = new Size(toolPanel.ClientSize.Width, 0);
         }
     }
 }


### PR DESCRIPTION
Fixes #8320

## Screenshots

### Before

![gitext_toolbar_bad](https://user-images.githubusercontent.com/12046452/87339113-c7e4c100-c54e-11ea-9572-132c2f0f366b.png)

With mono / linux reszing a form with layout issue sometimes helps, not in this case though. After maximizing / unmaximizing, the toolbar is extended to a proper width, but still the filter textbox is invisible

![gitext_toolbar_bad_re_layout](https://user-images.githubusercontent.com/12046452/87339282-0da18980-c54f-11ea-9743-014d677dd247.png)

### After

![gitext_toolbar_ok](https://user-images.githubusercontent.com/12046452/87339828-d67fa800-c54f-11ea-9df0-de3f992484e3.png)

## Test methodology

manually

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
