### PR TITLE
Custom difftool in RevDiff, FileHistory, Commit, RevGrid

### DIFF
--- a/GitCommands/CustomDiffMergeTool.cs
+++ b/GitCommands/CustomDiffMergeTool.cs
@@ -1,0 +1,16 @@
+﻿using System.Windows.Forms;
+
+namespace GitCommands
+{
+    public class CustomDiffMergeTool
+    {
+        public CustomDiffMergeTool(ToolStripMenuItem menuItem, System.EventHandler click)
+        {
+            MenuItem = menuItem;
+            Click = click;
+        }
+
+        public ToolStripMenuItem MenuItem { get; set; }
+        public System.EventHandler Click;
+    }
+}

--- a/GitCommands/CustomDiffMergeToolCache.cs
+++ b/GitCommands/CustomDiffMergeToolCache.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GitCommands.Config;
+using GitUI;
+using Microsoft.VisualStudio.Threading;
+
+namespace GitCommands
+{
+    public class CustomDiffMergeToolCache
+    {
+        private CustomDiffMergeToolCache(bool isDiff)
+        {
+            _isDiff = isDiff;
+        }
+
+        private bool _isDiff { get; set; }
+        private SemaphoreSlim _mutex = new(1);
+        private IEnumerable<string>? _tools = null;
+
+        public static CustomDiffMergeToolCache DiffToolCache { get; } = new(true);
+        public static CustomDiffMergeToolCache MergeToolCache { get; } = new(false);
+
+        /// <summary>
+        /// Clear the existing caches
+        /// </summary>
+        public void Clear()
+        {
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await _mutex.WaitAsync().ConfigureAwait(false);
+
+                try
+                {
+                    _tools = null;
+                }
+                finally
+                {
+                    _mutex.Release();
+                }
+            }).FileAndForget();
+        }
+
+        /// <summary>
+        /// Load the availble DiffMerge tools and apply to the menus
+        /// </summary>
+        /// <param name="module">The Git module</param>
+        /// <param name="delay">The delay before starting the operation</param>
+        public async Task<IEnumerable<string>> GetToolsAsync(GitModule module, int delay)
+        {
+            if (_tools is not null)
+            {
+                return _tools;
+            }
+
+            // The command will compete with other resources, avoid delaying startup
+            // Do not bother with cancel tokens
+            await Task.Delay(delay);
+
+            await _mutex.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                if (_tools is null)
+                {
+                    await TaskScheduler.Default;
+                    var toolKey = _isDiff ? SettingKeyString.DiffToolKey : SettingKeyString.MergeToolKey;
+                    var defaultTool = module.GetEffectiveSetting(toolKey);
+                    string output = module.GetCustomDiffMergeTools(_isDiff);
+                    _tools = ParseCustomDiffMergeTool(output, defaultTool);
+                }
+            }
+            finally
+            {
+                _mutex.Release();
+            }
+
+            return _tools;
+        }
+
+        /// <summary>
+        /// Parse the output from 'git difftool --tool-help'.
+        /// </summary>
+        /// <param name="output">The output string.</param>
+        /// <returns>list with tool names.</returns>
+        private IEnumerable<string> ParseCustomDiffMergeTool(string output, string defaultTool)
+        {
+            var tools = new List<string>();
+
+            // Simple parsing of the textual output opposite to porcelain format
+            // https://github.com/git/git/blob/main/git-mergetool--lib.sh#L298
+            // An alternative is to parse "git config --get-regexp difftool'\..*\.cmd'" and see show_tool_names()
+
+            // The sections to parse in the text has a 'header', then break parsing at first non match
+
+            foreach (var l in output.Split('\n'))
+            {
+                if (l == "The following tools are valid, but not currently available:")
+                {
+                    // No more usable tools
+                    break;
+                }
+
+                if (!l.StartsWith("\t\t"))
+                {
+                    continue;
+                }
+
+                // two tabs, then toolname, cmd (if split in 3) in second
+                // cmd is unreliable for diff and not needed but could be used for mergetool special handling
+                string[] delimit = { " ", ".cmd" };
+                var tool = l.Substring(2).Split(delimit, 2, StringSplitOptions.None);
+                if (tool.Length == 0)
+                {
+                    continue;
+                }
+
+                // Ignore (known) tools that must run in a terminal
+                string[] ignoredTools = { "vimdiff", "vimdiff2", "vimdiff3" };
+                var toolName = tool[0];
+                if (!string.IsNullOrWhiteSpace(toolName) && !tools.Contains(toolName) && !ignoredTools.Contains(toolName))
+                {
+                    tools.Add(toolName);
+                }
+            }
+
+            // Return the default tool first
+            return tools.OrderBy(tool => tool != defaultTool).ThenBy(tool => tool);
+        }
+
+        internal TestAccessor GetTestAccessor() => new(this);
+
+        internal readonly struct TestAccessor
+        {
+            private readonly CustomDiffMergeToolCache _cache;
+
+            public TestAccessor(CustomDiffMergeToolCache cache)
+            {
+                _cache = cache;
+            }
+
+            public IEnumerable<string> ParseCustomDiffMergeTool(string output, string defaultTool)
+                => _cache.ParseCustomDiffMergeTool(output, defaultTool);
+        }
+    }
+}

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1239,6 +1239,12 @@ namespace GitCommands
             set => SetBool("showdiffforallparents", value);
         }
 
+        public static bool ShowAvailableDiffTools
+        {
+            get => GetBool("difftools.showavailable", true);
+            set => SetBool("difftools.showavailable", value);
+        }
+
         public static int DiffVerticalRulerPosition
         {
             get => GetInt("diffverticalrulerposition", 0);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1593,7 +1593,9 @@ namespace GitUI.CommandsDialogs
             RevisionGrid.ReloadTranslation();
             fileTree.ReloadHotkeys();
             revisionDiff.ReloadHotkeys();
-            revisionDiff.ReloadCustomDifftools();
+            new CustomDiffMergeToolProvider().Clear();
+            revisionDiff.LoadCustomDifftools();
+            RevisionGrid.LoadCustomDifftools();
 
             _dashboard?.RefreshContent();
 

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -71,8 +71,6 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
             this.unstagedSubmoduleStageToolStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.openFolderMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.openDiffMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator16 = new System.Windows.Forms.ToolStripSeparator();
             this.copyFolderNameMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.gitItemStatusBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.Cancel = new System.Windows.Forms.Button();
@@ -263,10 +261,9 @@ namespace GitUI.CommandsDialogs
             //
             this.openWithDifftoolToolStripMenuItem.Image = global::GitUI.Properties.Images.Diff;
             this.openWithDifftoolToolStripMenuItem.Name = "openWithDifftoolToolStripMenuItem";
-            this.openWithDifftoolToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
             this.openWithDifftoolToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
             this.openWithDifftoolToolStripMenuItem.Text = "Open with difftool";
-            this.openWithDifftoolToolStripMenuItem.Click += new System.EventHandler(this.OpenWithDifftoolToolStripMenuItemClick);
+            this.openWithDifftoolToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
             //
             // toolStripSeparator9
             //
@@ -460,7 +457,6 @@ namespace GitUI.CommandsDialogs
             //
             this.stagedOpenDifftoolToolStripMenuItem9.Image = global::GitUI.Properties.Images.Diff;
             this.stagedOpenDifftoolToolStripMenuItem9.Name = "stagedOpenDifftoolToolStripMenuItem9";
-            this.stagedOpenDifftoolToolStripMenuItem9.ShortcutKeys = System.Windows.Forms.Keys.F3;
             this.stagedOpenDifftoolToolStripMenuItem9.Size = new System.Drawing.Size(232, 22);
             this.stagedOpenDifftoolToolStripMenuItem9.Text = "Open with difftool";
             this.stagedOpenDifftoolToolStripMenuItem9.Click += new System.EventHandler(this.stagedOpenDifftoolToolStripMenuItem9_Click);
@@ -504,8 +500,6 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator15,
             this.stageSubmoduleToolStripMenuItem,
             this.unstagedSubmoduleStageToolStripSeparator,
-            this.openDiffMenuItem,
-            this.toolStripSeparator16,
             this.copyFolderNameMenuItem,
             this.openFolderMenuItem,
             this.toolStripSeparator13,
@@ -586,20 +580,6 @@ namespace GitUI.CommandsDialogs
             this.openFolderMenuItem.Size = new System.Drawing.Size(228, 22);
             this.openFolderMenuItem.Text = "Show in folder";
             this.openFolderMenuItem.Click += new System.EventHandler(this.OpenToolStripMenuItemClick);
-            //
-            // openDiffMenuItem
-            //
-            this.openDiffMenuItem.Image = global::GitUI.Properties.Images.Diff;
-            this.openDiffMenuItem.Name = "openDiffMenuItem";
-            this.openDiffMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
-            this.openDiffMenuItem.Size = new System.Drawing.Size(228, 22);
-            this.openDiffMenuItem.Text = "Open with difftool";
-            this.openDiffMenuItem.Click += new System.EventHandler(this.OpenWithDifftoolToolStripMenuItemClick);
-            //
-            // toolStripSeparator16
-            //
-            this.toolStripSeparator16.Name = "toolStripSeparator16";
-            this.toolStripSeparator16.Size = new System.Drawing.Size(225, 6);
             //
             // copyFolderNameMenuItem
             //
@@ -1635,8 +1615,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripSeparator unstagedSubmoduleStageToolStripSeparator;
         private ToolStripSeparator toolStripSeparator15;
         private ToolStripMenuItem openFolderMenuItem;
-        private ToolStripMenuItem openDiffMenuItem;
-        private ToolStripSeparator toolStripSeparator16;
         private ToolStripMenuItem copyFolderNameMenuItem;
         private ToolStripMenuItem resetSubmoduleChanges;
         private ToolStripMenuItem commitSubmoduleChanges;

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -244,6 +244,8 @@ namespace GitUI.CommandsDialogs
             openToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenFile);
             openWithToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenFileWith);
             editFileToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.EditFile);
+            openWithDifftoolToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenWithDifftool);
+            stagedOpenDifftoolToolStripMenuItem9.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenWithDifftool);
 
             stageSubmoduleToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.StageSelectedFile);
 
@@ -447,6 +449,7 @@ namespace GitUI.CommandsDialogs
         {
             showUntrackedFilesToolStripMenuItem.Checked = Module.EffectiveConfigFile.GetValue("status.showUntrackedFiles") != "no";
             MinimizeBox = Owner is null;
+            LoadCustomDifftools();
             base.OnLoad(e);
         }
 
@@ -576,6 +579,17 @@ namespace GitUI.CommandsDialogs
             }
 
             return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        public void LoadCustomDifftools()
+        {
+            List<CustomDiffMergeTool> menus = new()
+            {
+                new(openWithDifftoolToolStripMenuItem, openWithDifftoolToolStripMenuItem_Click),
+                new(stagedOpenDifftoolToolStripMenuItem9, stagedOpenDifftoolToolStripMenuItem9_Click),
+            };
+
+            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true);
         }
 
         private void FileViewer_TopScrollReached(object sender, EventArgs e)
@@ -2498,23 +2512,37 @@ namespace GitUI.CommandsDialogs
             ClipboardUtil.TrySetText(fileNames.ToString());
         }
 
-        private void OpenFilesWithDiffTool(IEnumerable<FileStatusItem> items)
+        private void OpenFilesWithDiffTool(IEnumerable<FileStatusItem> items, object sender)
+        {
+            var item = sender as ToolStripMenuItem;
+            if (item?.DropDownItems != null)
+            {
+                // "main menu" clicked, cancel dropdown manually, invoke default mergetool
+                item.HideDropDown();
+                item.Owner.Hide();
+            }
+
+            string toolName = item?.Tag as string;
+            OpenFilesWithDiffTool(items, toolName);
+        }
+
+        private void OpenFilesWithDiffTool(IEnumerable<FileStatusItem> items, string toolName = null)
         {
             foreach (var item in items)
             {
                 GitRevision[] revs = new[] { item.SecondRevision, item.FirstRevision };
-                UICommands.OpenWithDifftool(this, revs, item.Item.Name, item.Item.OldName, RevisionDiffKind.DiffAB, item.Item.IsTracked);
+                UICommands.OpenWithDifftool(this, revs, item.Item.Name, item.Item.OldName, RevisionDiffKind.DiffAB, item.Item.IsTracked, customTool: toolName);
             }
         }
 
-        private void OpenWithDifftoolToolStripMenuItemClick(object sender, EventArgs e)
+        private void openWithDifftoolToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            OpenFilesWithDiffTool(Unstaged.SelectedItems);
+            OpenFilesWithDiffTool(Unstaged.SelectedItems, sender);
         }
 
         private void OpenWithDiffTool()
         {
-            (_currentItemStaged ? stagedOpenDifftoolToolStripMenuItem9 : openWithDifftoolToolStripMenuItem).PerformClick();
+            OpenFilesWithDiffTool(_currentItemStaged ? Staged.SelectedItems : Unstaged.SelectedItems);
         }
 
         private void ResetPartOfFileToolStripMenuItemClick(object sender, EventArgs e)
@@ -3083,7 +3111,7 @@ namespace GitUI.CommandsDialogs
 
         private void stagedOpenDifftoolToolStripMenuItem9_Click(object sender, EventArgs e)
         {
-            OpenFilesWithDiffTool(Staged.SelectedItems);
+            OpenFilesWithDiffTool(Staged.SelectedItems, sender);
         }
 
         private void openFolderToolStripMenuItem10_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -149,7 +149,7 @@ namespace GitUI.CommandsDialogs
             this.openWithDifftoolToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
             this.openWithDifftoolToolStripMenuItem.Size = new System.Drawing.Size(339, 22);
             this.openWithDifftoolToolStripMenuItem.Text = "Open with difftool";
-            this.openWithDifftoolToolStripMenuItem.Click += new System.EventHandler(this.OpenWithDifftoolToolStripMenuItemClick);
+            this.openWithDifftoolToolStripMenuItem.Click += new System.EventHandler(this.OpenWithDifftoolToolStripMenuItem_Click);
             // 
             // diffToolRemoteLocalStripMenuItem
             // 

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -196,6 +196,20 @@ namespace GitUI.CommandsDialogs
             {
                 FileChanges.Visible = false;
             }
+
+            LoadCustomDifftools();
+        }
+
+        public void LoadCustomDifftools()
+        {
+            List<CustomDiffMergeTool> menus = new()
+            {
+                new(openWithDifftoolToolStripMenuItem, OpenWithDifftoolToolStripMenuItem_Click),
+                new(diffToolRemoteLocalStripMenuItem, diffToolRemoteLocalStripMenuItem_Click),
+            };
+
+            const int ToolDelay = 10000;
+            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true, ToolDelay);
         }
 
         private void LoadFileHistory()
@@ -431,15 +445,28 @@ namespace GitUI.CommandsDialogs
             FileChanges.ViewSelectedRevisions();
         }
 
-        private void OpenWithDifftoolToolStripMenuItemClick(object sender, EventArgs e)
+        private void OpenWithDifftoolToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var selectedRevisions = FileChanges.GetSelectedRevisions();
+            OpenFilesWithDiffTool(RevisionDiffKind.DiffAB, sender);
+        }
 
+        private void OpenFilesWithDiffTool(RevisionDiffKind diffKind, object sender)
+        {
+            var item = sender as ToolStripMenuItem;
+            if (item?.DropDownItems != null)
+            {
+                // "main menu" clicked, cancel dropdown manually, invoke default mergetool
+                item.HideDropDown();
+                item.Owner.Hide();
+            }
+
+            var toolName = item?.Tag as string;
+            var selectedRevisions = FileChanges.GetSelectedRevisions();
             var orgFileName = selectedRevisions.Count != 0
                 ? selectedRevisions[0].Name
                 : null;
 
-            UICommands.OpenWithDifftool(this, selectedRevisions, FileName, orgFileName, RevisionDiffKind.DiffAB, true);
+            UICommands.OpenWithDifftool(this, selectedRevisions, FileName, orgFileName, diffKind, true, customTool: toolName);
         }
 
         private void saveAsToolStripMenuItem_Click(object sender, EventArgs e)
@@ -578,7 +605,7 @@ namespace GitUI.CommandsDialogs
 
         private void diffToolRemoteLocalStripMenuItem_Click(object sender, EventArgs e)
         {
-            UICommands.OpenWithDifftool(this, FileChanges.GetSelectedRevisions(), FileName, string.Empty, RevisionDiffKind.DiffBLocal, true);
+            OpenFilesWithDiffTool(RevisionDiffKind.DiffBLocal, sender);
         }
 
         private void toolStripSplitLoad_ButtonClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -295,20 +296,13 @@ namespace GitUI.CommandsDialogs
 
         private void LoadCustomMergetools()
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            List<CustomDiffMergeTool> menus = new()
             {
-                var tools = await Module.GetCustomDiffMergeTools(isDiff: false);
-                customMergetool.DropDown = null;
-                ContextMenuStrip customDiffToolDropDown = new();
-                foreach (var tool in tools)
-                {
-                    var toolStripItem = new ToolStripMenuItem(tool) { Tag = tool };
-                    toolStripItem.Click += customMergetool_Click;
-                    customDiffToolDropDown.Items.Add(toolStripItem);
-                }
+                new(customMergetool, customMergetool_Click),
+            };
 
-                customMergetool.DropDown = customDiffToolDropDown;
-            }).FileAndForget();
+            const int ToolDelay = 5000;
+            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: false, ToolDelay);
         }
 
         private readonly Dictionary<string, string> _mergeScripts = new Dictionary<string, string>
@@ -1263,21 +1257,22 @@ namespace GitUI.CommandsDialogs
 
         private void customMergetool_Click(object sender, EventArgs e)
         {
-            if (sender == customMergetool)
+            var item = sender as ToolStripMenuItem;
+            if (item?.DropDownItems != null)
             {
                 // "main menu" clicked, cancel dropdown manually, invoke default mergetool
-                customMergetool.HideDropDown();
-                ConflictedFilesContextMenu.Hide();
+                item.HideDropDown();
+                item.Owner.Hide();
             }
 
             using (WaitCursorScope.Enter())
             {
-                string customTool = (sender as ToolStripMenuItem)?.Tag as string;
+                var customTool = item?.Tag as string;
 
-                foreach (var item in GetConflicts())
+                foreach (var conflict in GetConflicts())
                 {
                     Directory.SetCurrentDirectory(Module.WorkingDir);
-                    Module.RunMergeTool(fileName: item.Filename, customTool: customTool);
+                    Module.RunMergeTool(fileName: conflict.Filename, customTool: customTool);
                     Initialize();
                 }
             }

--- a/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
@@ -35,7 +35,6 @@ namespace GitUI.CommandsDialogs
             this.DiffFiles = new GitUI.FileStatusList();
             this.DiffContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.openWithDifftoolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.openWithCustomDifftoolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.diffRememberStripSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.diffTwoSelectedDifftoolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.diffWithRememberedDifftoolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -154,7 +153,6 @@ namespace GitUI.CommandsDialogs
                 this.secondDiffCaptionMenuItem,
                 this.firstDiffCaptionMenuItem,
                 this.firstToSelectedToolStripMenuItem,
-                this.openWithCustomDifftoolToolStripMenuItem,
                 this.selectedToLocalToolStripMenuItem,
                 this.firstToLocalToolStripMenuItem,
                 this.diffRememberStripSeparator,
@@ -168,12 +166,6 @@ namespace GitUI.CommandsDialogs
             this.openWithDifftoolToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
             this.openWithDifftoolToolStripMenuItem.Text = "Open with difftool";
             this.openWithDifftoolToolStripMenuItem.DropDownOpening += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_DropDownOpening);
-            // 
-            // openWithCustomDifftoolToolStripMenuItem
-            // 
-            this.openWithCustomDifftoolToolStripMenuItem.Name = "openWithCustomDifftoolToolStripMenuItem";
-            this.openWithCustomDifftoolToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.openWithCustomDifftoolToolStripMenuItem.Text = "First -> Second...";
             // 
             // diffRememberStripSeparator
             // 
@@ -224,21 +216,21 @@ namespace GitUI.CommandsDialogs
             this.firstToSelectedToolStripMenuItem.Name = "firstToSelectedToolStripMenuItem";
             this.firstToSelectedToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
             this.firstToSelectedToolStripMenuItem.Text = "First -> Second";
-            this.firstToSelectedToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
+            this.firstToSelectedToolStripMenuItem.Click += new System.EventHandler(this.firstToSelectedToolStripMenuItem_Click);
             // 
             // firstToLocalToolStripMenuItem
             // 
             this.firstToLocalToolStripMenuItem.Name = "firstToLocalToolStripMenuItem";
             this.firstToLocalToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
             this.firstToLocalToolStripMenuItem.Text = "First -> Working directory";
-            this.firstToLocalToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
+            this.firstToLocalToolStripMenuItem.Click += new System.EventHandler(this.firstToLocalToolStripMenuItem_Click);
             // 
             // selectedToLocalToolStripMenuItem
             // 
             this.selectedToLocalToolStripMenuItem.Name = "selectedToLocalToolStripMenuItem";
             this.selectedToLocalToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
             this.selectedToLocalToolStripMenuItem.Text = "Second -> Working directory";
-            this.selectedToLocalToolStripMenuItem.Click += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_Click);
+            this.selectedToLocalToolStripMenuItem.Click += new System.EventHandler(this.selectedToLocalToolStripMenuItem_Click);
             // 
             // saveAsToolStripMenuItem1
             // 
@@ -507,7 +499,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem saveAsToolStripMenuItem1;
         private ToolStripMenuItem saveToolStripMenuItem;
         private ToolStripMenuItem openWithDifftoolToolStripMenuItem;
-        private ToolStripMenuItem openWithCustomDifftoolToolStripMenuItem;
         private ToolStripSeparator diffRememberStripSeparator;
         private ToolStripMenuItem diffTwoSelectedDifftoolToolStripMenuItem;
         private ToolStripMenuItem diffWithRememberedDifftoolToolStripMenuItem;

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -138,9 +138,9 @@ namespace GitUI.CommandsDialogs
                 case Command.DeleteSelectedFiles: diffDeleteFileToolStripMenuItem.PerformClick(); break;
                 case Command.ShowHistory: fileHistoryDiffToolstripMenuItem.PerformClick(); break;
                 case Command.Blame: blameToolStripMenuItem.PerformClick(); break;
-                case Command.OpenWithDifftool: firstToSelectedToolStripMenuItem.PerformClick(); break;
-                case Command.OpenWithDifftoolFirstToLocal: firstToLocalToolStripMenuItem.PerformClick(); break;
-                case Command.OpenWithDifftoolSelectedToLocal: selectedToLocalToolStripMenuItem.PerformClick(); break;
+                case Command.OpenWithDifftool: OpenFilesWithDiffTool(RevisionDiffKind.DiffAB); break;
+                case Command.OpenWithDifftoolFirstToLocal: OpenFilesWithDiffTool(RevisionDiffKind.DiffALocal); break;
+                case Command.OpenWithDifftoolSelectedToLocal: OpenFilesWithDiffTool(RevisionDiffKind.DiffBLocal); break;
                 case Command.EditFile: diffEditWorkingDirectoryFileToolStripMenuItem.PerformClick(); break;
                 case Command.OpenAsTempFile: diffOpenRevisionFileToolStripMenuItem.PerformClick(); break;
                 case Command.OpenAsTempFileWith: diffOpenRevisionFileWithToolStripMenuItem.PerformClick(); break;
@@ -173,22 +173,18 @@ namespace GitUI.CommandsDialogs
             DiffText.ReloadHotkeys();
         }
 
-        public void ReloadCustomDifftools()
+        public void LoadCustomDifftools()
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            List<CustomDiffMergeTool> menus = new()
             {
-                var tools = await Module.GetCustomDiffMergeTools(isDiff: true);
-                openWithCustomDifftoolToolStripMenuItem.DropDown = null;
-                ContextMenuStrip customDiffToolDropDown = new();
-                foreach (var tool in tools)
-                {
-                    var toolStripItem = new ToolStripMenuItem(tool) { Tag = tool };
-                    toolStripItem.Click += openWithDifftoolToolStripMenuItem_Click;
-                    customDiffToolDropDown.Items.Add(toolStripItem);
-                }
+                new(firstToSelectedToolStripMenuItem, firstToSelectedToolStripMenuItem_Click),
+                new(selectedToLocalToolStripMenuItem, selectedToLocalToolStripMenuItem_Click),
+                new(firstToLocalToolStripMenuItem, firstToLocalToolStripMenuItem_Click),
+                new(diffWithRememberedDifftoolToolStripMenuItem, diffWithRememberedDiffToolToolStripMenuItem_Click),
+                new(diffTwoSelectedDifftoolToolStripMenuItem, diffTwoSelectedDiffToolToolStripMenuItem_Click)
+            };
 
-                openWithCustomDifftoolToolStripMenuItem.DropDown = customDiffToolDropDown;
-            }).FileAndForget();
+            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true);
         }
 
         private string GetShortcutKeyDisplayString(Command cmd)
@@ -239,7 +235,7 @@ namespace GitUI.CommandsDialogs
             DiffText.SetFileLoader(GetNextPatchFile);
             DiffText.Font = AppSettings.FixedWidthFont;
             ReloadHotkeys();
-            ReloadCustomDifftools();
+            LoadCustomDifftools();
 
             base.OnRuntimeLoad();
         }
@@ -641,41 +637,65 @@ namespace GitUI.CommandsDialogs
             FormBrowse.OpenContainingFolder(DiffFiles, Module);
         }
 
-        private void openWithDifftoolToolStripMenuItem_Click(object sender, EventArgs e)
+        private void firstToSelectedToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            RevisionDiffKind diffKind;
-            string toolName = (sender as ToolStripMenuItem)?.Tag as string;
+            OpenFilesWithDiffTool(RevisionDiffKind.DiffAB, sender);
+        }
 
-            if (sender == firstToLocalToolStripMenuItem)
+        private void selectedToLocalToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            OpenFilesWithDiffTool(RevisionDiffKind.DiffBLocal, sender);
+        }
+
+        private void firstToLocalToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            OpenFilesWithDiffTool(RevisionDiffKind.DiffALocal, sender);
+        }
+
+        private void OpenFilesWithDiffTool(RevisionDiffKind diffKind, object sender)
+        {
+            var item = sender as ToolStripMenuItem;
+            if (item?.DropDownItems != null)
             {
-                diffKind = RevisionDiffKind.DiffALocal;
-            }
-            else if (sender == selectedToLocalToolStripMenuItem)
-            {
-                diffKind = RevisionDiffKind.DiffBLocal;
-            }
-            else
-            {
-                diffKind = RevisionDiffKind.DiffAB;
+                // "main menu" clicked, cancel dropdown manually, invoke default mergetool
+                item.HideDropDown();
+                item.Owner.Hide();
             }
 
-            foreach (var item in DiffFiles.SelectedItems)
+            var toolName = item?.Tag as string;
+            OpenFilesWithDiffTool(diffKind, toolName);
+        }
+
+        private void OpenFilesWithDiffTool(RevisionDiffKind diffKind, string toolName = null)
+        {
+            using (WaitCursorScope.Enter())
             {
-                if (item.FirstRevision?.ObjectId == ObjectId.CombinedDiffId)
+                foreach (var item in DiffFiles.SelectedItems)
                 {
-                    // CombinedDiff cannot be viewed in a difftool
-                    // Disabled in menus but can be activated from shortcuts, just ignore
-                    continue;
-                }
+                    if (item.FirstRevision?.ObjectId == ObjectId.CombinedDiffId)
+                    {
+                        // CombinedDiff cannot be viewed in a difftool
+                        // Disabled in menus but can be activated from shortcuts, just ignore
+                        continue;
+                    }
 
-                // If item.FirstRevision is null, compare to root commit
-                GitRevision[] revs = new[] { item.SecondRevision, item.FirstRevision };
-                UICommands.OpenWithDifftool(this, revs, item.Item.Name, item.Item.OldName, diffKind, item.Item.IsTracked, customTool: toolName);
+                    // If item.FirstRevision is null, compare to root commit
+                    GitRevision[] revs = new[] { item.SecondRevision, item.FirstRevision };
+                    UICommands.OpenWithDifftool(this, revs, item.Item.Name, item.Item.OldName, diffKind, item.Item.IsTracked, customTool: toolName);
+                }
             }
         }
 
         private void diffTwoSelectedDiffToolToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            var item = sender as ToolStripMenuItem;
+            if (item?.DropDownItems != null)
+            {
+                // "main menu" clicked, cancel dropdown manually, invoke default difftool
+                item.HideDropDown();
+            }
+
+            var toolName = item?.Tag as string;
             var diffFiles = DiffFiles.SelectedItems.ToList();
             if (diffFiles.Count != 2)
             {
@@ -691,11 +711,20 @@ namespace GitUI.CommandsDialogs
             var isSecondItemSecondRev = _rememberFileContextMenuController.ShouldEnableSecondItemDiff(DiffFiles.SelectedItem, isSecondRevision: true);
             var second = _rememberFileContextMenuController.GetGitCommit(Module.GetFileBlobHash, DiffFiles.SelectedItem, isSecondRevision: isSecondItemSecondRev);
 
-            Module.OpenFilesWithDifftool(first, second);
+            Module.OpenFilesWithDifftool(first, second, customTool: toolName);
         }
 
         private void diffWithRememberedDiffToolToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            var item = sender as ToolStripMenuItem;
+            if (item?.DropDownItems != null)
+            {
+                // "main menu" clicked, cancel dropdown manually, invoke default difftool
+                item.HideDropDown();
+            }
+
+            string toolName = item?.Tag as string;
+
             // For first item, the second revision is explicitly remembered
             var first = _rememberFileContextMenuController.GetGitCommit(Module.GetFileBlobHash,
                 _rememberFileContextMenuController.RememberedDiffFileItem, isSecondRevision: true);
@@ -704,7 +733,7 @@ namespace GitUI.CommandsDialogs
             var isSecond = _rememberFileContextMenuController.ShouldEnableSecondItemDiff(DiffFiles.SelectedItem, isSecondRevision: true);
             var second = _rememberFileContextMenuController.GetGitCommit(Module.GetFileBlobHash, DiffFiles.SelectedItem, isSecondRevision: isSecond);
 
-            Module.OpenFilesWithDifftool(first, second);
+            Module.OpenFilesWithDifftool(first, second, customTool: toolName);
         }
 
         private void rememberSecondDiffToolToolStripMenuItem_Click(object sender, EventArgs e)
@@ -840,8 +869,6 @@ namespace GitUI.CommandsDialogs
             firstToSelectedToolStripMenuItem.Enabled = _revisionDiffContextMenuController.ShouldShowMenuFirstToSelected(selectionInfo);
             firstToLocalToolStripMenuItem.Enabled = _revisionDiffContextMenuController.ShouldShowMenuFirstToLocal(selectionInfo);
             selectedToLocalToolStripMenuItem.Enabled = _revisionDiffContextMenuController.ShouldShowMenuSelectedToLocal(selectionInfo);
-
-            openWithCustomDifftoolToolStripMenuItem.Enabled = openWithCustomDifftoolToolStripMenuItem.DropDown.Items.Count > 0;
 
             var diffFiles = DiffFiles.SelectedItems.ToList();
             diffRememberStripSeparator.Visible = diffFiles.Count == 1 || diffFiles.Count == 2;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
@@ -40,6 +40,7 @@
             this.chkRememberShowSyntaxHighlightingInDiff = new System.Windows.Forms.CheckBox();
             this.chkOmitUninterestingDiff = new System.Windows.Forms.CheckBox();
             this.label1 = new System.Windows.Forms.Label();
+            this.chkShowAllCustomDiffTools = new UserControls.Settings.SettingsCheckBox();
             this.VerticalRulerPosition = new System.Windows.Forms.NumericUpDown();
             this.tableLayoutPanelForDiffViewer.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.VerticalRulerPosition)).BeginInit();
@@ -60,12 +61,13 @@
             this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkContScrollToNextFileOnlyWithAlt, 0, 6);
             this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkOpenSubmoduleDiffInSeparateWindow, 0, 7);
             this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkShowDiffForAllParents, 0, 8);
-            this.tableLayoutPanelForDiffViewer.Controls.Add(this.label1, 0, 9);
-            this.tableLayoutPanelForDiffViewer.Controls.Add(this.VerticalRulerPosition, 1, 9);
+            this.tableLayoutPanelForDiffViewer.Controls.Add(this.chkShowAllCustomDiffTools, 0, 9);
+            this.tableLayoutPanelForDiffViewer.Controls.Add(this.label1, 0, 10);
+            this.tableLayoutPanelForDiffViewer.Controls.Add(this.VerticalRulerPosition, 1, 10);
             this.tableLayoutPanelForDiffViewer.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanelForDiffViewer.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanelForDiffViewer.Name = "tableLayoutPanelForDiffViewer";
-            this.tableLayoutPanelForDiffViewer.RowCount = 11;
+            this.tableLayoutPanelForDiffViewer.RowCount = 12;
             this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanelForDiffViewer.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -163,12 +165,23 @@
             this.chkShowDiffForAllParents.AutoSize = true;
             this.chkShowDiffForAllParents.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.chkShowDiffForAllParents.Checked = false;
-            this.chkShowDiffForAllParents.Location = new System.Drawing.Point(3, 184);
+            this.chkShowDiffForAllParents.Location = new System.Drawing.Point(3, 187);
             this.chkShowDiffForAllParents.Name = "chkShowDiffForAllParents";
             this.chkShowDiffForAllParents.Size = new System.Drawing.Size(271, 17);
-            this.chkShowDiffForAllParents.TabIndex = 11;
+            this.chkShowDiffForAllParents.TabIndex = 12;
             this.chkShowDiffForAllParents.Text = "Show file differences for all parents in browse dialog";
             this.chkShowDiffForAllParents.ToolTipText = null;
+            // 
+            // chkShowAllCustomDiffTools
+            // 
+            this.chkShowAllCustomDiffTools.AutoSize = true;
+            this.chkShowDiffForAllParents.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.chkShowAllCustomDiffTools.Location = new System.Drawing.Point(3, 210);
+            this.chkShowAllCustomDiffTools.Name = "chkShowAllCustomDiffTools";
+            this.chkShowAllCustomDiffTools.Size = new System.Drawing.Size(280, 17);
+            this.chkShowAllCustomDiffTools.TabIndex = 13;
+            this.chkShowAllCustomDiffTools.Text = "Show all available difftools";
+            this.chkShowAllCustomDiffTools.ToolTipText = "Show all configured difftools in a dropdown.\nThe primary difftool can still be selected by clicking the main menu entry.";
             // 
             // label1
             // 
@@ -177,7 +190,7 @@
             this.label1.Location = new System.Drawing.Point(3, 191);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(144, 13);
-            this.label1.TabIndex = 13;
+            this.label1.TabIndex = 14;
             this.label1.Text = "Vertical ruler position [chars]";
             // 
             // VerticalRulerPosition
@@ -223,6 +236,7 @@
         private System.Windows.Forms.CheckBox chkOpenSubmoduleDiffInSeparateWindow;
         private System.Windows.Forms.CheckBox chkContScrollToNextFileOnlyWithAlt;
         private UserControls.Settings.SettingsCheckBox chkShowDiffForAllParents;
+        private UserControls.Settings.SettingsCheckBox chkShowAllCustomDiffTools;
         private System.Windows.Forms.NumericUpDown VerticalRulerPosition;
         private System.Windows.Forms.Label label1;
     }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
@@ -27,6 +27,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkOpenSubmoduleDiffInSeparateWindow.Checked = AppSettings.OpenSubmoduleDiffInSeparateWindow;
             chkContScrollToNextFileOnlyWithAlt.Checked = AppSettings.AutomaticContinuousScroll;
             chkShowDiffForAllParents.Checked = AppSettings.ShowDiffForAllParents;
+            chkShowAllCustomDiffTools.Checked = AppSettings.ShowAvailableDiffTools;
             VerticalRulerPosition.Value = AppSettings.DiffVerticalRulerPosition;
         }
 
@@ -41,6 +42,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.OpenSubmoduleDiffInSeparateWindow = chkOpenSubmoduleDiffInSeparateWindow.Checked;
             AppSettings.AutomaticContinuousScroll = chkContScrollToNextFileOnlyWithAlt.Checked;
             AppSettings.ShowDiffForAllParents = chkShowDiffForAllParents.Checked;
+            AppSettings.ShowAvailableDiffTools = chkShowAllCustomDiffTools.Checked;
             AppSettings.DiffVerticalRulerPosition = (int)VerticalRulerPosition.Value;
         }
 

--- a/GitUI/CustomDiffMergeToolProvider.cs
+++ b/GitUI/CustomDiffMergeToolProvider.cs
@@ -1,0 +1,114 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+using GitCommands;
+
+namespace GitUI
+{
+    public class CustomDiffMergeToolProvider
+    {
+        /// <summary>
+        /// Time to wait before loading custom diff tools in FormBrowse
+        /// Avoid loading while git-log and git-diff run
+        /// </summary>
+        private const int FormBrowseToolDelay = 15000;
+
+        /// <summary>
+        /// Clear the existing caches
+        /// </summary>
+        public void Clear()
+        {
+            CustomDiffMergeToolCache.DiffToolCache.Clear();
+            CustomDiffMergeToolCache.MergeToolCache.Clear();
+        }
+
+        /// <summary>
+        /// Load the available  DiffMerge tools and apply to the menus
+        /// </summary>
+        /// <param name="module">The Git module</param>
+        /// <param name="menus">The menus to update</param>
+        /// <param name="components">The calling Form components, to dispose correctly</param>
+        /// <param name="isDiff">True if diff, false if merge</param>
+        /// <param name="delay">The delay before starting the operation</param>
+        public void LoadCustomDiffMergeTools(GitModule module, IList<CustomDiffMergeTool> menus, IContainer components, bool isDiff, int delay = FormBrowseToolDelay)
+        {
+            InitMenus(menus);
+
+            if (isDiff && !AppSettings.ShowAvailableDiffTools)
+            {
+                return;
+            }
+
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                // get the tools, possibly with a delay as requesting requires considerable time
+                // cache is shared
+                List<string> tools = (await (isDiff ? CustomDiffMergeToolCache.DiffToolCache : CustomDiffMergeToolCache.MergeToolCache)
+                    .GetToolsAsync(module, delay))
+                    .ToList();
+
+                if (tools.Count() <= 1)
+                {
+                    // No need to show the menu
+                    return;
+                }
+
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                foreach (var menu in menus)
+                {
+                    menu.MenuItem.DropDown = new ContextMenuStrip(components);
+                    foreach (var tool in tools)
+                    {
+                        var item = new ToolStripMenuItem(tool) { Tag = tool };
+
+                        item.Click += menu.Click;
+                        menu.MenuItem.DropDown.Items.Add(item);
+                        if (menu.MenuItem.DropDownItems.Count == 1)
+                        {
+                            item.Font = new Font(item.Font, FontStyle.Bold);
+                            if (menu.MenuItem.ShortcutKeys != Keys.None)
+                            {
+                                item.ShortcutKeys = menu.MenuItem.ShortcutKeys;
+                            }
+                            else
+                            {
+                                item.ShortcutKeyDisplayString = menu.MenuItem.ShortcutKeyDisplayString;
+                            }
+                        }
+                    }
+
+                    if (isDiff)
+                    {
+                        // Allow disabling for difftools
+                        menu.MenuItem.DropDown.Items.Add(new ToolStripSeparator());
+                        var disableItem = new ToolStripMenuItem
+                        {
+                            Text = ResourceManager.Strings.DisableMenuItem
+                        };
+
+                        disableItem.Click += (o, s) =>
+                        {
+                            // Disables the dropdown in the current form only
+                            // RevDiff will not be affected from other forms, requires a restart
+                            // To overcome this limitation other forms would require a reference to RevDiff
+                            AppSettings.ShowAvailableDiffTools = false;
+                            InitMenus(menus);
+                        };
+                        menu.MenuItem.DropDown.Items.Add(disableItem);
+                    }
+                }
+            }).FileAndForget();
+            return;
+
+            static void InitMenus(IList<CustomDiffMergeTool> menus)
+            {
+                foreach (var menu in menus)
+                {
+                    menu.MenuItem.DropDown = null;
+                }
+            }
+        }
+    }
+}

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1248,6 +1248,15 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Remember the 'Show syntax highlighting' preference</source>
         <target />
       </trans-unit>
+      <trans-unit id="chkShowAllCustomDiffTools.Text">
+        <source>Show all available difftools</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="chkShowAllCustomDiffTools.ToolTipText">
+        <source>Show all configured difftools in a dropdown.
+The primary difftool can still be selected by clicking the main menu entry.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="chkShowDiffForAllParents.Text">
         <source>Show file differences for all parents in browse dialog</source>
         <target />
@@ -3565,10 +3574,6 @@ You can unset the template:
       </trans-unit>
       <trans-unit id="openContainingFolderToolStripMenuItem.Text">
         <source>Show in folder</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="openDiffMenuItem.Text">
-        <source>Open with difftool</source>
         <target />
       </trans-unit>
       <trans-unit id="openFolderMenuItem.Text">
@@ -8503,10 +8508,6 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <source>Show in folder</source>
         <target />
       </trans-unit>
-      <trans-unit id="openWithCustomDifftoolToolStripMenuItem.Text">
-        <source>First -&gt; Second...</source>
-        <target />
-      </trans-unit>
       <trans-unit id="openWithDifftoolToolStripMenuItem.Text">
         <source>Open with difftool</source>
         <target />
@@ -9630,6 +9631,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_directoryIsNotAValidRepository.Text">
         <source>The selected item is not a valid git repository.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_disableMenuItem.Text">
+        <source>Disable this dropdown</source>
         <target />
       </trans-unit>
       <trans-unit id="_error.Text">

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -534,7 +534,6 @@ namespace GitUI
             ((System.ComponentModel.ISupportInitialize)(this._gridView)).EndInit();
             this.mainContextMenu.ResumeLayout(false);
             this.ResumeLayout(false);
-            this.SetShortcutKeys();
         }
 
         #endregion

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -592,6 +592,17 @@ namespace GitUI
             }
 
             ForceRefreshRevisions();
+            LoadCustomDifftools();
+        }
+
+        public void LoadCustomDifftools()
+        {
+            List<CustomDiffMergeTool> menus = new()
+            {
+                new(openCommitsWithDiffToolMenuItem, diffSelectedCommitsMenuItem_Click)
+            };
+
+            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true);
         }
 
         private void SetSelectedIndex(int index, bool toggleSelection = false)
@@ -2571,13 +2582,21 @@ namespace GitUI
 
         private void diffSelectedCommitsMenuItem_Click(object sender, EventArgs e)
         {
-            DiffSelectedCommitsWithDifftool();
+            var item = sender as ToolStripMenuItem;
+            if (item?.DropDownItems != null)
+            {
+                // "main menu" clicked, cancel dropdown manually, invoke default difftool
+                item.HideDropDown();
+            }
+
+            var toolName = item?.Tag as string;
+            DiffSelectedCommitsWithDifftool(toolName);
         }
 
-        public void DiffSelectedCommitsWithDifftool()
+        public void DiffSelectedCommitsWithDifftool(string customTool = null)
         {
             var (first, selected) = getFirstAndSelected();
-            Module.OpenWithDifftoolDirDiff(first?.ToString(), selected.ObjectId.ToString());
+            Module.OpenWithDifftoolDirDiff(first?.ToString(), selected.ObjectId.ToString(), customTool: customTool);
         }
 
         private void getHelpOnHowToUseTheseFeaturesToolStripMenuItem_Click(object sender, EventArgs e)

--- a/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
@@ -159,7 +159,7 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                     DoEvents();
 
                     // Confirm the filter has been reset, all commits are shown
-                    revisionGridControl.LatestSelectedRevision.ObjectId.ToString().Should().Be(_headCommit);
+                    revisionGridControl.LatestSelectedRevision.ObjectId.ToString().Should().Be(_branch1Commit);
                     ta.VisibleRevisionCount.Should().Be(6);
                 });
         }

--- a/ResourceManager/Strings.cs
+++ b/ResourceManager/Strings.cs
@@ -48,6 +48,8 @@ Yes, I allow telemetry!");
         private readonly TranslationString _generalGitConfigExceptionMessage = new("Failed to read \"{0}\" due to the following error:{1}{1}{2}{1}{1}Due to the nature of this problem, the behavior of the application cannot be guaranteed and it must be closed.{1}{1}Please correct this issue and re-open Git Extensions.");
         private readonly TranslationString _generalGitConfigExceptionCaption = new("Repository Configuration Error");
 
+        private readonly TranslationString _disableMenuItem = new TranslationString("Disable this dropdown");
+
         // public only because of FormTranslate
         public Strings()
         {
@@ -83,6 +85,7 @@ Yes, I allow telemetry!");
 
         public static string GeneralGitConfigExceptionMessage => _instance.Value._generalGitConfigExceptionMessage.Text;
         public static string GeneralGitConfigExceptionCaption => _instance.Value._generalGitConfigExceptionCaption.Text;
+        public static string DisableMenuItem => _instance.Value._disableMenuItem.Text;
 
         public static string GetParents(int value)
         {

--- a/UnitTests/GitCommands.Tests/CustomDiffMergeToolCacheTests.cs
+++ b/UnitTests/GitCommands.Tests/CustomDiffMergeToolCacheTests.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using GitCommands;
+using NUnit.Framework;
+
+namespace GitCommandsTests
+{
+    [TestFixture]
+    public sealed class CustomDiffMergeToolCacheTests
+    {
+        [TestCase("'git difftool --tool=<tool>' may be set to one of the following:\n\t\tvimdiff\n\t\tvimdiff2\n\t\tvimdiff3\n\t\twinmerge\n\n\tuser-defined:\n\t\tDiffMerge.cmd \"C:/Program Files/SourceGear/Common/DiffMerge/sgdm.exe\" -merge -result=\"$MERGED\" \"$LOCAL\" \"$BASE\" \"$REMOTE\"\n\t\tdiffmerge.cmd \"C:/Program Files/SourceGear/Common/DiffMerge/sgdm.exe\" \"$LOCAL\" \"$REMOTE\"\n\t\tkdiff3.cmd \"C:/Program Files/KDiff3/kdiff3.exe\" \"$LOCAL\" \"$REMOTE\"\n\t\tmeld.cmd \"C:/Program Files (x86)/Meld/meld.exe\" \"$LOCAL\" \"$BASE\" \"$REMOTE\" --output \"$MERGED\"\n\t\tmeld.cmd \"C:/Program Files (x86)/Meld/meld.exe\" \"$LOCAL\" \"$REMOTE\"\n\t\tp4merge.cmd \"C:/Program Files/Perforce/p4merge.exe\" \"$BASE\" \"$LOCAL\" \"$REMOTE\" \"$MERGED\"\n\t\tp4merge.cmd \"C:/Program Files/Perforce/p4merge.exe\" \"$LOCAL\" \"$REMOTE\"\n\t\tsemanticdiff.cmd \"C:/Users/ejgo/AppData/Local/semanticmerge/semanticmergetool.exe\" -s \"$LOCAL\" -d \"$REMOTE\"\n\t\tsemanticmerge.cmd \"C:/Users/ejgo/AppData/Local/semanticmerge/semanticmergetool.exe\" -s \"$LOCAL\" -d \"$REMOTE\"\n\t\tsemanticmerge.cmd \"C:/Users/ejgo/AppData/Local/semanticmerge/semanticmergetool.exe\" -s \"$REMOTE\" -d \"$LOCAL\" -b \"$BASE\" -r \"$MERGED\"\n\t\tsourcetree.cmd 'C:/Program Files/TortoiseGit/bin/TortoiseGitMerge.exe'  -base:\"$BASE\" -mine:\"$LOCAL\" -theirs:\"$REMOTE\" -merged:\"$MERGED\"\n\t\tsourcetree.cmd 'C:/Program Files/TortoiseGit/bin/TortoiseGitMerge.exe' \"$LOCAL\" \"$REMOTE\"\n\t\tssss.cmd ggfjf dhdf df\n\t\ttortoisemerge.cmd \"C:/Program Files/TortoiseGit/bin/TortoiseGitMerge.exe\" -base:\"$BASE\" -mine:\"$LOCAL\"\n\t\ttortoisemerge.cmd \"C:/Program Files/TortoiseGit/bin/TortoiseGitMerge.exe\" -base:\"$BASE\" -mine:\"$LOCAL\" -theirs:\"$REMOTE\" -merged:\"$MERGED\"\n\t\ttortoisemerge2.cmd \"C:/Program Files/TortoiseGit/bin/TortoiseGitMerge.exe\" \"$LOCAL\" \"$REMOTE\"\n\t\tvsdiffmerge.cmd \"F:/Program Files (x86)/Microsoft Visual Studio/2017/Community/Common7/IDE/CommonExtensions/Microsoft/TeamFoundation/Team Explorer/vsDiffMerge.exe\" \"$LOCAL\" \"$REMOTE\"\n\t\twinmerge.cmd \"C:/Program Files/WinMerge/winmergeu.exe\" -e -u  -wl -wr -fm -dl \"Mine: $LOCAL\" -dm \"Merged: $BASE\" -dr \"Theirs: $REMOTE\" \"$LOCAL\" \"$BASE\" \"$REMOTE\" -o \"$MERGED\"\n\t\twinmerge.cmd \"C:/Program Files/WinMerge/winmergeu.exe\" -e -u \"$LOCAL\" \"$REMOTE\"\n\nThe following tools are valid, but not currently available:\n\t\taraxis\n\t\tbc\n\t\tbc3\n\t\tcodecompare\n\t\tdeltawalker\n\t\tdiffmerge\n\t\tdiffuse\n\t\tecmerge\n\t\temerge\n\t\texamdiff\n\t\tguiffy\n\t\tgvimdiff\n\t\tgvimdiff2\n\t\tgvimdiff3\n\t\tkdiff3\n\t\tkompare\n\t\tmeld\n\t\topendiff\n\t\tp4merge\n\t\tsmerge\n\t\ttkdiff\n\t\txxdiff\n\nSome of the tools listed above only work in a windowed\nenvironment. If run in a terminal-only session, they will fail.\n",
+            new[] { "winmerge", "diffmerge", "DiffMerge", "kdiff3", "meld", "p4merge", "semanticdiff", "semanticmerge", "sourcetree", "ssss", "tortoisemerge", "tortoisemerge2", "vsdiffmerge" })]
+        [TestCase("'git difftool --tool=<tool>' may be set to one of the following:\n\t\tvimdiff\n\t\tvimdiff2\n\t\tvimdiff3\n\t\twinmerge\n\nThe following tools are valid, but not currently available:\n\t\taraxis\n\t\tbc\n\t\tbc3\n\t\tcodecompare\n\t\tdeltawalker\n\t\tdiffmerge\n\t\tdiffuse\n\t\tecmerge\n\t\temerge\n\t\texamdiff\n\t\tguiffy\n\t\tgvimdiff\n\t\tgvimdiff2\n\t\tgvimdiff3\n\t\tkdiff3\n\t\tkompare\n\t\tmeld\n\t\topendiff\n\t\tp4merge\n\t\tsmerge\n\t\ttkdiff\n\t\txxdiff\n\nSome of the tools listed above only work in a windowed\nenvironment. If run in a terminal-only session, they will fail.\n",
+            new[] { "winmerge" })]
+        [TestCase("'git difftool --tool=<tool>' may be set to one of the following:\n\t\tvimdiff\n\t\tvimdiff2\n\t\tvimdiff3\n\t\twinmerge\n",
+            new[] { "winmerge" })]
+
+        public void ParseCustomDiffMergeToolTest(string output, string[] expected)
+        {
+            IEnumerable<string> tools = CustomDiffMergeToolCache.DiffToolCache.GetTestAccessor().ParseCustomDiffMergeTool(output, "winmerge");
+
+            tools.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -11,7 +11,6 @@ using FluentAssertions;
 using GitCommands;
 using GitCommands.Git;
 using GitCommands.Git.Commands;
-using GitCommands.Utils;
 using GitExtUtils;
 using GitUI;
 using GitUIPluginInterfaces;
@@ -739,19 +738,6 @@ namespace GitCommandsTests
         {
             var stagedStatus = _gitModule.GetTestAccessor().GetStagedStatus(firstRevision, secondRevision, parentToSecond);
             Assert.AreEqual(status, stagedStatus);
-        }
-
-        [TestCase("'git difftool --tool=<tool>' may be set to one of the following:\n\t\tvimdiff\n\t\tvimdiff2\n\t\tvimdiff3\n\t\twinmerge\n\n\tuser-defined:\n\t\tDiffMerge.cmd \"C:/Program Files/SourceGear/Common/DiffMerge/sgdm.exe\" -merge -result=\"$MERGED\" \"$LOCAL\" \"$BASE\" \"$REMOTE\"\n\t\tdiffmerge.cmd \"C:/Program Files/SourceGear/Common/DiffMerge/sgdm.exe\" \"$LOCAL\" \"$REMOTE\"\n\t\tkdiff3.cmd \"C:/Program Files/KDiff3/kdiff3.exe\" \"$LOCAL\" \"$REMOTE\"\n\t\tmeld.cmd \"C:/Program Files (x86)/Meld/meld.exe\" \"$LOCAL\" \"$BASE\" \"$REMOTE\" --output \"$MERGED\"\n\t\tmeld.cmd \"C:/Program Files (x86)/Meld/meld.exe\" \"$LOCAL\" \"$REMOTE\"\n\t\tp4merge.cmd \"C:/Program Files/Perforce/p4merge.exe\" \"$BASE\" \"$LOCAL\" \"$REMOTE\" \"$MERGED\"\n\t\tp4merge.cmd \"C:/Program Files/Perforce/p4merge.exe\" \"$LOCAL\" \"$REMOTE\"\n\t\tsemanticdiff.cmd \"C:/Users/ejgo/AppData/Local/semanticmerge/semanticmergetool.exe\" -s \"$LOCAL\" -d \"$REMOTE\"\n\t\tsemanticmerge.cmd \"C:/Users/ejgo/AppData/Local/semanticmerge/semanticmergetool.exe\" -s \"$LOCAL\" -d \"$REMOTE\"\n\t\tsemanticmerge.cmd \"C:/Users/ejgo/AppData/Local/semanticmerge/semanticmergetool.exe\" -s \"$REMOTE\" -d \"$LOCAL\" -b \"$BASE\" -r \"$MERGED\"\n\t\tsourcetree.cmd 'C:/Program Files/TortoiseGit/bin/TortoiseGitMerge.exe'  -base:\"$BASE\" -mine:\"$LOCAL\" -theirs:\"$REMOTE\" -merged:\"$MERGED\"\n\t\tsourcetree.cmd 'C:/Program Files/TortoiseGit/bin/TortoiseGitMerge.exe' \"$LOCAL\" \"$REMOTE\"\n\t\tssss.cmd ggfjf dhdf df\n\t\ttortoisemerge.cmd \"C:/Program Files/TortoiseGit/bin/TortoiseGitMerge.exe\" -base:\"$BASE\" -mine:\"$LOCAL\"\n\t\ttortoisemerge.cmd \"C:/Program Files/TortoiseGit/bin/TortoiseGitMerge.exe\" -base:\"$BASE\" -mine:\"$LOCAL\" -theirs:\"$REMOTE\" -merged:\"$MERGED\"\n\t\ttortoisemerge2.cmd \"C:/Program Files/TortoiseGit/bin/TortoiseGitMerge.exe\" \"$LOCAL\" \"$REMOTE\"\n\t\tvsdiffmerge.cmd \"F:/Program Files (x86)/Microsoft Visual Studio/2017/Community/Common7/IDE/CommonExtensions/Microsoft/TeamFoundation/Team Explorer/vsDiffMerge.exe\" \"$LOCAL\" \"$REMOTE\"\n\t\twinmerge.cmd \"C:/Program Files/WinMerge/winmergeu.exe\" -e -u  -wl -wr -fm -dl \"Mine: $LOCAL\" -dm \"Merged: $BASE\" -dr \"Theirs: $REMOTE\" \"$LOCAL\" \"$BASE\" \"$REMOTE\" -o \"$MERGED\"\n\t\twinmerge.cmd \"C:/Program Files/WinMerge/winmergeu.exe\" -e -u \"$LOCAL\" \"$REMOTE\"\n\nThe following tools are valid, but not currently available:\n\t\taraxis\n\t\tbc\n\t\tbc3\n\t\tcodecompare\n\t\tdeltawalker\n\t\tdiffmerge\n\t\tdiffuse\n\t\tecmerge\n\t\temerge\n\t\texamdiff\n\t\tguiffy\n\t\tgvimdiff\n\t\tgvimdiff2\n\t\tgvimdiff3\n\t\tkdiff3\n\t\tkompare\n\t\tmeld\n\t\topendiff\n\t\tp4merge\n\t\tsmerge\n\t\ttkdiff\n\t\txxdiff\n\nSome of the tools listed above only work in a windowed\nenvironment. If run in a terminal-only session, they will fail.\n",
-            new[] { "diffmerge", "DiffMerge", "kdiff3", "meld", "p4merge", "semanticdiff", "semanticmerge", "sourcetree", "ssss", "tortoisemerge", "tortoisemerge2", "winmerge", "vsdiffmerge" })]
-        [TestCase("'git difftool --tool=<tool>' may be set to one of the following:\n\t\tvimdiff\n\t\tvimdiff2\n\t\tvimdiff3\n\t\twinmerge\n\nThe following tools are valid, but not currently available:\n\t\taraxis\n\t\tbc\n\t\tbc3\n\t\tcodecompare\n\t\tdeltawalker\n\t\tdiffmerge\n\t\tdiffuse\n\t\tecmerge\n\t\temerge\n\t\texamdiff\n\t\tguiffy\n\t\tgvimdiff\n\t\tgvimdiff2\n\t\tgvimdiff3\n\t\tkdiff3\n\t\tkompare\n\t\tmeld\n\t\topendiff\n\t\tp4merge\n\t\tsmerge\n\t\ttkdiff\n\t\txxdiff\n\nSome of the tools listed above only work in a windowed\nenvironment. If run in a terminal-only session, they will fail.\n",
-            new[] { "winmerge" })]
-        [TestCase("'git difftool --tool=<tool>' may be set to one of the following:\n\t\tvimdiff\n\t\tvimdiff2\n\t\tvimdiff3\n\t\twinmerge\n",
-            new[] { "winmerge" })]
-        public void ParseCustomDiffMergeToolTest(string output, string[] expected)
-        {
-            IEnumerable<string> tools = _gitModule.GetTestAccessor().ParseCustomDiffMergeTool(output);
-
-            tools.Should().BeEquivalentTo(expected);
         }
 
         [Test]


### PR DESCRIPTION
Followup to #8194 (and #8660)

## Proposed changes

Make all configured difftools available in more situations

The default behavior is not changed, it is still possible to click the
dropdown "parent" item to enable the functionality.

The dropdown is not shown by default for entries existing in GE3.4 to not
confuse users and to show the shortcut (that is hidden when a dropdown
is enabled).
The dropdown is toggled with a rightclick.
A tooltip is added to enable discovery.

Note that for FormFileHistory the F3 shortcut is disabled as the
shortcut is not handled as a hotkey and a dropdown disables the shortcut.

Show the default tool first and checked in the dropdown.
This is also changed for FormResolveConflicts.

Remove the separate custom difftool menu in RevDiff.

Some notes

* ~~Submodule diff for Commit Unstaged is unchanged. Comparing commit sha in a difftool is quite meaningless (same as inFileViewer) and should be replaced with a diff _within_ the submodule (like update, reset).~~
* I would have preferred to enable this functionality by default, but there will be users that will be annoyed by the extra dropdowns.
* FormFileHistory could allow hotkeys to support F3 also when dropdown is shown. 
* It could be possible to show the shortcut key by overriding the ToolStripMenuItem (something like https://stackoverflow.com/questions/30391181/positioning-of-shortcut-key-of-toolstripmenu-item-properly). Not worth it.
* It takes some time to get the custom tools, 10s on my private PC, more than double that on corporate PCs with viruses like Symantec. RevDiff is not really an issue, the list is loaded at startup. For Commit, History and Resolve the functionality would be improved if the lists were cached.


## Screenshots <!-- Remove this section if PR does not change UI -->

All screenshots except where noted) done after custom tools are loaded

Marking additions since 3.4

Before|After
---|---
![image](https://user-images.githubusercontent.com/6248932/103159679-9abe5f00-47cc-11eb-92f1-172123696c6f.png)|![image](https://user-images.githubusercontent.com/6248932/105421509-7fffce80-5c42-11eb-89ef-3ea7ec3f2a40.png)
File remembered (similar if two files had been selected)|
![image](https://user-images.githubusercontent.com/6248932/103159714-e244eb00-47cc-11eb-911c-c81649790158.png)|![image](https://user-images.githubusercontent.com/6248932/105421640-b3425d80-5c42-11eb-9dfb-5c2be90f3751.png)
Similar for Index (Staged). Submodule is handled in a separate menu for worktree.|diff submodule removed, F3 still possible (in other situations the normal menu is used, difftool is still available)
![image](https://user-images.githubusercontent.com/6248932/103181939-02e17380-48a7-11eb-9710-424daed630bb.png)|![image](https://user-images.githubusercontent.com/6248932/105421826-03212480-5c43-11eb-948a-9189b9d4f7d9.png)
![image](https://user-images.githubusercontent.com/6248932/103159720-00aae680-47cd-11eb-8d39-e77533c519eb.png)|![image](https://user-images.githubusercontent.com/6248932/105422030-598e6300-5c43-11eb-8819-9190a5c7b1cf.png)
![image](https://user-images.githubusercontent.com/6248932/103159752-6a2af500-47cd-11eb-8c07-a182165a455c.png)|![image](https://user-images.githubusercontent.com/6248932/105422141-86db1100-5c43-11eb-9a09-5430f7adc96a.png)
![image](https://user-images.githubusercontent.com/6248932/103159769-c42bba80-47cd-11eb-9ec7-1cff28db7f42.png)|![image](https://user-images.githubusercontent.com/6248932/105422288-c4d83500-5c43-11eb-94e8-e09c2306795e.png)
![image](https://user-images.githubusercontent.com/6248932/103181974-7d11f800-48a7-11eb-9d00-13cd333c8b56.png)|![image](https://user-images.githubusercontent.com/6248932/105422194-9bb7a480-5c43-11eb-870a-86b55a599de5.png)

After: Example where tools are not yet loaded, no dropdown menu yet

![image](https://user-images.githubusercontent.com/6248932/103159888-fbe73200-47ce-11eb-8442-508136fd1d0a.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
