### PR TITLE
Prefer correct local and remote branches sort to tags

### DIFF
--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -131,7 +131,15 @@ namespace GitCommands.Git.Commands
                 }
 
                 // Sort by dereferenced data
-                return $"--sort={order}{sortBy} --sort={order}*{sortBy}";
+                //
+                // NOTE: This will cause tags to be sorted in a strange way, all tags will come first
+                // then all dereferences even though then may be pointing to commits that are younger
+                // then those of pointed by actual tags.
+                // If we swap the sort order, i.e. do "ref, deref" then we will be breaking the normal
+                // ref ordering (i.e. local and remote branches), and this is generally a significantly
+                // greater of two evils.
+                // Refer to https://github.com/gitextensions/gitextensions/issues/8621 for more info.
+                return $"--sort={order}*{sortBy} --sort={order}{sortBy}";
             }
         }
 

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -665,9 +665,9 @@ namespace GitCommandsTests.Git.Commands
                         }
 
                         yield return new TestCaseData(/* tags */ true, /* branches */ true, /* noLocks */ false, sortBy, sortOrder,
-                            /* expected */ $@"for-each-ref{sortCondition}{sortConditionRef}{format} refs/heads/ refs/remotes/ refs/tags/");
+                            /* expected */ $@"for-each-ref{sortConditionRef}{sortCondition}{format} refs/heads/ refs/remotes/ refs/tags/");
                         yield return new TestCaseData(/* tags */ true, /* branches */ false, /* noLocks */ false, sortBy, sortOrder,
-                            /* expected */ $@"for-each-ref{sortCondition}{sortConditionRef}{format} refs/tags/");
+                            /* expected */ $@"for-each-ref{sortConditionRef}{sortCondition}{format} refs/tags/");
                         yield return new TestCaseData(/* tags */ false, /* branches */ true, /* noLocks */ false, sortBy, sortOrder,
                             /* expected */ $@"for-each-ref{sortCondition} --format=""%(objectname) %(refname)"" refs/heads/");
                         yield return new TestCaseData(/* tags */ false, /* branches */ true, /* noLocks */ true, sortBy, sortOrder,


### PR DESCRIPTION

Relates to #8621


## Proposed changes

Git tags may be concrete refs and ephemeral (i.e. dereferences), which
adds a layer of complexity to sorting refs.

The original sort mechanism ordered by refs first, followed by derefs.
However it caused local and remote branches to be sorted incorrectly.

Invert the sort order to ensure branches are sorted correctly at the expense
of correct tags order.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
