### PR TITLE
Fix left panel broken sort and filtering

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -189,7 +189,7 @@ namespace GitUI.BranchTreePanel
             }
         }
 
-        [DebuggerDisplay("(Local) FullPath = {FullPath}, Hash = {ObjectId}, Visible: {IsVisible}")]
+        [DebuggerDisplay("(Local) FullPath = {FullPath}, Hash = {ObjectId}, Visible: {Visible}")]
         private sealed class LocalBranchNode : BaseBranchLeafNode, IGitRefActions, ICanRename, ICanDelete
         {
             public LocalBranchNode(Tree tree, in ObjectId objectId, string fullPath, bool isCurrent, bool visible)
@@ -341,6 +341,15 @@ namespace GitUI.BranchTreePanel
                 }
 
                 return FillBranchTree(_loadedBranches, token);
+            }
+
+            /// <inheritdoc/>
+            protected internal override void Refresh()
+            {
+                // Break the local cache to ensure the data is requeried to reflect the required sort order.
+                _loadedBranches = null;
+
+                base.Refresh();
             }
 
             private Nodes FillBranchTree(IReadOnlyList<IGitRef> branches, CancellationToken token)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -61,6 +61,15 @@ namespace GitUI.BranchTreePanel
                 return await FillBranchTreeAsync(_loadedBranches, token);
             }
 
+            /// <inheritdoc/>
+            protected internal override void Refresh()
+            {
+                // Break the local cache to ensure the data is requeried to reflect the required sort order.
+                _loadedBranches = null;
+
+                base.Refresh();
+            }
+
             private async Task<Nodes> FillBranchTreeAsync(IReadOnlyList<IGitRef> branches, CancellationToken token)
             {
                 var nodes = new Nodes(this);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -107,6 +107,15 @@ namespace GitUI.BranchTreePanel
                 return ReloadNodesAsync(LoadNodesAsync);
             }
 
+            /// <inheritdoc/>
+            protected internal override void Refresh()
+            {
+                // Break the local cache to ensure the data is requeried to reflect the required sort order.
+                _loadedTags = null;
+
+                base.Refresh();
+            }
+
             protected override async Task<Nodes> LoadNodesAsync(CancellationToken token)
             {
                 await TaskScheduler.Default;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -221,7 +221,16 @@ namespace GitUI.BranchTreePanel
             /// <summary>
             /// Requests to refresh the data tree and to apply filtering, if necessary.
             /// </summary>
-            internal void Refresh() => Refresh(_isCurrentlyFiltering);
+            protected internal virtual void Refresh()
+            {
+                // NOTE: descendants may need to break their local caches to ensure the latest data is loaded.
+
+                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    IsFiltering.Value = _isCurrentlyFiltering;
+                    await ReloadNodesAsync(LoadNodesAsync);
+                });
+            }
 
             /// <summary>
             /// Requests to refresh the data tree and to apply filtering, if necessary.
@@ -229,7 +238,7 @@ namespace GitUI.BranchTreePanel
             /// <param name="isFiltering">
             ///  <see langword="true"/>, if the data is being filtered; otherwise <see langword="false"/>.
             /// </param>
-            public void Refresh(bool isFiltering)
+            internal void ToggleFilterMode(bool isFiltering)
             {
                 // If we're not currently filtering and no need to filter now -> exit.
                 // Else we need to iterate over the list and rebind the tree - whilst there

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -243,11 +243,18 @@ namespace GitUI.BranchTreePanel
             _ = UICommandsSource;
         }
 
-        public void RefreshRefs(bool isFiltering)
+        /// <summary>
+        /// Toggles filtering mode on or off to the git refs present in the left panel depending on the app's global filtering rules .
+        /// These rules include: show all branches / show current branch / show filtered branches, etc.
+        /// </summary>
+        /// <param name="isFiltering">
+        ///  <see langword="true"/>, if the data is being filtered; otherwise <see langword="false"/>.
+        /// </param>
+        public void ToggleFilterMode(bool isFiltering)
         {
-            _branchesTree.Refresh(isFiltering);
-            _remotesTree.Refresh(isFiltering);
-            _tagTree.Refresh(isFiltering);
+            _branchesTree.ToggleFilterMode(isFiltering);
+            _remotesTree.ToggleFilterMode(isFiltering);
+            _tagTree.ToggleFilterMode(isFiltering);
         }
 
         public void SelectionChanged(IReadOnlyList<GitRevision> selectedRevisions)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -226,7 +226,7 @@ namespace GitUI.CommandsDialogs
                 //      b) filter on specific branch
                 bool isFiltering = !AppSettings.ShowReflogReferences
                                 && (AppSettings.ShowCurrentBranchOnly || AppSettings.BranchFilterEnabled);
-                repoObjectsTree.RefreshRefs(isFiltering);
+                repoObjectsTree.ToggleFilterMode(isFiltering);
             };
 
             _filterRevisionsHelper.SetFilter(filter);

--- a/GitUI/UserControls/TreeViewExtensions.cs
+++ b/GitUI/UserControls/TreeViewExtensions.cs
@@ -69,7 +69,7 @@ namespace GitUI.UserControls
             }
         }
 
-        private static TreeNode GetNodeFromPath(TreeNode node, string path)
+        public static TreeNode GetNodeFromPath(this TreeNode node, string path)
         {
             if (GetFullNamePath(node) == path)
             {


### PR DESCRIPTION
## Proposed changes

- Correct sorting in the left panel without enabled filters, as the current behaviour doesn't requery data, nor refresh the content.
    There are two distinct, yet connected, operations:
    - sort (with and without a filter), and
    - filtering.

    The "filter" is primarily concerned with rendering, i.e. visually indicate  which refs are accessible and which are not. Whilst the "sort"'s purpose    to requery data from git, and refresh the tree applying any existing filters.

    To facilitate the above two distinct API are provided:
    - `ToggleFilterMode(bool)` to turn filter-mode on/off
    - `Refresh()` which breaks local caches for each participating tree, and    refreshes data.

- Whenever the refs tree is refreshed due to changes in refs order    the tree would retain the `SelectedNode` by index. E.g. if before     a refresh the 3rd node was seected, after the refresh the     3rd node would remain selected.
    However after the reorder the currently selected ref (in the revision graph)     would very likely be at a different index, and the fix ensures the    originally selected ref node remains selected.

    This re-selection occurs before participating trees apply custom    node selection logic.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

* Before 406c6c390f5e3f41767a1554b5fa4c27ad772160
![sort1](https://user-images.githubusercontent.com/4403806/99656080-9659a480-2ab0-11eb-8022-6abed32d656a.gif)
* Before 9712e683b2882305642af6452d2e9c257876bcd1
![sort2](https://user-images.githubusercontent.com/4403806/99657766-b12d1880-2ab2-11eb-9c8b-13eae124e217.gif)


### After

* No filters
![sort3](https://user-images.githubusercontent.com/4403806/99659098-7a580200-2ab4-11eb-9503-85e5b525472b.gif)
* With filters
![sort4](https://user-images.githubusercontent.com/4403806/99659412-f2262c80-2ab4-11eb-9442-a5ec1b916bfa.gif)



## Test methodology <!-- How did you ensure quality? -->

- manual



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
