### PR TITLE
fix: Write and read enum setting as string not number

### DIFF
--- a/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using GitCommands;
 using GitCommands.Settings;
+using GitUIPluginInterfaces;
 using NUnit.Framework;
 
 namespace GitCommandsTests.Settings
@@ -8,12 +11,220 @@ namespace GitCommandsTests.Settings
     [TestFixture]
     internal sealed class SettingTests
     {
+        private const string SettingsFileContent = @"<?xml version=""1.0"" encoding=""utf-8""?><dictionary />";
+
+        private string _settingFilePath;
+        private RepoDistSettings _settingContainer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _settingFilePath = Path.GetTempFileName();
+
+            File.WriteAllText(_settingFilePath, SettingsFileContent);
+
+            _settingContainer = new RepoDistSettings(null, GitExtSettingsCache.Create(_settingFilePath), SettingLevel.Unknown);
+        }
+
+        #region Setting
+
+        [Test]
+        [TestCaseSource(nameof(CreateCases))]
+        public void Should_create_setting<T>(T settingDefault)
+            where T : struct
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            // Act
+            var setting = Setting.Create<T>(settingsPath, settingName, settingDefault);
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(settingDefault));
+            Assert.That(setting.IsUnset, Is.True);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCaseSource(nameof(SaveCases))]
+        public void Should_save_setting<T>(T settingDefault, T value)
+            where T : struct
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            T storedValue = default;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+                setting.Value = value;
+
+                AppSettings.SaveSettings();
+            });
+
+            var filePath = Path.GetTempFileName();
+
+            File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+            AppSettings.UsingContainer(container, () =>
+            {
+                var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+                storedValue = setting.Value;
+            });
+
+            // Assert
+            Assert.That(storedValue, Is.EqualTo(value));
+        }
+
+        [Test]
+        [TestCaseSource(nameof(SaveCases))]
+        public void Should_trigger_updated_event_for_setting<T>(T settingDefault, T value)
+            where T : struct
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.True);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(SaveCases))]
+        public void Should_not_trigger_updated_event_for_setting<T>(T settingDefault, T value)
+            where T : struct
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+            var updated = false;
+
+            // Act
+            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+            setting.Value = value;
+
+            setting.Updated += (source, eventArgs) =>
+            {
+                updated = true;
+            };
+
+            setting.Value = value;
+
+            // Assert
+            Assert.That(setting, Is.Not.Null);
+            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
+            Assert.That(setting.Name, Is.EqualTo(settingName));
+            Assert.That(setting.Default, Is.EqualTo(settingDefault));
+            Assert.That(setting.Value, Is.EqualTo(value));
+            Assert.That(setting.IsUnset, Is.False);
+            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(updated, Is.False);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(CreateCases))]
+        public void Should_return_default_value_for_setting_if_value_not_exist<T>(T settingDefault)
+            where T : struct
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            T storedValue = default;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+                storedValue = setting.Value;
+            });
+
+            // Assert
+            Assert.That(storedValue, Is.EqualTo(settingDefault));
+        }
+
+        [Test]
+        [TestCaseSource(nameof(CreateCases))]
+        public void Should_return_default_value_for_setting_if_value_is_incorrect<T>(T settingDefault)
+            where T : struct
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            T storedValue = default;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create(settingsPath, settingName, string.Empty);
+
+                setting.Value = Guid.NewGuid().ToString();
+
+                AppSettings.SaveSettings();
+            });
+
+            var filePath = Path.GetTempFileName();
+
+            File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+            AppSettings.UsingContainer(container, () =>
+            {
+                var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+                storedValue = setting.Value;
+            });
+
+            // Assert
+            Assert.That(storedValue, Is.EqualTo(settingDefault));
+        }
+
+        #endregion Setting
+
         #region String Setting
 
         [Test]
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase(" ")]
+        [TestCaseSource(nameof(CreateStringCases))]
         public void Should_create_string_setting(string settingDefault)
         {
             // Arrange
@@ -35,47 +246,44 @@ namespace GitCommandsTests.Settings
         }
 
         [Test]
-        [TestCase(null, null)]
-        [TestCase(null, "")]
-        [TestCase(null, " ")]
-        [TestCase("", null)]
-        [TestCase("", "")]
-        [TestCase("", " ")]
-        [TestCase(" ", null)]
-        [TestCase(" ", "")]
-        [TestCase(" ", " ")]
+        [TestCaseSource(nameof(SaveStringCases))]
         public void Should_save_string_setting(string settingDefault, string value)
         {
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
             var settingsPath = new AppSettingsPath(pathName);
+            string storedValue = null;
 
             // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create(settingsPath, settingName, settingDefault);
 
-            setting.Value = value;
+                setting.Value = value;
+
+                AppSettings.SaveSettings();
+            });
+
+            var filePath = Path.GetTempFileName();
+
+            File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+            AppSettings.UsingContainer(container, () =>
+            {
+                var setting = Setting.Create(settingsPath, settingName, settingDefault);
+
+                storedValue = setting.Value;
+            });
 
             // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault ?? string.Empty));
-            Assert.That(setting.Value, Is.EqualTo(value ?? string.Empty));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+            Assert.That(storedValue, Is.EqualTo(value ?? string.Empty));
         }
 
         [Test]
-        [TestCase(null, null)]
-        [TestCase(null, "")]
-        [TestCase(null, " ")]
-        [TestCase("", null)]
-        [TestCase("", "")]
-        [TestCase("", " ")]
-        [TestCase(" ", null)]
-        [TestCase(" ", "")]
-        [TestCase(" ", " ")]
+        [TestCaseSource(nameof(SaveStringCases))]
         public void Should_trigger_updated_event_for_string_setting(string settingDefault, string value)
         {
             // Arrange
@@ -106,15 +314,7 @@ namespace GitCommandsTests.Settings
         }
 
         [Test]
-        [TestCase(null, null)]
-        [TestCase(null, "")]
-        [TestCase(null, " ")]
-        [TestCase("", null)]
-        [TestCase("", "")]
-        [TestCase("", " ")]
-        [TestCase(" ", null)]
-        [TestCase(" ", "")]
-        [TestCase(" ", " ")]
+        [TestCaseSource(nameof(SaveStringCases))]
         public void Should_not_trigger_updated_event_for_string_setting(string settingDefault, string value)
         {
             // Arrange
@@ -149,126 +349,6 @@ namespace GitCommandsTests.Settings
         #endregion String Setting
 
         #region Bool Setting
-
-        [Test]
-        [TestCase(false)]
-        [TestCase(true)]
-        public void Should_create_bool_setting(bool settingDefault)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(settingDefault));
-            Assert.That(setting.IsUnset, Is.True);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-        }
-
-        [Test]
-        [TestCase(false, false)]
-        [TestCase(false, true)]
-        [TestCase(true, false)]
-        [TestCase(true, true)]
-        public void Should_save_bool_setting(bool settingDefault, bool value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-        }
-
-        [Test]
-        [TestCase(false, false)]
-        [TestCase(false, true)]
-        [TestCase(true, false)]
-        [TestCase(true, true)]
-        public void Should_trigger_updated_event_for_bool_setting(bool settingDefault, bool value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var updated = false;
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Updated += (source, eventArgs) =>
-            {
-                updated = true;
-            };
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-            Assert.That(updated, Is.True);
-        }
-
-        [Test]
-        [TestCase(false, false)]
-        [TestCase(false, true)]
-        [TestCase(true, false)]
-        [TestCase(true, true)]
-        public void Should_not_trigger_updated_event_for_bool_setting(bool settingDefault, bool value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var updated = false;
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Value = value;
-
-            setting.Updated += (source, eventArgs) =>
-            {
-                updated = true;
-            };
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-            Assert.That(updated, Is.False);
-        }
 
         [Test]
         public void Should_create_nullable_bool_setting()
@@ -384,145 +464,68 @@ namespace GitCommandsTests.Settings
             Assert.That(updated, Is.False);
         }
 
+        [Test]
+        public void Should_return_default_value_for_nullable_bool_setting_if_value_not_exist()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            bool? storedValue = null;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create<bool>(settingsPath, settingName);
+
+                storedValue = setting.Value;
+            });
+
+            // Assert
+            Assert.That(storedValue, Is.Null);
+        }
+
+        [Test]
+        public void Should_return_default_value_for_nullable_bool_setting_if_value_is_incorrect()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            bool? storedValue = null;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create(settingsPath, settingName, string.Empty);
+
+                setting.Value = Guid.NewGuid().ToString();
+
+                AppSettings.SaveSettings();
+            });
+
+            var filePath = Path.GetTempFileName();
+
+            File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+            AppSettings.UsingContainer(container, () =>
+            {
+                var setting = Setting.Create<bool>(settingsPath, settingName);
+
+                storedValue = setting.Value;
+            });
+
+            // Assert
+            Assert.That(storedValue, Is.Null);
+        }
+
         #endregion Bool Setting
 
         #region Char Setting
-
-        [Test]
-        [TestCase(char.MinValue)]
-        [TestCase(char.MaxValue)]
-        [TestCase(' ')]
-        public void Should_create_char_setting(char settingDefault)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(settingDefault));
-            Assert.That(setting.IsUnset, Is.True);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-        }
-
-        [Test]
-        [TestCase(char.MinValue, char.MinValue)]
-        [TestCase(char.MinValue, char.MaxValue)]
-        [TestCase(char.MinValue, ' ')]
-        [TestCase(char.MaxValue, char.MinValue)]
-        [TestCase(char.MaxValue, char.MaxValue)]
-        [TestCase(char.MaxValue, ' ')]
-        [TestCase(' ', char.MinValue)]
-        [TestCase(' ', char.MaxValue)]
-        [TestCase(' ', ' ')]
-        public void Should_save_char_setting(char settingDefault, char value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-        }
-
-        [Test]
-        [TestCase(char.MinValue, char.MinValue)]
-        [TestCase(char.MinValue, char.MaxValue)]
-        [TestCase(char.MinValue, ' ')]
-        [TestCase(char.MaxValue, char.MinValue)]
-        [TestCase(char.MaxValue, char.MaxValue)]
-        [TestCase(char.MaxValue, ' ')]
-        [TestCase(' ', char.MinValue)]
-        [TestCase(' ', char.MaxValue)]
-        [TestCase(' ', ' ')]
-        public void Should_trigger_updated_event_for_char_setting(char settingDefault, char value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var updated = false;
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Updated += (source, eventArgs) =>
-            {
-                updated = true;
-            };
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-            Assert.That(updated, Is.True);
-        }
-
-        [Test]
-        [TestCase(char.MinValue, char.MinValue)]
-        [TestCase(char.MinValue, char.MaxValue)]
-        [TestCase(char.MinValue, ' ')]
-        [TestCase(char.MaxValue, char.MinValue)]
-        [TestCase(char.MaxValue, char.MaxValue)]
-        [TestCase(char.MaxValue, ' ')]
-        [TestCase(' ', char.MinValue)]
-        [TestCase(' ', char.MaxValue)]
-        [TestCase(' ', ' ')]
-        public void Should_not_trigger_updated_event_for_char_setting(char settingDefault, char value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var updated = false;
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Value = value;
-
-            setting.Updated += (source, eventArgs) =>
-            {
-                updated = true;
-            };
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-            Assert.That(updated, Is.False);
-        }
 
         [Test]
         public void Should_create_nullable_char_setting()
@@ -548,7 +551,6 @@ namespace GitCommandsTests.Settings
         [Test]
         [TestCase(null)]
         [TestCase(char.MinValue)]
-        [TestCase(char.MaxValue)]
         [TestCase(' ')]
         public void Should_save_nullable_char_setting(char? value)
         {
@@ -574,7 +576,6 @@ namespace GitCommandsTests.Settings
 
         [Test]
         [TestCase(char.MinValue)]
-        [TestCase(char.MaxValue)]
         [TestCase(' ')]
         public void Should_trigger_updated_event_for_nullable_char_setting(char? value)
         {
@@ -608,7 +609,6 @@ namespace GitCommandsTests.Settings
         [Test]
         [TestCase(null)]
         [TestCase(char.MinValue)]
-        [TestCase(char.MaxValue)]
         [TestCase(' ')]
         public void Should_not_trigger_updated_event_for_nullable_char_setting(char? value)
         {
@@ -641,145 +641,68 @@ namespace GitCommandsTests.Settings
             Assert.That(updated, Is.False);
         }
 
+        [Test]
+        public void Should_return_default_value_for_nullable_char_setting_if_value_not_exist()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            char? storedValue = null;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create<char>(settingsPath, settingName);
+
+                storedValue = setting.Value;
+            });
+
+            // Assert
+            Assert.That(storedValue, Is.Null);
+        }
+
+        [Test]
+        public void Should_return_default_value_for_nullable_char_setting_if_value_is_incorrect()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            char? storedValue = null;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create(settingsPath, settingName, string.Empty);
+
+                setting.Value = Guid.NewGuid().ToString();
+
+                AppSettings.SaveSettings();
+            });
+
+            var filePath = Path.GetTempFileName();
+
+            File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+            AppSettings.UsingContainer(container, () =>
+            {
+                var setting = Setting.Create<char>(settingsPath, settingName);
+
+                storedValue = setting.Value;
+            });
+
+            // Assert
+            Assert.That(storedValue, Is.Null);
+        }
+
         #endregion Char Setting
 
         #region Byte Setting
-
-        [Test]
-        [TestCase(byte.MinValue)]
-        [TestCase(byte.MaxValue)]
-        [TestCase(0)]
-        public void Should_create_byte_setting(byte settingDefault)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(settingDefault));
-            Assert.That(setting.IsUnset, Is.True);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-        }
-
-        [Test]
-        [TestCase(byte.MinValue, byte.MinValue)]
-        [TestCase(byte.MinValue, byte.MaxValue)]
-        [TestCase(byte.MinValue, 0)]
-        [TestCase(byte.MaxValue, byte.MinValue)]
-        [TestCase(byte.MaxValue, byte.MaxValue)]
-        [TestCase(byte.MaxValue, 0)]
-        [TestCase(0, byte.MinValue)]
-        [TestCase(0, byte.MaxValue)]
-        [TestCase(0, 0)]
-        public void Should_save_byte_setting(byte settingDefault, byte value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-        }
-
-        [Test]
-        [TestCase(byte.MinValue, byte.MinValue)]
-        [TestCase(byte.MinValue, byte.MaxValue)]
-        [TestCase(byte.MinValue, 0)]
-        [TestCase(byte.MaxValue, byte.MinValue)]
-        [TestCase(byte.MaxValue, byte.MaxValue)]
-        [TestCase(byte.MaxValue, 0)]
-        [TestCase(0, byte.MinValue)]
-        [TestCase(0, byte.MaxValue)]
-        [TestCase(0, 0)]
-        public void Should_trigger_updated_event_for_byte_setting(byte settingDefault, byte value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var updated = false;
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Updated += (source, eventArgs) =>
-            {
-                updated = true;
-            };
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-            Assert.That(updated, Is.True);
-        }
-
-        [Test]
-        [TestCase(byte.MinValue, byte.MinValue)]
-        [TestCase(byte.MinValue, byte.MaxValue)]
-        [TestCase(byte.MinValue, 0)]
-        [TestCase(byte.MaxValue, byte.MinValue)]
-        [TestCase(byte.MaxValue, byte.MaxValue)]
-        [TestCase(byte.MaxValue, 0)]
-        [TestCase(0, byte.MinValue)]
-        [TestCase(0, byte.MaxValue)]
-        [TestCase(0, 0)]
-        public void Should_not_trigger_updated_event_for_byte_setting(byte settingDefault, byte value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var updated = false;
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Value = value;
-
-            setting.Updated += (source, eventArgs) =>
-            {
-                updated = true;
-            };
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-            Assert.That(updated, Is.False);
-        }
 
         [Test]
         public void Should_create_nullable_byte_setting()
@@ -898,145 +821,68 @@ namespace GitCommandsTests.Settings
             Assert.That(updated, Is.False);
         }
 
+        [Test]
+        public void Should_return_default_value_for_nullable_byte_setting_if_value_not_exist()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            byte? storedValue = null;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create<byte>(settingsPath, settingName);
+
+                storedValue = setting.Value;
+            });
+
+            // Assert
+            Assert.That(storedValue, Is.Null);
+        }
+
+        [Test]
+        public void Should_return_default_value_for_nullable_byte_setting_if_value_is_incorrect()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            byte? storedValue = null;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create(settingsPath, settingName, string.Empty);
+
+                setting.Value = Guid.NewGuid().ToString();
+
+                AppSettings.SaveSettings();
+            });
+
+            var filePath = Path.GetTempFileName();
+
+            File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+            AppSettings.UsingContainer(container, () =>
+            {
+                var setting = Setting.Create<byte>(settingsPath, settingName);
+
+                storedValue = setting.Value;
+            });
+
+            // Assert
+            Assert.That(storedValue, Is.Null);
+        }
+
         #endregion Byte Setting
 
         #region Int Setting
-
-        [Test]
-        [TestCase(int.MinValue)]
-        [TestCase(int.MaxValue)]
-        [TestCase(0)]
-        public void Should_create_int_setting(int settingDefault)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(settingDefault));
-            Assert.That(setting.IsUnset, Is.True);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-        }
-
-        [Test]
-        [TestCase(int.MinValue, int.MinValue)]
-        [TestCase(int.MinValue, int.MaxValue)]
-        [TestCase(int.MinValue, 0)]
-        [TestCase(int.MaxValue, int.MinValue)]
-        [TestCase(int.MaxValue, int.MaxValue)]
-        [TestCase(int.MaxValue, 0)]
-        [TestCase(0, int.MinValue)]
-        [TestCase(0, int.MaxValue)]
-        [TestCase(0, 0)]
-        public void Should_save_int_setting(int settingDefault, int value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-        }
-
-        [Test]
-        [TestCase(int.MinValue, int.MinValue)]
-        [TestCase(int.MinValue, int.MaxValue)]
-        [TestCase(int.MinValue, 0)]
-        [TestCase(int.MaxValue, int.MinValue)]
-        [TestCase(int.MaxValue, int.MaxValue)]
-        [TestCase(int.MaxValue, 0)]
-        [TestCase(0, int.MinValue)]
-        [TestCase(0, int.MaxValue)]
-        [TestCase(0, 0)]
-        public void Should_trigger_updated_event_for_int_setting(int settingDefault, int value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var updated = false;
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Updated += (source, eventArgs) =>
-            {
-                updated = true;
-            };
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-            Assert.That(updated, Is.True);
-        }
-
-        [Test]
-        [TestCase(int.MinValue, int.MinValue)]
-        [TestCase(int.MinValue, int.MaxValue)]
-        [TestCase(int.MinValue, 0)]
-        [TestCase(int.MaxValue, int.MinValue)]
-        [TestCase(int.MaxValue, int.MaxValue)]
-        [TestCase(int.MaxValue, 0)]
-        [TestCase(0, int.MinValue)]
-        [TestCase(0, int.MaxValue)]
-        [TestCase(0, 0)]
-        public void Should_not_trigger_updated_event_for_int_setting(int settingDefault, int value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var updated = false;
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Value = value;
-
-            setting.Updated += (source, eventArgs) =>
-            {
-                updated = true;
-            };
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-            Assert.That(updated, Is.False);
-        }
 
         [Test]
         public void Should_create_nullable_int_setting()
@@ -1155,145 +1001,68 @@ namespace GitCommandsTests.Settings
             Assert.That(updated, Is.False);
         }
 
+        [Test]
+        public void Should_return_default_value_for_nullable_int_setting_if_value_not_exist()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            int? storedValue = null;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create<int>(settingsPath, settingName);
+
+                storedValue = setting.Value;
+            });
+
+            // Assert
+            Assert.That(storedValue, Is.Null);
+        }
+
+        [Test]
+        public void Should_return_default_value_for_nullable_int_setting_if_value_is_incorrect()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            int? storedValue = null;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create(settingsPath, settingName, string.Empty);
+
+                setting.Value = Guid.NewGuid().ToString();
+
+                AppSettings.SaveSettings();
+            });
+
+            var filePath = Path.GetTempFileName();
+
+            File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+            AppSettings.UsingContainer(container, () =>
+            {
+                var setting = Setting.Create<int>(settingsPath, settingName);
+
+                storedValue = setting.Value;
+            });
+
+            // Assert
+            Assert.That(storedValue, Is.Null);
+        }
+
         #endregion Int Setting
 
         #region Float Setting
-
-        [Test]
-        [TestCase(float.MinValue)]
-        [TestCase(float.MaxValue)]
-        [TestCase(0f)]
-        public void Should_create_float_setting(float settingDefault)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(settingDefault));
-            Assert.That(setting.IsUnset, Is.True);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-        }
-
-        [Test]
-        [TestCase(float.MinValue, float.MinValue)]
-        [TestCase(float.MinValue, float.MaxValue)]
-        [TestCase(float.MinValue, 0f)]
-        [TestCase(float.MaxValue, float.MinValue)]
-        [TestCase(float.MaxValue, float.MaxValue)]
-        [TestCase(float.MaxValue, 0f)]
-        [TestCase(0f, float.MinValue)]
-        [TestCase(0f, float.MaxValue)]
-        [TestCase(0f, 0f)]
-        public void Should_save_float_setting(float settingDefault, float value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-        }
-
-        [Test]
-        [TestCase(float.MinValue, float.MinValue)]
-        [TestCase(float.MinValue, float.MaxValue)]
-        [TestCase(float.MinValue, 0f)]
-        [TestCase(float.MaxValue, float.MinValue)]
-        [TestCase(float.MaxValue, float.MaxValue)]
-        [TestCase(float.MaxValue, 0)]
-        [TestCase(0f, float.MinValue)]
-        [TestCase(0f, float.MaxValue)]
-        [TestCase(0f, 0f)]
-        public void Should_trigger_updated_event_for_float_setting(float settingDefault, float value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var updated = false;
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Updated += (source, eventArgs) =>
-            {
-                updated = true;
-            };
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-            Assert.That(updated, Is.True);
-        }
-
-        [Test]
-        [TestCase(float.MinValue, float.MinValue)]
-        [TestCase(float.MinValue, float.MaxValue)]
-        [TestCase(float.MinValue, 0f)]
-        [TestCase(float.MaxValue, float.MinValue)]
-        [TestCase(float.MaxValue, float.MaxValue)]
-        [TestCase(float.MaxValue, 0f)]
-        [TestCase(0f, float.MinValue)]
-        [TestCase(0f, float.MaxValue)]
-        [TestCase(0f, 0f)]
-        public void Should_not_trigger_updated_event_for_float_setting(float settingDefault, float value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var updated = false;
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Value = value;
-
-            setting.Updated += (source, eventArgs) =>
-            {
-                updated = true;
-            };
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-            Assert.That(updated, Is.False);
-        }
 
         [Test]
         public void Should_create_nullable_float_setting()
@@ -1412,129 +1181,68 @@ namespace GitCommandsTests.Settings
             Assert.That(updated, Is.False);
         }
 
+        [Test]
+        public void Should_return_default_value_for_nullable_float_setting_if_value_not_exist()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            float? storedValue = null;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create<float>(settingsPath, settingName);
+
+                storedValue = setting.Value;
+            });
+
+            // Assert
+            Assert.That(storedValue, Is.Null);
+        }
+
+        [Test]
+        public void Should_return_default_value_for_nullable_float_setting_if_value_is_incorrect()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            float? storedValue = null;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create(settingsPath, settingName, string.Empty);
+
+                setting.Value = Guid.NewGuid().ToString();
+
+                AppSettings.SaveSettings();
+            });
+
+            var filePath = Path.GetTempFileName();
+
+            File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+            AppSettings.UsingContainer(container, () =>
+            {
+                var setting = Setting.Create<float>(settingsPath, settingName);
+
+                storedValue = setting.Value;
+            });
+
+            // Assert
+            Assert.That(storedValue, Is.Null);
+        }
+
         #endregion Float Setting
 
         #region Enum Setting
-
-        [Test]
-        [TestCase(TestEnum.First)]
-        [TestCase(TestEnum.Second)]
-        public void Should_create_enum_setting(TestEnum settingDefault)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(settingDefault));
-            Assert.That(setting.IsUnset, Is.True);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-        }
-
-        [Test]
-        [TestCase(TestEnum.First, TestEnum.First)]
-        [TestCase(TestEnum.First, TestEnum.Second)]
-        [TestCase(TestEnum.Second, TestEnum.First)]
-        [TestCase(TestEnum.Second, TestEnum.Second)]
-        public void Should_save_enum_setting(TestEnum settingDefault, TestEnum value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-        }
-
-        [Test]
-        [TestCase(TestEnum.First, TestEnum.First)]
-        [TestCase(TestEnum.First, TestEnum.Second)]
-        [TestCase(TestEnum.Second, TestEnum.First)]
-        [TestCase(TestEnum.Second, TestEnum.Second)]
-        public void Should_trigger_updated_event_for_enum_setting(TestEnum settingDefault, TestEnum value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var updated = false;
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Updated += (source, eventArgs) =>
-            {
-                updated = true;
-            };
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-            Assert.That(updated, Is.True);
-        }
-
-        [Test]
-        [TestCase(TestEnum.First, TestEnum.First)]
-        [TestCase(TestEnum.First, TestEnum.Second)]
-        [TestCase(TestEnum.Second, TestEnum.First)]
-        [TestCase(TestEnum.Second, TestEnum.Second)]
-        public void Should_not_trigger_updated_event_for_enum_setting(TestEnum settingDefault, TestEnum value)
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var updated = false;
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Value = value;
-
-            setting.Updated += (source, eventArgs) =>
-            {
-                updated = true;
-            };
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-            Assert.That(updated, Is.False);
-        }
 
         [Test]
         public void Should_create_nullable_enum_setting()
@@ -1581,6 +1289,48 @@ namespace GitCommandsTests.Settings
             Assert.That(setting.Value, Is.EqualTo(value));
             Assert.That(setting.IsUnset, Is.False);
             Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(TestEnum.First)]
+        [TestCase(TestEnum.Second)]
+        public void Should_save_nullable_enum_setting_as_string(TestEnum? value)
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            string storedValue = string.Empty;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create<TestEnum>(settingsPath, settingName);
+
+                setting.Value = value;
+
+                AppSettings.SaveSettings();
+            });
+
+            var filePath = Path.GetTempFileName();
+
+            File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+            AppSettings.UsingContainer(container, () =>
+            {
+                var setting = Setting.Create(settingsPath, settingName, string.Empty);
+
+                storedValue = setting.Value;
+            });
+
+            var isNumber = int.TryParse(storedValue, out _);
+
+            // Assert
+            Assert.That(isNumber, Is.False);
         }
 
         [Test]
@@ -1650,6 +1400,65 @@ namespace GitCommandsTests.Settings
             Assert.That(updated, Is.False);
         }
 
+        [Test]
+        public void Should_return_default_value_for_nullable_enum_setting_if_value_not_exist()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            TestEnum? storedValue = null;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create<TestEnum>(settingsPath, settingName);
+
+                storedValue = setting.Value;
+            });
+
+            // Assert
+            Assert.That(storedValue, Is.Null);
+        }
+
+        [Test]
+        public void Should_return_default_value_for_nullable_enum_setting_if_value_is_incorrect()
+        {
+            // Arrange
+            var pathName = Guid.NewGuid().ToString();
+            var settingName = Guid.NewGuid().ToString();
+            var settingsPath = new AppSettingsPath(pathName);
+
+            TestEnum? storedValue = null;
+
+            // Act
+            AppSettings.UsingContainer(_settingContainer, () =>
+            {
+                var setting = Setting.Create(settingsPath, settingName, string.Empty);
+
+                setting.Value = Guid.NewGuid().ToString();
+
+                AppSettings.SaveSettings();
+            });
+
+            var filePath = Path.GetTempFileName();
+
+            File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
+
+            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+
+            AppSettings.UsingContainer(container, () =>
+            {
+                var setting = Setting.Create<TestEnum>(settingsPath, settingName);
+
+                storedValue = setting.Value;
+            });
+
+            // Assert
+            Assert.That(storedValue, Is.Null);
+        }
+
         public enum TestEnum
         {
             First,
@@ -1659,173 +1468,6 @@ namespace GitCommandsTests.Settings
         #endregion Enum Setting
 
         #region Struct Setting
-
-        [Test]
-        public void Should_create_struct_setting()
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var settingDefault = new TestStruct
-            {
-                Bool = false,
-                Char = ' ',
-                Byte = 0,
-                Int = 0,
-                Float = 0f
-            };
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(settingDefault));
-            Assert.That(setting.IsUnset, Is.True);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-        }
-
-        [Test]
-        public void Should_save_struct_setting()
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var settingDefault = new TestStruct
-            {
-                Bool = false,
-                Char = ' ',
-                Byte = 0,
-                Int = 0,
-                Float = 0f
-            };
-
-            var value = new TestStruct
-            {
-                Bool = false,
-                Char = ' ',
-                Byte = 0,
-                Int = 0,
-                Float = 0f
-            };
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-        }
-
-        [Test]
-        public void Should_trigger_updated_event_for_struct_setting()
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var settingDefault = new TestStruct
-            {
-                Bool = false,
-                Char = ' ',
-                Byte = 0,
-                Int = 0,
-                Float = 0f
-            };
-
-            var value = new TestStruct
-            {
-                Bool = false,
-                Char = ' ',
-                Byte = 0,
-                Int = 0,
-                Float = 0f
-            };
-
-            var updated = false;
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Updated += (source, eventArgs) =>
-            {
-                updated = true;
-            };
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-            Assert.That(updated, Is.True);
-        }
-
-        [Test]
-        public void Should_not_trigger_updated_event_for_struct_setting()
-        {
-            // Arrange
-            var pathName = Guid.NewGuid().ToString();
-            var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
-            var settingDefault = new TestStruct
-            {
-                Bool = false,
-                Char = ' ',
-                Byte = 0,
-                Int = 0,
-                Float = 0f
-            };
-
-            var value = new TestStruct
-            {
-                Bool = false,
-                Char = ' ',
-                Byte = 0,
-                Int = 0,
-                Float = 0f
-            };
-
-            var updated = false;
-
-            // Act
-            var setting = Setting.Create(settingsPath, settingName, settingDefault);
-
-            setting.Value = value;
-
-            setting.Updated += (source, eventArgs) =>
-            {
-                updated = true;
-            };
-
-            setting.Value = value;
-
-            // Assert
-            Assert.That(setting, Is.Not.Null);
-            Assert.That(setting.SettingsSource, Is.EqualTo(settingsPath));
-            Assert.That(setting.Name, Is.EqualTo(settingName));
-            Assert.That(setting.Default, Is.EqualTo(settingDefault));
-            Assert.That(setting.Value, Is.EqualTo(value));
-            Assert.That(setting.IsUnset, Is.False);
-            Assert.That(setting.FullPath, Is.EqualTo($"{pathName}.{settingName}"));
-            Assert.That(updated, Is.False);
-        }
 
         [Test]
         public void Should_create_nullable_struct_setting()
@@ -1973,5 +1615,153 @@ namespace GitCommandsTests.Settings
         }
 
         #endregion Struct Setting
+
+        #region Test Cases
+
+        private static IEnumerable<object[]> CreateCases()
+        {
+            foreach (var value in Values())
+            {
+                yield return new object[] { value };
+            }
+        }
+
+        private static IEnumerable<object[]> SaveCases()
+        {
+            foreach (var settingDefault in Values())
+            {
+                foreach (var value in Values())
+                {
+                    if (settingDefault.GetType() == value.GetType())
+                    {
+                        yield return new object[] { settingDefault, value };
+                    }
+                }
+            }
+        }
+
+        private static IEnumerable<object[]> CreateStringCases()
+        {
+            yield return new object[] { null };
+            yield return new object[] { string.Empty };
+            yield return new object[] { "_" };
+        }
+
+        private static IEnumerable<object[]> SaveStringCases()
+        {
+            yield return new object[] { null, null };
+            yield return new object[] { null, string.Empty };
+            yield return new object[] { null, "_" };
+
+            yield return new object[] { string.Empty, null };
+            yield return new object[] { string.Empty, string.Empty };
+            yield return new object[] { string.Empty, "_" };
+
+            yield return new object[] { "_", null };
+            yield return new object[] { "_", string.Empty };
+            yield return new object[] { "_", "_" };
+        }
+
+        private static IEnumerable<object> Values()
+        {
+            yield return false;
+            yield return true;
+
+            yield return char.MinValue;
+            yield return '_';
+            yield return '0';
+
+            yield return sbyte.MinValue;
+            yield return sbyte.MaxValue;
+            yield return (sbyte)0;
+            yield return (sbyte)1;
+            yield return (sbyte)-1;
+
+            yield return byte.MinValue;
+            yield return byte.MaxValue;
+            yield return (byte)1;
+
+            yield return short.MinValue;
+            yield return short.MaxValue;
+            yield return (short)0;
+            yield return (short)1;
+            yield return (short)-1;
+
+            yield return ushort.MinValue;
+            yield return ushort.MaxValue;
+            yield return (ushort)1;
+
+            yield return int.MinValue;
+            yield return int.MaxValue;
+            yield return 0;
+            yield return 1;
+            yield return -1;
+
+            yield return uint.MinValue;
+            yield return uint.MaxValue;
+
+            yield return long.MinValue;
+            yield return long.MaxValue;
+            yield return 0L;
+            yield return 1L;
+            yield return -1L;
+
+            yield return ulong.MinValue;
+            yield return ulong.MaxValue;
+            yield return 1UL;
+
+            yield return float.MinValue;
+            yield return float.MaxValue;
+            yield return float.Epsilon;
+            yield return float.PositiveInfinity;
+            yield return float.NegativeInfinity;
+            yield return float.NaN;
+            yield return 0F;
+            yield return 1F;
+            yield return -1F;
+
+            yield return double.MinValue;
+            yield return double.MaxValue;
+            yield return double.Epsilon;
+            yield return double.PositiveInfinity;
+            yield return double.NegativeInfinity;
+            yield return double.NaN;
+            yield return 0D;
+            yield return 1D;
+            yield return -1D;
+
+            yield return decimal.MinValue;
+            yield return decimal.MaxValue;
+            yield return decimal.Zero;
+            yield return decimal.One;
+            yield return decimal.MinusOne;
+
+            yield return DateTime.MinValue;
+            yield return DateTime.MaxValue.Day;
+            yield return DateTime.Today;
+
+            yield return TestEnum.First;
+            yield return TestEnum.Second;
+
+            yield return new TestStruct
+            {
+                Bool = false,
+                Char = char.MinValue,
+                Byte = 0,
+                Int = 0,
+                Float = 0F
+            };
+
+            yield return new TestStruct
+            {
+                Bool = true,
+                Char = '_',
+                Byte = 1,
+                Int = 1,
+                Float = 1F
+            };
+        }
+
+        #endregion Test Cases
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8493


## Proposed changes

- Write and read enum setting as string not number

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

- Enum value is stored as number

### After

- Enum value is stored as string

## Test methodology <!-- How did you ensure quality? -->

- Automation

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.4.3.9999
- Build d4b0f48bbf3e39a71f5d7ff5231be5678d4aa0f1
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4220.0
- DPI 96dpi (no scaling)

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
