### PR TITLE
Submodules window now keeps the splitter position

### DIFF
--- a/GitUI/CommandsDialogs/FormSubmodules.cs
+++ b/GitUI/CommandsDialogs/FormSubmodules.cs
@@ -16,6 +16,7 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormSubmodules : GitModuleForm
     {
+        private readonly SplitterManager _splitterManager = new SplitterManager(new AppSettingsPath("FormSubmodules"));
         private readonly TranslationString _removeSelectedSubmodule = new TranslationString("Are you sure you want remove the selected submodule?");
         private readonly TranslationString _removeSelectedSubmoduleCaption = new TranslationString("Remove");
 
@@ -39,6 +40,19 @@ namespace GitUI.CommandsDialogs
             splitContainer1.SplitterDistance = DpiUtil.Scale(222);
             Pull.AdaptImageLightness();
             InitializeComplete();
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            _splitterManager.AddSplitter(splitContainer1, nameof(splitContainer1));
+            _splitterManager.RestoreSplitters();
+            base.OnLoad(e);
+        }
+
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            _splitterManager.SaveSplitters();
+            base.OnClosing(e);
         }
 
         private void AddSubmoduleClick(object sender, EventArgs e)

--- a/contributors.txt
+++ b/contributors.txt
@@ -141,5 +141,6 @@ YYYY/MM/DD, github id, Full name, email
 2020/07/11, blitzmann, Ryan Holmes, holmes.ryan.90(at)gmail.com
 2020/10/01, racecrew, Otis Hix, otis.hix(at)protonmail.com
 2020/10/04, GintasS, Gintautas Švedas, svedgintas(at)gmail.com
+2020/10/07, JurjenBiewenga, Jurjen Biewenga, me@jurjenbiewenga.com
 2020/10/10, vrubleg, Evgeny Vrublevsky, me@veg.by
 2020/10/07, BrianFreemanAtlanta, Brian Freeman, freeman(at)carnegie.com


### PR DESCRIPTION
Fixes #4366 by saving the position of the splitter

## Test methodology <!-- How did you ensure quality? -->
- Manual

## Test environment(s) 
- Windows

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
