### PR TITLE
Detect when Azure DevOps token is invalid/expired

### DIFF
--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -14,6 +14,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.Remotes;
+using GitUI.CommandsDialogs.SettingsDialog.Pages;
 using GitUI.HelperDialogs;
 using GitUI.UserControls;
 using GitUI.UserControls.RevisionGrid;
@@ -333,7 +334,15 @@ namespace GitUI.BuildServerIntegration
 
                     var buildServerAdapter = export.Value;
 
-                    buildServerAdapter.Initialize(this, buildServerSettings.TypeSettings, objectId => _revisionGrid.GetRevision(objectId) != null);
+                    buildServerAdapter.Initialize(this, buildServerSettings.TypeSettings,
+                        () =>
+                        {
+                            // To run the `StartSettingsDialog()` in the UI Thread
+                            _revisionGrid.Invoke((Action)(() =>
+                            {
+                                _revisionGrid.UICommands.StartSettingsDialog(typeof(BuildServerIntegrationSettingsPage));
+                            }));
+                        }, objectId => _revisionGrid.GetRevision(objectId) != null);
                     return buildServerAdapter;
                 }
                 catch (InvalidOperationException ex)

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -25,8 +25,8 @@
   <ItemGroup>
     <PackageReference Include="AppInsights.WindowsDesktop" Version="$(AppInsightsWindowsDesktopVersion)" />
     <PackageReference Include="ExCSS" Version="2.0.6" />
-    <PackageReference Include="Microsoft-WindowsAPICodePack-Core" Version="1.1.3.3" />
-    <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.3.3" />
+    <PackageReference Include="Microsoft-WindowsAPICodePack-Core" Version="$(MicrosoftWindowsAPICodePackVersion)" />
+    <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" Version="$(MicrosoftWindowsAPICodePackVersion)" />
     <PackageReference Include="System.IO.Abstractions" Version="$(SystemIOAbstractionsVersion)" />
     <PackageReference Include="System.Reactive" Version="$(SystemReactiveVersion)" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="$(SystemRuntimeInteropServicesRuntimeInformationVersion)" />

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -937,6 +937,11 @@ namespace GitUI
             return StartSettingsDialog(null, new SettingsPageReferenceByPlugin(gitPlugin));
         }
 
+        public bool StartSettingsDialog(Type pageType)
+        {
+            return StartSettingsDialog(null, new SettingsPageReferenceByType(pageType));
+        }
+
         /// <summary>
         /// Open the archive dialog
         /// </summary>

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -65,6 +65,7 @@ namespace AppVeyorIntegration
         public void Initialize(
             IBuildServerWatcher buildServerWatcher,
             ISettingsSource config,
+            Action openSettings,
             Func<ObjectId, bool> isCommitInRevisionGrid = null)
         {
             if (_buildServerWatcher != null)

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -58,6 +59,11 @@ namespace AzureDevOpsIntegration
         {
             using (var response = await _httpClient.GetAsync(url))
             {
+                if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    throw new UnauthorizedAccessException();
+                }
+
                 response.EnsureSuccessStatusCode();
                 string json = await response.Content.ReadAsStringAsync();
 

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsIntegration.csproj
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsIntegration.csproj
@@ -4,6 +4,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft-WindowsAPICodePack-Core" Version="$(MicrosoftWindowsAPICodePackVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Reactive.Linq" Version="$(SystemReactiveVersion)" />
   </ItemGroup>

--- a/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
+++ b/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
@@ -61,7 +61,7 @@ namespace JenkinsIntegration
         private readonly Dictionary<string, long> _lastProjectBuildTime = new Dictionary<string, long>();
         private Regex _ignoreBuilds;
 
-        public void Initialize(IBuildServerWatcher buildServerWatcher, ISettingsSource config, Func<ObjectId, bool> isCommitInRevisionGrid = null)
+        public void Initialize(IBuildServerWatcher buildServerWatcher, ISettingsSource config, Action openSettings, Func<ObjectId, bool> isCommitInRevisionGrid = null)
         {
             if (_buildServerWatcher != null)
             {

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
@@ -105,7 +105,7 @@ namespace TeamCityIntegration
 
         public string LogAsGuestUrlParameter { get; set; }
 
-        public void Initialize(IBuildServerWatcher buildServerWatcher, ISettingsSource config, Func<ObjectId, bool> isCommitInRevisionGrid = null)
+        public void Initialize(IBuildServerWatcher buildServerWatcher, ISettingsSource config, Action openSettings, Func<ObjectId, bool> isCommitInRevisionGrid = null)
         {
             if (_buildServerWatcher != null)
             {

--- a/Plugins/BuildServerIntegration/TfsIntegration/TfsAdapter.cs
+++ b/Plugins/BuildServerIntegration/TfsIntegration/TfsAdapter.cs
@@ -51,7 +51,7 @@ namespace TfsIntegration
         private string _projectName;
         private Regex _tfsBuildDefinitionNameFilter;
 
-        public void Initialize(IBuildServerWatcher buildServerWatcher, ISettingsSource config, Func<ObjectId, bool> isCommitInRevisionGrid = null)
+        public void Initialize(IBuildServerWatcher buildServerWatcher, ISettingsSource config, Action openSettings, Func<ObjectId, bool> isCommitInRevisionGrid = null)
         {
             if (_buildServerWatcher != null)
             {

--- a/Plugins/GitUIPluginInterfaces/BuildServerIntegration/IBuildServerAdapter.cs
+++ b/Plugins/GitUIPluginInterfaces/BuildServerIntegration/IBuildServerAdapter.cs
@@ -5,7 +5,7 @@ namespace GitUIPluginInterfaces.BuildServerIntegration
 {
     public interface IBuildServerAdapter : IDisposable
     {
-        void Initialize(IBuildServerWatcher buildServerWatcher, ISettingsSource config, Func<ObjectId, bool> isCommitInRevisionGrid = null);
+        void Initialize(IBuildServerWatcher buildServerWatcher, ISettingsSource config, Action openSettings, Func<ObjectId, bool> isCommitInRevisionGrid = null);
 
         /// <summary>
         /// Gets a unique key which identifies this build server.

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -30,6 +30,7 @@ namespace GitUIPluginInterfaces
         bool StartCommandLineProcessDialog(IWin32Window owner, IGitCommand command);
         void StartBatchFileProcessDialog(string batchFile);
 
+        bool StartSettingsDialog(Type pageType);
         bool StartSettingsDialog(IGitPlugin gitPlugin);
         void AddCommitTemplate(string key, Func<string> addingText, Image icon);
         void RemoveCommitTemplate(string key);

--- a/Solution.Versions.props
+++ b/Solution.Versions.props
@@ -8,6 +8,7 @@
     <LibGit2SharpVersion>0.25.0</LibGit2SharpVersion>
     <MicrosoftVisualStudioCompositionVersion>15.6.36</MicrosoftVisualStudioCompositionVersion>
     <MicrosoftVisualStudioThreadingVersion>16.5.132</MicrosoftVisualStudioThreadingVersion>
+    <MicrosoftWindowsAPICodePackVersion>1.1.3.3</MicrosoftWindowsAPICodePackVersion>
     <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>
     <RestSharpVersion>106.11.4</RestSharpVersion>
     <SmartFormatNETVersion>2.0.0</SmartFormatNETVersion>

--- a/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegration.Tests/AppVeyorAdapterTests.cs
+++ b/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegration.Tests/AppVeyorAdapterTests.cs
@@ -50,7 +50,8 @@ namespace AppVeyorIntegrationTests
             var resultString = EmbeddedResourceLoader.Load(Assembly.GetExecutingAssembly(),
                 $"{GetType().Namespace}.MockData.{filename}");
             var appVeyorAdapter = new AppVeyorAdapter();
-            appVeyorAdapter.Initialize(Substitute.For<IBuildServerWatcher>(), Substitute.For<ISettingsSource>(), id => true);
+            appVeyorAdapter.Initialize(Substitute.For<IBuildServerWatcher>(), Substitute.For<ISettingsSource>(), () => { },
+                id => true);
 
             var buildInfo = appVeyorAdapter.ExtractBuildInfo(_project, resultString).ToList();
             return YamlSerialize(buildInfo);


### PR DESCRIPTION
## Proposed changes

- Detect when Azure DevOps token is invalid/expired
and display an explicit error message.

Better than the current behavior that is displaying nothing
so the user doesn't understand what is happening (even me that developped the plugin 🤣  )

It happens sometimes and is difficult to understand/detect
when the token has expired (because maximum duration is 1 year)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Nothing. Azure Devops pipeline results are just not displayed.

### After

An error message is displayed **once**:
![image](https://user-images.githubusercontent.com/460196/95959803-4168a580-0e03-11eb-8eed-2a22970daba3.png)


A tooltip is always displayed on the "Working directory" pseudo commit result (in case the user didn't carefully read the popup message):
![image](https://user-images.githubusercontent.com/460196/95635104-d37f4f80-0a8b-11eb-92b2-8f048e27826e.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual (change the token to set a bad one to see the new behavior)


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 905403fe2edfa879c96e293973afebe555eb6e8e
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4240.0
- DPI 192dpi (200% scaling)

