### PR TITLE
Fix rebase status displayed during a rebase

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1985,8 +1985,9 @@ namespace GitCommands
                     patchFiles.Add(new PatchFile
                     {
                         Author = error ?? data.Author,
+                        ObjectId = data?.ObjectId,
                         Subject = error ?? data.Body,
-                        Name = parts[0],
+                        Action = parts[0],
                         Date = error ?? data.CommitDate.LocalDateTime.ToString(),
                         IsNext = isApplying,
                         IsApplied = !isCurrentFound,

--- a/GitCommands/Patches/PatchFile.cs
+++ b/GitCommands/Patches/PatchFile.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO;
+using GitUIPluginInterfaces;
 
 namespace GitCommands.Patches
 {
@@ -8,7 +9,9 @@ namespace GitCommands.Patches
     {
         public string FullName { get; set; }
 
+        public string Action { get; set; }
         public string Name { get; set; }
+        public ObjectId ObjectId { get; set; }
 
         public string Author { get; set; }
 

--- a/GitUI/CommandsDialogs/FormApplyPatch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.Designer.cs
@@ -347,6 +347,7 @@
             this.ClientSize = new System.Drawing.Size(711, 436);
             this.Controls.Add(this.tableLayoutPanel1);
             this.MinimumSize = new System.Drawing.Size(720, 410);
+            this.Load += new System.EventHandler(this.FormApplyPatchLoad);
             this.Name = "FormApplyPatch";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Apply patch";

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -52,10 +52,13 @@ namespace GitUI.CommandsDialogs
 
             patchGrid1.SetSkipped(Skipped);
 
-            EnableButtons();
-
             SolveMergeConflicts.BackColor = AppColor.Branch.GetThemeColor();
             SolveMergeConflicts.SetForeColorForBackColor();
+        }
+
+        private void FormApplyPatchLoad(object sender, EventArgs e)
+        {
+            EnableButtons();
         }
 
         public void SetPatchFile(string name)

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git.Commands;
+using GitCommands.Patches;
 using GitExtUtils.GitUI.Theming;
 using GitUI.HelperDialogs;
 using GitUI.Theming;
@@ -34,6 +36,8 @@ namespace GitUI.CommandsDialogs
 
         #endregion
 
+        private static readonly List<PatchFile> Skipped = new List<PatchFile>();
+
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormApplyPatch()
         {
@@ -45,6 +49,9 @@ namespace GitUI.CommandsDialogs
         {
             InitializeComponent();
             InitializeComplete();
+
+            patchGrid1.SetSkipped(Skipped);
+
             EnableButtons();
 
             SolveMergeConflicts.BackColor = AppColor.Branch.GetThemeColor();
@@ -171,6 +178,8 @@ namespace GitUI.CommandsDialogs
 
             using (WaitCursorScope.Enter())
             {
+                Skipped.Clear();
+
                 if (PatchFileMode.Checked)
                 {
                     var arguments = IsDiffFile(patchFile)
@@ -231,6 +240,7 @@ namespace GitUI.CommandsDialogs
                 if (applyingPatch != null)
                 {
                     applyingPatch.IsSkipped = true;
+                    Skipped.Add(applyingPatch);
                 }
 
                 FormProcess.ShowDialog(this, process: null, arguments: GitCommandHelpers.SkipCmd(), Module.WorkingDir, input: null, useDialogSettings: true);
@@ -252,6 +262,7 @@ namespace GitUI.CommandsDialogs
             using (WaitCursorScope.Enter())
             {
                 FormProcess.ShowDialog(this, process: null, arguments: GitCommandHelpers.AbortCmd(), Module.WorkingDir, input: null, useDialogSettings: true);
+                Skipped.Clear();
                 EnableButtons();
             }
         }

--- a/GitUI/CommandsDialogs/FormRebase.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRebase.Designer.cs
@@ -398,6 +398,7 @@ namespace GitUI.CommandsDialogs
             // patchGrid1
             // 
             this.patchGrid1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.patchGrid1.IsManagingRebase = true;
             this.patchGrid1.Location = new System.Drawing.Point(3, 172);
             this.patchGrid1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.patchGrid1.Name = "patchGrid1";

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Windows.Documents;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git.Commands;
+using GitCommands.Patches;
 using GitExtUtils.GitUI.Theming;
 using GitUI.HelperDialogs;
 using GitUI.Theming;
@@ -13,6 +16,7 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormRebase : GitModuleForm
     {
+        private static readonly List<PatchFile> Skipped = new List<PatchFile>();
         private readonly TranslationString _continueRebaseText = new TranslationString("Continue rebase");
         private readonly TranslationString _solveConflictsText = new TranslationString("Solve conflicts");
 
@@ -48,6 +52,7 @@ namespace GitUI.CommandsDialogs
             InitializeComplete();
             helpImageDisplayUserControl1.Visible = !AppSettings.DontShowHelpImages;
             helpImageDisplayUserControl1.IsOnHoverShowImage2NoticeText = _hoverShowImageLabelText.Text;
+            patchGrid1.SetSkipped(Skipped);
             if (AppSettings.AlwaysShowAdvOpt)
             {
                 ShowOptions_LinkClicked(null, null);
@@ -231,6 +236,7 @@ namespace GitUI.CommandsDialogs
                 if (applyingPatch != null)
                 {
                     applyingPatch.IsSkipped = true;
+                    Skipped.Add(applyingPatch);
                 }
 
                 FormProcess.ShowDialog(this, process: null, arguments: GitCommandHelpers.SkipRebaseCmd(), Module.WorkingDir, input: null, useDialogSettings: true);
@@ -254,6 +260,7 @@ namespace GitUI.CommandsDialogs
 
                 if (!Module.InTheMiddleOfRebase())
                 {
+                    Skipped.Clear();
                     Close();
                 }
 
@@ -273,6 +280,8 @@ namespace GitUI.CommandsDialogs
                 }
 
                 AppSettings.RebaseAutoStash = chkStash.Checked;
+
+                Skipped.Clear();
 
                 string rebaseCmd;
                 if (chkSpecificRange.Checked && !string.IsNullOrWhiteSpace(txtFrom.Text) && !string.IsNullOrWhiteSpace(cboTo.Text))

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -603,6 +603,21 @@ namespace GitUI
             return DoActionOnRepo(owner, Action, requiresValidWorkingDir: false, changesRepo: false);
         }
 
+        public bool StartFormCommitDiff(ObjectId objectId)
+        {
+            bool Action()
+            {
+                using (var viewPatch = new FormCommitDiff(this, objectId))
+                {
+                    viewPatch.ShowDialog(null);
+                }
+
+                return true;
+            }
+
+            return DoActionOnRepo(null, Action, requiresValidWorkingDir: false, changesRepo: false);
+        }
+
         public bool StartViewPatchDialog(string patchFile)
         {
             return StartViewPatchDialog(null, patchFile);

--- a/GitUI/UserControls/PatchGrid.Designer.cs
+++ b/GitUI/UserControls/PatchGrid.Designer.cs
@@ -31,7 +31,9 @@
             this.components = new System.ComponentModel.Container();
             this.Patches = new System.Windows.Forms.DataGridView();
             this.patchFileBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.Action = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.FileName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.CommitHash = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.subjectDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.authorDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dateDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -48,11 +50,13 @@
             this.Patches.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
             this.Patches.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.Patches.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.Status,
+            this.Action,
             this.FileName,
+            this.CommitHash,
             this.subjectDataGridViewTextBoxColumn,
             this.authorDataGridViewTextBoxColumn,
-            this.dateDataGridViewTextBoxColumn,
-            this.Status});
+            this.dateDataGridViewTextBoxColumn});
             this.Patches.DataSource = this.patchFileBindingSource;
             this.Patches.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Patches.Location = new System.Drawing.Point(0, 0);
@@ -75,6 +79,22 @@
             this.FileName.HeaderText = "Name";
             this.FileName.Name = "FileName";
             this.FileName.ReadOnly = true;
+            // 
+            // Action
+            // 
+            this.Action.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.Action.DataPropertyName = "Action";
+            this.Action.HeaderText = "Action";
+            this.Action.Name = "Action";
+            this.Action.ReadOnly = true;
+            // 
+            // CommitHash
+            // 
+            this.CommitHash.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.CommitHash.DataPropertyName = "ObjectId";
+            this.CommitHash.HeaderText = "Commit hash";
+            this.CommitHash.Name = "CommitHash";
+            this.CommitHash.ReadOnly = true;
             // 
             // subjectDataGridViewTextBoxColumn
             // 
@@ -106,7 +126,6 @@
             // PatchGrid
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
-            
             this.Controls.Add(this.Patches);
             this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "PatchGrid";
@@ -121,7 +140,9 @@
 
         private System.Windows.Forms.DataGridView Patches;
         private System.Windows.Forms.BindingSource patchFileBindingSource;
+        private System.Windows.Forms.DataGridViewTextBoxColumn Action;
         private System.Windows.Forms.DataGridViewTextBoxColumn FileName;
+        private System.Windows.Forms.DataGridViewTextBoxColumn CommitHash;
         private System.Windows.Forms.DataGridViewTextBoxColumn subjectDataGridViewTextBoxColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn authorDataGridViewTextBoxColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn dateDataGridViewTextBoxColumn;

--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands.Patches;
 using GitExtUtils.GitUI;
+using GitExtUtils.GitUI.Theming;
 using ResourceManager;
 
 namespace GitUI
@@ -139,7 +141,9 @@ namespace GitUI
             if (shouldSelectIndex >= 0)
             {
                 Patches.ClearSelection();
-                Patches.Rows[shouldSelectIndex].Selected = true;
+                DataGridViewRow dataGridViewRow = Patches.Rows[shouldSelectIndex];
+                dataGridViewRow.DefaultCellStyle.ForeColor = Color.OrangeRed.AdaptTextColor();
+                dataGridViewRow.Selected = true;
             }
         }
     }

--- a/GitUI/UserControls/PatchGrid.resx
+++ b/GitUI/UserControls/PatchGrid.resx
@@ -112,18 +112,21 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="FileName.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="FileName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="Status.UserAddedColumn" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="CommitHash.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="patchFileBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="Status.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="patchFileBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
 </root>


### PR DESCRIPTION
Fixes #8540, #7152 and #6350

## Proposed changes

- Fix the list of displayed commits that are rebased to always display all of them and with the good `Status` displayed
- other adjustments:
    * Move the important 'Status' column to be the first one (and not lost after author and date so that it could be more easily compare to the `Action` and `Subject`)
    * Display commit hash
    * Rename "Name" header to "Action" (because it display the define action. Especially when doing an interactive rebase)
    * Being able to open a commit diff window by double click (like it is possible to see the patch file for the patches)
    * Set a minimum height for a row (to avoid possible strange behavior)
    * Resize some columns



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/95751244-9fc84380-0c9e-11eb-9635-1b70503950c0.png)

### After

* New list:
![image](https://user-images.githubusercontent.com/460196/100289840-29e01900-2f7a-11eb-84c8-5db939e59d23.png)

* Opening a commit:
![image](https://user-images.githubusercontent.com/460196/100290463-b5a67500-2f7b-11eb-9f5c-7f545337d0f8.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
