### PR TITLE
DiffTools: add 'tortoisediff' as a tool alias

### DIFF
--- a/GitCommands/DiffMergeTools/TortoiseDiff.cs
+++ b/GitCommands/DiffMergeTools/TortoiseDiff.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace GitCommands.DiffMergeTools
+{
+    /// <summary>
+    /// Alias for name 'tortoisemerge' as Git disables difftools with that name:
+    /// https://github.com/git/git/pull/471#issuecomment-660205096
+    /// </summary>
+    internal class TortoiseDiff : TortoiseGitMerge
+    {
+        /// <inheritdoc />
+        public override string Name => "tortoisediff";
+    }
+}

--- a/UnitTests/GitCommands.Tests/DiffMergeTools/RegisteredDiffMergeToolsTests.cs
+++ b/UnitTests/GitCommands.Tests/DiffMergeTools/RegisteredDiffMergeToolsTests.cs
@@ -12,7 +12,7 @@ namespace GitCommandsTests.DiffMergeTools
         {
             var tools = RegisteredDiffMergeTools.All(DiffMergeToolType.Diff);
 
-            tools.Should().BeEquivalentTo("bc", "bc3", "diffmerge", "kdiff3", "meld", "p4merge", "semanticmerge", "tortoisemerge", "vscode", "vsdiffmerge", "winmerge");
+            tools.Should().BeEquivalentTo("bc", "bc3", "diffmerge", "kdiff3", "meld", "p4merge", "semanticmerge", "tortoisediff", "tortoisemerge", "vscode", "vsdiffmerge", "winmerge");
         }
 
         [Test]
@@ -20,7 +20,7 @@ namespace GitCommandsTests.DiffMergeTools
         {
             var tools = RegisteredDiffMergeTools.All(DiffMergeToolType.Merge);
 
-            tools.Should().BeEquivalentTo("bc", "bc3", "diffmerge", "kdiff3", "meld", "p4merge", "semanticmerge", "tortoisemerge", "vscode", "vsdiffmerge", "winmerge");
+            tools.Should().BeEquivalentTo("bc", "bc3", "diffmerge", "kdiff3", "meld", "p4merge", "semanticmerge", "tortoisediff", "tortoisemerge", "vscode", "vsdiffmerge", "winmerge");
         }
     }
 }


### PR DESCRIPTION
Fixes #8332 


## Proposed changes

Add alias _tortoisediff_ for _tortoisemerge_ 
To get around Git built in handling
https://github.com/git/git/pull/471#issuecomment-660205096


## Test methodology <!-- How did you ensure quality? -->

Tests updated

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build da7659f46eed24c0d730898d8c6d0cf33d46abb2
- Git 2.27.0.windows.1
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
