### PR TITLE
support for range-diff

### DIFF
--- a/GitCommands/Git/GitItemStatus.cs
+++ b/GitCommands/Git/GitItemStatus.cs
@@ -38,7 +38,10 @@ namespace GitCommands
             IsSkipWorktree = 1 << 10,
             IsSubmodule = 1 << 11,
             IsDirty = 1 << 12,
-            IsStatusOnly = 1 << 13
+
+            // Other flags are parsed from Git status, set fake flags for special uses
+            IsStatusOnly = 1 << 13,
+            IsRangeDiff = 1 << 14
         }
 
         private JoinableTask<GitSubmoduleStatus> _submoduleStatus;
@@ -136,14 +139,24 @@ namespace GitCommands
             set => SetFlag(value, Flags.IsDirty);
         }
 
-        /// <summary>
+        /// <remarks>
         /// This item is not a Git item, just status information
         /// If ErrorMessage is set, this is an error from Git, otherwise just a marker that nothing is changed
-        /// </summary>
+        /// </remarks>
         public bool IsStatusOnly
         {
             get => _flags.HasFlag(Flags.IsStatusOnly);
             set => SetFlag(value, Flags.IsStatusOnly);
+        }
+
+        /// <remarks>
+        /// This item is not a native git item, but a status information
+        /// calculated with git range-diff command.
+        /// </remarks>
+        public bool IsRangeDiff
+        {
+            get => _flags.HasFlag(Flags.IsRangeDiff);
+            set => SetFlag(value, Flags.IsRangeDiff);
         }
 
         private void SetFlag(bool isSet, Flags flag)

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -133,6 +133,8 @@ namespace GitCommands
 
         public bool SupportGuiMergeTool => this >= v2_20_0;
 
+        public bool SupportRangeDiffTool => this >= v2_19_0;
+
         public bool IsUnknown => _a == 0 && _b == 0 && _c == 0 && _d == 0;
 
         // Returns true if it's possible to pass given string as command line

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -325,8 +325,9 @@ namespace GitUI.CommandsDialogs
             // First (A) is parent if one revision selected or if parent, then selected
             var parentIds = selectedItems.FirstIds().ToList();
 
-            // Combined diff is a display only diff, no manipulations
-            bool isAnyCombinedDiff = parentIds.Contains(ObjectId.CombinedDiffId);
+            // Combined diff, range diff etc are for display only, no manipulations
+            bool isStatusOnly = selectedItems.Any(item => item.Item.IsStatusOnly);
+            bool isDisplayOnlyDiff = parentIds.Contains(ObjectId.CombinedDiffId) || isStatusOnly;
             int selectedGitItemCount = selectedItems.Count();
 
             // No changes to files in bare repos
@@ -339,7 +340,8 @@ namespace GitUI.CommandsDialogs
 
             var selectionInfo = new ContextMenuSelectionInfo(
                 selectedRevision: selectedRev,
-                isAnyCombinedDiff: isAnyCombinedDiff,
+                isDisplayOnlyDiff: isDisplayOnlyDiff,
+                isStatusOnly: isStatusOnly,
                 selectedGitItemCount: selectedGitItemCount,
                 isAnyItemIndex: isAnyIndex,
                 isAnyItemWorkTree: isAnyWorkTree,
@@ -523,6 +525,7 @@ namespace GitUI.CommandsDialogs
             diffOpenRevisionFileToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuOpenRevision(selectionInfo);
             diffOpenRevisionFileWithToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuOpenRevision(selectionInfo);
             saveAsToolStripMenuItem1.Visible = _revisionDiffController.ShouldShowMenuSaveAs(selectionInfo);
+            openContainingFolderToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuShowInFolder(selectionInfo);
             diffEditWorkingDirectoryFileToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuEditWorkingDirectoryFile(selectionInfo);
             diffDeleteFileToolStripMenuItem.Text = ResourceManager.Strings.GetDeleteFile(selectionInfo.SelectedGitItemCount);
             diffDeleteFileToolStripMenuItem.Enabled = _revisionDiffController.ShouldShowMenuDeleteFile(selectionInfo);

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -326,7 +326,7 @@ namespace GitUI.CommandsDialogs
             var parentIds = selectedItems.FirstIds().ToList();
 
             // Combined diff, range diff etc are for display only, no manipulations
-            bool isStatusOnly = selectedItems.Any(item => item.Item.IsStatusOnly);
+            bool isStatusOnly = selectedItems.Any(item => item.Item.IsRangeDiff || item.Item.IsStatusOnly);
             bool isDisplayOnlyDiff = parentIds.Contains(ObjectId.CombinedDiffId) || isStatusOnly;
             int selectedGitItemCount = selectedItems.Count();
 

--- a/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -17,6 +17,7 @@ namespace GitUI.CommandsDialogs
         bool ShouldShowMenuFileHistory(ContextMenuSelectionInfo selectionInfo);
         bool ShouldShowMenuSaveAs(ContextMenuSelectionInfo selectionInfo);
         bool ShouldShowMenuCopyFileName(ContextMenuSelectionInfo selectionInfo);
+        bool ShouldShowMenuShowInFolder(ContextMenuSelectionInfo selectionInfo);
         bool ShouldShowMenuShowInFileTree(ContextMenuSelectionInfo selectionInfo);
         bool ShouldShowMenuStage(ContextMenuSelectionInfo selectionInfo);
         bool ShouldShowMenuUnstage(ContextMenuSelectionInfo selectionInfo);
@@ -29,7 +30,8 @@ namespace GitUI.CommandsDialogs
         // Defaults are set to simplify test cases, the defaults enables most
         public ContextMenuSelectionInfo(
             GitRevision selectedRevision,
-            bool isAnyCombinedDiff,
+            bool isDisplayOnlyDiff,
+            bool isStatusOnly,
             int selectedGitItemCount,
             bool isAnyItemIndex,
             bool isAnyItemWorkTree,
@@ -40,7 +42,8 @@ namespace GitUI.CommandsDialogs
             bool isAnySubmodule)
         {
             SelectedRevision = selectedRevision;
-            IsAnyCombinedDiff = isAnyCombinedDiff;
+            IsDisplayOnlyDiff = isDisplayOnlyDiff;
+            IsStatusOnly = isStatusOnly;
             SelectedGitItemCount = selectedGitItemCount;
             IsAnyItemIndex = isAnyItemIndex;
             IsAnyItemWorkTree = isAnyItemWorkTree;
@@ -53,7 +56,8 @@ namespace GitUI.CommandsDialogs
 
         [CanBeNull]
         public GitRevision SelectedRevision { get; }
-        public bool IsAnyCombinedDiff { get; }
+        public bool IsDisplayOnlyDiff { get; }
+        public bool IsStatusOnly { get; }
         public int SelectedGitItemCount { get; }
         public bool IsAnyItemIndex { get; }
         public bool IsAnyItemWorkTree { get; }
@@ -77,25 +81,29 @@ namespace GitUI.CommandsDialogs
 
         public bool ShouldShowDifftoolMenus(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.SelectedGitItemCount > 0 && !selectionInfo.IsAnyCombinedDiff;
+            return selectionInfo.SelectedGitItemCount > 0 && !selectionInfo.IsDisplayOnlyDiff;
         }
 
         public bool ShouldShowResetFileMenus(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.SelectedGitItemCount > 0 && !selectionInfo.IsBareRepository && selectionInfo.IsAnyTracked;
+            return selectionInfo.SelectedGitItemCount > 0
+                && !selectionInfo.IsBareRepository
+                && selectionInfo.IsAnyTracked
+                && !selectionInfo.IsDisplayOnlyDiff;
         }
 
         #region Main menu items
         public bool ShouldShowMenuSaveAs(ContextMenuSelectionInfo selectionInfo)
         {
             return selectionInfo.SelectedGitItemCount == 1 && !selectionInfo.IsAnySubmodule
-                && !(selectionInfo.SelectedRevision?.IsArtificial ?? false);
+                && !(selectionInfo.SelectedRevision?.IsArtificial ?? false)
+                && !selectionInfo.IsDisplayOnlyDiff;
         }
 
         public bool ShouldShowMenuCherryPick(ContextMenuSelectionInfo selectionInfo)
         {
             return selectionInfo.SelectedGitItemCount == 1 && !selectionInfo.IsAnySubmodule
-                && !selectionInfo.IsAnyCombinedDiff && !selectionInfo.IsBareRepository
+                && !selectionInfo.IsDisplayOnlyDiff && !selectionInfo.IsBareRepository
                 && !(selectionInfo.SelectedRevision?.IsArtificial ?? false);
         }
 
@@ -127,18 +135,27 @@ namespace GitUI.CommandsDialogs
 
         public bool ShouldShowMenuOpenRevision(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.SelectedGitItemCount == 1 && !selectionInfo.IsAnySubmodule &&
-                   !(selectionInfo.SelectedRevision?.IsArtificial ?? false);
+            return selectionInfo.SelectedGitItemCount == 1
+                && !selectionInfo.IsAnySubmodule
+                && !selectionInfo.IsDisplayOnlyDiff
+                && !(selectionInfo.SelectedRevision?.IsArtificial ?? false);
         }
 
         public bool ShouldShowMenuCopyFileName(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.SelectedGitItemCount != 0;
+            return selectionInfo.SelectedGitItemCount > 0 && !selectionInfo.IsStatusOnly;
+        }
+
+        public bool ShouldShowMenuShowInFolder(ContextMenuSelectionInfo selectionInfo)
+        {
+            return selectionInfo.SelectedGitItemCount > 0 && !selectionInfo.IsStatusOnly;
         }
 
         public bool ShouldShowMenuShowInFileTree(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.SelectedGitItemCount == 1 && !(selectionInfo.SelectedRevision?.IsArtificial ?? false);
+            return selectionInfo.SelectedGitItemCount == 1
+                && !(selectionInfo.SelectedRevision?.IsArtificial ?? false)
+                && !selectionInfo.IsStatusOnly;
         }
 
         public bool ShouldShowMenuFileHistory(ContextMenuSelectionInfo selectionInfo)

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -72,6 +73,22 @@ namespace GitUI
             {
                 // View blob guid from revision, or file for worktree
                 return fileViewer.ViewGitItemRevisionAsync(item.Item, item.SecondRevision.ObjectId, openWithDiffTool);
+            }
+
+            if (item.Item.IsRangeDiff)
+            {
+                // This command may take time, give an indication of what is going on
+                // The sha are incorrect if baseA/baseB is set, to simplify the presentation
+                fileViewer.ViewText("range-diff.sh", $"git range-diff {firstId}...{item.SecondRevision.ObjectId}");
+
+                string output = fileViewer.Module.GetRangeDiff(
+                        firstId,
+                        item.SecondRevision.ObjectId,
+                        item.BaseA,
+                        item.BaseB,
+                        fileViewer.GetExtraDiffArguments());
+
+                return fileViewer.ViewTextAsync(item.Item.Name, output ?? defaultText);
             }
 
             string selectedPatch = GetSelectedPatch(fileViewer, firstId, item.SecondRevision.ObjectId, item.Item)

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -69,6 +69,7 @@ namespace GitUI
         private readonly TranslationString _diffWithParent = new TranslationString("Diff with a/");
         private readonly TranslationString _diffBaseToB = new TranslationString("Unique diff BASE with b/");
         private readonly TranslationString _diffCommonBase = new TranslationString("Common diff with BASE a/");
+        private readonly TranslationString _diffRange = new TranslationString("Range diff");
         private readonly TranslationString _combinedDiff = new TranslationString("Combined diff");
 
         private readonly TranslationString _showDiffForAllParentsText = new TranslationString("Show file differences for all parents in browse dialog");
@@ -170,6 +171,7 @@ namespace GitUI
         public static string DiffWithParent => _instance.Value._diffWithParent.Text;
         public static string DiffBaseToB => _instance.Value._diffBaseToB.Text;
         public static string DiffCommonBase => _instance.Value._diffCommonBase.Text;
+        public static string DiffRange => _instance.Value._diffRange.Text;
         public static string CombinedDiff => _instance.Value._combinedDiff.Text;
         public static string ShowDiffForAllParentsText => _instance.Value._showDiffForAllParentsText.Text;
         public static string ShowDiffForAllParentsTooltip => _instance.Value._showDiffForAllParentsTooltip.Text;

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -66,6 +66,11 @@ namespace GitUI
         private readonly TranslationString _sortOrder = new TranslationString("&Sort order...");
 
         private readonly TranslationString _diffSelectedWithRememberedFile = new TranslationString("Diff with \"{0}\"");
+        private readonly TranslationString _diffWithParent = new TranslationString("Diff with a/");
+        private readonly TranslationString _diffBaseToB = new TranslationString("Unique diff BASE with b/");
+        private readonly TranslationString _diffCommonBase = new TranslationString("Common diff with BASE a/");
+        private readonly TranslationString _combinedDiff = new TranslationString("Combined diff");
+
         private readonly TranslationString _showDiffForAllParentsText = new TranslationString("Show file differences for all parents in browse dialog");
         private readonly TranslationString _showDiffForAllParentsTooltip = new TranslationString(@"Show all differences between the selected commits, not limiting to only one difference.
 
@@ -162,6 +167,10 @@ namespace GitUI
         public static string SortOrder => _instance.Value._sortOrder.Text;
 
         public static string DiffSelectedWithRememberedFile => _instance.Value._diffSelectedWithRememberedFile.Text;
+        public static string DiffWithParent => _instance.Value._diffWithParent.Text;
+        public static string DiffBaseToB => _instance.Value._diffBaseToB.Text;
+        public static string DiffCommonBase => _instance.Value._diffCommonBase.Text;
+        public static string CombinedDiff => _instance.Value._combinedDiff.Text;
         public static string ShowDiffForAllParentsText => _instance.Value._showDiffForAllParentsText.Text;
         public static string ShowDiffForAllParentsTooltip => _instance.Value._showDiffForAllParentsTooltip.Text;
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1296,22 +1296,6 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>No changes</source>
         <target />
       </trans-unit>
-      <trans-unit id="_combinedDiff.Text">
-        <source>Combined diff</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_diffBaseToB.Text">
-        <source>Unique diff BASE with b/</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_diffCommonBase.Text">
-        <source>Common diff with BASE a/</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_diffWithParent.Text">
-        <source>Diff with a/</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_openSubmoduleMenuItem.Text">
         <source>Open with Git Extensions</source>
         <target />
@@ -9253,6 +9237,10 @@ Select this commit to populate the full message.</source>
         <source>{0:Child|Children}</source>
         <target />
       </trans-unit>
+      <trans-unit id="_combinedDiff.Text">
+        <source>Combined diff</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_commitDateText.Text">
         <source>{0:Commit date|Commit dates}</source>
         <target />
@@ -9309,8 +9297,20 @@ Select this commit to populate the full message.</source>
         <source>{0:Delete file|Delete files}</source>
         <target />
       </trans-unit>
+      <trans-unit id="_diffBaseToB.Text">
+        <source>Unique diff BASE with b/</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_diffCommonBase.Text">
+        <source>Common diff with BASE a/</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_diffSelectedWithRememberedFile.Text">
         <source>Diff with "{0}"</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_diffWithParent.Text">
+        <source>Diff with a/</source>
         <target />
       </trans-unit>
       <trans-unit id="_directoryIsNotAValidRepository.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9305,6 +9305,10 @@ Select this commit to populate the full message.</source>
         <source>Common diff with BASE a/</source>
         <target />
       </trans-unit>
+      <trans-unit id="_diffRange.Text">
+        <source>Range diff</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_diffSelectedWithRememberedFile.Text">
         <source>Diff with "{0}"</source>
         <target />

--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GitCommands;
+using GitCommands.Git;
+using GitUIPluginInterfaces;
+
+namespace GitUI
+{
+    public class FileStatusDiffCalculator
+    {
+        private readonly Func<GitModule> _getModule;
+
+        public FileStatusDiffCalculator(Func<GitModule> getModule)
+        {
+            _getModule = getModule;
+        }
+
+        public IReadOnlyList<FileStatusWithDescription> SetDiffs(in IReadOnlyList<GitRevision> revisions, Func<ObjectId, string> describeRevision,
+            Func<ObjectId, GitRevision> getRevision = null)
+        {
+            var selectedRev = revisions?.FirstOrDefault();
+            if (selectedRev == null)
+            {
+                return Array.Empty<FileStatusWithDescription>();
+            }
+
+            GitModule module = GetModule();
+
+            var fileStatusDescs = new List<FileStatusWithDescription>();
+            if (revisions.Count == 1)
+            {
+                if (selectedRev.ParentIds == null || selectedRev.ParentIds.Count == 0)
+                {
+                    // No parent for the initial commit
+                    fileStatusDescs.Add(new FileStatusWithDescription(
+                        firstRev: null,
+                        secondRev: selectedRev,
+                        summary: GetDescriptionForRevision(describeRevision, selectedRev.ObjectId),
+                        statuses: module.GetTreeFiles(selectedRev.TreeGuid, full: true)));
+                }
+                else
+                {
+                    // Get the parents for the selected revision
+                    var multipleParents = AppSettings.ShowDiffForAllParents ? selectedRev.ParentIds.Count : 1;
+                    fileStatusDescs.AddRange(selectedRev
+                        .ParentIds?
+                        .Take(multipleParents)
+                        .Select(parentId =>
+                            new FileStatusWithDescription(
+                                firstRev: new GitRevision(parentId),
+                                secondRev: selectedRev,
+                                summary: Strings.DiffWithParent + GetDescriptionForRevision(describeRevision, parentId),
+                                statuses: module.GetDiffFilesWithSubmodulesStatus(parentId, selectedRev.ObjectId, selectedRev.FirstParentId))));
+                }
+
+                // Show combined (merge conflicts) when a single merge commit is selected
+                var isMergeCommit = fileStatusDescs.Count > 1;
+                if (AppSettings.ShowDiffForAllParents && isMergeCommit)
+                {
+                    var conflicts = module.GetCombinedDiffFileList(selectedRev.Guid);
+                    if (conflicts.Count != 0)
+                    {
+                        // Create an artificial commit
+                        fileStatusDescs.Add(new FileStatusWithDescription(
+                            firstRev: new GitRevision(ObjectId.CombinedDiffId), secondRev: selectedRev, summary: Strings.CombinedDiff, statuses: conflicts));
+                    }
+                }
+
+                return fileStatusDescs;
+            }
+
+            // With more than 4, only first -> selected is interesting
+            // Show multi compare if 2-4 are selected
+            const int maxMultiCompare = 4;
+
+            // With 4 selected, assume that ranges are selected: baseA..headA baseB..headB
+            // the first item is therefore the second selected
+            var firstRev = AppSettings.ShowDiffForAllParents && revisions.Count == maxMultiCompare
+                ? revisions[2]
+                : revisions.Last();
+
+            fileStatusDescs.Add(new FileStatusWithDescription(
+                firstRev: firstRev,
+                secondRev: selectedRev,
+                summary: Strings.DiffWithParent + GetDescriptionForRevision(describeRevision, firstRev.ObjectId),
+                statuses: module.GetDiffFilesWithSubmodulesStatus(firstRev.ObjectId, selectedRev.ObjectId, selectedRev.FirstParentId)));
+
+            if (!AppSettings.ShowDiffForAllParents || revisions.Count > maxMultiCompare)
+            {
+                return fileStatusDescs;
+            }
+
+            // Extra information with limited selection
+            var allAToB = fileStatusDescs[0].Statuses;
+
+            // Get base commit, add as parent if unique
+            Lazy<ObjectId> head = getRevision != null
+                ? new Lazy<ObjectId>(() => getRevision(ObjectId.IndexId).FirstParentId)
+                : new Lazy<ObjectId>(() => module.RevParse("HEAD"));
+            var firstRevHead = GetRevisionOrHead(firstRev, head);
+            var selectedRevHead = GetRevisionOrHead(selectedRev, head);
+            var baseRevGuid = module.GetMergeBase(firstRevHead, selectedRevHead);
+
+            // Four selected, to check if two ranges are selected
+            var baseA = (revisions.Count != 4 || baseRevGuid is null)
+                ? null
+                : module.GetMergeBase(GetRevisionOrHead(revisions[3], head), firstRevHead);
+            var baseB = baseA is null || baseA != revisions[3].ObjectId
+                ? null
+                : module.GetMergeBase(GetRevisionOrHead(revisions[1], head), selectedRevHead);
+            if (baseB != revisions[1].ObjectId)
+            {
+                baseB = null;
+            }
+
+            // Check for separate branches (note that artificial commits both have HEAD as BASE)
+            if (baseRevGuid is null
+                || baseRevGuid == firstRevHead
+                || baseRevGuid == selectedRevHead
+
+                // For three, show multi-diff if not base is selected
+                || (revisions.Count == 3 && baseRevGuid != revisions[1].ObjectId)
+
+                // For four, two ranges must be selected
+                || (revisions.Count == 4 && (baseA is null || baseB is null)))
+            {
+                // No variant of range diff, show multi diff
+                fileStatusDescs.AddRange(
+                    revisions
+                        .Where(rev => rev != firstRev && rev != selectedRev)
+                        .Select(rev => new FileStatusWithDescription(
+                            firstRev: rev,
+                            secondRev: selectedRev,
+                            summary: Strings.DiffWithParent + GetDescriptionForRevision(describeRevision, rev.ObjectId),
+                            statuses: module.GetDiffFilesWithSubmodulesStatus(rev.ObjectId, selectedRev.ObjectId, selectedRev.FirstParentId))));
+
+                return fileStatusDescs;
+            }
+
+            // Present common files in BASE->B, BASE->A separately
+            // For the following diff:  A->B a,c,d; BASE->B a,b,c; BASE->A a,b,d
+            // (the file a has unique changes, b has the same change and c,d is changed in one of the branches)
+            // The following groups will be shown: A->B a,c,d; BASE->B a,c; BASE->A a,d; Common BASE b
+            var allBaseToB = module.GetDiffFilesWithSubmodulesStatus(baseRevGuid, selectedRev.ObjectId, selectedRev.FirstParentId);
+            var allBaseToA = module.GetDiffFilesWithSubmodulesStatus(baseRevGuid, firstRev.ObjectId, firstRev.FirstParentId);
+
+            var comparer = new GitItemStatusNameEqualityComparer();
+            var commonBaseToAandB = allBaseToB.Intersect(allBaseToA, comparer).Except(allAToB, comparer).ToList();
+
+            var revBase = new GitRevision(baseRevGuid);
+            fileStatusDescs.Add(new FileStatusWithDescription(
+                firstRev: revBase,
+                secondRev: selectedRev,
+                summary: Strings.DiffBaseToB + GetDescriptionForRevision(describeRevision, selectedRev.ObjectId),
+                statuses: allBaseToB.Except(commonBaseToAandB, comparer).ToList()));
+            fileStatusDescs.Add(new FileStatusWithDescription(
+                firstRev: revBase,
+                secondRev: firstRev,
+                summary: Strings.DiffBaseToB + GetDescriptionForRevision(describeRevision, firstRev.ObjectId),
+                statuses: allBaseToA.Except(commonBaseToAandB, comparer).ToList()));
+            fileStatusDescs.Add(new FileStatusWithDescription(
+                firstRev: revBase,
+                secondRev: selectedRev,
+                summary: Strings.DiffCommonBase + GetDescriptionForRevision(describeRevision, baseRevGuid),
+                statuses: commonBaseToAandB));
+
+            return fileStatusDescs;
+
+            static ObjectId GetRevisionOrHead(GitRevision rev, Lazy<ObjectId> head)
+                => rev.IsArtificial ? head.Value : rev.ObjectId;
+
+            static string GetDescriptionForRevision(Func<ObjectId, string> describeRevision, ObjectId objectId)
+                => describeRevision != null ? describeRevision(objectId) : objectId?.ToShortString();
+        }
+
+        private GitModule GetModule()
+        {
+            var module = _getModule();
+
+            if (module == null)
+            {
+                throw new ArgumentException($"Require a valid instance of {nameof(GitModule)}");
+            }
+
+            return module;
+        }
+    }
+}

--- a/GitUI/UserControls/FileStatusItem.cs
+++ b/GitUI/UserControls/FileStatusItem.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using GitCommands;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
@@ -7,11 +8,13 @@ namespace GitUI.UserControls
 {
     public sealed class FileStatusItem
     {
-        public FileStatusItem([CanBeNull] GitRevision firstRev, [NotNull] GitRevision secondRev, [NotNull] GitItemStatus item)
+        public FileStatusItem([CanBeNull] GitRevision firstRev, [NotNull] GitRevision secondRev, [NotNull] GitItemStatus item, [CanBeNull] ObjectId baseA = null, [CanBeNull] ObjectId baseB = null)
         {
             FirstRevision = firstRev;
             SecondRevision = secondRev ?? throw new ArgumentNullException(nameof(secondRev));
             Item = item ?? throw new ArgumentNullException(nameof(item));
+            BaseA = baseA;
+            BaseB = baseB;
         }
 
         /// <summary>
@@ -27,6 +30,18 @@ namespace GitUI.UserControls
         /// </summary>
         [NotNull]
         public GitRevision SecondRevision { get; }
+
+        /// <summary>
+        /// If ranges are selected, the first commit (base) for <see cref="FirstRevision"/> (head)
+        /// </summary>
+        [CanBeNull]
+        public ObjectId BaseA { get; }
+
+        /// <summary>
+        /// If ranges are selected, the first commit (base) for <see cref="SecondRevision"/> (head)
+        /// </summary>
+        [CanBeNull]
+        public ObjectId BaseB { get; }
 
         /// <summary>
         /// The status item in the list

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -937,7 +937,7 @@ namespace GitUI
                         listItem.Selected = true;
                     }
 
-                    listItem.Tag = new FileStatusItem(i.FirstRev, i.SecondRev, item);
+                    listItem.Tag = new FileStatusItem(i.FirstRev, i.SecondRev, item, i.BaseA, i.BaseB);
                     list.Add(listItem);
                 }
             }
@@ -982,15 +982,20 @@ namespace GitUI
 
             static string GetItemImageKey(GitItemStatus gitItemStatus)
             {
-                if (!gitItemStatus.IsNew && !gitItemStatus.IsDeleted && !gitItemStatus.IsTracked)
+                if (!gitItemStatus.IsNew && !gitItemStatus.IsDeleted && !gitItemStatus.IsTracked && !gitItemStatus.IsRangeDiff)
                 {
-                    // Illegal combinations, no flags set?
+                    // Illegal flag combinations or no flags set?
                     return nameof(Images.FileStatusUnknown);
                 }
 
                 if (gitItemStatus.IsDeleted)
                 {
                     return nameof(Images.FileStatusRemoved);
+                }
+
+                if (gitItemStatus.IsRangeDiff)
+                {
+                    return nameof(Images.Diff);
                 }
 
                 if (gitItemStatus.IsNew || (!gitItemStatus.IsTracked && !gitItemStatus.IsSubmodule))

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -20,31 +20,23 @@ using GitUI.Properties;
 using GitUI.UserControls;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
-using ResourceManager;
 
 namespace GitUI
 {
-    public delegate string DescribeRevisionDelegate(ObjectId objectId);
-
     public sealed partial class FileStatusList : GitModuleControl
     {
         private static readonly TimeSpan SelectedIndexChangeThrottleDuration = TimeSpan.FromMilliseconds(50);
-        private readonly TranslationString _diffWithParent = new TranslationString("Diff with a/");
-        private readonly TranslationString _diffBaseToB = new TranslationString("Unique diff BASE with b/");
-        private readonly TranslationString _diffCommonBase = new TranslationString("Common diff with BASE a/");
-        private readonly TranslationString _combinedDiff = new TranslationString("Combined diff");
         private readonly IFullPathResolver _fullPathResolver;
+        private readonly FileStatusDiffCalculator _diffCalculator;
         private readonly SortDiffListContextMenuItem _sortByContextMenu;
         private readonly IReadOnlyList<GitItemStatus> _noItemStatuses;
 
         private int _nextIndexToSelect = -1;
-        private bool _groupByRevision;
         private bool _enableSelectedIndexChangeEvent = true;
         private bool _mouseEntered;
         private ToolStripItem _openSubmoduleMenuItem;
         private Rectangle _dragBoxFromMouseDown;
-        private IReadOnlyList<(GitRevision firstRev, GitRevision secondRev, string summary, IReadOnlyList<GitItemStatus> statuses)> _itemsWithDescription
-            = Array.Empty<(GitRevision, GitRevision, string, IReadOnlyList<GitItemStatus>)>();
+        private IReadOnlyList<FileStatusWithDescription> _itemsWithDescription = new List<FileStatusWithDescription>();
         [CanBeNull] private IDisposable _selectedIndexChangeSubscription;
         [CanBeNull] private IDisposable _diffListSortSubscription;
 
@@ -100,6 +92,7 @@ namespace GitUI
             FilterWatermarkLabel.Font = new Font(FilterWatermarkLabel.Font, FontStyle.Italic);
             FilterComboBox.Font = new Font(FilterComboBox.Font, FontStyle.Bold);
 
+            _diffCalculator = new FileStatusDiffCalculator(() => Module);
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
             _noItemStatuses = new[]
             {
@@ -145,7 +138,8 @@ namespace GitUI
                     (nameof(Images.SubmoduleRevisionSemiUp), ScaleHeight(Images.SubmoduleRevisionSemiUp)),
                     (nameof(Images.SubmoduleRevisionSemiUpDirty), ScaleHeight(Images.SubmoduleRevisionSemiUpDirty)),
                     (nameof(Images.SubmoduleRevisionSemiDown), ScaleHeight(Images.SubmoduleRevisionSemiDown)),
-                    (nameof(Images.SubmoduleRevisionSemiDownDirty), ScaleHeight(Images.SubmoduleRevisionSemiDownDirty))
+                    (nameof(Images.SubmoduleRevisionSemiDownDirty), ScaleHeight(Images.SubmoduleRevisionSemiDownDirty)),
+                    (nameof(Images.Diff), ScaleHeight(Images.Diff))
                 };
 
                 for (var i = 0; i < images.Length; i++)
@@ -243,11 +237,9 @@ namespace GitUI
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [Browsable(false)]
-        public DescribeRevisionDelegate DescribeRevision { get; set; }
+        public Func<ObjectId, string> DescribeRevision { get; set; }
 
         public bool FilterFocused => FilterComboBox.Focused;
-
-        public bool ShouldSerializeFilterVisible => FilterVisible != true;
 
         public bool FilterVisible
         {
@@ -295,14 +287,14 @@ namespace GitUI
         {
             get
             {
-                return GitItemStatusesWithDescription?.SelectMany(tuple => tuple.statuses).AsReadOnlyList()
+                return GitItemStatusesWithDescription?.SelectMany(tuple => tuple.Statuses).AsReadOnlyList()
                        ?? Array.Empty<GitItemStatus>();
             }
         }
 
-        private IReadOnlyList<(GitRevision firstRev, GitRevision secondRev, string summary, IReadOnlyList<GitItemStatus> statuses)> GitItemStatusesWithDescription
+        private IReadOnlyList<FileStatusWithDescription> GitItemStatusesWithDescription
         {
-            get { return _itemsWithDescription; }
+            get => _itemsWithDescription;
             set
             {
                 _itemsWithDescription = value ?? throw new ArgumentNullException(nameof(value));
@@ -310,18 +302,7 @@ namespace GitUI
             }
         }
 
-        public bool GroupByRevision
-        {
-            get => _groupByRevision;
-            set => _groupByRevision = value;
-        }
-
-        [DefaultValue(true)]
-        public bool MultiSelect
-        {
-            get => FileStatusListView.MultiSelect;
-            set => FileStatusListView.MultiSelect = value;
-        }
+        public bool GroupByRevision { get; set; }
 
         [Browsable(false)]
         [DefaultValue(true)]
@@ -440,7 +421,7 @@ namespace GitUI
         [DefaultValue(true)]
         public bool SelectFirstItemOnSetItems { get; set; }
 
-        public int UnfilteredItemsCount => GitItemStatusesWithDescription?.Sum(tuple => tuple.statuses.Count) ?? 0;
+        public int UnfilteredItemsCount => GitItemStatusesWithDescription?.Sum(tuple => tuple.Statuses.Count) ?? 0;
 
         // Public methods
 
@@ -659,106 +640,7 @@ namespace GitUI
         {
             _revisions = revisions;
             _getRevision = getRevision;
-
-            var tuples = new List<(GitRevision firstRev, GitRevision secondRev, string summary, IReadOnlyList<GitItemStatus> statuses)>();
-            var selectedRev = revisions?.FirstOrDefault();
-            if (selectedRev == null)
-            {
-                GitItemStatusesWithDescription = tuples;
-                return;
-            }
-
-            if (revisions.Count == 1)
-            {
-                if (selectedRev.ParentIds == null || selectedRev.ParentIds.Count == 0)
-                {
-                    // No parent for the initial commit
-                    tuples.Add((null, selectedRev, GetDescriptionForRevision(selectedRev.ObjectId), Module.GetTreeFiles(selectedRev.TreeGuid, full: true)));
-                }
-                else
-                {
-                    // Get the parents for the selected revision
-                    var multipleParents = AppSettings.ShowDiffForAllParents ? selectedRev.ParentIds.Count : 1;
-                    tuples.AddRange(selectedRev
-                        .ParentIds?
-                        .Take(multipleParents)
-                        .Select(parentId =>
-                            ((GitRevision, GitRevision, string, IReadOnlyList<GitItemStatus>))(new GitRevision(parentId),
-                                selectedRev,
-                                _diffWithParent.Text + GetDescriptionForRevision(parentId),
-                                Module.GetDiffFilesWithSubmodulesStatus(parentId, selectedRev.ObjectId, selectedRev.FirstParentId))));
-                }
-
-                // Show combined (merge conflicts) when a single merge commit is selected
-                var isMergeCommit = tuples.Count > 1;
-                if (AppSettings.ShowDiffForAllParents && isMergeCommit)
-                {
-                    var conflicts = Module.GetCombinedDiffFileList(selectedRev.Guid);
-                    if (conflicts.Count != 0)
-                    {
-                        // Create an artificial commit
-                        var desc = _combinedDiff.Text;
-                        tuples.Add((new GitRevision(ObjectId.CombinedDiffId), selectedRev, desc, conflicts));
-                    }
-                }
-            }
-            else
-            {
-                // With more than 4, only first -> selected is interesting
-                // Limited selections: Show multi selection if more than two selected
-                var multipleParents = AppSettings.ShowDiffForAllParents && revisions.Count <= 4 ? revisions.Count - 1 : 1;
-                tuples.AddRange(revisions
-                    .Skip(1)
-                    .Take(multipleParents)
-                    .Select(firstRev =>
-                        (firstRev,
-                            selectedRev,
-                            _diffWithParent.Text + GetDescriptionForRevision(firstRev.ObjectId),
-                            Module.GetDiffFilesWithSubmodulesStatus(firstRev.ObjectId, selectedRev.ObjectId, selectedRev.FirstParentId))));
-
-                if (AppSettings.ShowDiffForAllParents && revisions.Count == 2)
-                {
-                    var firstRev = revisions.Last();
-                    var allAToB = tuples[0].statuses;
-
-                    // Get base commit, add as parent if unique
-                    Lazy<ObjectId> head = getRevision != null
-                        ? new Lazy<ObjectId>(() => getRevision(ObjectId.IndexId).FirstParentId)
-                        : new Lazy<ObjectId>(() => Module.RevParse("HEAD"));
-                    var baseRevGuid = Module.GetMergeBase(GetRevisionOrHead(firstRev, head),
-                        GetRevisionOrHead(selectedRev, head));
-
-                    // Add if separate branches (note that artificial commits both have HEAD as BASE)
-                    if (baseRevGuid != null
-                        && baseRevGuid != GetRevisionOrHead(firstRev, head)
-                        && baseRevGuid != GetRevisionOrHead(selectedRev, head))
-                    {
-                        // Present common files in BASE->B, BASE->A separately
-                        // For the following diff:  A->B a,c,d; BASE->B a,b,c; BASE->A a,b,d
-                        // (the file a has unique changes, b has the same change and c,d is changed in one of the branches)
-                        // The following groups will be shown: A->B a,c,d; BASE->B a,c; BASE->A a,d; Common BASE b
-                        var allBaseToB = Module.GetDiffFilesWithSubmodulesStatus(baseRevGuid, selectedRev.ObjectId, selectedRev.FirstParentId);
-                        var allBaseToA = Module.GetDiffFilesWithSubmodulesStatus(baseRevGuid, firstRev.ObjectId, firstRev.FirstParentId);
-
-                        var comparer = new GitItemStatusNameEqualityComparer();
-                        var commonBaseToAandB = allBaseToB.Intersect(allBaseToA, comparer).Except(allAToB, comparer).ToList();
-                        var uniqueBaseToB = allBaseToB.Except(commonBaseToAandB, comparer).ToList();
-                        var uniqueBaseToA = allBaseToA.Except(commonBaseToAandB, comparer).ToList();
-
-                        var revBase = new GitRevision(baseRevGuid);
-                        tuples.Add((revBase, selectedRev, _diffBaseToB.Text + GetDescriptionForRevision(selectedRev.ObjectId), uniqueBaseToB));
-                        tuples.Add((revBase, firstRev, _diffBaseToB.Text + GetDescriptionForRevision(firstRev.ObjectId), uniqueBaseToA));
-                        tuples.Add((revBase, selectedRev, _diffCommonBase.Text + GetDescriptionForRevision(baseRevGuid), commonBaseToAandB));
-                    }
-                }
-            }
-
-            GitItemStatusesWithDescription = tuples;
-
-            return;
-
-            static ObjectId GetRevisionOrHead(GitRevision rev, Lazy<ObjectId> head)
-                => rev.IsArtificial ? head.Value : rev.ObjectId;
+            GitItemStatusesWithDescription = _diffCalculator.SetDiffs(revisions, DescribeRevision, getRevision);
         }
 
         /// <summary>
@@ -780,33 +662,41 @@ namespace GitUI
             [NotNull] IReadOnlyList<GitItemStatus> workTreeItems)
         {
             GroupByRevision = true;
-            GitItemStatusesWithDescription = new[]
+            GitItemStatusesWithDescription = new List<FileStatusWithDescription>
             {
-                (indexRev, workTreeRev, workTreeDesc, workTreeItems),
-                (headRev, indexRev, indexDesc, indexItems)
+                new FileStatusWithDescription(
+                    firstRev: indexRev,
+                    secondRev: workTreeRev,
+                    summary: workTreeDesc,
+                    statuses: workTreeItems),
+                new FileStatusWithDescription(
+                    firstRev: headRev,
+                    secondRev: indexRev,
+                    summary: indexDesc,
+                    statuses: indexItems)
             };
         }
 
         public void SetDiffs([CanBeNull] GitRevision firstRev, [CanBeNull] GitRevision secondRev, [NotNull] IReadOnlyList<GitItemStatus> items)
         {
             GroupByRevision = false;
-            GitItemStatusesWithDescription = new[] { (firstRev: firstRev, secondRev: secondRev, _diffWithParent.Text + GetDescriptionForRevision(firstRev?.ObjectId), items) };
+            GitItemStatusesWithDescription = new List<FileStatusWithDescription>
+            {
+                new FileStatusWithDescription(
+                    firstRev: firstRev,
+                    secondRev: secondRev,
+                    summary: Strings.DiffWithParent + GetDescriptionForRevision(firstRev?.ObjectId),
+                    statuses: items)
+            };
         }
 
         public void ClearDiffs()
         {
-            GitItemStatusesWithDescription = Array.Empty<(GitRevision, GitRevision, string, IReadOnlyList<GitItemStatus>)>();
+            GitItemStatusesWithDescription = new List<FileStatusWithDescription>();
         }
 
-        private string GetDescriptionForRevision(ObjectId objectId)
-        {
-            if (DescribeRevision != null)
-            {
-                return DescribeRevision(objectId);
-            }
-
-            return objectId?.ToShortString();
-        }
+        private string GetDescriptionForRevision(ObjectId objectId) =>
+            DescribeRevision != null ? DescribeRevision(objectId) : objectId?.ToShortString();
 
         public void SetNoFilesText(string text)
         {
@@ -982,35 +872,35 @@ namespace GitUI
             }
 
             FileStatusListView.BeginUpdate();
-            FileStatusListView.ShowGroups = GitItemStatusesWithDescription.Count > 1 || _groupByRevision;
+            FileStatusListView.ShowGroups = GitItemStatusesWithDescription.Count > 1 || GroupByRevision;
             FileStatusListView.Groups.Clear();
             FileStatusListView.Items.Clear();
 
-            bool hasChanges = GitItemStatusesWithDescription.Any(x => x.statuses.Count > 0);
+            bool hasChanges = GitItemStatusesWithDescription.Any(x => x.Statuses.Count > 0);
 
             var list = new List<ListViewItem>();
             foreach (var i in GitItemStatusesWithDescription)
             {
                 ListViewGroup group = null;
-                if (i.firstRev != null)
+                if (i.FirstRev != null)
                 {
-                    group = new ListViewGroup(i.summary)
+                    group = new ListViewGroup(i.Summary)
                     {
-                        Tag = i.firstRev
+                        Tag = i.FirstRev
                     };
 
                     FileStatusListView.Groups.Add(group);
                 }
 
                 IReadOnlyList<GitItemStatus> itemStatuses;
-                if (hasChanges && i.statuses.Count == 0)
+                if (hasChanges && i.Statuses.Count == 0)
                 {
                     itemStatuses = _noItemStatuses;
                     FileStatusListView.SetGroupState(group, NativeMethods.LVGS.Collapsible | NativeMethods.LVGS.Collapsed);
                 }
                 else
                 {
-                    itemStatuses = i.statuses;
+                    itemStatuses = i.Statuses;
                 }
 
                 foreach (var item in itemStatuses)
@@ -1047,7 +937,7 @@ namespace GitUI
                         listItem.Selected = true;
                     }
 
-                    listItem.Tag = new FileStatusItem(i.firstRev, i.secondRev, item);
+                    listItem.Tag = new FileStatusItem(i.FirstRev, i.SecondRev, item);
                     list.Add(listItem);
                 }
             }
@@ -1352,7 +1242,7 @@ namespace GitUI
                 showAllDiferencesItem.CheckedChanged += (s, e) =>
                 {
                     AppSettings.ShowDiffForAllParents = showAllDiferencesItem.Checked;
-                    SetDiffs(_revisions, _getRevision);
+                    GitItemStatusesWithDescription = _diffCalculator.SetDiffs(_revisions, DescribeRevision, _getRevision);
                 };
 
                 cm.Items.Add(showAllDiferencesItem);

--- a/GitUI/UserControls/FileStatusWithDescription.cs
+++ b/GitUI/UserControls/FileStatusWithDescription.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using GitCommands;
+using GitUIPluginInterfaces;
+using JetBrains.Annotations;
+
+namespace GitUI
+{
+    public class FileStatusWithDescription
+    {
+        public FileStatusWithDescription([CanBeNull] GitRevision firstRev, GitRevision secondRev, string summary, IReadOnlyList<GitItemStatus> statuses)
+        {
+            FirstRev = firstRev;
+            SecondRev = secondRev ?? throw new ArgumentNullException(nameof(secondRev));
+            Summary = summary ?? throw new ArgumentNullException(nameof(summary));
+            Statuses = statuses ?? throw new ArgumentNullException(nameof(statuses));
+        }
+
+        public GitRevision FirstRev { get; }
+        public GitRevision SecondRev { get; }
+        public string Summary { get; }
+        public IReadOnlyList<GitItemStatus> Statuses { get; }
+    }
+}

--- a/GitUI/UserControls/FileStatusWithDescription.cs
+++ b/GitUI/UserControls/FileStatusWithDescription.cs
@@ -8,17 +8,21 @@ namespace GitUI
 {
     public class FileStatusWithDescription
     {
-        public FileStatusWithDescription([CanBeNull] GitRevision firstRev, GitRevision secondRev, string summary, IReadOnlyList<GitItemStatus> statuses)
+        public FileStatusWithDescription([CanBeNull] GitRevision firstRev, GitRevision secondRev, string summary, IReadOnlyList<GitItemStatus> statuses, [CanBeNull] ObjectId baseA = null, [CanBeNull] ObjectId baseB = null)
         {
             FirstRev = firstRev;
             SecondRev = secondRev ?? throw new ArgumentNullException(nameof(secondRev));
             Summary = summary ?? throw new ArgumentNullException(nameof(summary));
             Statuses = statuses ?? throw new ArgumentNullException(nameof(statuses));
+            BaseA = baseA;
+            BaseB = baseB;
         }
 
         public GitRevision FirstRev { get; }
         public GitRevision SecondRev { get; }
         public string Summary { get; }
         public IReadOnlyList<GitItemStatus> Statuses { get; }
+        public ObjectId BaseA { get; }
+        public ObjectId BaseB { get; }
     }
 }

--- a/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString.ForScenario.fatal_error.approved.json
+++ b/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString.ForScenario.fatal_error.approved.json
@@ -18,7 +18,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": "adfs.h",
@@ -39,7 +40,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": "adfs.h",
@@ -60,6 +62,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString.ForScenario.status_ignored_files.approved.json
+++ b/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString.ForScenario.status_ignored_files.approved.json
@@ -18,7 +18,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": "untracked_file",
@@ -39,6 +40,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString.ForScenario.status_modified_files.approved.json
+++ b/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString.ForScenario.status_modified_files.approved.json
@@ -18,7 +18,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": true,
         "IsDirty": true,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": "subm2",
@@ -39,6 +40,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": true,
         "IsDirty": true,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString.ForScenario.status_staged_files.approved.json
+++ b/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString.ForScenario.status_staged_files.approved.json
@@ -18,7 +18,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": "adfs.h",
@@ -39,7 +40,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": "adfs.h",
@@ -60,6 +62,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString.ForScenario.status_untracked_files.approved.json
+++ b/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString.ForScenario.status_untracked_files.approved.json
@@ -18,7 +18,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": true,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": "ignored_file",
@@ -39,6 +40,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString.ForScenario.status_with_spaces.approved.json
+++ b/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.TestGetStatusChangedFilesFromString.ForScenario.status_with_spaces.approved.json
@@ -18,7 +18,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": " no trim space1 ",
@@ -39,6 +40,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": true,
         "IsDirty": true,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.Check_that_spaces_are_not_trimmed_in_file_names.approved.json
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.Check_that_spaces_are_not_trimmed_in_file_names.approved.json
@@ -18,7 +18,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": " no trim space1 ",
@@ -39,7 +40,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": " no trim space2 ",
@@ -60,6 +62,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.Check_that_the_staged_status_is_None_if_not_IndexWorkTree1.approved.json
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.Check_that_the_staged_status_is_None_if_not_IndexWorkTree1.approved.json
@@ -18,7 +18,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": "testfile2.txt",
@@ -39,6 +40,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.Check_that_the_staged_status_is_None_if_not_IndexWorkTree2.approved.json
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.Check_that_the_staged_status_is_None_if_not_IndexWorkTree2.approved.json
@@ -18,7 +18,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": "testfile2.txt",
@@ -39,6 +40,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.Ignore_unmerged_in_conflict_if_revision_is_work_tree.approved.json
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.Ignore_unmerged_in_conflict_if_revision_is_work_tree.approved.json
@@ -18,6 +18,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.Include_unmerged_in_conflict_if_revision_is_index.approved.json
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.Include_unmerged_in_conflict_if_revision_is_index.approved.json
@@ -18,7 +18,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": "testfile2.txt",
@@ -39,6 +40,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.Rename_with_spaces.approved.json
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.Rename_with_spaces.approved.json
@@ -18,7 +18,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": " apa.md",
@@ -39,7 +40,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": " co decov.yml",
@@ -60,7 +62,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": "CODE_OF_CONDUCT.md",
@@ -81,6 +84,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.WorkTree1.approved.json
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.WorkTree1.approved.json
@@ -18,6 +18,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.WorkTree2.approved.json
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.WorkTree2.approved.json
@@ -18,6 +18,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.WorkTree3.approved.json
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.WorkTree3.approved.json
@@ -18,6 +18,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.WorkTree4.approved.json
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.WorkTree4.approved.json
@@ -18,6 +18,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.fatal_error.approved.json
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.GetDiffChangedFilesFromString.ForScenario.fatal_error.approved.json
@@ -18,7 +18,8 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     },
     {
         "Name": "testfile2.txt",
@@ -39,6 +40,7 @@
         "IsSkipWorktree": false,
         "IsSubmodule": false,
         "IsDirty": false,
-        "IsStatusOnly": false
+        "IsStatusOnly": false,
+        "IsRangeDiff": false
     }
 ]

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
@@ -23,7 +23,8 @@ namespace GitUITests.CommandsDialogs
         }
 
         private ContextMenuSelectionInfo CreateContextMenuSelectionInfo(GitRevision selectedRevision = null,
-            bool isAnyCombinedDiff = false,
+            bool isDisplayOnlyDiff = false,
+            bool isStatusOnly = false,
             int selectedGitItemCount = 1,
             bool isAnyItemIndex = false,
             bool isAnyItemWorkTree = false,
@@ -34,7 +35,8 @@ namespace GitUITests.CommandsDialogs
             bool isAnySubmodule = false)
         {
             return new ContextMenuSelectionInfo(selectedRevision,
-                isAnyCombinedDiff,
+                isDisplayOnlyDiff,
+                isStatusOnly,
                 selectedGitItemCount,
                 isAnyItemIndex,
                 isAnyItemWorkTree,
@@ -70,6 +72,15 @@ namespace GitUITests.CommandsDialogs
             var rev = new GitRevision(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isBareRepository: t);
             _controller.ShouldShowDifftoolMenus(selectionInfo).Should().BeTrue();
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void BrowseDiff_DifftoolMenu_DisplayOnly(bool t)
+        {
+            var rev = new GitRevision(ObjectId.Random());
+            var selectionInfo = CreateContextMenuSelectionInfo(rev, isDisplayOnlyDiff: t);
+            _controller.ShouldShowDifftoolMenus(selectionInfo).Should().Be(!t);
         }
 
         #endregion
@@ -110,6 +121,15 @@ namespace GitUITests.CommandsDialogs
             _controller.ShouldShowResetFileMenus(selectionInfo).Should().Be(!t);
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public void BrowseDiff_ResetMenu_DisplayOnly(bool t)
+        {
+            var rev = new GitRevision(ObjectId.Random());
+            var selectionInfo = CreateContextMenuSelectionInfo(rev, isDisplayOnlyDiff: t);
+            _controller.ShouldShowResetFileMenus(selectionInfo).Should().Be(!t);
+        }
+
         #endregion
 
         #region main menu
@@ -127,6 +147,7 @@ namespace GitUITests.CommandsDialogs
             _controller.ShouldShowMenuOpenRevision(selectionInfo).Should().BeFalse();
             _controller.ShouldShowMenuDeleteFile(selectionInfo).Should().BeFalse();
             _controller.ShouldShowMenuCopyFileName(selectionInfo).Should().BeFalse();
+            _controller.ShouldShowMenuShowInFolder(selectionInfo).Should().BeFalse();
             _controller.ShouldShowMenuShowInFileTree(selectionInfo).Should().BeFalse();
             _controller.ShouldShowMenuFileHistory(selectionInfo).Should().BeFalse();
             _controller.ShouldShowMenuBlame(selectionInfo).Should().BeFalse();
@@ -146,6 +167,7 @@ namespace GitUITests.CommandsDialogs
             _controller.ShouldShowMenuOpenRevision(selectionInfo).Should().BeTrue();
             _controller.ShouldShowMenuDeleteFile(selectionInfo).Should().BeFalse();
             _controller.ShouldShowMenuCopyFileName(selectionInfo).Should().BeTrue();
+            _controller.ShouldShowMenuShowInFolder(selectionInfo).Should().BeTrue();
             _controller.ShouldShowMenuShowInFileTree(selectionInfo).Should().BeTrue();
             _controller.ShouldShowMenuFileHistory(selectionInfo).Should().BeTrue();
             _controller.ShouldShowMenuBlame(selectionInfo).Should().BeTrue();
@@ -166,6 +188,7 @@ namespace GitUITests.CommandsDialogs
             _controller.ShouldShowMenuOpenRevision(selectionInfo).Should().Be(t != 0);
             _controller.ShouldShowMenuDeleteFile(selectionInfo).Should().BeFalse();
             _controller.ShouldShowMenuCopyFileName(selectionInfo).Should().Be(t != 0);
+            _controller.ShouldShowMenuShowInFolder(selectionInfo).Should().Be(t != 0);
             _controller.ShouldShowMenuShowInFileTree(selectionInfo).Should().Be(t != 0);
             _controller.ShouldShowMenuFileHistory(selectionInfo).Should().Be(t != 0);
             _controller.ShouldShowMenuBlame(selectionInfo).Should().Be(t != 0);
@@ -222,6 +245,36 @@ namespace GitUITests.CommandsDialogs
             var rev = new GitRevision(ObjectId.IndexId);
             var selectionInfo = CreateContextMenuSelectionInfo(rev);
             _controller.ShouldShowMenuOpenRevision(selectionInfo).Should().BeFalse();
+        }
+
+        [Test]
+        public void BrowseDiff_OpenRevisionFile_DisplayOnly()
+        {
+            var rev = new GitRevision(ObjectId.Random());
+            var selectionInfo = CreateContextMenuSelectionInfo(rev, isDisplayOnlyDiff: true);
+            _controller.ShouldShowMenuOpenRevision(selectionInfo).Should().BeFalse();
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void BrowseDiff_DisplayOnlyDiff(bool t)
+        {
+            var rev = new GitRevision(ObjectId.Random());
+            var selectionInfo = CreateContextMenuSelectionInfo(rev, isDisplayOnlyDiff: t);
+            _controller.ShouldShowMenuSaveAs(selectionInfo).Should().Be(!t);
+            _controller.ShouldShowMenuCherryPick(selectionInfo).Should().Be(!t);
+            _controller.ShouldShowMenuOpenRevision(selectionInfo).Should().Be(!t);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void BrowseDiff_StatusOnlyDiff(bool t)
+        {
+            var rev = new GitRevision(ObjectId.Random());
+            var selectionInfo = CreateContextMenuSelectionInfo(rev, isStatusOnly: t);
+            _controller.ShouldShowMenuCopyFileName(selectionInfo).Should().Be(!t);
+            _controller.ShouldShowMenuShowInFolder(selectionInfo).Should().Be(!t);
+            _controller.ShouldShowMenuShowInFileTree(selectionInfo).Should().Be(!t);
         }
 
         [TestCase(true)]


### PR DESCRIPTION
Part of #8448 support for range diff

First 4 commits are refactoring, the two following are likely to be squashed (the second changes data structures, separated for review)

#8516 is a separate PR for presentation

## Proposed changes

Present range-diff in diff tab

Limit RevDiff context menu entries for combined diff and Git Errors, to limit for range-diff too (will be kept as a separate commit)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

range-diff is new

combined diff
![currentCombined diff](https://user-images.githubusercontent.com/6248932/95675646-168b1100-0bb9-11eb-95aa-1ce7e5f06c01.JPG)

### After

See #8516 for range-diff

Combined diff

![image](https://user-images.githubusercontent.com/6248932/95674941-e3924e80-0bb3-11eb-94c4-3d43a31f845b.png)


## Test methodology <!-- How did you ensure quality? -->

manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
