### PR TITLE
Fixes #8348. Allow to create patch for the root commit.

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1364,7 +1364,7 @@ namespace GitCommands
                 {
                     "-M -C -B",
                     { start != null, $"--start-number {start}" },
-                    $"{from.Quote()}..{to.Quote()}",
+                    { !string.IsNullOrEmpty(from), $"{from.Quote()}..{to.Quote()}", $"--root {to.Quote()}" },
                     $"-o {output.ToPosixPath().Quote()}"
                 });
         }

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -790,6 +790,26 @@ namespace GitCommandsTests
             _gitModule.FormatPatch(from, to, outputFile, start).Should().Be(dummyCommandOutput);
         }
 
+        [TestCase(new object[] { "", "567", "output.file", null })]
+        [TestCase(new object[] { "", "567", "output.file", 1 })]
+        [TestCase(new object[] { null, "567", "output.file", 2 })]
+        public void Test_FormatPatchInRoot(string from, string to, string outputFile, int? start)
+        {
+            var arguments = new StringBuilder();
+            arguments.Append("format-patch -M -C -B");
+            if (start != null)
+            {
+                arguments.AppendFormat(" --start-number {0}", start);
+            }
+
+            arguments.AppendFormat(" --root \"{0}\" -o \"{1}\"", to, outputFile);
+
+            string dummyCommandOutput = "The answer is 42. Just check that the Git arguments are as expected.";
+
+            _executable.StageOutput(arguments.ToString(), dummyCommandOutput);
+            _gitModule.FormatPatch(from, to, outputFile, start).Should().Be(dummyCommandOutput);
+        }
+
         [TestCase(null, "")]
         [TestCase(new string[] { }, "")]
         public void ResetFiles_should_handle_empty_list(string[] files, string expectedOutput)


### PR DESCRIPTION
Fixes #8348

## Proposed changes

If base commit is not defined, use `--root` argument to create patch for root or orphaned comit.

## Test methodology <!-- How did you ensure quality? -->

- Tested on empty repository with one commit
- Tested with non root commits. Merges and single ones.
- Added additional test case for when `from` is empty.

## Test environment(s)

- GIT  2.27.0.windows.1
- Windows 10 1909

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
