### PR TITLE
Longer GPG key input box (8 chars -> 16 chars)

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1358,7 +1358,7 @@ namespace GitUI.CommandsDialogs
             // toolStripGpgKeyTextBox
             //
             this.toolStripGpgKeyTextBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.toolStripGpgKeyTextBox.MaxLength = 8;
+            this.toolStripGpgKeyTextBox.MaxLength = 16;
             this.toolStripGpgKeyTextBox.Name = "toolStripGpgKeyTextBox";
             this.toolStripGpgKeyTextBox.Size = new System.Drawing.Size(230, 23);
             this.toolStripGpgKeyTextBox.Visible = false;

--- a/GitUI/CommandsDialogs/FormCreateTag.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.Designer.cs
@@ -104,7 +104,7 @@ namespace GitUI.CommandsDialogs
             // 
             this.textBoxGpgKey.Enabled = false;
             this.textBoxGpgKey.Location = new System.Drawing.Point(141, 115);
-            this.textBoxGpgKey.MaxLength = 8;
+            this.textBoxGpgKey.MaxLength = 16;
             this.textBoxGpgKey.Name = "textBoxGpgKey";
             this.textBoxGpgKey.Size = new System.Drawing.Size(60, 21);
             this.textBoxGpgKey.TabIndex = 7;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8418


## Proposed changes

- When choosing to sign with a specific GPG key, the input box now supports 16 characters (instead of 8).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
