### PR TITLE
Better exception presentation

### DIFF
--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -98,9 +98,18 @@ namespace GitCommands
 
                 _process.Exited += OnProcessExit;
 
-                _process.Start();
+                try
+                {
+                    _process.Start();
+                    _logOperation.SetProcessId(_process.Id);
+                }
+                catch (Exception ex)
+                {
+                    Dispose();
 
-                _logOperation.SetProcessId(_process.Id);
+                    _logOperation.LogProcessEnd(ex);
+                    throw new ExternalOperationException(fileName, arguments, workDir, ex);
+                }
             }
 
             private void OnProcessExit(object sender, EventArgs eventArgs)

--- a/GitCommands/Git/ExternalOperationException.cs
+++ b/GitCommands/Git/ExternalOperationException.cs
@@ -1,0 +1,44 @@
+﻿using System;
+
+#nullable enable
+
+namespace GitCommands
+{
+    /// <summary>
+    /// Represents errors that occur during execution of an external operation,
+    /// e.g. running a git operation or launching an external process.
+    /// </summary>
+    public class ExternalOperationException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExternalOperationException"/> class with a specified parameters
+        /// and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="command">The command that led to the exception.</param>
+        /// <param name="arguments">The command arguments.</param>
+        /// <param name="workingDirectory">The working directory.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
+        public ExternalOperationException(string command, string arguments, string workingDirectory, Exception innerException)
+            : base(innerException?.Message, innerException)
+        {
+            Command = command;
+            Arguments = arguments;
+            WorkingDirectory = workingDirectory;
+        }
+
+        /// <summary>
+        /// The command that led to the exception.
+        /// </summary>
+        public string Command { get; }
+
+        /// <summary>
+        /// The command arguments.
+        /// </summary>
+        public string Arguments { get; }
+
+        /// <summary>
+        /// The working directory.
+        /// </summary>
+        public string WorkingDirectory { get; }
+    }
+}

--- a/GitCommands/Git/UserExternalOperationException.cs
+++ b/GitCommands/Git/UserExternalOperationException.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-#nullable enable
+﻿#nullable enable
 
 namespace GitCommands
 {
@@ -13,13 +11,14 @@ namespace GitCommands
         /// Initializes a new instance of the <see cref="UserExternalOperationException"/> class with a specified parameters
         /// and a reference to the inner exception that is the cause of this exception.
         /// </summary>
-        /// <param name="command">The command that led to the exception.</param>
-        /// <param name="arguments">The command arguments.</param>
-        /// <param name="workingDirectory">The working directory.</param>
+        /// <param name="context">The command that led to the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception.</param>
-        public UserExternalOperationException(string command, string arguments, string workingDirectory, Exception innerException)
-            : base(command, arguments, workingDirectory, innerException)
+        public UserExternalOperationException(string context, ExternalOperationException innerException)
+            : base(innerException.Command, innerException.Arguments, innerException.WorkingDirectory, innerException.InnerException)
         {
+            Context = context;
         }
+
+        public string Context { get; }
     }
 }

--- a/GitCommands/Git/UserExternalOperationException.cs
+++ b/GitCommands/Git/UserExternalOperationException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+#nullable enable
+
+namespace GitCommands
+{
+    /// <summary>
+    /// Represents errors that occur during execution of user-configured operation, e.g. a script.
+    /// </summary>
+    public class UserExternalOperationException : ExternalOperationException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserExternalOperationException"/> class with a specified parameters
+        /// and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="command">The command that led to the exception.</param>
+        /// <param name="arguments">The command arguments.</param>
+        /// <param name="workingDirectory">The working directory.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
+        public UserExternalOperationException(string command, string arguments, string workingDirectory, Exception innerException)
+            : base(command, arguments, workingDirectory, innerException)
+        {
+        }
+    }
+}

--- a/GitUI/MessageBoxes.cs
+++ b/GitUI/MessageBoxes.cs
@@ -56,10 +56,6 @@ namespace GitUI
 
         private static MessageBoxes Instance => instance ?? (instance = new MessageBoxes());
 
-        public static void FailedToExecuteScript(IWin32Window owner, string scriptKey, Exception ex)
-            => ShowError(owner, $"{Instance._failedToExecuteScript.Text} {scriptKey.Quote()}.{Environment.NewLine}"
-                                + $"{Instance._reason.Text}: {ex.Message}");
-
         public static void FailedToRunShell(IWin32Window owner, string shell, Exception ex)
             => ShowError(owner, $"{Instance._failedToRunShell.Text} {shell.Quote()}.{Environment.NewLine}"
                                 + $"{Instance._reason.Text}: {ex.Message}");

--- a/GitUI/NBugReports/BugReportForm.cs
+++ b/GitUI/NBugReports/BugReportForm.cs
@@ -71,7 +71,7 @@ Send report anyway?");
             mainTabs.TabPages.Remove(mainTabs.TabPages["reportContentsTabPage"]);
         }
 
-        public DialogResult ShowDialog(Exception exception, string environmentInfo)
+        public DialogResult ShowDialog(IWin32Window owner, Exception exception, string environmentInfo)
         {
             _lastException = new SerializableException(exception);
             _lastReport = new Report(_lastException);
@@ -95,7 +95,7 @@ Send report anyway?");
             DialogResult = DialogResult.None;
 
             // ToDo: Fill in the 'Report Contents' tab);
-            var result = ShowDialog();
+            var result = ShowDialog(owner);
 
             // Write back the user description (as we passed 'report' as a reference since it is a reference object anyway)
             _lastReport.GeneralInfo.UserDescription = descriptionTextBox.Text;

--- a/GitUI/NBugReports/BugReporter.cs
+++ b/GitUI/NBugReports/BugReporter.cs
@@ -22,7 +22,10 @@ namespace GitExtensions
             StringBuilder sb = new StringBuilder();
 
             // Command: <command>
-            sb.AppendLine($"{Strings.Command}: {ex.Command}");
+            if (!string.IsNullOrWhiteSpace(ex.Command))
+            {
+                sb.AppendLine($"{Strings.Command}: {ex.Command}");
+            }
 
             // Arguments: <args>
             if (!string.IsNullOrWhiteSpace(ex.Arguments))
@@ -113,14 +116,11 @@ namespace GitExtensions
 
         private static void ReportUserException(UserExternalOperationException ex, bool isTerminating)
         {
-            // UserExternalOperationException wraps an actual exception, but be cautious just in case
-            string instructionText = ex.InnerException?.Message ?? Strings.InstructionOperationFailed;
-
             using var dialog = new TaskDialog
             {
                 OwnerWindowHandle = OwnerFormHandle,
                 Text = FormatText(ex, canRaiseBug: false),
-                InstructionText = instructionText,
+                InstructionText = ex.Context,
                 Caption = Strings.CaptionFailedExecute,
                 Icon = TaskDialogStandardIcon.Error,
                 Cancelable = true,

--- a/GitUI/NBugReports/BugReporter.cs
+++ b/GitUI/NBugReports/BugReporter.cs
@@ -1,0 +1,152 @@
+﻿#nullable enable
+
+using System;
+using System.Text;
+using System.Windows.Forms;
+using GitCommands;
+using GitUI;
+using Microsoft.WindowsAPICodePack.Dialogs;
+
+namespace GitExtensions
+{
+    public static class BugReporter
+    {
+        private static Form? OwnerForm
+            => Form.ActiveForm ?? (Application.OpenForms.Count > 0 ? Application.OpenForms[0] : null);
+
+        private static IntPtr OwnerFormHandle
+            => OwnerForm?.Handle ?? IntPtr.Zero;
+
+        private static string FormatText(ExternalOperationException ex, bool canRaiseBug)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            // Command: <command>
+            sb.AppendLine($"{Strings.Command}: {ex.Command}");
+
+            // Arguments: <args>
+            if (!string.IsNullOrWhiteSpace(ex.Arguments))
+            {
+                sb.AppendLine($"{Strings.Arguments}: {ex.Arguments}");
+            }
+
+            // Working directory: <working dir>
+            sb.AppendLine($"{Strings.WorkingDirectory}: {ex.WorkingDirectory}");
+
+            if (canRaiseBug)
+            {
+                // Directions to raise a bug
+                sb.AppendLine();
+                sb.AppendLine(Strings.ReportBug);
+            }
+
+            return sb.ToString();
+        }
+
+        public static void Report(Exception ex, bool isTerminating)
+        {
+            if (ex is UserExternalOperationException userExternalException)
+            {
+                // Something happened that was likely caused by the user
+                ReportUserException(userExternalException, isTerminating);
+                return;
+            }
+
+            if (ex is ExternalOperationException externalException)
+            {
+                // Something happened either in the app - can submit the bug to GitHub
+                ReportAppException(externalException, isTerminating);
+                return;
+            }
+
+            // Report any other exceptions
+            ReportGenericException(ex, isTerminating);
+        }
+
+        private static void ReportAppException(ExternalOperationException ex, bool isTerminating)
+        {
+            // UserExternalOperationException wraps an actual exception, but be cautious just in case
+            string instructionText = ex.InnerException?.Message ?? Strings.InstructionOperationFailed;
+
+            ReportException(FormatText(ex, canRaiseBug: true), instructionText, ex, isTerminating);
+        }
+
+        private static void ReportException(string text, string instructionText, Exception ex, bool isTerminating)
+        {
+            using var dialog = new TaskDialog
+            {
+                OwnerWindowHandle = OwnerFormHandle,
+                Text = text,
+                InstructionText = instructionText,
+                Caption = Strings.Error,
+                Icon = TaskDialogStandardIcon.Error,
+                Cancelable = true,
+            };
+            var btnReport = new TaskDialogCommandLink("Report", Strings.ButtonReportBug);
+            btnReport.Click += (s, e) =>
+            {
+                dialog.Close();
+                ShowNBug(OwnerForm, ex, isTerminating);
+            };
+            var btnIgnoreOrClose = new TaskDialogCommandLink("IgnoreOrClose", isTerminating ? Strings.ButtonCloseApp : Strings.ButtonIgnore);
+            btnIgnoreOrClose.Click += (s, e) =>
+            {
+                dialog.Close();
+            };
+            dialog.Controls.Add(btnReport);
+            dialog.Controls.Add(btnIgnoreOrClose);
+
+            dialog.Show();
+        }
+
+        private static void ReportGenericException(Exception ex, bool isTerminating)
+        {
+            // This exception is arbitrary, see if there's additional information
+            string? moreInfo = ex.InnerException?.Message;
+            if (moreInfo != null)
+            {
+                moreInfo += Environment.NewLine + Environment.NewLine;
+            }
+
+            ReportException($"{moreInfo}{Strings.ReportBug}", ex.Message, ex, isTerminating);
+        }
+
+        private static void ReportUserException(UserExternalOperationException ex, bool isTerminating)
+        {
+            // UserExternalOperationException wraps an actual exception, but be cautious just in case
+            string instructionText = ex.InnerException?.Message ?? Strings.InstructionOperationFailed;
+
+            using var dialog = new TaskDialog
+            {
+                OwnerWindowHandle = OwnerFormHandle,
+                Text = FormatText(ex, canRaiseBug: false),
+                InstructionText = instructionText,
+                Caption = Strings.CaptionFailedExecute,
+                Icon = TaskDialogStandardIcon.Error,
+                Cancelable = true,
+            };
+            var btnIgnoreOrClose = new TaskDialogCommandLink("IgnoreOrClose", isTerminating ? Strings.ButtonCloseApp : Strings.ButtonIgnore);
+            btnIgnoreOrClose.Click += (s, e) =>
+            {
+                dialog.Close();
+            };
+            dialog.Controls.Add(btnIgnoreOrClose);
+
+            dialog.Show();
+        }
+
+        private static void ShowNBug(IWin32Window? owner, Exception ex, bool isTerminating)
+        {
+            var envInfo = UserEnvironmentInformation.GetInformation();
+
+            using (var form = new GitUI.NBugReports.BugReportForm())
+            {
+                var result = form.ShowDialog(owner, ex, envInfo);
+                if (isTerminating || result == DialogResult.Abort)
+                {
+                    Environment.Exit(-1);
+                }
+            }
+        }
+    }
+}

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -37,10 +37,9 @@ namespace GitUI.Script
                 return RunScript(owner, module, scriptKey, uiCommands, revisionGrid,
                     msg => MessageBox.Show(owner, msg, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error));
             }
-            catch (Exception ex)
+            catch (ExternalOperationException ex)
             {
-                MessageBoxes.FailedToExecuteScript(owner, scriptKey, ex);
-                return new CommandStatus(false, false);
+                throw new UserExternalOperationException(ex.Command, ex.Arguments, ex.WorkingDirectory, ex.InnerException ?? ex);
             }
         }
 

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -54,7 +54,7 @@ namespace GitUI.Script
             var scriptInfo = ScriptManager.GetScript(scriptKey);
             if (scriptInfo is null)
             {
-                showError("Cannot find script: " + scriptKey);
+                showError($"{Strings.ScriptErrorCantFind}: '{scriptKey}'");
                 return false;
             }
 
@@ -71,12 +71,14 @@ namespace GitUI.Script
                                                                         && ScriptOptionsParser.Contains(arguments, option));
                 if (optionDependingOnSelectedRevision is object)
                 {
-                    showError($"Option {optionDependingOnSelectedRevision} is only supported when started with revision grid available.");
+                    showError($"{Strings.ScriptText}: '{scriptKey}'{Environment.NewLine}'{optionDependingOnSelectedRevision}' {Strings.ScriptErrorOptionWithoutRevisionGridText}");
                     return false;
                 }
             }
 
-            if (scriptInfo.AskConfirmation && MessageBox.Show(owner, $"Do you want to execute '{scriptInfo.Name}'?", "Script", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
+            if (scriptInfo.AskConfirmation &&
+                MessageBox.Show(owner, $"{Strings.ScriptConfirmExecute}: '{scriptInfo.Name}'?", Strings.ScriptText,
+                                MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
             {
                 return false;
             }
@@ -85,7 +87,7 @@ namespace GitUI.Script
             (string argument, bool abort) = ScriptOptionsParser.Parse(scriptInfo.Arguments, module, owner, revisionGrid);
             if (abort)
             {
-                showError($"There must be a revision in order to substitute the argument option(s) for the script to run.");
+                showError($"{Strings.ScriptText}: '{scriptKey}'{Environment.NewLine}{Strings.ScriptErrorOptionWithoutRevisionText}");
                 return false;
             }
 
@@ -103,7 +105,7 @@ namespace GitUI.Script
 
             if (command.StartsWith(PluginPrefix))
             {
-                command = command.Replace(PluginPrefix, "");
+                command = command.Replace(PluginPrefix, string.Empty);
 
                 lock (PluginRegistry.Plugins)
                 {

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -15,7 +15,13 @@ namespace GitUI
 
         private readonly TranslationString _buttonCheckoutBranch = new TranslationString("Checkout branch");
         private readonly TranslationString _buttonContinue = new TranslationString("Continue");
+        private readonly TranslationString _buttonCloseApp = new TranslationString("Close application");
         private readonly TranslationString _buttonCreateBranch = new TranslationString("Create branch");
+        private readonly TranslationString _buttonIgnore = new TranslationString("Ignore");
+        private readonly TranslationString _buttonReportBug = new TranslationString("Report bug!");
+
+        private readonly TranslationString _captionFailedExecute = new TranslationString("Failed to execute");
+        private readonly TranslationString _instructionOperationFailed = new TranslationString("Operation failed");
 
         private readonly TranslationString _containedInCurrentCommitText = new TranslationString("'{0}' is contained in the currently selected commit");
         private readonly TranslationString _containedInBranchesText = new TranslationString("Contained in branches:");
@@ -86,6 +92,11 @@ namespace GitUI
 
         private readonly TranslationString _rotInactive = new TranslationString("[ Inactive ]");
 
+        private readonly TranslationString _argumentsText = new TranslationString("Arguments");
+        private readonly TranslationString _commandText = new TranslationString("Command");
+        private readonly TranslationString _workingDirectoryText = new TranslationString("Working directory");
+        private readonly TranslationString _reportBugText = new TranslationString("If you think this was caused by Git Extensions, you can report a bug for the team to investigate.");
+
         // public only because of FormTranslate
         public Strings()
         {
@@ -111,7 +122,13 @@ namespace GitUI
 
         public static string ButtonContinue => _instance.Value._buttonContinue.Text;
         public static string ButtonCheckoutBranch => _instance.Value._buttonCheckoutBranch.Text;
+        public static string ButtonCloseApp => _instance.Value._buttonCloseApp.Text;
         public static string ButtonCreateBranch => _instance.Value._buttonCreateBranch.Text;
+        public static string ButtonIgnore => _instance.Value._buttonIgnore.Text;
+        public static string ButtonReportBug => _instance.Value._buttonReportBug.Text;
+
+        public static string CaptionFailedExecute => _instance.Value._captionFailedExecute.Text;
+        public static string InstructionOperationFailed => _instance.Value._instructionOperationFailed.Text;
 
         public static string ContainedInCurrentCommit => _instance.Value._containedInCurrentCommitText.Text;
         public static string ContainedInBranches => _instance.Value._containedInBranchesText.Text;
@@ -177,5 +194,10 @@ namespace GitUI
         public static string ShowDiffForAllParentsTooltip => _instance.Value._showDiffForAllParentsTooltip.Text;
 
         public static string Inactive => _instance.Value._rotInactive.Text;
+
+        public static string Arguments => _instance.Value._argumentsText.Text;
+        public static string Command => _instance.Value._commandText.Text;
+        public static string WorkingDirectory => _instance.Value._workingDirectoryText.Text;
+        public static string ReportBug => _instance.Value._reportBugText.Text;
     }
 }

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -199,5 +199,23 @@ namespace GitUI
         public static string Command => _instance.Value._commandText.Text;
         public static string WorkingDirectory => _instance.Value._workingDirectoryText.Text;
         public static string ReportBug => _instance.Value._reportBugText.Text;
+
+        #region Scripts
+
+        private readonly TranslationString _scriptConfirmExecuteText = new TranslationString("Do you want to execute script");
+        private readonly TranslationString _scriptErrorCantFindText = new TranslationString("Unable to find script");
+        private readonly TranslationString _scriptErrorFailedToExecuteText = new TranslationString("Failed to execute script");
+        private readonly TranslationString _scriptErrorOptionWithoutRevisionGridText = new TranslationString("option is only supported when invoked from the revision grid");
+        private readonly TranslationString _scriptErrorOptionWithoutRevisionText = new TranslationString("A valid revision is required to substitute the argument options");
+        private readonly TranslationString _scriptText = new TranslationString("Script");
+
+        public static string ScriptConfirmExecute => _instance.Value._scriptConfirmExecuteText.Text;
+        public static string ScriptErrorCantFind => _instance.Value._scriptErrorCantFindText.Text;
+        public static string ScriptErrorFailedToExecute => _instance.Value._scriptErrorFailedToExecuteText.Text;
+        public static string ScriptErrorOptionWithoutRevisionGridText => _instance.Value._scriptErrorOptionWithoutRevisionGridText.Text;
+        public static string ScriptErrorOptionWithoutRevisionText => _instance.Value._scriptErrorOptionWithoutRevisionText.Text;
+        public static string ScriptText => _instance.Value._scriptText.Text;
+
+        #endregion
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9230,6 +9230,10 @@ When OpenSSH is used, command line dialogs are shown!
   </file>
   <file datatype="plaintext" original="Strings" source-language="en">
     <body>
+      <trans-unit id="_argumentsText.Text">
+        <source>Arguments</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_authorDateText.Text">
         <source>{0:Author date|Author dates}</source>
         <target />
@@ -9265,6 +9269,10 @@ Select this commit to populate the full message.</source>
         <source>Checkout branch</source>
         <target />
       </trans-unit>
+      <trans-unit id="_buttonCloseApp.Text">
+        <source>Close application</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_buttonContinue.Text">
         <source>Continue</source>
         <target />
@@ -9273,8 +9281,20 @@ Select this commit to populate the full message.</source>
         <source>Create branch</source>
         <target />
       </trans-unit>
+      <trans-unit id="_buttonIgnore.Text">
+        <source>Ignore</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_buttonReportBug.Text">
+        <source>Report bug!</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_cancelText.Text">
         <source>Cancel</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_captionFailedExecute.Text">
+        <source>Failed to execute</source>
         <target />
       </trans-unit>
       <trans-unit id="_childrenText.Text">
@@ -9283,6 +9303,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_combinedDiff.Text">
         <source>Combined diff</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_commandText.Text">
+        <source>Command</source>
         <target />
       </trans-unit>
       <trans-unit id="_commitDateText.Text">
@@ -9413,6 +9437,10 @@ Select this commit to populate the full message.</source>
         <source>Install git...</source>
         <target />
       </trans-unit>
+      <trans-unit id="_instructionOperationFailed.Text">
+        <source>Operation failed</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_invisibleCommitText.Text">
         <source>'{0}' is not currently visible</source>
         <target />
@@ -9501,6 +9529,10 @@ Select this commit to populate the full message.</source>
         <source>Remove the selected invalid repository</source>
         <target />
       </trans-unit>
+      <trans-unit id="_reportBugText.Text">
+        <source>If you think this was caused by Git Extensions, you can report a bug for the team to investigate.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_rotInactive.Text">
         <source>[ Inactive ]</source>
         <target />
@@ -9581,6 +9613,10 @@ Yes, I allow telemetry!</source>
       </trans-unit>
       <trans-unit id="_weeksAgo.Text">
         <source>{0} {1:week|weeks} ago</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_workingDirectoryText.Text">
+        <source>Working directory</source>
         <target />
       </trans-unit>
       <trans-unit id="_workspaceText.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9537,6 +9537,30 @@ Select this commit to populate the full message.</source>
         <source>[ Inactive ]</source>
         <target />
       </trans-unit>
+      <trans-unit id="_scriptConfirmExecuteText.Text">
+        <source>Do you want to execute script</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_scriptErrorCantFindText.Text">
+        <source>Unable to find script</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_scriptErrorFailedToExecuteText.Text">
+        <source>Failed to execute script</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_scriptErrorOptionWithoutRevisionGridText.Text">
+        <source>option is only supported when invoked from the revision grid</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_scriptErrorOptionWithoutRevisionText.Text">
+        <source>A valid revision is required to substitute the argument options</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_scriptText.Text">
+        <source>Script</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_searchingFor.Text">
         <source>Searching for: </source>
         <target />

--- a/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
@@ -128,7 +128,8 @@ namespace GitCommandsTests.Git
                     GenerateStringByLength(Math.Max(1, arg2Len - _appPath.Length - 4))
                 }, _appPath.Length + 3, maxLength);
 
-            Assert.Throws(typeof(Win32Exception), () => _gitExecutable.RunBatchCommand(args));
+            var ex = Assert.Throws<ExternalOperationException>(() => _gitExecutable.RunBatchCommand(args));
+            Assert.IsInstanceOf<Win32Exception>(ex.InnerException);
         }
 
         private string GenerateStringByLength(int length)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Contributes to #7795

## Proposed changes

Trap and route as many exceptions as possible to the central handler.

For exceptions coming from the main thread it is possible to ignore those and continue the app's execution, but for unhandled exceptions coming from background threads the app will terminate.
The main focus of this work is to intercept exceptions originated from `Executable` (i.e. executing git commands, etc.), and user scripts. However it is not limited in this scope.

- An alternative simplified proposal for https://github.com/gitextensions/gitextensions/pull/8278.





## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/85960429-9f33c780-b9a3-11ea-94fd-6a75ba5a7b8d.png)


### After

* Settings
![image](https://user-images.githubusercontent.com/4403806/101240786-92cb4c00-3745-11eb-9487-6873cef03672.png)

* Script
![image](https://user-images.githubusercontent.com/4403806/101239455-c5704700-373b-11eb-9340-f588b643c57d.png)

* An arbitrary exception (reported in https://github.com/gitextensions/gitextensions/issues/8367)
![image](https://user-images.githubusercontent.com/4403806/101237559-f9dd0680-372d-11eb-9f11-7b465dcec365.png)

* An arbitrary exception (reported in https://github.com/gitextensions/gitextensions/issues/8647)
![image](https://user-images.githubusercontent.com/4403806/101240622-96120800-3744-11eb-99a3-ab954366f204.png)
Hitting "ignore" will close the app anyway, since the repo is gone. I'm not sure what the expect UX would be in this situation...

