### PR TITLE
Dont refresh after `FormInit` cancels

### DIFF
--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -529,15 +529,12 @@ namespace GitUI
                     dir = Module.IsValidGitWorkingDir() ? Module.WorkingDir : string.Empty;
                 }
 
-                using (var frm = new FormInit(dir, gitModuleChanged))
-                {
-                    frm.ShowDialog(owner);
-                }
-
+                using var frm = new FormInit(dir, gitModuleChanged);
+                frm.ShowDialog(owner);
                 return true;
             }
 
-            return DoActionOnRepo(owner, Action, requiresValidWorkingDir: false);
+            return DoActionOnRepo(owner, Action, requiresValidWorkingDir: false, changesRepo: false);
         }
 
         public bool StartPullDialogAndPullImmediately(IWin32Window owner = null, string remoteBranch = null, string remote = null, AppSettings.PullAction pullAction = AppSettings.PullAction.None)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

- If user creates a new repo, we switch to the new repo. If user cancels the dialog there is no reason to refresh the current view.
- (Refactor) Increase readability and simplify callsites of `DoActionOnRepo` method - these changes are automatic.

⚠️ Review commit by commit. Can be squashed.