### PR TITLE
FormResetAnotherBranch: display local tracking branches first

### DIFF
--- a/GitCommands/Git/GitRef.cs
+++ b/GitCommands/Git/GitRef.cs
@@ -204,5 +204,15 @@ namespace GitCommands
                 .Where(group => group.Count() > 1)
                 .ToHashSet(e => e.Key);
         }
+
+        public bool IsTrackingRemote(IGitRef remote)
+        {
+            if (remote == null || IsRemote || !remote.IsRemote)
+            {
+                return false;
+            }
+
+            return MergeWith == remote.LocalName && TrackingRemote == remote.Remote;
+        }
     }
 }

--- a/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -61,8 +61,12 @@ namespace GitUI.HelperDialogs
             var currentBranch = Module.GetSelectedBranch();
             var isDetachedHead = currentBranch == DetachedHeadParser.DetachedBranch;
 
+            var selectedRevisionRemotes = _revision.Refs.Where(r => r.IsRemote).ToList();
+
             return Module.GetRefs(false)
-                .Where(r => r.IsHead && (isDetachedHead || r.LocalName != currentBranch))
+                .Where(r => r.IsHead)
+                .Where(r => isDetachedHead || r.LocalName != currentBranch)
+                .OrderByDescending(r => selectedRevisionRemotes.Any(r.IsTrackingRemote)) // Put local branches that track these remotes first
                 .ToArray();
         }
 

--- a/Plugins/GitUIPluginInterfaces/IGitRef.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitRef.cs
@@ -39,5 +39,13 @@
         /// the revision graph.
         /// </summary>
         string GetMergeWith(ISettingsValueGetter configFile);
+
+        /// <summary>
+        /// Return if the current `GitRef` is tracking another `GitRef` as a remote.
+        /// </summary>
+        /// <param name="remote">the expected remote ref tracked</param>
+        /// <returns>true if the current ref is tracking the expected remote ref
+        /// false otherwise</returns>
+        bool IsTrackingRemote(IGitRef remote);
     }
 }

--- a/UnitTests/GitCommands.Tests/Git/GitRefTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitRefTests.cs
@@ -1,0 +1,106 @@
+﻿using GitCommands;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Git
+{
+    public sealed class GitRefTests
+    {
+        [Test]
+        public void IsTrackingRemote_should_return_true_when_tracking_remote()
+        {
+            string remoteBranchShortName = "remote_branch";
+            string remoteName = "origin";
+            GitRef localBranchRef = SetupLocalBranchWithATrackingReference(remoteBranchShortName, remoteName);
+
+            GitRef remoteBranchRef = SetupRemoteRef(remoteBranchShortName, remoteName);
+
+            Assert.IsTrue(localBranchRef.IsTrackingRemote(remoteBranchRef));
+        }
+
+        [Test]
+        public void IsTrackingRemote_should_return_false_when_remote_is_null()
+        {
+            GitRef localBranchRef = SetupLocalBranchWithATrackingReference("remote_branch", "origin");
+
+            Assert.IsFalse(localBranchRef.IsTrackingRemote(null));
+        }
+
+        [Test]
+        public void IsTrackingRemote_should_return_false_when_tracking_another_remote()
+        {
+            string remoteBranchShortName = "remote_branch";
+            GitRef localBranchRef = SetupLocalBranchWithATrackingReference(remoteBranchShortName, "origin");
+
+            GitRef remoteBranchRef = SetupRemoteRef(remoteBranchShortName, "upstream");
+
+            Assert.IsFalse(localBranchRef.IsTrackingRemote(remoteBranchRef));
+        }
+
+        [Test]
+        public void IsTrackingRemote_should_return_false_when_tracking_another_remote_branch()
+        {
+            GitRef localBranchRef = SetupLocalBranchWithATrackingReference("one_remote_branch", "origin");
+
+            GitRef remoteBranchRef = SetupRemoteRef("another_remote_branch", "origin");
+
+            Assert.IsFalse(localBranchRef.IsTrackingRemote(remoteBranchRef));
+        }
+
+        [Test]
+        public void IsTrackingRemote_should_return_false_when_supposedly_local_branch_is_a_remote_ref()
+        {
+            GitRef localBranchRef = SetupRemoteRef("a_remote_branch", "origin");
+
+            GitRef remoteBranchRef = SetupRemoteRef("a_remote_branch", "origin");
+
+            Assert.IsFalse(localBranchRef.IsTrackingRemote(remoteBranchRef));
+        }
+
+        [Test]
+        public void IsTrackingRemote_should_return_false_when_supposedly_remote_branch_is_a_local_ref()
+        {
+            GitRef localBranchRef = SetupLocalBranchWithATrackingReference("a_remote_branch", "origin");
+
+            GitRef remoteBranchRef = SetupLocalBranchWithATrackingReference("a_remote_branch", "origin");
+
+            Assert.IsFalse(localBranchRef.IsTrackingRemote(remoteBranchRef));
+        }
+
+        [Test]
+        public void IsTrackingRemote_should_return_false_when_local_branch_is_tracking_nothing()
+        {
+            var localGitModule = Substitute.For<IGitModule>();
+            var localConfigFileSettings = Substitute.For<IConfigFileSettings>();
+            localConfigFileSettings.GetValue($"branch.local_branch.merge").Returns(string.Empty);
+            localConfigFileSettings.GetValue($"branch.local_branch.remote").Returns(string.Empty);
+            localGitModule.LocalConfigFile.Returns(localConfigFileSettings);
+            var localBranchRef = new GitRef(localGitModule, ObjectId.Random(), "refs/heads/local_branch");
+
+            GitRef remoteBranchRef = SetupLocalBranchWithATrackingReference("a_remote_branch", "origin");
+
+            Assert.IsFalse(localBranchRef.IsTrackingRemote(remoteBranchRef));
+        }
+
+        private static GitRef SetupRemoteRef(string remoteBranchShortName, string remoteName)
+        {
+            var remoteGitModule = Substitute.For<IGitModule>();
+            var remoteConfigFileSettings = Substitute.For<IConfigFileSettings>();
+            remoteGitModule.LocalConfigFile.Returns(remoteConfigFileSettings);
+            var remoteBranchRef = new GitRef(remoteGitModule, ObjectId.Random(), $"refs/remotes/{remoteName}/{remoteBranchShortName}", remoteName);
+            return remoteBranchRef;
+        }
+
+        private static GitRef SetupLocalBranchWithATrackingReference(string remoteShortName, string remoteName)
+        {
+            var localGitModule = Substitute.For<IGitModule>();
+            var localConfigFileSettings = Substitute.For<IConfigFileSettings>();
+            localConfigFileSettings.GetValue($"branch.local_branch.merge").Returns($"refs/heads/{remoteShortName}");
+            localConfigFileSettings.GetValue($"branch.local_branch.remote").Returns(remoteName);
+            localGitModule.LocalConfigFile.Returns(localConfigFileSettings);
+            var localBranchRef = new GitRef(localGitModule, ObjectId.Random(), "refs/heads/local_branch");
+            return localBranchRef;
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

When using the "Reset another branch to here..." feature, if there are remotes on the selected commit, find the local tracking branches of these remotes and display them first (because there is a highest probability that this is these local branches that you want to reset).

It is very useful to easily update the local tracking branch without having to check it out before...

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/100293015-8f380800-2f82-11eb-9f4c-2d5eda6f95f4.png)


### After

![image](https://user-images.githubusercontent.com/460196/100293131-fe156100-2f82-11eb-9dd1-9b304e0e9c34.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 33.33.33
- Build d30897a43b6d17e20e7c8e9e645446cb93e83f3e
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4261.0
- DPI 192dpi (200% scaling)

