### PR TITLE
Submodule context menus: Only show if dir exists

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -512,6 +512,7 @@ namespace GitUI.CommandsDialogs
             this.viewHistoryMenuItem});
             this.UnstagedSubmoduleContext.Name = "UnstagedSubmoduleContext";
             this.UnstagedSubmoduleContext.Size = new System.Drawing.Size(229, 242);
+            this.UnstagedSubmoduleContext.Opening += UnstagedSubmoduleContext_Opening;
             //
             // commitSubmoduleChanges
             //

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1723,6 +1723,16 @@ namespace GitUI.CommandsDialogs
             stagedEditFileToolStripMenuItem11.Visible = singleFileExists;
         }
 
+        private void UnstagedSubmoduleContext_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            // Separate menu for single submodule items
+            bool allDirectoriesExist = Directory.Exists(_fullPathResolver.Resolve(Unstaged?.SelectedGitItem?.Name));
+            updateSubmoduleMenuItem.Enabled = allDirectoriesExist;
+            resetSubmoduleChanges.Enabled = allDirectoriesExist;
+            stashSubmoduleChangesToolStripMenuItem.Enabled = allDirectoriesExist;
+            commitSubmoduleChanges.Enabled = allDirectoriesExist;
+        }
+
         private void Unstaged_Enter(object sender, EnterEventArgs e)
         {
             if (_currentFilesList != Unstaged)

--- a/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -37,6 +37,7 @@ namespace GitUI.CommandsDialogs
             bool isAnyItemWorkTree,
             bool isBareRepository,
             bool allFilesExist,
+            bool allDirectoriesExist,
             bool allFilesOrUntrackedDirectoriesExist,
             bool isAnyTracked,
             bool supportPatches,
@@ -51,6 +52,7 @@ namespace GitUI.CommandsDialogs
             IsAnyItemWorkTree = isAnyItemWorkTree;
             IsBareRepository = isBareRepository;
             AllFilesExist = allFilesExist;
+            AllDirectoriesExist = allDirectoriesExist;
             AllFilesOrUntrackedDirectoriesExist = allFilesOrUntrackedDirectoriesExist;
             IsAnyTracked = isAnyTracked;
             SupportPatches = supportPatches;
@@ -67,6 +69,7 @@ namespace GitUI.CommandsDialogs
         public bool IsAnyItemWorkTree { get; }
         public bool IsBareRepository { get; }
         public bool AllFilesExist { get; }
+        public bool AllDirectoriesExist { get; }
         public bool AllFilesOrUntrackedDirectoriesExist { get; }
         public bool IsAnyTracked { get; }
         public bool SupportPatches { get; }
@@ -130,7 +133,7 @@ namespace GitUI.CommandsDialogs
 
         public bool ShouldShowSubmoduleMenus(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.IsAnySubmodule && selectionInfo.SelectedRevision?.ObjectId == ObjectId.WorkTreeId;
+            return selectionInfo.IsAnySubmodule && selectionInfo.SelectedRevision?.ObjectId == ObjectId.WorkTreeId && selectionInfo.AllDirectoriesExist;
         }
 
         public bool ShouldShowMenuEditWorkingDirectoryFile(ContextMenuSelectionInfo selectionInfo)

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
@@ -29,6 +29,7 @@ namespace GitUITests.CommandsDialogs
             bool isAnyItemWorkTree = false,
             bool isBareRepository = false,
             bool allFilesExist = true,
+            bool allDirectoriesExist = false,
             bool allFilesOrUntrackedDirectoriesExist = false,
             bool isAnyTracked = true,
             bool supportPatches = true,
@@ -43,6 +44,7 @@ namespace GitUITests.CommandsDialogs
                 isAnyItemWorkTree,
                 isBareRepository,
                 allFilesExist,
+                allDirectoriesExist,
                 allFilesOrUntrackedDirectoriesExist,
                 isAnyTracked,
                 supportPatches,
@@ -318,6 +320,17 @@ namespace GitUITests.CommandsDialogs
             var rev = new GitRevision(ObjectId.IndexId);
             var selectionInfo = CreateContextMenuSelectionInfo(rev, allFilesOrUntrackedDirectoriesExist: t);
             _controller.ShouldShowMenuDeleteFile(selectionInfo).Should().Be(t);
+        }
+
+        [TestCase(true, true, true)]
+        [TestCase(true, false, false)]
+        [TestCase(false, true, false)]
+        [TestCase(false, false, false)]
+        public void BrowseDiff_Submodules_WorkTree(bool isAnySubmodule, bool submodulesExist, bool expected)
+        {
+            var rev = new GitRevision(ObjectId.WorkTreeId);
+            var selectionInfo = CreateContextMenuSelectionInfo(rev, isAnySubmodule: isAnySubmodule, allDirectoriesExist: submodulesExist);
+            _controller.ShouldShowSubmoduleMenus(selectionInfo).Should().Be(expected);
         }
 
         #endregion


### PR DESCRIPTION
Fixes #8104 

A few other NBug issues exist. I have considered this to be a too much edge case to fix it. Maybe users experience this before they have downloaded submodules? Or this is an indication that there are few serious NBug issues that are not reported.

There has been cleanups for access to submodule dirs in changes the last year, for instance #7690 and #8117, to not access submodules if the directories does not exist.

## Proposed changes

Only show context menus for work tree submodules "internals" if the submodule directories exists, required for the Git commands to run.

For FormCommit, the menus are disabled.

For RevDiff the menus the are not shown. The Controller structure (which is made this way to test) adds another layer to handle enable/disable and makes this quite complicated, it is not worth the effort.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/100552813-c3187380-3289-11eb-8f66-d31fa07383b6.png)

![image](https://user-images.githubusercontent.com/6248932/100552819-d4618000-3289-11eb-930a-9142cae5ed97.png)

### After

![image](https://user-images.githubusercontent.com/6248932/100552865-2acebe80-328a-11eb-98be-d9314147e06c.png)

![image](https://user-images.githubusercontent.com/6248932/100552848-02df5b00-328a-11eb-9d90-42ac6f29ea9b.png)

## Test methodology 

Added a test

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
