### PR TITLE
Prevent adding "--prune --prune-tags" when run from toolbar

### DIFF
--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -163,7 +163,7 @@ namespace GitUI.CommandsDialogs
                 case AppSettings.PullAction.FetchPruneAll:
                     Fetch.Checked = true;
                     Prune.Checked = true;
-                    PruneTags.Checked = true;
+                    PruneTags.Checked = false;
 
                     if (string.IsNullOrEmpty(defaultRemote))
                     {

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormPullTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormPullTests.cs
@@ -114,7 +114,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         [TestCase(AppSettings.PullAction.Rebase, false, false, false, true, false, false, false, false)]
         [TestCase(AppSettings.PullAction.Fetch, false, false, false, false, true, false, true, true)]
         [TestCase(AppSettings.PullAction.FetchAll, false, false, false, false, true, false, true, true)]
-        [TestCase(AppSettings.PullAction.FetchPruneAll, false, true, true, false, true, false, true, true)]
+        [TestCase(AppSettings.PullAction.FetchPruneAll, false, true, false, false, true, false, true, true)]
         public void Should_correctly_setup_for_defined_pull_action(AppSettings.PullAction pullAction,
             bool mergeChecked, bool pruneRemoteBranches, bool pruneRemoteBranchesAndTags, bool rebaseChecked, bool fetchChecked, bool autoStashChecked, bool pruneRemoteBranchesEnabled, bool pruneRemoteBranchesAndTagsEnabled)
         {
@@ -141,7 +141,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         [TestCase(AppSettings.PullAction.Rebase, false, false, false, true, false, false, false, false)]
         [TestCase(AppSettings.PullAction.Fetch, false, false, false, false, true, false, true, true)]
         [TestCase(AppSettings.PullAction.FetchAll, false, false, false, false, true, false, true, true)]
-        [TestCase(AppSettings.PullAction.FetchPruneAll, false, true, true, false, true, false, true, true)]
+        [TestCase(AppSettings.PullAction.FetchPruneAll, false, true, false, false, true, false, true, true)]
         public void Should_use_user_DefaultPullAction_pull_action_None(AppSettings.PullAction pullAction,
             bool mergeChecked, bool pruneRemoteBranches, bool pruneRemoteBranchesAndTags, bool rebaseChecked, bool fetchChecked, bool autoStashChecked, bool pruneRemoteBranchesEnabled, bool pruneRemoteBranchesAndTagsEnabled)
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8463
Continuation #8433

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/3169265/93464275-993dea80-f8f1-11ea-84ed-f4771e349bbf.png)

### After

![image](https://user-images.githubusercontent.com/3169265/93464088-495f2380-f8f1-11ea-80bc-a9798f8546a6.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual
- Unit Tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.4.3.9999
- Build d4b0f48bbf3e39a71f5d7ff5231be5678d4aa0f1
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4220.0
- DPI 96dpi (no scaling)


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
