### PR TITLE
Allow highlight branch by ALT+Click in the grid

### DIFF
--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9651,6 +9651,10 @@ See the changes in the commit form.</source>
         <source>Go to &amp;parent commit</source>
         <target />
       </trans-unit>
+      <trans-unit id="HighlightSelectedBranch.Text">
+        <source>Highlight selected branch (until refresh)</source>
+        <target />
+      </trans-unit>
       <trans-unit id="NavigateBackward.Text">
         <source>Navigate &amp;backward</source>
         <target />
@@ -9717,10 +9721,6 @@ See the changes in the commit form.</source>
       </trans-unit>
       <trans-unit id="ToggleBetweenArtificialAndHeadCommits.Text">
         <source>&amp;Toggle between artificial and HEAD commits</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="ToggleHighlightSelectedBranch.Text">
-        <source>Highlight selected branch (until refresh)</source>
         <target />
       </trans-unit>
       <trans-unit id="TopoOrder.Text">

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1585,6 +1585,11 @@ namespace GitUI
         {
             var hti = _gridView.HitTest(e.X, e.Y);
             _latestSelectedRowIndex = hti.RowIndex;
+
+            if (Control.ModifierKeys.HasFlag(Keys.Alt))
+            {
+                HighlightSelectedBranch();
+            }
         }
 
         private void OnGridViewCellMouseDown(object sender, DataGridViewCellMouseEventArgs e)
@@ -2429,10 +2434,9 @@ namespace GitUI
             return ExecuteCommand((int)cmd);
         }
 
-        private void ToggleHighlightSelectedBranch()
+        private void HighlightSelectedBranch()
         {
-            var revision = GetSelectedRevisions().FirstOrDefault();
-
+            GitRevision revision = GetSelectedRevisions().FirstOrDefault();
             if (revision is null)
             {
                 return;
@@ -2870,7 +2874,7 @@ namespace GitUI
                 case Command.SelectNextForkPointAsDiffBase: SelectNextForkPointAsDiffBase(); break;
                 case Command.GoToMergeBase: GoToMergeBase(); break;
                 case Command.GoToChild: goToChildToolStripMenuItem_Click(); break;
-                case Command.ToggleHighlightSelectedBranch: ToggleHighlightSelectedBranch(); break;
+                case Command.ToggleHighlightSelectedBranch: HighlightSelectedBranch(); break;
                 case Command.NextQuickSearch: _quickSearchProvider.NextResult(down: true); break;
                 case Command.PrevQuickSearch: _quickSearchProvider.NextResult(down: false); break;
                 case Command.NavigateBackward:

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -417,9 +417,10 @@ namespace GitUI.UserControls.RevisionGrid
                 },
                 new MenuCommand
                 {
-                    Name = "ToggleHighlightSelectedBranch",
+                    Name = "HighlightSelectedBranch",
                     Text = "Highlight selected branch (until refresh)",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ToggleHighlightSelectedBranch),
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ToggleHighlightSelectedBranch)
+                    + $", {Keys.Alt}+{Keys.LButton}",
                     ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGridControl.Command.ToggleHighlightSelectedBranch)
                 },
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Proposed changes

Expose the same behaviour as "Highlight selected branch" in the revision grid via <kbd>ALT</kbd>+<kbd>Left Click</kbd>, similar to the default hotkey <kbd>CTRL</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd>.

![image](https://user-images.githubusercontent.com/6248932/180868501-34a8deff-f196-4c20-b68a-1fcf16394f80.png)


