### PR TITLE
FormEditor SaveCanges Changes

### DIFF
--- a/GitExtUtils/FileUtility.cs
+++ b/GitExtUtils/FileUtility.cs
@@ -1,0 +1,27 @@
+﻿using System.IO;
+using System.Text;
+
+namespace GitUI
+{
+    public static class FileUtility
+    {
+        /// <summary>
+        /// Writes all text to a file. Works around issues with hidden files encountered by File.WriteAllText.
+        /// </summary>
+        /// <param name="fileName">Destination file</param>
+        /// <param name="contents">Text to write as file contents</param>
+        public static void SafeWriteAllText(string fileName, string contents, Encoding encoding)
+        {
+            using (var fs = new FileStream(fileName, FileMode.Open))
+            {
+                using (TextWriter tw = new StreamWriter(fs, encoding, bufferSize: 4096, leaveOpen: true))
+                {
+                    tw.Write(contents);
+                }
+
+                // after flushing, set the stream length to the current position in order to truncate leftover text
+                fs.SetLength(fs.Position);
+            }
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -91,7 +91,7 @@ namespace GitUI.CommandsDialogs
                         }
                         catch (Exception ex)
                         {
-                            if (MessageBox.Show(this, _cannotSaveFile.Text + Environment.NewLine + ex.Message, Strings.Error, MessageBoxButtons.OKCancel, MessageBoxIcon.Error) == DialogResult.Cancel)
+                            if (MessageBox.Show(this, $"{_cannotSaveFile.Text}{Environment.NewLine}{ex.Message}", Strings.Error, MessageBoxButtons.OKCancel, MessageBoxIcon.Error) == DialogResult.Cancel)
                             {
                                 e.Cancel = true;
                                 return;
@@ -116,13 +116,18 @@ namespace GitUI.CommandsDialogs
 
         private void toolStripSaveButton_Click(object sender, EventArgs e)
         {
+            SaveChangesShowException();
+        }
+
+        private void SaveChangesShowException()
+        {
             try
             {
                 SaveChanges();
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, _cannotSaveFile.Text + Environment.NewLine + ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.ShowError(this, $"{_cannotSaveFile.Text}{Environment.NewLine}{ex.Message}");
             }
         }
 
@@ -132,7 +137,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (fileViewer.FilePreamble is null || Module.FilesEncoding.GetPreamble().SequenceEqual(fileViewer.FilePreamble))
                 {
-                    File.WriteAllText(_fileName, fileViewer.GetText(), Module.FilesEncoding);
+                    FileUtility.SafeWriteAllText(_fileName, fileViewer.GetText(), Module.FilesEncoding);
                 }
                 else
                 {
@@ -161,7 +166,7 @@ namespace GitUI.CommandsDialogs
                     Close();
                     return true;
                 case Keys.Control | Keys.S:
-                    SaveChanges();
+                    SaveChangesShowException();
                     return true;
                 default:
                     return base.ProcessCmdKey(ref msg, keyData);


### PR DESCRIPTION
Fixes #8347 


## Proposed changes

- Use the TextWriter Logic recommended on [StackOverflow](https://stackoverflow.com/questions/2246990/how-do-i-write-to-a-hidden-file/2247115#2247115)
   - Prevents issues with hidden files caused by File.WriteAllText
   - File.WriteAllBytes does not appear to have this issue based on reference source
- ~Move the general try/catch logic inside of SaveChanges()~
   - ~Added a paramter rethrowException (default: false) to allow custom handling such as on Form Close.~

## Test methodology (Not Tested yet, hence the **WIP** but the following will detail the testing plans)
-  Manual Testing Saving with no special circumstances
- Debugging to explicitly throw exceptions from inside SaveChanges to test rethrow on form close
- Manually Testing Saving Changes on ReadOnly Files, Hidden Files, and Files that are Locked ( I expect Readonly and Write Locked files to fail while hidden should succeed).


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.28.0.windows.1
- Window 10 (Latest)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
