### PR TITLE
FormPush show ahead/behind for  multiple branches

### DIFF
--- a/GitCommands/Git/AheadBehindData.cs
+++ b/GitCommands/Git/AheadBehindData.cs
@@ -5,6 +5,7 @@
         // gone: "plumbing" expression, see https://git-scm.com/docs/git-for-each-ref#Documentation/git-for-each-ref.txt-upstream
         public static readonly string Gone = "gone";
         public string Branch { get; set; }
+        public string RemoteRef { get; set; }
         public string AheadCount { get; set; }
         public string BehindCount { get; set; }
 

--- a/GitCommands/Git/AheadBehindDataProvider.cs
+++ b/GitCommands/Git/AheadBehindDataProvider.cs
@@ -88,6 +88,7 @@ namespace GitCommands.Git
                     {
                         // The information is displayed in the push button, so the push info is preferred (may differ from upstream)
                         Branch = branch,
+                        RemoteRef = remoteRef,
                         AheadCount =
                             // Prefer push to upstream for the count
                             match.Groups["ahead_p"].Success

--- a/GitCommands/Git/GitRefName.cs
+++ b/GitCommands/Git/GitRefName.cs
@@ -72,6 +72,23 @@ namespace GitCommands
             return string.Empty;
         }
 
+        [Pure, NotNull]
+        public static string GetRemoteBranch([NotNull] string refName)
+        {
+            if (refName.Length <= GitRefName.RefsRemotesPrefix.Length)
+            {
+                return string.Empty;
+            }
+
+            var startBranch = refName.IndexOf('/', GitRefName.RefsRemotesPrefix.Length);
+            if (startBranch < 0)
+            {
+                return string.Empty;
+            }
+
+            return refName.Substring(1 + startBranch);
+        }
+
         [Pure, CanBeNull]
         public static string GetFullBranchName([CanBeNull] string branch)
         {

--- a/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -411,7 +411,7 @@
             // NewColumn
             // 
             this.NewColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.NewColumn.HeaderText = "New at Remote";
+            this.NewColumn.HeaderText = "Ahead/Behind";
             this.NewColumn.Name = "NewColumn";
             this.NewColumn.ReadOnly = true;
             this.NewColumn.Width = 97;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5308,7 +5308,7 @@ This will initialize and update all submodules recursive.</source>
         <target />
       </trans-unit>
       <trans-unit id="NewColumn.HeaderText">
-        <source>New at Remote</source>
+        <source>Ahead/Behind</source>
         <target />
       </trans-unit>
       <trans-unit id="Pull.Text">

--- a/UnitTests/GitCommands.Tests/Git/AheadBehindDataProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/AheadBehindDataProviderTests.cs
@@ -115,6 +115,7 @@ namespace GitCommandsTests.Git
             aheadBehindData.AheadCount.Should().Be(string.Empty);
             aheadBehindData.BehindCount.Should().Be(string.Empty);
             aheadBehindData.Branch.Should().Be("my-branch");
+            aheadBehindData.RemoteRef.Should().Be("refs/remotes/upstream/branch");
             aheadBehindData.ToDisplay().Should().Be(string.Empty);
         }
 
@@ -130,6 +131,7 @@ namespace GitCommandsTests.Git
             aheadBehindData.AheadCount.Should().Be("10");
             aheadBehindData.BehindCount.Should().Be(string.Empty);
             aheadBehindData.Branch.Should().Be("my-branch");
+            aheadBehindData.RemoteRef.Should().Be("refs/remotes/upstream/branch");
             aheadBehindData.ToDisplay().Should().Be("10↑");
         }
 
@@ -145,6 +147,7 @@ namespace GitCommandsTests.Git
             aheadBehindData.AheadCount.Should().Be("0");
             aheadBehindData.BehindCount.Should().Be("2");
             aheadBehindData.Branch.Should().Be("my-branch");
+            aheadBehindData.RemoteRef.Should().Be("refs/remotes/upstream/my-branch");
             aheadBehindData.ToDisplay().Should().Be("2↓");
         }
 
@@ -163,8 +166,8 @@ namespace GitCommandsTests.Git
             aheadBehindData.ToDisplay().Should().Be("0↑↓");
         }
 
-        [TestCase("::ahead 99, behind 3::::refs/remotes/upstream/my-branch::my-branch")]
-        [TestCase("ahead 99, behind 3::::refs/remotes/upstream/my-branch::::my-branch")]
+        [TestCase("::ahead 99, behind 3::::refs/remotes/upstream/branch::my-branch")]
+        [TestCase("ahead 99, behind 3::::refs/remotes/upstream/branch::::my-branch")]
         public void GetData_should_return_ahead_and_behind_for_a_branch(string result)
         {
             SetResultOfGitCommand(result);
@@ -176,6 +179,7 @@ namespace GitCommandsTests.Git
             aheadBehindData.AheadCount.Should().Be("99");
             aheadBehindData.BehindCount.Should().Be("3");
             aheadBehindData.Branch.Should().Be("my-branch");
+            aheadBehindData.RemoteRef.Should().Be("refs/remotes/upstream/branch");
             aheadBehindData.ToDisplay().Should().Be("99↑ 3↓");
         }
 
@@ -191,6 +195,7 @@ namespace GitCommandsTests.Git
             aheadBehindData.AheadCount.Should().Be("99");
             aheadBehindData.BehindCount.Should().Be("97");
             aheadBehindData.Branch.Should().Be("my-branch");
+            aheadBehindData.RemoteRef.Should().Be("refs/remotes/upstream/push-branch");
             aheadBehindData.ToDisplay().Should().Be("99↑ 97↓");
         }
 
@@ -206,6 +211,7 @@ namespace GitCommandsTests.Git
             aheadBehindData.AheadCount.Should().Be("99");
             aheadBehindData.BehindCount.Should().Be("");
             aheadBehindData.Branch.Should().Be("my-branch");
+            aheadBehindData.RemoteRef.Should().Be("refs/remotes/upstream/push-branch");
             aheadBehindData.ToDisplay().Should().Be("99↑");
         }
 
@@ -221,6 +227,7 @@ namespace GitCommandsTests.Git
             aheadBehindData.AheadCount.Should().Be("");
             aheadBehindData.BehindCount.Should().Be("97");
             aheadBehindData.Branch.Should().Be("my-branch");
+            aheadBehindData.RemoteRef.Should().Be("refs/remotes/upstream/push-branch");
             aheadBehindData.ToDisplay().Should().Be("97↓");
         }
 
@@ -239,10 +246,10 @@ namespace GitCommandsTests.Git
             data.Should().BeEquivalentTo(
                 new Dictionary<string, AheadBehindData>
                 {
-                    { "branch-with-no-more-remote", new AheadBehindData { AheadCount = "gone", BehindCount = "", Branch = "branch-with-no-more-remote" } },
-                    { "ahead-behind-branch", new AheadBehindData { AheadCount = "99", BehindCount = "3", Branch = "ahead-behind-branch" } },
-                    { "ahead-branch", new AheadBehindData { AheadCount = "3", BehindCount = string.Empty, Branch = "ahead-branch" } },
-                    { "behind-branch", new AheadBehindData { AheadCount = "0", BehindCount = "4", Branch = "behind-branch" } },
+                    { "branch-with-no-more-remote", new AheadBehindData { AheadCount = "gone", BehindCount = "", Branch = "branch-with-no-more-remote", RemoteRef = "refs/remotes/upstream/branch" } },
+                    { "ahead-behind-branch", new AheadBehindData { AheadCount = "99", BehindCount = "3", Branch = "ahead-behind-branch", RemoteRef = "refs/remotes/upstream/branch" } },
+                    { "ahead-branch", new AheadBehindData { AheadCount = "3", BehindCount = string.Empty, Branch = "ahead-branch", RemoteRef = "refs/remotes/upstream/branch" } },
+                    { "behind-branch", new AheadBehindData { AheadCount = "0", BehindCount = "4", Branch = "behind-branch", RemoteRef = "refs/remotes/upstream/branch" } },
                 });
         }
 

--- a/UnitTests/GitCommands.Tests/Git/GitRefNameTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitRefNameTests.cs
@@ -33,6 +33,16 @@ namespace GitCommandsTests.Git
         }
 
         [Test]
+        public void GetRemoteBranch()
+        {
+            Assert.AreEqual("master", GitRefName.GetRemoteBranch("refs/remotes/foo/master"));
+            Assert.AreEqual("tmp/master", GitRefName.GetRemoteBranch("refs/remotes/foo/tmp/master"));
+
+            Assert.AreEqual("", GitRefName.GetRemoteBranch("refs/remotes/foo"));
+            Assert.AreEqual("", GitRefName.GetRemoteBranch("short"));
+        }
+
+        [Test]
         public void GetFullBranchName()
         {
             Assert.AreEqual("refs/heads/foo", GitRefName.GetFullBranchName("foo"));


### PR DESCRIPTION
Part of #8553 

Based on #8562 , really separated of the original intended change

## Proposed changes

Only show remote branch name if there is a tracking branch
Show ahead/behind information in FormPush multiple branches, like "0↑↓" and "gone" added in #8562
If the current branch is not the tracking branch but a name match is possible, show "=" and "<>".

(gone is discussed in #8562)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/97095361-98217b00-165e-11eb-830c-83b0c0979c38.png)

![image](https://user-images.githubusercontent.com/6248932/97095352-82ac5100-165e-11eb-8bc6-5e5115b2097c.png)

### After

![image](https://user-images.githubusercontent.com/6248932/97766128-65bbc600-1b15-11eb-8b1c-27c1537fb978.png)

![image](https://user-images.githubusercontent.com/6248932/97766159-84ba5800-1b15-11eb-87dc-242c2593d924.png)

## Test methodology 

Manual, added test for GitRef

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
