### PR TITLE
Draw a separator line at the top of the footer panel, similar to what Task Dialog does

### DIFF
--- a/GitUI/GitExtensionsDialog.cs
+++ b/GitUI/GitExtensionsDialog.cs
@@ -13,6 +13,8 @@ namespace GitUI
     /// <remarks>Includes support for font, hotkey, icon, translation, and position restore.</remarks>
     public partial class GitExtensionsDialog : GitModuleForm
     {
+        private static readonly Pen FooterDividerPen = new Pen(KnownColor.ControlLight.MakeBackgroundDarkerBy(0.04));
+
         /// <summary>Creates a new <see cref="GitExtensionsForm"/> without position restore.</summary>
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         protected GitExtensionsDialog()
@@ -31,6 +33,10 @@ namespace GitUI
 
             // Lighten up the control panel
             ControlsPanel.BackColor = KnownColor.ControlLight.MakeBackgroundDarkerBy(-0.04);
+
+            // Draw a separator line at the top of the footer panel, similar to what Task Dialog does
+            ControlsPanel.Paint += (s, e)
+                => e.Graphics.DrawLine(FooterDividerPen, new Point(e.ClipRectangle.Left, 0), new Point(e.ClipRectangle.Right, 0));
         }
 
         /// <summary>


### PR DESCRIPTION


# Screenshots <!-- Remove this section if PR does not change UI -->

* Task Dialog
![image](https://user-images.githubusercontent.com/4403806/94383498-952c8b00-0183-11eb-88f2-44fd3bacdce1.png)


* GitExtensionsDialog

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/4403806/96721841-6909d000-13f8-11eb-8fda-78498bbfac83.png) | ![image](https://user-images.githubusercontent.com/4403806/96721517-f698f000-13f7-11eb-8a12-fa52d9ca14af.png) |
| ![image](https://user-images.githubusercontent.com/4403806/96721788-5a231d80-13f8-11eb-8eeb-04b6ff073a18.png)  | ![image](https://user-images.githubusercontent.com/4403806/96721369-c2bdca80-13f7-11eb-85b1-d49a13882c9f.png) |




----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
