### PR TITLE
Disabled "Reset" mnemonic key in "Reset changes" form

### DIFF
--- a/GitUI/CommandsDialogs/FormResetChanges.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResetChanges.Designer.cs
@@ -53,9 +53,10 @@
             this.btnReset.Name = "btnReset";
             this.btnReset.Size = new System.Drawing.Size(95, 25);
             this.btnReset.TabIndex = 1;
-            this.btnReset.Text = "&Reset";
+            this.btnReset.Text = "Reset";
             this.btnReset.UseVisualStyleBackColor = true;
             this.btnReset.Click += new System.EventHandler(this.btnReset_Click);
+            this.btnReset.UseMnemonic = false;
             // 
             // btnCancel
             // 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6113,7 +6113,7 @@ Forcing a branch to reset if it has not been merged might leave some commits unr
         <target />
       </trans-unit>
       <trans-unit id="btnReset.Text">
-        <source>&amp;Reset</source>
+        <source>Reset</source>
         <target />
       </trans-unit>
       <trans-unit id="cbDeleteNewFilesAndDirectories.Text">


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8467 


## Proposed changes

- Disabled "Reset" button mnemonic key feature in "Reset changes" form

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
