### PR TITLE
Ahead/behind show up-to-date and gone

### DIFF
--- a/GitCommands/Git/AheadBehindData.cs
+++ b/GitCommands/Git/AheadBehindData.cs
@@ -2,15 +2,22 @@
 {
     public struct AheadBehindData
     {
+        // gone: "plumbing" expression, see https://git-scm.com/docs/git-for-each-ref#Documentation/git-for-each-ref.txt-upstream
+        public static readonly string Gone = "gone";
         public string Branch { get; set; }
         public string AheadCount { get; set; }
         public string BehindCount { get; set; }
 
         public string ToDisplay()
         {
-            return (!string.IsNullOrEmpty(AheadCount) ? AheadCount + "↑" : string.Empty)
-                   + (!string.IsNullOrEmpty(AheadCount) && !string.IsNullOrEmpty(BehindCount) ? " " : string.Empty)
-                   + (!string.IsNullOrEmpty(BehindCount) ? BehindCount + "↓" : string.Empty);
+            return AheadCount == Gone
+                ? AheadBehindData.Gone
+                : AheadCount == "0" && string.IsNullOrEmpty(BehindCount)
+                ? "0↑↓"
+                : (!string.IsNullOrEmpty(AheadCount) && AheadCount != "0"
+                    ? AheadCount + "↑" + (!string.IsNullOrEmpty(BehindCount) ? " " : string.Empty)
+                    : string.Empty)
+                + (!string.IsNullOrEmpty(BehindCount) ? BehindCount + "↓" : string.Empty);
         }
     }
 }

--- a/GitCommands/Git/AheadBehindDataProvider.cs
+++ b/GitCommands/Git/AheadBehindDataProvider.cs
@@ -17,10 +17,15 @@ namespace GitCommands.Git
     {
         private readonly Func<IExecutable> _getGitExecutable;
 
-        // TODO handle [gone] status to show that remote branch no longer exists
+        // Parse info about remote branches, see below for explanation
+        // This assumes that the Git output is not localised
         private readonly Regex _aheadBehindRegEx =
-            new Regex(@"^(\[(ahead (?<ahead_p>\d+))?(, )?(behind (?<behind_p>\d+))?\])?::(\[(ahead (?<ahead_u>\d+))?(, )?(behind (?<behind_u>\d+))?\])?::(?<branch>.*)$",
-                RegexOptions.Compiled | RegexOptions.Multiline);
+            new Regex(
+                @"^((?<gone_p>gone)|((ahead\s(?<ahead_p>\d+))?(,\s)?(behind\s(?<behind_p>\d+))?)|(?<unk_p>.*?))::
+                   ((?<gone_u>gone)|((ahead\s(?<ahead_u>\d+))?(,\s)?(behind\s(?<behind_u>\d+))?)|(?<unk_u>.*?))::
+                   (?<remote_p>.*?)::(?<remote_u>.*?)::(?<branch>.*)$",
+                RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnorePatternWhitespace | RegexOptions.ExplicitCapture);
+        private readonly string _refFormat = @"%(push:track,nobracket)::%(upstream:track,nobracket)::%(push)::%(upstream)::%(refname:short)";
 
         public AheadBehindDataProvider(Func<IExecutable> getGitExecutable)
         {
@@ -46,14 +51,15 @@ namespace GitCommands.Git
                 throw new ArgumentException(nameof(branchName));
             }
 
-            if (branchName == "(no branch)")
+            if (branchName == DetachedHeadParser.DetachedBranch)
             {
                 return null;
             }
 
             var aheadBehindGitCommand = new GitArgumentBuilder("for-each-ref")
             {
-                "--format=\"%(push:track)::%(upstream:track)::%(refname:short)\"",
+                $"--color=never",
+                $"--format=\"{_refFormat}\"",
                 "refs/heads/" + branchName
             };
 
@@ -64,24 +70,52 @@ namespace GitCommands.Git
             }
 
             var matches = _aheadBehindRegEx.Matches(result);
-            if (matches.Count < 1 || (matches.Count == 1 && (!matches[0].Groups["branch"].Success ||
-                                                             !(matches[0].Groups["ahead_p"].Success || matches[0].Groups["ahead_u"].Success ||
-                                                               matches[0].Groups["behind_p"].Success || matches[0].Groups["behind_u"].Success))))
-            {
-                return null;
-            }
-
             var aheadBehindForBranchesData = new Dictionary<string, AheadBehindData>();
             foreach (Match match in matches)
             {
+                var branch = match.Groups["branch"].Value;
+                var remoteRef = (match.Groups["remote_p"].Success && !string.IsNullOrEmpty(match.Groups["remote_p"].Value))
+                    ? match.Groups["remote_p"].Value
+                    : match.Groups["remote_u"].Value;
+                if (string.IsNullOrEmpty(branch) || string.IsNullOrEmpty(remoteRef))
+                {
+                    continue;
+                }
+
+#pragma warning disable SA1515 // Single-line comment should be preceded by blank line
                 aheadBehindForBranchesData.Add(match.Groups["branch"].Value,
                     new AheadBehindData
                     {
-                        // The information is displayed in the push button, so the push info  is preferred (may differ from upstream)
-                        Branch = match.Groups["branch"].Value,
-                        AheadCount = match.Groups["ahead_p"].Success ? match.Groups["ahead_p"].Value : match.Groups["ahead_u"].Value,
-                        BehindCount = match.Groups["behind_p"].Success ? match.Groups["behind_p"].Value : match.Groups["behind_u"].Value
+                        // The information is displayed in the push button, so the push info is preferred (may differ from upstream)
+                        Branch = branch,
+                        AheadCount =
+                            // Prefer push to upstream for the count
+                            match.Groups["ahead_p"].Success
+                            // Single-line comment should be preceded by blank line
+                            ? match.Groups["ahead_p"].Value
+                            // If behind is set for push, ahead is null
+                            : match.Groups["behind_p"].Success
+                            ? string.Empty
+                            : match.Groups["ahead_u"].Success
+                            ? match.Groups["ahead_u"].Value
+                            // No information about the remote branch, it is gone
+                            : match.Groups["gone_p"].Success || match.Groups["gone_u"].Success
+                            ? AheadBehindData.Gone
+                            // If the printout is unknown (translated?), do not assume that there are "0" changes
+                            : (match.Groups["unk_p"].Success && !string.IsNullOrWhiteSpace(match.Groups["unk_p"].Value))
+                                || (match.Groups["unk_u"].Success && !string.IsNullOrWhiteSpace(match.Groups["unk_u"].Value))
+                            ? string.Empty
+                            // A remote exists, but "track" does not display the count if ahead/behind match
+                            : "0",
+
+                        // Behind do not track '0' or 'gone', only in Ahead
+                        BehindCount = match.Groups["behind_p"].Success
+                            ? match.Groups["behind_p"].Value
+                            : !match.Groups["ahead_p"].Success
+                            ? match.Groups["behind_u"].Value
+                            : string.Empty
                     });
+#pragma warning restore SA1515
             }
 
             return aheadBehindForBranchesData;

--- a/UnitTests/GitCommands.Tests/Git/AheadBehindDataProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/AheadBehindDataProviderTests.cs
@@ -68,30 +68,60 @@ namespace GitCommandsTests.Git
             _provider.GetTestAccessor().GetData(Encoding.UTF8, "**").Should().BeNull();
         }
 
-        [TestCase("::::my-branch")]
-        [TestCase("::[gone]::branch-with-no-more-remote")]
-        [TestCase("::::")]
-        public void GetData_should_return_null_if_git_output_has_no_data(string result)
+        [TestCase("")]
+        [TestCase(null)]
+        public void GetData_should_return_null_result_if_unable_match_branch(string result)
         {
             SetResultOfGitCommand(result);
-
-            _provider.GetTestAccessor().GetData(Encoding.UTF8, "my-branch").Should().BeNull();
-        }
-
-        [Test]
-        public void GetData_should_return_empty_result_if_unable_match_branch()
-        {
-            SetResultOfGitCommand("results!");
 
             var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "**");
 
             data.Should().BeNull();
         }
 
+        [TestCase("::::::::my-branch")]
+        [TestCase("::gone::::::branch-with-no-more-remote")]
+        [TestCase("::::::::")]
+        [TestCase("results!")]
+        public void GetData_should_return_empty_if_git_output_has_no_data(string result)
+        {
+            SetResultOfGitCommand(result);
+
+            var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "**");
+
+            data.Should().HaveCount(0);
+        }
+
+        [TestCase("::ahead 1::::::my-branch")]
+        [TestCase("results!")]
+        public void GetData_should_return_empty_if_no_remote(string result)
+        {
+            SetResultOfGitCommand(result);
+
+            var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "**");
+
+            data.Should().HaveCount(0);
+        }
+
+        [Test]
+        public void GetData_should_return_empty_string_for_unknown()
+        {
+            SetResultOfGitCommand("::translated-ahead 3::::refs/remotes/upstream/branch::my-branch");
+
+            var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "my-branch");
+
+            data.Should().HaveCount(1);
+            var aheadBehindData = data.Values.First();
+            aheadBehindData.AheadCount.Should().Be(string.Empty);
+            aheadBehindData.BehindCount.Should().Be(string.Empty);
+            aheadBehindData.Branch.Should().Be("my-branch");
+            aheadBehindData.ToDisplay().Should().Be(string.Empty);
+        }
+
         [Test]
         public void GetData_should_return_ahead_for_a_branch()
         {
-            SetResultOfGitCommand("::[ahead 10]::my-branch");
+            SetResultOfGitCommand("::ahead 10::::refs/remotes/upstream/branch::my-branch");
 
             var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "my-branch");
 
@@ -106,22 +136,38 @@ namespace GitCommandsTests.Git
         [Test]
         public void GetData_should_return_behind_for_a_branch()
         {
-            SetResultOfGitCommand("::[behind 2]::my-branch");
+            SetResultOfGitCommand("::behind 2::::refs/remotes/upstream/my-branch::my-branch");
 
             var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "my-branch");
 
             data.Should().HaveCount(1);
             var aheadBehindData = data.Values.First();
-            aheadBehindData.AheadCount.Should().Be(string.Empty);
+            aheadBehindData.AheadCount.Should().Be("0");
             aheadBehindData.BehindCount.Should().Be("2");
             aheadBehindData.Branch.Should().Be("my-branch");
             aheadBehindData.ToDisplay().Should().Be("2↓");
         }
 
         [Test]
-        public void GetData_should_return_ahead_and_behind_for_a_branch()
+        public void GetData_should_return_zero_for_a_branch()
         {
-            SetResultOfGitCommand("::[ahead 99, behind 3]::my-branch");
+            SetResultOfGitCommand("::::::refs/remotes/upstream/my-branch::my-branch");
+
+            var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "my-branch");
+
+            data.Should().HaveCount(1);
+            var aheadBehindData = data.Values.First();
+            aheadBehindData.AheadCount.Should().Be("0");
+            aheadBehindData.BehindCount.Should().Be("");
+            aheadBehindData.Branch.Should().Be("my-branch");
+            aheadBehindData.ToDisplay().Should().Be("0↑↓");
+        }
+
+        [TestCase("::ahead 99, behind 3::::refs/remotes/upstream/my-branch::my-branch")]
+        [TestCase("ahead 99, behind 3::::refs/remotes/upstream/my-branch::::my-branch")]
+        public void GetData_should_return_ahead_and_behind_for_a_branch(string result)
+        {
+            SetResultOfGitCommand(result);
 
             var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "my-branch");
 
@@ -133,24 +179,70 @@ namespace GitCommandsTests.Git
             aheadBehindData.ToDisplay().Should().Be("99↑ 3↓");
         }
 
+        [TestCase("ahead 99, behind 97::ahead 9, behind 7::refs/remotes/upstream/push-branch::refs/remotes/upstream/upstream-branch::my-branch")]
+        public void GetData_should_prefer_push_before_upstream_ahead_behind(string result)
+        {
+            SetResultOfGitCommand(result);
+
+            var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "my-branch");
+
+            data.Should().HaveCount(1);
+            var aheadBehindData = data.Values.First();
+            aheadBehindData.AheadCount.Should().Be("99");
+            aheadBehindData.BehindCount.Should().Be("97");
+            aheadBehindData.Branch.Should().Be("my-branch");
+            aheadBehindData.ToDisplay().Should().Be("99↑ 97↓");
+        }
+
+        [TestCase("ahead 99::ahead 9, behind 7::refs/remotes/upstream/push-branch::refs/remotes/upstream/upstream-branch::my-branch")]
+        public void GetData_should_prefer_push_before_upstream_ahead(string result)
+        {
+            SetResultOfGitCommand(result);
+
+            var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "my-branch");
+
+            data.Should().HaveCount(1);
+            var aheadBehindData = data.Values.First();
+            aheadBehindData.AheadCount.Should().Be("99");
+            aheadBehindData.BehindCount.Should().Be("");
+            aheadBehindData.Branch.Should().Be("my-branch");
+            aheadBehindData.ToDisplay().Should().Be("99↑");
+        }
+
+        [TestCase("behind 97::ahead 9, behind 7::refs/remotes/upstream/push-branch::refs/remotes/upstream/upstream-branch::my-branch")]
+        public void GetData_should_prefer_push_before_upstream_behind(string result)
+        {
+            SetResultOfGitCommand(result);
+
+            var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "my-branch");
+
+            data.Should().HaveCount(1);
+            var aheadBehindData = data.Values.First();
+            aheadBehindData.AheadCount.Should().Be("");
+            aheadBehindData.BehindCount.Should().Be("97");
+            aheadBehindData.Branch.Should().Be("my-branch");
+            aheadBehindData.ToDisplay().Should().Be("97↓");
+        }
+
         [Test]
         public void GetData_should_return_ahead_and_behind_for_all_branches()
         {
-            SetResultOfGitCommand("::branch-not-changed\n"
-                    + "::[gone]::branch-with-no-more-remote\n"
-                    + "::[ahead 99, behind 3]::ahead-behind-branch\n"
-                    + "::[ahead 3]::ahead-branch\n"
-                    + "::[behind 4]::behind-branch");
+            SetResultOfGitCommand("::::::::branch-not-changed\n"
+                    + "::gone::::refs/remotes/upstream/branch::branch-with-no-more-remote\n"
+                    + "::ahead 99, behind 3::::refs/remotes/upstream/branch::ahead-behind-branch\n"
+                    + "::ahead 3::::refs/remotes/upstream/branch::ahead-branch\n"
+                    + "::behind 4::::refs/remotes/upstream/branch::behind-branch");
 
             var data = _provider.GetTestAccessor().GetData(Encoding.UTF8, "*");
 
-            data.Should().HaveCount(3);
+            data.Should().HaveCount(4);
             data.Should().BeEquivalentTo(
                 new Dictionary<string, AheadBehindData>
                 {
+                    { "branch-with-no-more-remote", new AheadBehindData { AheadCount = "gone", BehindCount = "", Branch = "branch-with-no-more-remote" } },
                     { "ahead-behind-branch", new AheadBehindData { AheadCount = "99", BehindCount = "3", Branch = "ahead-behind-branch" } },
                     { "ahead-branch", new AheadBehindData { AheadCount = "3", BehindCount = string.Empty, Branch = "ahead-branch" } },
-                    { "behind-branch", new AheadBehindData { AheadCount = string.Empty, BehindCount = "4", Branch = "behind-branch" } },
+                    { "behind-branch", new AheadBehindData { AheadCount = "0", BehindCount = "4", Branch = "behind-branch" } },
                 });
         }
 


### PR DESCRIPTION
First part of #8553 


## Proposed changes

- Show ahead/behind if remote is up to date
- Show if the tracking branch no longer exists "gone"

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Only the branch with differences displays the count
![branch-before](https://user-images.githubusercontent.com/6248932/96507421-6de44d80-1259-11eb-84e5-3983b5a3fd2b.JPG)

No indication if the branches are up to date
![push-none](https://user-images.githubusercontent.com/6248932/96507433-72a90180-1259-11eb-8e7c-27a5cec1171f.JPG)

### After

feature/i8553-ahead-zero-gone is not yet pushed
feature/i8548-multiple-force-push is deleted at the remote
feature/i8448-presentation is pushed and in sync with the remote
feature/i8448-range-diff-3 same as above (not displayed)
![branch-after](https://user-images.githubusercontent.com/6248932/96507774-efd47680-1259-11eb-8296-5c56362b63b1.JPG)

After a branch is pushed
![push-after](https://user-images.githubusercontent.com/6248932/96507812-febb2900-1259-11eb-8ea2-1a725b4b4ad2.JPG)


## Test methodology 

Tests adapted and expanded

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
