### PR TITLE
Don't refresh revision grid invoking toolstrip actions

### DIFF
--- a/GitUI/FilterBranchHelper.cs
+++ b/GitUI/FilterBranchHelper.cs
@@ -11,6 +11,8 @@ namespace GitUI
     public class FilterBranchHelper : IDisposable
     {
         private bool _applyingFilter;
+        private bool _filterBeingChanged;
+
         private readonly ToolStripComboBox _NO_TRANSLATE_toolStripBranches;
         private readonly RevisionGridControl _NO_TRANSLATE_RevisionGrid;
         private readonly ToolStripMenuItem _localToolStripMenuItem;
@@ -74,7 +76,7 @@ namespace GitUI
 
             _NO_TRANSLATE_toolStripBranches.DropDown += toolStripBranches_DropDown;
             _NO_TRANSLATE_toolStripBranches.TextUpdate += toolStripBranches_TextUpdate;
-            _NO_TRANSLATE_toolStripBranches.Leave += toolStripBranches_Leave;
+            _NO_TRANSLATE_toolStripBranches.TextChanged += (s, e) => _filterBeingChanged = true;
             _NO_TRANSLATE_toolStripBranches.KeyUp += toolStripBranches_KeyUp;
         }
 
@@ -155,6 +157,7 @@ namespace GitUI
 
         private void toolStripBranches_TextUpdate(object sender, EventArgs e)
         {
+            _filterBeingChanged = true;
             UpdateBranchFilterItems();
         }
 
@@ -162,7 +165,7 @@ namespace GitUI
         {
             if (e.KeyCode == Keys.Enter)
             {
-                ApplyBranchFilter(refresh: true);
+                ApplyBranchFilter(refresh: _filterBeingChanged);
             }
         }
 
@@ -179,6 +182,10 @@ namespace GitUI
             }
 
             _applyingFilter = true;
+
+            // The user has accepted the filter
+            _filterBeingChanged = false;
+
             try
             {
                 string filter = _NO_TRANSLATE_toolStripBranches.Items.Count > 0 ? _NO_TRANSLATE_toolStripBranches.Text : string.Empty;
@@ -221,11 +228,6 @@ namespace GitUI
         {
             _NO_TRANSLATE_toolStripBranches.Text = filter;
             ApplyBranchFilter(refresh);
-        }
-
-        private void toolStripBranches_Leave(object sender, EventArgs e)
-        {
-            ApplyBranchFilter(refresh: true);
         }
 
         public void Dispose()

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -829,6 +829,12 @@ namespace GitUI
         {
             ThreadHelper.AssertOnUIThread();
 
+            if (_isRefreshingRevisions)
+            {
+                return;
+            }
+
+            _isRefreshingRevisions = true;
             ShowLoading();
 
             var firstRevisionReceived = false;
@@ -863,7 +869,6 @@ namespace GitUI
                 }
 
                 CurrentCheckout = newCurrentCheckout;
-                _isRefreshingRevisions = true;
                 base.Refresh();
 
                 IndexWatcher.Reset();
@@ -984,8 +989,12 @@ namespace GitUI
                 {
                     var scc = await GetSuperprojectCheckoutAsync(ShowRemoteRef, capturedModule, noLocks: true);
                     await this.SwitchToMainThreadAsync();
-                    _superprojectCurrentCheckout = scc;
-                    Refresh();
+
+                    if (_superprojectCurrentCheckout != scc)
+                    {
+                        _superprojectCurrentCheckout = scc;
+                        Refresh();
+                    }
                 });
                 ResetNavigationHistory();
             }


### PR DESCRIPTION
Appears to be a regression from #8485 which caused the revision grid to be refreshed whenever an action was raised via the toolstrip, e.g. invoking fetch would refresh the grid before the fetch operation was performed, as well as after.

Somehow the toolstrip would pass focus to all its items, that included the Branch Filter which in turn would cause the refresh.
Update the logic to force the grid refresh only when the filter is being changed and applied.

What's worse, multiple refreshes could overlap each other due to peculiar behaviour of the toolstrip, which keeps on passing focus back to its items,
and with that invoke `FilterBranchHelper.toolStripBranches_Leave()`.
There was also another strange behaviour that could lead to a blank revision grid - if a user typed a filter but hasn't applied it, and then invoked
another action via the toolstrip (e.g. fetch) - the revision grid would refresh first after the fetch, and then another refresh operation would
be in flight that attempted to apply the pending filter.

Remove the method and in essence change the user behaviour - now users have to hit ENTER to apply a filter rather than leave the filter textbox.
And move the latch in `ForceRefreshRevisions()` a little higher, to reduce risks of race refreshes.

Also do not refresh the grid when fetching the status from the superproject if the status hasn't changed.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
