### PR TITLE
Settings [cleanup]

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -614,7 +614,7 @@ namespace GitCommands
             using (var blobStream = GetFileStream(blob))
             {
                 var blobData = blobStream.ToArray();
-                if (EffectiveConfigFile.core.autocrlf.ValueOrDefault == AutoCRLFType.@true)
+                if (EffectiveConfigFile.core.autocrlf.Value == AutoCRLFType.@true)
                 {
                     if (!FileHelper.IsBinaryFileName(this, saveAs) && !FileHelper.IsBinaryFileAccordingToContent(blobData))
                     {

--- a/GitCommands/Settings/RepoDistSettings.cs
+++ b/GitCommands/Settings/RepoDistSettings.cs
@@ -129,7 +129,7 @@ namespace GitCommands.Settings
             ShowBuildResultPage = Setting.Create(this, nameof(ShowBuildResultPage), true);
         }
 
-        public SettingsPath TypeSettings => new SettingsPath(this, Type.ValueOrDefault);
+        public SettingsPath TypeSettings => new SettingsPath(this, Type.Value);
     }
 
     public class DetailedGroup : SettingsPath

--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -306,12 +306,12 @@ namespace GitUI.BuildServerIntegration
 
             var buildServerSettings = _module().EffectiveSettings.BuildServer;
 
-            if (!buildServerSettings.EnableIntegration.ValueOrDefault)
+            if (!buildServerSettings.EnableIntegration.Value)
             {
                 return null;
             }
 
-            var buildServerType = buildServerSettings.Type.ValueOrDefault;
+            var buildServerType = buildServerSettings.Type.Value;
             if (string.IsNullOrEmpty(buildServerType))
             {
                 return null;

--- a/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
+++ b/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
@@ -215,7 +215,7 @@ namespace GitUI.CommandsDialogs
         private bool IsBuildResultPageEnabled()
         {
             var settings = GetModule().GetEffectiveSettings() as RepoDistSettings;
-            return settings?.BuildServer.ShowBuildResultPage.ValueOrDefault ?? false;
+            return settings?.BuildServer.ShowBuildResultPage.Value ?? false;
         }
 
         private IGitModule GetModule()

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -171,7 +171,7 @@ namespace GitUI.CommandsDialogs
             TreeTabPage.ImageKey = nameof(Images.FileTree);
             GpgInfoTabPage.ImageKey = nameof(Images.Key);
 
-            if (!AppSettings.ShowGpgInformation.ValueOrDefault)
+            if (!AppSettings.ShowGpgInformation.Value)
             {
                 CommitInfoTabControl.RemoveIfExists(GpgInfoTabPage);
             }
@@ -1290,7 +1290,7 @@ namespace GitUI.CommandsDialogs
 
         private async Task FillGpgInfoAsync(GitRevision revision)
         {
-            if (!AppSettings.ShowGpgInformation.ValueOrDefault || CommitInfoTabControl.SelectedTab != GpgInfoTabPage)
+            if (!AppSettings.ShowGpgInformation.Value || CommitInfoTabControl.SelectedTab != GpgInfoTabPage)
             {
                 return;
             }
@@ -2202,7 +2202,7 @@ namespace GitUI.CommandsDialogs
                 case Command.FocusCommitInfo: FocusCommitInfo(); break;
                 case Command.FocusDiff: FocusTabOf(revisionDiff, (c, alreadyContainedFocus) => c.SwitchFocus(alreadyContainedFocus)); break;
                 case Command.FocusFileTree: FocusTabOf(fileTree, (c, alreadyContainedFocus) => c.SwitchFocus(alreadyContainedFocus)); break;
-                case Command.FocusGpgInfo when AppSettings.ShowGpgInformation.ValueOrDefault: FocusTabOf(revisionGpgInfo1, (c, alreadyContainedFocus) => c.Focus()); break;
+                case Command.FocusGpgInfo when AppSettings.ShowGpgInformation.Value: FocusTabOf(revisionGpgInfo1, (c, alreadyContainedFocus) => c.Focus()); break;
                 case Command.FocusGitConsole: FocusGitConsole(); break;
                 case Command.FocusBuildServerStatus: FocusTabOf(_buildReportTabPageExtension.Control, (c, alreadyContainedFocus) => c.Focus()); break;
                 case Command.FocusNextTab: FocusNextTab(); break;
@@ -2825,7 +2825,7 @@ namespace GitUI.CommandsDialogs
         /// </summary>
         private void FillTerminalTab()
         {
-            if (!EnvUtils.RunningOnWindows() || !AppSettings.ShowConEmuTab.ValueOrDefault)
+            if (!EnvUtils.RunningOnWindows() || !AppSettings.ShowConEmuTab.Value)
             {
                 // ConEmu only works on WinNT
                 return;
@@ -2887,7 +2887,7 @@ namespace GitUI.CommandsDialogs
                     WhenConsoleProcessExits = WhenConsoleProcessExits.CloseConsoleEmulator
                 };
 
-                string shellType = AppSettings.ConEmuTerminal.ValueOrDefault;
+                string shellType = AppSettings.ConEmuTerminal.Value;
                 startInfo.ConsoleProcessCommandLine = _shellProvider.GetShellCommandLine(shellType);
 
                 // Set path to git in this window (actually, effective with CMD only)
@@ -2902,7 +2902,7 @@ namespace GitUI.CommandsDialogs
 
                 try
                 {
-                    _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, AppSettings.ConEmuStyle.ValueOrDefault, AppSettings.ConEmuFontSize.ValueOrDefault);
+                    _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, AppSettings.ConEmuStyle.Value, AppSettings.ConEmuFontSize.Value);
                 }
                 catch (InvalidOperationException)
                 {
@@ -2917,7 +2917,7 @@ namespace GitUI.CommandsDialogs
 
         public void ChangeTerminalActiveFolder(string path)
         {
-            string shellType = AppSettings.ConEmuTerminal.ValueOrDefault;
+            string shellType = AppSettings.ConEmuTerminal.Value;
             IShellDescriptor shell = _shellProvider.GetShell(shellType);
             _terminal?.ChangeFolder(shell, path);
         }

--- a/GitUI/CommandsDialogs/FormBrowseController.cs
+++ b/GitUI/CommandsDialogs/FormBrowseController.cs
@@ -62,7 +62,7 @@ namespace GitUI.CommandsDialogs
         [ItemCanBeNull]
         public async Task<GpgInfo> LoadGpgInfoAsync(GitRevision revision)
         {
-            if (!AppSettings.ShowGpgInformation.ValueOrDefault || revision?.ObjectId == null)
+            if (!AppSettings.ShowGpgInformation.Value || revision?.ObjectId == null)
             {
                 return null;
             }

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -44,8 +44,8 @@ namespace GitUI.CommandsDialogs
             _defaultBranch = defaultBranch;
 
             noFastForward.Checked = Module.EffectiveSettings.NoFastForwardMerge;
-            addLogMessages.Checked = Module.EffectiveSettings.Detailed.AddMergeLogMessages.ValueOrDefault;
-            nbMessages.Value = Module.EffectiveSettings.Detailed.MergeLogMessagesCount.ValueOrDefault;
+            addLogMessages.Checked = Module.EffectiveSettings.Detailed.AddMergeLogMessages.Value;
+            nbMessages.Value = Module.EffectiveSettings.Detailed.MergeLogMessagesCount.Value;
 
             advanced.Checked = AppSettings.AlwaysShowAdvOpt;
             advanced_CheckedChanged(null, null);

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -958,7 +958,7 @@ namespace GitUI.CommandsDialogs
             using (WaitCursorScope.Enter(Cursors.AppStarting))
             {
                 IReadOnlyList<IGitRef> remoteHeads;
-                if (Module.EffectiveSettings.Detailed.GetRemoteBranchesDirectlyFromRemote.ValueOrDefault)
+                if (Module.EffectiveSettings.Detailed.GetRemoteBranchesDirectlyFromRemote.Value)
                 {
                     EnsurePageant(remote);
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
@@ -40,7 +40,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             {
                 cboTerminal.Items.Add(shell);
 
-                if (string.Equals(shell.Name, AppSettings.ConEmuTerminal.ValueOrDefault, StringComparison.InvariantCultureIgnoreCase))
+                if (string.Equals(shell.Name, AppSettings.ConEmuTerminal.Value, StringComparison.InvariantCultureIgnoreCase))
                 {
                     cboTerminal.SelectedItem = shell;
                 }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -762,7 +762,7 @@ namespace GitUI.Editor
                 code = string.Join("\n", lines);
             }
 
-            ClipboardUtil.TrySetText(code.AdjustLineEndings(Module.EffectiveConfigFile.core.autocrlf.ValueOrDefault));
+            ClipboardUtil.TrySetText(code.AdjustLineEndings(Module.EffectiveConfigFile.core.autocrlf.Value));
         }
 
         private void SetVisibilityDiffContextMenu(bool visibleTextFile, [CanBeNull] string fileName)
@@ -1307,7 +1307,7 @@ namespace GitUI.Editor
                 }
             }
 
-            ClipboardUtil.TrySetText(code.AdjustLineEndings(Module.EffectiveConfigFile.core.autocrlf.ValueOrDefault));
+            ClipboardUtil.TrySetText(code.AdjustLineEndings(Module.EffectiveConfigFile.core.autocrlf.Value));
 
             return;
 

--- a/GitUI/Infrastructure/Telemetry/FormBrowseDiagnosticsReporter.cs
+++ b/GitUI/Infrastructure/Telemetry/FormBrowseDiagnosticsReporter.cs
@@ -30,7 +30,7 @@ namespace GitUI.Infrastructure.Telemetry
 
                     // commit info panel
                     { nameof(AppSettings.ShowAuthorAvatarInCommitInfo).FormatKey(), AppSettings.ShowAuthorAvatarInCommitInfo.ToString() },
-                    { nameof(AppSettings.ShowGpgInformation).FormatKey(), AppSettings.ShowGpgInformation.ValueOrDefault.ToString() },
+                    { nameof(AppSettings.ShowGpgInformation).FormatKey(), AppSettings.ShowGpgInformation.Value.ToString() },
 
                     // other
                     { nameof(AppSettings.ShowAheadBehindData).FormatKey(), AppSettings.ShowAheadBehindData.ToString() },

--- a/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
+++ b/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
@@ -120,7 +120,7 @@ namespace GitUI.UserControls
                     }
                 };
 
-                _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, AppSettings.ConEmuStyle.ValueOrDefault, AppSettings.ConEmuFontSize.ValueOrDefault);
+                _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, AppSettings.ConEmuStyle.Value, AppSettings.ConEmuFontSize.Value);
             }
             catch (Exception ex)
             {

--- a/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
@@ -39,7 +39,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
             var showIcon = AppSettings.ShowBuildStatusIconColumn;
             var showText = AppSettings.ShowBuildStatusTextColumn;
-            var columnVisible = settings.EnableIntegration.ValueOrDefault &&
+            var columnVisible = settings.EnableIntegration.Value &&
                                 (showIcon || showText);
 
             Column.Visible = columnVisible;

--- a/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
@@ -1,0 +1,1977 @@
+﻿using System;
+using GitCommands;
+using GitCommands.Settings;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Settings
+{
+    [TestFixture]
+    internal sealed class SettingTests
+    {
+        #region String Setting
+
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void Should_create_string_setting(string settingDefault)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault ?? string.Empty));
+            Assert.That(setting.Value, Is.EqualTo(settingDefault ?? string.Empty));
+            Assert.That(setting.IsUnset, Is.True);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(null, null)]
+        [TestCase(null, "")]
+        [TestCase(null, " ")]
+        [TestCase("", null)]
+        [TestCase("", "")]
+        [TestCase("", " ")]
+        [TestCase(" ", null)]
+        [TestCase(" ", "")]
+        [TestCase(" ", " ")]
+        public void Should_save_string_setting(string settingDefault, string value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault ?? string.Empty));
+            Assert.That(setting.Value, Is.EqualTo(value ?? string.Empty));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(null, null)]
+        [TestCase(null, "")]
+        [TestCase(null, " ")]
+        [TestCase("", null)]
+        [TestCase("", "")]
+        [TestCase("", " ")]
+        [TestCase(" ", null)]
+        [TestCase(" ", "")]
+        [TestCase(" ", " ")]
+        public void Should_trigger_updated_event_for_string_setting(string settingDefault, string value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault ?? string.Empty));
+            Assert.That(setting.Value, Is.EqualTo(value ?? string.Empty));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        [TestCase(null, null)]
+        [TestCase(null, "")]
+        [TestCase(null, " ")]
+        [TestCase("", null)]
+        [TestCase("", "")]
+        [TestCase("", " ")]
+        [TestCase(" ", null)]
+        [TestCase(" ", "")]
+        [TestCase(" ", " ")]
+        public void Should_not_trigger_updated_event_for_string_setting(string settingDefault, string value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault ?? string.Empty));
+            Assert.That(setting.Value, Is.EqualTo(value ?? string.Empty));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        #endregion String Setting
+
+        #region Bool Setting
+
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Should_create_bool_setting(bool settingDefault)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(settingDefault));
+            Assert.That(setting.IsUnset, Is.True);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(false, false)]
+        [TestCase(false, true)]
+        [TestCase(true, false)]
+        [TestCase(true, true)]
+        public void Should_save_bool_setting(bool settingDefault, bool value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(false, false)]
+        [TestCase(false, true)]
+        [TestCase(true, false)]
+        [TestCase(true, true)]
+        public void Should_trigger_updated_event_for_bool_setting(bool settingDefault, bool value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        [TestCase(false, false)]
+        [TestCase(false, true)]
+        [TestCase(true, false)]
+        [TestCase(true, true)]
+        public void Should_not_trigger_updated_event_for_bool_setting(bool settingDefault, bool value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        [Test]
+        public void Should_create_nullable_bool_setting()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create<bool>(settingsPath, settingName);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.Null);
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Should_save_nullable_bool_setting(bool? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create<bool>(settingsPath, settingName);
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Should_trigger_updated_event_for_nullable_bool_setting(bool? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create<bool>(settingsPath, settingName);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Should_not_trigger_updated_event_for_nullable_bool_setting(bool? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create<bool>(settingsPath, settingName);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        #endregion Bool Setting
+
+        #region Char Setting
+
+        [Test]
+        [TestCase(char.MinValue)]
+        [TestCase(char.MaxValue)]
+        [TestCase(' ')]
+        public void Should_create_char_setting(char settingDefault)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(settingDefault));
+            Assert.That(setting.IsUnset, Is.True);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(char.MinValue, char.MinValue)]
+        [TestCase(char.MinValue, char.MaxValue)]
+        [TestCase(char.MinValue, ' ')]
+        [TestCase(char.MaxValue, char.MinValue)]
+        [TestCase(char.MaxValue, char.MaxValue)]
+        [TestCase(char.MaxValue, ' ')]
+        [TestCase(' ', char.MinValue)]
+        [TestCase(' ', char.MaxValue)]
+        [TestCase(' ', ' ')]
+        public void Should_save_char_setting(char settingDefault, char value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(char.MinValue, char.MinValue)]
+        [TestCase(char.MinValue, char.MaxValue)]
+        [TestCase(char.MinValue, ' ')]
+        [TestCase(char.MaxValue, char.MinValue)]
+        [TestCase(char.MaxValue, char.MaxValue)]
+        [TestCase(char.MaxValue, ' ')]
+        [TestCase(' ', char.MinValue)]
+        [TestCase(' ', char.MaxValue)]
+        [TestCase(' ', ' ')]
+        public void Should_trigger_updated_event_for_char_setting(char settingDefault, char value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        [TestCase(char.MinValue, char.MinValue)]
+        [TestCase(char.MinValue, char.MaxValue)]
+        [TestCase(char.MinValue, ' ')]
+        [TestCase(char.MaxValue, char.MinValue)]
+        [TestCase(char.MaxValue, char.MaxValue)]
+        [TestCase(char.MaxValue, ' ')]
+        [TestCase(' ', char.MinValue)]
+        [TestCase(' ', char.MaxValue)]
+        [TestCase(' ', ' ')]
+        public void Should_not_trigger_updated_event_for_char_setting(char settingDefault, char value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        [Test]
+        public void Should_create_nullable_char_setting()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create<char>(settingsPath, settingName);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.Null);
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(char.MinValue)]
+        [TestCase(char.MaxValue)]
+        [TestCase(' ')]
+        public void Should_save_nullable_char_setting(char? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create<char>(settingsPath, settingName);
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(char.MinValue)]
+        [TestCase(char.MaxValue)]
+        [TestCase(' ')]
+        public void Should_trigger_updated_event_for_nullable_char_setting(char? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create<char>(settingsPath, settingName);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(char.MinValue)]
+        [TestCase(char.MaxValue)]
+        [TestCase(' ')]
+        public void Should_not_trigger_updated_event_for_nullable_char_setting(char? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create<char>(settingsPath, settingName);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        #endregion Char Setting
+
+        #region Byte Setting
+
+        [Test]
+        [TestCase(byte.MinValue)]
+        [TestCase(byte.MaxValue)]
+        [TestCase(0)]
+        public void Should_create_byte_setting(byte settingDefault)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(settingDefault));
+            Assert.That(setting.IsUnset, Is.True);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(byte.MinValue, byte.MinValue)]
+        [TestCase(byte.MinValue, byte.MaxValue)]
+        [TestCase(byte.MinValue, 0)]
+        [TestCase(byte.MaxValue, byte.MinValue)]
+        [TestCase(byte.MaxValue, byte.MaxValue)]
+        [TestCase(byte.MaxValue, 0)]
+        [TestCase(0, byte.MinValue)]
+        [TestCase(0, byte.MaxValue)]
+        [TestCase(0, 0)]
+        public void Should_save_byte_setting(byte settingDefault, byte value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(byte.MinValue, byte.MinValue)]
+        [TestCase(byte.MinValue, byte.MaxValue)]
+        [TestCase(byte.MinValue, 0)]
+        [TestCase(byte.MaxValue, byte.MinValue)]
+        [TestCase(byte.MaxValue, byte.MaxValue)]
+        [TestCase(byte.MaxValue, 0)]
+        [TestCase(0, byte.MinValue)]
+        [TestCase(0, byte.MaxValue)]
+        [TestCase(0, 0)]
+        public void Should_trigger_updated_event_for_byte_setting(byte settingDefault, byte value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        [TestCase(byte.MinValue, byte.MinValue)]
+        [TestCase(byte.MinValue, byte.MaxValue)]
+        [TestCase(byte.MinValue, 0)]
+        [TestCase(byte.MaxValue, byte.MinValue)]
+        [TestCase(byte.MaxValue, byte.MaxValue)]
+        [TestCase(byte.MaxValue, 0)]
+        [TestCase(0, byte.MinValue)]
+        [TestCase(0, byte.MaxValue)]
+        [TestCase(0, 0)]
+        public void Should_not_trigger_updated_event_for_byte_setting(byte settingDefault, byte value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        [Test]
+        public void Should_create_nullable_byte_setting()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create<byte>(settingsPath, settingName);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.Null);
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(byte.MinValue)]
+        [TestCase(byte.MaxValue)]
+        [TestCase(0)]
+        public void Should_save_nullable_byte_setting(byte? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create<byte>(settingsPath, settingName);
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(byte.MinValue)]
+        [TestCase(byte.MaxValue)]
+        [TestCase(0)]
+        public void Should_trigger_updated_event_for_nullable_byte_setting(byte? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create<byte>(settingsPath, settingName);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(byte.MinValue)]
+        [TestCase(byte.MaxValue)]
+        [TestCase(0)]
+        public void Should_not_trigger_updated_event_for_nullable_byte_setting(byte? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create<byte>(settingsPath, settingName);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        #endregion Byte Setting
+
+        #region Int Setting
+
+        [Test]
+        [TestCase(int.MinValue)]
+        [TestCase(int.MaxValue)]
+        [TestCase(0)]
+        public void Should_create_int_setting(int settingDefault)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(settingDefault));
+            Assert.That(setting.IsUnset, Is.True);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(int.MinValue, int.MinValue)]
+        [TestCase(int.MinValue, int.MaxValue)]
+        [TestCase(int.MinValue, 0)]
+        [TestCase(int.MaxValue, int.MinValue)]
+        [TestCase(int.MaxValue, int.MaxValue)]
+        [TestCase(int.MaxValue, 0)]
+        [TestCase(0, int.MinValue)]
+        [TestCase(0, int.MaxValue)]
+        [TestCase(0, 0)]
+        public void Should_save_int_setting(int settingDefault, int value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(int.MinValue, int.MinValue)]
+        [TestCase(int.MinValue, int.MaxValue)]
+        [TestCase(int.MinValue, 0)]
+        [TestCase(int.MaxValue, int.MinValue)]
+        [TestCase(int.MaxValue, int.MaxValue)]
+        [TestCase(int.MaxValue, 0)]
+        [TestCase(0, int.MinValue)]
+        [TestCase(0, int.MaxValue)]
+        [TestCase(0, 0)]
+        public void Should_trigger_updated_event_for_int_setting(int settingDefault, int value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        [TestCase(int.MinValue, int.MinValue)]
+        [TestCase(int.MinValue, int.MaxValue)]
+        [TestCase(int.MinValue, 0)]
+        [TestCase(int.MaxValue, int.MinValue)]
+        [TestCase(int.MaxValue, int.MaxValue)]
+        [TestCase(int.MaxValue, 0)]
+        [TestCase(0, int.MinValue)]
+        [TestCase(0, int.MaxValue)]
+        [TestCase(0, 0)]
+        public void Should_not_trigger_updated_event_for_int_setting(int settingDefault, int value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        [Test]
+        public void Should_create_nullable_int_setting()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create<int>(settingsPath, settingName);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.Null);
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(int.MinValue)]
+        [TestCase(int.MaxValue)]
+        [TestCase(0)]
+        public void Should_save_nullable_int_setting(int? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create<int>(settingsPath, settingName);
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(int.MinValue)]
+        [TestCase(int.MaxValue)]
+        [TestCase(0)]
+        public void Should_trigger_updated_event_for_nullable_int_setting(int? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create<int>(settingsPath, settingName);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(int.MinValue)]
+        [TestCase(int.MaxValue)]
+        [TestCase(0)]
+        public void Should_not_trigger_updated_event_for_nullable_int_setting(int? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create<int>(settingsPath, settingName);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        #endregion Int Setting
+
+        #region Float Setting
+
+        [Test]
+        [TestCase(float.MinValue)]
+        [TestCase(float.MaxValue)]
+        [TestCase(0f)]
+        public void Should_create_float_setting(float settingDefault)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(settingDefault));
+            Assert.That(setting.IsUnset, Is.True);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(float.MinValue, float.MinValue)]
+        [TestCase(float.MinValue, float.MaxValue)]
+        [TestCase(float.MinValue, 0f)]
+        [TestCase(float.MaxValue, float.MinValue)]
+        [TestCase(float.MaxValue, float.MaxValue)]
+        [TestCase(float.MaxValue, 0f)]
+        [TestCase(0f, float.MinValue)]
+        [TestCase(0f, float.MaxValue)]
+        [TestCase(0f, 0f)]
+        public void Should_save_float_setting(float settingDefault, float value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(float.MinValue, float.MinValue)]
+        [TestCase(float.MinValue, float.MaxValue)]
+        [TestCase(float.MinValue, 0f)]
+        [TestCase(float.MaxValue, float.MinValue)]
+        [TestCase(float.MaxValue, float.MaxValue)]
+        [TestCase(float.MaxValue, 0)]
+        [TestCase(0f, float.MinValue)]
+        [TestCase(0f, float.MaxValue)]
+        [TestCase(0f, 0f)]
+        public void Should_trigger_updated_event_for_float_setting(float settingDefault, float value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        [TestCase(float.MinValue, float.MinValue)]
+        [TestCase(float.MinValue, float.MaxValue)]
+        [TestCase(float.MinValue, 0f)]
+        [TestCase(float.MaxValue, float.MinValue)]
+        [TestCase(float.MaxValue, float.MaxValue)]
+        [TestCase(float.MaxValue, 0f)]
+        [TestCase(0f, float.MinValue)]
+        [TestCase(0f, float.MaxValue)]
+        [TestCase(0f, 0f)]
+        public void Should_not_trigger_updated_event_for_float_setting(float settingDefault, float value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        [Test]
+        public void Should_create_nullable_float_setting()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create<float>(settingsPath, settingName);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.Null);
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(float.MinValue)]
+        [TestCase(float.MaxValue)]
+        [TestCase(0f)]
+        public void Should_save_nullable_float_setting(float? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create<float>(settingsPath, settingName);
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(float.MinValue)]
+        [TestCase(float.MaxValue)]
+        [TestCase(0f)]
+        public void Should_trigger_updated_event_for_nullable_float_setting(float? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create<float>(settingsPath, settingName);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(float.MinValue)]
+        [TestCase(float.MaxValue)]
+        [TestCase(0f)]
+        public void Should_not_trigger_updated_event_for_nullable_float_setting(float? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create<float>(settingsPath, settingName);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        #endregion Float Setting
+
+        #region Enum Setting
+
+        [Test]
+        [TestCase(TestEnum.First)]
+        [TestCase(TestEnum.Second)]
+        public void Should_create_enum_setting(TestEnum settingDefault)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(settingDefault));
+            Assert.That(setting.IsUnset, Is.True);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(TestEnum.First, TestEnum.First)]
+        [TestCase(TestEnum.First, TestEnum.Second)]
+        [TestCase(TestEnum.Second, TestEnum.First)]
+        [TestCase(TestEnum.Second, TestEnum.Second)]
+        public void Should_save_enum_setting(TestEnum settingDefault, TestEnum value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(TestEnum.First, TestEnum.First)]
+        [TestCase(TestEnum.First, TestEnum.Second)]
+        [TestCase(TestEnum.Second, TestEnum.First)]
+        [TestCase(TestEnum.Second, TestEnum.Second)]
+        public void Should_trigger_updated_event_for_enum_setting(TestEnum settingDefault, TestEnum value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        [TestCase(TestEnum.First, TestEnum.First)]
+        [TestCase(TestEnum.First, TestEnum.Second)]
+        [TestCase(TestEnum.Second, TestEnum.First)]
+        [TestCase(TestEnum.Second, TestEnum.Second)]
+        public void Should_not_trigger_updated_event_for_enum_setting(TestEnum settingDefault, TestEnum value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        [Test]
+        public void Should_create_nullable_enum_setting()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create<TestEnum>(settingsPath, settingName);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.Null);
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(TestEnum.First)]
+        [TestCase(TestEnum.Second)]
+        public void Should_save_nullable_enum_setting(TestEnum? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create<TestEnum>(settingsPath, settingName);
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(TestEnum.First)]
+        [TestCase(TestEnum.Second)]
+        public void Should_trigger_updated_event_for_nullable_enum_setting(TestEnum? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create<TestEnum>(settingsPath, settingName);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(TestEnum.First)]
+        [TestCase(TestEnum.Second)]
+        public void Should_not_trigger_updated_event_for_nullable_enum_setting(TestEnum? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create<TestEnum>(settingsPath, settingName);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        public enum TestEnum
+        {
+            First,
+            Second
+        }
+
+        #endregion Enum Setting
+
+        #region Struct Setting
+
+        [Test]
+        public void Should_create_struct_setting()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var settingDefault = new TestStruct
+            {
+                Bool = false,
+                Char = ' ',
+                Byte = 0,
+                Int = 0,
+                Float = 0f
+            };
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(settingDefault));
+            Assert.That(setting.IsUnset, Is.True);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        public void Should_save_struct_setting()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var settingDefault = new TestStruct
+            {
+                Bool = false,
+                Char = ' ',
+                Byte = 0,
+                Int = 0,
+                Float = 0f
+            };
+
+            var value = new TestStruct
+            {
+                Bool = false,
+                Char = ' ',
+                Byte = 0,
+                Int = 0,
+                Float = 0f
+            };
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        public void Should_trigger_updated_event_for_struct_setting()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var settingDefault = new TestStruct
+            {
+                Bool = false,
+                Char = ' ',
+                Byte = 0,
+                Int = 0,
+                Float = 0f
+            };
+
+            var value = new TestStruct
+            {
+                Bool = false,
+                Char = ' ',
+                Byte = 0,
+                Int = 0,
+                Float = 0f
+            };
+
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        public void Should_not_trigger_updated_event_for_struct_setting()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var settingDefault = new TestStruct
+            {
+                Bool = false,
+                Char = ' ',
+                Byte = 0,
+                Int = 0,
+                Float = 0f
+            };
+
+            var value = new TestStruct
+            {
+                Bool = false,
+                Char = ' ',
+                Byte = 0,
+                Int = 0,
+                Float = 0f
+            };
+
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        [Test]
+        public void Should_create_nullable_struct_setting()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create<TestStruct>(settingsPath, settingName);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.Null);
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        public void Should_save_nullable_struct_setting()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            TestStruct? value = new TestStruct
+            {
+                Bool = false,
+                Char = ' ',
+                Byte = 0,
+                Int = 0,
+                Float = 0f
+            };
+
+            // Act
+            var setting = Setting.Create<TestStruct>(settingsPath, settingName);
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        public void Should_trigger_updated_event_for_nullable_struct_setting()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            TestStruct? value = new TestStruct
+            {
+                Bool = false,
+                Char = ' ',
+                Byte = 0,
+                Int = 0,
+                Float = 0f
+            };
+
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create<TestStruct>(settingsPath, settingName);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        public void Should_not_trigger_updated_event_for_nullable_struct_setting()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            TestStruct? value = new TestStruct
+            {
+                Bool = false,
+                Char = ' ',
+                Byte = 0,
+                Int = 0,
+                Float = 0f
+            };
+
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create<TestStruct>(settingsPath, settingName);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.Null);
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        public struct TestStruct
+        {
+            public bool Bool { get; set; }
+
+            public char Char { get; set; }
+
+            public byte Byte { get; set; }
+
+            public int Int { get; set; }
+
+            public float Float { get; set; }
+        }
+
+        #endregion Struct Setting
+    }
+}


### PR DESCRIPTION
Continuation #8450, #8451

## Proposed changes

- Drop ValueOrDefault property
- Add IsUnset property

For non nullable
          Value = (value ?? Default), IsUnset = (value == null)
For nullable except "String", all values is significant
          Value = value, IsUnset = false

## Screenshots <!-- Remove this section if PR does not change UI -->

### After

![image](https://user-images.githubusercontent.com/3169265/93139002-ac319e80-f6e8-11ea-9711-b84ffd5d29e4.png)

![image](https://user-images.githubusercontent.com/3169265/93138957-9a4ffb80-f6e8-11ea-92e2-846d976864c3.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.4.3.9999
- Build d4b0f48bbf3e39a71f5d7ff5231be5678d4aa0f1
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4220.0
- DPI 96dpi (no scaling)

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
