### PR TITLE
Don't use "AddSettingBinding" in "FormBrowseRepoSettingsPage"

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
@@ -20,20 +20,22 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void Init(ISettingsPageHost pageHost)
         {
             base.Init(pageHost);
-
-            // Bind settings with controls
-            AddSettingBinding(AppSettings.ShowConEmuTab, chkChowConsoleTab);
-            AddSettingBinding(AppSettings.ShowGpgInformation, chkShowGpgInformation);
         }
 
         protected override void PageToSettings()
         {
+            AppSettings.ShowConEmuTab.Value = chkChowConsoleTab.Checked;
+            AppSettings.ShowGpgInformation.Value = chkShowGpgInformation.Checked;
+
             AppSettings.ConEmuTerminal.Value = ((IShellDescriptor)cboTerminal.SelectedItem).Name.ToLowerInvariant();
             base.PageToSettings();
         }
 
         protected override void SettingsToPage()
         {
+            chkChowConsoleTab.Checked = AppSettings.ShowConEmuTab.Value;
+            chkShowGpgInformation.Checked = AppSettings.ShowGpgInformation.Value;
+
             foreach (IShellDescriptor shell in _shellProvider.GetShells())
             {
                 cboTerminal.Items.Add(shell);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8446


## Proposed changes

- The use "AddSettingBinding" in "FormBrowseRepoSettingsPage" doesn't make sense because the page implements only IGlobalSettingsPage


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/3169265/93210409-379e4480-f768-11ea-91a8-019c9d9a258e.png)

### After

![image](https://user-images.githubusercontent.com/3169265/93210055-a6c76900-f767-11ea-9ed7-641aa7e1626f.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

### How to test

![image](https://user-images.githubusercontent.com/3169265/93210215-e0986f80-f767-11ea-8e22-ddc16bec20d7.png)

#### Before

![image](https://user-images.githubusercontent.com/3169265/93210444-497fe780-f768-11ea-9adb-d00c85b3d8c6.png)

#### After 

![image](https://user-images.githubusercontent.com/3169265/93210250-f27a1280-f767-11ea-886b-a8d54e11bd31.png)

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.4.3.9999
- Build d4b0f48bbf3e39a71f5d7ff5231be5678d4aa0f1
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4220.0
- DPI 96dpi (no scaling)


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
