### PR TITLE
Fix #8188: cannot force push tags

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -473,7 +473,7 @@ namespace GitUI.CommandsDialogs
 
         private ForcePushOptions GetForcePushOption()
         {
-            if (ForcePushBranches.Checked)
+            if (ForcePushBranches.Checked || ForcePushTags.Checked /* tags cannot be pushed using --force-with-lease */)
             {
                 return ForcePushOptions.Force;
             }
@@ -1262,6 +1262,26 @@ namespace GitUI.CommandsDialogs
 
                 pushCheckBox.Value = willPush(row);
             }
+        }
+
+        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+        internal readonly struct TestAccessor
+        {
+            private readonly FormPush _form;
+
+            public TestAccessor(FormPush form)
+            {
+                _form = form;
+            }
+
+            public CheckBox ckForceWithLease => _form.ckForceWithLease;
+
+            public CheckBox ForcePushBranches => _form.ForcePushBranches;
+
+            public CheckBox ForcePushTags => _form.ForcePushTags;
+
+            public ForcePushOptions GetForcePushOption() => _form.GetForcePushOption();
         }
     }
 }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormPushTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormPushTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CommonTestUtils;
+using FluentAssertions;
+using GitCommands.Git;
+using GitUI;
+using GitUI.CommandsDialogs;
+using NUnit.Framework;
+
+namespace GitExtensions.UITests.CommandsDialogs
+{
+    [Apartment(ApartmentState.STA)]
+    public class FormPushTests
+    {
+        // Created once for the fixture
+        private ReferenceRepository _referenceRepository;
+
+        // Created once for each test
+        private GitUICommands _commands;
+
+        [SetUp]
+        public void SetUp()
+        {
+            if (_referenceRepository == null)
+            {
+                _referenceRepository = new ReferenceRepository();
+            }
+            else
+            {
+                _referenceRepository.Reset();
+            }
+
+            _commands = new GitUICommands(_referenceRepository.Module);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _referenceRepository.Dispose();
+        }
+
+        // Note: the DataBindings between ForcePushTags and ForcePushBranches or ckForceWithLease (depending on Git version) do not function in this test environment
+        [TestCase(false, false, false, ForcePushOptions.DoNotForce)]
+        [TestCase(false, true, false, ForcePushOptions.Force)]
+        [TestCase(false, false, true, ForcePushOptions.Force)] // ForcePushTag requires normal force as with-lease is not allowed for tags
+        [TestCase(false, true, true, ForcePushOptions.Force)]
+        [TestCase(true, false, false, ForcePushOptions.ForceWithLease)] // would be ForcePushOptions.DoNotForce if DataBindings were working
+        [TestCase(true, true, false, ForcePushOptions.Force)]
+        [TestCase(true, false, true, ForcePushOptions.Force)] // ForcePushBranches and ForcePushTags take precedence over ckForceWithLease
+        [TestCase(true, true, true, ForcePushOptions.Force)] // ForcePushBranches and ForcePushTags take precedence over ckForceWithLease
+        public void Should_choose_correct_force_push_option_for_checkbox_state(
+            bool forcePushBranchWithLeaseChecked, bool forcePushBranchChecked, bool forcePushTagChecked, ForcePushOptions forcePushOption)
+        {
+            RunFormTest(
+                form =>
+                {
+                    var accessor = form.GetTestAccessor();
+
+                    accessor.ForcePushTags.Checked = forcePushTagChecked;
+                    accessor.ckForceWithLease.Checked = forcePushBranchWithLeaseChecked;
+                    accessor.ForcePushBranches.Checked = forcePushBranchChecked;
+
+                    accessor.GetForcePushOption().Should().Be(forcePushOption);
+                });
+        }
+
+        private void RunFormTest(Action<FormPush> testDriver)
+        {
+            RunFormTest(
+                form =>
+                {
+                    testDriver(form);
+                    return Task.CompletedTask;
+                });
+        }
+
+        private void RunFormTest(Func<FormPush, Task> testDriverAsync)
+        {
+            UITest.RunForm(
+                () =>
+                {
+                    // False because we haven't performed any actions
+                    Assert.False(_commands.StartPushDialog(owner: null, pushOnShow: false, forceWithLease: false, out _));
+                },
+                testDriverAsync);
+        }
+    }
+}


### PR DESCRIPTION
Fix #8188: cannot force push tags
- Checking the "force push" option in the tags tab of the push form resulted in passing ForcePushOptions.ForceWithLease to the git push command builder
- Add a check for the force push checkbox for the tags tab in order to pass the correct ForcePushOptions.Force value to the command builder

## Test methodology <!-- How did you ensure quality? -->

- I've tested this out with a dummy remote repo on GitHub and verified that I am now able to force push a tag from one commit to another


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.28.0.windows.1
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
