### PR TITLE
RevDiff context menu for cherry-pick

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -335,6 +335,7 @@ namespace GitUI.CommandsDialogs
             bool isAnyTracked = selectedItems.Any(item => item.Item.IsTracked);
             bool isAnyIndex = selectedItems.Any(item => item.Item.Staged == StagedStatus.Index);
             bool isAnyWorkTree = selectedItems.Any(item => item.Item.Staged == StagedStatus.WorkTree);
+            bool isDeleted = selectedItems.Any(item => item.Item.IsDeleted);
             bool isAnySubmodule = selectedItems.Any(item => item.Item.IsSubmodule);
             (bool allFilesExist, bool allFilesOrUntrackedDirectoriesExist) = FileOrUntrackedDirExists(selectedItems, _fullPathResolver);
 
@@ -349,6 +350,7 @@ namespace GitUI.CommandsDialogs
                 allFilesExist: allFilesExist,
                 allFilesOrUntrackedDirectoriesExist: allFilesOrUntrackedDirectoriesExist,
                 isAnyTracked: isAnyTracked,
+                isDeleted: isDeleted,
                 isAnySubmodule: isAnySubmodule);
             return selectionInfo;
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -335,6 +335,7 @@ namespace GitUI.CommandsDialogs
             bool isAnyTracked = selectedItems.Any(item => item.Item.IsTracked);
             bool isAnyIndex = selectedItems.Any(item => item.Item.Staged == StagedStatus.Index);
             bool isAnyWorkTree = selectedItems.Any(item => item.Item.Staged == StagedStatus.WorkTree);
+            bool supportPatches = selectedGitItemCount == 1 && DiffText.HasAnyPatches();
             bool isDeleted = selectedItems.Any(item => item.Item.IsDeleted);
             bool isAnySubmodule = selectedItems.Any(item => item.Item.IsSubmodule);
             (bool allFilesExist, bool allFilesOrUntrackedDirectoriesExist) = FileOrUntrackedDirExists(selectedItems, _fullPathResolver);
@@ -350,6 +351,7 @@ namespace GitUI.CommandsDialogs
                 allFilesExist: allFilesExist,
                 allFilesOrUntrackedDirectoriesExist: allFilesOrUntrackedDirectoriesExist,
                 isAnyTracked: isAnyTracked,
+                supportPatches: supportPatches,
                 isDeleted: isDeleted,
                 isAnySubmodule: isAnySubmodule);
             return selectionInfo;

--- a/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -39,6 +39,7 @@ namespace GitUI.CommandsDialogs
             bool allFilesExist,
             bool allFilesOrUntrackedDirectoriesExist,
             bool isAnyTracked,
+            bool supportPatches,
             bool isDeleted,
             bool isAnySubmodule)
         {
@@ -52,6 +53,7 @@ namespace GitUI.CommandsDialogs
             AllFilesExist = allFilesExist;
             AllFilesOrUntrackedDirectoriesExist = allFilesOrUntrackedDirectoriesExist;
             IsAnyTracked = isAnyTracked;
+            SupportPatches = supportPatches;
             IsDeleted = isDeleted;
             IsAnySubmodule = isAnySubmodule;
         }
@@ -67,6 +69,7 @@ namespace GitUI.CommandsDialogs
         public bool AllFilesExist { get; }
         public bool AllFilesOrUntrackedDirectoriesExist { get; }
         public bool IsAnyTracked { get; }
+        public bool SupportPatches { get; }
         public bool IsDeleted { get; }
         public bool IsAnySubmodule { get; }
     }
@@ -105,8 +108,12 @@ namespace GitUI.CommandsDialogs
 
         public bool ShouldShowMenuCherryPick(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.SelectedGitItemCount == 1 && !selectionInfo.IsAnySubmodule
-                && !selectionInfo.IsDisplayOnlyDiff && !selectionInfo.IsBareRepository
+            return selectionInfo.SelectedGitItemCount == 1
+                && !selectionInfo.IsAnySubmodule
+                && !selectionInfo.IsDisplayOnlyDiff
+                && !selectionInfo.IsBareRepository
+                && selectionInfo.AllFilesExist
+                && selectionInfo.SupportPatches
                 && !(selectionInfo.SelectedRevision?.IsArtificial ?? false);
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -39,6 +39,7 @@ namespace GitUI.CommandsDialogs
             bool allFilesExist,
             bool allFilesOrUntrackedDirectoriesExist,
             bool isAnyTracked,
+            bool isDeleted,
             bool isAnySubmodule)
         {
             SelectedRevision = selectedRevision;
@@ -51,6 +52,7 @@ namespace GitUI.CommandsDialogs
             AllFilesExist = allFilesExist;
             AllFilesOrUntrackedDirectoriesExist = allFilesOrUntrackedDirectoriesExist;
             IsAnyTracked = isAnyTracked;
+            IsDeleted = isDeleted;
             IsAnySubmodule = isAnySubmodule;
         }
 
@@ -65,6 +67,7 @@ namespace GitUI.CommandsDialogs
         public bool AllFilesExist { get; }
         public bool AllFilesOrUntrackedDirectoriesExist { get; }
         public bool IsAnyTracked { get; }
+        public bool IsDeleted { get; }
         public bool IsAnySubmodule { get; }
     }
 
@@ -155,6 +158,7 @@ namespace GitUI.CommandsDialogs
         {
             return selectionInfo.SelectedGitItemCount == 1
                 && !(selectionInfo.SelectedRevision?.IsArtificial ?? false)
+                && !selectionInfo.IsDeleted
                 && !selectionInfo.IsStatusOnly;
         }
 

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
@@ -1,5 +1,4 @@
 ﻿using FluentAssertions;
-using GitCommands;
 using GitCommands.Git;
 using GitUI.CommandsDialogs;
 using GitUIPluginInterfaces;
@@ -32,6 +31,7 @@ namespace GitUITests.CommandsDialogs
             bool allFilesExist = true,
             bool allFilesOrUntrackedDirectoriesExist = false,
             bool isAnyTracked = true,
+            bool isDeleted = false,
             bool isAnySubmodule = false)
         {
             return new ContextMenuSelectionInfo(selectedRevision,
@@ -44,6 +44,7 @@ namespace GitUITests.CommandsDialogs
                 allFilesExist,
                 allFilesOrUntrackedDirectoriesExist,
                 isAnyTracked,
+                isDeleted,
                 isAnySubmodule);
         }
 
@@ -274,6 +275,17 @@ namespace GitUITests.CommandsDialogs
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isStatusOnly: t);
             _controller.ShouldShowMenuCopyFileName(selectionInfo).Should().Be(!t);
             _controller.ShouldShowMenuShowInFolder(selectionInfo).Should().Be(!t);
+            _controller.ShouldShowMenuShowInFileTree(selectionInfo).Should().Be(!t);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void BrowseDiff_ShowInFileTree(bool t)
+        {
+            var rev = new GitRevision(ObjectId.Random());
+            var selectionInfo = CreateContextMenuSelectionInfo(rev, isDeleted: t);
+            _controller.ShouldShowMenuCopyFileName(selectionInfo).Should().Be(true);
+            _controller.ShouldShowMenuShowInFolder(selectionInfo).Should().Be(true);
             _controller.ShouldShowMenuShowInFileTree(selectionInfo).Should().Be(!t);
         }
 

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
@@ -31,6 +31,7 @@ namespace GitUITests.CommandsDialogs
             bool allFilesExist = true,
             bool allFilesOrUntrackedDirectoriesExist = false,
             bool isAnyTracked = true,
+            bool supportPatches = true,
             bool isDeleted = false,
             bool isAnySubmodule = false)
         {
@@ -44,6 +45,7 @@ namespace GitUITests.CommandsDialogs
                 allFilesExist,
                 allFilesOrUntrackedDirectoriesExist,
                 isAnyTracked,
+                supportPatches,
                 isDeleted,
                 isAnySubmodule);
         }
@@ -254,6 +256,17 @@ namespace GitUITests.CommandsDialogs
             var rev = new GitRevision(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isDisplayOnlyDiff: true);
             _controller.ShouldShowMenuOpenRevision(selectionInfo).Should().BeFalse();
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void BrowseDiff_SupportLinePatches(bool t)
+        {
+            var rev = new GitRevision(ObjectId.Random());
+            var selectionInfo = CreateContextMenuSelectionInfo(rev, supportPatches: t);
+            _controller.ShouldShowMenuSaveAs(selectionInfo).Should().BeTrue();
+            _controller.ShouldShowMenuCherryPick(selectionInfo).Should().Be(t);
+            _controller.ShouldShowMenuOpenRevision(selectionInfo).Should().BeTrue();
         }
 
         [TestCase(true)]


### PR DESCRIPTION
Fixes #8588 

## Proposed changes

- Do not show cherry-pick in the file status list if the file is added or if the file does not exist 
Note that the FileViewer check for support patches is quite incomplete and fails for instance for 8a8985d78edb997d094ad9642220a8457b2c7f9b GitUI\Editor\Diff\RangeDiffHighlightService.cs
This is fixed in #7825 (that is blocked for other reasons.) Will not be handled here.

- Do not show _Show in File tree_ if the file has been deleted (as it will not exist in the tree)


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/98475668-2452a700-21f6-11eb-9d20-72dc3b1fbe4b.png)

![image](https://user-images.githubusercontent.com/6248932/98478006-fde13b80-21f6-11eb-99e9-0a89911b88b2.png)

### After

![image](https://user-images.githubusercontent.com/6248932/98474531-ab534f80-21f5-11eb-9e16-b7230288017c.png)

![image](https://user-images.githubusercontent.com/6248932/98474980-ddfd4800-21f5-11eb-9b1e-5e695303cc22.png)

## Test methodology <!-- How did you ensure quality? -->

Tests updated

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
