### PR TITLE
SubmoduleTests: Setup repos once for all tests

### DIFF
--- a/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
+++ b/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
@@ -32,6 +32,12 @@ namespace CommonTestUtils
             // Don't assume global user/email
             SetDummyUserEmail(module);
 
+            // Stage operations may fail due to different line endings, so want only warning and not a fatal error
+            //
+            //  fatal: LF would be replaced by CRLF in .gitmodules
+            //         Failed to register submodule 'repo2'
+            module.GitExecutable.GetOutput(@"config core.safecrlf false");
+
             return;
 
             string GetTemporaryPath()


### PR DESCRIPTION
Fixes #8279

## Proposed changes

Setup the Git repos used in the tests only once, to speed up tests.
For me, test time goes down from 1,6 mon to 11s, about twice the time for one test. (Longer time for other users.) 
- Setup attributes for Parallelizable to disallow the individual tests in parallel

More comments in the code

I consider this to be a major hack.

## Test methodology

Tests only

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build da7659f46eed24c0d730898d8c6d0cf33d46abb2
- Git 2.27.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
