### PR TITLE
Fix up splitter positions

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -584,7 +584,10 @@ namespace GitUI.CommandsDialogs
                     new WindowsThumbnailToolbarButton(toolStripButtonCommit.Text, toolStripButtonCommit.Image, CommitToolStripMenuItemClick),
                     new WindowsThumbnailToolbarButton(toolStripButtonPush.Text, toolStripButtonPush.Image, PushToolStripMenuItemClick),
                     new WindowsThumbnailToolbarButton(toolStripButtonPull.Text, toolStripButtonPull.Image, PullToolStripMenuItemClick)));
+            SetSplitterPositions();
             HideVariableMainMenuItems();
+            RefreshSplitViewLayout();
+            LayoutRevisionInfo();
             InternalInitialize(false);
 
             if (!Module.IsValidGitWorkingDir())
@@ -621,8 +624,6 @@ namespace GitUI.CommandsDialogs
 
             base.OnLoad(e);
 
-            RefreshSplitViewLayout();
-            LayoutRevisionInfo();
             SetSplitterPositions();
         }
 


### PR DESCRIPTION
#8155/fad41db6b0981a1764bb2353b651d150ee37125c by @mstv
missing in merge 5dae3022679a3b65dd6bffd0eb5054f220a67933

Fixup of 0bc3963f700ca61eb7987e37effa638e55543ff7

## Proposed changes

If starting to dashboard, then open a repo, panels and splitter positions are not restored

Fix missing patch from release/3.4 -> master
No investigation of other possibly missing patches done

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/89583138-162d6d00-d83a-11ea-9877-96c2883e6bd6.png)


### After

Window positions/panels restored, see #8155

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
