### PR TITLE
Fixed "Show in folder" for paths with comma

### DIFF
--- a/GitUI/OsShellUtil.cs
+++ b/GitUI/OsShellUtil.cs
@@ -18,7 +18,7 @@ namespace GitUI
 
         public static void SelectPathInFileExplorer(string filePath)
         {
-            Process.Start("explorer.exe", "/select, \"" + filePath + "\"");
+            Process.Start("explorer.exe", $"/select, {filePath.Quote()}");
         }
 
         public static void OpenWithFileExplorer(string filePath)

--- a/GitUI/OsShellUtil.cs
+++ b/GitUI/OsShellUtil.cs
@@ -18,7 +18,7 @@ namespace GitUI
 
         public static void SelectPathInFileExplorer(string filePath)
         {
-            Process.Start("explorer.exe", "/select, " + filePath);
+            Process.Start("explorer.exe", "/select, \"" + filePath + "\"");
         }
 
         public static void OpenWithFileExplorer(string filePath)

--- a/contributors.txt
+++ b/contributors.txt
@@ -139,3 +139,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/09/09, adamshakhabov, Adam Shakhabov, theadamo86(at)gmail.com
 2020/09/13, hoborm, Mihaly Hobor, mail(at)hobor.xyz
 2020/07/11, blitzmann, Ryan Holmes, holmes.ryan.90(at)gmail.com
+2020/10/03, m417z, ,


### PR DESCRIPTION
A simple fix. I didn't test the code, but I tested the command line and it works.