### PR TITLE
fix: Resolve script "c"-variables

### DIFF
--- a/GitCommands/ExternalLinks/ExternalLinkFormat.cs
+++ b/GitCommands/ExternalLinks/ExternalLinkFormat.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml.Serialization;
+using GitUIPluginInterfaces;
 
 namespace GitCommands.ExternalLinks
 {

--- a/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
+++ b/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using GitCommands.Remotes;
+using GitUIPluginInterfaces;
 
 namespace GitCommands.ExternalLinks
 {

--- a/GitCommands/ExternalLinks/GitRevisionExternalLinksParser.cs
+++ b/GitCommands/ExternalLinks/GitRevisionExternalLinksParser.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using GitCommands.Settings;
+using GitUIPluginInterfaces;
 
 namespace GitCommands.ExternalLinks
 {

--- a/GitCommands/Git/Extensions/GitRevisionExtensions.cs
+++ b/GitCommands/Git/Extensions/GitRevisionExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace GitCommands.Git.Extensions
+﻿using GitUIPluginInterfaces;
+
+namespace GitCommands.Git.Extensions
 {
     public static class GitRevisionExtensions
     {

--- a/GitCommands/Git/GitRefName.cs
+++ b/GitCommands/Git/GitRefName.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 
 namespace GitCommands

--- a/GitCommands/Git/RevisionDiffProvider.cs
+++ b/GitCommands/Git/RevisionDiffProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using GitExtUtils;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 
 namespace GitCommands.Git

--- a/GitUI/CommandsDialogs/FormArchive.cs
+++ b/GitUI/CommandsDialogs/FormArchive.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitUI.HelperDialogs;
+using GitUIPluginInterfaces;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs

--- a/GitUI/CommandsDialogs/FormBlame.cs
+++ b/GitUI/CommandsDialogs/FormBlame.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using GitCommands;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 
 namespace GitUI.CommandsDialogs

--- a/GitUI/CommandsDialogs/FormBrowseController.cs
+++ b/GitUI/CommandsDialogs/FormBrowseController.cs
@@ -6,6 +6,7 @@ using GitCommands;
 using GitCommands.Git;
 using GitCommands.Gpg;
 using GitCommands.UserRepositoryHistory;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 
 namespace GitUI.CommandsDialogs

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -5,6 +5,7 @@ using GitCommands;
 using GitCommands.Git.Commands;
 using GitExtUtils;
 using GitUI.HelperDialogs;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using ResourceManager;
 

--- a/GitUI/CommandsDialogs/FormFormatPatch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.Designer.cs
@@ -70,7 +70,7 @@ namespace GitUI.CommandsDialogs
             // 
             // gitRevisionBindingSource
             // 
-            this.gitRevisionBindingSource.DataSource = typeof(GitCommands.GitRevision);
+            this.gitRevisionBindingSource.DataSource = typeof(GitUIPluginInterfaces.GitRevision);
             // 
             // gitItemBindingSource
             // 

--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -6,6 +6,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Config;
 using GitUI.CommandsDialogs.FormatPatchDialog;
+using GitUIPluginInterfaces;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs

--- a/GitUI/CommandsDialogs/FormRevertCommit.cs
+++ b/GitUI/CommandsDialogs/FormRevertCommit.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Drawing;
 using System.Windows.Forms;
-using GitCommands;
 using GitCommands.Git.Commands;
 using GitUI.HelperDialogs;
+using GitUIPluginInterfaces;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -14,7 +14,7 @@ using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.Hotkey;
 using GitUI.Properties;
-using GitUI.UserControls;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using ResourceManager;
 

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git.Commands;
 using GitExtUtils.GitUI.Theming;
+using GitUIPluginInterfaces;
 using ResourceManager;
 
 namespace GitUI.HelperDialogs

--- a/GitUI/RevisionDiffInfoProvider.cs
+++ b/GitUI/RevisionDiffInfoProvider.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using GitCommands;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 
 namespace GitUI

--- a/GitUI/Script/IScriptHostControl.cs
+++ b/GitUI/Script/IScriptHostControl.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Drawing;
-using GitCommands;
+using GitUIPluginInterfaces;
 
 namespace GitUI.Script
 {

--- a/GitUI/Script/ScriptOptionsParser.cs
+++ b/GitUI/Script/ScriptOptionsParser.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
-using GitCommands;
 using GitCommands.Config;
 using GitCommands.Git;
 using GitCommands.UserRepositoryHistory;
@@ -114,7 +113,7 @@ namespace GitUI.Script
 
                 if (currentRevision == null && option.StartsWith("c"))
                 {
-                    currentRevision = GetCurrentRevision(module, scriptHostControl, currentTags, currentLocalBranches, currentRemoteBranches, currentBranches);
+                    currentRevision = GetCurrentRevision(module, currentTags, currentLocalBranches, currentRemoteBranches, currentBranches);
                     if (currentRevision == null)
                     {
                         return (arguments: null, abort: true);
@@ -239,22 +238,13 @@ namespace GitUI.Script
 
         [CanBeNull]
         private static GitRevision GetCurrentRevision(
-            [NotNull] IGitModule module, [CanBeNull] IScriptHostControl scriptHostControl, List<IGitRef> currentTags, List<IGitRef> currentLocalBranches,
+            [NotNull] IGitModule module, List<IGitRef> currentTags, List<IGitRef> currentLocalBranches,
             List<IGitRef> currentRemoteBranches, List<IGitRef> currentBranches)
         {
             GitRevision currentRevision;
             IEnumerable<IGitRef> refs;
-            if (scriptHostControl == null)
-            {
-                var currentRevisionGuid = module.GetCurrentCheckout();
-                currentRevision = currentRevisionGuid == null ? null : new GitRevision(currentRevisionGuid);
-                refs = module.GetRefs(true, true).Where(gitRef => gitRef.ObjectId == currentRevisionGuid);
-            }
-            else
-            {
-                currentRevision = scriptHostControl.GetCurrentRevision();
-                refs = currentRevision?.Refs ?? Array.Empty<IGitRef>();
-            }
+            currentRevision = module.GetRevision(shortFormat: true, loadRefs: true);
+            refs = currentRevision?.Refs ?? Array.Empty<IGitRef>();
 
             foreach (var gitRef in refs)
             {
@@ -551,9 +541,9 @@ namespace GitUI.Script
             public string CreateOption([NotNull] string option, bool quoted)
                 => ScriptOptionsParser.CreateOption(option, quoted);
 
-            public GitRevision GetCurrentRevision(IGitModule module, [CanBeNull] IScriptHostControl scriptHostControl, List<IGitRef> currentTags,
+            public GitRevision GetCurrentRevision(IGitModule module, List<IGitRef> currentTags,
                 List<IGitRef> currentLocalBranches, List<IGitRef> currentRemoteBranches, List<IGitRef> currentBranches)
-                => ScriptOptionsParser.GetCurrentRevision(module, scriptHostControl, currentTags, currentLocalBranches, currentRemoteBranches, currentBranches);
+                => ScriptOptionsParser.GetCurrentRevision(module, currentTags, currentLocalBranches, currentRemoteBranches, currentBranches);
 
             public string ParseScriptArguments(string arguments, string option, IWin32Window owner, IScriptHostControl scriptHostControl,
                 IGitModule module, IReadOnlyList<GitRevision> allSelectedRevisions, List<IGitRef> selectedTags, List<IGitRef> selectedBranches,

--- a/GitUI/UserControls/CommitSummaryUserControl.cs
+++ b/GitUI/UserControls/CommitSummaryUserControl.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Drawing;
 using System.Linq;
-using GitCommands;
 using GitExtUtils.GitUI.Theming;
+using GitUIPluginInterfaces;
 using ResourceManager;
 using ResourceManager.CommitDataRenders;
 

--- a/GitUI/UserControls/FileStatusItem.cs
+++ b/GitUI/UserControls/FileStatusItem.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using GitCommands;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 
 namespace GitUI.UserControls

--- a/GitUI/UserControls/RevisionGrid/Columns/AuthorNameColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/AuthorNameColumnProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System.Windows.Forms;
 using GitCommands;
 using GitExtUtils.GitUI;
+using GitUIPluginInterfaces;
 
 namespace GitUI.UserControls.RevisionGrid.Columns
 {

--- a/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
@@ -6,6 +6,7 @@ using GitCommands;
 using GitExtUtils.GitUI;
 using GitUI.Avatars;
 using GitUI.Properties;
+using GitUIPluginInterfaces;
 
 namespace GitUI.UserControls.RevisionGrid.Columns
 {

--- a/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
@@ -4,6 +4,7 @@ using System.Drawing.Drawing2D;
 using System.Windows.Forms;
 using GitCommands;
 using GitExtUtils.GitUI;
+using GitUIPluginInterfaces;
 using GitUIPluginInterfaces.BuildServerIntegration;
 
 namespace GitUI.UserControls.RevisionGrid.Columns

--- a/GitUI/UserControls/RevisionGrid/Columns/ColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/ColumnProvider.cs
@@ -2,6 +2,7 @@ using System.Drawing;
 using System.Windows.Forms;
 using GitCommands;
 using GitExtUtils.GitUI;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 
 namespace GitUI.UserControls.RevisionGrid.Columns

--- a/GitUI/UserControls/RevisionGrid/Columns/DateColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/DateColumnProvider.cs
@@ -2,6 +2,7 @@
 using System.Windows.Forms;
 using GitCommands;
 using GitExtUtils.GitUI;
+using GitUIPluginInterfaces;
 using ResourceManager;
 
 namespace GitUI.UserControls.RevisionGrid.Columns

--- a/GitUI/UserControls/RevisionGrid/Columns/MultilineIndicator.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MultilineIndicator.cs
@@ -2,6 +2,7 @@
 using System.Windows.Forms;
 using GitCommands;
 using GitExtUtils.GitUI;
+using GitUIPluginInterfaces;
 
 namespace GitUI.UserControls.RevisionGrid.Columns
 {

--- a/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
-using GitCommands;
 using GitExtUtils;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Properties;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using ResourceManager;
 

--- a/GitUI/UserControls/RevisionGrid/DoubleClickRevisionEventArgs.cs
+++ b/GitUI/UserControls/RevisionGrid/DoubleClickRevisionEventArgs.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using GitCommands;
+using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 
 namespace GitUI.UserControls.RevisionGrid

--- a/IntegrationTests/UI.IntegrationTests/Script/ScriptRunnerTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/Script/ScriptRunnerTests.cs
@@ -126,6 +126,9 @@ namespace GitExtensions.UITests.Script
             _exampleScript.Command = "cmd";
             _exampleScript.Arguments = "/c echo {cHash}";
 
+            var revision = new GitRevision(ObjectId.IndexId);
+            _module.GetRevision(shortFormat: true, loadRefs: true).Returns(x => revision);
+
             var result = ScriptRunner.RunScript(null, _module, _keyOfExampleScript, uiCommands: null, revisionGrid: null);
 
             result.Should().BeEquivalentTo(new CommandStatus(true, needsGridRefresh: false));

--- a/Plugins/GitUIPluginInterfaces/GitRevision.cs
+++ b/Plugins/GitUIPluginInterfaces/GitRevision.cs
@@ -4,11 +4,10 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
-using GitUIPluginInterfaces;
 using GitUIPluginInterfaces.BuildServerIntegration;
 using JetBrains.Annotations;
 
-namespace GitCommands
+namespace GitUIPluginInterfaces
 {
     public sealed class GitRevision : IGitItem, INotifyPropertyChanged
     {

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -109,6 +109,8 @@ namespace GitUIPluginInterfaces
         /// <summary>Gets the remote of the current branch; or "" if no remote is configured.</summary>
         string GetCurrentRemote();
 
+        GitRevision GetRevision([CanBeNull] ObjectId objectId = null, bool shortFormat = false, bool loadRefs = false);
+
         Task<IReadOnlyList<Remote>> GetRemotesAsync();
 
         string GetSetting(string setting);

--- a/UnitTests/GitCommands.Tests/Git/Extensions/GitRevisionExtensionsTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/Extensions/GitRevisionExtensionsTests.cs
@@ -1,6 +1,6 @@
 ﻿using FluentAssertions;
-using GitCommands;
 using GitCommands.Git.Extensions;
+using GitUIPluginInterfaces;
 using NUnit.Framework;
 
 namespace GitCommandsTests.Git.Extensions

--- a/UnitTests/GitCommands.Tests/Git/RevisionDiffProviderTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/RevisionDiffProviderTest.cs
@@ -2,6 +2,7 @@ using System;
 using FluentAssertions;
 using GitCommands;
 using GitCommands.Git;
+using GitUIPluginInterfaces;
 using NUnit.Framework;
 
 namespace GitCommandsTests.Git

--- a/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
+++ b/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
@@ -95,47 +95,25 @@ namespace GitUITests.Script
         }
 
         [Test]
-        public void GetCurrentRevision_should_return_null_if_scriptHostControl_unset_bare_or_empty_repo()
+        public void GetCurrentRevision_should_return_null_if_bare_or_empty_repo()
         {
             // bare repo has no current checkout, empty repo has no commits
-            _module.GetCurrentCheckout().Returns(x => null);
+            _module.GetRevision(shortFormat: true, loadRefs: true).Returns(x => null);
 
             var result = ScriptOptionsParser.GetTestAccessor()
-                .GetCurrentRevision(module: _module, scriptHostControl: null, currentTags: null, currentLocalBranches: null, currentRemoteBranches: null, currentBranches: null);
+                .GetCurrentRevision(module: _module, currentTags: null, currentLocalBranches: null, currentRemoteBranches: null, currentBranches: null);
 
             result.Should().Be(null);
         }
 
         [Test]
-        public void GetCurrentRevision_should_return_expected_if_scriptHostControl_unset_unmatched_ref()
-        {
-            _module.GetCurrentCheckout().Returns(x => ObjectId.IndexId);
-
-            var result = ScriptOptionsParser.GetTestAccessor()
-                .GetCurrentRevision(module: _module, scriptHostControl: null, currentTags: null, currentLocalBranches: null, currentRemoteBranches: null, currentBranches: null);
-
-            result.ObjectId.Should().Be(ObjectId.IndexId);
-        }
-
-        [Test]
-        public void GetCurrentRevision_should_return_null_if_scriptHostControl_set_current_revision_null()
-        {
-            _scriptHostControl.GetCurrentRevision().Returns(x => null);
-
-            var result = ScriptOptionsParser.GetTestAccessor()
-                .GetCurrentRevision(module: _module, scriptHostControl: _scriptHostControl, currentTags: null, currentLocalBranches: null, currentRemoteBranches: null, currentBranches: null);
-
-            result.Should().Be(null);
-        }
-
-        [Test]
-        public void GetCurrentRevision_should_return_expected_if_scriptHostControl_set_current_revision_has_no_refs()
+        public void GetCurrentRevision_should_return_expected_if_current_revision_has_no_refs()
         {
             var revision = new GitRevision(ObjectId.IndexId);
-            _scriptHostControl.GetCurrentRevision().Returns(x => revision);
+            _module.GetRevision(shortFormat: true, loadRefs: true).Returns(x => revision);
 
             var result = ScriptOptionsParser.GetTestAccessor()
-                .GetCurrentRevision(module: _module, scriptHostControl: _scriptHostControl, currentTags: null, currentLocalBranches: null, currentRemoteBranches: null, currentBranches: null);
+                .GetCurrentRevision(module: _module, currentTags: null, currentLocalBranches: null, currentRemoteBranches: null, currentBranches: null);
 
             result.Should().Be(revision);
         }
@@ -168,6 +146,21 @@ namespace GitUITests.Script
             var result = ScriptOptionsParser.Parse(arguments: arguments, module: _module, owner: null, scriptHostControl: null);
 
             result.arguments.Should().Be(arguments);
+            result.abort.Should().Be(false);
+        }
+
+        [Test]
+        public void Parse_should_parse_c_arguments()
+        {
+            var revision = new GitRevision(ObjectId.IndexId)
+            {
+                Subject = "line1"
+            };
+            _module.GetRevision(shortFormat: true, loadRefs: true).Returns(x => revision);
+
+            var result = ScriptOptionsParser.Parse("echo \"{cMessage}\"", module: _module, owner: null, scriptHostControl: null);
+
+            result.arguments.Should().Be($"echo \"{revision.Subject}\"");
             result.abort.Should().Be(false);
         }
 


### PR DESCRIPTION
Fixes part of #8486

## Proposed changes

Whenever a script, run outside the revision grid, needed to resolve
a "c"-variable, it would  and Original implementation would retrieve
the current checkout information, that didn't have enough information
available to process a requested variable.

Replace the call with `GetRevision` call, that is made by the revision grid,
and which has all information about a revision (except for the full body).
With that consolidate the revision retrieval logic.

Expose `GetRevision` method at the `IGitModule` level, and move
`GitRevision`type to GitUIPluginInterfaces, so it is universally available.



## Test methodology <!-- How did you ensure quality? -->

- manual
- unit tests
