### PR TITLE
Add paddings and borders for panels

### DIFF
--- a/GitExtUtils/GitUI/Theming/ColorHelper.cs
+++ b/GitExtUtils/GitUI/Theming/ColorHelper.cs
@@ -186,7 +186,7 @@ namespace GitExtUtils.GitUI.Theming
         }
 
         public static Color GetSplitterColor() =>
-            KnownColor.ControlLight.MakeBackgroundDarkerBy(0.035);
+            KnownColor.Window.MakeBackgroundDarkerBy(0);
 
         public static void AdaptImageLightness(this ToolStripItem item) =>
             item.Image = ((Bitmap)item.Image)?.AdaptLightness();

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -134,7 +134,7 @@ namespace GitUI.BranchTreePanel
             this.treeMain.Name = "treeMain";
             this.treeMain.PathSeparator = "/";
             this.treeMain.ShowNodeToolTips = true;
-            this.treeMain.Size = new System.Drawing.Size(300, 350);
+            this.treeMain.Size = new System.Drawing.Size(300, 150);
             this.treeMain.TabIndex = 3;
             // 
             // menuMain

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -670,6 +670,8 @@ namespace GitUI.CommandsDialogs
             // MainSplitContainer.Panel1
             // 
             this.MainSplitContainer.Panel1.Controls.Add(this.repoObjectsTree);
+            this.MainSplitContainer.Panel1.Padding = new System.Windows.Forms.Padding(1);
+            this.MainSplitContainer.Panel1MinSize = 192;
             // 
             // MainSplitContainer.Panel2
             // 
@@ -717,6 +719,8 @@ namespace GitUI.CommandsDialogs
             this.RevisionsSplitContainer.Location = new System.Drawing.Point(0, 0);
             this.RevisionsSplitContainer.Margin = new System.Windows.Forms.Padding(0);
             this.RevisionsSplitContainer.Name = "RevisionsSplitContainer";
+            this.RevisionsSplitContainer.Panel1.Padding = new System.Windows.Forms.Padding(1);
+            this.RevisionsSplitContainer.Panel2.Padding = new System.Windows.Forms.Padding(1);
             // 
             // RevisionsSplitContainer.Panel1
             // 
@@ -740,7 +744,6 @@ namespace GitUI.CommandsDialogs
             // 
             this.RevisionGrid.Dock = System.Windows.Forms.DockStyle.Fill;
             this.RevisionGrid.Location = new System.Drawing.Point(0, 0);
-            this.RevisionGrid.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.RevisionGrid.Name = "RevisionGrid";
             this.RevisionGrid.Size = new System.Drawing.Size(350, 209);
             this.RevisionGrid.TabIndex = 0;
@@ -1737,14 +1740,15 @@ namespace GitUI.CommandsDialogs
             // 
             this.toolPanel.ContentPanel.Controls.Add(this.MainSplitContainer);
             this.toolPanel.ContentPanel.Margin = new System.Windows.Forms.Padding(0);
-            this.toolPanel.ContentPanel.Padding = new System.Windows.Forms.Padding(0, 4, 0, 0);
+            this.toolPanel.ContentPanel.Padding = new System.Windows.Forms.Padding(8);
             this.toolPanel.ContentPanel.Size = new System.Drawing.Size(1846, 1023);
             this.toolPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.toolPanel.LeftToolStripPanelVisible = false;
             this.toolPanel.Location = new System.Drawing.Point(0, 24);
             this.toolPanel.Margin = new System.Windows.Forms.Padding(0);
             this.toolPanel.Name = "toolPanel";
-            this.toolPanel.Padding = new System.Windows.Forms.Padding(0, 2, 0, 0);
+            this.toolPanel.Padding = new System.Windows.Forms.Padding(0);
+            this.toolPanel.TopToolStripPanel.Padding = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.toolPanel.RightToolStripPanelVisible = false;
             this.toolPanel.Size = new System.Drawing.Size(923, 527);
             this.toolPanel.TabIndex = 1;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3134,6 +3134,11 @@ namespace GitUI.CommandsDialogs
 
             RevisionInfo.Parent.BackColor = RevisionInfo.BackColor;
             RevisionInfo.ResumeLayout(performLayout: true);
+
+            MainSplitContainer.Panel1.BackColor = Color.LightGray.AdaptBackColor();
+            RevisionsSplitContainer.Panel1.BackColor = Color.LightGray.AdaptBackColor();
+            RevisionsSplitContainer.Panel2.BackColor = Color.LightGray.AdaptBackColor();
+
             CommitInfoTabControl.ResumeLayout(performLayout: true);
             RevisionsSplitContainer.ResumeLayout(performLayout: true);
         }

--- a/GitUI/CommandsDialogs/FullBleedTabControl.cs
+++ b/GitUI/CommandsDialogs/FullBleedTabControl.cs
@@ -15,9 +15,9 @@ namespace GitUI.CommandsDialogs
             {
                 var rc = (RECT)m.GetLParam(typeof(RECT));
                 rc.Left -= 3;
-                rc.Right += 1;
+                rc.Right += 3;
                 rc.Top -= 1;
-                rc.Bottom += 2;
+                rc.Bottom += 3;
                 Marshal.StructureToPtr(rc, m.LParam, true);
             }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Add paddings and borders for panels.
- Adds expressiveness and allows to clearly delineate the main panels.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/3169265/96533912-70fe2e80-1297-11eb-9c24-9e974b9a73a3.png)

### After

![image](https://user-images.githubusercontent.com/3169265/96533936-7bb8c380-1297-11eb-93ad-8a75dc4c0ef5.png)
![image](https://user-images.githubusercontent.com/3169265/96533942-807d7780-1297-11eb-8599-34214abf890c.png)
![image](https://user-images.githubusercontent.com/3169265/96533971-8c693980-1297-11eb-9787-5596cccaca25.png)

It would be nice to make the colors softer. Like this.

![2020-10-20 052832](https://user-images.githubusercontent.com/3169265/96534071-b3c00680-1297-11eb-8027-6728fdedb59f.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual
- Visually

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
