### PR TITLE
Interactive rebase: Highlight 4 byte sha

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3017,7 +3017,7 @@ namespace GitCommands
             //
             // Lines may also use \t as a column delimiter, such as output of "ls-remote --heads origin".
 
-            var regex = new Regex(@"^(?<objectid>[0-9a-f]{40})[ \t](?<refname>.+)$", RegexOptions.Multiline);
+            var regex = new Regex(@"^(?<objectid>[0-9a-f]{40})[ \t](?<refname>.+)$", RegexOptions.Multiline | RegexOptions.Compiled);
 
             var matches = regex.Matches(refList);
 

--- a/GitUI/Editor/RebaseTodoHighlightingStrategy.cs
+++ b/GitUI/Editor/RebaseTodoHighlightingStrategy.cs
@@ -127,7 +127,7 @@ namespace GitUI.Editor
                         {
                             var idLength = index - idStartIndex;
 
-                            if (idLength <= 5)
+                            if (idLength < 4)
                             {
                                 return false;
                             }


### PR DESCRIPTION
## Proposed changes 

TryHighlightInteractiveRebaseCommand() assumes that Git sha are longer than 5 chars when highlighting.
The minimum is 4, can be set:
`git config --global core.abbrev 4`
(Separate note: I would like to read and use this value in the GUI to limit printouts, separate.)

Also a minor optimization to use a compiled RegEx. (One of the few situations where `RegexOptions.Compiled` makes sense, should slow down in most other situations.)
(Seen in other situations, no good PR to attach it to and not worth a PR on its own.)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/100557735-4e563100-32ab-11eb-8afc-8f801aafb0ff.png)

### After

![image](https://user-images.githubusercontent.com/6248932/100557757-6332c480-32ab-11eb-9590-7d8b4f889a9b.png)

## Test methodology 

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
