### PR TITLE
Default debug startup arguments

### DIFF
--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -8,8 +8,6 @@
     <OutputType>WinExe</OutputType>
     <StartupObject />
 
-    <!-- Default debugging command starts GitExtensions browsing this repository -->
-    <StartArguments>browse "$(MSBuildThisFileDirectory).."</StartArguments>
     <Prefer32bit>true</Prefer32bit>
 
     <IsPublishable>true</IsPublishable>

--- a/GitExtensions/Properties/launchSettings.json
+++ b/GitExtensions/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "GitExtensions": {
+      "commandName": "Project",
+      "commandLineArgs": "browse \"$(MSBuildThisFileDirectory)..\""
+    }
+  }
+}


### PR DESCRIPTION
Move the hidden start arguments from .csproj to launchSettings.json
This allows view and edit of the arguments, otherwise hidden in MSVS

Regression of a regression fixed in #7147 
Probably introduced by SDK style projects

## Proposed changes

Store the debug startup args in the new defaults so it can be viewed and changed.
This is needed to debug the GE startup. (See related issues and PRs for a discussion.)
Without this, it is quite hard to realize that the GE command line behavior is different in the debugger.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

args not visible

### After

![image](https://user-images.githubusercontent.com/6248932/100522015-f2ef4a80-31a7-11eb-9492-0ca70113d873.png)

## Test methodology

Manual, starting in debugger

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
