### PR TITLE
Save Settings When User ran with args

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -84,6 +84,7 @@ namespace GitExtensions
                 ThreadHelper.JoinableTaskContext = new JoinableTaskContext();
             }
 
+            bool saveAppSettings;
             AppSettings.LoadSettings();
 
             if (EnvUtils.RunningOnWindows())
@@ -100,11 +101,13 @@ namespace GitExtensions
                 }
             }
 
+            bool telemetrySettingChanged = false;
             if (!AppSettings.TelemetryEnabled.HasValue)
             {
                 AppSettings.TelemetryEnabled = MessageBox.Show(null, Strings.TelemetryPermissionMessage,
                                                                Strings.TelemetryPermissionCaption, MessageBoxButtons.YesNo,
                                                                MessageBoxIcon.Question) == DialogResult.Yes;
+                telemetrySettingChanged = true;
             }
 
             try
@@ -156,6 +159,7 @@ namespace GitExtensions
 
             if (args.Length <= 1)
             {
+                saveAppSettings = true;
                 commands.StartBrowseDialog();
             }
             else
@@ -165,13 +169,16 @@ namespace GitExtensions
                 // Avoid replacing the ExitCode eventually set while parsing arguments,
                 // i.e. assume -1 and afterwards, only set it to 0 if no error is indicated.
                 Environment.ExitCode = -1;
-                if (commands.RunCommand(args))
+                if (commands.RunCommand(args, out saveAppSettings))
                 {
                     Environment.ExitCode = 0;
                 }
             }
 
-            AppSettings.SaveSettings();
+            if (saveAppSettings || telemetrySettingChanged)
+            {
+                AppSettings.SaveSettings();
+            }
         }
 
         [CanBeNull]

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1381,8 +1381,10 @@ namespace GitUI
                 });
         }
 
-        public bool RunCommand(IReadOnlyList<string> args)
+        public bool RunCommand(IReadOnlyList<string> args, out bool saveAppSettings)
         {
+            saveAppSettings = false;
+
             var arguments = InitializeArguments(args);
 
             if (args.Count <= 1)
@@ -1422,12 +1424,13 @@ namespace GitUI
                 return false;
             }
 
-            return RunCommandBasedOnArgument(args, arguments);
+            return RunCommandBasedOnArgument(args, arguments, out saveAppSettings);
         }
 
         // Please update FormCommandlineHelp if you add or change commands
-        private bool RunCommandBasedOnArgument(IReadOnlyList<string> args, IReadOnlyDictionary<string, string> arguments)
+        private bool RunCommandBasedOnArgument(IReadOnlyList<string> args, IReadOnlyDictionary<string, string> arguments, out bool saveAppSettings)
         {
+            saveAppSettings = false;
 #pragma warning disable SA1025 // Code should not contain multiple whitespace in a row
             var command = args[1];
             switch (command)
@@ -1449,6 +1452,7 @@ namespace GitUI
                 case "branch":
                     return StartCreateBranchDialog();
                 case "browse":      // [path] [-filter]
+                    saveAppSettings = true;
                     return RunBrowseCommand(args);
                 case "checkout":
                 case "checkoutbranch":
@@ -1936,7 +1940,7 @@ namespace GitUI
 
             internal string NormalizeFileName(string fileName) => _commands.NormalizeFileName(fileName);
 
-            internal bool RunCommandBasedOnArgument(string[] args) => _commands.RunCommandBasedOnArgument(args, InitializeArguments(args));
+            internal bool RunCommandBasedOnArgument(string[] args) => _commands.RunCommandBasedOnArgument(args, InitializeArguments(args), out var saveAppSettings);
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6142


## Proposed changes

- Use an out bool variable which indicates whether the app. settings should be saved or not
- Pass the variable as an argument to the method which run the commands


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
