### PR TITLE
Show empty diffs as patch, not text

### DIFF
--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -74,10 +74,11 @@ namespace GitUI
                 return fileViewer.ViewGitItemRevisionAsync(item.Item, item.SecondRevision.ObjectId, openWithDiffTool);
             }
 
-            string selectedPatch = GetSelectedPatch(fileViewer, firstId, item.SecondRevision.ObjectId, item.Item);
+            string selectedPatch = GetSelectedPatch(fileViewer, firstId, item.SecondRevision.ObjectId, item.Item)
+                ?? defaultText;
 
-            return item.Item.IsSubmodule || selectedPatch == null
-                ? fileViewer.ViewTextAsync(item.Item.Name, text: selectedPatch ?? defaultText, openWithDifftool: openWithDiffTool)
+            return item.Item.IsSubmodule
+                ? fileViewer.ViewTextAsync(item.Item.Name, text: selectedPatch, openWithDifftool: openWithDiffTool)
                 : fileViewer.ViewPatchAsync(item.Item.Name, text: selectedPatch, openWithDifftool: openWithDiffTool);
 
             void OpenWithDiffTool()


### PR DESCRIPTION
Fixes #5547

## Proposed changes
* A null patch was displayed as a text file instead of a patch, so the toolbar was missing

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/94349354-e897bf80-0043-11eb-9cfb-4f7a89039337.png)

### After

![image](https://user-images.githubusercontent.com/6248932/94349345-dae23a00-0043-11eb-858e-f4c5380e8e2a.png)


## Test methodology <!-- How did you ensure quality? -->

Manual
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
