### PR TITLE
FormPush multiple: force-with-lease if rejected

### DIFF
--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5401,16 +5401,24 @@ Would you like to do it now?</source>
         <source>Pull with rebase</source>
         <target />
       </trans-unit>
-      <trans-unit id="_pullRepository.Text">
-        <source>The push was rejected because the tip of your current branch is behind its remote counterpart. Merge the remote changes before pushing again.</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_pullRepositoryCaption.Text">
         <source>Push was rejected from "{0}"</source>
         <target />
       </trans-unit>
-      <trans-unit id="_pullRepositoryMainInstruction.Text">
+      <trans-unit id="_pullRepositoryForceInstruction.Text">
+        <source>The push was rejected because the tip of your current branch is behind its remote counterpart</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_pullRepositoryMainForceInstruction.Text">
+        <source>Push rejected</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_pullRepositoryMainMergeInstruction.Text">
         <source>Pull latest changes from remote repository</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_pullRepositoryMergeInstruction.Text">
+        <source>The push was rejected because the tip of your current branch is behind its remote counterpart. Merge the remote changes before pushing again.</source>
         <target />
       </trans-unit>
       <trans-unit id="_pushCaption.Text">


### PR DESCRIPTION
Fixes #8548

## Proposed changes

- Slightly safer regex to check for current branch
- If push is rejected for other than current, offer a slim-down variant of the error dialog. Currently, this is a subset of the "full" dialog, this could change

Note that the full dialog is displayed if current branch is pushed at the same time as any other branch. This is OK, the pull actions have no effect on the non current branches

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

none - see #8548

### After

![force-only](https://user-images.githubusercontent.com/6248932/96349268-c62b1c00-10ae-11eb-9176-eea0be631a17.JPG)

## Test methodology 

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
