### PR TITLE
Do not  throw if Git is upgraded  while GE is started

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -416,8 +416,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                             {
                                 // No action
                             }
-
-                            throw;
                         }
                         finally
                         {

--- a/GitUI/UserControls/InteractiveGitActionControl.cs
+++ b/GitUI/UserControls/InteractiveGitActionControl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 using GitCommands.Git.Commands;
 using GitExtUtils.GitUI.Theming;
@@ -56,7 +57,17 @@ namespace GitUI.UserControls
                 return;
             }
 
-            bool hasConflicts = Module.InTheMiddleOfConflictedMerge();
+            bool hasConflicts;
+            try
+            {
+                hasConflicts = Module.InTheMiddleOfConflictedMerge();
+            }
+            catch (Win32Exception)
+            {
+                // This command can be executed seemingly in the background (selecting Browse),
+                // do not notify the user (this can occur if Git is upgraded)
+                hasConflicts = false;
+            }
 
             if (Module.InTheMiddleOfRebase())
             {

--- a/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
+++ b/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
@@ -93,21 +93,39 @@ namespace BackgroundFetch
                                       GitArgumentBuilder args;
                                       if (_fetchAllSubmodules.ValueOrDefault(Settings))
                                       {
-                                        args = new GitArgumentBuilder("submodule")
-                                        {
+                                          // The Git command is hardcoded compared, not using _gitCommand
+                                          args = new GitArgumentBuilder("submodule")
+                                          {
                                             "foreach",
                                             "--recursive",
                                             "git",
                                             "fetch",
                                             "--all"
-                                        };
+                                          };
 
-                                        _currentGitUiCommands.GitModule.GitExecutable.GetOutput(args);
+                                          try
+                                          {
+                                              _currentGitUiCommands.GitModule.GitExecutable.GetOutput(args);
+                                          }
+                                          catch
+                                          {
+                                              // Ignore background errors
+                                          }
                                       }
 
                                       var gitCmd = _gitCommand.ValueOrDefault(Settings).Trim().SplitBySpace();
                                       args = new GitArgumentBuilder(gitCmd[0]) { gitCmd.Skip(1) };
-                                      var msg = _currentGitUiCommands.GitModule.GitExecutable.GetOutput(args);
+                                      string msg;
+                                      try
+                                      {
+                                          msg = _currentGitUiCommands.GitModule.GitExecutable.GetOutput(args);
+                                      }
+                                      catch
+                                      {
+                                          // Ignore background errors
+                                          return;
+                                      }
+
                                       if (_autoRefresh.ValueOrDefault(Settings))
                                       {
                                           if (gitCmd[0].Equals("fetch", StringComparison.InvariantCultureIgnoreCase))


### PR DESCRIPTION
Related to the closed issue of #6692 and others
Submitted to minimize time wasted on this again.

With regards to https://github.com/gitextensions/gitextensions/issues/6692#issuecomment-710881897
This change is like allowing the user to hot swap the engine while running, as long as they do not touch any controls,
or they have changed specific addons.

## Proposed changes

Ignore exceptions for GitStatusMonitor and Background fetch plugin,
as well as "Browse activation" (selecting the window).
This is the most common background use of Git.
The primary usage is to allow Git upgrades while GE is active.

Active use of GE will raise exceptions, not much can be done when Git is not available.
#8278 or #8358 improves the error message.

Note that GitStatusMonitor will not monitor changes until refresh or a new repo is opened,
and that possible merge conflicts will be ignored (to not trigger the user to select Resolve).

## Test methodology <!-- How did you ensure quality? -->

Manual, removing git.exe after startup

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
