### PR TITLE
Constrain child windows to monitor bounds

### DIFF
--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -109,7 +109,7 @@ namespace GitUI
 
             _needsPositionRestore = false;
 
-            var workingArea = _getScreensWorkingArea();
+            IReadOnlyList<Rectangle> workingArea = _getScreensWorkingArea();
             if (!workingArea.Any(screen => screen.IntersectsWith(position.Rect)))
             {
                 if (position.State == FormWindowState.Maximized)
@@ -133,21 +133,17 @@ namespace GitUI
 
             if (Owner is null || !windowCentred)
             {
-                var location = DpiUtil.Scale(position.Rect.Location, originalDpi: position.DeviceDpi);
+                Point calculatedLocation = DpiUtil.Scale(position.Rect.Location, originalDpi: position.DeviceDpi);
 
-                if (WindowPositionManager.FindWindowScreen(location, workingArea) is Rectangle rect)
-                {
-                    location.Y = rect.Y;
-                }
-
-                DesktopLocation = location;
+                DesktopLocation = WindowPositionManager.FitWindowOnScreen(new Rectangle(calculatedLocation, Size), workingArea);
             }
             else
             {
                 // Calculate location for modal form with parent
-                Location = new Point(
+                Point calculatedLocation = new Point(
                     Owner.Left + (Owner.Width / 2) - (Width / 2),
                     Owner.Top + (Owner.Height / 2) - (Height / 2));
+                Location = WindowPositionManager.FitWindowOnScreen(new Rectangle(calculatedLocation, Size), workingArea);
             }
 
             if (WindowState != position.State)

--- a/UnitTests/GitUI.Tests/GitExtensionsFormTests.cs
+++ b/UnitTests/GitUI.Tests/GitExtensionsFormTests.cs
@@ -149,7 +149,7 @@ namespace GitUITests
 
         [TestCase(-1000, 100, /* -1000 + (800 - 300)/2 */ -750, /* 100 + (600-200)/2 */300)]
         [TestCase(0, 0, /* 0 + (800 - 300)/2 */ 250, /* 0 + (600-200)/2 */200)]
-        [TestCase(1000, -400, /* 1000 + (800 - 300)/2 */ 1250, /* -400 + (600-200)/2 */ -200)]
+        [TestCase(1000, -400, /* falls off the screen */ 0, /* falls off the screen */ 0)]
         public void RestorePosition_should_position_window_with_Owner_set_and_CenterParent(int ownerFormTop, int ownerFormLeft, int expectFormTop, int expectedFormLeft)
         {
             if (DpiUtil.IsNonStandard)

--- a/UnitTests/GitUI.Tests/WindowPositionManagerTests.cs
+++ b/UnitTests/GitUI.Tests/WindowPositionManagerTests.cs
@@ -10,26 +10,64 @@ namespace GitUITests
     public class WindowPositionManagerTests
     {
         [Test]
-        public void FindWindowScreen_should_return_empty_rect_if_no_screen_supplied()
+        public void IsDisplayedOn10Percent_should_return_false_if_no_screen_supplied()
         {
-            WindowPositionManager.FindWindowScreen(new Point(10, 10), Array.Empty<Rectangle>()).Should().Be(Rectangle.Empty);
+            WindowPositionManagerTestAccessor.IsDisplayedOn10Percent(Rectangle.Empty, new Rectangle(1, 1, 1, 1))
+                .Should().BeFalse();
         }
 
         [Test]
-        public void FindWindowScreen_should_not_crash_if_point_in_dead_middle_between_monitors()
+        public void IsDisplayedOn10Percent_should_return_false_if_no_window_supplied()
         {
-            // imagine 3 monitors 1920x1080 positioned side-by-side, the middle monitor is the main one (0,0)
-            // the other two are positioned on the same level (Y=0)
-            // Place the point at the dead center
-            var point = new Point(960, 540);
-            var screens = new[]
-            {
-                new Rectangle(-1920, 0, 1920, 1080),
-                new Rectangle(1920, 0, 1920, 1080),
-                new Rectangle(0, 0, 1920, 1080)
-            };
+            WindowPositionManagerTestAccessor.IsDisplayedOn10Percent(new Rectangle(1, 1, 1, 1), Rectangle.Empty)
+                .Should().BeFalse();
+        }
 
-            WindowPositionManager.FindWindowScreen(point, screens).Should().Be(null);
+        [TestCase(500, 500)] // normal window
+        [TestCase(50, 50)] // less than 10% visibility
+        public void IsDisplayedOn10Percent_should_return_true_if_window_fully_fit_on_screen(int width, int height)
+        {
+            Rectangle screen = new(0, 0, 1920, 1080);
+            Rectangle window = new(0, 0, width, height);
+
+            WindowPositionManagerTestAccessor.IsDisplayedOn10Percent(screen, window)
+                .Should().BeTrue();
+        }
+
+        //// clipped on the left
+        [TestCase(-500, 100, 500, 500, false)] // less than 10% visible horizontally
+        [TestCase(-192, 100, 500, 500, true)] // 10% visible horizontally
+        //// clipped on the top
+        [TestCase(50, -50, 500, 500, false)]
+        //// clipped on the right
+        [TestCase(1727, 100, 500, 500, true)] // 10% visible horizontally, (1920 * 90% - 1)
+        [TestCase(1728, 100, 500, 500, false)] // less than 10% visible horizontally, (1920 * 90%)
+        //// clipped at the bottom
+        [TestCase(100, 971, 500, 500, true)] // 10% visible vertically, (1080 * 90% - 1)
+        [TestCase(100, 972, 500, 500, false)] // 10% visible vertically, (1080 * 90%)
+        //// clipped on both the left and right
+        [TestCase(-500, 100, 2100, 500, true)] // more than 10% visible horizontally
+        [TestCase(-2700, 100, 5000, 500, false)] // unexpected case! neither left-middle-rights points are visible
+        public void IsDisplayedOn10Percent_should_return_expected_if_window_partially_fit_on_screen(int x, int y, int width, int height, bool expected)
+        {
+            Rectangle screen = new(0, 0, 1920, 1080);
+            Rectangle window = new(x, y, width, height);
+
+            WindowPositionManagerTestAccessor.IsDisplayedOn10Percent(screen, window)
+                .Should().Be(expected);
+        }
+
+        private class WindowPositionManagerTestAccessor : TestAccessor<WindowPositionManager>
+        {
+            // Accessor for static members
+            private static readonly dynamic Static = typeof(WindowPositionManager).TestAccessor().Dynamic;
+
+            public WindowPositionManagerTestAccessor(WindowPositionManager instance)
+                : base(instance)
+            {
+            }
+
+            public static bool IsDisplayedOn10Percent(Rectangle screen, Rectangle window) => Static.IsDisplayedOn10Percent(screen, window);
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

If a parent window is at a corner of a desktop, and it is smaller than a child window, it is possible to end up in a situation where the child window is positioned outside of visible and reachable area.
Coupled with the fact that locations and dimensions of most windows get persisted this may lead to a situation where the window may become permanently inaccessible until the settings are reset.


## Proposed changes

- Constrain the window to be within the desktop bounds



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Steps to replicate:

1. Open the app at the top left corner of the desktop
2. Resize it to be smaller than a typical "Setting" dialog windows size
3. Open "Settings" dialog
4. Observe the dialog opened at negative coordinates, something like:
    ![image](https://user-images.githubusercontent.com/4403806/87893598-b7b76f00-ca83-11ea-873e-4dc5dfb49066.png)




## Test methodology <!-- How did you ensure quality? -->

- Manual

❗ **NB:** I have a single monitor and unable to test multi-monitor setup, where a secondary monitor is placed to the left or to the bottom of the main monitor. It is possible that the code need to be tweaked further to account for these cases.


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
