### PR TITLE
Fix 7726 - "Latest version not running under new install of windows 10"

### DIFF
--- a/GitUI/Translation/Czech.xlf
+++ b/GitUI/Translation/Czech.xlf
@@ -11017,7 +11017,8 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
-        <source>Find git...</source>
+        <source>Browse to Git
+Find Git on your computer</source>
         <target>Najít git...</target>
         
       </trans-unit>
@@ -11034,7 +11035,7 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
-        <source>The Git executable could not be located on your system.</source>
+        <source>Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.</source>
         
       </trans-unit>
       <trans-unit id="_hoursAgo.Text">
@@ -11048,7 +11049,9 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
-        <source>Install git...</source>
+        <source>Install Git
+Go to GitExtensions wiki
+        </source>
         <target>Instalovat git...</target>
         
       </trans-unit>

--- a/GitUI/Translation/Dutch.xlf
+++ b/GitUI/Translation/Dutch.xlf
@@ -11219,7 +11219,8 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
-        <source>Find git...</source>
+        <source>Browse to Git
+Find Git on your computer</source>
         
       </trans-unit>
       <trans-unit id="_forkCloneRepo.Text">
@@ -11235,7 +11236,7 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
-        <source>The Git executable could not be located on your system.</source>
+        <source>Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.</source>
         
       </trans-unit>
       <trans-unit id="_hoursAgo.Text">
@@ -11249,7 +11250,9 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
-        <source>Install git...</source>
+        <source>Install Git
+Go to GitExtensions wiki
+        </source>
         <target>Installeer git...</target>
         
       </trans-unit>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9298,7 +9298,8 @@ Select this commit to populate the full message.</source>
         <target />
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
-        <source>Find git...</source>
+        <source>Browse to Git
+Find Git on your computer</source>
         <target />
       </trans-unit>
       <trans-unit id="_forkCloneRepo.Text">
@@ -9314,7 +9315,7 @@ Select this commit to populate the full message.</source>
         <target />
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
-        <source>The Git executable could not be located on your system.</source>
+        <source>Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.</source>
         <target />
       </trans-unit>
       <trans-unit id="_hoursAgo.Text">
@@ -9326,7 +9327,9 @@ Select this commit to populate the full message.</source>
         <target />
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
-        <source>Install git...</source>
+        <source>Install Git
+Go to GitExtensions wiki
+        </source>
         <target />
       </trans-unit>
       <trans-unit id="_invisibleCommitText.Text">

--- a/GitUI/Translation/French.xlf
+++ b/GitUI/Translation/French.xlf
@@ -11400,7 +11400,8 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
-        <source>Find git...</source>
+        <source>Browse to Git
+Find Git on your computer</source>
         <target>Trouver git...</target>
         
       </trans-unit>
@@ -11418,7 +11419,7 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
-        <source>The Git executable could not be located on your system.</source>
+        <source>Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.</source>
         <target>L'exécutable Git n'a pas pu être localisé sur votre système.</target>
         
       </trans-unit>
@@ -11433,7 +11434,9 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
-        <source>Install git...</source>
+        <source>Install Git
+Go to GitExtensions wiki
+        </source>
         <target>Installer git...</target>
         
       </trans-unit>

--- a/GitUI/Translation/German.xlf
+++ b/GitUI/Translation/German.xlf
@@ -11609,7 +11609,8 @@ Vollständiger Nachrichten Text ist nicht in älteren Commits enthalten. Wählen
         
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
-        <source>Find git...</source>
+        <source>Browse to Git
+Find Git on your computer</source>
         <target>Git finden...</target>
         
       </trans-unit>
@@ -11629,7 +11630,7 @@ Vollständiger Nachrichten Text ist nicht in älteren Commits enthalten. Wählen
         
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
-        <source>The Git executable could not be located on your system.</source>
+        <source>Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.</source>
         <target>Die ausführbare Git-Datei konnte auf Ihrem System nicht gefunden werden.</target>
         
       </trans-unit>
@@ -11644,7 +11645,9 @@ Vollständiger Nachrichten Text ist nicht in älteren Commits enthalten. Wählen
         
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
-        <source>Install git...</source>
+        <source>Install Git
+Go to GitExtensions wiki
+        </source>
         <target>Git installieren...</target>
         
       </trans-unit>

--- a/GitUI/Translation/Italian.xlf
+++ b/GitUI/Translation/Italian.xlf
@@ -10970,7 +10970,8 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
-        <source>Find git...</source>
+        <source>Browse to Git
+Find Git on your computer</source>
         <target>Trova git...</target>
         
       </trans-unit>
@@ -10987,7 +10988,7 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
-        <source>The Git executable could not be located on your system.</source>
+        <source>Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.</source>
         
       </trans-unit>
       <trans-unit id="_hoursAgo.Text">
@@ -11001,7 +11002,9 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
-        <source>Install git...</source>
+        <source>Install Git
+Go to GitExtensions wiki
+        </source>
         <target>Installa git...</target>
         
       </trans-unit>

--- a/GitUI/Translation/Japanese.xlf
+++ b/GitUI/Translation/Japanese.xlf
@@ -11589,7 +11589,8 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
-        <source>Find git...</source>
+        <source>Browse to Git
+Find Git on your computer</source>
         <target>gitを検索…</target>
         
       </trans-unit>
@@ -11609,7 +11610,7 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
-        <source>The Git executable could not be located on your system.</source>
+        <source>Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.</source>
         <target>gitの実行ファイルはシステムで見つかりませんでした。</target>
         
       </trans-unit>
@@ -11624,7 +11625,9 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
-        <source>Install git...</source>
+        <source>Install Git
+Go to GitExtensions wiki
+        </source>
         <target>gitをインストール…</target>
         
       </trans-unit>

--- a/GitUI/Translation/Latvian.xlf
+++ b/GitUI/Translation/Latvian.xlf
@@ -10987,7 +10987,8 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
-        <source>Find git...</source>
+        <source>Browse to Git
+Find Git on your computer</source>
         <target>Atrast git...</target>
         
       </trans-unit>
@@ -11004,7 +11005,7 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
-        <source>The Git executable could not be located on your system.</source>
+        <source>Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.</source>
         <target>Izpildāmo Git nevar atrast jūsu sistēmā.</target>
         
       </trans-unit>
@@ -11019,7 +11020,9 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
-        <source>Install git...</source>
+        <source>Install Git
+Go to GitExtensions wiki
+        </source>
         <target>Instalēt git...</target>
         
       </trans-unit>

--- a/GitUI/Translation/Polish.xlf
+++ b/GitUI/Translation/Polish.xlf
@@ -11546,7 +11546,8 @@ Wybierz to zatwierdzenie, aby wyświetlić pełną wiadomość.</target>
         
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
-        <source>Find git...</source>
+        <source>Browse to Git
+Find Git on your computer</source>
         <target>Znajdź git...</target>
         
       </trans-unit>
@@ -11564,7 +11565,7 @@ Wybierz to zatwierdzenie, aby wyświetlić pełną wiadomość.</target>
         
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
-        <source>The Git executable could not be located on your system.</source>
+        <source>Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.</source>
         <target>Nie udało się znaleźć pliku wykonywalnego Git w Twoim systemie.</target>
         
       </trans-unit>
@@ -11579,7 +11580,9 @@ Wybierz to zatwierdzenie, aby wyświetlić pełną wiadomość.</target>
         
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
-        <source>Install git...</source>
+        <source>Install Git
+Go to GitExtensions wiki
+        </source>
         <target>Zainstaluj git...</target>
         
       </trans-unit>

--- a/GitUI/Translation/Portuguese (Brazil).xlf
+++ b/GitUI/Translation/Portuguese (Brazil).xlf
@@ -10974,7 +10974,8 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
-        <source>Find git...</source>
+        <source>Browse to Git
+Find Git on your computer</source>
         <target>Procurar git...</target>
         
       </trans-unit>
@@ -10991,7 +10992,7 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
-        <source>The Git executable could not be located on your system.</source>
+        <source>Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.</source>
         
       </trans-unit>
       <trans-unit id="_hoursAgo.Text">
@@ -11005,7 +11006,9 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
-        <source>Install git...</source>
+        <source>Install Git
+Go to GitExtensions wiki
+        </source>
         <target>Instalar git...</target>
         
       </trans-unit>

--- a/GitUI/Translation/Russian.xlf
+++ b/GitUI/Translation/Russian.xlf
@@ -11518,7 +11518,8 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
-        <source>Find git...</source>
+        <source>Browse to Git
+Find Git on your computer</source>
         <target>Найти git...</target>
         
       </trans-unit>
@@ -11537,7 +11538,7 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
-        <source>The Git executable could not be located on your system.</source>
+        <source>Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.</source>
         <target>Исполняемый файл Git не найден в системе.</target>
         
       </trans-unit>
@@ -11552,7 +11553,9 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
-        <source>Install git...</source>
+        <source>Install Git
+Go to GitExtensions wiki
+        </source>
         <target>Установить git...</target>
         
       </trans-unit>

--- a/GitUI/Translation/Simplified Chinese.xlf
+++ b/GitUI/Translation/Simplified Chinese.xlf
@@ -11512,7 +11512,8 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
-        <source>Find git...</source>
+        <source>Browse to Git
+Find Git on your computer</source>
         <target>查找git...</target>
         
       </trans-unit>
@@ -11530,7 +11531,7 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
-        <source>The Git executable could not be located on your system.</source>
+        <source>Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.</source>
         <target>无法在你的系统中定位到git可执行文件</target>
         
       </trans-unit>
@@ -11545,7 +11546,9 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
-        <source>Install git...</source>
+        <source>Install Git
+Go to GitExtensions wiki
+        </source>
         <target>安装git...</target>
         
       </trans-unit>

--- a/GitUI/Translation/Spanish (Argentina).xlf
+++ b/GitUI/Translation/Spanish (Argentina).xlf
@@ -11169,7 +11169,8 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
-        <source>Find git...</source>
+        <source>Browse to Git
+Find Git on your computer</source>
         
       </trans-unit>
       <trans-unit id="_forkCloneRepo.Text">
@@ -11185,7 +11186,7 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
-        <source>The Git executable could not be located on your system.</source>
+        <source>Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.</source>
         
       </trans-unit>
       <trans-unit id="_hoursAgo.Text">
@@ -11197,7 +11198,9 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
-        <source>Install git...</source>
+        <source>Install Git
+Go to GitExtensions wiki
+        </source>
         
       </trans-unit>
       <trans-unit id="_loadingDataText.Text">

--- a/GitUI/Translation/Spanish.xlf
+++ b/GitUI/Translation/Spanish.xlf
@@ -11441,7 +11441,8 @@ Seleccione este commit para llenar el mensaje completo.</target>
         
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
-        <source>Find git...</source>
+        <source>Browse to Git
+Find Git on your computer</source>
         <target>Buscar git...</target>
         
       </trans-unit>
@@ -11458,7 +11459,7 @@ Seleccione este commit para llenar el mensaje completo.</target>
         
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
-        <source>The Git executable could not be located on your system.</source>
+        <source>Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.</source>
         <target>No se ha encontrado el archivo ejecutable de Git en tu sistema.</target>
         
       </trans-unit>
@@ -11473,7 +11474,9 @@ Seleccione este commit para llenar el mensaje completo.</target>
         
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
-        <source>Install git...</source>
+        <source>Install Git
+Go to GitExtensions wiki
+        </source>
         <target>Installar git...</target>
         
       </trans-unit>

--- a/GitUI/Translation/en_pseudo.xlf
+++ b/GitUI/Translation/en_pseudo.xlf
@@ -11592,7 +11592,8 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
-        <source>Find git...</source>
+        <source>Browse to Git
+Find Git on your computer</source>
         <target>[Ƒīƞḓ ɠīŧ... ςϱϕǋ ǅǈǋϕǲ衋]</target>
         
       </trans-unit>
@@ -11612,7 +11613,7 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
-        <source>The Git executable could not be located on your system.</source>
+        <source>Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.</source>
         <target>[Ŧħḗ Ɠīŧ ḗẋḗƈŭŧȧƀŀḗ ƈǿŭŀḓ ƞǿŧ ƀḗ ŀǿƈȧŧḗḓ ǿƞ ẏǿŭř şẏşŧḗḿ. ΰ靐ϖ ǈΰǲ]</target>
         
       </trans-unit>
@@ -11627,7 +11628,9 @@ Select this commit to populate the full message.</source>
         
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
-        <source>Install git...</source>
+        <source>Install Git
+Go to GitExtensions wiki
+        </source>
         <target>[Īƞşŧȧŀŀ ɠīŧ... ϕϵẛ衋ϕ靐ς ǋΐẛẛ]</target>
         
       </trans-unit>

--- a/ResourceManager/Strings.cs
+++ b/ResourceManager/Strings.cs
@@ -27,10 +27,9 @@ You can change your mind at any time.
 
 Yes, I allow telemetry!");
 
-        private readonly TranslationString _installGitInstructions = new TranslationString("Install git...");
-        private readonly TranslationString _findGitExecutable = new TranslationString("Find git...");
-        private readonly TranslationString _gitExecutableNotFoundText =
-            new TranslationString("The Git executable could not be located on your system.");
+        private readonly TranslationString _installGitInstructions = new TranslationString("Install Git\r\nGo to GitExtensions wiki");
+        private readonly TranslationString _findGitExecutable = new TranslationString("Browse to Git\r\n Find Git on your computer");
+        private readonly TranslationString _gitExecutableNotFoundText = new TranslationString("Git Extensions requires a Git executable to be on your computer which does not appear to be the case. Please install Git or click Browse to find Git on your computer manually.");
         private readonly TranslationString _authorDateText = new TranslationString("{0:Author date|Author dates}");
         private readonly TranslationString _committerText = new TranslationString("Committer");
         private readonly TranslationString _commitDateText = new TranslationString("{0:Commit date|Commit dates}");


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #
Rewritten UI text with the wording discussed in the Issue comment section.

## Proposed changes

- New Find Git text
- New Install Git text
- New alert text
- Simple replacement in translation files (*.xlf)



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

[In this reply](https://github.com/gitextensions/gitextensions/issues/7726#issuecomment-582328310)

### After

![image](https://user-images.githubusercontent.com/20760348/95017066-3ff6ea80-0657-11eb-9cce-07ef29ffa43c.png)



## Test methodology <!-- How did you ensure quality? -->

- Ran the UI tests
- No new tests though


## Test environment(s) <!-- Remove any that don't apply -->

- GIT git version 2.28.0.windows.1
- Windows Version	10.0.19041 Build 19041

<!-- Mention language, UI scaling, or anything else that might be relevant -->
I could not change the wording in the translated languages, all of the changes should be translated again.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
