### PR TITLE
range-diff presentation

### DIFF
--- a/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -147,31 +147,39 @@ namespace GitUI.Editor.Diff
         }
 
         protected void ProcessLineSegment(IDocument document, ref int line,
-            LineSegment lineSegment, string prefixStr, Color color)
+            LineSegment lineSegment, string prefixStr, Color color, bool invertMatch = false)
         {
-            if (LinePrefixHelper.DoesLineStartWith(document, lineSegment.Offset, prefixStr))
+            if (!DoesLineStartWith(document, lineSegment.Offset, prefixStr, invertMatch))
             {
-                var endLine = document.GetLineSegment(line);
-
-                for (; line < document.TotalNumberOfLines
-                    && LinePrefixHelper.DoesLineStartWith(document, endLine.Offset, prefixStr);
-                    line++)
-                {
-                    endLine = document.GetLineSegment(line);
-                }
-
-                line--;
-                line--;
-                endLine = document.GetLineSegment(line);
-
-                document.MarkerStrategy.AddMarker(new TextMarker(lineSegment.Offset,
-                                                        (endLine.Offset + endLine.TotalLength) -
-                                                        lineSegment.Offset, TextMarkerType.SolidBlock, color,
-                                                        ColorHelper.GetForeColorForBackColor(color)));
+                return;
             }
+
+            var endLine = document.GetLineSegment(line);
+
+            for (;
+                line < document.TotalNumberOfLines
+                && DoesLineStartWith(document, endLine.Offset, prefixStr, invertMatch);
+                line++)
+            {
+                endLine = document.GetLineSegment(line);
+            }
+
+            line--;
+            line--;
+            endLine = document.GetLineSegment(line);
+
+            document.MarkerStrategy.AddMarker(new TextMarker(lineSegment.Offset,
+                (endLine.Offset + endLine.TotalLength) -
+                lineSegment.Offset, TextMarkerType.SolidBlock, color,
+                ColorHelper.GetForeColorForBackColor(color)));
+
+            return;
+
+            bool DoesLineStartWith(IDocument document, int offset, string prefixStr, bool invertMatch)
+                => invertMatch ^ LinePrefixHelper.DoesLineStartWith(document, offset, prefixStr);
         }
 
-        public void AddPatchHighlighting(IDocument document)
+        public virtual void AddPatchHighlighting(IDocument document)
         {
             bool forceAbort = false;
 

--- a/GitUI/Editor/Diff/LinePrefixHelper.cs
+++ b/GitUI/Editor/Diff/LinePrefixHelper.cs
@@ -50,7 +50,6 @@ namespace GitUI.Editor.Diff
 
         public bool DoesLineStartWith(IDocument document, int lineOffset, string prefixStr)
         {
-            Debug.Assert(prefixStr.Length <= 2 && prefixStr.Length >= 1, "prefixStr.Length <= 2 && prefixStr.Length >= 1");
             if (prefixStr.Length == 1)
             {
                 return document.GetCharAt(lineOffset) == prefixStr[0];
@@ -61,10 +60,15 @@ namespace GitUI.Editor.Diff
                 return false;
             }
 
-            var firstChar = document.GetCharAt(lineOffset);
-            var secondChar = document.GetCharAt(lineOffset + 1);
+            for (int i = 0; i < prefixStr.Length; i++)
+            {
+                if (document.GetCharAt(lineOffset + i) != prefixStr[i])
+                {
+                    return false;
+                }
+            }
 
-            return firstChar == prefixStr[0] && secondChar == prefixStr[1];
+            return true;
         }
 
         public bool DoesLineStartWith(IDocument document, int lineOffset, string[] prefixStrs)

--- a/GitUI/Editor/Diff/RangeDiffHighlightService.cs
+++ b/GitUI/Editor/Diff/RangeDiffHighlightService.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using GitExtUtils.GitUI.Theming;
+using GitUI.Theming;
+using ICSharpCode.TextEditor.Document;
+
+namespace GitUI.Editor.Diff
+{
+    public class RangeDiffHighlightService : DiffHighlightService
+    {
+        public static new RangeDiffHighlightService Instance { get; } = new RangeDiffHighlightService();
+
+        protected RangeDiffHighlightService()
+        {
+        }
+
+        protected override int GetDiffContentOffset()
+        {
+            // Four spaces and two space/+/-
+            return 6;
+        }
+
+        public override void AddPatchHighlighting(IDocument document)
+        {
+            bool forceAbort = false;
+
+            for (var line = 0; line < document.TotalNumberOfLines && !forceAbort; line++)
+            {
+                var lineSegment = document.GetLineSegment(line);
+
+                if (lineSegment.TotalLength == 0)
+                {
+                    continue;
+                }
+
+                if (line == document.TotalNumberOfLines - 1)
+                {
+                    forceAbort = true;
+                }
+
+                line = TryHighlightAddedAndDeletedLines(document, line, lineSegment);
+
+                ProcessLineSegment(document, ref line, lineSegment, "    ", AppColor.AuthoredHighlight.GetThemeColor(), true);
+                ProcessLineSegment(document, ref line, lineSegment, "    @@", AppColor.DiffSection.GetThemeColor());
+                ProcessLineSegment(document, ref line, lineSegment, "     @@", AppColor.DiffSection.GetThemeColor());
+                ProcessLineSegment(document, ref line, lineSegment, "    -@@", AppColor.DiffSection.GetThemeColor());
+                ProcessLineSegment(document, ref line, lineSegment, "    +@@", AppColor.DiffSection.GetThemeColor());
+                ProcessLineSegment(document, ref line, lineSegment, "      ## ", AppColor.DiffSection.GetThemeColor());
+                ProcessLineSegment(document, ref line, lineSegment, "       ##", AppColor.DiffSection.GetThemeColor());
+            }
+        }
+
+        protected override int TryHighlightAddedAndDeletedLines(IDocument document, int line, LineSegment lineSegment)
+        {
+            // part of range-diff dual-color
+
+            // Only changed in selected
+            ProcessLineSegment(document, ref line, lineSegment, "    ++", AppColor.DiffAddedExtra.GetThemeColor());
+            ProcessLineSegment(document, ref line, lineSegment, "    +-", AppColor.DiffRemovedExtra.GetThemeColor());
+
+            // Only changed in first or same change in both
+            ProcessLineSegment(document, ref line, lineSegment, "    -+", AppColor.DiffAdded.GetThemeColor());
+            ProcessLineSegment(document, ref line, lineSegment, "    --", AppColor.DiffRemoved.GetThemeColor());
+            ProcessLineSegment(document, ref line, lineSegment, "     -", AppColor.DiffRemoved.GetThemeColor());
+            ProcessLineSegment(document, ref line, lineSegment, "     +", AppColor.DiffAdded.GetThemeColor());
+
+            // No highlight for lines removed in both first/selected
+            return line;
+        }
+
+        protected override List<ISegment> GetAddedLines(IDocument document, ref int line, ref bool found)
+        {
+            return LinePrefixHelper.GetLinesStartingWith(document, ref line, new[] { "+", " +" }, ref found);
+        }
+
+        protected override List<ISegment> GetRemovedLines(IDocument document, ref int line, ref bool found)
+        {
+            return LinePrefixHelper.GetLinesStartingWith(document, ref line, new[] { "-", " -" }, ref found);
+        }
+    }
+}

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -234,11 +234,16 @@ namespace GitUI.Editor
 
         public void SetText(string text, Action openWithDifftool, bool isDiff = false)
         {
+            SetText(text, openWithDifftool, isDiff, false);
+        }
+
+        public void SetText(string text, Action openWithDifftool, bool isDiff, bool isRangeDiff)
+        {
             _currentViewPositionCache.Capture();
 
             OpenWithDifftool = openWithDifftool;
-            _lineNumbersControl.Clear(isDiff);
-            _lineNumbersControl.SetVisibility(isDiff);
+            _lineNumbersControl.Clear(isDiff && !isRangeDiff);
+            _lineNumbersControl.SetVisibility(isDiff && !isRangeDiff);
 
             if (isDiff)
             {
@@ -248,11 +253,16 @@ namespace GitUI.Editor
                     TextEditor.ActiveTextAreaControl.TextArea.InsertLeftMargin(0, _lineNumbersControl);
                 }
 
-                _diffHighlightService = DiffHighlightService.IsCombinedDiff(text)
-                    ? CombinedDiffHighlightService.Instance
-                    : DiffHighlightService.Instance;
+                _diffHighlightService = isRangeDiff
+                    ? RangeDiffHighlightService.Instance
+                    : DiffHighlightService.IsCombinedDiff(text)
+                        ? CombinedDiffHighlightService.Instance
+                        : DiffHighlightService.Instance;
 
-                _lineNumbersControl.DisplayLineNumFor(text);
+                if (!isRangeDiff)
+                {
+                    _lineNumbersControl.DisplayLineNumFor(text);
+                }
             }
 
             TextEditor.Text = text;

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -86,9 +87,13 @@ namespace GitUI
                         item.SecondRevision.ObjectId,
                         item.BaseA,
                         item.BaseB,
-                        fileViewer.GetExtraDiffArguments());
+                        fileViewer.GetExtraDiffArguments(isRangeDiff: true));
 
-                return fileViewer.ViewTextAsync(item.Item.Name, output ?? defaultText);
+                // Try set highlighting from first found filename
+                var match = new Regex(@"\n\s*(@@|##)\s+(?<file>[^#:\n]+)").Match(output ?? "");
+                var filename = match.Groups["file"].Success ? match.Groups["file"].Value : item.Item.Name;
+
+                return fileViewer.ViewRangeDiffAsync(filename, output ?? defaultText);
             }
 
             string selectedPatch = GetSelectedPatch(fileViewer, firstId, item.SecondRevision.ObjectId, item.Item)


### PR DESCRIPTION
Fixes #8448 

Based on #8471 . Except for one line, this is independent of #8471, but it is meaningless as nothing is changed. However, changes in #8471 should result in minimal changes this PR. This is therefore not a draft.

## Proposed changes

Present range-diff output as a special diff variant with highlighting etc.
- ViewMode for range-diff, to limit menu actions (copy patches, apply patches)
- Next/previous change moves to the commit-pair header. The important with this feature is not really to see the patches
- Set syntax highlight to first found filename
- Highlight for content:
  - Commit-pair "headers" - AuthoredHighlight
  - Filename or patch start (very random contents...) - DiffSection
  - Lines only changed in last selected - DiffAddedExtra/DiffRemovedExtra
  - Lines only changed in first or same change in both - DiffAdded/DiffRemoved

Some notes of what is not done:
 * Parsing the output, separating the commit pairs (the files in the pairs are much too instable right now). This would have been a part of #8471. The overview is better, but this will require another command when selecting. This is not 
 * "Patch" (including new/old) copying. I actually implemented but removed this, as it is unclear what new/old/patch really is here
 * Use Git "dual coloring" information. Hard to handle, not giving much better information.
 * New theme colors to display output better
 * Some way to explain what is seen - there is no good description in the git-range-diff command either...

This will be used for an alternative implementation of #7825 too.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/95000775-1640b380-05c4-11eb-93c0-c01f72075e67.png)

### After

![image](https://user-images.githubusercontent.com/6248932/95000623-d5946a80-05c2-11eb-8bdf-411e9041a1d1.png)

![image](https://user-images.githubusercontent.com/6248932/95000612-b8f83280-05c2-11eb-850e-28ed6099625f.png)

![image](https://user-images.githubusercontent.com/6248932/95000719-76832580-05c3-11eb-9fa6-2bdb76265865.png)

## Test methodology 

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
