### PR TITLE
FileViewer: ViewMode to track what is currently displayed

### DIFF
--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -63,6 +63,7 @@ namespace GitUI.CommandsDialogs
             columnParent.MinimumWidth = DpiUtil.Scale(75);
 
             _selectedItemsHeader.AttachTo(columnIsLostObjectSelected);
+            fileViewer.ExtraDiffArgumentsChanged += Warnings_SelectionChanged;
 
             InitializeComplete();
             Warnings.AutoGenerateColumns = false;
@@ -243,7 +244,7 @@ namespace GitUI.CommandsDialogs
             if (_previewedItem.ObjectType == LostObjectType.Commit)
             {
                 ThreadHelper.JoinableTaskFactory.RunAsync(() =>
-                    fileViewer.ViewPatchAsync("commit.patch", content, null))
+                    fileViewer.ViewFixedPatchAsync("commit.patch", content, null))
                 .FileAndForget();
             }
             else

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -27,6 +27,7 @@ namespace GitUI.CommandsDialogs
 
             typeDataGridViewTextBoxColumn.Width = DpiUtil.Scale(70);
             File.Width = DpiUtil.Scale(50);
+            ChangesList.ExtraDiffArgumentsChanged += GridChangedFiles_SelectionChanged;
 
             InitializeComplete();
 
@@ -55,7 +56,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            ChangesList.ViewPatch(patch.FileNameB, patch.Text ?? "");
+            ChangesList.ViewFixedPatch(patch.FileNameB, patch.Text ?? "");
         }
 
         private void BrowsePatch_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -48,6 +48,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         {
             InitializeComponent();
             _selectHostedRepoCB.DisplayMember = nameof(IHostedRemote.DisplayData);
+            _diffViewer.ExtraDiffArgumentsChanged += _fileStatusList_SelectedIndexChanged;
             _loader.LoadingError += (sender, ex) =>
                 {
                     MessageBox.Show(this, ex.Exception.ToString(), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -494,7 +495,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             }
             else
             {
-                _diffViewer.ViewPatch(gis.Name, text: data);
+                _diffViewer.ViewFixedPatch(gis.Name, text: data);
             }
         }
 


### PR DESCRIPTION
There is at least one issue discussing this that I cannot find right now...

## Proposed changes

- Replace a couple of booleans tracking current information in the file viewer with an enum
- Hide actions in GitHub view pull request form that have no functionality 
- Refresh Patch and GitHub file  viewer pull requests when changing the syntax highlight

This will also be used for the presentation part of https://github.com/gitextensions/gitextensions/pull/8471 that adds more internal changes as well as for #7825 when unifying code from FormCommit/RevDiff (FileStatusList will be required too then).
A CommitDiff mode can remove some duplicated code from FormCommit

## Screenshots

Note that the title bar is not following the normal style, same for all plugins.

### Before

![image](https://user-images.githubusercontent.com/6248932/94861354-adc4cb80-0437-11eb-99eb-1ed3a3c9300a.png)

![image](https://user-images.githubusercontent.com/6248932/94861620-19a73400-0438-11eb-863c-31a4677f7a75.png)

### After

![image](https://user-images.githubusercontent.com/6248932/94861237-78b87900-0437-11eb-8d90-eeaab72129f1.png)

![image](https://user-images.githubusercontent.com/6248932/94861706-3d6a7a00-0438-11eb-9ac1-e5814d15669a.png)

## Test methodology

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
