### PR TITLE
Reduced the number of draw calls on the commit info panel.

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -291,7 +291,6 @@ namespace GitUI.CommitInfo
 
             if (_revision != null && !_revision.IsArtificial)
             {
-                UpdateRevisionInfo();
                 StartAsyncDataLoad();
             }
 
@@ -321,37 +320,46 @@ namespace GitUI.CommitInfo
             void StartAsyncDataLoad()
             {
                 var cancellationToken = _asyncLoadCancellation.Next();
-
                 var initialRevision = _revision;
-
-                ThreadHelper.JoinableTaskFactory.RunAsync(async () => { await LoadLinksForRevisionAsync(initialRevision); }).FileAndForget();
 
                 ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
+                    var tasks = new List<Task>();
+
+                    tasks.Add(LoadLinksForRevisionAsync(initialRevision));
+
                     // No branch/tag data for artificial commands
                     if (AppSettings.CommitInfoShowContainedInBranches)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        await LoadBranchInfoAsync(initialRevision.ObjectId);
+
+                        tasks.Add(LoadBranchInfoAsync(initialRevision.ObjectId));
                     }
 
                     if (AppSettings.ShowAnnotatedTagsMessages)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        await LoadAnnotatedTagInfoAsync(initialRevision.Refs);
+
+                        tasks.Add(LoadAnnotatedTagInfoAsync(initialRevision.Refs));
                     }
 
                     if (AppSettings.CommitInfoShowContainedInTags)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        await LoadTagInfoAsync(initialRevision.ObjectId);
+
+                        tasks.Add(LoadTagInfoAsync(initialRevision.ObjectId));
                     }
 
                     if (AppSettings.CommitInfoShowTagThisCommitDerivesFrom)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        await LoadDescribeInfoAsync(initialRevision.ObjectId);
+
+                        tasks.Add(LoadDescribeInfoAsync(initialRevision.ObjectId));
                     }
+
+                    await Task.WhenAll(tasks);
+
+                    UpdateRevisionInfo();
                 }).FileAndForget();
 
                 return;
@@ -374,7 +382,6 @@ namespace GitUI.CommitInfo
 
                     await this.SwitchToMainThreadAsync(cancellationToken);
                     _linksInfo = linksInfo;
-                    UpdateRevisionInfo();
 
                     return;
 
@@ -400,7 +407,6 @@ namespace GitUI.CommitInfo
 
                     await this.SwitchToMainThreadAsync(cancellationToken);
                     _annotatedTagsMessages = annotatedTagsMessages;
-                    UpdateRevisionInfo();
 
                     return;
 
@@ -463,7 +469,6 @@ namespace GitUI.CommitInfo
 
                     await this.SwitchToMainThreadAsync(cancellationToken);
                     _tags = tags;
-                    UpdateRevisionInfo();
                 }
 
                 async Task LoadBranchInfoAsync(ObjectId revision)
@@ -481,7 +486,6 @@ namespace GitUI.CommitInfo
 
                     await this.SwitchToMainThreadAsync(cancellationToken);
                     _branches = branches;
-                    UpdateRevisionInfo();
                 }
 
                 async Task LoadDescribeInfoAsync(ObjectId commitId)
@@ -492,7 +496,6 @@ namespace GitUI.CommitInfo
 
                     await this.SwitchToMainThreadAsync(cancellationToken);
                     _gitDescribeInfo = info;
-                    UpdateRevisionInfo();
 
                     return;
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Reduce the number of calls to the UpdateRevisionInfo method.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![2](https://user-images.githubusercontent.com/3169265/96807529-7ab29e00-141f-11eb-998b-6ae2ab72ef5e.gif)

### After

![3](https://user-images.githubusercontent.com/3169265/96807549-843c0600-141f-11eb-9580-1322dbf1de3d.gif)

## Test methodology <!-- How did you ensure quality? -->

- Manual
- Visual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build a1c3adc78a89fed5f0d6074454164ee42a5eba65 (Dirty)
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4250.0
- DPI 96dpi (no scaling)

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
