### PR TITLE
Prevent a crash when opening the settings

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.cs
@@ -18,7 +18,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         protected override void SettingsToPage()
         {
-            for (int i = 0; i < AppSettings.CascadeShellMenuItems.Length; i++)
+            var itemsCount = Math.Min(AppSettings.CascadeShellMenuItems.Length, chlMenuEntries.Items.Count);
+            for (int i = 0; i < itemsCount; i++)
             {
                 chlMenuEntries.SetItemChecked(i, AppSettings.CascadeShellMenuItems[i] == '1');
             }


### PR DESCRIPTION


## Proposed changes

Prevent a crash when opening the settings when they are not the same numbers of elements in the 2 collections.

From what I understand, it is not supposed to happen with the released version.
But it happened to me... surely when testing a PR.
So, I think it couldn't be bad to harden the code here....

## Test methodology <!-- How did you ensure quality? -->

- Manual
