### PR TITLE
Fix #8630: better handle "forbidden" filename

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseUtil.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseUtil.cs
@@ -7,7 +7,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         public static bool FileOrParentDirectoryExists(string path)
         {
             var fileInfo = new FileInfo(path);
-            return fileInfo.Exists || fileInfo.Directory.Exists;
+            return fileInfo.Exists || (fileInfo.Directory != null && fileInfo.Directory.Exists);
         }
 
         public static bool IsFileOrDirectory(string path)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8630


## Proposed changes

- FileInfo.Directory may fails if the name is forbidden.


### Before

Forbidden filename can't be created when checkout.

So file are shown missing in the diff window.

Click right on this file generate exception.

### After

No more exception.

## Test methodology <!-- How did you ensure quality? -->

- Sorry, didn't write tests…


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build cf43b769311b80db2bf7c92a05f6b366a69ceba0
- Git 2.22.0.windows.1 (recommended: 2.28.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4250.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
