### PR TITLE
Release/3.4 servicing

### DIFF
--- a/GitCommands/SshPathLocator.cs
+++ b/GitCommands/SshPathLocator.cs
@@ -54,7 +54,10 @@ namespace GitCommands
 
             try
             {
-                var gitDirInfo = _fileSystem.Directory.GetParent(gitBinDirectory);
+                // gitBinDirectory will normally end with a directory separator
+                // (at least this is what AppSettings.GitBinDir ensures),
+                // but then GetParent() returns the same directory, only without the trailing separator
+                var gitDirInfo = _fileSystem.Directory.GetParent(gitBinDirectory.RemoveTrailingPathSeparator());
                 if (gitDirInfo == null)
                 {
                     return null;

--- a/GitUI/Avatars/BackupAvatarProvider.cs
+++ b/GitUI/Avatars/BackupAvatarProvider.cs
@@ -1,8 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using System.Threading.Tasks;
-using GitCommands;
 
 namespace GitUI.Avatars
 {
@@ -10,6 +9,7 @@ namespace GitUI.Avatars
     {
         private readonly IAvatarProvider _inner;
         private readonly Image _backupImage;
+        private readonly Dictionary<int, Image> _cacheBackupImage = new Dictionary<int, Image>();
 
         public BackupAvatarProvider(IAvatarProvider inner, Image backupImage)
         {
@@ -29,15 +29,36 @@ namespace GitUI.Avatars
         {
             try
             {
-                return await _inner.GetAvatarAsync(email, name, imageSize) ?? _backupImage;
+                return await _inner.GetAvatarAsync(email, name, imageSize) ?? BackupImageResized();
             }
             catch
             {
-                return _backupImage;
+                return BackupImageResized();
+            }
+
+            Image BackupImageResized()
+            {
+                lock (_cacheBackupImage)
+                {
+                    if (_cacheBackupImage.TryGetValue(imageSize, out var image))
+                    {
+                        return image;
+                    }
+
+                    var backupImageResized = (imageSize == _backupImage.Height)
+                        ? _backupImage
+                        : new Bitmap(_backupImage, new Size(imageSize, imageSize));
+                    _cacheBackupImage.Add(imageSize, backupImageResized);
+                    return backupImageResized;
+                }
             }
         }
 
         /// <inheritdoc />
-        public Task ClearCacheAsync() => _inner.ClearCacheAsync();
+        public Task ClearCacheAsync()
+        {
+            _cacheBackupImage.Clear();
+            return _inner.ClearCacheAsync();
+        }
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2152,8 +2152,8 @@ namespace GitUI.CommandsDialogs
                 case Command.GoToSuperproject: toolStripButtonLevelUp_ButtonClick(null, null); break;
                 case Command.GoToSubmodule: toolStripButtonLevelUp.ShowDropDown(); break;
                 case Command.ToggleBetweenArtificialAndHeadCommits: RevisionGrid?.ExecuteCommand(RevisionGridControl.Command.ToggleBetweenArtificialAndHeadCommits); break;
-                case Command.GoToChild: RevisionGrid?.ExecuteCommand(RevisionGridControl.Command.GoToChild); break;
-                case Command.GoToParent: RevisionGrid?.ExecuteCommand(RevisionGridControl.Command.GoToParent); break;
+                case Command.GoToChild: RestoreFileStatusListFocus(() => RevisionGrid?.ExecuteCommand(RevisionGridControl.Command.GoToChild)); break;
+                case Command.GoToParent: RestoreFileStatusListFocus(() => RevisionGrid?.ExecuteCommand(RevisionGridControl.Command.GoToParent)); break;
                 default: return base.ExecuteCommand(cmd);
             }
 
@@ -2249,6 +2249,18 @@ namespace GitUI.CommandsDialogs
                 else if (fileTree.Visible)
                 {
                     fileTree.ExecuteCommand(RevisionFileTreeControl.Command.EditFile);
+                }
+            }
+
+            void RestoreFileStatusListFocus(Action action)
+            {
+                bool restoreFocus = revisionDiff.ContainsFocus;
+
+                action();
+
+                if (restoreFocus)
+                {
+                    revisionDiff.SwitchFocus(alreadyContainedFocus: false);
                 }
             }
         }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2368,12 +2368,14 @@ namespace GitUI.CommandsDialogs
             }
 
             Dictionary<string, string> modules = stagedFiles
-                .Where(item => item.IsSubmodule)
+                .Where(item => item.IsSubmodule
+                               && Directory.Exists(_fullPathResolver.Resolve(item.Name))
+                               && configFile.ConfigSections.FirstOrDefault(section => section.GetValue("path").Trim() == item.Name)?.SubSection != null)
                 .Select(item => item.Name)
                 .ToDictionary(localPath =>
                 {
                     var submodule = configFile.ConfigSections.FirstOrDefault(section => section.GetValue("path").Trim() == localPath);
-                    return submodule?.SubSection.Trim();
+                    return submodule?.SubSection?.Trim();
                 });
 
             if (modules.Count == 0)

--- a/GitUI/CommandsDialogs/FormVerify.Designer.cs
+++ b/GitUI/CommandsDialogs/FormVerify.Designer.cs
@@ -33,13 +33,8 @@
             this.NoReflogs = new System.Windows.Forms.CheckBox();
             this.FullCheck = new System.Windows.Forms.CheckBox();
             this.Unreachable = new System.Windows.Forms.CheckBox();
-            this.mnuLostObjects = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.mnuLostObjectView = new System.Windows.Forms.ToolStripMenuItem();
-            this.mnuLostObjectsCreateTag = new System.Windows.Forms.ToolStripMenuItem();
-            this.mnuLostObjectsCreateBranch = new System.Windows.Forms.ToolStripMenuItem();
-            this.copyHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.Warnings = new System.Windows.Forms.DataGridView();
-            this.copyParentHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.columnIsLostObjectSelected = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.columnDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnType = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -47,15 +42,26 @@
             this.columnAuthor = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnHash = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnParent = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.mnuLostObjects = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.mnuLostObjectView = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuLostObjectsCreateTag = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuLostObjectsCreateBranch = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyParentHashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fileViewer = new GitUI.Editor.FileViewer();
             panel1 = new System.Windows.Forms.Panel();
             panel2 = new System.Windows.Forms.Panel();
             flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             panel1.SuspendLayout();
             panel2.SuspendLayout();
             flowLayoutPanel1.SuspendLayout();
-            this.mnuLostObjects.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.Warnings)).BeginInit();
+            this.mnuLostObjects.SuspendLayout();
             this.SuspendLayout();
             // 
             // panel1
@@ -151,7 +157,7 @@
             flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
             flowLayoutPanel1.Name = "flowLayoutPanel1";
             flowLayoutPanel1.Padding = new System.Windows.Forms.Padding(5);
-            flowLayoutPanel1.Size = new System.Drawing.Size(322, 134);
+            flowLayoutPanel1.Size = new System.Drawing.Size(318, 134);
             flowLayoutPanel1.TabIndex = 13;
             // 
             // label2
@@ -159,7 +165,7 @@
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(8, 5);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(306, 91);
+            this.label2.Size = new System.Drawing.Size(302, 91);
             this.label2.TabIndex = 15;
             this.label2.Text = resources.GetString("label2.Text");
             // 
@@ -169,7 +175,7 @@
             this.label1.Location = new System.Drawing.Point(8, 101);
             this.label1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(177, 13);
+            this.label1.Size = new System.Drawing.Size(179, 13);
             this.label1.TabIndex = 16;
             this.label1.Text = "Double-click on a row for quick view";
             // 
@@ -178,7 +184,7 @@
             this.ShowOtherObjects.AutoSize = true;
             this.ShowOtherObjects.Location = new System.Drawing.Point(588, 9);
             this.ShowOtherObjects.Name = "ShowOtherObjects";
-            this.ShowOtherObjects.Size = new System.Drawing.Size(119, 17);
+            this.ShowOtherObjects.Size = new System.Drawing.Size(117, 17);
             this.ShowOtherObjects.TabIndex = 0;
             this.ShowOtherObjects.Text = "Show other objects";
             this.ShowOtherObjects.UseVisualStyleBackColor = true;
@@ -204,7 +210,7 @@
             this.NoReflogs.CheckState = System.Windows.Forms.CheckState.Checked;
             this.NoReflogs.Location = new System.Drawing.Point(430, 35);
             this.NoReflogs.Name = "NoReflogs";
-            this.NoReflogs.Size = new System.Drawing.Size(345, 30);
+            this.NoReflogs.Size = new System.Drawing.Size(335, 30);
             this.NoReflogs.TabIndex = 1;
             this.NoReflogs.Text = "Do not consider commits that are referenced only by an entry in a \r\nreflog to be " +
     "reachable.";
@@ -216,7 +222,7 @@
             this.FullCheck.AutoSize = true;
             this.FullCheck.Location = new System.Drawing.Point(430, 101);
             this.FullCheck.Name = "FullCheck";
-            this.FullCheck.Size = new System.Drawing.Size(376, 30);
+            this.FullCheck.Size = new System.Drawing.Size(382, 30);
             this.FullCheck.TabIndex = 3;
             this.FullCheck.Text = "Check not just objects in GIT_OBJECT_DIRECTORY ($GIT_DIR/objects), \r\nbut also the" +
     " ones found in alternate object pools.\r\n";
@@ -228,59 +234,31 @@
             this.Unreachable.AutoSize = true;
             this.Unreachable.Location = new System.Drawing.Point(430, 68);
             this.Unreachable.Name = "Unreachable";
-            this.Unreachable.Size = new System.Drawing.Size(403, 30);
+            this.Unreachable.Size = new System.Drawing.Size(383, 30);
             this.Unreachable.TabIndex = 2;
             this.Unreachable.Text = "Print out objects that exist but that aren\'t readable from any of the reference \r" +
     "\nnodes.\r\n";
             this.Unreachable.UseVisualStyleBackColor = true;
             this.Unreachable.CheckedChanged += new System.EventHandler(this.UnreachableCheckedChanged);
             // 
-            // mnuLostObjects
+            // splitContainer1
             // 
-            this.mnuLostObjects.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.mnuLostObjectView,
-            this.mnuLostObjectsCreateTag,
-            this.mnuLostObjectsCreateBranch,
-            this.copyHashToolStripMenuItem,
-            this.copyParentHashToolStripMenuItem,
-            this.saveAsToolStripMenuItem});
-            this.mnuLostObjects.Name = "mnuLostObjects";
-            this.mnuLostObjects.Size = new System.Drawing.Size(190, 114);
-            this.mnuLostObjects.Opening += new System.ComponentModel.CancelEventHandler(this.mnuLostObjects_Opening);
+            this.splitContainer1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.splitContainer1.Location = new System.Drawing.Point(0, 134);
+            this.splitContainer1.Name = "splitContainer1";
             // 
-            // mnuLostObjectView
+            // splitContainer1.Panel1
             // 
-            this.mnuLostObjectView.Image = global::GitUI.Properties.Images.ViewFile;
-            this.mnuLostObjectView.Name = "mnuLostObjectView";
-            this.mnuLostObjectView.Size = new System.Drawing.Size(189, 22);
-            this.mnuLostObjectView.Text = "View";
-            this.mnuLostObjectView.Click += new System.EventHandler(this.mnuLostObjectView_Click);
+            this.splitContainer1.Panel1.Controls.Add(this.Warnings);
             // 
-            // mnuLostObjectsCreateTag
+            // splitContainer1.Panel2
             // 
-            this.mnuLostObjectsCreateTag.Image = global::GitUI.Properties.Images.TagCreate;
-            this.mnuLostObjectsCreateTag.Name = "mnuLostObjectsCreateTag";
-            this.mnuLostObjectsCreateTag.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.T)));
-            this.mnuLostObjectsCreateTag.Size = new System.Drawing.Size(189, 22);
-            this.mnuLostObjectsCreateTag.Text = "Create tag";
-            this.mnuLostObjectsCreateTag.Click += new System.EventHandler(this.mnuLostObjectsCreateTag_Click);
-            // 
-            // mnuLostObjectsCreateBranch
-            // 
-            this.mnuLostObjectsCreateBranch.Image = global::GitUI.Properties.Images.BranchCreate;
-            this.mnuLostObjectsCreateBranch.Name = "mnuLostObjectsCreateBranch";
-            this.mnuLostObjectsCreateBranch.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.B)));
-            this.mnuLostObjectsCreateBranch.Size = new System.Drawing.Size(189, 22);
-            this.mnuLostObjectsCreateBranch.Text = "Create branch";
-            this.mnuLostObjectsCreateBranch.Click += new System.EventHandler(this.mnuLostObjectsCreateBranch_Click);
-            // 
-            // copyHashToolStripMenuItem
-            // 
-            this.copyHashToolStripMenuItem.Image = global::GitUI.Properties.Images.CopyToClipboard;
-            this.copyHashToolStripMenuItem.Name = "copyHashToolStripMenuItem";
-            this.copyHashToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
-            this.copyHashToolStripMenuItem.Text = "Copy object hash";
-            this.copyHashToolStripMenuItem.Click += new System.EventHandler(this.copyHashToolStripMenuItem_Click);
+            this.splitContainer1.Panel2.Controls.Add(this.fileViewer);
+            this.splitContainer1.Size = new System.Drawing.Size(859, 374);
+            this.splitContainer1.SplitterDistance = 700;
+            this.splitContainer1.TabIndex = 17;
             // 
             // Warnings
             // 
@@ -300,26 +278,19 @@
             this.columnParent});
             this.Warnings.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Warnings.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnEnter;
-            this.Warnings.Location = new System.Drawing.Point(0, 134);
+            this.Warnings.Location = new System.Drawing.Point(0, 0);
             this.Warnings.MultiSelect = false;
             this.Warnings.Name = "Warnings";
             this.Warnings.RowHeadersVisible = false;
             this.Warnings.RowTemplate.ContextMenuStrip = this.mnuLostObjects;
             this.Warnings.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             this.Warnings.ShowEditingIcon = false;
-            this.Warnings.Size = new System.Drawing.Size(859, 380);
+            this.Warnings.Size = new System.Drawing.Size(700, 374);
             this.Warnings.TabIndex = 4;
             this.Warnings.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.Warnings_CellMouseDoubleClick);
             this.Warnings.CellMouseDown += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.Warnings_CellMouseDown);
+            this.Warnings.SelectionChanged += new System.EventHandler(this.Warnings_SelectionChanged);
             this.Warnings.KeyDown += new System.Windows.Forms.KeyEventHandler(this.Warnings_KeyDown);
-            // 
-            // copyParentHashToolStripMenuItem
-            // 
-            this.copyParentHashToolStripMenuItem.Image = global::GitUI.Properties.Images.CopyToClipboard;
-            this.copyParentHashToolStripMenuItem.Name = "copyParentHashToolStripMenuItem";
-            this.copyParentHashToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
-            this.copyParentHashToolStripMenuItem.Text = "Copy parent hash";
-            this.copyParentHashToolStripMenuItem.Click += new System.EventHandler(this.copyParentHashToolStripMenuItem_Click);
             // 
             // columnIsLostObjectSelected
             // 
@@ -373,6 +344,61 @@
             this.columnParent.Name = "columnParent";
             this.columnParent.ReadOnly = true;
             // 
+            // mnuLostObjects
+            // 
+            this.mnuLostObjects.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.mnuLostObjectView,
+            this.mnuLostObjectsCreateTag,
+            this.mnuLostObjectsCreateBranch,
+            this.copyHashToolStripMenuItem,
+            this.copyParentHashToolStripMenuItem,
+            this.saveAsToolStripMenuItem});
+            this.mnuLostObjects.Name = "mnuLostObjects";
+            this.mnuLostObjects.Size = new System.Drawing.Size(190, 136);
+            this.mnuLostObjects.Opening += new System.ComponentModel.CancelEventHandler(this.mnuLostObjects_Opening);
+            // 
+            // mnuLostObjectView
+            // 
+            this.mnuLostObjectView.Image = global::GitUI.Properties.Images.ViewFile;
+            this.mnuLostObjectView.Name = "mnuLostObjectView";
+            this.mnuLostObjectView.Size = new System.Drawing.Size(189, 22);
+            this.mnuLostObjectView.Text = "View";
+            this.mnuLostObjectView.Click += new System.EventHandler(this.mnuLostObjectView_Click);
+            // 
+            // mnuLostObjectsCreateTag
+            // 
+            this.mnuLostObjectsCreateTag.Image = global::GitUI.Properties.Images.TagCreate;
+            this.mnuLostObjectsCreateTag.Name = "mnuLostObjectsCreateTag";
+            this.mnuLostObjectsCreateTag.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.T)));
+            this.mnuLostObjectsCreateTag.Size = new System.Drawing.Size(189, 22);
+            this.mnuLostObjectsCreateTag.Text = "Create tag";
+            this.mnuLostObjectsCreateTag.Click += new System.EventHandler(this.mnuLostObjectsCreateTag_Click);
+            // 
+            // mnuLostObjectsCreateBranch
+            // 
+            this.mnuLostObjectsCreateBranch.Image = global::GitUI.Properties.Images.BranchCreate;
+            this.mnuLostObjectsCreateBranch.Name = "mnuLostObjectsCreateBranch";
+            this.mnuLostObjectsCreateBranch.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.B)));
+            this.mnuLostObjectsCreateBranch.Size = new System.Drawing.Size(189, 22);
+            this.mnuLostObjectsCreateBranch.Text = "Create branch";
+            this.mnuLostObjectsCreateBranch.Click += new System.EventHandler(this.mnuLostObjectsCreateBranch_Click);
+            // 
+            // copyHashToolStripMenuItem
+            // 
+            this.copyHashToolStripMenuItem.Image = global::GitUI.Properties.Images.CopyToClipboard;
+            this.copyHashToolStripMenuItem.Name = "copyHashToolStripMenuItem";
+            this.copyHashToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
+            this.copyHashToolStripMenuItem.Text = "Copy object hash";
+            this.copyHashToolStripMenuItem.Click += new System.EventHandler(this.copyHashToolStripMenuItem_Click);
+            // 
+            // copyParentHashToolStripMenuItem
+            // 
+            this.copyParentHashToolStripMenuItem.Image = global::GitUI.Properties.Images.CopyToClipboard;
+            this.copyParentHashToolStripMenuItem.Name = "copyParentHashToolStripMenuItem";
+            this.copyParentHashToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
+            this.copyParentHashToolStripMenuItem.Text = "Copy parent hash";
+            this.copyParentHashToolStripMenuItem.Click += new System.EventHandler(this.copyParentHashToolStripMenuItem_Click);
+            // 
             // saveAsToolStripMenuItem
             // 
             this.saveAsToolStripMenuItem.Image = global::GitUI.Properties.Images.SaveAs;
@@ -381,14 +407,23 @@
             this.saveAsToolStripMenuItem.Text = "Save as...";
             this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.saveAsToolStripMenuItem_Click);
             // 
+            // fileViewer
+            // 
+            this.fileViewer.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.fileViewer.Location = new System.Drawing.Point(0, 0);
+            this.fileViewer.Margin = new System.Windows.Forms.Padding(0);
+            this.fileViewer.Name = "fileViewer";
+            this.fileViewer.Size = new System.Drawing.Size(155, 374);
+            this.fileViewer.TabIndex = 0;
+            // 
             // FormVerify
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.btnCloseDialog;
             this.ClientSize = new System.Drawing.Size(859, 575);
-            this.Controls.Add(this.Warnings);
             this.Controls.Add(panel2);
+            this.Controls.Add(this.splitContainer1);
             this.Controls.Add(panel1);
             this.MinimizeBox = false;
             this.Name = "FormVerify";
@@ -400,8 +435,12 @@
             panel2.PerformLayout();
             flowLayoutPanel1.ResumeLayout(false);
             flowLayoutPanel1.PerformLayout();
-            this.mnuLostObjects.ResumeLayout(false);
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.Warnings)).EndInit();
+            this.mnuLostObjects.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -436,5 +475,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn columnParent;
         private System.Windows.Forms.CheckBox ShowOtherObjects;
         private System.Windows.Forms.ToolStripMenuItem saveAsToolStripMenuItem;
+        private System.Windows.Forms.SplitContainer splitContainer1;
+        private Editor.FileViewer fileViewer;
     }
 }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -29,6 +29,18 @@ namespace GitUI.CommandsDialogs
 
         private LostObject _previewedItem;
 
+        private static readonly Dictionary<string, string> LanguagesStartOfFile = new Dictionary<string, string>
+        {
+            { "{", "recovery.json" },
+            { "#include", "recovery.cpp" },
+            { "import", "recovery.java" },
+            { "from", "recovery.py" },
+            { "package", "recovery.go" },
+            { "#!", "recovery.sh" },
+            { "[", "recovery.ini" },
+            { "using", "recovery.cs" },
+        };
+
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormVerify()
         {
@@ -238,9 +250,33 @@ namespace GitUI.CommandsDialogs
             {
                 ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
-                    await fileViewer.ViewTextAsync("recovery", content ?? string.Empty, null);
+                    var filename = GuessFileTypeWithContent(content);
+                    await fileViewer.ViewTextAsync(filename, content ?? string.Empty, null);
                 }).FileAndForget();
             }
+        }
+
+        private static string GuessFileTypeWithContent(string content)
+        {
+            if (content.StartsWith("<"))
+            {
+                return content.Contains("<html", StringComparison.InvariantCultureIgnoreCase) ? "recovery.html" : "recovery.xml";
+            }
+
+            foreach (var pair in LanguagesStartOfFile)
+            {
+                if (content.StartsWith(pair.Key))
+                {
+                    return pair.Value;
+                }
+            }
+
+            if (content.Contains("function"))
+            {
+                return "recovery.ts";
+            }
+
+            return "recovery.txt";
         }
 
         #endregion

--- a/GitUI/CommandsDialogs/FormVerify.resx
+++ b/GitUI/CommandsDialogs/FormVerify.resx
@@ -135,9 +135,6 @@ dangling objects"
 Check commits you want to recover and press Recover button
 Context menu for additional operations</value>
   </data>
-  <metadata name="mnuLostObjects.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <metadata name="columnIsLostObjectSelected.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -158,6 +155,9 @@ Context menu for additional operations</value>
   </metadata>
   <metadata name="columnParent.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
+  </metadata>
+  <metadata name="mnuLostObjects.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>43</value>

--- a/GitUI/Infrastructure/Telemetry/DiagnosticsClient.cs
+++ b/GitUI/Infrastructure/Telemetry/DiagnosticsClient.cs
@@ -22,6 +22,7 @@ namespace GitUI.Infrastructure.Telemetry
             TelemetryConfiguration.Active.TelemetryInitializers.Add(new AppEnvironmentTelemetryInitializer());
             TelemetryConfiguration.Active.TelemetryInitializers.Add(new AppInfoTelemetryInitializer(isDirty));
             TelemetryConfiguration.Active.TelemetryInitializers.Add(new MonitorsTelemetryInitializer());
+            TelemetryConfiguration.Active.TelemetryInitializers.Add(new ThemingTelemetryInitializer());
 
             _initialized = true;
 

--- a/GitUI/Infrastructure/Telemetry/ThemingTelemetryInitializer.cs
+++ b/GitUI/Infrastructure/Telemetry/ThemingTelemetryInitializer.cs
@@ -1,0 +1,21 @@
+﻿using GitExtUtils.GitUI.Theming;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace GitUI.Infrastructure.Telemetry
+{
+    internal class ThemingTelemetryInitializer : ITelemetryInitializer
+    {
+        public void Initialize(ITelemetry telemetry)
+        {
+            var properties = telemetry.Context.GlobalProperties;
+            var themeSettings = Theming.ThemeModule.Settings;
+            properties["Theme dark"] = FlagString(themeSettings.Theme.Id.Name == "dark");
+            properties["Theme builtin"] = FlagString(themeSettings.Theme.Id.IsBuiltin);
+            properties["Theme systemstyles"] = FlagString(themeSettings.UseSystemVisualStyle);
+        }
+
+        private static string FlagString(bool value) =>
+            value ? "1" : "0";
+    }
+}

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -127,6 +127,8 @@ namespace GitFlow
         private void LoadBranches(string branchType)
         {
             cbManageType.Enabled = false;
+            btnFinish.Enabled = false;
+
             cbBranches.DataSource = new List<string> { _loading.Text };
             if (!Branches.ContainsKey(branchType))
             {
@@ -140,6 +142,8 @@ namespace GitFlow
             {
                 DisplayBranchData();
             }
+
+            btnFinish.Enabled = Branches.Any();
         }
 
         private IReadOnlyList<string> GetBranches(string typeBranch)

--- a/UnitTests/GitUI.Tests/Editor/FindAndReplaceFormTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/FindAndReplaceFormTests.cs
@@ -1,0 +1,260 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GitUI;
+using ICSharpCode.TextEditor;
+using ICSharpCode.TextEditor.Document;
+using NUnit.Framework;
+
+namespace GitUITests.Editor
+{
+    [Apartment(ApartmentState.STA)]
+    [TestFixture]
+    public class FindAndReplaceFormTests
+    {
+        private FindAndReplaceForm _findAndReplaceForm;
+        private FindAndReplaceForm.TestAccessor _testAccessor;
+        private TextEditorControl _textEditorControl;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _findAndReplaceForm = new FindAndReplaceForm();
+            _textEditorControl = new TextEditorControl();
+            _testAccessor = _findAndReplaceForm.GetTestAccessor();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _findAndReplaceForm.Dispose();
+            _textEditorControl.Dispose();
+        }
+
+        public static IEnumerable<TestCaseData> MatchCase
+        {
+            get
+            {
+                yield return new TestCaseData("line one", "one", false, new TextRange(5, 3));
+                yield return new TestCaseData("line one", "ONE", false, new TextRange(5, 3));
+                yield return new TestCaseData("line one", "one", true, new TextRange(5, 3));
+                yield return new TestCaseData("line one", "ONE", true, null);
+            }
+        }
+
+        [Test, TestCaseSource(nameof(MatchCase))]
+        public async Task FindNextAsync_match_case(string text, string searchPhrase, bool matchCase, TextRange expectedRange)
+        {
+            Arrange(text, searchPhrase, matchCase);
+
+            var actualRange = await _findAndReplaceForm.FindNextAsync(false, false, null);
+
+            AssertTextRange(expectedRange, actualRange);
+        }
+
+        public static IEnumerable<TestCaseData> MatchWholeWordOnly
+        {
+            get
+            {
+                yield return new TestCaseData("line one", "one", new TextRange(5, 3));
+                yield return new TestCaseData("line one", "on", null);
+            }
+        }
+
+        [Test, TestCaseSource(nameof(MatchWholeWordOnly))]
+        public async Task FindNextAsync_match_whole_world_only(string text, string searchPhrase, TextRange expectedRange)
+        {
+            Arrange(text, searchPhrase, matchWholeWordOnly: true);
+
+            var actualRange = await _findAndReplaceForm.FindNextAsync(false, true, null);
+
+            AssertTextRange(expectedRange, actualRange);
+        }
+
+        public static IEnumerable<TestCaseData> LoopAround
+        {
+            get
+            {
+                const string textToSearch = "line odd\r\nline even\r\nline odd";
+
+                // Search entire document, both directions
+                yield return new TestCaseData(textToSearch, "odd", false, default, default, new[]
+                {
+                    new TextRange(5, 3),
+                    new TextRange(26, 3),
+                    new TextRange(5, 3),
+                });
+
+                yield return new TestCaseData(textToSearch, "odd", true, default, default, new[]
+                {
+                    new TextRange(26, 3),
+                    new TextRange(5, 3),
+                    new TextRange(26, 3),
+                });
+
+                // Search scan region, both directions
+                yield return new TestCaseData(textToSearch, "line", false, new TextLocation(0, 1), new TextLocation(5, 2), new[]
+                {
+                    new TextRange(10, 4),
+                    new TextRange(21, 4),
+                    new TextRange(10, 4),
+                });
+
+                yield return new TestCaseData(textToSearch, "line", true, new TextLocation(0, 1), new TextLocation(5, 2), new[]
+                {
+                    new TextRange(21, 4),
+                    new TextRange(10, 4),
+                    new TextRange(21, 4),
+                });
+            }
+        }
+
+        [Test, TestCaseSource(nameof(LoopAround))]
+        public async Task FindNextAsync_should_make_a_loop_and_return_to_first_occurrence(
+            string text,
+            string searchPhrase,
+            bool searchBackwards,
+            TextLocation scanRegionStart,
+            TextLocation scanRegionEnd,
+            IEnumerable<TextRange> expectedRanges)
+        {
+            Arrange(text, searchPhrase, scanRegionStart: scanRegionStart, scanRegionEnd: scanRegionEnd);
+
+            foreach (TextRange expectedRange in expectedRanges)
+            {
+                var actualRange = await _findAndReplaceForm.FindNextAsync(false, searchBackwards, null);
+
+                AssertTextRange(expectedRange, actualRange);
+            }
+        }
+
+        [Test]
+        public async Task FindNextAsync_pressing_f3_outside_of_scan_region_should_clear_it()
+        {
+            Arrange("line one\r\nline two\r\nline three",
+                "line",
+                scanRegionStart: new TextLocation(0, 0),
+                scanRegionEnd: new TextLocation(0, 1));
+
+            var actualRange = await _findAndReplaceForm.FindNextAsync(false, false, null);
+            AssertTextRange(new TextRange(0, 4), actualRange);
+
+            // Move the caret outside of the originally selected region.
+            var newCaretPosition = new TextLocation(1, 1);
+            _textEditorControl.ActiveTextAreaControl.Caret.Position = newCaretPosition;
+
+            actualRange = await _findAndReplaceForm.FindNextAsync(true, false, null);
+            AssertTextRange(new TextRange(20, 4), actualRange);
+        }
+
+        public static IEnumerable<TestCaseData> MultiFileSearch
+        {
+            get
+            {
+                // Should find occurrences in both files
+                yield return new TestCaseData(
+                    new[] { "line one\r\nline two\r\nline three", "content one\r\ncontent two\r\ncontent three" },
+                    "two",
+                    default,
+                    default,
+                    new[] { new TextRange(15, 3), new TextRange(21, 3), new TextRange(15, 3) });
+
+                // Has scan region, should search the first file only
+                yield return new TestCaseData(
+                    new[] { "line one\r\nline two\r\nline three", "content one\r\ncontent two\r\ncontent three" },
+                    "two",
+                    new TextLocation(0, 1),
+                    new TextLocation(0, 2),
+                    new[] { new TextRange(15, 3), new TextRange(15, 3) });
+            }
+        }
+
+        [Test, TestCaseSource(nameof(MultiFileSearch))]
+        public async Task FindNextAsync_should_iterate_over_files(
+            string[] texts,
+            string searchPhrase,
+            TextLocation scanRegionStart,
+            TextLocation scanRegionEnd,
+            IEnumerable<TextRange> expectedRanges)
+        {
+            int currentIndex = 0;
+
+            bool FileLoader(bool backward, bool loop, out int index, out Task content)
+            {
+                currentIndex = (currentIndex + 1) % texts.Length;
+                index = currentIndex;
+                content = Task.CompletedTask;
+                _textEditorControl.Text = texts[currentIndex];
+
+                return true;
+            }
+
+            Arrange(texts.First(), searchPhrase, scanRegionStart: scanRegionStart, scanRegionEnd: scanRegionEnd, fileLoader: FileLoader);
+
+            foreach (TextRange expectedRange in expectedRanges)
+            {
+                var actualRange = await _findAndReplaceForm.FindNextAsync(false, false, null);
+
+                AssertTextRange(expectedRange, actualRange);
+            }
+        }
+
+        [Test]
+        public void FindAndReplaceForm_scan_region_clears_if_new_text_was_set()
+        {
+            Arrange("line 1\r\nline 2\r\nline 3", "line",
+                scanRegionStart: new TextLocation(0, 1),
+                scanRegionEnd: new TextLocation(0, 2));
+
+            Assert.IsTrue(_testAccessor.Search.HasScanRegion);
+
+            _textEditorControl.Text = "new text";
+
+            Assert.IsFalse(_testAccessor.Search.HasScanRegion);
+        }
+
+        private void Arrange(string text,
+            string searchPhrase,
+            bool matchCase = false,
+            bool matchWholeWordOnly = false,
+            TextLocation scanRegionStart = default,
+            TextLocation scanRegionEnd = default,
+            GetNextFileFnc fileLoader = null)
+        {
+            _textEditorControl.Text = text;
+            _testAccessor.SetEditor(_textEditorControl);
+            _testAccessor.TxtLookFor.Text = searchPhrase;
+            _testAccessor.ChkMatchCase.Checked = matchCase;
+            _testAccessor.ChkMatchWholeWord.Checked = matchWholeWordOnly;
+            _findAndReplaceForm.SetFileLoader(fileLoader);
+
+            if (scanRegionStart != default || scanRegionEnd != default)
+            {
+                var selection = new DefaultSelection(_textEditorControl.Document, scanRegionStart, scanRegionEnd);
+                _textEditorControl.ActiveTextAreaControl.SelectionManager.SetSelection(selection);
+                _textEditorControl.ActiveTextAreaControl.Caret.Position = scanRegionEnd;
+                _testAccessor.Search.SetScanRegion(selection);
+            }
+        }
+
+        private void AssertTextRange(TextRange expectedRange, TextRange actualRange)
+        {
+            // Assert returned value
+            Assert.That(actualRange, Is.EqualTo(expectedRange).Using(new SegmentComparer()));
+
+            if (expectedRange == null)
+            {
+                return;
+            }
+
+            // Assert text selected
+            var actualSelection = _textEditorControl.ActiveTextAreaControl.SelectionManager.SelectionCollection.Single();
+            Assert.AreEqual(expectedRange.Offset, actualSelection.Offset);
+            Assert.AreEqual(expectedRange.Length, actualSelection.Length);
+
+            // Assert caret is at the end of the found range.
+            Assert.AreEqual(expectedRange.Offset + expectedRange.Length, _textEditorControl.ActiveTextAreaControl.Caret.Offset);
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

- Fix "selection only" text search on Diff view (#7784) (cherry picked from commit 4df3fb431232f80ee51a96b87d9fb5e0322663b4)
- When `ssh.exe` is not in the path, the attempt to find it in git directory will fail, resulting in a nasty crash of the whole GitExtensions process if it is needed (an example is when downloading a patchset in Gerrit plugin). (cherry picked from commit 9a9d55d7877fd101c4b8e4f6c397d3bbb43baa07)
-  Restore FileStatusList focus after GoToChild/Parent (cherry picked from commit e889d7513e9bf8eb98c3d6a9b62c29c3dd8ccbc2)
- Disable Finish button while loading branches in GitFlow form. (#8296) (cherry picked from commit 8d628246c3e9b415467bb55af3e2a01bf26f9547)
- Track theme colors (cherry picked from commit c5c8d52723c3c7837c3ce5b1b58e8a872ae08b17)
- Resize also the backup/default avatar image and keep them in a cache. fix #8241 (cherry picked from commit 617dd7b4e964900eaa4991418ceadb436ae7b6cf)
- FormCommit: No summary  for deleted submodules (cherry picked from commit 9a79928fe6944eaad7beeaca9e75708d340e8b16)
- ConEmu 20.07.13 (cherry picked from commit 50d07e2d6722f9504b13c225bb9a019c9e39010b)
- Recovery lost objects: Add a preview panel (cherry picked from commit 32b5d02143effa298bfedbc83318303dfa1300fd)
- Enable syntax highlighting in preview panel in best effort by trying to detect the file type when displaying blobs (cherry picked from commit 36de36e8e54e89f2e81bec433bb3b7abc16442c8)
