### PR TITLE
FileHistory: Git command log

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -68,6 +68,7 @@ namespace GitUI.CommandsDialogs
             this.showLineNumbersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showOriginalFilePathToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showAuthorAvatarToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.gitcommandLogToolStripMenuItem = new System.Windows.Forms.ToolStripButton();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -347,7 +348,8 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator3,
             this.toolStripSplitLoad,
             this.ShowFullHistory,
-            this.toolStripBlameOptions});
+            this.toolStripBlameOptions,
+            this.gitcommandLogToolStripMenuItem});
             this.ToolStrip.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
             this.ToolStrip.Location = new System.Drawing.Point(0, 0);
             this.ToolStrip.Name = "ToolStrip";
@@ -584,6 +586,14 @@ namespace GitUI.CommandsDialogs
             this.showAuthorAvatarToolStripMenuItem.Text = "Show author avatar";
             this.showAuthorAvatarToolStripMenuItem.Click += new System.EventHandler(this.showAuthorAvatarToolStripMenuItem_Click);
             // 
+            // gitcommandLogToolStripMenuItem
+            // 
+            this.gitcommandLogToolStripMenuItem.Image = global::GitUI.Properties.Images.GitCommandLog;
+            this.gitcommandLogToolStripMenuItem.Name = "gitcommandLogToolStripMenuItem";
+            this.gitcommandLogToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
+            this.gitcommandLogToolStripMenuItem.ToolTipText = "Git command log";
+            this.gitcommandLogToolStripMenuItem.Click += new System.EventHandler(this.GitcommandLogToolStripMenuItemClick);
+            // 
             // FormFileHistory
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -671,5 +681,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripMenuItem showAuthorToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showOriginalFilePathToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showAuthorAvatarToolStripMenuItem;
+        private System.Windows.Forms.ToolStripButton gitcommandLogToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitExtUtils;
 using GitExtUtils.GitUI;
+using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.Properties;
 using GitUI.UserControls;
 using GitUIPluginInterfaces;
@@ -731,6 +732,11 @@ namespace GitUI.CommandsDialogs
             AppSettings.BlameShowAuthorAvatar = !AppSettings.BlameShowAuthorAvatar;
             showAuthorAvatarToolStripMenuItem.Checked = AppSettings.BlameShowAuthorAvatar;
             UpdateSelectedFileViewers(true);
+        }
+
+        private void GitcommandLogToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            FormGitCommandLog.ShowOrActivate(this);
         }
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -4234,6 +4234,10 @@ If you are not sure just close this window.</source>
         <source>Full history</source>
         <target />
       </trans-unit>
+      <trans-unit id="gitcommandLogToolStripMenuItem.ToolTipText">
+        <source>Git command log</source>
+        <target />
+      </trans-unit>
       <trans-unit id="ignoreWhitespaceToolStripMenuItem.Text">
         <source>Ignore whitespace</source>
         <target />


### PR DESCRIPTION
## Proposed changes

Add button to show _Git command log_ in FormFileHistory
#8076 changed FormFileHistory to run in a separate instance and Git command log is no longer including those commands.

There are no appropriate menus to put this is in, so a button on the top level is added
An alternative is maybe to only use a shortcut key.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/99874445-60b7d700-2be8-11eb-8a3b-318f88ea3b4d.png)

### After

![image](https://user-images.githubusercontent.com/6248932/99874467-7cbb7880-2be8-11eb-8063-a4b28d371577.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
