### PR TITLE
Colorblind syntax colors

### DIFF
--- a/GitExtUtils/GitUI/Theming/ColorHelper.cs
+++ b/GitExtUtils/GitUI/Theming/ColorHelper.cs
@@ -160,6 +160,11 @@ namespace GitExtUtils.GitUI.Theming
 
         private static Color AdaptColor(Color originalRgb, KnownColor exampleName, KnownColor oppositeName)
         {
+            if (ThemeSettings.Variations.Contains(ThemeVariations.Colorblind))
+            {
+                originalRgb = originalRgb.AdaptToColorblindness();
+            }
+
             var exampleOrig = RgbHsl(ThemeSettings.InvariantTheme.GetNonEmptyColor(exampleName));
             var oppositeOrig = RgbHsl(ThemeSettings.InvariantTheme.GetNonEmptyColor(oppositeName));
             var example = RgbHsl(ThemeSettings.Theme.GetNonEmptyColor(exampleName));
@@ -242,6 +247,26 @@ namespace GitExtUtils.GitUI.Theming
         private static bool IsLightColor(this Color color)
         {
             return new HslColor(color).L > 0.5;
+        }
+
+        private static Color AdaptToColorblindness(this Color color)
+        {
+            double excludeHTo = 15d; // orange
+
+            var hsl = new HslColor(color);
+            var deltaH = ((hsl.H * 360d) - excludeHTo + 180).Modulo(360) - 180;
+
+            const double deltaFrom = -140d;
+            const double deltaTo = 0d;
+
+            if (deltaH <= deltaFrom || deltaH >= deltaTo)
+            {
+                return color;
+            }
+
+            double correctedDelta = deltaFrom + ((deltaH - deltaFrom) / 2d);
+            double correctedH = (excludeHTo + correctedDelta).Modulo(360);
+            return new HslColor(correctedH / 360d, hsl.S, hsl.L).ToColor();
         }
     }
 }

--- a/GitExtUtils/GitUI/Theming/ThemeSettings.cs
+++ b/GitExtUtils/GitUI/Theming/ThemeSettings.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using JetBrains.Annotations;
 
 namespace GitExtUtils.GitUI.Theming
 {
@@ -7,16 +8,18 @@ namespace GitExtUtils.GitUI.Theming
         private static ThemeSettings _default;
 
         public static ThemeSettings Default =>
-            _default ?? (_default = new ThemeSettings(Theme.Default, Theme.Default, true));
+            _default ??= new ThemeSettings(Theme.Default, Theme.Default, ThemeVariations.None, useSystemVisualStyle: true);
 
         public ThemeSettings(
             [NotNull] Theme theme,
             [NotNull] Theme invariantTheme,
+            [NotNull] string[] variations,
             bool useSystemVisualStyle)
         {
             Theme = theme;
             InvariantTheme = invariantTheme;
             UseSystemVisualStyle = useSystemVisualStyle;
+            Variations = variations;
         }
 
         [NotNull]
@@ -24,6 +27,9 @@ namespace GitExtUtils.GitUI.Theming
 
         [NotNull]
         public Theme InvariantTheme { get; }
+
+        [NotNull]
+        public string[] Variations { get; }
 
         public bool UseSystemVisualStyle { get; }
     }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using GitCommands;
 using GitExtUtils.GitUI.Theming;
@@ -55,7 +55,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private string[] SelectedThemeVariations
         {
-            get => chkColorblind.Checked ? new[] { ThemeVariations.Colorblind } : ThemeVariations.None;
+            get => chkColorblind.Checked
+                ? new[] { ThemeVariations.Colorblind }
+                : GitExtUtils.GitUI.Theming.ThemeVariations.None;
+
             set => chkColorblind.Checked = value.Contains(ThemeVariations.Colorblind);
         }
 

--- a/GitUI/Theming/ThemeModule.cs
+++ b/GitUI/Theming/ThemeModule.cs
@@ -59,7 +59,7 @@ namespace GitUI.Theming
             ThemeId themeId = AppSettings.ThemeId;
             if (string.IsNullOrEmpty(themeId.Name))
             {
-                return new ThemeSettings(Theme.Default, invariantTheme, AppSettings.UseSystemVisualStyle);
+                return CreateFallbackSettings(invariantTheme);
             }
 
             Theme theme;
@@ -70,7 +70,7 @@ namespace GitUI.Theming
             catch (ThemeException ex)
             {
                 MessageBoxes.ShowError(null, $"Failed to load {(themeId.IsBuiltin ? "preinstalled" : "user-defined")} theme {themeId.Name}: {ex}");
-                return new ThemeSettings(Theme.Default, invariantTheme, AppSettings.UseSystemVisualStyle);
+                return CreateFallbackSettings(invariantTheme);
             }
 
             try
@@ -80,12 +80,12 @@ namespace GitUI.Theming
             catch (Exception ex)
             {
                 MessageBoxes.ShowError(null, $"Failed to install Win32 theming hooks: {ex}");
-                return new ThemeSettings(Theme.Default, invariantTheme, AppSettings.UseSystemVisualStyle);
+                return CreateFallbackSettings(invariantTheme);
             }
 
             IsDarkTheme = theme.SysColorValues[KnownColor.Window].GetBrightness() < 0.5;
 
-            return new ThemeSettings(theme, invariantTheme, AppSettings.UseSystemVisualStyle);
+            return new ThemeSettings(theme, invariantTheme, AppSettings.ThemeVariations, AppSettings.UseSystemVisualStyle);
         }
 
         private static void ResetGdiCaches()
@@ -138,5 +138,8 @@ namespace GitUI.Theming
                     break;
             }
         }
+
+        private static ThemeSettings CreateFallbackSettings(Theme invariantTheme) =>
+            new ThemeSettings(Theme.Default, invariantTheme, ThemeVariations.None, useSystemVisualStyle: true);
     }
 }


### PR DESCRIPTION
**Attention this PR is made above #8424 so only last 2 commits are to be reviewed here**

Correct color calculations to make result colorblind-friendly If "Colorblind" checkbox is set in ColorSettings page, replace red-ish colors with blue-ish by compressing blue-orange ark in hue circle into blue-violet

![image](https://user-images.githubusercontent.com/12046452/91637529-d3624d80-ea11-11ea-8fad-781b468b051c.png)

before
![image](https://user-images.githubusercontent.com/12046452/91636594-7e6f0900-ea0a-11ea-8655-8f4d59aadad8.png)

after
![image](https://user-images.githubusercontent.com/12046452/91636599-88910780-ea0a-11ea-9cbd-129b350d666a.png)

after v2, modified to reduce contrast loss, as @neil5280 noticed

![image](https://user-images.githubusercontent.com/12046452/92306643-58f97680-ef99-11ea-9a8e-14b8789ce2a2.png)

Besides syntax highlighting colors, other auto-calculated colors get affected as well.
Observe how build status colors change

before
![image](https://user-images.githubusercontent.com/12046452/91641436-167dea00-ea2d-11ea-8a67-fff0cf8f738d.png)

after
![image](https://user-images.githubusercontent.com/12046452/91641411-dae32000-ea2c-11ea-8f75-c20b12a78680.png)

after v2
![image](https://user-images.githubusercontent.com/12046452/92306392-74638200-ef97-11ea-99e0-abf70974c50c.png)
