### PR TITLE
GitStatusMonitor: Display when inactive

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -281,6 +281,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                     oldCommands.PreCheckoutRevision -= GitUICommands_PreCheckout;
                     oldCommands.PostCheckoutBranch -= GitUICommands_PostCheckout;
                     oldCommands.PostCheckoutRevision -= GitUICommands_PostCheckout;
+                    oldCommands.PostRepositoryChanged -= GitUICommands_PostRepositoryChanged;
                 }
 
                 commandsSource_activate(sender as IGitUICommandsSource);
@@ -293,6 +294,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 newCommands.PreCheckoutRevision += GitUICommands_PreCheckout;
                 newCommands.PostCheckoutBranch += GitUICommands_PostCheckout;
                 newCommands.PostCheckoutRevision += GitUICommands_PostCheckout;
+                newCommands.PostRepositoryChanged += GitUICommands_PostRepositoryChanged;
 
                 var module = newCommands.Module;
                 StartWatchingChanges(module.WorkingDir, module.WorkingDirGitDir);
@@ -305,6 +307,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             void GitUICommands_PostCheckout(object sender, GitUIPostActionEventArgs e)
             {
+                CurrentStatus = GitStatusMonitorState.Running;
+            }
+
+            void GitUICommands_PostRepositoryChanged(object sender, GitUIEventArgs e)
+            {
+                CurrentStatus = GitStatusMonitorState.Inactive;
                 CurrentStatus = GitStatusMonitorState.Running;
             }
         }

--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -39,6 +39,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         private readonly FileSystemWatcher _gitDirWatcher = new FileSystemWatcher();
         private readonly System.Windows.Forms.Timer _timerRefresh;
         private bool _commandIsRunning;
+        private bool _isFirstPostRepoChanged;
         private string _gitPath;
         private string _submodulesPath;
         private readonly CancellationTokenSequence _statusSequence = new CancellationTokenSequence();
@@ -314,6 +315,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             {
                 CurrentStatus = GitStatusMonitorState.Inactive;
                 CurrentStatus = GitStatusMonitorState.Running;
+                _isFirstPostRepoChanged = true;
             }
         }
 
@@ -430,7 +432,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                         try
                         {
                             var cmd = GitCommandHelpers.GetAllChangedFilesCmd(true, UntrackedFilesMode.Default,
-                                noLocks: true);
+                                noLocks: !_isFirstPostRepoChanged);
+                            _isFirstPostRepoChanged = false;
                             var output = await module.GitExecutable.GetOutputAsync(cmd).ConfigureAwait(false);
                             IReadOnlyList<GitItemStatus> changedFiles = _getAllChangedFilesOutputParser.Parse(output);
 

--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -164,7 +164,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         public void InvalidateGitWorkingDirectoryStatus()
         {
-            GitWorkingDirectoryStatusChanged?.Invoke(this, new GitWorkingDirectoryStatusEventArgs());
+            GitWorkingDirectoryStatusChanged?.Invoke(this, null);
         }
 
         public void RequestRefresh()

--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitorState.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitorState.cs
@@ -4,6 +4,7 @@
     {
         Stopped = 0,
         Running,
+        Inactive,
         Paused
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -368,7 +368,7 @@ namespace GitUI.CommandsDialogs
 
                 gitStatusMonitor.GitWorkingDirectoryStatusChanged += (s, e) =>
                 {
-                    IReadOnlyList<GitItemStatus> status = e.ItemStatuses;
+                    IReadOnlyList<GitItemStatus> status = e?.ItemStatuses;
 
                     bool countToolbar = AppSettings.ShowGitStatusInBrowseToolbar;
                     bool countArtificial = AppSettings.ShowGitStatusForArtificialCommits && AppSettings.RevisionGraphShowWorkingDirChanges;


### PR DESCRIPTION
## Proposed changes

Display when the commit count is inactive or not yet updated.
Currently the status is shown as zero changes or shown the changes before for instance Commit or minimize.
Update is scheduled immediately after running again.
- When refreshing
- After switching to a new repo
- Minimizing GE, then activating
- Open a modal dialog, like FormCommit

@mstv has asked about about status being incorrect, for instance when committing. 
The modal dialog ("lock the repo") could still keep GitStatusMonitor active, even if I believe I prefer this.

--
A slightly separate change that builds on the change above, could be separated
@pmiossec  asked about this

Run first update with locks
GitStatusMonitor normally do not try to lock the git-status, to not interfere with Commit.
However, a lock will speed up subsequent git-status.
If for instance you are building while opening GE, a lot of file changed events will fire
and git-status will run as often as allowed (max 1/3 of the time, but git-status can take some seconds).

If Commit button is pressed while still gray there may be a conflict though.
(But next FormCommit git-status should be faster.)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Shown while operations like Commit are ongoing
![image](https://user-images.githubusercontent.com/6248932/102700862-73f2ac80-4251-11eb-8cf7-973a667e5132.png)

Shown after a repo is opened, before status is available
![image](https://user-images.githubusercontent.com/6248932/102700882-ab615900-4251-11eb-8fd7-69188c09d9e4.png)

### After

Until git-status has run
![image](https://user-images.githubusercontent.com/6248932/102700928-06934b80-4252-11eb-85f0-5646dbe00cc2.png)

## Test methodology

At work with Symantec virus git-status may require 10s (at least the initial updated.
On my PC at home, git-status requires about 200 ms for the GE repo. This change can be hard to see. To simulate a slow git-status execution, you may simulate a delay:

GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs line 437
Thread.Delay(5000);

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
