### PR TITLE
RangeDiff: Commit count in name

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -818,11 +818,11 @@ namespace GitCommands
             return null;
         }
 
-        public int? GetCommitDiffCount(string parentHash, string childHash)
+        public int? GetCommitDiffCount(ObjectId baseId, ObjectId parentId)
         {
             var args = new GitArgumentBuilder("rev-list")
             {
-                $"{parentHash}...{childHash}",
+                $"{baseId} {parentId}",
                 "--count"
             };
             var output = _gitExecutable.GetOutput(args);
@@ -833,6 +833,25 @@ namespace GitCommands
             }
 
             return null;
+        }
+
+        public (int? first, int? second) GetCommitRangeDiffCount(ObjectId firstId, ObjectId secondId)
+        {
+            var args = new GitArgumentBuilder("rev-list")
+            {
+                $"{firstId}...{secondId}",
+                "--count",
+                "--left-right"
+            };
+            var output = _gitExecutable.GetOutput(args);
+
+            var counts = output.Split('\t');
+            if (counts.Length == 2 && int.TryParse(counts[0], out var first) && int.TryParse(counts[1], out var second))
+            {
+                return (first, second);
+            }
+
+            return (null, null);
         }
 
         public string GetCommitCountString(string from, string to)

--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -168,12 +168,13 @@ namespace GitUI
                 statuses: commonBaseToAandB));
 
             // Add rangeDiff as a separate group (range is not the same as diff with artificial commits)
-            List<GitItemStatus> statuses = new List<GitItemStatus> { new GitItemStatus { Name = Strings.DiffRange, IsRangeDiff = true } };
-
-            var desc = Strings.DiffRange + ": " + GetDescriptionForRevision(describeRevision, firstRevHead) + " -> " +
-                       GetDescriptionForRevision(describeRevision, selectedRevHead);
+            var statuses = new List<GitItemStatus> { new GitItemStatus { Name = Strings.DiffRange, IsRangeDiff = true } };
             var first = firstRev.ObjectId == firstRevHead ? firstRev : new GitRevision(firstRevHead);
             var selected = selectedRev.ObjectId == selectedRevHead ? selectedRev : new GitRevision(selectedRevHead);
+            var (baseToFirstCount, baseToSecondCount) = module.GetCommitRangeDiffCount(first.ObjectId, selected.ObjectId);
+            const int rangeDiffCommitLimit = 100;
+            var desc = $"{Strings.DiffRange} {baseToFirstCount ?? rangeDiffCommitLimit}↓ {baseToSecondCount ?? rangeDiffCommitLimit}↑";
+
             var rangeDiff = new FileStatusWithDescription(
                 firstRev: first,
                 secondRev: selected,
@@ -185,13 +186,12 @@ namespace GitUI
 
             // Git range-diff has cubic runtime complexity and can be slow and memory consuming, so just skip if diff is large
             // to avoid that GE seem to hang when selecting the range diff
-            const int maxRangeDiffCommits = 100;
             int count = (baseA == null || baseB == null
-                ? module.GetCommitDiffCount(firstRevHead.ToString(), selectedRevHead.ToString())
-                : module.GetCommitDiffCount(baseA.ToString(), firstRevHead.ToString())
-                + module.GetCommitDiffCount(baseB.ToString(), selectedRevHead.ToString()))
-                ?? maxRangeDiffCommits + 1;
-            if (!GitVersion.Current.SupportRangeDiffTool || count > maxRangeDiffCommits)
+                ? baseToFirstCount + baseToSecondCount
+                : module.GetCommitDiffCount(baseA, firstRevHead)
+                + module.GetCommitDiffCount(baseB, selectedRevHead))
+                ?? rangeDiffCommitLimit;
+            if (!GitVersion.Current.SupportRangeDiffTool || count >= rangeDiffCommitLimit)
             {
                 var range = baseA is null || baseB is null
                     ? $"{first.ObjectId}...{selected.ObjectId}"
@@ -199,11 +199,12 @@ namespace GitUI
                 statuses[0].IsStatusOnly = true;
 
                 // Message is not translated, considered as an error message
-                statuses[0].ErrorMessage = $"# The symmetric difference from {first.ObjectId.ToShortString()} to {selected.ObjectId.ToShortString()} is {count} which is higher than the limit {maxRangeDiffCommits}\n" +
-                    "# Git range-diff may take a long time and Git Extensions seem to hang during execution, why the command is not executed\n" +
-                    "# You can still run the command in a Git terminal\n" +
-                    "# Remove '--no-patch' to see changes to files too\n" +
-                    $"git range-diff {range} --no-patch";
+                statuses[0].ErrorMessage =
+                    $"# The symmetric difference from {first.ObjectId.ToShortString()} to {selected.ObjectId.ToShortString()} is {count} >= {rangeDiffCommitLimit}\n"
+                    + "# Git range-diff may take a long time and Git Extensions seem to hang during execution, why the command is not executed.\n"
+                    + "# You can still run the command in a Git terminal.\n"
+                    + "# Remove '--no-patch' to see changes to files too.\n"
+                    + $"git range-diff {range} --no-patch";
             }
 
             return fileStatusDescs;


### PR DESCRIPTION
## Proposed changes

#8516 etc added git-range-diff. After some usage, I would like to change the presentation a little.

Currently the first and second commits are presented. I have found that I often want to know the commit count for first/second  to the merge-base, similar to ahead/behind info. The first/second is (normally, see below) listed anyway in other groups and the second commit is not often seen as as the group name is too long.

If one of the first/second selected is artificial, the range diff uses HEAD. This is not listed in the other group names, but should be obvious.
To avoid a second call to git-rev-list (adding about 40 ms on my PC), a modified git-rev-list call was added.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

FileStatusList must be wide to see the second revision

![image](https://user-images.githubusercontent.com/6248932/99886190-e7959f80-2c3a-11eb-92c6-e74bebc383d0.png)

![image](https://user-images.githubusercontent.com/6248932/99886205-faa86f80-2c3a-11eb-8273-96cdb92b1474.png)

### After

![image](https://user-images.githubusercontent.com/6248932/99886155-a69d8b00-2c3a-11eb-8f11-bfc9b88a3321.png)

![image](https://user-images.githubusercontent.com/6248932/99886125-77871980-2c3a-11eb-8624-d0fdb58c6cce.png)

## Test methodology <!-- How did you ensure quality? -->

Manual


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
