### PR TITLE
FormPush: Add context menu to easily manage multiple push selection

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -56,6 +56,10 @@
             this.folderBrowserButton1 = new GitUI.UserControls.FolderBrowserButton();
             this.Pull = new System.Windows.Forms.Button();
             this.PushOptionsPanel = new System.Windows.Forms.Panel();
+            this.menuPushSelection = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.unselectAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.selectTrackedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.selectAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ForcePushOptionPanel.SuspendLayout();
             this.TabControlTagBranch.SuspendLayout();
             this.BranchTab.SuspendLayout();
@@ -66,6 +70,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.BranchGrid)).BeginInit();
             this.groupBox2.SuspendLayout();
             this.PushOptionsPanel.SuspendLayout();
+            this.menuPushSelection.SuspendLayout();
             this.SuspendLayout();
             // 
             // ForcePushOptionPanel
@@ -542,6 +547,36 @@
             this.PushOptionsPanel.TabIndex = 3;
             this.PushOptionsPanel.Visible = false;
             // 
+            // contextMenuStripPush
+            // 
+            this.menuPushSelection.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.unselectAllToolStripMenuItem,
+            this.selectTrackedToolStripMenuItem,
+            this.selectAllToolStripMenuItem});
+            this.menuPushSelection.Name = "menuPushSelection";
+            this.menuPushSelection.Size = new System.Drawing.Size(181, 92);
+            // 
+            // unselectAllToolStripMenuItem
+            // 
+            this.unselectAllToolStripMenuItem.Name = "unselectAllToolStripMenuItem";
+            this.unselectAllToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.unselectAllToolStripMenuItem.Text = "Unselect all";
+            this.unselectAllToolStripMenuItem.Click += new System.EventHandler(this.unselectAllToolStripMenuItem_Click);
+            // 
+            // selectTrackedToolStripMenuItem
+            // 
+            this.selectTrackedToolStripMenuItem.Name = "selectTrackedToolStripMenuItem";
+            this.selectTrackedToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.selectTrackedToolStripMenuItem.Text = "Select tracked";
+            this.selectTrackedToolStripMenuItem.Click += new System.EventHandler(this.selectTrackedToolStripMenuItem_Click);
+            // 
+            // selectAllToolStripMenuItem
+            // 
+            this.selectAllToolStripMenuItem.Name = "selectAllToolStripMenuItem";
+            this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.selectAllToolStripMenuItem.Text = "Select all";
+            this.selectAllToolStripMenuItem.Click += new System.EventHandler(this.selectAllToolStripMenuItem_Click);
+            // 
             // FormPush
             // 
             this.AcceptButton = this.Push;
@@ -576,6 +611,7 @@
             this.groupBox2.PerformLayout();
             this.PushOptionsPanel.ResumeLayout(false);
             this.PushOptionsPanel.PerformLayout();
+            this.menuPushSelection.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -622,5 +658,9 @@
         private System.Windows.Forms.CheckBox ckForceWithLease;
         private System.Windows.Forms.FlowLayoutPanel ForcePushOptionPanel;
         private System.Windows.Forms.Panel PushOptionsPanel;
+        private System.Windows.Forms.ContextMenuStrip menuPushSelection;
+        private System.Windows.Forms.ToolStripMenuItem unselectAllToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem selectTrackedToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem selectAllToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormPush.resx
+++ b/GitUI/CommandsDialogs/FormPush.resx
@@ -138,4 +138,25 @@
   <metadata name="DeleteColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="LocalColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="RemoteColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="NewColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="PushColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="ForceColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="DeleteColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="menuPushSelection.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>114, 17</value>
+  </metadata>
 </root>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5481,6 +5481,18 @@ Would you like to do it now?</source>
         <source>to</source>
         <target />
       </trans-unit>
+      <trans-unit id="selectAllToolStripMenuItem.Text">
+        <source>Select all</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="selectTrackedToolStripMenuItem.Text">
+        <source>Select tracked</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="unselectAllToolStripMenuItem.Text">
+        <source>Unselect all</source>
+        <target />
+      </trans-unit>
     </body>
   </file>
   <file datatype="plaintext" original="FormPuttyError" source-language="en">


### PR DESCRIPTION
Contribute to fixes in #4421

## Proposed changes

New contextual menu when right or left click on the "Push" column header with some options
* to unselect all
* to select all
* to select only the ones already tracked (default state)


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Nothing

### After

New contextual menu when right or left click on the "Push" column header:

![image](https://user-images.githubusercontent.com/460196/95025588-21aae200-068b-11eb-98e9-080d91469e56.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s)

- Git Extensions 33.33.33
- Build 746264ccaf851fcc7e51d3cb7b49b062eec7c2e7 (Dirty)
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4240.0
- DPI 192dpi (200% scaling)
