### PR TITLE
Handle multi-part names for author initials

### DIFF
--- a/GitUI/Avatars/InitialsAvatarGenerator.cs
+++ b/GitUI/Avatars/InitialsAvatarGenerator.cs
@@ -32,33 +32,59 @@ namespace GitUI.Avatars
 
         protected internal (string initials, int hashCode) GetInitialsAndHashCode(string email, string name)
         {
-            string initials;
-            int hashCode;
+            string initials = null;
+            int hashCode = _unkownCounter;
             if (!string.IsNullOrWhiteSpace(name))
             {
-                var trimmedName = name.Trim();
-                var indexSpace = trimmedName.IndexOf(' ');
-                initials = trimmedName[0].ToString().ToUpper();
-                if (indexSpace != -1)
+                initials = GetInitials(name.Trim().Split());
+                if (!string.IsNullOrWhiteSpace(initials))
                 {
-                    initials += trimmedName[indexSpace + 1].ToString().ToUpper();
+                    hashCode = name.GetHashCode();
+                    return (initials, hashCode);
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(email))
+            {
+                var e = email.TrimStart();
+                if (e.Contains("@"))
+                {
+                    e = e.Split('@')[0];
                 }
 
-                hashCode = string.IsNullOrWhiteSpace(email) ? name.GetHashCode() : email.GetHashCode();
-            }
-            else if (!string.IsNullOrWhiteSpace(email))
-            {
-                initials = ("" + email.TrimStart().First()).ToUpper();
-                hashCode = email.GetHashCode();
-            }
-            else
-            {
-                initials = "?";
-                hashCode = _unkownCounter;
-                _unkownCounter++;
+                initials = GetInitials(e.Split('.', '-', '_'));
+                if (!string.IsNullOrWhiteSpace(initials))
+                {
+                    hashCode = email.GetHashCode();
+                    return (initials, hashCode);
+                }
             }
 
+            initials = "?";
+            hashCode = _unkownCounter;
+            _unkownCounter++;
+
             return (initials, hashCode);
+
+            static string GetInitials(string[] names)
+            {
+                var names2 = names?.Where(s => !string.IsNullOrWhiteSpace(s) && char.IsLetter(s[0])).ToList();
+                if (names2 == null || names2.Count == 0)
+                {
+                    return null;
+                }
+                else if (names2.Count == 1)
+                {
+                    if (names2[0].Length == 1)
+                    {
+                        return names2[0][0].ToString().ToUpper();
+                    }
+
+                    return new string(new char[] { char.ToUpper(names2[0][0]), names2[0][1] });
+                }
+
+                return new string(new char[] { names2[0][0], names2[names2.Count - 1][0] }).ToUpper();
+            }
         }
 
         private readonly Graphics _graphics = Graphics.FromImage(new Bitmap(1, 1));

--- a/UnitTests/GitUI.Tests/Avatars/InitialsAvatarGeneratorTests.cs
+++ b/UnitTests/GitUI.Tests/Avatars/InitialsAvatarGeneratorTests.cs
@@ -10,36 +10,24 @@ namespace GitUITests.Avatars
     [TestFixture]
     public sealed class InitialsAvatarGeneratorTests
     {
-        [Test]
-        public void GetInitialsAndHashCode_return_initials_of_a_user()
+        [TestCase("albert.einstein@noreply.com", "albert einstein", "AE")]
+        [TestCase("albert.einstein@noreply.com", "albert z middlename einstein (k)", "AE")]
+        [TestCase("albert.einstein@noreply.com", "albert einstein (Nobel_price_winner)", "AE")]
+        [TestCase("albert.einstein@noreply.com", "EINSTEIN, Albert middlename (Nobel_price_winner)", "EM")]
+        [TestCase("albert.einstein@noreply.com", "albert", "Al")]
+        [TestCase("albert.einstein@noreply.com", "", "AE")]
+        [TestCase("albert.einstein@noreply.com", null, "AE")]
+        [TestCase("albert.z.einstein@noreply.com", null, "AE")]
+        [TestCase("albert_z_einstein@noreply.com", null, "AE")]
+        [TestCase("albert.bose-einstein@noreply.com", null, "AE")]
+        [TestCase("albert", "", "Al")]
+        [TestCase("albert.einstein", "", "AE")]
+        [TestCase(null, null, "?")]
+        public void GetInitialsAndHashCode_return_initials_of_a_user(string email, string name, string expected)
         {
-            var (initials, _) = new InitialsAvatarGenerator().GetInitialsAndHashCode("albert.einstein@noreply.com", "albert einstein");
+            var (initials, _) = new InitialsAvatarGenerator().GetInitialsAndHashCode(email, name);
 
-            Assert.AreEqual("AE", initials);
-        }
-
-        [Test]
-        public void GetInitialsAndHashCode_return_the_initial_of_a_user_based_on_its_name()
-        {
-            var (initials, _) = new InitialsAvatarGenerator().GetInitialsAndHashCode("albert.einstein@noreply.com", "albert");
-
-            Assert.AreEqual("A", initials);
-        }
-
-        [Test]
-        public void GetInitialsAndHashCode_return_the_initial_of_a_user_based_on_its_email()
-        {
-            var (initials, _) = new InitialsAvatarGenerator().GetInitialsAndHashCode("albert.einstein@noreply.com", null);
-
-            Assert.AreEqual("A", initials);
-        }
-
-        [Test]
-        public void GetInitialsAndHashCode_return_question_mark_when_no_data_provided()
-        {
-            var (initials, _) = new InitialsAvatarGenerator().GetInitialsAndHashCode(null, null);
-
-            Assert.AreEqual("?", initials);
+            Assert.AreEqual(expected, initials);
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

Tune the author initials to handle middle names and additional info in the name and email addresses.
See test cases for details.

I initially wanted it to handle "Lastname Firstname" as "FL", but that is too hard to find out.
The French convention to use uppercase LASTNAME could be useful to detect lastnames...

## Test methodology <!-- How did you ensure quality? -->

Tests expanded and updated.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
