### PR TITLE
Disable merge rebase commands when branch is local

### DIFF
--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -956,6 +956,7 @@ namespace GitUI.CommandsDialogs
             _NO_TRANSLATE_Remotes.Select();
 
             UpdateFormTitleAndButton();
+            DisableMergeOptionsWhenCurrentBranchIsLocal();
         }
 
         private void UpdateFormTitleAndButton()
@@ -1161,6 +1162,17 @@ namespace GitUI.CommandsDialogs
         {
             Prune.Checked = Prune.Checked || PruneTags.Checked;
             AllTags.Checked = AllTags.Checked || PruneTags.Checked;
+        }
+
+        private void DisableMergeOptionsWhenCurrentBranchIsLocal()
+        {
+            var isLocalBranch = string.IsNullOrEmpty(Module.GetRemoteBranch(localBranch.Text));
+
+            Rebase.Enabled =
+                Merge.Enabled =
+                Merge.Checked = !isLocalBranch;
+
+            Fetch.Checked = isLocalBranch;
         }
 
         internal TestAccessor GetTestAccessor() => new TestAccessor(this);

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -957,6 +957,17 @@ namespace GitUI.CommandsDialogs
 
             UpdateFormTitleAndButton();
             DisableMergeOptionsWhenCurrentBranchIsLocal();
+
+            void DisableMergeOptionsWhenCurrentBranchIsLocal()
+            {
+                var isLocalBranch = string.IsNullOrEmpty(Module.GetRemoteBranch(localBranch.Text));
+
+                Rebase.Enabled =
+                    Merge.Enabled =
+                    Merge.Checked = !isLocalBranch;
+
+                Fetch.Checked = isLocalBranch;
+            }
         }
 
         private void UpdateFormTitleAndButton()
@@ -1162,17 +1173,6 @@ namespace GitUI.CommandsDialogs
         {
             Prune.Checked = Prune.Checked || PruneTags.Checked;
             AllTags.Checked = AllTags.Checked || PruneTags.Checked;
-        }
-
-        private void DisableMergeOptionsWhenCurrentBranchIsLocal()
-        {
-            var isLocalBranch = string.IsNullOrEmpty(Module.GetRemoteBranch(localBranch.Text));
-
-            Rebase.Enabled =
-                Merge.Enabled =
-                Merge.Checked = !isLocalBranch;
-
-            Fetch.Checked = isLocalBranch;
         }
 
         internal TestAccessor GetTestAccessor() => new TestAccessor(this);

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -957,17 +957,17 @@ namespace GitUI.CommandsDialogs
 
             UpdateFormTitleAndButton();
             DisableMergeOptionsWhenCurrentBranchIsLocal();
+        }
 
-            void DisableMergeOptionsWhenCurrentBranchIsLocal()
-            {
-                var isLocalBranch = string.IsNullOrEmpty(Module.GetRemoteBranch(localBranch.Text));
+        private void DisableMergeOptionsWhenCurrentBranchIsLocal()
+        {
+            var isLocalBranch = string.IsNullOrEmpty(Module.GetRemoteBranch(localBranch.Text));
 
-                Rebase.Enabled =
-                    Merge.Enabled =
-                    Merge.Checked = !isLocalBranch;
+            Rebase.Enabled =
+                Merge.Enabled =
+                Merge.Checked = !isLocalBranch;
 
-                Fetch.Checked = isLocalBranch;
-            }
+            Fetch.Checked = isLocalBranch;
         }
 
         private void UpdateFormTitleAndButton()
@@ -1002,6 +1002,8 @@ namespace GitUI.CommandsDialogs
 
             Merge.Enabled = !IsPullAll();
             Rebase.Enabled = !IsPullAll();
+
+            DisableMergeOptionsWhenCurrentBranchIsLocal();
         }
 
         private bool IsPullAll()
@@ -1023,9 +1025,6 @@ namespace GitUI.CommandsDialogs
             _NO_TRANSLATE_Remotes.Enabled = false;
             AddRemote.Enabled = false;
 
-            Merge.Enabled = true;
-            Rebase.Enabled = true;
-
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 var repositoryHistory = await RepositoryHistoryManager.Remotes.LoadRecentHistoryAsync();
@@ -1036,6 +1035,8 @@ namespace GitUI.CommandsDialogs
                 comboBoxPullSource.DisplayMember = nameof(Repository.Path);
                 comboBoxPullSource.Text = prevUrl;
             });
+
+            DisableMergeOptionsWhenCurrentBranchIsLocal();
         }
 
         private void AddRemoteClick(object sender, EventArgs e)
@@ -1077,6 +1078,8 @@ namespace GitUI.CommandsDialogs
             {
                 ReachableTags.Checked = true;
             }
+
+            DisableMergeOptionsWhenCurrentBranchIsLocal();
         }
 
         private void RebaseCheckedChanged(object sender, EventArgs e)
@@ -1099,6 +1102,8 @@ namespace GitUI.CommandsDialogs
             {
                 ReachableTags.Checked = true;
             }
+
+            DisableMergeOptionsWhenCurrentBranchIsLocal();
         }
 
         private void FetchCheckedChanged(object sender, EventArgs e)
@@ -1118,6 +1123,8 @@ namespace GitUI.CommandsDialogs
             PruneTags.Enabled = true;
 
             UpdateFormTitleAndButton();
+
+            DisableMergeOptionsWhenCurrentBranchIsLocal();
         }
 
         private void PullSourceValidating(object sender, CancelEventArgs e)
@@ -1148,6 +1155,8 @@ namespace GitUI.CommandsDialogs
             {
                 Fetch.Checked = true;
             }
+
+            DisableMergeOptionsWhenCurrentBranchIsLocal();
         }
 
         private void ResetRemoteHeads()
@@ -1167,12 +1176,16 @@ namespace GitUI.CommandsDialogs
         private void Prune_CheckedChanged(object sender, EventArgs e)
         {
             PruneTags.Checked = Prune.Checked && PruneTags.Checked;
+
+            DisableMergeOptionsWhenCurrentBranchIsLocal();
         }
 
         private void PruneTags_CheckedChanged(object sender, EventArgs e)
         {
             Prune.Checked = Prune.Checked || PruneTags.Checked;
             AllTags.Checked = AllTags.Checked || PruneTags.Checked;
+
+            DisableMergeOptionsWhenCurrentBranchIsLocal();
         }
 
         internal TestAccessor GetTestAccessor() => new TestAccessor(this);

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormPullTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormPullTests.cs
@@ -231,9 +231,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                     accessor.Fetch.Enabled.Should().Be(true);
                     accessor.Fetch.Checked.Should().Be(true);
                 },
-                null, null,
-                //// select an action different from None/fetch
-                AppSettings.PullAction.Merge);
+                null, null, AppSettings.PullAction.None);
         }
 
         private void RunFormTest(Action<FormPull> testDriver, string remoteBranch, string remote, AppSettings.PullAction pullAction)

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormPullTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormPullTests.cs
@@ -109,9 +109,9 @@ namespace GitExtensions.UITests.CommandsDialogs
                 AppSettings.PullAction.Merge);
         }
 
-        [TestCase(AppSettings.PullAction.None, true, false, false, false, false, false, false, false)]
-        [TestCase(AppSettings.PullAction.Merge, true, false, false, false, false, false, false, false)]
-        [TestCase(AppSettings.PullAction.Rebase, false, false, false, true, false, false, false, false)]
+        [TestCase(AppSettings.PullAction.None, false, false, false, false, true, false, true, true)]
+        [TestCase(AppSettings.PullAction.Merge, false, false, false, false, true, false, true, true)]
+        [TestCase(AppSettings.PullAction.Rebase, false, false, false, false, true, false, true, true)]
         [TestCase(AppSettings.PullAction.Fetch, false, false, false, false, true, false, true, true)]
         [TestCase(AppSettings.PullAction.FetchAll, false, false, false, false, true, false, true, true)]
         [TestCase(AppSettings.PullAction.FetchPruneAll, false, true, false, false, true, false, true, true)]
@@ -136,9 +136,9 @@ namespace GitExtensions.UITests.CommandsDialogs
                 null, null, pullAction);
         }
 
-        [TestCase(AppSettings.PullAction.None, true, false, false, false, false, false, false, false)]
-        [TestCase(AppSettings.PullAction.Merge, true, false, false, false, false, false, false, false)]
-        [TestCase(AppSettings.PullAction.Rebase, false, false, false, true, false, false, false, false)]
+        [TestCase(AppSettings.PullAction.None, false, false, false, false, true, false, true, true)]
+        [TestCase(AppSettings.PullAction.Merge, false, false, false, false, true, false, true, true)]
+        [TestCase(AppSettings.PullAction.Rebase, false, false, false, false, true, false, true, true)]
         [TestCase(AppSettings.PullAction.Fetch, false, false, false, false, true, false, true, true)]
         [TestCase(AppSettings.PullAction.FetchAll, false, false, false, false, true, false, true, true)]
         [TestCase(AppSettings.PullAction.FetchPruneAll, false, true, false, false, true, false, true, true)]
@@ -201,6 +201,35 @@ namespace GitExtensions.UITests.CommandsDialogs
                     accessor.UpdateSettingsDuringPull();
 
                     AppSettings.AutoStash.Should().Be(autoStashChecked);
+                },
+                null, null,
+                //// select an action different from None/fetch
+                AppSettings.PullAction.Merge);
+        }
+
+        [Test]
+        public void Should_disable_enable_merge_options_when_no_tracking()
+        {
+            RunFormTest(
+                form =>
+                {
+                    /* Since we're using _commands.StartPullDialog, later FormPullLoad gets called and
+                       in it we call DisableMergeOptionsWhenCurrentBranchIsNotTracking(),
+                       so no need to call it again after the accessor initialization.
+                       Thus, control states are:
+                       Rebase.Enabled = false
+                       Merge.Enabled = false
+                       Fetch.Enabled = true
+                       Fetch.Checked = true
+                    */
+                    var accessor = form.GetTestAccessor();
+
+                    accessor.Merge.Enabled.Should().Be(false);
+                    accessor.Merge.Checked.Should().Be(false);
+                    accessor.Rebase.Enabled.Should().Be(false);
+                    accessor.Rebase.Checked.Should().Be(false);
+                    accessor.Fetch.Enabled.Should().Be(true);
+                    accessor.Fetch.Checked.Should().Be(true);
                 },
                 null, null,
                 //// select an action different from None/fetch


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1248


## Proposed changes

Like the author of the issue has said, I'm disabling these two buttons when the branch is local.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/20372363/95014544-49c91f80-0650-11eb-8e38-b234df6d8545.png)





### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/20372363/96333924-885dd180-1075-11eb-8afd-1879e48abf5d.png)







## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
