### PR TITLE
gray additional commit lines in revision grid

### DIFF
--- a/GitExtUtils/GitUI/Theming/ColorHelper.cs
+++ b/GitExtUtils/GitUI/Theming/ColorHelper.cs
@@ -72,7 +72,8 @@ namespace GitExtUtils.GitUI.Theming
         public static Color GetHighlightGrayTextColor(
             KnownColor backgroundColorName,
             KnownColor textColorName,
-            KnownColor highlightColorName)
+            KnownColor highlightColorName,
+            float degreeOfGrayness = 1f)
         {
             var grayTextHsl = new HslColor(ThemeSettings.InvariantTheme.GetNonEmptyColor(KnownColor.GrayText));
             var textHsl = new HslColor(ThemeSettings.InvariantTheme.GetNonEmptyColor(textColorName));
@@ -80,12 +81,28 @@ namespace GitExtUtils.GitUI.Theming
             var backgroundHsl = new HslColor(ThemeSettings.InvariantTheme.GetNonEmptyColor(backgroundColorName));
             var highlightBackgroundHsl = new HslColor(ThemeSettings.InvariantTheme.GetNonEmptyColor(highlightColorName));
 
+            double grayTextL = textHsl.L + (degreeOfGrayness * (grayTextHsl.L - textHsl.L));
+
             double highlightGrayTextL = Transform(
-                grayTextHsl.L,
+                grayTextL,
                 textHsl.L, backgroundHsl.L,
                 highlightTextHsl.L, highlightBackgroundHsl.L);
 
             var highlightGrayTextHsl = grayTextHsl.WithLuminosity(highlightGrayTextL);
+            return AdaptTextColor(highlightGrayTextHsl.ToColor());
+        }
+
+        /// <summary>
+        /// Get a color to be used instead of SystemColors.GrayText which is more ore less gray than
+        /// the usual SystemColors.GrayText
+        /// </summary>
+        public static Color GetGrayTextColor(KnownColor textColorName, float degreeOfGrayness = 1f)
+        {
+            var grayTextHsl = new HslColor(ThemeSettings.InvariantTheme.GetNonEmptyColor(KnownColor.GrayText));
+            var textHsl = new HslColor(ThemeSettings.InvariantTheme.GetNonEmptyColor(textColorName));
+
+            double grayTextL = textHsl.L + (degreeOfGrayness * (grayTextHsl.L - textHsl.L));
+            var highlightGrayTextHsl = grayTextHsl.WithLuminosity(grayTextL);
             return AdaptTextColor(highlightGrayTextHsl.ToColor());
         }
 

--- a/GitUI/UserControls/RevisionGrid/CellStyle.cs
+++ b/GitUI/UserControls/RevisionGrid/CellStyle.cs
@@ -6,14 +6,16 @@ namespace GitUI.UserControls.RevisionGrid
     {
         public readonly Brush BackBrush;
         public readonly Color ForeColor;
+        public readonly Color GrayForeColor;
         public readonly Font NormalFont;
         public readonly Font BoldFont;
         public readonly Font MonospaceFont;
 
-        public CellStyle(Brush backBrush, Color foreColor, Font normalFont, Font boldFont, Font monospaceFont)
+        public CellStyle(Brush backBrush, Color foreColor, Color grayForeColor, Font normalFont, Font boldFont, Font monospaceFont)
         {
             BackBrush = backBrush;
             ForeColor = foreColor;
+            GrayForeColor = grayForeColor;
             NormalFont = normalFont;
             BoldFont = boldFont;
             MonospaceFont = monospaceFont;

--- a/GitUI/UserControls/RevisionGrid/CellStyle.cs
+++ b/GitUI/UserControls/RevisionGrid/CellStyle.cs
@@ -6,16 +6,16 @@ namespace GitUI.UserControls.RevisionGrid
     {
         public readonly Brush BackBrush;
         public readonly Color ForeColor;
-        public readonly Color GrayForeColor;
+        public readonly Color CommitBodyForeColor;
         public readonly Font NormalFont;
         public readonly Font BoldFont;
         public readonly Font MonospaceFont;
 
-        public CellStyle(Brush backBrush, Color foreColor, Color grayForeColor, Font normalFont, Font boldFont, Font monospaceFont)
+        public CellStyle(Brush backBrush, Color foreColor, Color commitBodyForeColor, Font normalFont, Font boldFont, Font monospaceFont)
         {
             BackBrush = backBrush;
             ForeColor = foreColor;
-            GrayForeColor = grayForeColor;
+            CommitBodyForeColor = commitBodyForeColor;
             NormalFont = normalFont;
             BoldFont = boldFont;
             MonospaceFont = monospaceFont;

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -202,8 +202,24 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 }
 
                 // Draw the summary text
-                var bounds = messageBounds.ReduceLeft(offset);
-                _grid.DrawColumnText(e, text, revision.ObjectId == _grid.CurrentCheckout ? style.BoldFont : normalFont, style.ForeColor, bounds);
+                var textBounds = messageBounds.ReduceLeft(offset);
+
+                var lines = text.SplitLines();
+                var commitTitle = lines.FirstOrDefault();
+                var commitDescriptionBuilder = new StringBuilder();
+                foreach (var line in lines.Skip(1))
+                {
+                    commitDescriptionBuilder.Append(' ').Append(line);
+                }
+
+                Font font = revision.ObjectId == _grid.CurrentCheckout ? style.BoldFont : normalFont;
+                int titleOffset = _grid.DrawColumnText(e, commitTitle, font, style.ForeColor, textBounds);
+
+                if (commitDescriptionBuilder.Length > 0)
+                {
+                    textBounds.Offset(titleOffset, y: 0);
+                    _grid.DrawColumnText(e, commitDescriptionBuilder.ToString(), font, style.GrayForeColor, textBounds);
+                }
 
                 // Draw the multi-line indicator
                 indicator.Render();
@@ -274,15 +290,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         {
             if (!revision.IsArtificial)
             {
-                if (revision.HasMultiLineMessage && revision.Body != null)
-                {
-                    e.Value = Regex.Replace(revision.Body.Trim(), "[\r\n]", " ");
-                }
-                else
-                {
-                    e.Value = revision.Subject.Trim();
-                }
-
+                e.Value = revision.Body?.Trim() ?? string.Empty;
                 e.FormattingApplied = true;
             }
         }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -336,22 +336,18 @@ namespace GitUI
 
         internal int DrawColumnText(DataGridViewCellPaintingEventArgs e, string text, Font font, Color color, Rectangle bounds, bool useEllipsis = true)
         {
-            var flags = TextFormatFlags.NoPrefix | TextFormatFlags.VerticalCenter | TextFormatFlags.NoPadding;
+            var flags =
+                TextFormatFlags.NoPrefix |
+                TextFormatFlags.VerticalCenter |
+                TextFormatFlags.NoPadding |
+                TextFormatFlags.SingleLine;
 
             if (useEllipsis)
             {
                 flags |= TextFormatFlags.EndEllipsis;
             }
 
-            var size = TextRenderer.MeasureText(
-                e.Graphics,
-                text,
-                font,
-                new Size(
-                    bounds.Width + 16,
-                    bounds.Height),
-                flags);
-
+            var size = TextRenderer.MeasureText(e.Graphics, text, font, bounds.Size, flags);
             TextRenderer.DrawText(e.Graphics, text, font, bounds, color, flags);
 
             _toolTipProvider.SetTruncation(e.ColumnIndex, e.RowIndex, truncated: size.Width > bounds.Width);


### PR DESCRIPTION
## Proposed changes
As [promised](https://github.com/gitextensions/gitextensions/pull/8371#issuecomment-694135580)

- Render commit body using gray text color in revision graph
to separate it from commit subject

- Apply draw non relatives text gray appearance setting to selected row
since now we have a ready-to use mechanism to produce a gray text color for highlighted text

- Split commit message rendering in Revision Grid to smaller methods

## Screenshots

unselected row
![image](https://user-images.githubusercontent.com/12046452/96352578-e1a51f80-10cc-11eb-96d5-7846c4c27a6d.png)

selected row
![image](https://user-images.githubusercontent.com/12046452/96352585-f4b7ef80-10cc-11eb-8656-dd44b4f9c77b.png)

draw non-relative text gray in selected row
![image](https://user-images.githubusercontent.com/12046452/96352595-07cabf80-10cd-11eb-989b-d31f23b8ad64.png)

## Test environment(s)
Tested manually in Windows10
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
