### PR TITLE
Fix Open with Diff Tool does not work with staged renamed file in FormCommit dialog

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2611,21 +2611,18 @@ namespace GitUI.CommandsDialogs
             ClipboardUtil.TrySetText(fileNames.ToString());
         }
 
-        private void OpenFilesWithDiffTool(IEnumerable<GitItemStatus> items, string firstRevision, string secondRevision)
+        private void OpenFilesWithDiffTool(IEnumerable<FileStatusItem> items)
         {
             foreach (var item in items)
             {
-                string output = Module.OpenWithDifftool(item.Name, firstRevision: firstRevision, secondRevision: secondRevision, isTracked: item.IsTracked);
-                if (!string.IsNullOrEmpty(output))
-                {
-                    MessageBox.Show(this, output, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
+                GitRevision[] revs = new[] { item.SecondRevision, item.FirstRevision };
+                UICommands.OpenWithDifftool(this, revs, item.Item.Name, item.Item.OldName, RevisionDiffKind.DiffAB, item.Item.IsTracked);
             }
         }
 
         private void OpenWithDifftoolToolStripMenuItemClick(object sender, EventArgs e)
         {
-            OpenFilesWithDiffTool(Unstaged.SelectedItems.Items(), GitRevision.IndexGuid, GitRevision.WorkTreeGuid);
+            OpenFilesWithDiffTool(Unstaged.SelectedItems);
         }
 
         private void OpenWithDiffTool()
@@ -3197,7 +3194,7 @@ namespace GitUI.CommandsDialogs
 
         private void stagedOpenDifftoolToolStripMenuItem9_Click(object sender, EventArgs e)
         {
-            OpenFilesWithDiffTool(Staged.SelectedItems.Items(), "HEAD", GitRevision.IndexGuid);
+            OpenFilesWithDiffTool(Staged.SelectedItems);
         }
 
         private void openFolderToolStripMenuItem10_Click(object sender, EventArgs e)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8600


## Proposed changes

- Use `UICommands.OpenWithDiffTool`, just like `RevisionDiffControl`, with `diffKind = RevisionDiffKind.DiffAB`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual test. FormCommit has no unit test. I found an integration test for FormCommit, but there's no test for difftool yet.

## Test environment(s) <!-- Remove any that don't apply -->

- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.17763.0
- .NET Framework 4.8.4250.0
- DPI 144dpi (150% scaling)

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
