### PR TITLE
Fixes #8263 by catching file IO exception and showing message box

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -611,21 +611,29 @@ namespace GitCommands
 
         public void SaveBlobAs(string saveAs, string blob)
         {
-            using (var blobStream = GetFileStream(blob))
+            try
             {
-                var blobData = blobStream.ToArray();
-                if (EffectiveConfigFile.core.autocrlf.Value == AutoCRLFType.@true)
+                using (var blobStream = GetFileStream(blob))
                 {
-                    if (!FileHelper.IsBinaryFileName(this, saveAs) && !FileHelper.IsBinaryFileAccordingToContent(blobData))
+                    var blobData = blobStream.ToArray();
+                    if (EffectiveConfigFile.core.autocrlf.Value == AutoCRLFType.@true)
                     {
-                        blobData = GitConvert.ConvertCrLfToWorktree(blobData);
+                        if (!FileHelper.IsBinaryFileName(this, saveAs) && !FileHelper.IsBinaryFileAccordingToContent(blobData))
+                        {
+                            blobData = GitConvert.ConvertCrLfToWorktree(blobData);
+                        }
+                    }
+
+                    using (var stream = File.Create(saveAs))
+                    {
+                        stream.Write(blobData, 0, blobData.Length);
                     }
                 }
-
-                using (var stream = File.Create(saveAs))
-                {
-                    stream.Write(blobData, 0, blobData.Length);
-                }
+            }
+            catch (IOException)
+            {
+                // currently only handling IOException in client code
+                throw;
             }
         }
 

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -463,7 +463,16 @@ namespace GitUI.CommandsDialogs
                         "|All files (*.*)|*.*";
                     if (fileDialog.ShowDialog(this) == DialogResult.OK)
                     {
-                        Module.SaveBlobAs(fileDialog.FileName, selectedRows[0].Guid + ":\"" + orgFileName + "\"");
+                        var originalName = $"{selectedRows[0].Guid}:\"{orgFileName}\"";
+                        var saveAsName = fileDialog.FileName;
+                        try
+                        {
+                            Module.SaveBlobAs(saveAsName, originalName);
+                        }
+                        catch (IOException ex)
+                        {
+                            MessageBoxes.FailedToSaveAs(this, originalName, saveAsName, ex);
+                        }
                     }
                 }
             }

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -489,7 +489,16 @@ namespace GitUI.CommandsDialogs
                 {
                     if (fileDialog.ShowDialog(this) == DialogResult.OK)
                     {
-                        Module.SaveBlobAs(fileDialog.FileName, lostObject.ObjectId.ToString());
+                        var saveAsName = fileDialog.FileName;
+                        var originalName = lostObject.ObjectId.ToString();
+                        try
+                        {
+                            Module.SaveBlobAs(saveAsName, originalName);
+                        }
+                        catch (System.IO.IOException ex)
+                        {
+                            MessageBoxes.FailedToSaveAs(this, originalName, saveAsName, ex);
+                        }
                     }
                 }
             }

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -783,11 +783,20 @@ namespace GitUI.CommandsDialogs
                     return;
                 }
 
-                var fileName = PathUtil.GetFileName(item.Item.Name);
-                fileName = (Path.GetTempPath() + fileName).ToNativePath();
-                Module.SaveBlobAs(fileName, blob.ToString());
+                var originalName = blob.ToString();
+                var saveAsName = PathUtil.GetFileName(item.Item.Name);
+                saveAsName = (Path.GetTempPath() + saveAsName).ToNativePath();
+                try
+                {
+                    Module.SaveBlobAs(saveAsName, originalName);
+                }
+                catch (IOException ex)
+                {
+                    MessageBoxes.FailedToSaveAs(this, originalName, saveAsName, ex);
+                    return; // TODO: is return appropriate here? Look into what onSaved can potentially be doing
+                }
 
-                onSaved(fileName);
+                onSaved(saveAsName);
             }).FileAndForget();
         }
 
@@ -950,7 +959,16 @@ namespace GitUI.CommandsDialogs
 
                 if (fileDialog.ShowDialog(this) == DialogResult.OK)
                 {
-                    Module.SaveBlobAs(fileDialog.FileName, $"{item.SecondRevision.Guid}:\"{item.Item.Name}\"");
+                    var saveAsName = fileDialog.FileName;
+                    var originalName = $"{item.SecondRevision.Guid}:\"{item.Item.Name}\"";
+                    try
+                    {
+                        Module.SaveBlobAs(saveAsName, originalName);
+                    }
+                    catch (IOException ex)
+                    {
+                        MessageBoxes.FailedToSaveAs(this, originalName, saveAsName, ex);
+                    }
                 }
             }
         }

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -323,11 +323,20 @@ See the changes in the commit form.");
                 gitItem.ObjectType == GitObjectType.Blob &&
                 !string.IsNullOrWhiteSpace(gitItem.FileName))
             {
-                var fileName = gitItem.FileName.SubstringAfterLast('/').SubstringAfterLast('\\');
+                var originalName = gitItem.Guid;
+                var saveAsName = gitItem.FileName.SubstringAfterLast('/').SubstringAfterLast('\\');
+                saveAsName = (Path.GetTempPath() + saveAsName).ToNativePath();
+                try
+                {
+                    Module.SaveBlobAs(saveAsName, originalName);
+                }
+                catch (IOException ex)
+                {
+                    MessageBoxes.FailedToSaveAs(this, originalName, saveAsName, ex);
+                    return null;
+                }
 
-                fileName = (Path.GetTempPath() + fileName).ToNativePath();
-                Module.SaveBlobAs(fileName, gitItem.Guid);
-                return fileName;
+                return saveAsName;
             }
 
             return null;
@@ -743,7 +752,16 @@ See the changes in the commit form.");
                     fileDialog.Filter = $@"{_saveFileFilterCurrentFormat.Text}(*{extension})|*{extension}| {_saveFileFilterAllFiles.Text} (*.*)|*.*";
                     if (fileDialog.ShowDialog(this) == DialogResult.OK)
                     {
-                        Module.SaveBlobAs(fileDialog.FileName, gitItem.Guid);
+                        var saveAsName = fileDialog.FileName;
+                        var originalName = gitItem.Guid;
+                        try
+                        {
+                            Module.SaveBlobAs(saveAsName, originalName);
+                        }
+                        catch (IOException ex)
+                        {
+                            MessageBoxes.FailedToSaveAs(this, originalName, saveAsName, ex);
+                        }
                     }
                 }
             }

--- a/GitUI/MessageBoxes.cs
+++ b/GitUI/MessageBoxes.cs
@@ -16,6 +16,8 @@ namespace GitUI
 
         private readonly TranslationString _failedToRunShell = new TranslationString("Failed to run shell");
 
+        private readonly TranslationString _failedToSave = new TranslationString("Failed to save \"{0}\" as \"{1}\" due to the following exception:\r\n\r\n{2}");
+
         private readonly TranslationString _notValidGitDirectory = new TranslationString("The current directory is not a valid git repository.");
 
         private readonly TranslationString _unresolvedMergeConflictsCaption = new TranslationString("Merge conflicts");
@@ -63,6 +65,9 @@ namespace GitUI
         public static void FailedToRunShell(IWin32Window owner, string shell, Exception ex)
             => ShowError(owner, $"{Instance._failedToRunShell.Text} {shell.Quote()}.{Environment.NewLine}"
                                 + $"{Instance._reason.Text}: {ex.Message}");
+
+        public static void FailedToSaveAs(IWin32Window owner, string originalName, string saveAsName, Exception ex)
+            => ShowError(owner, string.Format(Instance._failedToSave.ToString(), originalName, saveAsName, ex.Message));
 
         public static void NotValidGitDirectory([CanBeNull] IWin32Window owner)
             => ShowError(owner, Instance._notValidGitDirectory.Text);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8263, a crash due to not being able to save a file to a locked filepath


## Proposed changes

- catch file IO exception and display the error to the user without crashing

## Screenshots <!-- Remove this section if PR does not change UI -->

Example message pop-up
![image](https://user-images.githubusercontent.com/14078392/95646025-425fa700-0a92-11eb-8088-d3d77245e6f8.png)

## Test methodology <!-- How did you ensure quality? -->

- tested by attempting to save a file from the commit diff list to a file that was locked by opening an archive using 7-zip


## Test environment(s) <!-- Remove any that don't apply -->

- Windows 10

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
