### PR TITLE
Fixes #7557 - Dashboard: GitHub clone shortcut missing at initial load

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -883,6 +883,14 @@ namespace GitUI.CommandsDialogs
                         pluginsToolStripMenuItem.DropDownItems.Insert(0, item);
                     }
                 }
+
+                if (_dashboard?.Visible ?? false)
+                {
+                    // now that plugins are registered, populate Git-host-plugin actions on Dashboard, like "Clone GitHub repository"
+                    _dashboard.RefreshContent();
+                }
+
+                menuStrip1?.Refresh();
             }
 
             // Allow the plugin to perform any self-registration actions
@@ -1930,7 +1938,6 @@ namespace GitUI.CommandsDialogs
                 RevisionInfo.SetRevisionWithChildren(null, Array.Empty<ObjectId>());
                 UICommands.RepoChangedNotifier.Notify();
                 RevisionGrid.IndexWatcher.Reset();
-                RegisterPlugins();
             }
             else
             {
@@ -1940,6 +1947,8 @@ namespace GitUI.CommandsDialogs
                 MainSplitContainer.Visible = false;
                 ShowDashboard();
             }
+
+            RegisterPlugins();
         }
 
         private void TranslateToolStripMenuItemClick(object sender, EventArgs e)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7557 - Dashboard: GitHub clone shortcut missing at initial load

## Proposed changes

- refresh the UI when plugins are done registering
- also re-register plugins whenever setting git module to an invalid git repo (means we are going to the dashboard)

### Before

Opening straight to the dashboard has missing plugin-action entries under "Clone repository"
![image](https://user-images.githubusercontent.com/14078392/96520967-36b47300-123e-11eb-81b8-c578b3a27840.png)

Closing out of a repo to the dashboard has missing plugin action menus
![image](https://user-images.githubusercontent.com/14078392/96521092-767b5a80-123e-11eb-8f8d-ba7e6da05d98.png)


### After

A refresh is done when opening straight to the dashboard to render the asynchronously loaded Git-host plugins
![image](https://user-images.githubusercontent.com/14078392/96521183-ad517080-123e-11eb-8210-c1520cc9ca3d.png)

Similar behavior occurs when closing out to the dashboard from a valid repo


## Test methodology <!-- How did you ensure quality? -->

- interactive testing with changes (launching straight from Visual Studio), compared against a clean install from my machine

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.28.0.windows.1
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
