### PR TITLE
update button mnemonic for Reset button on Reset Form to "E"

### DIFF
--- a/GitUI/CommandsDialogs/FormResetChanges.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResetChanges.Designer.cs
@@ -53,7 +53,7 @@
             this.btnReset.Name = "btnReset";
             this.btnReset.Size = new System.Drawing.Size(95, 25);
             this.btnReset.TabIndex = 2;
-            this.btnReset.Text = "&Reset";
+            this.btnReset.Text = "R&eset";
             this.btnReset.UseVisualStyleBackColor = true;
             this.btnReset.Click += new System.EventHandler(this.btnReset_Click);
             // 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6117,7 +6117,7 @@ Forcing a branch to reset if it has not been merged might leave some commits unr
         <target />
       </trans-unit>
       <trans-unit id="btnReset.Text">
-        <source>&amp;Reset</source>
+        <source>R&amp;eset</source>
         <target />
       </trans-unit>
       <trans-unit id="cbDeleteNewFilesAndDirectories.Text">


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8467 


## Proposed changes
Set button mnemonic to "E" for the reset button on the reset form.


## Screenshots (during design time, mnemonic not shown during run-time)

### Before
![image](https://user-images.githubusercontent.com/7062409/96481061-09010700-1209-11eb-9cbe-34491b678128.png)

### After

![image](https://user-images.githubusercontent.com/7062409/96480138-dc002480-1207-11eb-891d-a569ddb410b1.png)

## Test methodology 
visual review.


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.28
- Windows 10

----
I agree to the Developer Certificate of Origin.

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
