### PR TITLE
FullPathResolver: Avoid exception for illegal characters

### DIFF
--- a/GitCommands/FileAssociatedIconProvider.cs
+++ b/GitCommands/FileAssociatedIconProvider.cs
@@ -51,7 +51,7 @@ namespace GitCommands
         /// </remarks>
         public Icon Get(string workingDirectory, string relativeFilePath)
         {
-            var extension = Path.GetExtension(relativeFilePath);
+            var extension = PathUtil.GetExtension(relativeFilePath);
             if (string.IsNullOrWhiteSpace(extension))
             {
                 return null;
@@ -68,7 +68,7 @@ namespace GitCommands
                     // extensions from the registry and using p/invokes and WinAPI, which have
                     // significantly higher maintenance overhead.
 
-                    var fullPath = Path.Combine(workingDirectory, relativeFilePath);
+                    var fullPath = PathUtil.Combine(workingDirectory, relativeFilePath);
                     if (!_fileSystem.File.Exists(fullPath))
                     {
                         tempFile = CreateTempFile(Path.GetFileName(fullPath));

--- a/GitCommands/FullPathResolver.cs
+++ b/GitCommands/FullPathResolver.cs
@@ -32,6 +32,11 @@ namespace GitCommands
         /// <summary>
         /// Resolves the provided path (folder or file) against the current working directory.
         /// </summary>
+        /// <remarks>
+        /// Behaves similar to the .NET Core 2.1 version that do not throw on paths with illegal
+        /// Windows characters (that could be OK in Git paths or for cross platform) but returns
+        /// null instead of an possible path.
+        /// but </remarks>
         /// <param name="path">Folder or file path to resolve.</param>
         /// <returns>
         /// <paramref name="path" /> if <paramref name="path" /> is rooted; otherwise resolved path from working directory of the current repository.
@@ -41,12 +46,21 @@ namespace GitCommands
         {
             if (string.IsNullOrWhiteSpace(path))
             {
-                throw new ArgumentNullException(nameof(path));
+                return null;
             }
 
-            if (Path.IsPathRooted(path))
+            try
             {
-                return path;
+                if (Path.IsPathRooted(path))
+                {
+                    return path;
+                }
+            }
+            catch (ArgumentException)
+            {
+                // Illegal characters in path.
+                // This is used for Git paths that may not be possible in the host file system
+                return null;
             }
 
             var workingDir = _getWorkingDir();

--- a/GitCommands/Git/GitItemStatusFileExtensionComparer.cs
+++ b/GitCommands/Git/GitItemStatusFileExtensionComparer.cs
@@ -28,8 +28,8 @@ namespace GitCommands.Git
 
             var lhsPath = GetPrimarySortingPath(x);
             var rhsPath = GetPrimarySortingPath(y);
-            var lhsExt = Path.GetExtension(lhsPath);
-            var rhsExt = Path.GetExtension(rhsPath);
+            var lhsExt = PathUtil.GetExtension(lhsPath);
+            var rhsExt = PathUtil.GetExtension(rhsPath);
 
             var comparisonResult = StringComparer.InvariantCulture.Compare(lhsExt, rhsExt);
             if (comparisonResult == 0)

--- a/GitCommands/GitRevisionInfoProvider.cs
+++ b/GitCommands/GitRevisionInfoProvider.cs
@@ -59,9 +59,7 @@ namespace GitCommands
                 {
                     if (subItem is GitItem gitItem)
                     {
-                        gitItem.FileName = Path.Combine(
-                            basePath,
-                            gitItem.FileName ?? string.Empty);
+                        gitItem.FileName = PathUtil.Combine(basePath, gitItem.FileName) ?? string.Empty;
                     }
 
                     yield return subItem;

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -132,6 +132,54 @@ namespace GitCommands
             }
         }
 
+        /// <summary>
+        /// Wrapper for Path.Combine
+        /// </summary>
+        /// <remark>
+        /// Similar to the .NET Core 2.1 variant, except that null is returned if Windows
+        /// invalid characters (that may be accepted in Git or other filesystems)
+        /// are in the paths instead of a possible path (the OS or file system will throw
+        /// if the paths are invalid).
+        /// </remark>
+        /// <param name="path1">initial part</param>
+        /// <param name="path2">second part</param>
+        /// <returns>path if it can be combined, null otherwise</returns>
+        [CanBeNull]
+        public static string Combine(string path1, string path2)
+        {
+            try
+            {
+                return Path.Combine(path1, path2);
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Wrapper for Path.GetExtension
+        /// </summary>
+        /// <remark>
+        /// <see cref="Combine"/> for motivation.
+        /// </remark>
+        /// <param name="path">path to check</param>
+        /// <returns>path if it can be combined, empty otherwise</returns>
+        [NotNull]
+        public static string GetExtension(string path)
+        {
+            try
+            {
+                return Path.GetExtension(path);
+            }
+            catch (ArgumentException)
+            {
+                // This could return part after a '.' using string commands,
+                // but wait for .NET Core with this edge case
+                return string.Empty;
+            }
+        }
+
         [NotNull]
         public static string Resolve([NotNull] string path, string relativePath = "")
         {
@@ -223,7 +271,7 @@ namespace GitCommands
 
                 foreach (var path in EnvironmentPathsProvider.GetEnvironmentValidPaths())
                 {
-                    fullPath = Path.Combine(path, fileName);
+                    fullPath = Combine(path, fileName);
                     if (File.Exists(fullPath))
                     {
                         return true;
@@ -251,7 +299,7 @@ namespace GitCommands
                     return true;
                 }
 
-                shellPath = Path.Combine(AppSettings.GitBinDir, shell);
+                shellPath = Combine(AppSettings.GitBinDir, shell);
                 if (File.Exists(shellPath))
                 {
                     return true;
@@ -369,7 +417,7 @@ namespace GitCommands
                     return null;
                 }
 
-                var path = Path.Combine(envVarFolder, location);
+                var path = Combine(envVarFolder, location);
                 if (!Directory.Exists(path))
                 {
                     return null;
@@ -380,7 +428,7 @@ namespace GitCommands
 
             string FindFile(string location, string fileName1)
             {
-                string fullName = Path.Combine(location, fileName1);
+                string fullName = Combine(location, fileName1);
                 if (File.Exists(fullName))
                 {
                     return fullName;

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -179,18 +179,18 @@ namespace System
         }
 
         /// <summary>
-        /// Quotes this string with the specified <paramref name="quotationMark"/>
+        /// Quotes this string with the specified <paramref name="q"/>
         /// </summary>
         [Pure]
         [NotNull]
-        public static string Quote([CanBeNull] this string s, [NotNull] string quotationMark = "\"")
+        public static string Quote([CanBeNull] this string s, [NotNull] string q = "\"")
         {
             if (s == null)
             {
                 return "";
             }
 
-            return quotationMark + s + quotationMark;
+            return $"{q}{s.Replace(q, "\\" + q)}{q}";
         }
 
         /// <summary>

--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -41,7 +41,7 @@ namespace GitUI.AutoCompletion
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var regex = GetRegexForExtension(Path.GetExtension(file.Name));
+                var regex = GetRegexForExtension(PathUtil.GetExtension(file.Name));
 
                 if (regex != null)
                 {
@@ -94,7 +94,7 @@ namespace GitUI.AutoCompletion
 
         private static IEnumerable<string> ReadOrInitializeAutoCompleteRegexes()
         {
-            var path = Path.Combine(AppSettings.ApplicationDataPath.Value, "AutoCompleteRegexes.txt");
+            var path = PathUtil.Combine(AppSettings.ApplicationDataPath.Value, "AutoCompleteRegexes.txt");
 
             if (File.Exists(path))
             {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2015,6 +2015,12 @@ namespace GitUI.CommandsDialogs
             var fileNames = new StringBuilder();
             foreach (var item in diffFiles.SelectedItems)
             {
+                var path = PathUtil.Combine(module.WorkingDir, item.Item.Name);
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    continue;
+                }
+
                 // Only use append line when multiple items are selected.
                 // This to make it easier to use the text from clipboard when 1 file is selected.
                 if (fileNames.Length > 0)
@@ -2022,7 +2028,7 @@ namespace GitUI.CommandsDialogs
                     fileNames.AppendLine();
                 }
 
-                fileNames.Append(Path.Combine(module.WorkingDir, item.Item.Name).ToNativePath());
+                fileNames.Append(path.ToNativePath());
             }
 
             ClipboardUtil.TrySetText(fileNames.ToString());
@@ -2423,7 +2429,12 @@ namespace GitUI.CommandsDialogs
 
             foreach (var item in diffFiles.SelectedItems)
             {
-                string filePath = Path.Combine(module.WorkingDir, item.Item.Name.ToNativePath());
+                string filePath = PathUtil.Combine(module.WorkingDir, item.Item.Name.ToNativePath());
+                if (string.IsNullOrWhiteSpace(filePath))
+                {
+                    continue;
+                }
+
                 FormBrowseUtil.ShowFileOrParentFolderInFileExplorer(filePath);
             }
         }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2598,6 +2598,12 @@ namespace GitUI.CommandsDialogs
             var fileNames = new StringBuilder();
             foreach (var item in list.SelectedItems)
             {
+                var fileName = _fullPathResolver.Resolve(item.Item.Name);
+                if (string.IsNullOrWhiteSpace(fileName))
+                {
+                    continue;
+                }
+
                 // Only use append line when multiple items are selected.
                 // This to make it easier to use the text from clipboard when 1 file is selected.
                 if (fileNames.Length > 0)
@@ -2605,7 +2611,7 @@ namespace GitUI.CommandsDialogs
                     fileNames.AppendLine();
                 }
 
-                fileNames.Append(_fullPathResolver.Resolve(item.Item.Name).ToNativePath());
+                fileNames.Append(fileName.ToNativePath());
             }
 
             ClipboardUtil.TrySetText(fileNames.ToString());
@@ -2700,12 +2706,17 @@ namespace GitUI.CommandsDialogs
             }
 
             var item = list.SelectedGitItem;
-            if (item == null)
+            if (item is null)
             {
                 return;
             }
 
             var fileName = _fullPathResolver.Resolve(item.Name);
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                return;
+            }
+
             UICommands.StartFileEditorDialog(fileName);
 
             UnstagedSelectionChanged(null, null);
@@ -3184,13 +3195,10 @@ namespace GitUI.CommandsDialogs
         {
             foreach (var item in list.SelectedItems)
             {
-                var fileNames = new StringBuilder();
-                fileNames.Append(_fullPathResolver.Resolve(item.Item.Name).ToNativePath());
-
-                string filePath = fileNames.ToString();
+                string filePath = _fullPathResolver.Resolve(item.Item.Name);
                 if (File.Exists(filePath))
                 {
-                    OsShellUtil.SelectPathInFileExplorer(filePath);
+                    OsShellUtil.SelectPathInFileExplorer(filePath.ToNativePath());
                 }
             }
         }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -446,8 +446,13 @@ namespace GitUI.CommandsDialogs
                     orgFileName = FileName;
                 }
 
-                string fullName = _fullPathResolver.Resolve(orgFileName.ToNativePath());
+                string fullName = _fullPathResolver.Resolve(orgFileName);
+                if (string.IsNullOrWhiteSpace(fullName))
+                {
+                    return;
+                }
 
+                fullName = fullName.ToNativePath();
                 using (var fileDialog = new SaveFileDialog
                 {
                     InitialDirectory = Path.GetDirectoryName(fullName),

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -314,17 +314,17 @@ namespace GitUI.CommandsDialogs
 
             try
             {
-                string extension = Path.GetExtension(fileName).ToLower();
+                string extension = PathUtil.GetExtension(fileName).ToLower();
                 if (extension.Length <= 1)
                 {
                     return false;
                 }
 
-                string dir = Path.Combine(Path.GetDirectoryName(Application.ExecutablePath), "Diff-Scripts").EnsureTrailingPathSeparator();
+                string dir = PathUtil.Combine(Path.GetDirectoryName(Application.ExecutablePath), "Diff-Scripts").EnsureTrailingPathSeparator();
                 if (Directory.Exists(dir))
                 {
                     if (_mergeScripts.TryGetValue(extension, out var mergeScript) &&
-                        File.Exists(Path.Combine(dir, mergeScript)))
+                        File.Exists(PathUtil.Combine(dir, mergeScript)))
                     {
                         if (MessageBox.Show(this, string.Format(_uskUseCustomMergeScript.Text, mergeScript),
                                             _uskUseCustomMergeScriptCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) ==

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -537,7 +537,7 @@ namespace GitUI.CommandsDialogs
             foreach (var item in DiffFiles.SelectedItems)
             {
                 string filePath = _fullPathResolver.Resolve(item.Item.Name);
-                if (FormBrowseUtil.FileOrParentDirectoryExists(filePath))
+                if (filePath != null && FormBrowseUtil.FileOrParentDirectoryExists(filePath))
                 {
                     openContainingFolderToolStripMenuItem.Enabled = true;
                     break;
@@ -979,8 +979,7 @@ namespace GitUI.CommandsDialogs
                 foreach (var item in items)
                 {
                     var path = _fullPathResolver.Resolve(item.Item.Name);
-                    bool isDir = (File.GetAttributes(path) & FileAttributes.Directory) == FileAttributes.Directory;
-                    if (isDir)
+                    if (Directory.Exists(path))
                     {
                         Directory.Delete(path, recursive: true);
                     }

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -675,7 +675,10 @@ See the changes in the commit form.");
             if (tvGitTree.SelectedNode?.Tag is GitItem gitItem && gitItem.ObjectType == GitObjectType.Blob)
             {
                 var fileName = _fullPathResolver.Resolve(gitItem.FileName);
-                OsShellUtil.OpenAs(fileName.ToNativePath());
+                if (File.Exists(fileName))
+                {
+                    OsShellUtil.OpenAs(fileName.ToNativePath());
+                }
             }
         }
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeController.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeController.cs
@@ -120,7 +120,8 @@ namespace GitUI.CommandsDialogs
 
                     case GitObjectType.Blob:
                         {
-                            var extension = Path.GetExtension(gitItem.FileName);
+                            var extension = PathUtil.GetExtension(gitItem.FileName);
+
                             if (string.IsNullOrWhiteSpace(extension))
                             {
                                 continue;
@@ -128,8 +129,8 @@ namespace GitUI.CommandsDialogs
 
                             if (!imageCollection.ContainsKey(extension))
                             {
-                                // a little optimisation - initialise the first time it is required
-                                workingDir = workingDir ?? _getWorkingDir();
+                                // lazy - initialise the first time used
+                                workingDir ??= _getWorkingDir();
 
                                 var fileIcon = _iconProvider.Get(workingDir, gitItem.FileName);
                                 if (fileIcon == null)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -555,8 +555,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                                                       null)))
             {
                 // Check if shell extensions are installed
-                string path32 = Path.Combine(AppSettings.GetInstallDir(), CommonLogic.GitExtensionsShellEx32Name);
-                string path64 = Path.Combine(AppSettings.GetInstallDir(), CommonLogic.GitExtensionsShellEx64Name);
+                string path32 = PathUtil.Combine(AppSettings.GetInstallDir(), CommonLogic.GitExtensionsShellEx32Name);
+                string path64 = PathUtil.Combine(AppSettings.GetInstallDir(), CommonLogic.GitExtensionsShellEx64Name);
                 if (!File.Exists(path32) || (IntPtr.Size == 8 && !File.Exists(path64)))
                 {
                     RenderSettingSet(ShellExtensionsRegistered, ShellExtensionsRegistered_Fix, _shellExtNoInstalled.Text);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
@@ -36,7 +36,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             foreach (string translation in translations)
             {
-                var imagePath = Path.Combine(Translator.GetTranslationDir(), translation + ".gif");
+                var imagePath = PathUtil.Combine(Translator.GetTranslationDir(), translation + ".gif");
                 if (File.Exists(imagePath))
                 {
                     var image = Image.FromFile(imagePath);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -64,7 +64,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     try
                     {
                         if (!string.IsNullOrEmpty(candidate) &&
-                            File.Exists(Path.Combine(candidate, ".gitconfig")))
+                            File.Exists(PathUtil.Combine(candidate, ".gitconfig")))
                         {
                             return true;
                         }
@@ -138,7 +138,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             try
             {
                 string userHomeDir = Environment.GetEnvironmentVariable("HOME", EnvironmentVariableTarget.User);
-                if (!string.IsNullOrEmpty(userHomeDir) && File.Exists(Path.Combine(userHomeDir, ".gitconfig")))
+                if (!string.IsNullOrEmpty(userHomeDir) && File.Exists(PathUtil.Combine(userHomeDir, ".gitconfig")))
                 {
                     MessageBox.Show(this, string.Format(_gitconfigFoundHome.Text, userHomeDir), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     defaultHome.Checked = true;
@@ -156,7 +156,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             {
                 var path = Environment.GetEnvironmentVariable("HOMEDRIVE") +
                            Environment.GetEnvironmentVariable("HOMEPATH");
-                if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
+                if (!string.IsNullOrEmpty(path) && File.Exists(PathUtil.Combine(path, ".gitconfig")))
                 {
                     MessageBox.Show(this, string.Format(_gitconfigFoundHomedrive.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     defaultHome.Checked = true;
@@ -173,7 +173,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             try
             {
                 var path = Environment.GetEnvironmentVariable("USERPROFILE");
-                if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
+                if (!string.IsNullOrEmpty(path) && File.Exists(PathUtil.Combine(path, ".gitconfig")))
                 {
                     MessageBox.Show(this, string.Format(_gitconfigFoundUserprofile.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     userprofileHome.Checked = true;
@@ -190,7 +190,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             try
             {
                 var path = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-                if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
+                if (!string.IsNullOrEmpty(path) && File.Exists(PathUtil.Combine(path, ".gitconfig")))
                 {
                     MessageBox.Show(this, string.Format(_gitconfigFoundPersonalFolder.Text, Environment.GetFolderPath(Environment.SpecialFolder.Personal)),
                         "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -613,7 +613,7 @@ namespace GitUI.Editor
         /// <returns>Task</returns>
         public Task ViewFileAsync(string fileName, bool isSubmodule = false, [CanBeNull] Action openWithDifftool = null)
         {
-            string fullPath = Path.GetFullPath(_fullPathResolver.Resolve(fileName));
+            string fullPath = _fullPathResolver.Resolve(fileName);
 
             if (isSubmodule && !GitModule.IsValidGitWorkingDir(fullPath))
             {
@@ -828,7 +828,6 @@ namespace GitUI.Editor
         {
             bool changePhysicalFile = (viewMode == ViewMode.Diff || viewMode == ViewMode.FixedDiff)
                                       && !Module.IsBareRepository()
-                                      && !string.IsNullOrWhiteSpace(fileName)
                                       && File.Exists(_fullPathResolver.Resolve(fileName));
 
             cherrypickSelectedLinesToolStripMenuItem.Visible = changePhysicalFile;
@@ -879,10 +878,11 @@ namespace GitUI.Editor
             {
                 try
                 {
-                    var file = GetFileInfo(fileName);
+                    var resolvedPath = _fullPathResolver.Resolve(fileName);
 
-                    if (file.Exists)
+                    if (File.Exists(resolvedPath))
                     {
+                        var file = new FileInfo(resolvedPath);
                         return file.Length;
                     }
                 }
@@ -1073,12 +1073,6 @@ namespace GitUI.Editor
                     text => ThreadHelper.JoinableTaskFactory.Run(
                         () => ViewTextAsync(fileName, text, openWithDifftool, checkGitAttributes: true)));
             }
-        }
-
-        private FileInfo GetFileInfo(string fileName)
-        {
-            var resolvedPath = _fullPathResolver.Resolve(fileName);
-            return new FileInfo(resolvedPath);
         }
 
         private static string ToHexDump(byte[] bytes, StringBuilder str, int columnWidth = 8, int columnCount = 2)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -567,7 +567,7 @@ namespace GitUI.Editor
             {
                 // File system access for other than Worktree,
                 // to handle that git-status does not detect details for untracked (git-diff --no-index will not give info)
-                var fullPath = Path.Combine(Module.WorkingDir, file.Name);
+                var fullPath = PathUtil.Combine(Module.WorkingDir, file.Name);
                 if (Directory.Exists(fullPath) && GitModule.IsValidGitWorkingDir(fullPath))
                 {
                     isSubmodule = true;

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1431,7 +1431,10 @@ namespace GitUI
                     {
                         string fileName = _fullPathResolver.Resolve(item.Item.Name);
 
-                        fileList.Add(fileName.ToNativePath());
+                        if (!string.IsNullOrWhiteSpace(fileName))
+                        {
+                            fileList.Add(fileName.ToNativePath());
+                        }
                     }
 
                     var obj = new DataObject();

--- a/Plugins/Statistics/GitStatistics/LineCounter.cs
+++ b/Plugins/Statistics/GitStatistics/LineCounter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using GitCommands;
 
 namespace GitStatistics
 {
@@ -53,7 +54,7 @@ namespace GitStatistics
             {
                 foreach (var file in filesToCheck)
                 {
-                    if (extensions.Contains(Path.GetExtension(file)))
+                    if (extensions.Contains(PathUtil.GetExtension(file)))
                     {
                         FileInfo fileInfo;
                         try

--- a/UnitTests/GitCommands.Tests/Config/ConfigFileTest.cs
+++ b/UnitTests/GitCommands.Tests/Config/ConfigFileTest.cs
@@ -54,19 +54,6 @@ namespace GitCommandsTests.Config
             return content.ToString();
         }
 
-        private void AddConfigValue(string cfgFile, string section, string value)
-        {
-            var args = new GitArgumentBuilder("config")
-            {
-                "-f",
-                cfgFile.Quote(),
-                "--add",
-                section,
-                value
-            };
-            Module.GitExecutable.GetOutput(args);
-        }
-
         private string GetConfigValue(string cfgFile, string key)
         {
             var args = new GitArgumentBuilder("config")
@@ -74,7 +61,9 @@ namespace GitCommandsTests.Config
                 "-f",
                 cfgFile.Quote(),
                 "--get",
-                key.Quote()
+
+                // Quote the key without unescaping internal quotes
+                $"\"{key}\""
             };
             return Module.GitExecutable.GetOutput(args).TrimEnd('\n');
         }

--- a/UnitTests/GitCommands.Tests/EnvironmentPathsProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/EnvironmentPathsProviderTests.cs
@@ -41,7 +41,7 @@ namespace GitCommandsTests
         public void GetEnvironmentValidPaths_quoted()
         {
             var paths = GetValidPaths().Concat(GetInvalidPaths());
-            var quotedPaths = paths.Select(path => path.Quote(" ")).Select(path => path.Quote());
+            var quotedPaths = paths.Select(path => path.Quote());
             string pathVariable = string.Join(_separator, quotedPaths);
             _environment.GetEnvironmentVariable("PATH").Returns(pathVariable);
 

--- a/UnitTests/GitCommands.Tests/FullPathResolverTests.cs
+++ b/UnitTests/GitCommands.Tests/FullPathResolverTests.cs
@@ -21,9 +21,12 @@ namespace GitCommandsTests
         [TestCase(null)]
         [TestCase("")]
         [TestCase(" ")]
-        public void Resolve_should_throw_if_path_null_or_empty(string path)
+
+        // A few samples from Path.GetInvalidFileNameChars() and Path.GetInvalidPathChars()
+        [TestCase("\"\r\t*\\|<>")]
+        public void Resolve_should_return_null_if_path_null_or_illegal_chars(string path)
         {
-            ((Action)(() => _resolver.Resolve(path))).Should().Throw<ArgumentNullException>();
+            _resolver.Resolve(path).Should().BeNull();
         }
 
         [TestCase(@"c:\")]

--- a/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
@@ -188,6 +188,24 @@ namespace GitCommandsTests.Helpers
             PathUtil.NormalizePath(path).Should().Be(expected);
         }
 
+        [TestCase(@"C:\work\t.txt", "whatever", @"C:\work\t.txt\whatever")]
+        [TestCase(@"C:\wor""k\t.txt", "whatever", null)]
+        [TestCase(@"\\WSL$\Ubuntu\home\jack\.\work\", "whatever", @"\\WSL$\Ubuntu\home\jack\.\work\whatever")]
+        public void Combine(string path1, string path2, string expected)
+        {
+            PathUtil.Combine(path1, path2).Should().Be(expected);
+        }
+
+        [TestCase(@"C:\work\t.txt", @".txt")]
+        [TestCase(@"C:\work\t.", @"")]
+        [TestCase(@"work/t.bmp", @".bmp")]
+        [TestCase(@"work""/t.bmp", @"")]
+        [TestCase(@"\\WSL$\Ubuntu\home\jack\.\work", @"")]
+        public void GetExtension(string path, string expected)
+        {
+            PathUtil.GetExtension(path).Should().Be(expected);
+        }
+
         [TestCase(@"C:\WORK\GitExtensions\", @"C:\WORK\GitExtensions\")]
         [TestCase(@"\\my-pc\Work\GitExtensions\", @"\\my-pc\Work\GitExtensions\")]
         [TestCase(@"\\wsl$\Ubuntu\home\jack\work\", @"\\wsl$\Ubuntu\home\jack\work\")]


### PR DESCRIPTION
Fixes #8571 
Fixes #8364 
Fixes #8437
Fixes #7862

## Proposed changes

FullPathResolver throws if a file name contains Windows illegal characters that could be OK in Git repos. 
As FullPathResolver is often used to check if a local file exists for instance to enable menu items, an exception
is normally not required and null can be returned instead. 
For instance `File.Exists(null) ==false`.

In some situations returning null will still cause a null exceptions instead.
Reviewed the usage of Resolve() to change situations where null should not be fatal. This review is best effort, there may be other situations that should be changed too. Most "null unhandled" are used in Process(), there are other PRs there.
Some handling already use try-catch, like Delete in FormCommit.

An alternative would be to add a new method like `bool TryResolve(string path)` or `bool Resolve(string path, bool throw = true)` and change the about 45 of 60 Resolve() call sites to explicitly not throw.

## Test methodology

Tests updated

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
