### PR TITLE
Improve printout for flaky test

### DIFF
--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -788,12 +788,10 @@ namespace GitCommandsTests
                 root.Module.GitExecutable.GetOutput(@"submodule update --init --recursive");
 
                 var paths = root.Module.GetSubmodulesLocalPaths(recursive: true);
-                Assert.AreEqual(3, paths.Count);
-                Assert.AreEqual(new string[] { "repo1", "repo1/repo2", "repo1/repo2/repo3" }, paths);
+                Assert.AreEqual(new string[] { "repo1", "repo1/repo2", "repo1/repo2/repo3" }, paths, $"Modules: {string.Join(" ", paths)}");
 
                 paths = root.Module.GetSubmodulesLocalPaths(recursive: false);
-                Assert.AreEqual(1, paths.Count);
-                Assert.AreEqual(new string[] { "repo1" }, paths);
+                Assert.AreEqual(new string[] { "repo1" }, paths, $"Modules: {string.Join(" ", paths)}");
             }
             finally
             {


### PR DESCRIPTION
Tests occasionally fails:
https://ci.appveyor.com/project/gitextensions/gitextensions/builds/36792510#L514
The branch test just before was successful

## Proposed changes

Not fixing the test as there is no information, just improve printout by removing the count check to better see what fails.

Before:
```
    Expected: 3
    But was:  2
```

After (removed first item in compare list)
```
  Message: 
      Modules: repo1 repo1/repo2 repo1/repo2/repo3
      Expected is <System.String[2]>, actual is <System.Collections.Generic.List`1[System.String]> with 3 elements
      Values differ at index [0]
      Expected string length 11 but was 5. Strings differ at index 5.
      Expected: "repo1/repo2"
      But was:  "repo1"
      ----------------^
```

There are other tests that should be changed in a sililar way, like GetRemotes_should_parse_correctly_configured_remotes:576
(but not a real test involving Git so the test should be stable).

```
                    Assert.AreEqual(1, remotes[0].PushUrls.Count);
                    Assert.AreEqual("git://github.com/RussKie/gitextensions.git", remotes[0].PushUrls[0]);
```

```
                    Assert.AreEqual(new List<string> { "git://github.com/RussKie/gitextensions.git" }, remotes[0].PushUrls);
```

## Test methodology <!-- How did you ensure quality? -->

Updated test

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
