### PR TITLE
Custom mergetool

### DIFF
--- a/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
@@ -37,6 +37,7 @@ namespace GitUI.CommandsDialogs
             this.authorDataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.ConflictedFilesContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.OpenMergetool = new System.Windows.Forms.ToolStripMenuItem();
+            this.customMergetool = new System.Windows.Forms.ToolStripMenuItem();
             this.ContextMarkAsSolved = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.ContextChooseLocal = new System.Windows.Forms.ToolStripMenuItem();
@@ -141,6 +142,7 @@ namespace GitUI.CommandsDialogs
             // 
             this.ConflictedFilesContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.OpenMergetool,
+            this.customMergetool,
             this.ContextMarkAsSolved,
             this.toolStripSeparator3,
             this.ContextChooseLocal,
@@ -169,6 +171,13 @@ namespace GitUI.CommandsDialogs
             this.OpenMergetool.Size = new System.Drawing.Size(195, 22);
             this.OpenMergetool.Text = "Open in mergetool";
             this.OpenMergetool.Click += new System.EventHandler(this.OpenMergetool_Click);
+            // 
+            // customMergetool
+            // 
+            this.customMergetool.Name = "customMergetool";
+            this.customMergetool.Size = new System.Drawing.Size(195, 22);
+            this.customMergetool.Text = "Open in &mergetool";
+            this.customMergetool.Click += new System.EventHandler(this.customMergetool_Click);
             // 
             // ContextMarkAsSolved
             // 
@@ -594,6 +603,7 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripMenuItem ContextOpenRemoteWith;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem OpenMergetool;
+        private System.Windows.Forms.ToolStripMenuItem customMergetool;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
         private System.Windows.Forms.ToolStripMenuItem ContextSaveBaseAs;
         private System.Windows.Forms.ToolStripMenuItem ContextSaveLocalAs;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6538,6 +6538,10 @@ Do you want to use this custom merge script?</source>
         <source>Select file</source>
         <target />
       </trans-unit>
+      <trans-unit id="customMergetool.Text">
+        <source>Open in &amp;mergetool</source>
+        <target />
+      </trans-unit>
       <trans-unit id="fileHistoryToolStripMenuItem.Text">
         <source>File history</source>
         <target />


### PR DESCRIPTION
#8194 for merge tools

## Proposed changes

Adds a dropdown menu in FormResolve to choose the merge tool without changing the defaults.
Some tools work better in some situations.
(a separate fixup to remove unused code, will be squashed)

There are some alternatives not handled hare:
* Expose this in the split button
* Implement this in the "Git Extensions" workflow where handling of files changed is asked in a terminal instead of a popup, 2way merge filters etc is handled. 

I just do not think it is worth it to implement this.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/101292281-c45c1a00-380e-11eb-96da-42e4ff551abd.png)

### After

![image](https://user-images.githubusercontent.com/6248932/101292258-98d92f80-380e-11eb-8e62-73464532d0a9.png)

## Test methodology <!-- How did you ensure quality? -->

Tests were added in #8194

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
