### PR TITLE
FormGoToCommit: set focus on commit textbox when no control has focus

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -131,6 +131,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             {
                 _selectedRevision = _selectedBranch != null ? _selectedBranch.Guid : "";
             }
+            else
+            {
+                textboxCommitExpression.Focus();
+            }
         }
 
         private void comboBoxTags_TextChanged(object sender, EventArgs e)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8591 


## Proposed changes

- When opening the form, the focus is on the commit textbox and the text is selected if textbox if filled with the clipboard content.

Perhaps not the best way to fix but it works...


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 7a52bdf65744b5d760d9edb9afc9a1863b88d2e7
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4261.0
- DPI 192dpi (200% scaling)
