### PR TITLE
A variety of accessibility-related fixes for the contents of the main pane on the Config page 

### DIFF
--- a/GitExtensions/app.config
+++ b/GitExtensions/app.config
@@ -27,6 +27,7 @@
         <bindingRedirect oldVersion="0.0.0.0-106.11.4.0" newVersion="106.11.4.0" />
       </dependentAssembly>
     </assemblyBinding>
+    <AppContextSwitchOverrides value="Switch.UseLegacyAccessibilityFeatures=false;Switch.UseLegacyAccessibilityFeatures.2=false;Switch.UseLegacyAccessibilityFeatures.3=false;Switch.UseLegacyAccessibilityFeatures.4=false" />
   </runtime>
   <connectionStrings></connectionStrings>
   <applicationSettings>

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
@@ -80,7 +80,6 @@
             this.label60.Location = new System.Drawing.Point(3, 417);
             this.label60.Name = "label60";
             this.label60.Size = new System.Drawing.Size(114, 13);
-            this.label60.TabIndex = 79;
             this.label60.Text = "Files content encoding";
             // 
             // Global_FilesEncoding
@@ -90,15 +89,14 @@
             this.Global_FilesEncoding.Location = new System.Drawing.Point(129, 413);
             this.Global_FilesEncoding.Name = "Global_FilesEncoding";
             this.Global_FilesEncoding.Size = new System.Drawing.Size(241, 21);
-            this.Global_FilesEncoding.TabIndex = 17;
             // 
             // btnCommitTemplateBrowse
             // 
+            this.btnCommitTemplateBrowse.AccessibleName = "Browse Path to commit template";
             this.btnCommitTemplateBrowse.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCommitTemplateBrowse.Location = new System.Drawing.Point(1037, 260);
             this.btnCommitTemplateBrowse.Name = "btnCommitTemplateBrowse";
             this.btnCommitTemplateBrowse.Size = new System.Drawing.Size(123, 25);
-            this.btnCommitTemplateBrowse.TabIndex = 15;
             this.btnCommitTemplateBrowse.Text = "Browse";
             this.btnCommitTemplateBrowse.UseVisualStyleBackColor = true;
             this.btnCommitTemplateBrowse.Click += new System.EventHandler(this.btnCommitTemplateBrowse_Click);
@@ -110,7 +108,6 @@
             this.lblCommitTemplatePath.Location = new System.Drawing.Point(3, 266);
             this.lblCommitTemplatePath.Name = "lblCommitTemplatePath";
             this.lblCommitTemplatePath.Size = new System.Drawing.Size(120, 13);
-            this.lblCommitTemplatePath.TabIndex = 76;
             this.lblCommitTemplatePath.Text = "Path to commit template";
             // 
             // txtCommitTemplatePath
@@ -119,15 +116,14 @@
             this.txtCommitTemplatePath.Location = new System.Drawing.Point(129, 262);
             this.txtCommitTemplatePath.Name = "txtCommitTemplatePath";
             this.txtCommitTemplatePath.Size = new System.Drawing.Size(902, 20);
-            this.txtCommitTemplatePath.TabIndex = 14;
             // 
             // btnDiffToolCommandSuggest
             // 
+            this.btnDiffToolCommandSuggest.AccessibleName = "Suggest Difftool command";
             this.btnDiffToolCommandSuggest.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.btnDiffToolCommandSuggest.Location = new System.Drawing.Point(1037, 229);
             this.btnDiffToolCommandSuggest.Name = "btnDiffToolCommandSuggest";
             this.btnDiffToolCommandSuggest.Size = new System.Drawing.Size(123, 25);
-            this.btnDiffToolCommandSuggest.TabIndex = 13;
             this.btnDiffToolCommandSuggest.Text = "Suggest";
             this.btnDiffToolCommandSuggest.UseVisualStyleBackColor = true;
             this.btnDiffToolCommandSuggest.Click += new System.EventHandler(this.btnDiffToolCommandSuggest_Click);
@@ -138,7 +134,6 @@
             this.txtDiffToolCommand.Location = new System.Drawing.Point(129, 231);
             this.txtDiffToolCommand.Name = "txtDiffToolCommand";
             this.txtDiffToolCommand.Size = new System.Drawing.Size(902, 20);
-            this.txtDiffToolCommand.TabIndex = 12;
             // 
             // lblDiffToolCommand
             // 
@@ -147,16 +142,15 @@
             this.lblDiffToolCommand.Location = new System.Drawing.Point(3, 235);
             this.lblDiffToolCommand.Name = "lblDiffToolCommand";
             this.lblDiffToolCommand.Size = new System.Drawing.Size(89, 13);
-            this.lblDiffToolCommand.TabIndex = 72;
             this.lblDiffToolCommand.Text = "Difftool command";
             // 
             // btnDiffToolBrowse
             // 
+            this.btnDiffToolBrowse.AccessibleName = "Browse Difftool command";
             this.btnDiffToolBrowse.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.btnDiffToolBrowse.Location = new System.Drawing.Point(1037, 198);
             this.btnDiffToolBrowse.Name = "btnDiffToolBrowse";
             this.btnDiffToolBrowse.Size = new System.Drawing.Size(123, 25);
-            this.btnDiffToolBrowse.TabIndex = 11;
             this.btnDiffToolBrowse.Text = "Browse";
             this.btnDiffToolBrowse.UseVisualStyleBackColor = true;
             this.btnDiffToolBrowse.Click += new System.EventHandler(this.btnDiffToolBrowse_Click);
@@ -168,7 +162,6 @@
             this.lblDiffToolPath.Location = new System.Drawing.Point(3, 204);
             this.lblDiffToolPath.Name = "lblDiffToolPath";
             this.lblDiffToolPath.Size = new System.Drawing.Size(75, 13);
-            this.lblDiffToolPath.TabIndex = 70;
             this.lblDiffToolPath.Text = "Path to difftool";
             // 
             // txtDiffToolPath
@@ -177,7 +170,6 @@
             this.txtDiffToolPath.Location = new System.Drawing.Point(129, 200);
             this.txtDiffToolPath.Name = "txtDiffToolPath";
             this.txtDiffToolPath.Size = new System.Drawing.Size(902, 20);
-            this.txtDiffToolPath.TabIndex = 10;
             this.txtDiffToolPath.LostFocus += new System.EventHandler(this.txtDiffMergeToolPath_LostFocus);
             // 
             // _NO_TRANSLATE_cboDiffTool
@@ -187,7 +179,6 @@
             this._NO_TRANSLATE_cboDiffTool.Location = new System.Drawing.Point(129, 171);
             this._NO_TRANSLATE_cboDiffTool.Name = "_NO_TRANSLATE_cboDiffTool";
             this._NO_TRANSLATE_cboDiffTool.Size = new System.Drawing.Size(241, 21);
-            this._NO_TRANSLATE_cboDiffTool.TabIndex = 9;
             this._NO_TRANSLATE_cboDiffTool.TextChanged += new System.EventHandler(this.cboDiffTool_TextChanged);
             // 
             // lblDiffTool
@@ -197,7 +188,6 @@
             this.lblDiffTool.Location = new System.Drawing.Point(3, 175);
             this.lblDiffTool.Name = "lblDiffTool";
             this.lblDiffTool.Size = new System.Drawing.Size(40, 13);
-            this.lblDiffTool.TabIndex = 67;
             this.lblDiffTool.Text = "Difftool";
             // 
             // InvalidGitPathGlobal
@@ -207,14 +197,13 @@
             this.InvalidGitPathGlobal.BackColor = System.Drawing.SystemColors.Info;
             this.InvalidGitPathGlobal.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.tableLayoutPanelGitConfig.SetColumnSpan(this.InvalidGitPathGlobal, 2);
-            this.InvalidGitPathGlobal.Controls.Add(this.label9);
             this.InvalidGitPathGlobal.Controls.Add(this.pictureBox1);
+            this.InvalidGitPathGlobal.Controls.Add(this.label9);
             this.InvalidGitPathGlobal.Location = new System.Drawing.Point(1037, 29);
             this.InvalidGitPathGlobal.Name = "InvalidGitPathGlobal";
             this.InvalidGitPathGlobal.Padding = new System.Windows.Forms.Padding(3, 3, 3, 3);
             this.tableLayoutPanelGitConfig.SetRowSpan(this.InvalidGitPathGlobal, 4);
             this.InvalidGitPathGlobal.Size = new System.Drawing.Size(237, 47);
-            this.InvalidGitPathGlobal.TabIndex = 65;
             this.InvalidGitPathGlobal.Visible = false;
             // 
             // label9
@@ -224,7 +213,6 @@
             this.label9.Location = new System.Drawing.Point(57, 3);
             this.label9.Name = "label9";
             this.label9.Size = new System.Drawing.Size(175, 39);
-            this.label9.TabIndex = 19;
             this.label9.Text = "You need to set the correct path to \r\ngit before you can change\r\nglobal settings." +
     "\r\n";
             // 
@@ -236,16 +224,15 @@
             this.pictureBox1.Name = "pictureBox1";
             this.pictureBox1.Size = new System.Drawing.Size(54, 39);
             this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
-            this.pictureBox1.TabIndex = 18;
             this.pictureBox1.TabStop = false;
             // 
             // btnMergeToolCommandSuggest
             // 
+            this.btnMergeToolCommandSuggest.AccessibleName = "Suggest Mergetool command";
             this.btnMergeToolCommandSuggest.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.btnMergeToolCommandSuggest.Location = new System.Drawing.Point(1037, 140);
             this.btnMergeToolCommandSuggest.Name = "btnMergeToolCommandSuggest";
             this.btnMergeToolCommandSuggest.Size = new System.Drawing.Size(123, 25);
-            this.btnMergeToolCommandSuggest.TabIndex = 7;
             this.btnMergeToolCommandSuggest.Text = "Suggest";
             this.btnMergeToolCommandSuggest.UseVisualStyleBackColor = true;
             this.btnMergeToolCommandSuggest.Click += new System.EventHandler(this.btnMergeToolCommandSuggest_Click);
@@ -256,7 +243,6 @@
             this.txtMergeToolCommand.Location = new System.Drawing.Point(129, 142);
             this.txtMergeToolCommand.Name = "txtMergeToolCommand";
             this.txtMergeToolCommand.Size = new System.Drawing.Size(902, 20);
-            this.txtMergeToolCommand.TabIndex = 6;
             // 
             // lblMergeToolCommand
             // 
@@ -265,16 +251,15 @@
             this.lblMergeToolCommand.Location = new System.Drawing.Point(3, 146);
             this.lblMergeToolCommand.Name = "lblMergeToolCommand";
             this.lblMergeToolCommand.Size = new System.Drawing.Size(103, 13);
-            this.lblMergeToolCommand.TabIndex = 62;
             this.lblMergeToolCommand.Text = "Mergetool command";
             // 
             // btnMergeToolBrowse
             // 
+            this.btnMergeToolBrowse.AccessibleName = "Browse Path to mergetool";
             this.btnMergeToolBrowse.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.btnMergeToolBrowse.Location = new System.Drawing.Point(1037, 109);
             this.btnMergeToolBrowse.Name = "btnMergeToolBrowse";
             this.btnMergeToolBrowse.Size = new System.Drawing.Size(123, 25);
-            this.btnMergeToolBrowse.TabIndex = 5;
             this.btnMergeToolBrowse.Text = "Browse";
             this.btnMergeToolBrowse.UseVisualStyleBackColor = true;
             this.btnMergeToolBrowse.Click += new System.EventHandler(this.btnMergeToolBrowse_Click);
@@ -286,7 +271,6 @@
             this._NO_TRANSLATE_cboMergeTool.Location = new System.Drawing.Point(129, 82);
             this._NO_TRANSLATE_cboMergeTool.Name = "_NO_TRANSLATE_cboMergeTool";
             this._NO_TRANSLATE_cboMergeTool.Size = new System.Drawing.Size(241, 21);
-            this._NO_TRANSLATE_cboMergeTool.TabIndex = 3;
             this._NO_TRANSLATE_cboMergeTool.TextChanged += new System.EventHandler(this.cboMergeTool_TextChanged);
             // 
             // lblMergeToolPath
@@ -296,7 +280,6 @@
             this.lblMergeToolPath.Location = new System.Drawing.Point(3, 115);
             this.lblMergeToolPath.Name = "lblMergeToolPath";
             this.lblMergeToolPath.Size = new System.Drawing.Size(90, 13);
-            this.lblMergeToolPath.TabIndex = 59;
             this.lblMergeToolPath.Text = "Path to mergetool";
             // 
             // txtMergeToolPath
@@ -305,7 +288,6 @@
             this.txtMergeToolPath.Location = new System.Drawing.Point(129, 111);
             this.txtMergeToolPath.Name = "txtMergeToolPath";
             this.txtMergeToolPath.Size = new System.Drawing.Size(902, 20);
-            this.txtMergeToolPath.TabIndex = 4;
             this.txtMergeToolPath.LostFocus += new System.EventHandler(this.txtDiffMergeToolPath_LostFocus);
             // 
             // lblMergeTool
@@ -315,7 +297,6 @@
             this.lblMergeTool.Location = new System.Drawing.Point(3, 86);
             this.lblMergeTool.Name = "lblMergeTool";
             this.lblMergeTool.Size = new System.Drawing.Size(54, 13);
-            this.lblMergeTool.TabIndex = 56;
             this.lblMergeTool.Text = "Mergetool";
             // 
             // GlobalEditor
@@ -324,7 +305,6 @@
             this.GlobalEditor.Location = new System.Drawing.Point(129, 55);
             this.GlobalEditor.Name = "GlobalEditor";
             this.GlobalEditor.Size = new System.Drawing.Size(902, 21);
-            this.GlobalEditor.TabIndex = 2;
             // 
             // label6
             // 
@@ -333,7 +313,6 @@
             this.label6.Location = new System.Drawing.Point(3, 59);
             this.label6.Name = "label6";
             this.label6.Size = new System.Drawing.Size(34, 13);
-            this.label6.TabIndex = 54;
             this.label6.Text = "Editor";
             // 
             // GlobalUserEmail
@@ -342,7 +321,6 @@
             this.GlobalUserEmail.Location = new System.Drawing.Point(129, 29);
             this.GlobalUserEmail.Name = "GlobalUserEmail";
             this.GlobalUserEmail.Size = new System.Drawing.Size(241, 20);
-            this.GlobalUserEmail.TabIndex = 1;
             // 
             // GlobalUserName
             // 
@@ -350,7 +328,6 @@
             this.GlobalUserName.Location = new System.Drawing.Point(129, 3);
             this.GlobalUserName.Name = "GlobalUserName";
             this.GlobalUserName.Size = new System.Drawing.Size(241, 20);
-            this.GlobalUserName.TabIndex = 0;
             // 
             // label4
             // 
@@ -359,7 +336,6 @@
             this.label4.Location = new System.Drawing.Point(3, 32);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(56, 13);
-            this.label4.TabIndex = 51;
             this.label4.Text = "User email";
             // 
             // label3
@@ -369,7 +345,6 @@
             this.label3.Location = new System.Drawing.Point(3, 6);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(58, 13);
-            this.label3.TabIndex = 50;
             this.label3.Text = "User name";
             // 
             // groupBoxLineEndings
@@ -383,7 +358,6 @@
             this.groupBoxLineEndings.Margin = new System.Windows.Forms.Padding(3, 3, 3, 6);
             this.groupBoxLineEndings.Name = "groupBoxLineEndings";
             this.groupBoxLineEndings.Size = new System.Drawing.Size(1271, 111);
-            this.groupBoxLineEndings.TabIndex = 16;
             this.groupBoxLineEndings.TabStop = false;
             this.groupBoxLineEndings.Text = "Line endings";
             // 
@@ -399,7 +373,6 @@
             this.flowLayoutPanelLineEndings.Location = new System.Drawing.Point(3, 16);
             this.flowLayoutPanelLineEndings.Name = "flowLayoutPanelLineEndings";
             this.flowLayoutPanelLineEndings.Size = new System.Drawing.Size(1265, 92);
-            this.flowLayoutPanelLineEndings.TabIndex = 5;
             // 
             // globalAutoCrlfTrue
             // 
@@ -407,7 +380,6 @@
             this.globalAutoCrlfTrue.Location = new System.Drawing.Point(3, 3);
             this.globalAutoCrlfTrue.Name = "globalAutoCrlfTrue";
             this.globalAutoCrlfTrue.Size = new System.Drawing.Size(439, 17);
-            this.globalAutoCrlfTrue.TabIndex = 0;
             this.globalAutoCrlfTrue.TabStop = true;
             this.globalAutoCrlfTrue.Text = "Checkout Windows-style, commit Unix-style line endings (\"core.autocrlf\"  is set t" +
     "o \"true\")";
@@ -419,7 +391,6 @@
             this.globalAutoCrlfInput.Location = new System.Drawing.Point(3, 26);
             this.globalAutoCrlfInput.Name = "globalAutoCrlfInput";
             this.globalAutoCrlfInput.Size = new System.Drawing.Size(397, 17);
-            this.globalAutoCrlfInput.TabIndex = 1;
             this.globalAutoCrlfInput.TabStop = true;
             this.globalAutoCrlfInput.Text = "Checkout as-is, commit Unix-style line endings (\"core.autocrlf\"  is set to \"input" +
     "\")";
@@ -431,7 +402,6 @@
             this.globalAutoCrlfFalse.Location = new System.Drawing.Point(3, 49);
             this.globalAutoCrlfFalse.Name = "globalAutoCrlfFalse";
             this.globalAutoCrlfFalse.Size = new System.Drawing.Size(313, 17);
-            this.globalAutoCrlfFalse.TabIndex = 2;
             this.globalAutoCrlfFalse.TabStop = true;
             this.globalAutoCrlfFalse.Text = "Checkout as-is, commit as-is (\"core.autocrlf\"  is set to \"false\")";
             this.globalAutoCrlfFalse.UseVisualStyleBackColor = true;
@@ -442,7 +412,6 @@
             this.globalAutoCrlfNotSet.Location = new System.Drawing.Point(3, 72);
             this.globalAutoCrlfNotSet.Name = "globalAutoCrlfNotSet";
             this.globalAutoCrlfNotSet.Size = new System.Drawing.Size(59, 17);
-            this.globalAutoCrlfNotSet.TabIndex = 4;
             this.globalAutoCrlfNotSet.TabStop = true;
             this.globalAutoCrlfNotSet.Text = "Not set";
             this.globalAutoCrlfNotSet.UseVisualStyleBackColor = true;
@@ -454,36 +423,36 @@
             this.tableLayoutPanelGitConfig.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanelGitConfig.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanelGitConfig.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanelGitConfig.Controls.Add(this.ConfigureEncoding, 2, 11);
             this.tableLayoutPanelGitConfig.Controls.Add(this.label3, 0, 0);
-            this.tableLayoutPanelGitConfig.Controls.Add(this.label60, 0, 11);
-            this.tableLayoutPanelGitConfig.Controls.Add(this.groupBoxLineEndings, 0, 10);
             this.tableLayoutPanelGitConfig.Controls.Add(this.GlobalUserName, 1, 0);
             this.tableLayoutPanelGitConfig.Controls.Add(this.label4, 0, 1);
             this.tableLayoutPanelGitConfig.Controls.Add(this.GlobalUserEmail, 1, 1);
             this.tableLayoutPanelGitConfig.Controls.Add(this.label6, 0, 2);
-            this.tableLayoutPanelGitConfig.Controls.Add(this.txtCommitTemplatePath, 1, 9);
-            this.tableLayoutPanelGitConfig.Controls.Add(lblCommitTemplatePath, 0, 9);
             this.tableLayoutPanelGitConfig.Controls.Add(this.GlobalEditor, 1, 2);
-            this.tableLayoutPanelGitConfig.Controls.Add(this.InvalidGitPathGlobal, 2, 0);
             this.tableLayoutPanelGitConfig.Controls.Add(lblMergeTool, 0, 3);
-            this.tableLayoutPanelGitConfig.Controls.Add(this.txtDiffToolCommand, 1, 8);
             this.tableLayoutPanelGitConfig.Controls.Add(this._NO_TRANSLATE_cboMergeTool, 1, 3);
-            this.tableLayoutPanelGitConfig.Controls.Add(lblDiffToolCommand, 0, 8);
             this.tableLayoutPanelGitConfig.Controls.Add(lblMergeToolPath, 0, 4);
             this.tableLayoutPanelGitConfig.Controls.Add(this.txtMergeToolPath, 1, 4);
-            this.tableLayoutPanelGitConfig.Controls.Add(this.txtDiffToolPath, 1, 7);
-            this.tableLayoutPanelGitConfig.Controls.Add(lblDiffToolPath, 0, 7);
-            this.tableLayoutPanelGitConfig.Controls.Add(lblMergeToolCommand, 0, 5);
-            this.tableLayoutPanelGitConfig.Controls.Add(this._NO_TRANSLATE_cboDiffTool, 1, 6);
-            this.tableLayoutPanelGitConfig.Controls.Add(this.txtMergeToolCommand, 1, 5);
-            this.tableLayoutPanelGitConfig.Controls.Add(lblDiffTool, 0, 6);
-            this.tableLayoutPanelGitConfig.Controls.Add(this.Global_FilesEncoding, 1, 11);
             this.tableLayoutPanelGitConfig.Controls.Add(this.btnMergeToolBrowse, 2, 4);
+            this.tableLayoutPanelGitConfig.Controls.Add(lblMergeToolCommand, 0, 5);
+            this.tableLayoutPanelGitConfig.Controls.Add(this.txtMergeToolCommand, 1, 5);
             this.tableLayoutPanelGitConfig.Controls.Add(this.btnMergeToolCommandSuggest, 2, 5);
+            this.tableLayoutPanelGitConfig.Controls.Add(lblDiffTool, 0, 6);
+            this.tableLayoutPanelGitConfig.Controls.Add(this._NO_TRANSLATE_cboDiffTool, 1, 6);
+            this.tableLayoutPanelGitConfig.Controls.Add(lblDiffToolPath, 0, 7);
+            this.tableLayoutPanelGitConfig.Controls.Add(this.txtDiffToolPath, 1, 7);
             this.tableLayoutPanelGitConfig.Controls.Add(this.btnDiffToolBrowse, 2, 7);
+            this.tableLayoutPanelGitConfig.Controls.Add(lblDiffToolCommand, 0, 8);
+            this.tableLayoutPanelGitConfig.Controls.Add(this.txtDiffToolCommand, 1, 8);
             this.tableLayoutPanelGitConfig.Controls.Add(this.btnDiffToolCommandSuggest, 2, 8);
+            this.tableLayoutPanelGitConfig.Controls.Add(lblCommitTemplatePath, 0, 9);
+            this.tableLayoutPanelGitConfig.Controls.Add(this.txtCommitTemplatePath, 1, 9);
             this.tableLayoutPanelGitConfig.Controls.Add(this.btnCommitTemplateBrowse, 2, 9);
+            this.tableLayoutPanelGitConfig.Controls.Add(this.groupBoxLineEndings, 0, 10);
+            this.tableLayoutPanelGitConfig.Controls.Add(this.label60, 0, 11);
+            this.tableLayoutPanelGitConfig.Controls.Add(this.InvalidGitPathGlobal, 2, 0);
+            this.tableLayoutPanelGitConfig.Controls.Add(this.Global_FilesEncoding, 1, 11);
+            this.tableLayoutPanelGitConfig.Controls.Add(this.ConfigureEncoding, 2, 11);
             this.tableLayoutPanelGitConfig.Dock = System.Windows.Forms.DockStyle.Top;
             this.tableLayoutPanelGitConfig.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanelGitConfig.Name = "tableLayoutPanelGitConfig";
@@ -503,7 +472,6 @@
             this.tableLayoutPanelGitConfig.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanelGitConfig.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanelGitConfig.Size = new System.Drawing.Size(1277, 778);
-            this.tableLayoutPanelGitConfig.TabIndex = 81;
             // 
             // ConfigureEncoding
             // 
@@ -511,7 +479,6 @@
             this.ConfigureEncoding.Location = new System.Drawing.Point(1037, 411);
             this.ConfigureEncoding.Name = "ConfigureEncoding";
             this.ConfigureEncoding.Size = new System.Drawing.Size(123, 25);
-            this.ConfigureEncoding.TabIndex = 81;
             this.ConfigureEncoding.Text = "Configure";
             this.ConfigureEncoding.UseVisualStyleBackColor = true;
             this.ConfigureEncoding.Click += new System.EventHandler(this.ConfigureEncoding_Click);

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7370,20 +7370,40 @@ Context menu for additional operations</source>
         <source>Select file</source>
         <target />
       </trans-unit>
+      <trans-unit id="btnCommitTemplateBrowse.AccessibleName">
+        <source>Browse Path to commit template</source>
+        <target />
+      </trans-unit>
       <trans-unit id="btnCommitTemplateBrowse.Text">
         <source>Browse</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="btnDiffToolBrowse.AccessibleName">
+        <source>Browse Difftool command</source>
         <target />
       </trans-unit>
       <trans-unit id="btnDiffToolBrowse.Text">
         <source>Browse</source>
         <target />
       </trans-unit>
+      <trans-unit id="btnDiffToolCommandSuggest.AccessibleName">
+        <source>Suggest Difftool command</source>
+        <target />
+      </trans-unit>
       <trans-unit id="btnDiffToolCommandSuggest.Text">
         <source>Suggest</source>
         <target />
       </trans-unit>
+      <trans-unit id="btnMergeToolBrowse.AccessibleName">
+        <source>Browse Path to mergetool</source>
+        <target />
+      </trans-unit>
       <trans-unit id="btnMergeToolBrowse.Text">
         <source>Browse</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="btnMergeToolCommandSuggest.AccessibleName">
+        <source>Suggest Mergetool command</source>
         <target />
       </trans-unit>
       <trans-unit id="btnMergeToolCommandSuggest.Text">

--- a/contributors.txt
+++ b/contributors.txt
@@ -150,3 +150,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/01/11, keco2, Robert Keco, mobil750 at-sign gmail com
 2021/01/17, thimmy687, Ricardo Krause, kaser23@gmx.de
 2021/01/24, bcolaco, Bruno Colaço, bcolaco[@)gmail.com
+2021/01/25, guybark, Guy Barker, guybark(at)microsoft.com


### PR DESCRIPTION
1. Update app.config to pick up some .NET Framework accessibility fixes up to 4.8, depending on what version of .NET Framework is available on the device at runtime.

2. Add unique accessible names for the Browse and Suggest buttons to avoid duplicate names being exposed programmatically on sibling buttons. (If the UI is ever localized, the accessible names must be localized too.)

3. Change the order in which controls are added to their containers, in order to have the programmatic order (as exposed through the UI Automation API) of the controls match their logical order.

4. Remove the TabIndex property being set on the controls, because that interferes with WinForms setting accessible names on TextBox and ComboBox controls based on the text from the Labels that programmatically precedes them. The default tab order is now based on the order in which the controls are added to their containers.

### Before

The Accessibility Insights for Windows tool reports 31 failures against the UI, as shown in the following image

![AIWinBefore](https://user-images.githubusercontent.com/14315611/102382652-85049a80-3f7f-11eb-8804-ef8d78cae03d.jpg)

### After

The Accessibility Insights for Windows tool reports 7 failures against the UI, as shown in the following image. Note that today the remaining failures cannot be avoided while building for .NET Framework.

![AIWinAfter](https://user-images.githubusercontent.com/14315611/102382814-b4b3a280-3f7f-11eb-89f9-11055f85887c.jpg)



