### PR TITLE
Fix Gource avatar feature

### DIFF
--- a/Plugins/Gource/GourcePlugin.cs
+++ b/Plugins/Gource/GourcePlugin.cs
@@ -119,7 +119,7 @@ namespace Gource
                 Settings.SetValue(_gourcePath.Name, gourceStart.PathToGource, s => s);
             }
 
-            return true;
+            return false;
         }
 
         #endregion

--- a/Plugins/Gource/GourceStart.cs
+++ b/Plugins/Gource/GourceStart.cs
@@ -114,7 +114,7 @@ namespace Gource
                 try
                 {
                     var image = await AvatarService.Default.GetAvatarAsync(author.email, author.name, imageSize: 90);
-                    var filePath = Path.Combine(gourceAvatarsDir, author + ".png");
+                    var filePath = Path.Combine(gourceAvatarsDir, author.name + ".png");
                     image.Save(filePath, ImageFormat.Png);
                 }
                 catch

--- a/Plugins/Gource/GourceStart.cs
+++ b/Plugins/Gource/GourceStart.cs
@@ -114,7 +114,14 @@ namespace Gource
                 try
                 {
                     var image = await AvatarService.Default.GetAvatarAsync(author.email, author.name, imageSize: 90);
-                    var filePath = Path.Combine(gourceAvatarsDir, author.name + ".png");
+                    var filename = author.name + ".png";
+
+                    if (filename.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+                    {
+                        return;
+                    }
+
+                    var filePath = Path.Combine(gourceAvatarsDir, filename);
                     image.Save(filePath, ImageFormat.Png);
                 }
                 catch


### PR DESCRIPTION
by generating the avatars in the expected format by Gource:
i.e. `authorname.png`

The previously generated file were not found by Gource...

From [Gource documentation](https://github.com/acaudwell/Gource/blob/master/README):

```
    --user-image-dir DIRECTORY
            Directory containing .jpg or .png images of users
            (eg "Full Name.png") to use as avatars.
```

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/87361306-32582a00-c56c-11ea-8c11-413da2417e22.png)


### After

![image](https://user-images.githubusercontent.com/460196/87361536-bc07f780-c56c-11ea-8996-1891a8d125c3.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build dee83f5839711e3d365bfa5f4346f4d0673f412a
- Git 2.25.0.windows.1 (recommended: 2.25.1 or later)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4180.0
- DPI 168dpi (175% scaling)

