### PR TITLE
#8441: Add shortcut for "Show this branch only"

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -518,6 +518,11 @@ namespace GitUI.BranchTreePanel
         private void OnNodeClick(object sender, TreeNodeMouseClickEventArgs e)
         {
             Node.OnNode<Node>(e.Node, node => node.OnClick());
+            if ((ModifierKeys & Keys.Control) != 0 && e.Button == MouseButtons.Left)
+            {
+                var branchNode = (BaseBranchNode)e.Node.Tag;
+                _filterBranchHelper.SetBranchFilter(branchNode.FullPath, refresh: true);
+            }
         }
 
         private void OnNodeDoubleClick(object sender, TreeNodeMouseClickEventArgs e)


### PR DESCRIPTION
Adding <kbd>CTRL+Left MB</kbd>  shortcut for "**Show this branch only**" command.
___


The feature is not completely finished. I am a little be stuck on the selecting top branch's revision after revision grid has been filtered. On the below gif you can see that it does not always select last revision after filtered:

![GE-8441](https://user-images.githubusercontent.com/5969304/94301192-d437c200-ff72-11ea-9fdd-4ec9974e1367.gif)

It seems I made changes in the not right place or some additional changes should be added.
___

Could someone just point me?


