### PR TITLE
fix test: SaveImpl_should_throw_if_invalid_path

### DIFF
--- a/GitCommands/Settings/FileSettingsCache.cs
+++ b/GitCommands/Settings/FileSettingsCache.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.Windows.Forms;
 using GitCommands.Utils;
 
 namespace GitCommands.Settings
@@ -172,7 +171,7 @@ namespace GitCommands.Settings
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show(ex.Message, "Cannot save settings", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    throw new SaveSettingsException(ex);
                 }
 
                 _lastFileModificationDate = GetLastFileModificationUtc();
@@ -182,10 +181,9 @@ namespace GitCommands.Settings
                     _fileWatcher.EnableRaisingEvents = _canEnableFileWatcher;
                 }
             }
-            catch (IOException e)
+            catch (IOException ex)
             {
-                Debug.WriteLine(e.Message);
-                throw;
+                throw new SaveSettingsException(ex);
             }
         }
 

--- a/GitCommands/Settings/SaveSettingsException.cs
+++ b/GitCommands/Settings/SaveSettingsException.cs
@@ -1,0 +1,14 @@
+﻿#nullable enable
+
+using System;
+
+namespace GitCommands.Settings
+{
+    public class SaveSettingsException : Exception
+    {
+        public SaveSettingsException(Exception? innerException)
+            : base(message: null, innerException)
+        {
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -24,12 +24,6 @@ namespace GitUI.CommandsDialogs
         #region Translation
 
         private readonly TranslationString _cantSaveSettings = new TranslationString("Failed to save all settings");
-        private readonly TranslationString _cantFindGitMessage =
-            new TranslationString("The command to run git is not configured correct." + Environment.NewLine +
-                "You need to set the correct path to be able to use Git Extensions." + Environment.NewLine +
-                Environment.NewLine + "Do you want to set the correct command now? If not Global and Local Settings will not be saved.");
-
-        private readonly TranslationString _cantFindGitMessageCaption = new TranslationString("Incorrect path");
 
         #endregion
 
@@ -239,15 +233,6 @@ namespace GitUI.CommandsDialogs
 
         private bool Save()
         {
-            if (!CheckSettingsLogic.CanFindGitCmd())
-            {
-                if (MessageBox.Show(this, _cantFindGitMessage.Text, _cantFindGitMessageCaption.Text,
-                                     MessageBoxButtons.YesNo) == DialogResult.Yes)
-                {
-                    return false;
-                }
-            }
-
             try
             {
                 foreach (var settingsPage in SettingsPages)

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6618,15 +6618,8 @@ Do you want to use this custom merge script?</source>
         <source>Settings</source>
         <target />
       </trans-unit>
-      <trans-unit id="_cantFindGitMessage.Text">
-        <source>The command to run git is not configured correct.
-You need to set the correct path to be able to use Git Extensions.
-
-Do you want to set the correct command now? If not Global and Local Settings will not be saved.</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_cantFindGitMessageCaption.Text">
-        <source>Incorrect path</source>
+      <trans-unit id="_cantSaveSettings.Text">
+        <source>Failed to save all settings</source>
         <target />
       </trans-unit>
       <trans-unit id="buttonApply.Text">

--- a/UnitTests/GitCommands.Tests/Settings/FileSettingsCacheTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/FileSettingsCacheTests.cs
@@ -50,7 +50,6 @@ namespace GitCommandsTests.Settings
             new MockFileSettingsCache(settingsFilePath, false).GetTestAccessor().CanEnableFileWatcher.Should().BeFalse();
         }
 
-        [Ignore("Popup instead of a throw")]
         [TestCase(null)]
         [TestCase("")]
         [TestCase("C:\\" + "\t")]
@@ -58,7 +57,7 @@ namespace GitCommandsTests.Settings
         {
             var cache = new MockFileSettingsCache(settingsFilePath, false).GetTestAccessor();
             cache.SetLastModificationDate(DateTime.Now);
-            ((Action)(() => cache.SaveImpl())).Should().Throw<Exception>();
+            ((Action)(() => cache.SaveImpl())).Should().Throw<SaveSettingsException>();
         }
 
         [Test]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #


## Proposed changes

- Don't show a message box when unable to save settings to a file.
Instead raise a `SaveSettingsException` that gets handled at the UI layer, and displayed in a task dialog.
- Remove FormSettings.Save check for git
    - If git is missing the process will crash, so the check is not adding any value, but consumes cycles.
    - If git is present, running `Module.GitExecutable.GetOutput("")` is for the most part pointless.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

* ![image](https://user-images.githubusercontent.com/4403806/88477121-de444100-cf80-11ea-9f35-8e555e1d8b16.png)



## Test methodology <!-- How did you ensure quality? -->

- manual
- enabled unit tests


## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
