### PR TITLE
Jenkins: Present most recent interesting build info

### DIFF
--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -97,7 +97,7 @@ namespace GitUI.BuildServerIntegration
                     {
                         fullDayObservable.OnErrorResumeNext(fullObservable)
                                          .OnErrorResumeNext(Observable.Empty<BuildInfo>()
-                                                                      .DelaySubscription(TimeSpan.FromMinutes(1))
+                                                                      .DelaySubscription(LongPollInterval)
                                                                       .OnErrorResumeNext(fromNowObservable)
                                                                       .Retry()
                                                                       .Repeat())


### PR DESCRIPTION
## Proposed changes
 
Jenkins can start many builds for a commit, for instance for the branch and the pull request.
In some occasions the subsequent build(s) are aborted immediately, getting status NOT_BUILT
It is of course possible to abort builds too

The Jenkins build adapter presents the status for the latest build started for a commit regardless if it is complete or not.
This tries to present the most interesting status instead. 

- Cleanup from Re#, some manual adjustments
- The intervall for retrieving running builds was changed to two minutes in 3fcb4788b42d9b485880eb756e4bdc0af47d321b, but the full day obervable was kept at one minute

## Test methodology

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
