### PR TITLE
fix: Branch filter isn't truly reset

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -12,20 +12,24 @@ using Microsoft.VisualStudio.Threading;
 
 namespace GitCommands
 {
+#pragma warning disable SA1025 // Code should not contain multiple whitespace in a row
     [Flags]
     public enum RefFilterOptions
     {
-        Branches = 1,              // --branches
-        Remotes = 2,               // --remotes
-        Tags = 4,                  // --tags
-        Stashes = 8,               //
-        All = 15,                  // --all
-        Boundary = 16,             // --boundary
-        ShowGitNotes = 32,         // --not --glob=notes --not
-        NoMerges = 64,             // --no-merges
-        FirstParent = 128,         // --first-parent
-        SimplifyByDecoration = 256 // --simplify-by-decoration
+        None                    = 0x000,
+        Branches                = 0x001,    // --branches
+        Remotes                 = 0x002,    // --remotes
+        Tags                    = 0x004,    // --tags
+        Stashes                 = 0x008,    //
+        All                     = 0x00F,    // --all
+        Boundary                = 0x010,    // --boundary
+        ShowGitNotes            = 0x020,    // --not --glob=notes --not
+        NoMerges                = 0x040,    // --no-merges
+        FirstParent             = 0x080,    // --first-parent
+        SimplifyByDecoration    = 0x100,    // --simplify-by-decoration
+        Reflogs                 = 0x200,    // --reflog
     }
+#pragma warning restore SA1025 // Code should not contain multiple whitespace in a row
 
     public sealed class RevisionReader : IDisposable
     {
@@ -178,7 +182,7 @@ namespace GitCommands
                     "--first-parent",
                     new ArgumentBuilder
                     {
-                        { AppSettings.ShowReflogReferences, "--reflog" },
+                        { refFilterOptions.HasFlag(RefFilterOptions.Reflogs), "--reflog" },
                         { AppSettings.SortByAuthorDate, "--author-date-order" },
                         {
                             refFilterOptions.HasFlag(RefFilterOptions.All),

--- a/GitUI/FilterBranchHelper.cs
+++ b/GitUI/FilterBranchHelper.cs
@@ -20,41 +20,50 @@ namespace GitUI
 
         private static readonly string[] _noResultsFound = { Strings.NoResultsFound };
 
-        public FilterBranchHelper()
+        public FilterBranchHelper(ToolStripComboBox toolStripBranches, ToolStripDropDownButton toolStripDropDownButton2, RevisionGridControl revisionGrid)
         {
-            _localToolStripMenuItem = new ToolStripMenuItem();
-            _tagsToolStripMenuItem = new ToolStripMenuItem();
-            _remoteToolStripMenuItem = new ToolStripMenuItem();
-
             //
             // localToolStripMenuItem
             //
-            _localToolStripMenuItem.Checked = true;
-            _localToolStripMenuItem.CheckOnClick = true;
-            _localToolStripMenuItem.Name = "localToolStripMenuItem";
-            _localToolStripMenuItem.Text = Strings.Local;
+            _localToolStripMenuItem = new ToolStripMenuItem
+            {
+                Checked = true,
+                CheckOnClick = true,
+                Name = "localToolStripMenuItem",
+                Text = Strings.Local
+            };
 
             //
             // tagsToolStripMenuItem
             //
-            _tagsToolStripMenuItem.CheckOnClick = true;
-            _tagsToolStripMenuItem.Name = "tagToolStripMenuItem";
-            _tagsToolStripMenuItem.Text = Strings.Tag;
+            _tagsToolStripMenuItem = new ToolStripMenuItem
+            {
+                CheckOnClick = true,
+                Name = "tagToolStripMenuItem",
+                Text = Strings.Tag
+            };
 
             //
             // remoteToolStripMenuItem
             //
-            _remoteToolStripMenuItem.CheckOnClick = true;
-            _remoteToolStripMenuItem.Name = "remoteToolStripMenuItem";
-            _remoteToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
-            _remoteToolStripMenuItem.Text = Strings.Remote;
-        }
+            _remoteToolStripMenuItem = new ToolStripMenuItem
+            {
+                CheckOnClick = true,
+                Name = "remoteToolStripMenuItem",
+                Size = new System.Drawing.Size(115, 22),
+                Text = Strings.Remote
+            };
 
-        public FilterBranchHelper(ToolStripComboBox toolStripBranches, ToolStripDropDownButton toolStripDropDownButton2, RevisionGridControl revisionGrid)
-            : this()
-        {
             _NO_TRANSLATE_toolStripBranches = toolStripBranches;
             _NO_TRANSLATE_RevisionGrid = revisionGrid;
+            _NO_TRANSLATE_RevisionGrid.RefFilterOptionsChanged += (s, e) =>
+            {
+                if (e.RefFilterOptions.HasFlag(RefFilterOptions.All | RefFilterOptions.Boundary))
+                {
+                    // This means show all branches
+                    _NO_TRANSLATE_toolStripBranches.Text = string.Empty;
+                }
+            };
 
             toolStripDropDownButton2.DropDownItems.AddRange(new ToolStripItem[]
             {
@@ -151,9 +160,9 @@ namespace GitUI
 
         private void toolStripBranches_KeyUp(object sender, KeyEventArgs e)
         {
-            if (e.KeyValue == (char)Keys.Enter)
+            if (e.KeyCode == Keys.Enter)
             {
-                ApplyBranchFilter(true);
+                ApplyBranchFilter(refresh: true);
             }
         }
 
@@ -216,7 +225,7 @@ namespace GitUI
 
         private void toolStripBranches_Leave(object sender, EventArgs e)
         {
-            ApplyBranchFilter(true);
+            ApplyBranchFilter(refresh: true);
         }
 
         public void Dispose()

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -187,7 +187,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         public void SetBranchFilter(string filter)
         {
-            BranchFilter.Text = filter;
+            BranchFilter.Text = filter?.Trim();
         }
 
         private void OkClick(object sender, EventArgs e)

--- a/GitUI/UserControls/RevisionGrid/RefFilterOptionsEventArgs.cs
+++ b/GitUI/UserControls/RevisionGrid/RefFilterOptionsEventArgs.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using GitCommands;
+
+namespace GitUI
+{
+    public class RefFilterOptionsEventArgs : EventArgs
+    {
+        public RefFilterOptionsEventArgs(RefFilterOptions refFilterOptions)
+        {
+            RefFilterOptions = refFilterOptions;
+        }
+
+        public RefFilterOptions RefFilterOptions { get; }
+    }
+}

--- a/UnitTests/CommonTestUtils/ReferenceRepository.cs
+++ b/UnitTests/CommonTestUtils/ReferenceRepository.cs
@@ -32,6 +32,14 @@ namespace CommonTestUtils
             return commit.Id.Sha;
         }
 
+        public void CreateBranch(string branchName, string commitHash, bool allowOverwrite = false)
+        {
+            using (var repository = new LibGit2Sharp.Repository(_moduleTestHelper.Module.WorkingDir))
+            {
+                repository.Branches.Add(branchName, commitHash, allowOverwrite);
+            }
+        }
+
         public void CreateCommit(string commitMessage, string content = null)
         {
             using (var repository = new LibGit2Sharp.Repository(_moduleTestHelper.Module.WorkingDir))

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text;
-using CommonTestUtils;
 using FluentAssertions;
 using GitCommands;
 using NUnit.Framework;
@@ -10,20 +9,12 @@ namespace GitCommandsTests
     [TestFixture]
     public sealed class RevisionReaderTests
     {
-        private bool _showReflogReferences;
         private RevisionReader _revisionReader;
 
         [SetUp]
         public void Setup()
         {
-            _showReflogReferences = AppSettings.ShowReflogReferences;
             _revisionReader = new RevisionReader();
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            AppSettings.ShowReflogReferences = _showReflogReferences;
         }
 
         [Test]
@@ -34,17 +25,15 @@ namespace GitCommandsTests
             args.ToString().Should().Contain(" log -z ");
         }
 
-        [TestCase(RefFilterOptions.FirstParent, false, false)]
-        [TestCase(RefFilterOptions.FirstParent, true, false)]
-        [TestCase(RefFilterOptions.All, false, false)]
-        [TestCase(RefFilterOptions.All, true, true)]
-        public void BuildArguments_should_add_reflog_if_requested(RefFilterOptions refFilterOptions, bool reflog, bool expected)
+        [TestCase(RefFilterOptions.FirstParent, false)]
+        [TestCase(RefFilterOptions.FirstParent | RefFilterOptions.Reflogs, false)]
+        [TestCase(RefFilterOptions.All, false)]
+        [TestCase(RefFilterOptions.All | RefFilterOptions.Reflogs, true)]
+        public void BuildArguments_should_add_reflog_if_requested(RefFilterOptions refFilterOptions, bool expected)
         {
-            AppSettings.ShowReflogReferences = reflog;
-
             var args = _revisionReader.GetTestAccessor().BuildArgumentsBuildArguments(refFilterOptions, "", "", "");
 
-            if (expected && reflog)
+            if (expected)
             {
                 args.ToString().Should().Contain(" --reflog ");
             }


### PR DESCRIPTION

Fixes #8484

<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

Whenever the filter value is being cleared in the UI, the filter isn't getting reset in the underlying plumbing.
The fix resets the filter.

This unblocks #8414 

## Test methodology <!-- How did you ensure quality? -->

- manual
- integration tests


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
