### PR TITLE
Don't expand branches node on refresh

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -10,7 +10,6 @@ using GitUI.BranchTreePanel.Interfaces;
 using GitUI.Properties;
 using JetBrains.Annotations;
 using Microsoft.VisualStudio.Threading;
-using ResourceManager;
 
 namespace GitUI.BranchTreePanel
 {
@@ -259,7 +258,7 @@ namespace GitUI.BranchTreePanel
         {
             private readonly IAheadBehindDataProvider _aheadBehindDataProvider;
 
-            public BranchTree(TreeNode treeNode, IGitUICommandsSource uiCommands, [CanBeNull]IAheadBehindDataProvider aheadBehindDataProvider)
+            public BranchTree(TreeNode treeNode, IGitUICommandsSource uiCommands, [CanBeNull] IAheadBehindDataProvider aheadBehindDataProvider)
                 : base(treeNode, uiCommands)
             {
                 _aheadBehindDataProvider = aheadBehindDataProvider;
@@ -346,6 +345,12 @@ namespace GitUI.BranchTreePanel
                 if (firstTime)
                 {
                     TreeViewNode.Expand();
+                }
+
+                if (TreeViewNode.TreeView.SelectedNode != null)
+                {
+                    // If there's a selected treenode, don't stomp over it
+                    return;
                 }
 
                 var activeBranch = Nodes.DepthEnumerator<LocalBranchNode>().FirstOrDefault(b => b.IsActive);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -261,31 +261,24 @@ namespace GitUI.BranchTreePanel
             {
                 if (TreeViewNode.TreeView.SelectedNode != null)
                 {
-                    SetSelectedNode(TreeViewNode.TreeView.SelectedNode);
-                    EnsureNodeVisible(TreeViewNode.TreeView.SelectedNode);
+                    EnsureNodeVisible(TreeViewNode.TreeView.Handle, TreeViewNode.TreeView.SelectedNode);
                 }
-
-                if (TreeViewNode.TreeView.Nodes.Count > 0)
+                else if (TreeViewNode.TreeView.Nodes.Count > 0)
                 {
                     // No selected node, just make sure the first node is visible
-                    EnsureNodeVisible(TreeViewNode.TreeView.Nodes[0]);
+                    EnsureNodeVisible(TreeViewNode.TreeView.Handle, TreeViewNode.TreeView.Nodes[0]);
                 }
 
                 return;
 
-                void SetSelectedNode(TreeNode node)
-                {
-                    TreeViewNode.TreeView.SelectedNode = node;
-                }
-
-                void EnsureNodeVisible(TreeNode node)
+                static void EnsureNodeVisible(IntPtr hwnd, TreeNode node)
                 {
                     node.EnsureVisible();
 
                     // EnsureVisible leads to horizontal scrolling in some cases. We make sure to force horizontal
                     // scroll back to 0. Note that we use SendMessage rather than SetScrollPos as the former works
                     // outside of Begin/EndUpdate.
-                    NativeMethods.SendMessageW(TreeViewNode.TreeView.Handle, NativeMethods.WM_HSCROLL, (IntPtr)NativeMethods.SBH.LEFT, IntPtr.Zero);
+                    NativeMethods.SendMessageW(hwnd, NativeMethods.WM_HSCROLL, (IntPtr)NativeMethods.SBH.LEFT, IntPtr.Zero);
                 }
             }
         }


### PR DESCRIPTION
Fixes #7676



## Proposed changes

Whenever the treeview in the left panel is refreshed, the currently checked out branch is being selected irrespective of whether the branches node is expanded or not.
This causes unnecessary refreshes, change of selection, and generally unpleasant UX.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![ge-branch-selection-old](https://user-images.githubusercontent.com/4403806/92927641-4e4f4d80-f481-11ea-80fb-c62139cb6263.gif)



### After

![ge-branch-selection-new](https://user-images.githubusercontent.com/4403806/92927669-54ddc500-f481-11ea-9fa6-07499185aa6e.gif)



## Test methodology <!-- How did you ensure quality? -->

- manual
