### PR TITLE
Improve handling of Drag and drop

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3227,15 +3227,20 @@ namespace GitUI.CommandsDialogs
 
         private void FormBrowse_DragDrop(object sender, DragEventArgs e)
         {
-            CommitInfoTabControl.SelectedTab = TreeTabPage;
             HandleDrop(e);
         }
 
         private void HandleDrop(DragEventArgs e)
         {
-            var itemPath = (e.Data.GetData(DataFormats.Text) ?? e.Data.GetData(DataFormats.UnicodeText)) as string;
-            if (itemPath != null && (File.Exists(itemPath) || Directory.Exists(itemPath)))
+            if (TreeTabPage.Parent == null)
             {
+                return;
+            }
+
+            var itemPath = (e.Data.GetData(DataFormats.Text) ?? e.Data.GetData(DataFormats.UnicodeText)) as string;
+            if (IsFileExistingInRepo(itemPath))
+            {
+                CommitInfoTabControl.SelectedTab = TreeTabPage;
                 fileTree.SelectFileOrFolder(itemPath);
                 return;
             }
@@ -3248,11 +3253,25 @@ namespace GitUI.CommandsDialogs
 
             foreach (string path in paths)
             {
+                if (!IsFileExistingInRepo(path))
+                {
+                    continue;
+                }
+
+                if (CommitInfoTabControl.SelectedTab != TreeTabPage)
+                {
+                    CommitInfoTabControl.SelectedTab = TreeTabPage;
+                }
+
                 if (fileTree.SelectFileOrFolder(path))
                 {
                     return;
                 }
             }
+
+            bool IsPathExists(string path) => path != null && (File.Exists(path) || Directory.Exists(path));
+
+            bool IsFileExistingInRepo(string path) => IsPathExists(path) && path.StartsWith(Module.WorkingDir, StringComparison.InvariantCultureIgnoreCase);
         }
 
         private void FormBrowse_DragEnter(object sender, DragEventArgs e)


### PR DESCRIPTION


Fixes #8669

## Proposed changes

* Don't try to select "File tree" if it is not displayed
* Switch to "File tree" after some content check (to prevent inopportune switch to the tab)


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build f5362ec637de01d40be55f5d0abfbbc7b6e9d828
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4261.0
- DPI 192dpi (200% scaling)
