### PR TITLE
updated removeFiles to use GetBatchOutput and added unit tests

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1373,13 +1373,13 @@ namespace GitCommands
                 return "";
             }
 
-            return _gitExecutable.GetOutput(
+            return _gitExecutable.GetBatchOutput(
                 new GitArgumentBuilder("rm")
                 {
                     { force, "--force" },
-                    "--",
-                    files.Select(f => f.ToPosixPath().Quote())
-                });
+                    "--"
+                }
+                    .BuildBatchArgumentsForFiles(files));
         }
 
         /// <summary>Tries to start Pageant for the specified remote repo (using the remote's PuTTY key file).</summary>

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -912,6 +912,26 @@ namespace GitCommandsTests
             }
         }
 
+        [TestCase(new string[] { "abc", "def" }, "rm -- \"abc\" \"def\"")]
+        public void RemoveFiles_shouldWorkAsExpected(string[] files, string args)
+        {
+            // Real GitModule is need to access AppSettings.GitCommand static property, avoid exception with dummy GitModule
+            using (var moduleTestHelper = new GitModuleTestHelper())
+            {
+                var gitModule = GetGitModuleWithExecutable(_executable, module: moduleTestHelper.Module);
+                string dummyCommandOutput = "The answer is 42. Just check that the Git arguments are as expected.";
+                _executable.StageOutput(args, dummyCommandOutput);
+                var result = gitModule.RemoveFiles(files.ToList(), false);
+                Assert.AreEqual(dummyCommandOutput, result);
+            }
+        }
+
+        [TestCase(new string[] { }, "")]
+        public void RemoveFiles_should_handle_empty_list(string[] files, string expectedOutput)
+        {
+            Assert.AreEqual(expectedOutput, _gitModule.RemoveFiles(files.ToList(), false));
+        }
+
         [TestCaseSource(nameof(BatchUnstageFilesTestCases))]
         public void BatchUnstageFiles_should_work_as_expected(GitItemStatus[] files, string[] args, bool expectedResult)
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8404 (Remove Files generates FileName or extension too long)


## Proposed changes

- Updated GitModule.RemoveFiles to use GetBatchOutput with BuildBatchArgumentsForFiles


## Test methodology <!-- How did you ensure quality? -->

- Added unit test for empty file list 
- Added unit test for 2 files in the list 
- 


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.8
- Windows 10

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
