### PR TITLE
Add dialog help that navigates to the docs

### DIFF
--- a/GitUI/CommandsDialogs/FormCheckoutBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.Designer.cs
@@ -411,7 +411,9 @@ namespace GitUI.CommandsDialogs
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(626, 260);
-            this.DoubleBuffered = true;
+            this.HelpButton = true;
+            this.ManualSectionAnchorName = "checkout-branch";
+            this.ManualSectionSubfolder = "branches";
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "FormCheckoutBranch";

--- a/GitUI/CommandsDialogs/FormClone.Designer.cs
+++ b/GitUI/CommandsDialogs/FormClone.Designer.cs
@@ -378,6 +378,9 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(647, 351);
+            this.HelpButton = true;
+            this.ManualSectionAnchorName = "clone-repository";
+            this.ManualSectionSubfolder = "getting_started";
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "FormClone";

--- a/GitUI/CommandsDialogs/FormCreateBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.Designer.cs
@@ -41,7 +41,6 @@
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.gotoUserManualControl1 = new GitUI.UserControls.GotoUserManualControl();
             this.MainPanel.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             this.groupBox1.SuspendLayout();
@@ -52,7 +51,7 @@
             // 
             this.MainPanel.Controls.Add(this.Ok);
             this.MainPanel.Controls.Add(this.tableLayoutPanel1);
-            this.MainPanel.Size = new System.Drawing.Size(480, 203);
+            this.MainPanel.Size = new System.Drawing.Size(480, 175);
             // 
             // label2
             // 
@@ -139,15 +138,19 @@
             // 
             // Ok
             // 
-            this.Ok.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.Ok.AutoSize = true;
+            this.Ok.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.Ok.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.Ok.Image = global::GitUI.Properties.Images.BranchCreate;
             this.Ok.ImageAlign = System.Drawing.ContentAlignment.TopLeft;
-            this.Ok.Location = new System.Drawing.Point(-2, 3);
+            this.Ok.Location = new System.Drawing.Point(7, 3);
             this.Ok.MinimumSize = new System.Drawing.Size(75, 23);
             this.Ok.Name = "Ok";
-            this.Ok.Size = new System.Drawing.Size(75, 23);
+            this.Ok.Size = new System.Drawing.Size(100, 23);
             this.Ok.TabIndex = 7;
             this.Ok.Text = "&Create branch";
+            this.Ok.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.Ok.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
             this.Ok.UseVisualStyleBackColor = true;
             this.Ok.Click += new System.EventHandler(this.OkClick);
             // 
@@ -166,17 +169,16 @@
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.label2, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.chkbxCheckoutAfterCreate, 1, 2);
-            this.tableLayoutPanel1.Controls.Add(this.gotoUserManualControl1, 0, 4);
             this.tableLayoutPanel1.Location = new System.Drawing.Point(9, 9);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 5;
+            this.tableLayoutPanel1.RowCount = 4;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 28F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 28F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 28F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(462, 173);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(462, 142);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // groupBox1
@@ -207,29 +209,18 @@
             this.flowLayoutPanel1.Size = new System.Drawing.Size(440, 23);
             this.flowLayoutPanel1.TabIndex = 1;
             // 
-            // gotoUserManualControl1
-            // 
-            this.gotoUserManualControl1.AutoSize = true;
-            this.gotoUserManualControl1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.gotoUserManualControl1.Location = new System.Drawing.Point(3, 150);
-            this.gotoUserManualControl1.ManualSectionAnchorName = "create-branch";
-            this.gotoUserManualControl1.ManualSectionSubfolder = "branches";
-            this.gotoUserManualControl1.Margin = new System.Windows.Forms.Padding(3, 8, 3, 3);
-            this.gotoUserManualControl1.MinimumSize = new System.Drawing.Size(70, 20);
-            this.gotoUserManualControl1.Name = "gotoUserManualControl1";
-            this.gotoUserManualControl1.Size = new System.Drawing.Size(70, 20);
-            this.gotoUserManualControl1.TabIndex = 8;
-            // 
             // FormCreateBranch
             // 
             this.AcceptButton = this.Ok;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(480, 235);
-            this.DoubleBuffered = true;
+            this.ClientSize = new System.Drawing.Size(480, 207);
+            this.HelpButton = true;
+            this.ManualSectionAnchorName = "create-branch";
+            this.ManualSectionSubfolder = "branches";
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(480, 250);
+            this.MinimumSize = new System.Drawing.Size(480, 246);
             this.Name = "FormCreateBranch";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Create branch";
@@ -256,7 +247,6 @@
         private System.Windows.Forms.Label label2;
         private UserControls.CommitPickerSmallControl commitPickerSmallControl1;
         private System.Windows.Forms.GroupBox groupBox1;
-        private UserControls.GotoUserManualControl gotoUserManualControl1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Button Ok;
         private System.Windows.Forms.CheckBox chkbxCheckoutAfterCreate;

--- a/GitUI/CommandsDialogs/FormInit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormInit.Designer.cs
@@ -129,6 +129,9 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(542, 173);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.HelpButton = true;
+            this.ManualSectionAnchorName = "create-new-repository";
+            this.ManualSectionSubfolder = "getting_started";
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "FormInit";

--- a/GitUI/GitExtensionsDialog.Designer.cs
+++ b/GitUI/GitExtensionsDialog.Designer.cs
@@ -65,6 +65,7 @@ namespace GitUI
             this.ClientSize = new System.Drawing.Size(553, 337);
             this.Controls.Add(this.MainPanel);
             this.Controls.Add(this.ControlsPanel);
+            this.DoubleBuffered = true;
             this.Name = "GitExtensionsDialog";
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/GitUI/GitExtensionsDialog.cs
+++ b/GitUI/GitExtensionsDialog.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
 using GitExtUtils.GitUI.Theming;
@@ -30,6 +31,43 @@ namespace GitUI
 
             // Lighten up the control panel
             ControlsPanel.BackColor = KnownColor.ControlLight.MakeBackgroundDarkerBy(-0.04);
+        }
+
+        /// <summary>
+        /// Gets or sets the anchor pointing to a section in the manual pertaining to this dialog.
+        /// </summary>
+        /// <remarks>
+        /// The URL structure:
+        /// https://git-extensions-documentation.readthedocs.io/en/latest/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}
+        /// </remarks>
+        public string ManualSectionAnchorName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of a document pertaining to this dialog.
+        /// </summary>
+        /// <remarks>
+        /// The URL structure:
+        /// https://git-extensions-documentation.readthedocs.io/en/latest/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}
+        /// </remarks>
+        public string ManualSectionSubfolder { get; set; }
+
+        protected override void OnHelpButtonClicked(CancelEventArgs e)
+        {
+            // If we show the Help button but we have failed to specify where the docs are -> hide the button, and exit
+            if (string.IsNullOrWhiteSpace(ManualSectionAnchorName) || string.IsNullOrWhiteSpace(ManualSectionSubfolder))
+            {
+                HelpButton = false;
+                e.Cancel = true;
+                return;
+            }
+
+            base.OnHelpButtonClicked(e);
+
+            string url = UserManual.UserManual.UrlFor(ManualSectionSubfolder, ManualSectionAnchorName);
+            OsShellUtil.OpenUrlInDefaultBrowser(url);
+
+            // We've handled the event
+            e.Cancel = true;
         }
     }
 }


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Addendum to #8490 

## Proposed changes

- Fix button layout in `FormCreateBranch` which slipped in #8490 due to an incorrect rebase.
- Replace the custom `GotoUserManualControl` control on dialogs that inherit from `GitExtensionsDialog` with the Windows default help mechanics, i.e. [?] button in the caption box of a dialog.
- Add missing links for the existing forms.


## Screenshots <!-- Remove this section if PR does not change UI -->

* Before:
![image](https://user-images.githubusercontent.com/4403806/96551462-10560c80-12fe-11eb-9bf8-f3f83c72866d.png)


* After
![image](https://user-images.githubusercontent.com/4403806/96585259-10b8cc80-132b-11eb-9c5d-602dc0291256.png)
![image](https://user-images.githubusercontent.com/4403806/96584661-49a47180-132a-11eb-8a15-61f57b8c974b.png)
![image](https://user-images.githubusercontent.com/4403806/96584670-4dd08f00-132a-11eb-863f-3d69a00cc993.png)
![image](https://user-images.githubusercontent.com/4403806/96584674-4f9a5280-132a-11eb-893a-55c868065101.png)




----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
