### PR TITLE
Optimise `FormSettings` load

### DIFF
--- a/GitUI/CommandsDialogs/FormSettings.Designer.cs
+++ b/GitUI/CommandsDialogs/FormSettings.Designer.cs
@@ -221,7 +221,6 @@ namespace GitUI.CommandsDialogs
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Settings";
-            this.Load += new System.EventHandler(this.FormSettings_Load);
             this.Shown += new System.EventHandler(this.FormSettings_Shown);
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.repositoryBindingSource)).EndInit();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Contributes to #8339


## Proposed changes



Settings dialog takes on average 4+ seconds to load and show to a user. With that the initial load is tearing the UI, which is visually unpleasant.

Few major culprits:

* HasClippedControl() - ~2.5 seconds, which is 60%+ of the observed 4 seconds.
This appears to be trying to detect whether the settings dialig fully fits on a user's screen, and, if not, reduces the current font.

* settingsTreeView.GotoPage(_initialPage) - 500-600ms on average, which deals with raising notification events, removing the currently shown control, and binding the requested page. Depending on a complexity of UI of the selected page this can take anywhere from 10ms to 1 second (or longer).

* RevisionLinksSettingsPage - on average it takes 850-900ms to create this page, which breaks down to:
    - InitializeComponent: 50-55%
    - InitializeComplete: 40%
    - everything else: 5-10%.

To speed up the load the following has been done:

* HasClippedControl() is removed. It is up to a user to set an appropriate font size. Also the current telemetry shows that there is only a very small
percent of our users (out of those who opted in to the telemetry) have monitors with resolution of less than 800px high.

* The dialog load sequence has been rearranged to:
    - build the tree and load pages upon loading the dialog (OnRuntimeLoad),
    - navigate to a selected page upon showing the diialog.

The above makes the dialog to appear slightly faster by 50% (slightly over ~2 seconds vs 4+ seconds), and slightly more responsive.

Some of the slowness is likely caused by the Windows Forms layout engine, and could be improved by migrating the .NET Core/.NET versions.
But by far and large the handling of settings and the dialog's load sequence must be rewritten to utilise lazy, on-demand and async patterns.



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
