### PR TITLE
FileViewer: Show toolbar for all files

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -141,12 +141,9 @@ namespace GitUI.Editor
 
             internalFileViewer.MouseMove += (_, e) =>
             {
-                if (IsDiffView(_viewMode) && !fileviewerToolbar.Visible)
-                {
-                    fileviewerToolbar.Visible = true;
-                    fileviewerToolbar.Location = new Point(Width - fileviewerToolbar.Width - 40, 0);
-                    fileviewerToolbar.BringToFront();
-                }
+                fileviewerToolbar.Visible = true;
+                fileviewerToolbar.Location = new Point(Width - fileviewerToolbar.Width - 40, 0);
+                fileviewerToolbar.BringToFront();
             };
             internalFileViewer.MouseLeave += (_, e) =>
             {


### PR DESCRIPTION
Fixes #8248 
~~Related to #5547~~
~~Based on #8496~~

## Proposed changes
* The toolbar should be available also for normal textfiles, so file encoding can be set. (There are context menu actions for other actions.)

Applies for all file viewers, not just diff tab

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/6248932/94349618-8096a880-0046-11eb-82fe-fa98be6bb3c7.png)

### After

![image](https://user-images.githubusercontent.com/6248932/94349613-68268e00-0046-11eb-91c4-7c0622c14acb.png)

## Test methodology 

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
