### PR TITLE
fix background / foreground contrast for gray text

### DIFF
--- a/GitUI/Themes/dark.css
+++ b/GitUI/Themes/dark.css
@@ -12,7 +12,7 @@
 .ControlLightLight       { color: #292c2c; }
 .ControlText             { color: #afb1b3; }
 .Desktop                 { color: #2b2b2b; }
-.GrayText                { color: #727272; }
+.GrayText                { color: #767676; }
 .Highlight               { color: #6290e6; }
 .HighlightText           { color: #000000; }
 .HotTrack                { color: #98b7ef; }
@@ -34,7 +34,7 @@
 
 /* Application colors */
 .OtherTag                    { color: #a1a1a1; }
-.AuthoredHighlight           { color: #373832; }
+.AuthoredHighlight           { color: #2a2b26; }
 .HighlightAllOccurences      { color: #606020; }
 .Tag                         { color: #408080; }
 .Graph                       { color: #882d00; }

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -258,10 +258,10 @@ namespace GitUI.UserControls.RevisionGrid
             {
                 (isNonRelativeGray: false, isSelected: false) => SystemColors.GrayText,
                 (isNonRelativeGray: false, isSelected: true) => getHighlightedGrayTextColor(),
-                (isNonRelativeGray: true, isSelected: false) => getGrayTextColor(degreeOfGrayness: 1.75f),
+                (isNonRelativeGray: true, isSelected: false) => getGrayTextColor(degreeOfGrayness: 1.4f),
 
                 // (isGray: true, isSelected: true)
-                _ => getHighlightedGrayTextColor(degreeOfGrayness: 1.75f)
+                _ => getHighlightedGrayTextColor(degreeOfGrayness: 1.4f)
             };
         }
 


### PR DESCRIPTION
Fix too low contrast between commit body and background in dark theme.

Problem was introduced in #8550 and [pointed out](https://github.com/gitextensions/gitextensions/pull/8550#issuecomment-716208279) by @gerhardol

## Before fix

![image](https://user-images.githubusercontent.com/12046452/97121136-02a0ec80-172d-11eb-982a-f9666fb8410b.png)


## Screenshot after fix:

![image](https://user-images.githubusercontent.com/12046452/97121013-7989b580-172c-11eb-9499-e0d972431bdb.png)
