### PR TITLE
Add script options {sSubject} and {cSubject}

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -47,6 +47,7 @@ Selected Branch:
 {sRemotePathFromUrl}
 {sHash}
 {sMessage}
+{sSubject}
 {sAuthor}
 {sCommitter}
 {sAuthorDate}
@@ -60,6 +61,7 @@ Current Branch:
 {cRemoteBranchName}   (without the remote's name)
 {cHash}
 {cMessage}
+{cSubject}
 {cAuthor}
 {cCommitter}
 {cAuthorDate}

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8934,6 +8934,7 @@ Selected Branch:
 {sRemotePathFromUrl}
 {sHash}
 {sMessage}
+{sSubject}
 {sAuthor}
 {sCommitter}
 {sAuthorDate}
@@ -8947,6 +8948,7 @@ Current Branch:
 {cRemoteBranchName}   (without the remote's name)
 {cHash}
 {cMessage}
+{cSubject}
 {cAuthor}
 {cCommitter}
 {cAuthorDate}


### PR DESCRIPTION
Fixes #8486
together with #8487, on which this PR is based.

## Proposed changes

- add script options `{cSubject}` and `{sSubject}`
- change script options `{cMessage}` and `{sMessage}`to yield the full message
  The linefeed characters are replaced with `\n`.

## Test methodology <!-- How did you ensure quality? -->

- adapted and added NUnit tests
- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 8bc7355730d48b869ea0389bed8ffd59f3d77695
- Git 2.27.0.windows.1 (recommended: 2.28.0 or later)
- Microsoft Windows NT 10.0.18362.0
- .NET Framework 4.8.4220.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
