### PR TITLE
Add a button to be able to open Application and User theme folders

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
@@ -40,8 +40,8 @@
             this.fpnlTheme = new System.Windows.Forms.FlowLayoutPanel();
             this.lblRestartNeeded = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_cbSelectTheme = new System.Windows.Forms.ComboBox();
-            this.chkUseSystemVisualStyle = new System.Windows.Forms.CheckBox();
             this.chkColorblind = new System.Windows.Forms.CheckBox();
+            this.chkUseSystemVisualStyle = new System.Windows.Forms.CheckBox();
             tlpnlMain = new System.Windows.Forms.TableLayoutPanel();
             tlpnlMain.SuspendLayout();
             this.gbRevisionGraph.SuspendLayout();
@@ -66,7 +66,7 @@
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            tlpnlMain.Size = new System.Drawing.Size(1004, 612);
+            tlpnlMain.Size = new System.Drawing.Size(1421, 792);
             tlpnlMain.TabIndex = 0;
             // 
             // gbRevisionGraph
@@ -78,7 +78,7 @@
             this.gbRevisionGraph.Location = new System.Drawing.Point(3, 3);
             this.gbRevisionGraph.Name = "gbRevisionGraph";
             this.gbRevisionGraph.Padding = new System.Windows.Forms.Padding(8);
-            this.gbRevisionGraph.Size = new System.Drawing.Size(998, 157);
+            this.gbRevisionGraph.Size = new System.Drawing.Size(1415, 144);
             this.gbRevisionGraph.TabIndex = 0;
             this.gbRevisionGraph.TabStop = false;
             this.gbRevisionGraph.Text = "Revision graph";
@@ -97,7 +97,7 @@
             this.tlpnlRevisionGraph.Controls.Add(this.DrawNonRelativesTextGray, 0, 3);
             this.tlpnlRevisionGraph.Controls.Add(this.DrawNonRelativesGray, 0, 2);
             this.tlpnlRevisionGraph.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tlpnlRevisionGraph.Location = new System.Drawing.Point(8, 24);
+            this.tlpnlRevisionGraph.Location = new System.Drawing.Point(8, 21);
             this.tlpnlRevisionGraph.Name = "tlpnlRevisionGraph";
             this.tlpnlRevisionGraph.RowCount = 5;
             this.tlpnlRevisionGraph.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -106,16 +106,16 @@
             this.tlpnlRevisionGraph.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlRevisionGraph.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlRevisionGraph.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tlpnlRevisionGraph.Size = new System.Drawing.Size(982, 125);
+            this.tlpnlRevisionGraph.Size = new System.Drawing.Size(1399, 115);
             this.tlpnlRevisionGraph.TabIndex = 0;
             // 
             // chkHighlightAuthored
             // 
             this.chkHighlightAuthored.AutoSize = true;
             this.chkHighlightAuthored.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkHighlightAuthored.Location = new System.Drawing.Point(3, 103);
+            this.chkHighlightAuthored.Location = new System.Drawing.Point(3, 95);
             this.chkHighlightAuthored.Name = "chkHighlightAuthored";
-            this.chkHighlightAuthored.Size = new System.Drawing.Size(183, 19);
+            this.chkHighlightAuthored.Size = new System.Drawing.Size(167, 17);
             this.chkHighlightAuthored.TabIndex = 5;
             this.chkHighlightAuthored.Text = "Highlight authored revisions";
             this.chkHighlightAuthored.UseVisualStyleBackColor = true;
@@ -126,7 +126,7 @@
             this.MulticolorBranches.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MulticolorBranches.Location = new System.Drawing.Point(3, 3);
             this.MulticolorBranches.Name = "MulticolorBranches";
-            this.MulticolorBranches.Size = new System.Drawing.Size(183, 19);
+            this.MulticolorBranches.Size = new System.Drawing.Size(167, 17);
             this.MulticolorBranches.TabIndex = 0;
             this.MulticolorBranches.Text = "Multicolor branches";
             this.MulticolorBranches.UseVisualStyleBackColor = true;
@@ -135,9 +135,9 @@
             // 
             this.chkDrawAlternateBackColor.AutoSize = true;
             this.chkDrawAlternateBackColor.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkDrawAlternateBackColor.Location = new System.Drawing.Point(3, 28);
+            this.chkDrawAlternateBackColor.Location = new System.Drawing.Point(3, 26);
             this.chkDrawAlternateBackColor.Name = "chkDrawAlternateBackColor";
-            this.chkDrawAlternateBackColor.Size = new System.Drawing.Size(183, 19);
+            this.chkDrawAlternateBackColor.Size = new System.Drawing.Size(167, 17);
             this.chkDrawAlternateBackColor.TabIndex = 2;
             this.chkDrawAlternateBackColor.Text = "Draw alternate background";
             this.chkDrawAlternateBackColor.UseVisualStyleBackColor = true;
@@ -146,9 +146,9 @@
             // 
             this.DrawNonRelativesTextGray.AutoSize = true;
             this.DrawNonRelativesTextGray.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DrawNonRelativesTextGray.Location = new System.Drawing.Point(3, 78);
+            this.DrawNonRelativesTextGray.Location = new System.Drawing.Point(3, 72);
             this.DrawNonRelativesTextGray.Name = "DrawNonRelativesTextGray";
-            this.DrawNonRelativesTextGray.Size = new System.Drawing.Size(183, 19);
+            this.DrawNonRelativesTextGray.Size = new System.Drawing.Size(167, 17);
             this.DrawNonRelativesTextGray.TabIndex = 4;
             this.DrawNonRelativesTextGray.Text = "Draw non relatives text gray";
             this.DrawNonRelativesTextGray.UseVisualStyleBackColor = true;
@@ -157,9 +157,9 @@
             // 
             this.DrawNonRelativesGray.AutoSize = true;
             this.DrawNonRelativesGray.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DrawNonRelativesGray.Location = new System.Drawing.Point(3, 53);
+            this.DrawNonRelativesGray.Location = new System.Drawing.Point(3, 49);
             this.DrawNonRelativesGray.Name = "DrawNonRelativesGray";
-            this.DrawNonRelativesGray.Size = new System.Drawing.Size(183, 19);
+            this.DrawNonRelativesGray.Size = new System.Drawing.Size(167, 17);
             this.DrawNonRelativesGray.TabIndex = 3;
             this.DrawNonRelativesGray.Text = "Draw non relatives graph gray";
             this.DrawNonRelativesGray.UseVisualStyleBackColor = true;
@@ -170,9 +170,9 @@
             this.gbTheme.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.gbTheme.Controls.Add(this.fpnlTheme);
             this.gbTheme.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.gbTheme.Location = new System.Drawing.Point(3, 166);
+            this.gbTheme.Location = new System.Drawing.Point(3, 153);
             this.gbTheme.Name = "gbTheme";
-            this.gbTheme.Size = new System.Drawing.Size(998, 76);
+            this.gbTheme.Size = new System.Drawing.Size(1415, 73);
             this.gbTheme.TabIndex = 3;
             this.gbTheme.TabStop = false;
             this.gbTheme.Text = "Theme";
@@ -186,9 +186,9 @@
             this.fpnlTheme.Controls.Add(this.chkColorblind);
             this.fpnlTheme.Controls.Add(this.chkUseSystemVisualStyle);
             this.fpnlTheme.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.fpnlTheme.Location = new System.Drawing.Point(3, 19);
+            this.fpnlTheme.Location = new System.Drawing.Point(3, 16);
             this.fpnlTheme.Name = "fpnlTheme";
-            this.fpnlTheme.Size = new System.Drawing.Size(992, 54);
+            this.fpnlTheme.Size = new System.Drawing.Size(1409, 54);
             this.fpnlTheme.TabIndex = 0;
             // 
             // lblRestartNeeded
@@ -211,21 +211,9 @@
             this._NO_TRANSLATE_cbSelectTheme.FormattingEnabled = true;
             this._NO_TRANSLATE_cbSelectTheme.Location = new System.Drawing.Point(3, 30);
             this._NO_TRANSLATE_cbSelectTheme.Name = "_NO_TRANSLATE_cbSelectTheme";
-            this._NO_TRANSLATE_cbSelectTheme.Size = new System.Drawing.Size(179, 23);
+            this._NO_TRANSLATE_cbSelectTheme.Size = new System.Drawing.Size(179, 21);
             this._NO_TRANSLATE_cbSelectTheme.TabIndex = 0;
             this._NO_TRANSLATE_cbSelectTheme.SelectedIndexChanged += new System.EventHandler(this.ComboBoxTheme_SelectedIndexChanged);
-            // 
-            // chkUseSystemVisualStyle
-            // 
-            this.chkUseSystemVisualStyle.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.chkUseSystemVisualStyle.AutoSize = true;
-            this.chkUseSystemVisualStyle.Location = new System.Drawing.Point(188, 31);
-            this.chkUseSystemVisualStyle.Name = "chkUseSystemVisualStyle";
-            this.chkUseSystemVisualStyle.Size = new System.Drawing.Size(339, 19);
-            this.chkUseSystemVisualStyle.TabIndex = 4;
-            this.chkUseSystemVisualStyle.Text = "Use system-defined visual style (looks bad with dark colors)";
-            this.chkUseSystemVisualStyle.UseVisualStyleBackColor = true;
-            this.chkUseSystemVisualStyle.CheckedChanged += new System.EventHandler(this.ChkUseSystemVisualStyle_CheckedChanged);
             // 
             // chkColorblind
             // 
@@ -239,6 +227,18 @@
             this.chkColorblind.UseVisualStyleBackColor = true;
             this.chkColorblind.CheckedChanged += new System.EventHandler(this.ChkColorblind_CheckedChanged);
             // 
+            // chkUseSystemVisualStyle
+            // 
+            this.chkUseSystemVisualStyle.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.chkUseSystemVisualStyle.AutoSize = true;
+            this.chkUseSystemVisualStyle.Location = new System.Drawing.Point(266, 32);
+            this.chkUseSystemVisualStyle.Name = "chkUseSystemVisualStyle";
+            this.chkUseSystemVisualStyle.Size = new System.Drawing.Size(304, 17);
+            this.chkUseSystemVisualStyle.TabIndex = 4;
+            this.chkUseSystemVisualStyle.Text = "Use system-defined visual style (looks bad with dark colors)";
+            this.chkUseSystemVisualStyle.UseVisualStyleBackColor = true;
+            this.chkUseSystemVisualStyle.CheckedChanged += new System.EventHandler(this.ChkUseSystemVisualStyle_CheckedChanged);
+            // 
             // ColorsSettingsPage
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -246,7 +246,7 @@
             this.Controls.Add(tlpnlMain);
             this.Name = "ColorsSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
-            this.Size = new System.Drawing.Size(1020, 628);
+            this.Size = new System.Drawing.Size(1437, 808);
             tlpnlMain.ResumeLayout(false);
             tlpnlMain.PerformLayout();
             this.gbRevisionGraph.ResumeLayout(false);
@@ -259,6 +259,7 @@
             this.fpnlTheme.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
+
         }
 
         #endregion

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
@@ -38,21 +38,21 @@
             this.DrawNonRelativesTextGray = new System.Windows.Forms.CheckBox();
             this.DrawNonRelativesGray = new System.Windows.Forms.CheckBox();
             this.gbTheme = new System.Windows.Forms.GroupBox();
-            this.fpnlTheme = new System.Windows.Forms.FlowLayoutPanel();
-            this.lblRestartNeeded = new System.Windows.Forms.Label();
-            this._NO_TRANSLATE_cbSelectTheme = new System.Windows.Forms.ComboBox();
-            this.chkColorblind = new System.Windows.Forms.CheckBox();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.chkUseSystemVisualStyle = new System.Windows.Forms.CheckBox();
+            this.chkColorblind = new System.Windows.Forms.CheckBox();
             this.sbOpenThemeFolder = new GitUI.Script.SplitButton();
             this.cmsOpenThemeFolders = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.tsmiApplicationFolder = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiUserFolder = new System.Windows.Forms.ToolStripMenuItem();
+            this._NO_TRANSLATE_cbSelectTheme = new System.Windows.Forms.ComboBox();
+            this.lblRestartNeeded = new System.Windows.Forms.Label();
             tlpnlMain = new System.Windows.Forms.TableLayoutPanel();
             tlpnlMain.SuspendLayout();
             this.gbRevisionGraph.SuspendLayout();
             this.tlpnlRevisionGraph.SuspendLayout();
             this.gbTheme.SuspendLayout();
-            this.fpnlTheme.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
             this.cmsOpenThemeFolders.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -72,7 +72,7 @@
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            tlpnlMain.Size = new System.Drawing.Size(1421, 617);
+            tlpnlMain.Size = new System.Drawing.Size(1421, 428);
             tlpnlMain.TabIndex = 0;
             // 
             // gbRevisionGraph
@@ -93,10 +93,10 @@
             // 
             this.tlpnlRevisionGraph.AutoSize = true;
             this.tlpnlRevisionGraph.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tlpnlRevisionGraph.ColumnCount = 3;
+            this.tlpnlRevisionGraph.ColumnCount = 2;
             this.tlpnlRevisionGraph.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlRevisionGraph.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tlpnlRevisionGraph.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tlpnlRevisionGraph.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tlpnlRevisionGraph.Controls.Add(this.chkHighlightAuthored, 0, 4);
             this.tlpnlRevisionGraph.Controls.Add(this.MulticolorBranches, 0, 0);
             this.tlpnlRevisionGraph.Controls.Add(this.chkDrawAlternateBackColor, 0, 1);
@@ -111,7 +111,6 @@
             this.tlpnlRevisionGraph.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlRevisionGraph.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlRevisionGraph.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlRevisionGraph.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tlpnlRevisionGraph.Size = new System.Drawing.Size(1399, 115);
             this.tlpnlRevisionGraph.TabIndex = 0;
             // 
@@ -174,85 +173,73 @@
             // 
             this.gbTheme.AutoSize = true;
             this.gbTheme.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.gbTheme.Controls.Add(this.fpnlTheme);
+            this.gbTheme.Controls.Add(this.tableLayoutPanel1);
             this.gbTheme.Dock = System.Windows.Forms.DockStyle.Fill;
             this.gbTheme.Location = new System.Drawing.Point(3, 153);
             this.gbTheme.Name = "gbTheme";
-            this.gbTheme.Size = new System.Drawing.Size(1415, 75);
+            this.gbTheme.Padding = new System.Windows.Forms.Padding(8);
+            this.gbTheme.Size = new System.Drawing.Size(1415, 120);
             this.gbTheme.TabIndex = 3;
             this.gbTheme.TabStop = false;
             this.gbTheme.Text = "Theme";
             // 
-            // fpnlTheme
+            // tableLayoutPanel1
             // 
-            this.fpnlTheme.AutoSize = true;
-            this.fpnlTheme.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.fpnlTheme.Controls.Add(this.lblRestartNeeded);
-            this.fpnlTheme.Controls.Add(this._NO_TRANSLATE_cbSelectTheme);
-            this.fpnlTheme.Controls.Add(this.chkColorblind);
-            this.fpnlTheme.Controls.Add(this.chkUseSystemVisualStyle);
-            this.fpnlTheme.Controls.Add(this.sbOpenThemeFolder);
-            this.fpnlTheme.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.fpnlTheme.Location = new System.Drawing.Point(3, 16);
-            this.fpnlTheme.Name = "fpnlTheme";
-            this.fpnlTheme.Size = new System.Drawing.Size(1409, 56);
-            this.fpnlTheme.TabIndex = 0;
-            // 
-            // lblRestartNeeded
-            // 
-            this.lblRestartNeeded.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.fpnlTheme.SetFlowBreak(this.lblRestartNeeded, true);
-            this.lblRestartNeeded.Image = global::GitUI.Properties.Images.Warning;
-            this.lblRestartNeeded.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.lblRestartNeeded.Location = new System.Drawing.Point(3, 5);
-            this.lblRestartNeeded.Name = "lblRestartNeeded";
-            this.lblRestartNeeded.Size = new System.Drawing.Size(221, 16);
-            this.lblRestartNeeded.TabIndex = 5;
-            this.lblRestartNeeded.Text = "Restart required to apply changes";
-            this.lblRestartNeeded.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // _NO_TRANSLATE_cbSelectTheme
-            // 
-            this._NO_TRANSLATE_cbSelectTheme.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this._NO_TRANSLATE_cbSelectTheme.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this._NO_TRANSLATE_cbSelectTheme.FormattingEnabled = true;
-            this._NO_TRANSLATE_cbSelectTheme.Location = new System.Drawing.Point(3, 31);
-            this._NO_TRANSLATE_cbSelectTheme.Name = "_NO_TRANSLATE_cbSelectTheme";
-            this._NO_TRANSLATE_cbSelectTheme.Size = new System.Drawing.Size(179, 21);
-            this._NO_TRANSLATE_cbSelectTheme.TabIndex = 0;
-            this._NO_TRANSLATE_cbSelectTheme.SelectedIndexChanged += new System.EventHandler(this.ComboBoxTheme_SelectedIndexChanged);
-            // 
-            // chkColorblind
-            // 
-            this.chkColorblind.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.chkColorblind.AutoSize = true;
-            this.chkColorblind.Location = new System.Drawing.Point(188, 33);
-            this.chkColorblind.Name = "chkColorblind";
-            this.chkColorblind.Size = new System.Drawing.Size(72, 17);
-            this.chkColorblind.TabIndex = 6;
-            this.chkColorblind.Text = "Colorblind";
-            this.chkColorblind.UseVisualStyleBackColor = true;
-            this.chkColorblind.CheckedChanged += new System.EventHandler(this.ChkColorblind_CheckedChanged);
+            this.tableLayoutPanel1.AutoSize = true;
+            this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.tableLayoutPanel1.ColumnCount = 3;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.Controls.Add(this.chkUseSystemVisualStyle, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.chkColorblind, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.sbOpenThemeFolder, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_cbSelectTheme, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.lblRestartNeeded, 0, 0);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(8, 21);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 4;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1399, 91);
+            this.tableLayoutPanel1.TabIndex = 9;
             // 
             // chkUseSystemVisualStyle
             // 
             this.chkUseSystemVisualStyle.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.chkUseSystemVisualStyle.AutoSize = true;
-            this.chkUseSystemVisualStyle.Location = new System.Drawing.Point(266, 33);
+            this.tableLayoutPanel1.SetColumnSpan(this.chkUseSystemVisualStyle, 2);
+            this.chkUseSystemVisualStyle.Location = new System.Drawing.Point(3, 71);
             this.chkUseSystemVisualStyle.Name = "chkUseSystemVisualStyle";
             this.chkUseSystemVisualStyle.Size = new System.Drawing.Size(304, 17);
             this.chkUseSystemVisualStyle.TabIndex = 4;
             this.chkUseSystemVisualStyle.Text = "Use system-defined visual style (looks bad with dark colors)";
             this.chkUseSystemVisualStyle.UseVisualStyleBackColor = true;
-            this.chkUseSystemVisualStyle.CheckedChanged += new System.EventHandler(this.ChkUseSystemVisualStyle_CheckedChanged);
+            // 
+            // chkColorblind
+            // 
+            this.chkColorblind.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.chkColorblind.AutoSize = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.chkColorblind, 2);
+            this.chkColorblind.Location = new System.Drawing.Point(3, 48);
+            this.chkColorblind.Name = "chkColorblind";
+            this.chkColorblind.Size = new System.Drawing.Size(72, 17);
+            this.chkColorblind.TabIndex = 6;
+            this.chkColorblind.Text = "Colorblind";
+            this.chkColorblind.UseVisualStyleBackColor = true;
             // 
             // sbOpenThemeFolder
             // 
-            this.sbOpenThemeFolder.AutoSize = true;
             this.sbOpenThemeFolder.ContextMenuStrip = this.cmsOpenThemeFolders;
-            this.sbOpenThemeFolder.Location = new System.Drawing.Point(576, 30);
+            this.sbOpenThemeFolder.Image = global::GitUI.Properties.Images.BrowseFileExplorer;
+            this.sbOpenThemeFolder.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.sbOpenThemeFolder.Location = new System.Drawing.Point(222, 19);
             this.sbOpenThemeFolder.Name = "sbOpenThemeFolder";
-            this.sbOpenThemeFolder.Size = new System.Drawing.Size(122, 23);
+            this.sbOpenThemeFolder.Padding = new System.Windows.Forms.Padding(40, 0, 0, 0);
+            this.sbOpenThemeFolder.Size = new System.Drawing.Size(162, 23);
             this.sbOpenThemeFolder.SplitMenuStrip = this.cmsOpenThemeFolders;
             this.sbOpenThemeFolder.TabIndex = 7;
             this.sbOpenThemeFolder.Text = "Open theme folder";
@@ -265,21 +252,44 @@
             this.tsmiApplicationFolder,
             this.tsmiUserFolder});
             this.cmsOpenThemeFolders.Name = "cmsOpenThemeFolders";
-            this.cmsOpenThemeFolders.Size = new System.Drawing.Size(181, 70);
+            this.cmsOpenThemeFolders.Size = new System.Drawing.Size(170, 48);
             // 
             // tsmiApplicationFolder
             // 
             this.tsmiApplicationFolder.Name = "tsmiApplicationFolder";
-            this.tsmiApplicationFolder.Size = new System.Drawing.Size(180, 22);
+            this.tsmiApplicationFolder.Size = new System.Drawing.Size(169, 22);
             this.tsmiApplicationFolder.Text = "Application folder";
             this.tsmiApplicationFolder.Click += new System.EventHandler(this.tsmiApplicationFolder_Click);
             // 
             // tsmiUserFolder
             // 
             this.tsmiUserFolder.Name = "tsmiUserFolder";
-            this.tsmiUserFolder.Size = new System.Drawing.Size(180, 22);
+            this.tsmiUserFolder.Size = new System.Drawing.Size(169, 22);
             this.tsmiUserFolder.Text = "User folder";
             this.tsmiUserFolder.Click += new System.EventHandler(this.tsmiUserFolder_Click);
+            // 
+            // _NO_TRANSLATE_cbSelectTheme
+            // 
+            this._NO_TRANSLATE_cbSelectTheme.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this._NO_TRANSLATE_cbSelectTheme.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this._NO_TRANSLATE_cbSelectTheme.FormattingEnabled = true;
+            this._NO_TRANSLATE_cbSelectTheme.Location = new System.Drawing.Point(3, 20);
+            this._NO_TRANSLATE_cbSelectTheme.Name = "_NO_TRANSLATE_cbSelectTheme";
+            this._NO_TRANSLATE_cbSelectTheme.Size = new System.Drawing.Size(213, 21);
+            this._NO_TRANSLATE_cbSelectTheme.TabIndex = 0;
+            // 
+            // lblRestartNeeded
+            // 
+            this.lblRestartNeeded.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.tableLayoutPanel1.SetColumnSpan(this.lblRestartNeeded, 2);
+            this.lblRestartNeeded.Image = global::GitUI.Properties.Images.Warning;
+            this.lblRestartNeeded.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblRestartNeeded.Location = new System.Drawing.Point(3, 0);
+            this.lblRestartNeeded.Name = "lblRestartNeeded";
+            this.lblRestartNeeded.Size = new System.Drawing.Size(200, 16);
+            this.lblRestartNeeded.TabIndex = 5;
+            this.lblRestartNeeded.Text = "Restart required to apply changes";
+            this.lblRestartNeeded.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // ColorsSettingsPage
             // 
@@ -288,7 +298,7 @@
             this.Controls.Add(tlpnlMain);
             this.Name = "ColorsSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
-            this.Size = new System.Drawing.Size(1437, 633);
+            this.Size = new System.Drawing.Size(1437, 444);
             tlpnlMain.ResumeLayout(false);
             tlpnlMain.PerformLayout();
             this.gbRevisionGraph.ResumeLayout(false);
@@ -297,8 +307,8 @@
             this.tlpnlRevisionGraph.PerformLayout();
             this.gbTheme.ResumeLayout(false);
             this.gbTheme.PerformLayout();
-            this.fpnlTheme.ResumeLayout(false);
-            this.fpnlTheme.PerformLayout();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.cmsOpenThemeFolders.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -314,14 +324,14 @@
         private System.Windows.Forms.TableLayoutPanel tlpnlRevisionGraph;
         private System.Windows.Forms.CheckBox chkHighlightAuthored;
         private System.Windows.Forms.GroupBox gbTheme;
-        private System.Windows.Forms.ComboBox _NO_TRANSLATE_cbSelectTheme;
-        private System.Windows.Forms.FlowLayoutPanel fpnlTheme;
-        private System.Windows.Forms.CheckBox chkUseSystemVisualStyle;
-        private System.Windows.Forms.Label lblRestartNeeded;
-        private System.Windows.Forms.CheckBox chkColorblind;
-        private Script.SplitButton sbOpenThemeFolder;
         private System.Windows.Forms.ContextMenuStrip cmsOpenThemeFolders;
         private System.Windows.Forms.ToolStripMenuItem tsmiApplicationFolder;
         private System.Windows.Forms.ToolStripMenuItem tsmiUserFolder;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.CheckBox chkUseSystemVisualStyle;
+        private System.Windows.Forms.CheckBox chkColorblind;
+        private Script.SplitButton sbOpenThemeFolder;
+        private System.Windows.Forms.ComboBox _NO_TRANSLATE_cbSelectTheme;
+        private System.Windows.Forms.Label lblRestartNeeded;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.Windows.Forms.TableLayoutPanel tlpnlMain;
             this.gbRevisionGraph = new System.Windows.Forms.GroupBox();
             this.tlpnlRevisionGraph = new System.Windows.Forms.TableLayoutPanel();
@@ -42,12 +43,17 @@
             this._NO_TRANSLATE_cbSelectTheme = new System.Windows.Forms.ComboBox();
             this.chkColorblind = new System.Windows.Forms.CheckBox();
             this.chkUseSystemVisualStyle = new System.Windows.Forms.CheckBox();
+            this.sbOpenThemeFolder = new GitUI.Script.SplitButton();
+            this.cmsOpenThemeFolders = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.tsmiApplicationFolder = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiUserFolder = new System.Windows.Forms.ToolStripMenuItem();
             tlpnlMain = new System.Windows.Forms.TableLayoutPanel();
             tlpnlMain.SuspendLayout();
             this.gbRevisionGraph.SuspendLayout();
             this.tlpnlRevisionGraph.SuspendLayout();
             this.gbTheme.SuspendLayout();
             this.fpnlTheme.SuspendLayout();
+            this.cmsOpenThemeFolders.SuspendLayout();
             this.SuspendLayout();
             // 
             // tlpnlMain
@@ -66,7 +72,7 @@
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            tlpnlMain.Size = new System.Drawing.Size(1421, 792);
+            tlpnlMain.Size = new System.Drawing.Size(1421, 617);
             tlpnlMain.TabIndex = 0;
             // 
             // gbRevisionGraph
@@ -172,7 +178,7 @@
             this.gbTheme.Dock = System.Windows.Forms.DockStyle.Fill;
             this.gbTheme.Location = new System.Drawing.Point(3, 153);
             this.gbTheme.Name = "gbTheme";
-            this.gbTheme.Size = new System.Drawing.Size(1415, 73);
+            this.gbTheme.Size = new System.Drawing.Size(1415, 75);
             this.gbTheme.TabIndex = 3;
             this.gbTheme.TabStop = false;
             this.gbTheme.Text = "Theme";
@@ -185,10 +191,11 @@
             this.fpnlTheme.Controls.Add(this._NO_TRANSLATE_cbSelectTheme);
             this.fpnlTheme.Controls.Add(this.chkColorblind);
             this.fpnlTheme.Controls.Add(this.chkUseSystemVisualStyle);
+            this.fpnlTheme.Controls.Add(this.sbOpenThemeFolder);
             this.fpnlTheme.Dock = System.Windows.Forms.DockStyle.Fill;
             this.fpnlTheme.Location = new System.Drawing.Point(3, 16);
             this.fpnlTheme.Name = "fpnlTheme";
-            this.fpnlTheme.Size = new System.Drawing.Size(1409, 54);
+            this.fpnlTheme.Size = new System.Drawing.Size(1409, 56);
             this.fpnlTheme.TabIndex = 0;
             // 
             // lblRestartNeeded
@@ -209,7 +216,7 @@
             this._NO_TRANSLATE_cbSelectTheme.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this._NO_TRANSLATE_cbSelectTheme.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this._NO_TRANSLATE_cbSelectTheme.FormattingEnabled = true;
-            this._NO_TRANSLATE_cbSelectTheme.Location = new System.Drawing.Point(3, 30);
+            this._NO_TRANSLATE_cbSelectTheme.Location = new System.Drawing.Point(3, 31);
             this._NO_TRANSLATE_cbSelectTheme.Name = "_NO_TRANSLATE_cbSelectTheme";
             this._NO_TRANSLATE_cbSelectTheme.Size = new System.Drawing.Size(179, 21);
             this._NO_TRANSLATE_cbSelectTheme.TabIndex = 0;
@@ -219,7 +226,7 @@
             // 
             this.chkColorblind.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.chkColorblind.AutoSize = true;
-            this.chkColorblind.Location = new System.Drawing.Point(188, 32);
+            this.chkColorblind.Location = new System.Drawing.Point(188, 33);
             this.chkColorblind.Name = "chkColorblind";
             this.chkColorblind.Size = new System.Drawing.Size(72, 17);
             this.chkColorblind.TabIndex = 6;
@@ -231,13 +238,48 @@
             // 
             this.chkUseSystemVisualStyle.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.chkUseSystemVisualStyle.AutoSize = true;
-            this.chkUseSystemVisualStyle.Location = new System.Drawing.Point(266, 32);
+            this.chkUseSystemVisualStyle.Location = new System.Drawing.Point(266, 33);
             this.chkUseSystemVisualStyle.Name = "chkUseSystemVisualStyle";
             this.chkUseSystemVisualStyle.Size = new System.Drawing.Size(304, 17);
             this.chkUseSystemVisualStyle.TabIndex = 4;
             this.chkUseSystemVisualStyle.Text = "Use system-defined visual style (looks bad with dark colors)";
             this.chkUseSystemVisualStyle.UseVisualStyleBackColor = true;
             this.chkUseSystemVisualStyle.CheckedChanged += new System.EventHandler(this.ChkUseSystemVisualStyle_CheckedChanged);
+            // 
+            // sbOpenThemeFolder
+            // 
+            this.sbOpenThemeFolder.AutoSize = true;
+            this.sbOpenThemeFolder.ContextMenuStrip = this.cmsOpenThemeFolders;
+            this.sbOpenThemeFolder.Location = new System.Drawing.Point(576, 30);
+            this.sbOpenThemeFolder.Name = "sbOpenThemeFolder";
+            this.sbOpenThemeFolder.Size = new System.Drawing.Size(122, 23);
+            this.sbOpenThemeFolder.SplitMenuStrip = this.cmsOpenThemeFolders;
+            this.sbOpenThemeFolder.TabIndex = 7;
+            this.sbOpenThemeFolder.Text = "Open theme folder";
+            this.sbOpenThemeFolder.UseVisualStyleBackColor = true;
+            this.sbOpenThemeFolder.WholeButtonDropdown = true;
+            // 
+            // cmsOpenThemeFolders
+            // 
+            this.cmsOpenThemeFolders.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.tsmiApplicationFolder,
+            this.tsmiUserFolder});
+            this.cmsOpenThemeFolders.Name = "cmsOpenThemeFolders";
+            this.cmsOpenThemeFolders.Size = new System.Drawing.Size(181, 70);
+            // 
+            // tsmiApplicationFolder
+            // 
+            this.tsmiApplicationFolder.Name = "tsmiApplicationFolder";
+            this.tsmiApplicationFolder.Size = new System.Drawing.Size(180, 22);
+            this.tsmiApplicationFolder.Text = "Application folder";
+            this.tsmiApplicationFolder.Click += new System.EventHandler(this.tsmiApplicationFolder_Click);
+            // 
+            // tsmiUserFolder
+            // 
+            this.tsmiUserFolder.Name = "tsmiUserFolder";
+            this.tsmiUserFolder.Size = new System.Drawing.Size(180, 22);
+            this.tsmiUserFolder.Text = "User folder";
+            this.tsmiUserFolder.Click += new System.EventHandler(this.tsmiUserFolder_Click);
             // 
             // ColorsSettingsPage
             // 
@@ -246,7 +288,7 @@
             this.Controls.Add(tlpnlMain);
             this.Name = "ColorsSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
-            this.Size = new System.Drawing.Size(1437, 808);
+            this.Size = new System.Drawing.Size(1437, 633);
             tlpnlMain.ResumeLayout(false);
             tlpnlMain.PerformLayout();
             this.gbRevisionGraph.ResumeLayout(false);
@@ -257,6 +299,7 @@
             this.gbTheme.PerformLayout();
             this.fpnlTheme.ResumeLayout(false);
             this.fpnlTheme.PerformLayout();
+            this.cmsOpenThemeFolders.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -276,5 +319,9 @@
         private System.Windows.Forms.CheckBox chkUseSystemVisualStyle;
         private System.Windows.Forms.Label lblRestartNeeded;
         private System.Windows.Forms.CheckBox chkColorblind;
+        private Script.SplitButton sbOpenThemeFolder;
+        private System.Windows.Forms.ContextMenuStrip cmsOpenThemeFolders;
+        private System.Windows.Forms.ToolStripMenuItem tsmiApplicationFolder;
+        private System.Windows.Forms.ToolStripMenuItem tsmiUserFolder;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using GitCommands;
 using GitExtUtils.GitUI.Theming;
@@ -11,6 +13,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
     {
         private int _updateThemeSettingsCounter;
         private readonly ThemeRepository _themeRepository = new ThemeRepository();
+        private readonly ThemePathProvider _themePathProvider = new ThemePathProvider();
 
         private static readonly TranslationString FormatBuiltinThemeName =
             new TranslationString("{0}");
@@ -226,6 +229,18 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             private bool Equals(FormattedThemeId other) =>
                 ThemeId.Equals(other.ThemeId);
+        }
+
+        private void tsmiApplicationFolder_Click(object sender, EventArgs e) => OpenFolder(_themePathProvider.AppThemesDirectory);
+
+        private void tsmiUserFolder_Click(object sender, EventArgs e) => OpenFolder(_themePathProvider.UserThemesDirectory);
+
+        private void OpenFolder(string folderPath)
+        {
+            if (Directory.Exists(folderPath))
+            {
+                Process.Start(folderPath);
+            }
         }
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using GitCommands;
+using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Theming;
 using ResourceManager;
@@ -28,6 +29,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             InitializeComponent();
             Text = "Colors";
+            sbOpenThemeFolder.AutoSize = false;
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.resx
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.resx
@@ -120,4 +120,7 @@
   <metadata name="tlpnlMain.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
+  <metadata name="cmsOpenThemeFolders.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -739,6 +739,18 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Restart required to apply changes</source>
         <target />
       </trans-unit>
+      <trans-unit id="sbOpenThemeFolder.Text">
+        <source>Open theme folder</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiApplicationFolder.Text">
+        <source>Application folder</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiUserFolder.Text">
+        <source>User folder</source>
+        <target />
+      </trans-unit>
     </body>
   </file>
   <file datatype="plaintext" original="CommitDialogSettingsPage" source-language="en">


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/gitextensions/gitextensions/pull/8424#issuecomment-688712943

## Proposed changes

- Add a button to be able to open Application and User theme folders

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

(same than after without the button)

### After

![image](https://user-images.githubusercontent.com/460196/95633593-50102f00-0a88-11eb-9ef6-05981b03953f.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 62fcfcbd924a264d34b02ae9831749acc43fef8f (Dirty)
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4240.0
- DPI 192dpi (200% scaling)

