### PR TITLE
Break the toolstrip

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
@@ -44,6 +44,8 @@ namespace GitUI.CommandsDialogs
 
             CreateMenuItems();
             Translate();
+
+            _toolStripContextMenu.Opening += (s, e) => RefreshToolbarsMenuItemCheckedState(_toolStripContextMenu.Items);
         }
 
         public void Dispose()
@@ -89,7 +91,7 @@ namespace GitUI.CommandsDialogs
 
             foreach (ToolStrip toolStrip in toolStrips)
             {
-                Debug.Assert(!string.IsNullOrEmpty(toolStrip.Text), "Toolstrip must specify its name via Text property");
+                Debug.Assert(!string.IsNullOrEmpty(toolStrip.Text), "Toolstrip must specify its name via Text property.");
 
                 _toolStripContextMenu.Items.Add(CreateItem(toolStrip));
                 _toolbarsMenuItem.DropDownItems.Add(CreateItem(toolStrip));
@@ -100,9 +102,10 @@ namespace GitUI.CommandsDialogs
                 var toolStripItem = new ToolStripMenuItem(senderToolStrip.Text)
                 {
                     Checked = senderToolStrip.Visible,
-                    CheckOnClick = true
+                    CheckOnClick = true,
+                    Tag = senderToolStrip
                 };
-                toolStripItem.CheckedChanged += (s, e) =>
+                toolStripItem.Click += (s, e) =>
                 {
                     senderToolStrip.Visible = !senderToolStrip.Visible;
                 };
@@ -223,6 +226,7 @@ namespace GitUI.CommandsDialogs
                     Name = "toolbarsMenuItem",
                     Text = "Toolbars",
                 };
+                _toolbarsMenuItem.DropDownOpening += (s, e) => RefreshToolbarsMenuItemCheckedState(_toolbarsMenuItem.DropDownItems);
             }
         }
 
@@ -298,6 +302,15 @@ namespace GitUI.CommandsDialogs
             else
             {
                 throw new ApplicationException("this case is not allowed");
+            }
+        }
+
+        private void RefreshToolbarsMenuItemCheckedState(ToolStripItemCollection toolStripItems)
+        {
+            foreach (ToolStripMenuItem item in toolStripItems)
+            {
+                Debug.Assert(item.Tag is ToolStrip, "Toolbars context menu items must reference Toolstrips via Tag property.");
+                item.Checked = ((ToolStrip)item.Tag).Visible;
             }
         }
     }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
@@ -23,9 +23,9 @@ namespace GitUI.CommandsDialogs
         private readonly ToolStrip _mainMenuStrip;
 
         /// <summary>
-        /// The context menu that be shown to allow toggle visibilty of toolbars in <see cref="FormBrowse"/>.
+        /// The menu items that be shown to allow toggle visibilty of toolbars in <see cref="FormBrowse"/>.
         /// </summary>
-        private readonly ContextMenuStrip _toolStripContextMenu = new ContextMenuStrip();
+        private ToolStripItem[] _toolsMenuItems = Array.Empty<ToolStripItem>();
 
         private List<MenuCommand> _navigateMenuCommands;
         private List<MenuCommand> _viewMenuCommands;
@@ -79,7 +79,7 @@ namespace GitUI.CommandsDialogs
 
         /// <summary>
         /// Creates menu items for each toolbar supplied in <paramref name="toolStrips"/>. These menus will
-        /// be surfaced in <see cref="_mainMenuStrip"/>, and <see cref="_toolStripContextMenu"/>,
+        /// be surfaced in <see cref="_mainMenuStrip"/>, and <see cref="_toolsMenuItems"/>,
         /// and will allow to toggle visibility of the toolbars.
         /// </summary>
         /// <param name="toolStrips">The list of toobars to toggle visibility for.</param>
@@ -87,13 +87,10 @@ namespace GitUI.CommandsDialogs
         {
             Debug.Assert(_toolbarsMenuItem != null, "Toolbars menu item must be already created.");
 
-            foreach (ToolStrip toolStrip in toolStrips)
-            {
-                Debug.Assert(!string.IsNullOrEmpty(toolStrip.Text), "Toolstrip must specify its name via Text property");
-
-                _toolStripContextMenu.Items.Add(CreateItem(toolStrip));
-                _toolbarsMenuItem.DropDownItems.Add(CreateItem(toolStrip));
-            }
+            _toolsMenuItems = toolStrips
+                .Where(x => !string.IsNullOrEmpty(x.Text))
+                .Select(CreateItem)
+                .ToArray();
 
             static ToolStripItem CreateItem(ToolStrip senderToolStrip)
             {
@@ -102,6 +99,7 @@ namespace GitUI.CommandsDialogs
                     Checked = senderToolStrip.Visible,
                     CheckOnClick = true
                 };
+
                 toolStripItem.CheckedChanged += (s, e) =>
                 {
                     senderToolStrip.Visible = !senderToolStrip.Visible;
@@ -111,7 +109,15 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        public void ShowToolStripContextMenu(Point point) => _toolStripContextMenu.Show(point);
+        public void ShowToolStripContextMenu(Point point)
+        {
+            var contextMenu = new ContextMenuStrip();
+
+            contextMenu.Items
+                .AddRange(_toolsMenuItems);
+
+            contextMenu.Show(point);
+        }
 
         public void ResetMenuCommandSets()
         {
@@ -179,7 +185,7 @@ namespace GitUI.CommandsDialogs
 
             // We're a bit lying here - "Toolbars" is not a RevisionGrid menu item,
             // however it is the logical place to add it to the "View" menu
-            if (_toolbarsMenuItem.DropDownItems.Count > 0)
+            if (_toolsMenuItems.Length > 0)
             {
                 _viewToolStripMenuItem.DropDownItems.Add(new ToolStripSeparator());
                 _viewToolStripMenuItem.DropDownItems.Add(_toolbarsMenuItem);
@@ -222,6 +228,15 @@ namespace GitUI.CommandsDialogs
                 {
                     Name = "toolbarsMenuItem",
                     Text = "Toolbars",
+                };
+
+                _toolbarsMenuItem.MouseEnter += (sender, args) =>
+                {
+                    if (_toolsMenuItems.Length > 0 && _toolbarsMenuItem.DropDownItems.Count == 0)
+                    {
+                        _toolbarsMenuItem.DropDownItems
+                            .AddRange(_toolsMenuItems);
+                    }
                 };
             }
         }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
@@ -15,24 +17,49 @@ namespace GitUI.CommandsDialogs
     /// </summary>
     internal class FormBrowseMenus : ITranslate, IDisposable
     {
-        private readonly ToolStrip _menuStrip;
+        /// <summary>
+        /// The menu to which we will be adding RevisionGrid command menus.
+        /// </summary>
+        private readonly ToolStrip _mainMenuStrip;
 
-        private IList<MenuCommand> _navigateMenuCommands;
-        private IList<MenuCommand> _viewMenuCommands;
+        /// <summary>
+        /// The context menu that be shown to allow toggle visibilty of toolbars in <see cref="FormBrowse"/>.
+        /// </summary>
+        private readonly ContextMenuStrip _toolStripContextMenu = new ContextMenuStrip();
+
+        private List<MenuCommand> _navigateMenuCommands;
+        private List<MenuCommand> _viewMenuCommands;
 
         private ToolStripMenuItem _navigateToolStripMenuItem;
         private ToolStripMenuItem _viewToolStripMenuItem;
+        private ToolStripMenuItem _toolbarsMenuItem;
 
         // we have to remember which items we registered with the menucommands because other
         // location (RevisionGrid) can register items too!
-        private readonly IList<ToolStripMenuItem> _itemsRegisteredWithMenuCommand = new List<ToolStripMenuItem>();
+        private readonly List<ToolStripMenuItem> _itemsRegisteredWithMenuCommand = new List<ToolStripMenuItem>();
 
         public FormBrowseMenus(ToolStrip menuStrip)
         {
-            _menuStrip = menuStrip;
+            _mainMenuStrip = menuStrip;
 
-            CreateAdditionalMainMenuItems();
+            CreateMenuItems();
             Translate();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _navigateToolStripMenuItem.Dispose();
+                _viewToolStripMenuItem.Dispose();
+                _toolbarsMenuItem.Dispose();
+            }
         }
 
         public void Translate()
@@ -50,6 +77,42 @@ namespace GitUI.CommandsDialogs
             TranslationUtils.TranslateItemsFromList("FormBrowse", translation, GetAdditionalMainMenuItemsForTranslation());
         }
 
+        /// <summary>
+        /// Creates menu items for each toolbar supplied in <paramref name="toolStrips"/>. These menus will
+        /// be surfaced in <see cref="_mainMenuStrip"/>, and <see cref="_toolStripContextMenu"/>,
+        /// and will allow to toggle visibility of the toolbars.
+        /// </summary>
+        /// <param name="toolStrips">The list of toobars to toggle visibility for.</param>
+        public void CreateToolbarsMenus(params ToolStripEx[] toolStrips)
+        {
+            Debug.Assert(_toolbarsMenuItem != null, "Toolbars menu item must be already created.");
+
+            foreach (ToolStrip toolStrip in toolStrips)
+            {
+                Debug.Assert(!string.IsNullOrEmpty(toolStrip.Text), "Toolstrip must specify its name via Text property");
+
+                _toolStripContextMenu.Items.Add(CreateItem(toolStrip));
+                _toolbarsMenuItem.DropDownItems.Add(CreateItem(toolStrip));
+            }
+
+            static ToolStripItem CreateItem(ToolStrip senderToolStrip)
+            {
+                var toolStripItem = new ToolStripMenuItem(senderToolStrip.Text)
+                {
+                    Checked = senderToolStrip.Visible,
+                    CheckOnClick = true
+                };
+                toolStripItem.CheckedChanged += (s, e) =>
+                {
+                    senderToolStrip.Visible = !senderToolStrip.Visible;
+                };
+
+                return toolStripItem;
+            }
+        }
+
+        public void ShowToolStripContextMenu(Point point) => _toolStripContextMenu.Show(point);
+
         public void ResetMenuCommandSets()
         {
             _navigateMenuCommands = null;
@@ -57,10 +120,16 @@ namespace GitUI.CommandsDialogs
         }
 
         /// <summary>
-        /// each new command set will be automatically separated by a separator
+        /// Appends the provided <paramref name="menuCommands"/> list to the commands menus specified by <paramref name="mainMenuItem"/>.
         /// </summary>
+        /// <remarks>
+        /// Each new command set will be automatically separated by a separator.
+        /// </remarks>
         public void AddMenuCommandSet(MainMenuItem mainMenuItem, IEnumerable<MenuCommand> menuCommands)
         {
+            // In the current implementation command menus are defined in the RevisionGrid control,
+            // and added to the main menu of the FormBrowse for the ease of use
+
             IList<MenuCommand> selectedMenuCommands = null; // make that more clear
 
             switch (mainMenuItem)
@@ -96,30 +165,39 @@ namespace GitUI.CommandsDialogs
         }
 
         /// <summary>
-        /// inserts
-        /// - Navigate (after Repository)
-        /// - View (after Navigate)
+        /// Inserts "Navigate" and "View" menus after the <paramref name="insertAfterMenuItem"/>.
         /// </summary>
-        public void InsertAdditionalMainMenuItems(ToolStripItem insertAfterMenuItem)
+        public void InsertRevisionGridMainMenuItems(ToolStripItem insertAfterMenuItem)
         {
-            RemoveAdditionalMainMenuItems();
+            RemoveRevisionGridMainMenuItems();
 
             SetDropDownItems(_navigateToolStripMenuItem, _navigateMenuCommands);
             SetDropDownItems(_viewToolStripMenuItem, _viewMenuCommands);
 
-            _menuStrip.Items.Insert(_menuStrip.Items.IndexOf(insertAfterMenuItem) + 1, _navigateToolStripMenuItem);
-            _menuStrip.Items.Insert(_menuStrip.Items.IndexOf(_navigateToolStripMenuItem) + 1, _viewToolStripMenuItem);
+            _mainMenuStrip.Items.Insert(_mainMenuStrip.Items.IndexOf(insertAfterMenuItem) + 1, _navigateToolStripMenuItem);
+            _mainMenuStrip.Items.Insert(_mainMenuStrip.Items.IndexOf(_navigateToolStripMenuItem) + 1, _viewToolStripMenuItem);
+
+            // We're a bit lying here - "Toolbars" is not a RevisionGrid emenu item,
+            // however it is the logical place to add it to the "View" menu
+            if (_toolbarsMenuItem.DropDownItems.Count > 0)
+            {
+                _viewToolStripMenuItem.DropDownItems.Add(new ToolStripSeparator());
+                _viewToolStripMenuItem.DropDownItems.Add(_toolbarsMenuItem);
+            }
 
             // maybe set check marks on menu items
             OnMenuCommandsPropertyChanged();
         }
 
         /// <summary>
-        /// call in ctor before translation
+        /// Creates menu items to be added to the main mene of the <see cref="FormBrowse"/>.
         /// </summary>
-        private void CreateAdditionalMainMenuItems()
+        /// <remarks>
+        /// Call in ctor before translation.
+        /// </remarks>
+        private void CreateMenuItems()
         {
-            if (_navigateToolStripMenuItem == null)
+            if (_navigateToolStripMenuItem is null)
             {
                 _navigateToolStripMenuItem = new ToolStripMenuItem
                 {
@@ -128,7 +206,7 @@ namespace GitUI.CommandsDialogs
                 };
             }
 
-            if (_viewToolStripMenuItem == null)
+            if (_viewToolStripMenuItem is null)
             {
                 _viewToolStripMenuItem = new ToolStripMenuItem
                 {
@@ -136,12 +214,23 @@ namespace GitUI.CommandsDialogs
                     Text = "View"
                 };
             }
+
+            if (_toolbarsMenuItem is null)
+            {
+                _toolbarsMenuItem = new ToolStripMenuItem
+                {
+                    Name = "toolbarsMenuItem",
+                    Text = "Toolbars",
+                };
+            }
         }
 
         private IEnumerable<(string name, object item)> GetAdditionalMainMenuItemsForTranslation()
         {
-            var list = new[] { _navigateToolStripMenuItem, _viewToolStripMenuItem };
-            return list.Select(menuItem => (menuItem.Name, (object)menuItem));
+            foreach (ToolStripMenuItem menuItem in new[] { _navigateToolStripMenuItem, _viewToolStripMenuItem, _toolbarsMenuItem })
+            {
+                yield return (menuItem.Name, menuItem);
+            }
         }
 
         private void SetDropDownItems(ToolStripMenuItem toolStripMenuItemTarget, IEnumerable<MenuCommand> menuCommands)
@@ -168,10 +257,10 @@ namespace GitUI.CommandsDialogs
         // TODO: is everything cleared correct or are there leftover references?
         //       is this relevant here at all?
         //         see also ResetMenuCommandSets()?
-        public void RemoveAdditionalMainMenuItems()
+        public void RemoveRevisionGridMainMenuItems()
         {
-            _menuStrip.Items.Remove(_navigateToolStripMenuItem);
-            _menuStrip.Items.Remove(_viewToolStripMenuItem);
+            _mainMenuStrip.Items.Remove(_navigateToolStripMenuItem);
+            _mainMenuStrip.Items.Remove(_viewToolStripMenuItem);
 
             // don't forget to clear old associated menu items
             if (_itemsRegisteredWithMenuCommand != null)
@@ -208,21 +297,6 @@ namespace GitUI.CommandsDialogs
             else
             {
                 throw new ApplicationException("this case is not allowed");
-            }
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                _navigateToolStripMenuItem.Dispose();
-                _viewToolStripMenuItem.Dispose();
             }
         }
     }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
@@ -177,7 +177,7 @@ namespace GitUI.CommandsDialogs
             _mainMenuStrip.Items.Insert(_mainMenuStrip.Items.IndexOf(insertAfterMenuItem) + 1, _navigateToolStripMenuItem);
             _mainMenuStrip.Items.Insert(_mainMenuStrip.Items.IndexOf(_navigateToolStripMenuItem) + 1, _viewToolStripMenuItem);
 
-            // We're a bit lying here - "Toolbars" is not a RevisionGrid emenu item,
+            // We're a bit lying here - "Toolbars" is not a RevisionGrid menu item,
             // however it is the logical place to add it to the "View" menu
             if (_toolbarsMenuItem.DropDownItems.Count > 0)
             {
@@ -190,7 +190,8 @@ namespace GitUI.CommandsDialogs
         }
 
         /// <summary>
-        /// Creates menu items to be added to the main mene of the <see cref="FormBrowse"/>.
+        /// Creates menu items to be added to the main menu of the <see cref="FormBrowse"/>
+        /// (represented by <see cref="_mainMenuStrip"/>).
         /// </summary>
         /// <remarks>
         /// Call in ctor before translation.

--- a/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
@@ -82,6 +82,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         public Image Image { get; set; }
 
         public Keys ShortcutKeys { get; set; }
+
         public string ShortcutKeyDisplayString { get; set; }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -23,7 +23,7 @@ namespace GitUI.CommandsDialogs
             System.Windows.Forms.ToolStripMenuItem toolStripMenuItem4;
             System.Windows.Forms.ToolStripSeparator toolStripSeparator14;
             System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
-            this.ToolStrip = new GitUI.ToolStripEx();
+            this.ToolStripMain = new GitUI.ToolStripEx();
             this.RefreshButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator0 = new System.Windows.Forms.ToolStripSeparator();
             this.toggleBranchTreePanel = new System.Windows.Forms.ToolStripButton();
@@ -190,11 +190,13 @@ namespace GitUI.CommandsDialogs
             this.gitRevisionBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.toolPanel = new System.Windows.Forms.ToolStripContainer();
             this._addUpstreamRemoteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.ToolStripFilters = new GitUI.ToolStripEx();
             toolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
             toolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
             toolStripSeparator14 = new System.Windows.Forms.ToolStripSeparator();
             toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
-            this.ToolStrip.SuspendLayout();
+            this.ToolStripMain.SuspendLayout();
+            this.ToolStripFilters.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.MainSplitContainer)).BeginInit();
             this.MainSplitContainer.Panel1.SuspendLayout();
             this.MainSplitContainer.Panel2.SuspendLayout();
@@ -237,14 +239,13 @@ namespace GitUI.CommandsDialogs
             toolStripSeparator14.Name = "toolStripSeparator14";
             toolStripSeparator14.Size = new System.Drawing.Size(236, 6);
             // 
-            // ToolStrip
+            // ToolStripMain
             // 
-            this.ToolStrip.ClickThrough = true;
-            this.ToolStrip.Dock = System.Windows.Forms.DockStyle.None;
-            this.ToolStrip.GripMargin = new System.Windows.Forms.Padding(0);
-            this.ToolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-            this.ToolStrip.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.ToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ToolStripMain.ClickThrough = true;
+            this.ToolStripMain.Dock = System.Windows.Forms.DockStyle.None;
+            this.ToolStripMain.GripMargin = new System.Windows.Forms.Padding(0);
+            this.ToolStripMain.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.ToolStripMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.RefreshButton,
             this.toolStripSeparator0,
             this.toggleBranchTreePanel,
@@ -263,7 +264,21 @@ namespace GitUI.CommandsDialogs
             this.toolStripFileExplorer,
             this.userShell,
             this.EditSettings,
-            this.toolStripSeparator5,
+            this.toolStripSeparator5});
+            this.ToolStripMain.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
+            this.ToolStripMain.Location = new System.Drawing.Point(3, 0);
+            this.ToolStripMain.Name = "ToolStripMain";
+            this.ToolStripMain.Padding = new System.Windows.Forms.Padding(0);
+            this.ToolStripMain.Size = new System.Drawing.Size(479, 25);
+            this.ToolStripMain.TabIndex = 0;
+            //
+            // ToolStripFilters
+            // 
+            this.ToolStripFilters.ClickThrough = true;
+            this.ToolStripFilters.Dock = System.Windows.Forms.DockStyle.None;
+            this.ToolStripFilters.GripMargin = new System.Windows.Forms.Padding(0);
+            this.ToolStripFilters.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.ToolStripFilters.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripLabel1,
             this.toolStripBranchFilterComboBox,
             this.toolStripBranchFilterDropDownButton,
@@ -272,12 +287,12 @@ namespace GitUI.CommandsDialogs
             this.toolStripRevisionFilterTextBox,
             this.toolStripRevisionFilterDropDownButton,
             this.ShowFirstParent});
-            this.ToolStrip.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
-            this.ToolStrip.Location = new System.Drawing.Point(3, 0);
-            this.ToolStrip.Name = "ToolStrip";
-            this.ToolStrip.Size = new System.Drawing.Size(920, 25);
-            this.ToolStrip.Padding = new System.Windows.Forms.Padding(6, 0, 0, 0);
-            this.ToolStrip.TabIndex = 0;
+            this.ToolStripFilters.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
+            this.ToolStripFilters.Location = new System.Drawing.Point(584, 0);
+            this.ToolStripFilters.Name = "ToolStripFilters";
+            this.ToolStripFilters.Padding = new System.Windows.Forms.Padding(0);
+            this.ToolStripFilters.Size = new System.Drawing.Size(339, 25);
+            this.ToolStripFilters.TabIndex = 1;
             // 
             // RefreshButton
             // 
@@ -362,8 +377,6 @@ namespace GitUI.CommandsDialogs
             this.toolStripButtonLevelUp.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripButtonLevelUp.Name = "toolStripButtonLevelUp";
             this.toolStripButtonLevelUp.Size = new System.Drawing.Size(32, 22);
-            this.toolStripButtonLevelUp.Text = "";
-            this.toolStripButtonLevelUp.ToolTipText = "";
             this.toolStripButtonLevelUp.ButtonClick += new System.EventHandler(this.toolStripButtonLevelUp_ButtonClick);
             this.toolStripButtonLevelUp.DropDownOpening += new System.EventHandler(this.toolStripButtonLevelUp_DropDownOpening);
             // 
@@ -1743,10 +1756,11 @@ namespace GitUI.CommandsDialogs
             // 
             // toolPanel.TopToolStripPanel
             // 
-            this.toolPanel.TopToolStripPanel.Controls.Add(this.ToolStrip);
+            this.toolPanel.TopToolStripPanel.Controls.Add(this.ToolStripMain);
+            this.toolPanel.TopToolStripPanel.Controls.Add(this.ToolStripFilters);
             // 
             // addUpstreamRemoteToolStripMenuItem
-            // 
+            //
             this._addUpstreamRemoteToolStripMenuItem.Name = "_addUpstreamRemoteToolStripMenuItem";
             this._addUpstreamRemoteToolStripMenuItem.Size = new System.Drawing.Size(360, 38);
             this._addUpstreamRemoteToolStripMenuItem.Text = "Add upstream remote";
@@ -1762,8 +1776,10 @@ namespace GitUI.CommandsDialogs
             this.Controls.Add(this.menuStrip1);
             this.Name = "FormBrowse";
             this.Text = "Git Extensions";
-            this.ToolStrip.ResumeLayout(false);
-            this.ToolStrip.PerformLayout();
+            this.ToolStripFilters.ResumeLayout(false);
+            this.ToolStripFilters.PerformLayout();
+            this.ToolStripMain.ResumeLayout(false);
+            this.ToolStripMain.PerformLayout();
             this.MainSplitContainer.Panel1.ResumeLayout(false);
             this.MainSplitContainer.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.MainSplitContainer)).EndInit();
@@ -1809,7 +1825,7 @@ namespace GitUI.CommandsDialogs
         private BindingSource gitRevisionBindingSource;
         private BindingSource gitItemBindingSource;
         private GitUI.RevisionGridControl RevisionGrid;
-        private ToolStripEx ToolStrip;
+        private ToolStripEx ToolStripMain;
         private CommitInfo.CommitInfo RevisionInfo;
         private MenuStripEx menuStrip1;
         private GitUI.BranchTreePanel.RepoObjectsTree repoObjectsTree;
@@ -1966,5 +1982,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem tsmiTelemetryEnabled;
         private Panel RevisionGridContainer;
         private UserControls.InteractiveGitActionControl RevisionHeader;
+        private ToolStripEx ToolStripFilters;
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -184,7 +184,7 @@ namespace GitUI.CommandsDialogs
             this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.gitcommandLogToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuStrip1 = new GitUI.MenuStripEx();
+            this.mainMenuStrip = new GitUI.MenuStripEx();
             this.gitItemBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.gitRevisionBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.toolPanel = new System.Windows.Forms.ToolStripContainer();
@@ -213,7 +213,7 @@ namespace GitUI.CommandsDialogs
             this.TreeTabPage.SuspendLayout();
             this.DiffTabPage.SuspendLayout();
             this.GpgInfoTabPage.SuspendLayout();
-            this.menuStrip1.SuspendLayout();
+            this.mainMenuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.gitItemBindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.gitRevisionBindingSource)).BeginInit();
             this.toolPanel.ContentPanel.SuspendLayout();
@@ -269,6 +269,7 @@ namespace GitUI.CommandsDialogs
             this.ToolStripMain.Padding = new System.Windows.Forms.Padding(0);
             this.ToolStripMain.Size = new System.Drawing.Size(479, 25);
             this.ToolStripMain.TabIndex = 0;
+            this.ToolStripMain.Text = "Standard";
             //
             // ToolStripFilters
             // 
@@ -291,6 +292,7 @@ namespace GitUI.CommandsDialogs
             this.ToolStripFilters.Padding = new System.Windows.Forms.Padding(0);
             this.ToolStripFilters.Size = new System.Drawing.Size(339, 25);
             this.ToolStripFilters.TabIndex = 1;
+            this.ToolStripFilters.Text = "Filters";
             // 
             // RefreshButton
             // 
@@ -1711,8 +1713,8 @@ namespace GitUI.CommandsDialogs
             // 
             // menuStrip1
             // 
-            this.menuStrip1.ClickThrough = true;
-            this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.mainMenuStrip.ClickThrough = true;
+            this.mainMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem,
             this.dashboardToolStripMenuItem,
             this.repositoryToolStripMenuItem,
@@ -1721,11 +1723,11 @@ namespace GitUI.CommandsDialogs
             this.pluginsToolStripMenuItem,
             this.toolsToolStripMenuItem,
             this.helpToolStripMenuItem});
-            this.menuStrip1.Location = new System.Drawing.Point(0, 0);
-            this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(923, 24);
-            this.menuStrip1.Padding = new System.Windows.Forms.Padding(4);
-            this.menuStrip1.TabIndex = 0;
+            this.mainMenuStrip.Location = new System.Drawing.Point(0, 0);
+            this.mainMenuStrip.Name = "menuStrip1";
+            this.mainMenuStrip.Size = new System.Drawing.Size(923, 24);
+            this.mainMenuStrip.Padding = new System.Windows.Forms.Padding(4);
+            this.mainMenuStrip.TabIndex = 0;
             // 
             // toolPanel
             // 
@@ -1751,6 +1753,7 @@ namespace GitUI.CommandsDialogs
             // 
             this.toolPanel.TopToolStripPanel.Controls.Add(this.ToolStripMain);
             this.toolPanel.TopToolStripPanel.Controls.Add(this.ToolStripFilters);
+            this.toolPanel.TopToolStripPanel.MouseClick += new System.Windows.Forms.MouseEventHandler(this.toolPanel_TopToolStripPanel_MouseClick);
             // 
             // addUpstreamRemoteToolStripMenuItem
             //
@@ -1766,11 +1769,9 @@ namespace GitUI.CommandsDialogs
             this.AutoValidate = System.Windows.Forms.AutoValidate.EnablePreventFocusChange;
             this.ClientSize = new System.Drawing.Size(923, 573);
             this.Controls.Add(this.toolPanel);
-            this.Controls.Add(this.menuStrip1);
+            this.Controls.Add(this.mainMenuStrip);
             this.Name = "FormBrowse";
             this.Text = "Git Extensions";
-            this.ToolStripFilters.ResumeLayout(false);
-            this.ToolStripFilters.PerformLayout();
             this.ToolStripMain.ResumeLayout(false);
             this.ToolStripMain.PerformLayout();
             this.MainSplitContainer.Panel1.ResumeLayout(false);
@@ -1790,8 +1791,8 @@ namespace GitUI.CommandsDialogs
             this.TreeTabPage.ResumeLayout(false);
             this.DiffTabPage.ResumeLayout(false);
             this.GpgInfoTabPage.ResumeLayout(false);
-            this.menuStrip1.ResumeLayout(false);
-            this.menuStrip1.PerformLayout();
+            this.mainMenuStrip.ResumeLayout(false);
+            this.mainMenuStrip.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.gitItemBindingSource)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.gitRevisionBindingSource)).EndInit();
             this.toolPanel.ContentPanel.ResumeLayout(false);
@@ -1799,6 +1800,8 @@ namespace GitUI.CommandsDialogs
             this.toolPanel.TopToolStripPanel.PerformLayout();
             this.toolPanel.ResumeLayout(false);
             this.toolPanel.PerformLayout();
+            this.ToolStripFilters.ResumeLayout(false);
+            this.ToolStripFilters.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
         }
@@ -1818,9 +1821,10 @@ namespace GitUI.CommandsDialogs
         private BindingSource gitRevisionBindingSource;
         private BindingSource gitItemBindingSource;
         private GitUI.RevisionGridControl RevisionGrid;
+        private MenuStripEx mainMenuStrip;
         private ToolStripEx ToolStripMain;
+        private ToolStripEx ToolStripFilters;
         private CommitInfo.CommitInfo RevisionInfo;
-        private MenuStripEx menuStrip1;
         private GitUI.BranchTreePanel.RepoObjectsTree repoObjectsTree;
         private ToolTip FilterToolTip;
         private RevisionFileTreeControl fileTree;
@@ -1974,6 +1978,5 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem tsmiTelemetryEnabled;
         private Panel RevisionGridContainer;
         private UserControls.InteractiveGitActionControl RevisionHeader;
-        private ToolStripEx ToolStripFilters;
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -1753,7 +1753,6 @@ namespace GitUI.CommandsDialogs
             // 
             this.toolPanel.TopToolStripPanel.Controls.Add(this.ToolStripMain);
             this.toolPanel.TopToolStripPanel.Controls.Add(this.ToolStripFilters);
-            this.toolPanel.TopToolStripPanel.MouseClick += new System.Windows.Forms.MouseEventHandler(this.toolPanel_TopToolStripPanel_MouseClick);
             // 
             // addUpstreamRemoteToolStripMenuItem
             //

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -57,7 +57,6 @@ namespace GitUI.CommandsDialogs
             this.toolStripFileExplorer = new System.Windows.Forms.ToolStripButton();
             this.userShell = new System.Windows.Forms.ToolStripSplitButton();
             this.EditSettings = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripLabel1 = new System.Windows.Forms.ToolStripLabel();
             this.toolStripBranchFilterComboBox = new System.Windows.Forms.ToolStripComboBox();
             this.toolStripBranchFilterDropDownButton = new System.Windows.Forms.ToolStripDropDownButton();
@@ -263,8 +262,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator2,
             this.toolStripFileExplorer,
             this.userShell,
-            this.EditSettings,
-            this.toolStripSeparator5});
+            this.EditSettings});
             this.ToolStripMain.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
             this.ToolStripMain.Location = new System.Drawing.Point(3, 0);
             this.ToolStripMain.Name = "ToolStripMain";
@@ -599,11 +597,6 @@ namespace GitUI.CommandsDialogs
             this.EditSettings.Size = new System.Drawing.Size(23, 22);
             this.EditSettings.ToolTipText = "Settings";
             this.EditSettings.Click += new System.EventHandler(this.OnShowSettingsClick);
-            // 
-            // toolStripSeparator5
-            // 
-            this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(6, 25);
             // 
             // toolStripLabel1
             // 
@@ -1843,7 +1836,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripSeparator toolStripSeparator2;
         private ToolStripButton EditSettings;
         private ToolStripButton RefreshButton;
-        private ToolStripSeparator toolStripSeparator5;
         private ToolStripTextBox toolStripRevisionFilterTextBox;
         private ToolStripPushButton toolStripButtonPush;
         private ToolStripLabel toolStripRevisionFilterLabel;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -152,6 +152,8 @@ namespace GitUI.CommandsDialogs
             MainSplitContainer.Visible = false;
             MainSplitContainer.SplitterDistance = DpiUtil.Scale(260);
 
+            ToolStripManager.LoadSettings(this, "toolsettings");
+
             // set tab page images
             CommitInfoTabControl.ImageList = new ImageList
             {
@@ -660,7 +662,9 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
+            ToolStripManager.SaveSettings(this, "toolsettings");
             SaveApplicationSettings();
+
             foreach (var control in this.FindDescendants())
             {
                 control.DragEnter -= FormBrowse_DragEnter;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -152,8 +152,6 @@ namespace GitUI.CommandsDialogs
             MainSplitContainer.Visible = false;
             MainSplitContainer.SplitterDistance = DpiUtil.Scale(260);
 
-            ToolStripManager.LoadSettings(this, "toolsettings");
-
             // set tab page images
             CommitInfoTabControl.ImageList = new ImageList
             {
@@ -266,7 +264,7 @@ namespace GitUI.CommandsDialogs
             FillBuildReport(revision: null); // Ensure correct page visibility
             RevisionGrid.ShowBuildServerInfo = true;
 
-            _formBrowseMenus = new FormBrowseMenus(menuStrip1);
+            _formBrowseMenus = new FormBrowseMenus(mainMenuStrip);
             RevisionGrid.MenuCommands.MenuChanged += (sender, e) => _formBrowseMenus.OnMenuCommandsPropertyChanged();
             SystemEvents.SessionEnding += (sender, args) => SaveApplicationSettings();
 
@@ -276,24 +274,10 @@ namespace GitUI.CommandsDialogs
             var toolForeColor = SystemColors.WindowText;
             BackColor = toolBackColor;
             ForeColor = toolForeColor;
-            ToolStripMain.BackColor = toolBackColor;
-            ToolStripMain.ForeColor = toolForeColor;
-            toolStripRevisionFilterDropDownButton.BackColor = toolBackColor;
-            toolStripRevisionFilterDropDownButton.ForeColor = toolForeColor;
-            menuStrip1.BackColor = toolBackColor;
-            menuStrip1.ForeColor = toolForeColor;
-            toolPanel.TopToolStripPanel.BackColor = toolBackColor;
-            toolPanel.TopToolStripPanel.ForeColor = toolForeColor;
+            mainMenuStrip.BackColor = toolBackColor;
+            mainMenuStrip.ForeColor = toolForeColor;
 
-            var toolTextBoxBackColor = SystemColors.Window;
-            toolStripBranchFilterComboBox.BackColor = toolTextBoxBackColor;
-            toolStripBranchFilterComboBox.ForeColor = toolForeColor;
-            toolStripRevisionFilterTextBox.BackColor = toolTextBoxBackColor;
-            toolStripRevisionFilterTextBox.ForeColor = toolForeColor;
-
-            // Scale tool strip items according to DPI
-            toolStripBranchFilterComboBox.Size = DpiUtil.Scale(toolStripBranchFilterComboBox.Size);
-            toolStripRevisionFilterTextBox.Size = DpiUtil.Scale(toolStripRevisionFilterTextBox.Size);
+            InitToolStripStyles(toolForeColor, toolBackColor);
 
             foreach (var control in this.FindDescendants())
             {
@@ -437,6 +421,29 @@ namespace GitUI.CommandsDialogs
                         }
                     }
                 };
+            }
+
+            void InitToolStripStyles(Color toolForeColor, Color toolBackColor)
+            {
+                toolPanel.TopToolStripPanel.BackColor = toolBackColor;
+                toolPanel.TopToolStripPanel.ForeColor = toolForeColor;
+
+                ToolStripMain.BackColor = toolBackColor;
+                ToolStripMain.ForeColor = toolForeColor;
+                ToolStripFilters.BackColor = toolBackColor;
+                ToolStripFilters.ForeColor = toolForeColor;
+                toolStripRevisionFilterDropDownButton.BackColor = toolBackColor;
+                toolStripRevisionFilterDropDownButton.ForeColor = toolForeColor;
+
+                var toolTextBoxBackColor = SystemColors.Window;
+                toolStripBranchFilterComboBox.BackColor = toolTextBoxBackColor;
+                toolStripBranchFilterComboBox.ForeColor = toolForeColor;
+                toolStripRevisionFilterTextBox.BackColor = toolTextBoxBackColor;
+                toolStripRevisionFilterTextBox.ForeColor = toolForeColor;
+
+                // Scale tool strip items according to DPI
+                toolStripBranchFilterComboBox.Size = DpiUtil.Scale(toolStripBranchFilterComboBox.Size);
+                toolStripRevisionFilterTextBox.Size = DpiUtil.Scale(toolStripRevisionFilterTextBox.Size);
             }
 
             Brush UpdateCommitButtonAndGetBrush(IReadOnlyList<GitItemStatus> status, bool showCount)
@@ -600,7 +607,9 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnLoad(EventArgs e)
         {
-            SetSplitterPositions();
+            ToolStripManager.LoadSettings(this, "toolsettings");
+            _formBrowseMenus.CreateToolbarsMenus(ToolStripMain, ToolStripFilters);
+
             HideVariableMainMenuItems();
             RefreshSplitViewLayout();
             LayoutRevisionInfo();
@@ -894,7 +903,7 @@ namespace GitUI.CommandsDialogs
                     _dashboard.RefreshContent();
                 }
 
-                menuStrip1?.Refresh();
+                mainMenuStrip?.Refresh();
             }
 
             // Allow the plugin to perform any self-registration actions
@@ -927,8 +936,8 @@ namespace GitUI.CommandsDialogs
             refreshToolStripMenuItem.ShortcutKeys = Keys.None;
             refreshDashboardToolStripMenuItem.ShortcutKeys = Keys.None;
             _repositoryHostsToolStripMenuItem.Visible = false;
-            _formBrowseMenus.RemoveAdditionalMainMenuItems();
-            menuStrip1.Refresh();
+            _formBrowseMenus.RemoveRevisionGridMainMenuItems();
+            mainMenuStrip.Refresh();
         }
 
         private void InternalInitialize(bool hard)
@@ -1044,7 +1053,7 @@ namespace GitUI.CommandsDialogs
                     _formBrowseMenus.AddMenuCommandSet(MainMenuItem.NavigateMenu, RevisionGrid.MenuCommands.NavigateMenuCommands);
                     _formBrowseMenus.AddMenuCommandSet(MainMenuItem.ViewMenu, RevisionGrid.MenuCommands.ViewMenuCommands);
 
-                    _formBrowseMenus.InsertAdditionalMainMenuItems(repositoryToolStripMenuItem);
+                    _formBrowseMenus.InsertRevisionGridMainMenuItems(repositoryToolStripMenuItem);
                 }
                 else
                 {
@@ -3224,6 +3233,14 @@ namespace GitUI.CommandsDialogs
         private void HelpToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
         {
             tsmiTelemetryEnabled.Checked = AppSettings.TelemetryEnabled ?? false;
+        }
+
+        private void toolPanel_TopToolStripPanel_MouseClick(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right)
+            {
+                _formBrowseMenus.ShowToolStripContextMenu(Cursor.Position);
+            }
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -277,6 +277,14 @@ namespace GitUI.CommandsDialogs
             mainMenuStrip.BackColor = toolBackColor;
             mainMenuStrip.ForeColor = toolForeColor;
 
+            toolPanel.TopToolStripPanel.MouseClick += (s, e) =>
+            {
+                if (e.Button == MouseButtons.Right)
+                {
+                    _formBrowseMenus.ShowToolStripContextMenu(Cursor.Position);
+                }
+            };
+
             InitToolStripStyles(toolForeColor, toolBackColor);
 
             foreach (var control in this.FindDescendants())
@@ -607,7 +615,10 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnLoad(EventArgs e)
         {
+            toolPanel.TopToolStripPanel.SuspendLayout();
             ToolStripManager.LoadSettings(this, "toolsettings");
+            toolPanel.TopToolStripPanel.ResumeLayout();
+
             _formBrowseMenus.CreateToolbarsMenus(ToolStripMain, ToolStripFilters);
 
             HideVariableMainMenuItems();
@@ -3233,14 +3244,6 @@ namespace GitUI.CommandsDialogs
         private void HelpToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
         {
             tsmiTelemetryEnabled.Checked = AppSettings.TelemetryEnabled ?? false;
-        }
-
-        private void toolPanel_TopToolStripPanel_MouseClick(object sender, MouseEventArgs e)
-        {
-            if (e.Button == MouseButtons.Right)
-            {
-                _formBrowseMenus.ShowToolStripContextMenu(Cursor.Position);
-            }
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -274,8 +274,8 @@ namespace GitUI.CommandsDialogs
             var toolForeColor = SystemColors.WindowText;
             BackColor = toolBackColor;
             ForeColor = toolForeColor;
-            ToolStrip.BackColor = toolBackColor;
-            ToolStrip.ForeColor = toolForeColor;
+            ToolStripMain.BackColor = toolBackColor;
+            ToolStripMain.ForeColor = toolForeColor;
             toolStripRevisionFilterDropDownButton.BackColor = toolBackColor;
             toolStripRevisionFilterDropDownButton.ForeColor = toolForeColor;
             menuStrip1.BackColor = toolBackColor;
@@ -1076,11 +1076,11 @@ namespace GitUI.CommandsDialogs
                     .Where(script => script.Enabled && script.OnEvent == ScriptEvent.ShowInUserMenuBar)
                     .ToList();
 
-                for (int i = ToolStrip.Items.Count - 1; i >= 0; i--)
+                for (int i = ToolStripMain.Items.Count - 1; i >= 0; i--)
                 {
-                    if (ToolStrip.Items[i].Tag as string == "userscript")
+                    if (ToolStripMain.Items[i].Tag as string == "userscript")
                     {
-                        ToolStrip.Items.RemoveAt(i);
+                        ToolStripMain.Items.RemoveAt(i);
                     }
                 }
 
@@ -1089,7 +1089,7 @@ namespace GitUI.CommandsDialogs
                     return;
                 }
 
-                ToolStrip.Items.Add(new ToolStripSeparator { Tag = "userscript" });
+                ToolStripMain.Items.Add(new ToolStripSeparator { Tag = "userscript" });
 
                 foreach (var script in scripts)
                 {
@@ -1113,7 +1113,7 @@ namespace GitUI.CommandsDialogs
                     };
 
                     // add to toolstrip
-                    ToolStrip.Items.Add(button);
+                    ToolStripMain.Items.Add(button);
                 }
             }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -954,6 +954,8 @@ namespace GitUI.CommandsDialogs
         private void InternalInitialize(bool hard)
         {
             toolPanel.SuspendLayout();
+            toolPanel.TopToolStripPanel.SuspendLayout();
+
             using (WaitCursorScope.Enter())
             {
                 // check for updates
@@ -1074,6 +1076,7 @@ namespace GitUI.CommandsDialogs
                 UICommands.RaisePostBrowseInitialize(this);
             }
 
+            toolPanel.TopToolStripPanel.ResumeLayout();
             toolPanel.ResumeLayout();
 
             return;

--- a/GitUI/CommandsDialogs/FormBrowse.resx
+++ b/GitUI/CommandsDialogs/FormBrowse.resx
@@ -129,7 +129,7 @@
   <metadata name="toolStripSeparator11.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
-  <metadata name="ToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="ToolStripMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>251, 17</value>
   </metadata>
   <metadata name="FilterToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -143,6 +143,9 @@
   </metadata>
   <metadata name="gitRevisionBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>352, 17</value>
+  </metadata>
+  <metadata name="ToolStripFilters.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>711, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>82</value>

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -54,7 +54,7 @@ namespace GitUI.CommandsDialogs
             _formBrowseMenus.ResetMenuCommandSets();
             _formBrowseMenus.AddMenuCommandSet(MainMenuItem.NavigateMenu, FileChanges.MenuCommands.NavigateMenuCommands);
             _formBrowseMenus.AddMenuCommandSet(MainMenuItem.ViewMenu, FileChanges.MenuCommands.ViewMenuCommands);
-            _formBrowseMenus.InsertAdditionalMainMenuItems(toolStripSeparator4);
+            _formBrowseMenus.InsertRevisionGridMainMenuItems(toolStripSeparator4);
 
             _commitDataManager = new CommitDataManager(() => Module);
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2093,6 +2093,14 @@ compare with first:</source>
         <source>Show first parents</source>
         <target />
       </trans-unit>
+      <trans-unit id="ToolStripFilters.Text">
+        <source>Filters</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="ToolStripMain.Text">
+        <source>Standard</source>
+        <target />
+      </trans-unit>
       <trans-unit id="TreeTabPage.Text">
         <source>File tree</source>
         <target />
@@ -2573,6 +2581,10 @@ Do you want to continue?</source>
       </trans-unit>
       <trans-unit id="toolStripSplitStash.ToolTipText">
         <source>Manage stashes</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="toolbarsMenuItem.Text">
+        <source>Toolbars</source>
         <target />
       </trans-unit>
       <trans-unit id="toolsToolStripMenuItem.Text">


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->


Relates to #5525

## Proposed changes

- Break the main toolbar into two - general operations and filters. This is arbitrary, filters were the easiest to break out. The main point of the PR was to attempt the split and see how well it works. This then maybe used as a foundation for further refactoring of the toolstrip area, such as moving user scripts to own toolstrip, view-related, repo-related... Possibilities are endless.
- Save/restore positions of the toolbars


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/97083964-62c95d00-165f-11eb-85cc-a04dd1d79a34.png)


### After

![image](https://user-images.githubusercontent.com/4403806/97083967-6bba2e80-165f-11eb-8afa-099f555a586e.png)

![image](https://user-images.githubusercontent.com/4403806/97108372-50aff300-1721-11eb-8686-dc0a4eb1d11b.png)

![image](https://user-images.githubusercontent.com/4403806/97108381-56a5d400-1721-11eb-8042-9f88c00a16b7.png)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
