### PR TITLE
Blame: Spinner not dismissed for empty files and errors

### DIFF
--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -320,6 +320,11 @@ namespace GitUI.Blame
 
         private (string gutter, string body, List<GitBlameEntry> gitBlameDisplays) BuildBlameContents(string filename, int avatarSize)
         {
+            if (_blame.Lines.Count == 0)
+            {
+                return ("", "", new List<GitBlameEntry>(0));
+            }
+
             var body = new StringBuilder(capacity: 4096);
 
             GitBlameCommit lastCommit = null;


### PR DESCRIPTION
## Proposed changes

Seem to be regression from 3.2 6eeaa4c5acbab99a1a0d4ed8376092d06230b4fc

If an empty file is selected or there are errors parsing git-blame, viewing blame will just show the spinner.
It is possible to select other commits or select another tab, so the app is not hanging.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/99854967-20c00800-2b86-11eb-9233-79765b3ef60f.png)

### After

![image](https://user-images.githubusercontent.com/6248932/99854884-f5d5b400-2b85-11eb-9489-5535ac16fd43.png)

## Test methodology

Manual, one of the following:
* Add an empty file (touch t.txt (emptylines will also cause the problem), add it to Git).
* Make sure git-blame fails by setting `git config blame.ignoreRevsFile .git-blame-ignore-revs` to a file that do not exist (that was what got me started with this - Git need to support `git blame --ignore-revs-file` better to make GE support meaningful.)
The handling of Git failures need a general overhaul - after the current error handling changes are done.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
