### PR TITLE
Ensure focus is on cancel button for Reset Form

### DIFF
--- a/GitUI/CommandsDialogs/FormResetChanges.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResetChanges.Designer.cs
@@ -52,7 +52,7 @@
             this.btnReset.Location = new System.Drawing.Point(261, 3);
             this.btnReset.Name = "btnReset";
             this.btnReset.Size = new System.Drawing.Size(95, 25);
-            this.btnReset.TabIndex = 1;
+            this.btnReset.TabIndex = 2;
             this.btnReset.Text = "&Reset";
             this.btnReset.UseVisualStyleBackColor = true;
             this.btnReset.Click += new System.EventHandler(this.btnReset_Click);
@@ -64,7 +64,7 @@
             this.btnCancel.Location = new System.Drawing.Point(362, 3);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(95, 25);
-            this.btnCancel.TabIndex = 2;
+            this.btnCancel.TabIndex = 1;
             this.btnCancel.Text = "&Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8467 


## Proposed changes
- Added `btnCancel.Select()` to the constructor. Left existing mnemonic of "r" for the reset button.
- "Focus" did not stick after form was shown, but after testing found that "select" worked during form load/initialization


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/7062409/95334831-98f39800-087c-11eb-89aa-79e2ec156fad.png)


### After
![image](https://user-images.githubusercontent.com/7062409/95355021-175b3480-0893-11eb-80d2-5c9e5835975c.png)



## Test methodology <!-- How did you ensure quality? -->
- I currently performed manual UI tests both visual and then message feedback (removed after test) to verify focus. I can add UI test if desired.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.28
- Windows 10

<!-- Mention language, UI scaling, or anything else that might be relevant -->
As mentioned in the issue report - user reported they pushed r twice and files reset. This will not change that behavior due to mnemonic, but will prevent "enter" key from automatically resetting files.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
