### PR TITLE
Fix 6310 Provide ability to sort/order branches and tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ tree.txt
 *.binlog
 artifacts/
 .tools/vswhere/
+.dotnet/

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -17,13 +17,14 @@ namespace GitCommands
         private static readonly GitVersion v2_7_0 = new GitVersion("2.7.0");
         private static readonly GitVersion v2_9_0 = new GitVersion("2.9.0");
         private static readonly GitVersion v2_11_0 = new GitVersion("2.11.0");
+        private static readonly GitVersion v2_14_6 = new GitVersion("2.14.6");
         private static readonly GitVersion v2_15_0 = new GitVersion("2.15.0");
         private static readonly GitVersion v2_15_2 = new GitVersion("2.15.2");
         private static readonly GitVersion v2_19_0 = new GitVersion("2.19.0");
         private static readonly GitVersion v2_20_0 = new GitVersion("2.20.0");
 
-        public static readonly GitVersion LastSupportedVersion = v2_11_0;
-        public static readonly GitVersion LastRecommendedVersion = new GitVersion("2.25.1");
+        public static readonly GitVersion LastSupportedVersion = v2_19_0;
+        public static readonly GitVersion LastRecommendedVersion = new GitVersion("2.28.0");
 
         private static GitVersion _current;
 
@@ -127,6 +128,8 @@ namespace GitCommands
         public bool SupportNoOptionalLocks => this >= v2_15_2;
 
         public bool SupportRebaseMerges => this >= v2_19_0;
+
+        public bool SupportRefSort => this >= v2_14_6;
 
         public bool SupportGuiMergeTool => this >= v2_20_0;
 

--- a/GitCommands/IDiffListSortService.cs
+++ b/GitCommands/IDiffListSortService.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace GitCommands
 {

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1579,6 +1579,18 @@ namespace GitCommands
             set => SetBool("UseConsoleEmulatorForCommands", value);
         }
 
+        public static GitRefsSortBy RefsSortBy
+        {
+            get => GetEnum("RefsSortBy", GitRefsSortBy.Default);
+            set => SetEnum("RefsSortBy", value);
+        }
+
+        public static GitRefsSortOrder RefsSortOrder
+        {
+            get => GetEnum("RefsSortOrder", GitRefsSortOrder.Descending);
+            set => SetEnum("RefsSortOrder", value);
+        }
+
         public static DiffListSortType DiffListSorting
         {
             get => GetEnum("DiffListSortType", DiffListSortType.FilePath);

--- a/GitUI/BranchTreePanel/ContextMenu/GitRefsSortByContextMenuItem.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/GitRefsSortByContextMenuItem.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Linq;
+using System.Windows.Forms;
+using GitCommands;
+using GitCommands.Utils;
+using GitUI.Properties;
+using GitUIPluginInterfaces;
+
+namespace GitUI.BranchTreePanel.ContextMenu
+{
+    internal class GitRefsSortByContextMenuItem : ToolStripMenuItem
+    {
+        private readonly Action _onSortByChanged;
+
+        public GitRefsSortByContextMenuItem(Action onSortByChanged)
+        {
+            _onSortByChanged = onSortByChanged;
+
+            Image = Images.SortBy;
+            Text = Strings.SortBy;
+
+            foreach (var option in EnumHelper.GetValues<GitRefsSortBy>().Select(e => (Text: e.GetDescription(), Value: e)))
+            {
+                var item = new ToolStripMenuItem()
+                {
+                    Text = option.Text,
+                    Image = null,
+                    Tag = option.Value
+                };
+
+                item.Click += Item_Click;
+                DropDownItems.Add(item);
+            }
+
+            DropDownOpening += (s, e) => RequerySortingMethod();
+            RequerySortingMethod();
+        }
+
+        private void RequerySortingMethod()
+        {
+            var currentSort = AppSettings.RefsSortBy;
+            foreach (ToolStripMenuItem item in DropDownItems)
+            {
+                item.Checked = currentSort.Equals(item.Tag);
+            }
+        }
+
+        private void Item_Click(object sender, EventArgs e)
+        {
+            if (sender is ToolStripMenuItem item)
+            {
+                var sortingType = (GitRefsSortBy)item.Tag;
+                AppSettings.RefsSortBy = sortingType;
+
+                _onSortByChanged?.Invoke();
+            }
+        }
+
+        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+        internal struct TestAccessor
+        {
+            private readonly GitRefsSortByContextMenuItem _contextMenuItem;
+
+            public TestAccessor(GitRefsSortByContextMenuItem menuitem)
+            {
+                _contextMenuItem = menuitem;
+            }
+
+            public void RaiseDropDownOpening() => _contextMenuItem.RequerySortingMethod();
+        }
+    }
+}

--- a/GitUI/BranchTreePanel/ContextMenu/GitRefsSortOrderContextMenuItem.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/GitRefsSortOrderContextMenuItem.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Linq;
+using System.Windows.Forms;
+using GitCommands;
+using GitCommands.Utils;
+using GitUI.Properties;
+using GitUIPluginInterfaces;
+
+namespace GitUI.BranchTreePanel.ContextMenu
+{
+    internal class GitRefsSortOrderContextMenuItem : ToolStripMenuItem
+    {
+        internal const string MenuItemName = "GitRefsSortOrderContextMenuItem";
+        private readonly Action _onSortOrderChanged;
+
+        public GitRefsSortOrderContextMenuItem(Action onSortOrderChanged)
+        {
+            _onSortOrderChanged = onSortOrderChanged;
+
+            Image = Images.SortBy;
+            Text = Strings.SortOrder;
+            Name = MenuItemName;
+
+            foreach (var option in EnumHelper.GetValues<GitRefsSortOrder>().Select(e => (Text: e.GetDescription(), Value: e)))
+            {
+                var item = new ToolStripMenuItem()
+                {
+                    Text = option.Text,
+                    Image = null,
+                    Tag = option.Value
+                };
+
+                item.Click += Item_Click;
+                DropDownItems.Add(item);
+            }
+
+            DropDownOpening += (s, e) => RequerySortingMethod();
+            RequerySortingMethod();
+        }
+
+        private void RequerySortingMethod()
+        {
+            var currentSort = AppSettings.RefsSortOrder;
+            foreach (ToolStripMenuItem item in DropDownItems)
+            {
+                item.Checked = currentSort.Equals(item.Tag);
+            }
+        }
+
+        private void Item_Click(object sender, EventArgs e)
+        {
+            if (sender is ToolStripMenuItem item)
+            {
+                var sortingType = (GitRefsSortOrder)item.Tag;
+                AppSettings.RefsSortOrder = sortingType;
+
+                _onSortOrderChanged?.Invoke();
+            }
+        }
+
+        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+        internal struct TestAccessor
+        {
+            private readonly GitRefsSortOrderContextMenuItem _contextMenuItem;
+
+            public TestAccessor(GitRefsSortOrderContextMenuItem menuitem)
+            {
+                _contextMenuItem = menuitem;
+            }
+
+            public void RaiseDropDownOpening() => _contextMenuItem.RequerySortingMethod();
+        }
+    }
+}

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -279,7 +279,7 @@ namespace GitUI.BranchTreePanel
                 await TaskScheduler.Default;
                 token.ThrowIfCancellationRequested();
 
-                var branchNames = Module.GetRefs(tags: false, branches: true, noLocks: true).Select(b => b.Name);
+                var branchNames = Module.GetRefs(tags: false, branches: true).Select(b => b.Name);
                 return FillBranchTree(branchNames, token);
             }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -8,6 +8,7 @@ using System.Windows.Forms;
 using GitCommands.Git;
 using GitUI.BranchTreePanel.Interfaces;
 using GitUI.Properties;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using Microsoft.VisualStudio.Threading;
 
@@ -118,9 +119,10 @@ namespace GitUI.BranchTreePanel
 
             private bool _isMerged = false;
 
-            public BaseBranchLeafNode(Tree tree, string fullPath, string imageKeyUnmerged, string imageKeyMerged)
+            public BaseBranchLeafNode(Tree tree, in ObjectId objectId, string fullPath, string imageKeyUnmerged, string imageKeyMerged)
                 : base(tree, fullPath)
             {
+                ObjectId = objectId;
                 _imageKeyUnmerged = imageKeyUnmerged;
                 _imageKeyMerged = imageKeyMerged;
             }
@@ -141,6 +143,9 @@ namespace GitUI.BranchTreePanel
                 }
             }
 
+            [CanBeNull]
+            public ObjectId ObjectId { get; }
+
             protected override void ApplyStyle()
             {
                 base.ApplyStyle();
@@ -150,8 +155,8 @@ namespace GitUI.BranchTreePanel
 
         private sealed class LocalBranchNode : BaseBranchLeafNode, IGitRefActions, ICanRename, ICanDelete
         {
-            public LocalBranchNode(Tree tree, string fullPath, bool isCurrent)
-                : base(tree, fullPath, nameof(Images.BranchLocal), nameof(Images.BranchLocalMerged))
+            public LocalBranchNode(Tree tree, in ObjectId objectId, string fullPath, bool isCurrent)
+                : base(tree, objectId, fullPath, nameof(Images.BranchLocal), nameof(Images.BranchLocalMerged))
             {
                 IsActive = isCurrent;
             }
@@ -264,14 +269,19 @@ namespace GitUI.BranchTreePanel
                 _aheadBehindDataProvider = aheadBehindDataProvider;
             }
 
-            protected override Task OnAttachedAsync()
-            {
-                return ReloadNodesAsync(LoadNodesAsync);
-            }
+            protected override Task OnAttachedAsync() => ReloadNodesAsync(LoadNodesAsync);
 
-            protected override Task PostRepositoryChangedAsync()
+            protected override Task PostRepositoryChangedAsync() => ReloadNodesAsync(LoadNodesAsync);
+
+            /// <summary>
+            /// Requests to refresh the data tree retaining the current filtering rules.
+            /// </summary>
+            internal void RefreshRefs()
             {
-                return ReloadNodesAsync(LoadNodesAsync);
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    await ReloadNodesAsync(LoadNodesAsync);
+                });
             }
 
             private async Task<Nodes> LoadNodesAsync(CancellationToken token)
@@ -279,11 +289,11 @@ namespace GitUI.BranchTreePanel
                 await TaskScheduler.Default;
                 token.ThrowIfCancellationRequested();
 
-                var branchNames = Module.GetRefs(tags: false, branches: true).Select(b => b.Name);
-                return FillBranchTree(branchNames, token);
+                IReadOnlyList<IGitRef> branches = Module.GetRefs(tags: false, branches: true);
+                return FillBranchTree(branches, token);
             }
 
-            private Nodes FillBranchTree(IEnumerable<string> branches, CancellationToken token)
+            private Nodes FillBranchTree(IReadOnlyList<IGitRef> branches, CancellationToken token)
             {
                 #region ex
 
@@ -323,7 +333,7 @@ namespace GitUI.BranchTreePanel
                 foreach (var branch in branches)
                 {
                     token.ThrowIfCancellationRequested();
-                    var localBranchNode = new LocalBranchNode(this, branch, branch == currentBranch);
+                    var localBranchNode = new LocalBranchNode(this, branch.ObjectId, branch.Name, branch.Name == currentBranch);
 
                     if (aheadBehindData != null && aheadBehindData.ContainsKey(localBranchNode.FullPath))
                     {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -27,14 +27,19 @@ namespace GitUI.BranchTreePanel
             {
             }
 
-            protected override Task OnAttachedAsync()
-            {
-                return ReloadNodesAsync(LoadNodesAsync);
-            }
+            protected override Task OnAttachedAsync() => ReloadNodesAsync(LoadNodesAsync);
 
-            protected override Task PostRepositoryChangedAsync()
+            protected override Task PostRepositoryChangedAsync() => ReloadNodesAsync(LoadNodesAsync);
+
+            /// <summary>
+            /// Requests to refresh the data tree retaining the current filtering rules.
+            /// </summary>
+            internal void RefreshRefs()
             {
-                return ReloadNodesAsync(LoadNodesAsync);
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    await ReloadNodesAsync(LoadNodesAsync);
+                });
             }
 
             private async Task<Nodes> LoadNodesAsync(CancellationToken token)
@@ -44,10 +49,8 @@ namespace GitUI.BranchTreePanel
                 var nodes = new Nodes(this);
                 var pathToNodes = new Dictionary<string, BaseBranchNode>();
 
-                var branches = Module.GetRefs(tags: true, branches: true)
-                    .Where(branch => branch.IsRemote && !branch.IsTag)
-                    .OrderBy(branch => branch.Name)
-                    .Select(branch => branch.Name);
+                IEnumerable<IGitRef> branches = Module.GetRefs(tags: true, branches: true)
+                    .Where(branch => branch.IsRemote && !branch.IsTag);
 
                 token.ThrowIfCancellationRequested();
 
@@ -57,13 +60,13 @@ namespace GitUI.BranchTreePanel
                 var remotesManager = new ConfigFileRemoteSettingsManager(() => Module);
 
                 // Create nodes for enabled remotes with branches
-                foreach (var branchPath in branches)
+                foreach (IGitRef branch in branches)
                 {
                     token.ThrowIfCancellationRequested();
-                    var remoteName = branchPath.SubstringUntil('/');
+                    var remoteName = branch.Name.SubstringUntil('/');
                     if (remoteByName.TryGetValue(remoteName, out var remote))
                     {
-                        var remoteBranchNode = new RemoteBranchNode(this, branchPath);
+                        var remoteBranchNode = new RemoteBranchNode(this, branch.ObjectId, branch.Name);
                         var parent = remoteBranchNode.CreateRootNode(
                             pathToNodes,
                             (tree, parentPath) => CreateRemoteBranchPathNode(tree, parentPath, remote));
@@ -157,8 +160,8 @@ namespace GitUI.BranchTreePanel
 
         private sealed class RemoteBranchNode : BaseBranchLeafNode, IGitRefActions, ICanDelete, ICanRename
         {
-            public RemoteBranchNode(Tree tree, string fullPath)
-                : base(tree, fullPath, nameof(Images.BranchRemote), nameof(Images.BranchRemoteMerged))
+            public RemoteBranchNode(Tree tree, in ObjectId objectId, string fullPath)
+                : base(tree, objectId, fullPath, nameof(Images.BranchRemote), nameof(Images.BranchRemoteMerged))
             {
             }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -44,7 +44,7 @@ namespace GitUI.BranchTreePanel
                 var nodes = new Nodes(this);
                 var pathToNodes = new Dictionary<string, BaseBranchNode>();
 
-                var branches = Module.GetRefs(tags: true, branches: true, noLocks: true)
+                var branches = Module.GetRefs(tags: true, branches: true)
                     .Where(branch => branch.IsRemote && !branch.IsTag)
                     .OrderBy(branch => branch.Name)
                     .Select(branch => branch.Name);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -2,13 +2,11 @@
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using GitCommands;
 using GitUI.BranchTreePanel.Interfaces;
 using GitUI.CommandsDialogs;
 using GitUI.Properties;
 using GitUIPluginInterfaces;
 using Microsoft.VisualStudio.Threading;
-using ResourceManager;
 
 namespace GitUI.BranchTreePanel
 {
@@ -91,7 +89,7 @@ namespace GitUI.BranchTreePanel
             {
                 await TaskScheduler.Default;
                 token.ThrowIfCancellationRequested();
-                return FillTagTree(Module.GetTagRefs(GitModule.GetTagRefsSortOrder.ByName), token);
+                return FillTagTree(Module.GetRefs(tags: true, branches: false), token);
             }
 
             private Nodes FillTagTree(IEnumerable<IGitRef> tags, CancellationToken token)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -406,7 +406,7 @@ namespace GitUI.BranchTreePanel
             }
 
             [CanBeNull]
-            private static T GetNodeSafe<T>([CanBeNull] TreeNode treeNode) where T : class, INode
+            internal static T GetNodeSafe<T>([CanBeNull] TreeNode treeNode) where T : class, INode
             {
                 return treeNode?.Tag as T;
             }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -78,7 +78,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             comboBoxTags.Text = Strings.LoadingData;
             return _tagsLoader.LoadAsync(
-                () => Module.GetTagRefs(GitModule.GetTagRefsSortOrder.ByCommitDateDescending).ToList(),
+                () => Module.GetRefs(tags: true, branches: false).ToList(),
                 list =>
                 {
                     comboBoxTags.Text = string.Empty;
@@ -92,7 +92,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             comboBoxBranches.Text = Strings.LoadingData;
             return _branchesLoader.LoadAsync(
-                () => Module.GetRefs(false).ToList(),
+                () => Module.GetRefs(tags: false, branches: true).ToList(),
                 list =>
                 {
                     comboBoxBranches.Text = string.Empty;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2025,7 +2025,7 @@ namespace GitUI.CommandsDialogs
                     // Make sure there are never more than a 100 branches added to the menu
                     // Git Extensions will hang when the drop down is too large...
                     return Module
-                        .GetRefs(tags: false, branches: true, noLocks: true)
+                        .GetRefs(tags: false, branches: true)
                         .Select(b => b.Name)
                         .Take(100);
                 }

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -524,7 +524,7 @@ namespace GitUI.CommandsDialogs
         {
             if (_localBranches == null)
             {
-                _localBranches = Module.GetRefs(false);
+                _localBranches = Module.GetRefs(tags: false, branches: true);
             }
 
             return _localBranches;
@@ -534,7 +534,7 @@ namespace GitUI.CommandsDialogs
         {
             if (_remoteBranches == null)
             {
-                _remoteBranches = Module.GetRefs(true, true).Where(h => h.IsRemote && !h.IsTag).ToList();
+                _remoteBranches = Module.GetRefs(tags: true, branches: true).Where(h => h.IsRemote && !h.IsTag).ToList();
             }
 
             return _remoteBranches;

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1030,7 +1030,7 @@ namespace GitUI.CommandsDialogs
                 remoteNameLabel.Click -= _branchNameLabelOnClick;
             }
 
-            var currentBranch = Module.GetRefs(false, true).FirstOrDefault(r => r.LocalName == currentBranchName);
+            var currentBranch = Module.GetRefs(tags: false, branches: true).FirstOrDefault(r => r.LocalName == currentBranchName);
             if (currentBranch == null)
             {
                 branchNameLabel.Text = currentBranchName;

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -40,7 +40,7 @@ namespace GitUI.CommandsDialogs
 
         private void FormDeleteBranchLoad(object sender, EventArgs e)
         {
-            Branches.BranchesToSelect = Module.GetRefs(true, true).Where(h => h.IsHead && !h.IsRemote).ToList();
+            Branches.BranchesToSelect = Module.GetRefs(tags: true, branches: true).Where(h => h.IsHead && !h.IsRemote).ToList();
             foreach (var branch in Module.GetMergedBranches())
             {
                 if (!branch.StartsWith("* "))

--- a/GitUI/CommandsDialogs/FormDeleteTag.cs
+++ b/GitUI/CommandsDialogs/FormDeleteTag.cs
@@ -33,7 +33,7 @@ namespace GitUI.CommandsDialogs
         private void FormDeleteTagLoad(object sender, EventArgs e)
         {
             Tags.DisplayMember = nameof(IGitRef.LocalName);
-            Tags.DataSource = Module.GetRefs(true, false);
+            Tags.DataSource = Module.GetRefs(tags: true, branches: false);
             Tags.Text = Tag as string;
             remotesComboboxControl1.SelectedRemote = Module.GetCurrentRemote();
             EnableOrDisableRemotesCombobox();

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -907,8 +907,9 @@ namespace GitUI.CommandsDialogs
         private void FillTagDropDown()
         {
             // var tags = Module.GetTagHeads(GitModule.GetTagHeadsOption.OrderByCommitDateDescending); // comment out to sort by commit date
-            var tags = Module.GetTagRefs(GitModule.GetTagRefsSortOrder.ByName)
-                .Select(tag => tag.Name).ToList();
+            List<string> tags = Module.GetRefs(tags: true, branches: false)
+                                      .Select(tag => tag.Name)
+                                      .ToList();
             tags.Insert(0, AllRefs);
             TagComboBox.DataSource = tags;
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
@@ -61,6 +61,10 @@
             this.fixedWidthFontDialog = new System.Windows.Forms.FontDialog();
             this.applicationDialog = new System.Windows.Forms.FontDialog();
             this.commitFontDialog = new System.Windows.Forms.FontDialog();
+            this.lblBranchesSortBy = new System.Windows.Forms.Label();
+            this.lblBranchesOrder = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_cmbBranchesSortBy = new System.Windows.Forms.ComboBox();
+            this._NO_TRANSLATE_cmbBranchesOrder = new System.Windows.Forms.ComboBox();
             tlpnlMain = new System.Windows.Forms.TableLayoutPanel();
             tlpnlMain.SuspendLayout();
             this.gbGeneral.SuspendLayout();
@@ -89,7 +93,7 @@
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 10F));
-            tlpnlMain.Size = new System.Drawing.Size(1542, 481);
+            tlpnlMain.Size = new System.Drawing.Size(1565, 1339);
             tlpnlMain.TabIndex = 0;
             // 
             // gbGeneral
@@ -101,7 +105,7 @@
             this.gbGeneral.Location = new System.Drawing.Point(3, 3);
             this.gbGeneral.Name = "gbGeneral";
             this.gbGeneral.Padding = new System.Windows.Forms.Padding(8);
-            this.gbGeneral.Size = new System.Drawing.Size(1536, 125);
+            this.gbGeneral.Size = new System.Drawing.Size(1559, 225);
             this.gbGeneral.TabIndex = 0;
             this.gbGeneral.TabStop = false;
             this.gbGeneral.Text = "General";
@@ -114,24 +118,30 @@
             this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tlpnlGeneral.Controls.Add(this._NO_TRANSLATE_cmbBranchesOrder, 0, 6);
+            this.tlpnlGeneral.Controls.Add(this._NO_TRANSLATE_cmbBranchesSortBy, 0, 5);
+            this.tlpnlGeneral.Controls.Add(this.lblBranchesOrder, 0, 6);
+            this.tlpnlGeneral.Controls.Add(this.lblBranchesSortBy, 0, 5);
             this.tlpnlGeneral.Controls.Add(this.chkShowRelativeDate, 0, 0);
             this.tlpnlGeneral.Controls.Add(this.chkShowRepoCurrentBranch, 0, 1);
             this.tlpnlGeneral.Controls.Add(this.chkShowCurrentBranchInVisualStudio, 0, 2);
             this.tlpnlGeneral.Controls.Add(this.chkEnableAutoScale, 0, 3);
             this.tlpnlGeneral.Controls.Add(this.chkSortByAuthorDate, 0, 4);
-            this.tlpnlGeneral.Controls.Add(this.truncateLongFilenames, 0, 5);
-            this.tlpnlGeneral.Controls.Add(this.truncatePathMethod, 1, 5);
+            this.tlpnlGeneral.Controls.Add(this.truncateLongFilenames, 0, 7);
+            this.tlpnlGeneral.Controls.Add(this.truncatePathMethod, 1, 7);
             this.tlpnlGeneral.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tlpnlGeneral.Location = new System.Drawing.Point(8, 21);
             this.tlpnlGeneral.Name = "tlpnlGeneral";
-            this.tlpnlGeneral.RowCount = 6;
+            this.tlpnlGeneral.RowCount = 8;
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlGeneral.Size = new System.Drawing.Size(1035, 119);
+            this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlGeneral.Size = new System.Drawing.Size(1543, 196);
             this.tlpnlGeneral.TabIndex = 0;
             // 
             // chkShowRelativeDate
@@ -141,7 +151,7 @@
             this.chkShowRelativeDate.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkShowRelativeDate.Location = new System.Drawing.Point(3, 3);
             this.chkShowRelativeDate.Name = "chkShowRelativeDate";
-            this.chkShowRelativeDate.Size = new System.Drawing.Size(314, 17);
+            this.chkShowRelativeDate.Size = new System.Drawing.Size(448, 17);
             this.chkShowRelativeDate.TabIndex = 0;
             this.chkShowRelativeDate.Text = "Show relative date instead of full date";
             this.chkShowRelativeDate.UseVisualStyleBackColor = true;
@@ -153,7 +163,7 @@
             this.chkShowRepoCurrentBranch.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkShowRepoCurrentBranch.Location = new System.Drawing.Point(3, 26);
             this.chkShowRepoCurrentBranch.Name = "chkShowRepoCurrentBranch";
-            this.chkShowRepoCurrentBranch.Size = new System.Drawing.Size(314, 17);
+            this.chkShowRepoCurrentBranch.Size = new System.Drawing.Size(448, 17);
             this.chkShowRepoCurrentBranch.TabIndex = 5;
             this.chkShowRepoCurrentBranch.Text = "Show current branch names in the dashboard and the recent repositories dropdown menu";
             this.chkShowRepoCurrentBranch.UseVisualStyleBackColor = true;
@@ -165,7 +175,7 @@
             this.chkShowCurrentBranchInVisualStudio.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkShowCurrentBranchInVisualStudio.Location = new System.Drawing.Point(3, 49);
             this.chkShowCurrentBranchInVisualStudio.Name = "chkShowCurrentBranchInVisualStudio";
-            this.chkShowCurrentBranchInVisualStudio.Size = new System.Drawing.Size(314, 17);
+            this.chkShowCurrentBranchInVisualStudio.Size = new System.Drawing.Size(448, 17);
             this.chkShowCurrentBranchInVisualStudio.TabIndex = 1;
             this.chkShowCurrentBranchInVisualStudio.Text = "Show current branch in Visual Studio";
             this.chkShowCurrentBranchInVisualStudio.UseVisualStyleBackColor = true;
@@ -175,9 +185,9 @@
             this.chkEnableAutoScale.AutoSize = true;
             this.tlpnlGeneral.SetColumnSpan(this.chkEnableAutoScale, 2);
             this.chkEnableAutoScale.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkEnableAutoScale.Location = new System.Drawing.Point(3, 69);
+            this.chkEnableAutoScale.Location = new System.Drawing.Point(3, 72);
             this.chkEnableAutoScale.Name = "chkEnableAutoScale";
-            this.chkEnableAutoScale.Size = new System.Drawing.Size(314, 17);
+            this.chkEnableAutoScale.Size = new System.Drawing.Size(448, 17);
             this.chkEnableAutoScale.TabIndex = 2;
             this.chkEnableAutoScale.Text = "Auto scale user interface when high DPI is used";
             this.chkEnableAutoScale.UseVisualStyleBackColor = true;
@@ -185,9 +195,11 @@
             // chkSortByAuthorDate
             // 
             this.chkSortByAuthorDate.AutoSize = true;
-            this.chkSortByAuthorDate.Location = new System.Drawing.Point(3, 89);
+            this.chkSortByAuthorDate.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.chkSortByAuthorDate.Checked = false;
+            this.chkSortByAuthorDate.Location = new System.Drawing.Point(3, 95);
             this.chkSortByAuthorDate.Name = "chkSortByAuthorDate";
-            this.chkSortByAuthorDate.Size = new System.Drawing.Size(116, 17);
+            this.chkSortByAuthorDate.Size = new System.Drawing.Size(118, 17);
             this.chkSortByAuthorDate.TabIndex = 3;
             this.chkSortByAuthorDate.Text = "Sort by author date";
             // 
@@ -195,7 +207,7 @@
             // 
             this.truncateLongFilenames.AutoSize = true;
             this.truncateLongFilenames.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.truncateLongFilenames.Location = new System.Drawing.Point(3, 109);
+            this.truncateLongFilenames.Location = new System.Drawing.Point(3, 169);
             this.truncateLongFilenames.Name = "truncateLongFilenames";
             this.truncateLongFilenames.Size = new System.Drawing.Size(120, 27);
             this.truncateLongFilenames.TabIndex = 4;
@@ -212,9 +224,9 @@
             "Compact",
             "Trim start",
             "Filename only"});
-            this.truncatePathMethod.Location = new System.Drawing.Point(129, 72);
+            this.truncatePathMethod.Location = new System.Drawing.Point(129, 172);
             this.truncatePathMethod.Name = "truncatePathMethod";
-            this.truncatePathMethod.Size = new System.Drawing.Size(188, 21);
+            this.truncatePathMethod.Size = new System.Drawing.Size(322, 21);
             this.truncatePathMethod.TabIndex = 4;
             // 
             // gbAuthorImages
@@ -223,10 +235,10 @@
             this.gbAuthorImages.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.gbAuthorImages.Controls.Add(this.tlpnlAuthor);
             this.gbAuthorImages.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.gbAuthorImages.Location = new System.Drawing.Point(3, 134);
+            this.gbAuthorImages.Location = new System.Drawing.Point(3, 234);
             this.gbAuthorImages.Name = "gbAuthorImages";
             this.gbAuthorImages.Padding = new System.Windows.Forms.Padding(8);
-            this.gbAuthorImages.Size = new System.Drawing.Size(1536, 184);
+            this.gbAuthorImages.Size = new System.Drawing.Size(1559, 184);
             this.gbAuthorImages.TabIndex = 1;
             this.gbAuthorImages.TabStop = false;
             this.gbAuthorImages.Text = "Author images";
@@ -259,7 +271,7 @@
             this.tlpnlAuthor.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlAuthor.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlAuthor.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlAuthor.Size = new System.Drawing.Size(1520, 155);
+            this.tlpnlAuthor.Size = new System.Drawing.Size(1543, 155);
             this.tlpnlAuthor.TabIndex = 0;
             // 
             // lblAvatarProvider
@@ -327,10 +339,10 @@
             this.gbLanguages.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.gbLanguages.Controls.Add(this.tlpnlLanguage);
             this.gbLanguages.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.gbLanguages.Location = new System.Drawing.Point(3, 324);
+            this.gbLanguages.Location = new System.Drawing.Point(3, 424);
             this.gbLanguages.Name = "gbLanguages";
             this.gbLanguages.Padding = new System.Windows.Forms.Padding(8);
-            this.gbLanguages.Size = new System.Drawing.Size(1536, 83);
+            this.gbLanguages.Size = new System.Drawing.Size(1559, 83);
             this.gbLanguages.TabIndex = 2;
             this.gbLanguages.TabStop = false;
             this.gbLanguages.Text = "Language";
@@ -356,7 +368,7 @@
             this.tlpnlLanguage.RowCount = 2;
             this.tlpnlLanguage.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlLanguage.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlLanguage.Size = new System.Drawing.Size(1520, 54);
+            this.tlpnlLanguage.Size = new System.Drawing.Size(1543, 54);
             this.tlpnlLanguage.TabIndex = 0;
             // 
             // Dictionary
@@ -501,6 +513,58 @@
             this.commitFontDialog.AllowVerticalFonts = false;
             this.commitFontDialog.Color = System.Drawing.SystemColors.ControlText;
             // 
+            // lblBranchesSortBy
+            // 
+            this.lblBranchesSortBy.AutoSize = true;
+            this.lblBranchesSortBy.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblBranchesSortBy.Location = new System.Drawing.Point(3, 115);
+            this.lblBranchesSortBy.Name = "lblBranchesSortBy";
+            this.lblBranchesSortBy.Size = new System.Drawing.Size(120, 27);
+            this.lblBranchesSortBy.TabIndex = 6;
+            this.lblBranchesSortBy.Text = "Sort branches by";
+            this.lblBranchesSortBy.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // lblBranchesOrder
+            // 
+            this.lblBranchesOrder.AutoSize = true;
+            this.lblBranchesOrder.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblBranchesOrder.Location = new System.Drawing.Point(3, 142);
+            this.lblBranchesOrder.Name = "lblBranchesOrder";
+            this.lblBranchesOrder.Size = new System.Drawing.Size(120, 27);
+            this.lblBranchesOrder.TabIndex = 7;
+            this.lblBranchesOrder.Text = "Order branches";
+            this.lblBranchesOrder.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // _NO_TRANSLATE_cmbBranchesSortBy
+            // 
+            this._NO_TRANSLATE_cmbBranchesSortBy.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_cmbBranchesSortBy.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this._NO_TRANSLATE_cmbBranchesSortBy.FormattingEnabled = true;
+            this._NO_TRANSLATE_cmbBranchesSortBy.Items.AddRange(new object[] {
+            "None",
+            "Compact",
+            "Trim start",
+            "Filename only"});
+            this._NO_TRANSLATE_cmbBranchesSortBy.Location = new System.Drawing.Point(129, 118);
+            this._NO_TRANSLATE_cmbBranchesSortBy.Name = "_NO_TRANSLATE_cmbBranchesSortBy";
+            this._NO_TRANSLATE_cmbBranchesSortBy.Size = new System.Drawing.Size(322, 21);
+            this._NO_TRANSLATE_cmbBranchesSortBy.TabIndex = 8;
+            // 
+            // _NO_TRANSLATE_cmbBranchesOrder
+            // 
+            this._NO_TRANSLATE_cmbBranchesOrder.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_cmbBranchesOrder.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this._NO_TRANSLATE_cmbBranchesOrder.FormattingEnabled = true;
+            this._NO_TRANSLATE_cmbBranchesOrder.Items.AddRange(new object[] {
+            "None",
+            "Compact",
+            "Trim start",
+            "Filename only"});
+            this._NO_TRANSLATE_cmbBranchesOrder.Location = new System.Drawing.Point(129, 145);
+            this._NO_TRANSLATE_cmbBranchesOrder.Name = "_NO_TRANSLATE_cmbBranchesOrder";
+            this._NO_TRANSLATE_cmbBranchesOrder.Size = new System.Drawing.Size(322, 21);
+            this._NO_TRANSLATE_cmbBranchesOrder.TabIndex = 9;
+            // 
             // AppearanceSettingsPage
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -509,7 +573,7 @@
             this.MinimumSize = new System.Drawing.Size(258, 255);
             this.Name = "AppearanceSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
-            this.Size = new System.Drawing.Size(1558, 497);
+            this.Size = new System.Drawing.Size(1581, 1355);
             tlpnlMain.ResumeLayout(false);
             tlpnlMain.PerformLayout();
             this.gbGeneral.ResumeLayout(false);
@@ -564,5 +628,9 @@
         private System.Windows.Forms.Label lblAvatarProvider;
         private System.Windows.Forms.ComboBox AvatarProvider;
         private GitUI.UserControls.Settings.SettingsCheckBox chkSortByAuthorDate;
+        private System.Windows.Forms.Label lblBranchesOrder;
+        private System.Windows.Forms.Label lblBranchesSortBy;
+        private System.Windows.Forms.ComboBox _NO_TRANSLATE_cmbBranchesSortBy;
+        private System.Windows.Forms.ComboBox _NO_TRANSLATE_cmbBranchesOrder;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -7,6 +7,7 @@ using GitCommands;
 using GitCommands.Utils;
 using GitExtUtils.GitUI;
 using GitUI.Avatars;
+using GitUIPluginInterfaces;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
@@ -24,6 +25,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Text = "Appearance";
             InitializeComplete();
 
+            FillComboBoxWithEnumValues<GitRefsSortOrder>(_NO_TRANSLATE_cmbBranchesOrder);
+            FillComboBoxWithEnumValues<GitRefsSortBy>(_NO_TRANSLATE_cmbBranchesSortBy);
             FillComboBoxWithEnumValues<AvatarProvider>(AvatarProvider);
             FillComboBoxWithEnumValues<GravatarFallbackAvatarType>(_NO_TRANSLATE_NoImageService);
         }
@@ -47,16 +50,16 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             pictureAvatarHelp.Size = DpiUtil.Scale(pictureAvatarHelp.Size);
 
             // align 1st columns across all tables
-            tlpnlGeneral.AdjustWidthToSize(0, truncateLongFilenames, lblCacheDays, lblNoImageService, lblLanguage, lblSpellingDictionary);
-            tlpnlAuthor.AdjustWidthToSize(0, truncateLongFilenames, lblCacheDays, lblNoImageService, lblLanguage, lblSpellingDictionary);
-            tlpnlLanguage.AdjustWidthToSize(0, truncateLongFilenames, lblCacheDays, lblNoImageService, lblLanguage, lblSpellingDictionary);
+            tlpnlGeneral.AdjustWidthToSize(0, lblBranchesSortBy, lblBranchesOrder, truncateLongFilenames, lblCacheDays, lblNoImageService, lblLanguage, lblSpellingDictionary);
+            tlpnlAuthor.AdjustWidthToSize(0, lblBranchesSortBy, lblBranchesOrder, truncateLongFilenames, lblCacheDays, lblNoImageService, lblLanguage, lblSpellingDictionary);
+            tlpnlLanguage.AdjustWidthToSize(0, lblBranchesSortBy, lblBranchesOrder, truncateLongFilenames, lblCacheDays, lblNoImageService, lblLanguage, lblSpellingDictionary);
 
             // align 2nd columns across all tables
             truncatePathMethod.AdjustWidthToFitContent();
             Language.AdjustWidthToFitContent();
-            tlpnlGeneral.AdjustWidthToSize(1, truncatePathMethod, _NO_TRANSLATE_NoImageService, Language);
-            tlpnlAuthor.AdjustWidthToSize(1, truncatePathMethod, _NO_TRANSLATE_NoImageService, Language);
-            tlpnlLanguage.AdjustWidthToSize(1, truncatePathMethod, _NO_TRANSLATE_NoImageService, Language);
+            tlpnlGeneral.AdjustWidthToSize(1, _NO_TRANSLATE_cmbBranchesSortBy, _NO_TRANSLATE_cmbBranchesOrder, truncatePathMethod, _NO_TRANSLATE_NoImageService, Language);
+            tlpnlAuthor.AdjustWidthToSize(1, _NO_TRANSLATE_cmbBranchesSortBy, _NO_TRANSLATE_cmbBranchesOrder, truncatePathMethod, _NO_TRANSLATE_NoImageService, Language);
+            tlpnlLanguage.AdjustWidthToSize(1, _NO_TRANSLATE_cmbBranchesSortBy, _NO_TRANSLATE_cmbBranchesOrder, truncatePathMethod, _NO_TRANSLATE_NoImageService, Language);
         }
 
         public static SettingsPageReference GetPageReference()
@@ -84,6 +87,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Language.Text = AppSettings.Translation;
 
             truncatePathMethod.SelectedIndex = GetTruncatePathMethodIndex(AppSettings.TruncatePathMethod);
+            _NO_TRANSLATE_cmbBranchesOrder.SelectedIndex = (int)AppSettings.RefsSortOrder;
+            _NO_TRANSLATE_cmbBranchesSortBy.SelectedIndex = (int)AppSettings.RefsSortBy;
 
             Dictionary.Items.Clear();
             Dictionary.Items.Add(_noDictFile.Text);
@@ -135,6 +140,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.ShowAuthorAvatarInCommitInfo = ShowAuthorAvatarInCommitInfo.Checked;
             AppSettings.AvatarImageCacheDays = (int)_NO_TRANSLATE_DaysToCacheImages.Value;
             AppSettings.SortByAuthorDate = chkSortByAuthorDate.Checked;
+            AppSettings.RefsSortOrder = (GitRefsSortOrder)_NO_TRANSLATE_cmbBranchesOrder.SelectedIndex;
+            AppSettings.RefsSortBy = (GitRefsSortBy)_NO_TRANSLATE_cmbBranchesSortBy.SelectedIndex;
 
             AppSettings.Translation = Language.Text;
             ResourceManager.Strings.Reinitialize();
@@ -162,20 +169,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             return;
 
-            TruncatePathMethod GetTruncatePathMethodString(int index)
+            TruncatePathMethod GetTruncatePathMethodString(int index) => index switch
             {
-                switch (index)
-                {
-                    case 1:
-                        return TruncatePathMethod.Compact;
-                    case 2:
-                        return TruncatePathMethod.TrimStart;
-                    case 3:
-                        return TruncatePathMethod.FileNameOnly;
-                    default:
-                        return TruncatePathMethod.None;
-                }
-            }
+                1 => TruncatePathMethod.Compact,
+                2 => TruncatePathMethod.TrimStart,
+                3 => TruncatePathMethod.FileNameOnly,
+                _ => TruncatePathMethod.None,
+            };
         }
 
         private void Dictionary_DropDown(object sender, EventArgs e)

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -61,6 +61,9 @@ namespace GitUI
         private readonly TranslationString _open = new TranslationString("Open");
         private readonly TranslationString _directoryIsNotAValidRepository = new TranslationString("The selected item is not a valid git repository.");
 
+        private readonly TranslationString _sortBy = new TranslationString("&Sort by...");
+        private readonly TranslationString _sortOrder = new TranslationString("&Sort order...");
+
         private readonly TranslationString _diffSelectedWithRememberedFile = new TranslationString("Diff with \"{0}\"");
         private readonly TranslationString _showDiffForAllParentsText = new TranslationString("Show file differences for all parents in browse dialog");
         private readonly TranslationString _showDiffForAllParentsTooltip = new TranslationString(@"Show all differences between the selected commits, not limiting to only one difference.
@@ -150,6 +153,9 @@ namespace GitUI
         public static string RemoveAllInvalidRepositories => _instance.Value._removeAllInvalidRepositories.Text;
         public static string Open => _instance.Value._open.Text;
         public static string DirectoryInvalidRepository => _instance.Value._directoryIsNotAValidRepository.Text;
+
+        public static string SortBy => _instance.Value._sortBy.Text;
+        public static string SortOrder => _instance.Value._sortOrder.Text;
 
         public static string DiffSelectedWithRememberedFile => _instance.Value._diffSelectedWithRememberedFile.Text;
         public static string ShowDiffForAllParentsText => _instance.Value._showDiffForAllParentsText.Text;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7936,6 +7936,14 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <source>Show/hide branches/remotes/tags</source>
         <target />
       </trans-unit>
+      <trans-unit id="_sortByContextMenuItem.Text">
+        <source>&amp;Sort by...</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_sortOrderContextMenuItem.Text">
+        <source>&amp;Sort order...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="lblSearchBranch.Text">
         <source>Search:</source>
         <target />
@@ -9414,6 +9422,14 @@ Select this commit to populate the full message.</source>
    - The difference of common files (identical changes) from BASE to the commits.
 - For multiple selected commits (up to four), show the difference for all the first selected with the last selected commit.
 - For more than four selected commits, show the difference from the first to the last selected commit.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_sortBy.Text">
+        <source>&amp;Sort by...</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_sortOrder.Text">
+        <source>&amp;Sort order...</source>
         <target />
       </trans-unit>
       <trans-unit id="_submodulesText.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -192,6 +192,14 @@ See http://en.gravatar.com/site/implement/images#default-image for more details.
         <source>Avatar provider</source>
         <target />
       </trans-unit>
+      <trans-unit id="lblBranchesOrder.Text">
+        <source>Order branches</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="lblBranchesSortBy.Text">
+        <source>Sort branches by</source>
+        <target />
+      </trans-unit>
       <trans-unit id="lblCacheDays.Text">
         <source>Cache images (days)</source>
         <target />

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -33,7 +33,6 @@ namespace GitUI
         private readonly TranslationString _diffBaseToB = new TranslationString("Unique diff BASE with b/");
         private readonly TranslationString _diffCommonBase = new TranslationString("Common diff with BASE a/");
         private readonly TranslationString _combinedDiff = new TranslationString("Combined diff");
-        private readonly IGitRevisionTester _revisionTester;
         private readonly IFullPathResolver _fullPathResolver;
         private readonly SortDiffListContextMenuItem _sortByContextMenu;
         private readonly IReadOnlyList<GitItemStatus> _noItemStatuses;
@@ -77,7 +76,11 @@ namespace GitUI
             InitializeComponent();
             InitialiseFiltering();
             CreateOpenSubmoduleMenuItem();
-            _sortByContextMenu = CreateSortByContextMenuItem();
+            _sortByContextMenu = new SortDiffListContextMenuItem(DiffListSortService.Instance)
+            {
+                Name = "sortListByContextMenuItem"
+            };
+
             SetupUnifiedDiffListSorting();
             lblSplitter.Height = DpiUtil.Scale(1);
             InitializeComplete();
@@ -98,7 +101,6 @@ namespace GitUI
             FilterComboBox.Font = new Font(FilterComboBox.Font, FontStyle.Bold);
 
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
-            _revisionTester = new GitRevisionTester(_fullPathResolver);
             _noItemStatuses = new[]
             {
                 new GitItemStatus
@@ -200,14 +202,6 @@ namespace GitUI
                     return Observable.Empty<DiffListSortType>();
                 })
                 .Subscribe();
-        }
-
-        private static SortDiffListContextMenuItem CreateSortByContextMenuItem()
-        {
-            return new SortDiffListContextMenuItem(DiffListSortService.Instance)
-            {
-                Name = "sortListByContextMenuItem"
-            };
         }
 
         // Properties

--- a/GitUI/UserControls/SortDiffListContextMenuItem.cs
+++ b/GitUI/UserControls/SortDiffListContextMenuItem.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 using GitUI.Properties;
@@ -12,7 +9,6 @@ namespace GitUI.UserControls
 {
     public class SortDiffListContextMenuItem : ToolStripMenuItem
     {
-        private readonly TranslationString _sortByText = new TranslationString("&Sort by...");
         private readonly TranslationString _filePathSortText = new TranslationString("File &Path");
         private readonly TranslationString _fileExtensionSortText = new TranslationString("File &Extension");
         private readonly TranslationString _fileStatusSortText = new TranslationString("File &Status");
@@ -26,7 +22,7 @@ namespace GitUI.UserControls
         {
             _sortService = sortService ?? throw new ArgumentNullException(nameof(sortService));
             Image = Images.SortBy;
-            Text = _sortByText.Text;
+            Text = Strings.SortBy;
 
             _filePathSortItem = new ToolStripMenuItem()
             {
@@ -64,8 +60,6 @@ namespace GitUI.UserControls
             RequerySortingMethod();
         }
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
-
         private IReadOnlyList<ToolStripMenuItem> AllItems()
         {
             return _allItems;
@@ -87,7 +81,9 @@ namespace GitUI.UserControls
             _sortService.DiffListSorting = sortingType;
         }
 
-        public struct TestAccessor
+        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+        internal struct TestAccessor
         {
             private readonly SortDiffListContextMenuItem _contextMenuItem;
 
@@ -96,7 +92,7 @@ namespace GitUI.UserControls
                 _contextMenuItem = menuitem;
             }
 
-            public void SimulateOpeningEvent() => _contextMenuItem.RequerySortingMethod();
+            public void RaiseDropDownOpening() => _contextMenuItem.RequerySortingMethod();
         }
     }
 }

--- a/Plugins/GitUIPluginInterfaces/GitRefsOrder.cs
+++ b/Plugins/GitUIPluginInterfaces/GitRefsOrder.cs
@@ -1,0 +1,41 @@
+﻿using System.ComponentModel;
+
+namespace GitUIPluginInterfaces
+{
+    // NB: The values are fed directly into git commands, casing is important!
+    public enum GitRefsSortBy
+    {
+        [Description("Git default")]
+        Default = 0,
+
+        [Description("Author date")]
+        authordate,
+
+        [Description("Committer date")]
+        committerdate,
+
+        [Description("Creator date")]
+        creatordate,
+
+        [Description("Tagger date")]
+        taggerdate,
+
+        [Description("Alpha-numeric")]
+        refname,
+
+        [Description("Object size")]
+        objectsize,
+
+        [Description("Originating remote")]
+        upstream,
+    }
+
+    public enum GitRefsSortOrder
+    {
+        [Description("A ↓ Z")]
+        Ascending = 0,
+
+        [Description("Z ↑ A")]
+        Descending = 1,
+    }
+}

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -11,6 +11,7 @@ using FluentAssertions;
 using GitCommands;
 using GitCommands.Git;
 using GitCommands.Git.Commands;
+using GitCommands.Utils;
 using GitExtUtils;
 using GitUI;
 using GitUIPluginInterfaces;

--- a/UnitTests/GitUI.Tests/BranchTreePanel/ContextMenu/GitRefsSortByContextMenuItemTests.cs
+++ b/UnitTests/GitUI.Tests/BranchTreePanel/ContextMenu/GitRefsSortByContextMenuItemTests.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using GitCommands;
+using GitCommands.Utils;
+using GitUI.BranchTreePanel.ContextMenu;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitUITests.UserControls
+{
+    [SetCulture("en-US")]
+    [SetUICulture("en-US")]
+    [TestFixture]
+    public class GitRefsSortByContextMenuItemTests
+    {
+        private Action _onSortOrderChanged;
+        private GitRefsSortByContextMenuItem _itemUnderTest;
+
+        [SetUp]
+        public void Setup()
+        {
+            _onSortOrderChanged = Substitute.For<Action>();
+            _itemUnderTest = new GitRefsSortByContextMenuItem(_onSortOrderChanged);
+        }
+
+        [Test]
+        public void Should_show_all_sort_options()
+        {
+            Assert.IsTrue(_itemUnderTest.HasDropDownItems);
+            Assert.AreEqual(EnumHelper.GetValues<GitRefsSortBy>().Length, _itemUnderTest.DropDownItems.Count);
+        }
+
+        private static IEnumerable<TestCaseData> SortOrderOptions
+        {
+            get
+            {
+                foreach (GitRefsSortBy order in EnumHelper.GetValues<GitRefsSortBy>())
+                {
+                    yield return new TestCaseData(order);
+                }
+            }
+        }
+
+        [TestCaseSource(nameof(SortOrderOptions))]
+        public void Only_the_current_sort_option_is_selected(GitRefsSortBy order)
+        {
+            GitRefsSortBy original = AppSettings.RefsSortBy;
+            try
+            {
+                AppSettings.RefsSortBy = order;
+
+                // invoke the requery method to reselect the proper sub item
+                _itemUnderTest.GetTestAccessor().RaiseDropDownOpening();
+
+                AssertOnlyCheckedItemIs(order);
+            }
+            finally
+            {
+                AppSettings.RefsSortBy = original;
+            }
+        }
+
+        [Test]
+        public void Clicking_an_item_sets_sort_in_service()
+        {
+            GitRefsSortBy original = AppSettings.RefsSortBy;
+            try
+            {
+                // Reset to the default
+                AppSettings.RefsSortBy = GitRefsSortBy.Default;
+
+                foreach (var item in _itemUnderTest.DropDownItems.Cast<ToolStripMenuItem>())
+                {
+                    item.PerformClick();
+                    _onSortOrderChanged.Received(1).Invoke();
+                    _onSortOrderChanged.ClearReceivedCalls();
+                }
+            }
+            finally
+            {
+                AppSettings.RefsSortBy = original;
+            }
+        }
+
+        private void AssertOnlyCheckedItemIs(GitRefsSortBy sortType)
+        {
+            var matchingSubItem = _itemUnderTest.DropDownItems.Cast<ToolStripMenuItem>().Single(i => i.Tag.Equals(sortType));
+            Assert.IsTrue(matchingSubItem.Checked);
+
+            foreach (var otherItem in _itemUnderTest.DropDownItems.Cast<ToolStripMenuItem>().Except(new[] { matchingSubItem }))
+            {
+                Assert.IsFalse(otherItem.Checked);
+            }
+        }
+    }
+}

--- a/UnitTests/GitUI.Tests/BranchTreePanel/ContextMenu/GitRefsSortOrderContextMenuItemTests.cs
+++ b/UnitTests/GitUI.Tests/BranchTreePanel/ContextMenu/GitRefsSortOrderContextMenuItemTests.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using GitCommands;
+using GitCommands.Utils;
+using GitUI.BranchTreePanel.ContextMenu;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitUITests.UserControls
+{
+    [SetCulture("en-US")]
+    [SetUICulture("en-US")]
+    [TestFixture]
+    public class GitRefsSortOrderContextMenuItemTests
+    {
+        private Action _onSortOrderChanged;
+        private GitRefsSortOrderContextMenuItem _itemUnderTest;
+
+        [SetUp]
+        public void Setup()
+        {
+            _onSortOrderChanged = Substitute.For<Action>();
+            _itemUnderTest = new GitRefsSortOrderContextMenuItem(_onSortOrderChanged);
+        }
+
+        [Test]
+        public void Should_show_all_sort_options()
+        {
+            Assert.IsTrue(_itemUnderTest.HasDropDownItems);
+            Assert.AreEqual(EnumHelper.GetValues<GitRefsSortOrder>().Length, _itemUnderTest.DropDownItems.Count);
+        }
+
+        private static IEnumerable<TestCaseData> SortOrderOptions
+        {
+            get
+            {
+                foreach (GitRefsSortOrder order in EnumHelper.GetValues<GitRefsSortOrder>())
+                {
+                    yield return new TestCaseData(order);
+                }
+            }
+        }
+
+        [TestCaseSource(nameof(SortOrderOptions))]
+        public void Only_the_current_sort_option_is_selected(GitRefsSortOrder order)
+        {
+            GitRefsSortOrder original = AppSettings.RefsSortOrder;
+            try
+            {
+                AppSettings.RefsSortOrder = order;
+
+                // invoke the requery method to reselect the proper sub item
+                _itemUnderTest.GetTestAccessor().RaiseDropDownOpening();
+
+                AssertOnlyCheckedItemIs(order);
+            }
+            finally
+            {
+                AppSettings.RefsSortOrder = original;
+            }
+        }
+
+        [Test]
+        public void Clicking_an_item_sets_sort_in_service()
+        {
+            GitRefsSortOrder original = AppSettings.RefsSortOrder;
+            try
+            {
+                // Reset to the default
+                AppSettings.RefsSortOrder = GitRefsSortOrder.Descending;
+
+                foreach (var item in _itemUnderTest.DropDownItems.Cast<ToolStripMenuItem>())
+                {
+                    item.PerformClick();
+                    _onSortOrderChanged.Received(1).Invoke();
+                    _onSortOrderChanged.ClearReceivedCalls();
+                }
+            }
+            finally
+            {
+                AppSettings.RefsSortOrder = original;
+            }
+        }
+
+        private void AssertOnlyCheckedItemIs(GitRefsSortOrder sortType)
+        {
+            var matchingSubItem = _itemUnderTest.DropDownItems.Cast<ToolStripMenuItem>().Single(i => i.Tag.Equals(sortType));
+            Assert.IsTrue(matchingSubItem.Checked);
+
+            foreach (var otherItem in _itemUnderTest.DropDownItems.Cast<ToolStripMenuItem>().Except(new[] { matchingSubItem }))
+            {
+                Assert.IsFalse(otherItem.Checked);
+            }
+        }
+    }
+}

--- a/UnitTests/GitUI.Tests/UserControls/SortDiffListContextMenuItemTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/SortDiffListContextMenuItemTests.cs
@@ -50,7 +50,7 @@ namespace GitUITests.UserControls
             _testingSortService.DiffListSorting.Returns(sortType);
 
             // invoke the requery method to reselect the proper sub item
-            _itemUnderTest.GetTestAccessor().SimulateOpeningEvent();
+            _itemUnderTest.GetTestAccessor().RaiseDropDownOpening();
 
             AssertOnlyCheckedItemIs(sortType);
         }


### PR DESCRIPTION
Fixes #6310
Fixes #8301
Resolves #7472
Closes #4869
Closes #8309 as obsolete

## Proposed changes

- Provide ability to sort/order branches

Restore the functionality (albeit improved) removed in 9c7c76fb619480429cbe02e11ce889b00423eac2.

Allow to either defer sorting to git (i.e. sort by Default) which is either implicit, or configured via `git config branch.sort`.

Alternatively expose the following sort by options:
- authordate
- committerdate
- creatordate
- taggerdate
- refname
- objectsize
- upstream

For user-specified sort, allow to select ascending or descending order (default: desc).

Git v2.19+ is required to facilitate the above, hence bump in the min version.

The sort configuration applies to both the left panel and the branches dropdown in the toolstrip.


## Screenshots <!-- Remove this section if PR does not change UI -->



### After

* Settings:
![image](https://user-images.githubusercontent.com/4403806/91638483-3f18da80-ea53-11ea-8830-a5db883c8e21.png)
![image](https://user-images.githubusercontent.com/4403806/91638593-ef86de80-ea53-11ea-8613-ca1306ba4953.png)

* The left panel:
![image](https://user-images.githubusercontent.com/4403806/91638621-1fce7d00-ea54-11ea-853c-60706d15d77d.png)


## Test methodology <!-- How did you ensure quality? -->

- manual 
- added few unit tests



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
