### PR TITLE
Dark titlebar when using a dark theme on a recent Win10

### DIFF
--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -4,6 +4,8 @@ using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using GitExtUtils.GitUI;
+using GitUI.Interops.DwmApi;
+using GitUI.Theming;
 using ResourceManager;
 
 namespace GitUI
@@ -37,6 +39,12 @@ namespace GitUI
             var cancelButton = new Button();
             cancelButton.Click += CancelButtonClick;
             CancelButton = cancelButton;
+
+            if (ThemeModule.IsDarkTheme)
+            {
+                // Warning: This call freezes the CI in AppVeyor, however dark theme is not used on build machines
+                DwmApi.UseImmersiveDarkMode(Handle, true);
+            }
 
             void GitExtensionsForm_FormClosing(object sender, FormClosingEventArgs e)
             {

--- a/GitUI/Interops/DwmApi/DwmApi.cs
+++ b/GitUI/Interops/DwmApi/DwmApi.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace GitUI.Interops.DwmApi
+{
+    /// <summary>
+    /// Allow to set dark title bar on Win10. From: https://stackoverflow.com/questions/57124243/winforms-dark-title-bar-on-windows-10/62811758#62811758
+    /// </summary>
+    internal static class DwmApi
+    {
+        [DllImport("dwmapi.dll", ExactSpelling = true)]
+        private static extern int DwmSetWindowAttribute(IntPtr hwnd, uint attr, ref int attrValue, int attrSize);
+
+        // Non-documented Windows constants
+        private const uint DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 = 19;
+        private const uint DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
+
+        private static readonly bool _isSupported = IsWindows10BuildOrGreater(17763);
+        private static readonly uint _dwmAttribute = IsWindows10BuildOrGreater(18985)
+            ? DWMWA_USE_IMMERSIVE_DARK_MODE
+            : DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1;
+
+        internal static bool UseImmersiveDarkMode(IntPtr hwnd, bool enabled)
+        {
+            if (!_isSupported || hwnd == IntPtr.Zero)
+            {
+                return false;
+            }
+
+            int useImmersiveDarkMode = enabled ? 1 : 0;
+
+            try
+            {
+                return DwmSetWindowAttribute(hwnd, _dwmAttribute, ref useImmersiveDarkMode, sizeof(int)) == 0;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        private static bool IsWindows10BuildOrGreater(int build) => Environment.OSVersion.Version.Major >= 10 && Environment.OSVersion.Version.Build >= build;
+    }
+}

--- a/GitUI/Theming/ThemeModule.cs
+++ b/GitUI/Theming/ThemeModule.cs
@@ -15,6 +15,7 @@ namespace GitUI.Theming
         public static ThemeSettings Settings { get; private set; } = ThemeSettings.Default;
 
         private static ThemeRepository Repository { get; } = new ThemeRepository(new ThemePersistence());
+        public static bool IsDarkTheme { get; private set; }
 
         public static void Load()
         {
@@ -65,6 +66,8 @@ namespace GitUI.Theming
             {
                 return new ThemeSettings(Theme.Default, invariantTheme, AppSettings.UseSystemVisualStyle);
             }
+
+            IsDarkTheme = theme.SysColorValues[KnownColor.Window].GetBrightness() < 0.5;
 
             return new ThemeSettings(theme, invariantTheme, AppSettings.UseSystemVisualStyle);
         }


### PR DESCRIPTION
## Proposed changes

- Set a dark titlebar when using a dark theme when the user use a supported version of Win10


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The title bar is always white...
![image](https://user-images.githubusercontent.com/460196/92366753-d934ee80-f0f5-11ea-9cf6-cc671ce1052b.png)


### After

light theme:

![image](https://user-images.githubusercontent.com/460196/92336254-f68a9e00-f09e-11ea-92c2-cd8543009136.png)

dark theme:

![image](https://user-images.githubusercontent.com/460196/92336288-541eea80-f09f-11ea-8da5-86d429b7bafc.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 26402f0898e7107f5b8978fa8c8a2416198a864b
- Git 2.27.0.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4180.0
- DPI 96dpi (no scaling)



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
