### PR TITLE
Filter out hidden branches

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -224,15 +224,15 @@ namespace GitUI.BranchTreePanel
         {
             _sortOrderContextMenuItem = new GitRefsSortOrderContextMenuItem(() =>
             {
-                _branchesTree.RefreshRefs();
-                _remotesTree.RefreshRefs();
-                _tagTree.RefreshRefs();
+                _branchesTree.Refresh();
+                _remotesTree.Refresh();
+                _tagTree.Refresh();
             });
             _sortByContextMenuItem = new GitRefsSortByContextMenuItem(() =>
             {
-                _branchesTree.RefreshRefs();
-                _remotesTree.RefreshRefs();
-                _tagTree.RefreshRefs();
+                _branchesTree.Refresh();
+                _remotesTree.Refresh();
+                _tagTree.Refresh();
             });
 
             _localBranchMenuItems = new LocalBranchMenuItems<LocalBranchNode>(this);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -13,6 +13,7 @@ using GitExtUtils.GitUI.Theming;
 using GitUI.CommandsDialogs;
 using GitUI.Properties;
 using GitUI.UserControls;
+using GitUI.UserControls.RevisionGrid;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using ResourceManager;
@@ -39,6 +40,7 @@ namespace GitUI.BranchTreePanel
         private FilterBranchHelper _filterBranchHelper;
         private IAheadBehindDataProvider _aheadBehindDataProvider;
         private bool _searchCriteriaChanged;
+        private ICheckRefs _refsSource;
 
         public RepoObjectsTree()
         {
@@ -225,14 +227,22 @@ namespace GitUI.BranchTreePanel
             }
         }
 
-        public void Initialize([CanBeNull] IAheadBehindDataProvider aheadBehindDataProvider, FilterBranchHelper filterBranchHelper)
+        public void Initialize([CanBeNull] IAheadBehindDataProvider aheadBehindDataProvider, FilterBranchHelper filterBranchHelper, ICheckRefs refsSource)
         {
             _aheadBehindDataProvider = aheadBehindDataProvider;
             _filterBranchHelper = filterBranchHelper;
+            _refsSource = refsSource;
 
             // This lazily sets the command source, invoking OnUICommandsSourceSet, which is required for setting up
             // notifications for each Tree.
             _ = UICommandsSource;
+        }
+
+        public void RefreshRefs(bool isFiltering)
+        {
+            _branchesTree.Refresh(isFiltering);
+            _remotesTree.Refresh(isFiltering);
+            _tagTree.Refresh(isFiltering);
         }
 
         public void SelectionChanged(IReadOnlyList<GitRevision> selectedRevisions)
@@ -310,7 +320,7 @@ namespace GitUI.BranchTreePanel
                 ImageKey = nameof(Images.BranchLocalRoot),
                 SelectedImageKey = nameof(Images.BranchLocalRoot),
             };
-            _branchesTree = new BranchTree(rootNode, UICommandsSource, _aheadBehindDataProvider);
+            _branchesTree = new BranchTree(rootNode, UICommandsSource, _aheadBehindDataProvider, _refsSource);
         }
 
         private void CreateRemotes()
@@ -321,7 +331,7 @@ namespace GitUI.BranchTreePanel
                 ImageKey = nameof(Images.BranchRemoteRoot),
                 SelectedImageKey = nameof(Images.BranchRemoteRoot),
             };
-            _remotesTree = new RemoteBranchTree(rootNode, UICommandsSource)
+            _remotesTree = new RemoteBranchTree(rootNode, UICommandsSource, _refsSource)
             {
                 TreeViewNode =
                 {
@@ -338,7 +348,7 @@ namespace GitUI.BranchTreePanel
                 ImageKey = nameof(Images.TagHorizontal),
                 SelectedImageKey = nameof(Images.TagHorizontal),
             };
-            _tagTree = new TagTree(rootNode, UICommandsSource);
+            _tagTree = new TagTree(rootNode, UICommandsSource, _refsSource);
         }
 
         private void CreateSubmodules()

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -22,6 +22,7 @@ namespace GitUI
         private readonly TranslationString _containedInNoBranchText = new TranslationString("Contained in no branch");
         private readonly TranslationString _containedInTagsText = new TranslationString("Contained in tags:");
         private readonly TranslationString _containedInNoTagText = new TranslationString("Contained in no tag");
+        private readonly TranslationString _invisibleCommitText = new TranslationString("'{0}' is not currently visible");
         private readonly TranslationString _viewPullRequest = new TranslationString("View pull requests");
         private readonly TranslationString _createPullRequest = new TranslationString("Create pull request");
         private readonly TranslationString _forkCloneRepo = new TranslationString("Fork or clone a repository");
@@ -77,6 +78,8 @@ namespace GitUI
 - For multiple selected commits (up to four), show the difference for all the first selected with the last selected commit.
 - For more than four selected commits, show the difference from the first to the last selected commit.");
 
+        private readonly TranslationString _rotInactive = new TranslationString("[ Inactive ]");
+
         // public only because of FormTranslate
         public Strings()
         {
@@ -109,6 +112,7 @@ namespace GitUI
         public static string ContainedInNoBranch => _instance.Value._containedInNoBranchText.Text;
         public static string ContainedInTags => _instance.Value._containedInTagsText.Text;
         public static string ContainedInNoTag => _instance.Value._containedInNoTagText.Text;
+        public static string InvisibleCommit => _instance.Value._invisibleCommitText.Text;
 
         public static string CreatePullRequest => _instance.Value._createPullRequest.Text;
         public static string ForkCloneRepo => _instance.Value._forkCloneRepo.Text;
@@ -160,5 +164,7 @@ namespace GitUI
         public static string DiffSelectedWithRememberedFile => _instance.Value._diffSelectedWithRememberedFile.Text;
         public static string ShowDiffForAllParentsText => _instance.Value._showDiffForAllParentsText.Text;
         public static string ShowDiffForAllParentsTooltip => _instance.Value._showDiffForAllParentsTooltip.Text;
+
+        public static string Inactive => _instance.Value._rotInactive.Text;
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9329,6 +9329,10 @@ Select this commit to populate the full message.</source>
         <source>Install git...</source>
         <target />
       </trans-unit>
+      <trans-unit id="_invisibleCommitText.Text">
+        <source>'{0}' is not currently visible</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_loadingDataText.Text">
         <source>Loading data...</source>
         <target />
@@ -9411,6 +9415,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_removeSelectedInvalidRepository.Text">
         <source>Remove the selected invalid repository</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_rotInactive.Text">
+        <source>[ Inactive ]</source>
         <target />
       </trans-unit>
       <trans-unit id="_searchingFor.Text">

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -56,6 +56,13 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
         public int Count => _nodes.Count;
 
+        /// <summary>
+        /// Checks whether the given hash is present in the graph.
+        /// </summary>
+        /// <param name="objectId">The hash to find.</param>
+        /// <returns><see langword="true"/>, if the given hash if found; otherwise <see langword="false"/>.</returns>
+        public bool Contains(ObjectId objectId) => _nodeByObjectId.ContainsKey(objectId);
+
         public int GetCachedCount()
         {
             if (_orderedRowCache == null)

--- a/GitUI/UserControls/RevisionGrid/ICheckRefs.cs
+++ b/GitUI/UserControls/RevisionGrid/ICheckRefs.cs
@@ -1,0 +1,14 @@
+﻿using GitUIPluginInterfaces;
+
+namespace GitUI.UserControls.RevisionGrid
+{
+    public interface ICheckRefs
+    {
+        /// <summary>
+        /// Checks whether the given hash is present in a collection.
+        /// </summary>
+        /// <param name="objectId">The hash to find.</param>
+        /// <returns><see langword="true"/>, if the given hash if found; otherwise <see langword="false"/>.</returns>
+        bool Contains(ObjectId objectId);
+    }
+}

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -331,6 +331,13 @@ namespace GitUI.UserControls.RevisionGrid
             StartBackgroundProcessingTask(cancellationToken);
         }
 
+        /// <summary>
+        /// Checks whether the given hash is present in the graph.
+        /// </summary>
+        /// <param name="objectId">The hash to find.</param>
+        /// <returns><see langword="true"/>, if the given hash if found; otherwise <see langword="false"/>.</returns>
+        public bool Contains(ObjectId objectId) => _revisionGraph.Contains(objectId);
+
         private void StartBackgroundProcessingTask(CancellationToken cancellationToken)
         {
             // Start the background processing via JoinableTaskContext.Factory to avoid tracking the long-running

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -56,10 +56,11 @@ namespace GitUI
     }
 
     [DefaultEvent("DoubleClick")]
-    public sealed partial class RevisionGridControl : GitModuleControl, IScriptHostControl
+    public sealed partial class RevisionGridControl : GitModuleControl, IScriptHostControl, ICheckRefs
     {
         public event EventHandler<DoubleClickRevisionEventArgs> DoubleClickRevision;
         public event EventHandler<EventArgs> ShowFirstParentsToggled;
+        public event EventHandler RevisionGraphLoaded;
         public event EventHandler SelectionChanged;
 
         /// <summary>
@@ -329,6 +330,8 @@ namespace GitUI
             {
                 Controls.Add(content);
             }
+
+            RevisionGraphLoaded?.Invoke(content == _gridView ? _gridView : null, EventArgs.Empty);
         }
 
         internal int DrawColumnText(DataGridViewCellPaintingEventArgs e, string text, Font font, Color color, Rectangle bounds, bool useEllipsis = true)
@@ -2757,6 +2760,13 @@ namespace GitUI
             => GetQuickItemSelectorLocation();
 
         #endregion
+
+        /// <summary>
+        /// Checks whether the given hash is present in the graph.
+        /// </summary>
+        /// <param name="objectId">The hash to find.</param>
+        /// <returns><see langword="true"/>, if the given hash if found; otherwise <see langword="false"/>.</returns>
+        bool ICheckRefs.Contains(ObjectId objectId) => _gridView.Contains(objectId);
 
         internal TestAccessor GetTestAccessor()
             => new TestAccessor(this);

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.Remotes.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.Remotes.cs
@@ -26,9 +26,6 @@ namespace GitExtensions.UITests.CommandsDialogs
         private bool _originalShowAuthorAvatarColumn;
         private static readonly string[] RemoteNames = new[] { "remote1", "remote5", "remote3", "remote4", "remote2" };
 
-        // TODO: how do we reference RemoteBranchTree._inactiveRemoteNodeLabel?
-        private const string InactiveLabel = @"Inactive";
-
         [OneTimeSetUp]
         public void SetUpFixture()
         {
@@ -121,7 +118,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                     // no-op: by the virtue of loading the form, the left panel has loaded its content
 
                     // assert
-                    remotesNode.Nodes.OfType<TreeNode>().Any(n => n.Text == InactiveLabel).Should().BeFalse();
+                    remotesNode.Nodes.OfType<TreeNode>().Any(n => n.Text == Strings.Inactive).Should().BeFalse();
                 });
         }
 
@@ -138,7 +135,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                     // no-op: by the virtue of loading the form, the left panel has loaded its content
 
                     // assert
-                    remotesNode.Nodes.OfType<TreeNode>().Count(n => n.Text == InactiveLabel).Should().Be(1);
+                    remotesNode.Nodes.OfType<TreeNode>().Count(n => n.Text == Strings.Inactive).Should().Be(1);
                 });
         }
 
@@ -155,7 +152,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                     // no-op: by the virtue of loading the form, the left panel has loaded its content
 
                     // assert
-                    remotesNode.Nodes.OfType<TreeNode>().Last().Text.Should().Be(InactiveLabel);
+                    remotesNode.Nodes.OfType<TreeNode>().Last().Text.Should().Be(Strings.Inactive);
                 });
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Proposed changes

Indicate branches and tags in the left panel that are currently filtered out and not visible in the revision grid.

* The hidden refs are greyed out and their icon is changed to "closed eye".
* Each node in the tree now has a new property `IsVisible` that can be used as a conditional flag when implementing necessary logic.

Detection of whether a given ref is visible or not is done by checking the revision grid, which is currently the source of truth. 
Whenever the revision grid is refreshed, it raises an event that causes the left panel to update its state, and show or hide nodes.




## Screenshots <!-- Remove this section if PR does not change UI -->


### After

* Show all
![image](https://user-images.githubusercontent.com/4403806/90959127-42a0e480-e4dc-11ea-8619-6bac8e390afa.png)

* Show only current branch
  ![image](https://user-images.githubusercontent.com/4403806/93034056-211abf00-f67c-11ea-8cc3-04b06c8cfca4.png)
  ![image](https://user-images.githubusercontent.com/4403806/93034092-44456e80-f67c-11ea-9ce5-5d834d6f57ee.png)
  ![image](https://user-images.githubusercontent.com/4403806/94330067-ea419300-0003-11eb-8d37-f7210a4e7ecf.png)



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
