### PR TITLE
Fix 8351 - "Araxis does not show up in Mergetool/Difftool dropdown box"

### DIFF
--- a/GitCommands/DiffMergeTools/Araxis.cs
+++ b/GitCommands/DiffMergeTools/Araxis.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitCommands.DiffMergeTools
+{
+    internal class Araxis : DiffMergeTool
+    {
+        /// <inheritdoc />
+        public override string ExeFileName => "Compare.exe";
+
+        /// <inheritdoc />
+        public override string MergeCommand => "/merge /wait /a2 /3 \"$LOCAL\" \"$BASE\" \"$REMOTE\" \"$MERGED\"";
+
+        /// <inheritdoc />
+        public override string Name => "araxis";
+
+        /// <inheritdoc />
+        public override IEnumerable<string> SearchPaths => new[]
+        {
+            @"Araxis\"
+        };
+    }
+}

--- a/UnitTests/GitCommands.Tests/DiffMergeTools/RegisteredDiffMergeToolsTests.cs
+++ b/UnitTests/GitCommands.Tests/DiffMergeTools/RegisteredDiffMergeToolsTests.cs
@@ -12,7 +12,7 @@ namespace GitCommandsTests.DiffMergeTools
         {
             var tools = RegisteredDiffMergeTools.All(DiffMergeToolType.Diff);
 
-            tools.Should().BeEquivalentTo("bc", "bc3", "diffmerge", "kdiff3", "meld", "p4merge", "semanticmerge", "tortoisediff", "tortoisemerge", "vscode", "vsdiffmerge", "winmerge");
+            tools.Should().BeEquivalentTo("araxis", "bc", "bc3", "diffmerge", "kdiff3", "meld", "p4merge", "semanticmerge", "tortoisediff", "tortoisemerge", "vscode", "vsdiffmerge", "winmerge");
         }
 
         [Test]
@@ -20,7 +20,7 @@ namespace GitCommandsTests.DiffMergeTools
         {
             var tools = RegisteredDiffMergeTools.All(DiffMergeToolType.Merge);
 
-            tools.Should().BeEquivalentTo("bc", "bc3", "diffmerge", "kdiff3", "meld", "p4merge", "semanticmerge", "tortoisediff", "tortoisemerge", "vscode", "vsdiffmerge", "winmerge");
+            tools.Should().BeEquivalentTo("araxis", "bc", "bc3", "diffmerge", "kdiff3", "meld", "p4merge", "semanticmerge", "tortoisediff", "tortoisemerge", "vscode", "vsdiffmerge", "winmerge");
         }
     }
 }

--- a/contributors.txt
+++ b/contributors.txt
@@ -136,3 +136,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/07/03, gtisdelle, George Tisdelle, gwnt97(at)gmail.com
 2020/07/07, bstecisa, Borja Serrano, borjaserrano(at)gmail.com
 2020/08/02, FodderMK, Kevin Yockey, gitex{at]foddermk.com
+2020/09/13, hoborm, Mihaly Hobor, mail{{at]]hobor.xyz


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8351
Added back the Araxis merge/diff tool as requested in #8351 

## Proposed changes

- Created a new class for Araxis.cs in the DiffMergeTools.cs

## Test methodology <!-- How did you ensure quality? -->

- Extended the existing unit tests
- Manual testing


## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
2.28.0
- Windows <!-- Add version 7 SP1 or above -->
Version	10.0.19041 Build 19041
<!-- Mention language, UI scaling, or anything else that might be relevant -->

It's my first PR for GitExtensions please let me know if I need to change anything.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
