### PR TITLE
RevisionGrid: Prevent inopportune crash

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1456,24 +1456,31 @@ namespace GitUI
 
         private void OnGridViewCellMouseDown(object sender, DataGridViewCellMouseEventArgs e)
         {
-            if (e.Button != MouseButtons.Right)
+            try
             {
-                return;
+                if (e.Button != MouseButtons.Right)
+                {
+                    return;
+                }
+
+                if (_latestSelectedRowIndex == e.RowIndex
+                    && _latestSelectedRowIndex < _gridView.Rows.Count
+                    && _gridView.Rows[_latestSelectedRowIndex].Selected)
+                {
+                    return;
+                }
+
+                _latestSelectedRowIndex = e.RowIndex;
+                _gridView.ClearSelection();
+
+                if (IsValidRevisionIndex(_latestSelectedRowIndex))
+                {
+                    _gridView.Rows[_latestSelectedRowIndex].Selected = true;
+                }
             }
-
-            if (_latestSelectedRowIndex == e.RowIndex
-                && _latestSelectedRowIndex < _gridView.Rows.Count
-                && _gridView.Rows[_latestSelectedRowIndex].Selected)
+            catch (Exception)
             {
-                return;
-            }
-
-            _latestSelectedRowIndex = e.RowIndex;
-            _gridView.ClearSelection();
-
-            if (IsValidRevisionIndex(_latestSelectedRowIndex))
-            {
-                _gridView.Rows[_latestSelectedRowIndex].Selected = true;
+                // Checks for bounds seems not enough. See https://github.com/gitextensions/gitextensions/issues/8475
             }
         }
 


### PR DESCRIPTION
when right clicking in the grid

Fixes #8475

## Proposed changes

- try/catch to swallow an exception that we were unable to prevent... 


## Test methodology <!-- How did you ensure quality? -->

- none (reading stacktrace)

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 905403fe2edfa879c96e293973afebe555eb6e8e
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4240.0
- DPI 192dpi (200% scaling)
