### PR TITLE
Avoid assert for null syntax color

### DIFF
--- a/GitUI/Theming/ThemeBasedHighlighting.cs
+++ b/GitUI/Theming/ThemeBasedHighlighting.cs
@@ -27,7 +27,10 @@ namespace GitUI.Theming
             {
                 foreach (var word in line.Words)
                 {
-                    word.SyntaxColor = word.SyntaxColor?.Transform();
+                    if (word.SyntaxColor != null)
+                    {
+                        word.SyntaxColor = word.SyntaxColor.Transform();
+                    }
                 }
             }
         }
@@ -39,7 +42,10 @@ namespace GitUI.Theming
             {
                 foreach (var word in line.Words)
                 {
-                    word.SyntaxColor = word.SyntaxColor?.Transform();
+                    if (word.SyntaxColor != null)
+                    {
+                        word.SyntaxColor = word.SyntaxColor.Transform();
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Proposed changes

If ICSharpCode.TextEditor is in Debug mode, an assert occurs if setting SyntaxColor with a null value.
SyntaxColor is empty for empty lines, no need to set the value to null again.
The default configuration for the module is Release, so by default no change.

## Test methodology <!-- How did you ensure quality? -->

Manual, using Debug

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
