### PR TITLE
AppSettings Updated event

### DIFF
--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="$(JetBrainsAnnotationsVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.IO.Abstractions" Version="$(SystemIOAbstractionsVersion)" />
     <PackageReference Include="System.Reactive.Linq" Version="$(SystemReactiveVersion)" />
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />

--- a/GitCommands/Settings/BasicSettingTypes.cs
+++ b/GitCommands/Settings/BasicSettingTypes.cs
@@ -8,12 +8,6 @@ namespace GitCommands.Settings
             : base(name, settingsSource, defaultValue)
         {
         }
-
-        public override string Value
-        {
-            get => SettingsSource.GetString(Name, null);
-            set => SettingsSource.SetString(Name, value);
-        }
     }
 
     public class BoolNullableSetting : Setting<bool?>
@@ -21,12 +15,6 @@ namespace GitCommands.Settings
         public BoolNullableSetting(string name, SettingsPath settingsSource, bool defaultValue)
             : base(name, settingsSource, defaultValue)
         {
-        }
-
-        public override bool? Value
-        {
-            get => SettingsSource.GetBool(Name);
-            set => SettingsSource.SetBool(Name, value);
         }
 
         public new bool ValueOrDefault => base.ValueOrDefault.Value;
@@ -39,12 +27,6 @@ namespace GitCommands.Settings
         {
         }
 
-        public override int? Value
-        {
-            get => SettingsSource.GetInt(Name);
-            set => SettingsSource.SetInt(Name, value);
-        }
-
         public new int ValueOrDefault => base.ValueOrDefault.Value;
     }
 
@@ -53,12 +35,6 @@ namespace GitCommands.Settings
         public BoolSetting(string name, SettingsPath settingsSource, bool defaultValue)
             : base(name, settingsSource, defaultValue)
         {
-        }
-
-        public override bool Value
-        {
-            get => SettingsSource.GetBool(Name, DefaultValue);
-            set => SettingsSource.SetBool(Name, value);
         }
     }
 


### PR DESCRIPTION
## Proposed changes

- Add the ability to receive an event about a change in the setting value.
- Also, in the future, we can remove all classes inherited from Setting<T> and use one generic.

## Screenshots <!-- Remove this section if PR does not change UI -->

### After

![image](https://user-images.githubusercontent.com/3169265/92933142-88ebc280-f44e-11ea-981f-9aa64fee74fd.png)

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.4.3.9999
- Build d4b0f48bbf3e39a71f5d7ff5231be5678d4aa0f1
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4220.0
- DPI 96dpi (no scaling)

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
