### PR TITLE
BackgroundFetch & push --force-with-lease : add a warning message

### DIFF
--- a/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
+++ b/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
@@ -25,6 +25,11 @@ namespace BackgroundFetch
         private IDisposable _cancellationToken;
         private IGitUICommands _currentGitUiCommands;
 
+        private readonly PseudoSetting _warningForceWithLease = new PseudoSetting("WARNING: be careful when force push with lease having the periodic background fetch enabled but chose not to auto-refresh after each fetch.\r\n\r\nYou could lose new commits pushed by others to the remote branch.\r\n\r\nBe sure to refresh the revision grid before doing a force push with lease.", textboxSettings: tb =>
+        {
+            tb.Multiline = true;
+            tb.Height = 500;
+        });
         private readonly StringSetting _gitCommand = new StringSetting("Arguments of git command to run", "fetch --all");
         private readonly NumberSetting<int> _fetchInterval = new NumberSetting<int>("Fetch every (seconds) - set to 0 to disable", 0);
         private readonly BoolSetting _autoRefresh = new BoolSetting("Refresh view after fetch", false);
@@ -37,6 +42,7 @@ namespace BackgroundFetch
             yield return _fetchInterval;
             yield return _autoRefresh;
             yield return _fetchAllSubmodules;
+            yield return _warningForceWithLease;
         }
 
         public override void Register(IGitUICommands gitUiCommands)


### PR DESCRIPTION
## Proposed changes

- Add a warning in the "background fetch" plugin to warn the user 
about some risk when using the "git push --force-with-lease" feature
 
## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

no warning message.

### After

![image](https://user-images.githubusercontent.com/460196/95692803-d06d9600-0c28-11eb-8f8f-3b3876314f1d.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 905403fe2edfa879c96e293973afebe555eb6e8e
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4240.0
- DPI 192dpi (200% scaling)
