### PR TITLE
Push multiple: Set default push to false

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -421,7 +421,7 @@
             // ForceColumn
             // 
             this.ForceColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.ForceColumn.HeaderText = "Push (Force Rewind)";
+            this.ForceColumn.HeaderText = "Force";
             this.ForceColumn.Name = "ForceColumn";
             this.ForceColumn.Width = 101;
             // 

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -1034,7 +1034,7 @@ namespace GitUI.CommandsDialogs
                     row[LocalColumnName] = head.Name;
                     row[RemoteColumnName] = remoteName;
                     row[NewColumnName] = isKnownAtRemote ? Strings.No : Strings.Yes;
-                    row[PushColumnName] = isKnownAtRemote;
+                    row[PushColumnName] = false;
 
                     _branchTable.Rows.Add(row);
                 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5288,7 +5288,7 @@ This will initialize and update all submodules recursive.</source>
         <target />
       </trans-unit>
       <trans-unit id="ForceColumn.HeaderText">
-        <source>Push (Force Rewind)</source>
+        <source>Force</source>
         <target />
       </trans-unit>
       <trans-unit id="ForcePushBranches.Text">


### PR DESCRIPTION
Fixes #4421

## Proposed changes

- Set push to default for multiple branches
- Change column name _Push (Force Rewind)_ to _Force_ (The tickbox is either Push or Force, but I believe just Force is clear enough)

No implementation of ticking multiple branches

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/94999768-e4c3ea00-05bb-11eb-907d-e77496e45290.png)

### After

![image](https://user-images.githubusercontent.com/6248932/94999783-fd340480-05bb-11eb-8729-f54703037167.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
