### PR TITLE
 Submodule browse: Select both first/second commits

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -122,7 +122,14 @@ namespace GitUI.CommandsDialogs
             InitializeComplete();
         }
 
-        public FormBrowse([NotNull] GitUICommands commands, string filter, ObjectId selectCommit = null)
+        /// <summary>
+        /// Open Browse - main GUI including dashboard
+        /// </summary>
+        /// <param name="commands">commands in the current form</param>
+        /// <param name="filter">filter to apply to browse</param>
+        /// <param name="selectedId">Currently (last) selected commit id</param>
+        /// <param name="firstId">First selected commit id (as in a diff)</param>
+        public FormBrowse([NotNull] GitUICommands commands, string filter, ObjectId selectedId = null, ObjectId firstId = null)
             : base(commands)
         {
             InitializeComponent();
@@ -294,10 +301,8 @@ namespace GitUI.CommandsDialogs
                 control.DragDrop += FormBrowse_DragDrop;
             }
 
-            if (selectCommit != null)
-            {
-                RevisionGrid.InitialObjectId = selectCommit;
-            }
+            RevisionGrid.SelectedId = selectedId;
+            RevisionGrid.FirstId = firstId;
 
             InitializeComplete();
             UpdateCommitButtonAndGetBrush(null, AppSettings.ShowGitStatusInBrowseToolbar);

--- a/GitUI/CommandsDialogs/FormCommandlineHelp.resx
+++ b/GitUI/CommandsDialogs/FormCommandlineHelp.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="_NO_TRANSLATE_commands.Text" xml:space="preserve">
-    <value>browse [path] [-filter=] [-commit=]
+    <value>browse [path] [-filter=] [-commit=&lt;selectedSha&gt;[,&lt;firstSha&gt;]]
 about
 add [filename]
 addfiles [filename]

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -94,10 +94,18 @@ namespace GitUI.CommandsDialogs
             }
         }
 
+        /// <summary>
+        /// Open FileHistory form
+        /// </summary>
+        /// <param name="commands">commands in the current form</param>
+        /// <param name="fileName">name in repo of file to view</param>
+        /// <param name="revision">initial selected commit</param>
+        /// <param name="filterByRevision">add filter</param>
+        /// <param name="showBlame">show blame initially instead of diff view</param>
         public FormFileHistory(GitUICommands commands, string fileName, GitRevision revision = null, bool filterByRevision = false, bool showBlame = false)
             : this(commands)
         {
-            FileChanges.InitialObjectId = revision?.ObjectId;
+            FileChanges.SelectedId = revision?.ObjectId;
             FileChanges.ShowBuildServerInfo = true;
 
             FileName = fileName;

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -451,24 +451,10 @@ namespace GitUI.CommandsDialogs
 
             if (AppSettings.OpenSubmoduleDiffInSeparateWindow && item.Item.IsSubmodule)
             {
-                var submoduleName = item.Item.Name;
-
                 ThreadHelper.JoinableTaskFactory.RunAsync(
                     async () =>
                     {
-                        var status = await item.Item.GetSubmoduleStatusAsync().ConfigureAwait(false);
-
-                        var process = new Process
-                        {
-                            StartInfo =
-                            {
-                                FileName = Application.ExecutablePath,
-                                Arguments = "browse -commit=" + status.Commit,
-                                WorkingDirectory = _fullPathResolver.Resolve(submoduleName.EnsureTrailingPathSeparator())
-                            }
-                        };
-
-                        process.Start();
+                        await DiffFiles.OpenSubmoduleAsync();
                     });
             }
             else

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -33,7 +33,7 @@ namespace GitUI.HelperDialogs
                 var objectId = Module.RevParse(preselectCommit);
                 if (objectId != null)
                 {
-                    revisionGrid.InitialObjectId = objectId;
+                    revisionGrid.SelectedId = objectId;
                 }
             }
         }

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -790,18 +790,29 @@ namespace GitUI
             return text;
         }
 
-        private async Task OpenSubmoduleAsync()
+        /// <summary>
+        /// Open the currently selected submodule (no checks done) in a new Browse instance
+        /// If the submodule is a diff, both first and currently selected commits are initially selected
+        /// </summary>
+        /// <returns>async Task</returns>
+        public async Task OpenSubmoduleAsync()
         {
             var submoduleName = SelectedItem.Item.Name;
 
             var status = await SelectedItem.Item.GetSubmoduleStatusAsync().ConfigureAwait(false);
+            var selected = SelectedItem.SecondRevision.ObjectId == ObjectId.WorkTreeId
+                ? SelectedItem.SecondRevision.ObjectId.ToString()
+                : status?.Commit.ToString() ?? string.Empty;
+            var first = string.IsNullOrWhiteSpace(status?.OldCommit?.ToString())
+                ? string.Empty
+                : $",{status.OldCommit}";
 
             var process = new Process
             {
                 StartInfo =
                 {
                     FileName = Application.ExecutablePath,
-                    Arguments = "browse -commit=" + status.Commit,
+                    Arguments = $"browse -commit={selected}{first}",
                     WorkingDirectory = _fullPathResolver.Resolve(submoduleName.EnsureTrailingPathSeparator())
                 }
             };

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -161,8 +161,16 @@ namespace GitUI
         internal bool ShowBuildServerInfo { get; set; }
         internal bool DoubleClickDoesNotOpenCommitInfo { get; set; }
 
+        /// <summary>
+        /// The last selected commit in the grid (with related CommitInfo in Browse)
+        /// </summary>
         [CanBeNull]
-        internal ObjectId InitialObjectId { private get; set; }
+        internal ObjectId SelectedId { private get; set; }
+
+        /// <summary>
+        /// The first selected, the first commit in a diff
+        /// </summary>
+        internal ObjectId FirstId { private get; set; }
 
         internal RevisionGridMenuCommands MenuCommands { get; }
         internal bool IsShowCurrentBranchOnlyChecked { get; private set; }
@@ -1198,16 +1206,30 @@ namespace GitUI
                      string.IsNullOrEmpty(InMemMessageFilter));
         }
 
+        /// <summary>
+        /// Select initial revision(s) in the grid
+        /// The SelectedId is the last selected commit in the grid (with related CommitInfo in Browse)
+        /// The FirstId is first selected, the first commit in a diff
+        /// </summary>
         private void SelectInitialRevision()
         {
             var toBeSelectedObjectIds = _selectedObjectIds;
 
             if (toBeSelectedObjectIds == null || toBeSelectedObjectIds.Count == 0)
             {
-                if (InitialObjectId != null)
+                if (SelectedId != null)
                 {
-                    toBeSelectedObjectIds = new ObjectId[] { InitialObjectId };
-                    InitialObjectId = null;
+                    if (FirstId != null)
+                    {
+                        toBeSelectedObjectIds = new ObjectId[] { FirstId, SelectedId };
+                        FirstId = null;
+                    }
+                    else
+                    {
+                        toBeSelectedObjectIds = new ObjectId[] { SelectedId };
+                    }
+
+                    SelectedId = null;
                 }
                 else
                 {
@@ -2447,7 +2469,7 @@ namespace GitUI
             {
                 if (_isReadingRevisions || !SetSelectedRevision(revisionGuid, toggleSelection))
                 {
-                    InitialObjectId = revisionGuid;
+                    SelectedId = revisionGuid;
                     _selectedObjectIds = null;
                 }
             }

--- a/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
@@ -11,6 +11,7 @@ using GitCommands;
 using GitExtensions.UITests;
 using GitUI;
 using GitUI.CommandsDialogs;
+using GitUIPluginInterfaces;
 using NUnit.Framework;
 
 namespace GitUITests.GitUICommandsTests
@@ -117,7 +118,12 @@ namespace GitUITests.GitUICommandsTests
 
         [Test]
         public void RunCommandBasedOnArgument_browse()
-            => RunCommandBasedOnArgument<FormBrowse>(new string[] { "ge.exe", "browse" });
+        {
+            var selected = ObjectId.Random();
+            var first = ObjectId.Random();
+            var otherIgnored = ObjectId.Random();
+            RunCommandBasedOnArgument<FormBrowse>(new string[] { "ge.exe", "browse", $"-commit={selected},{first},,{otherIgnored}" });
+        }
 
         [TestCase("checkout")]
         [TestCase("checkoutbranch")]


### PR DESCRIPTION
Related to discussions in #8700 how to handle diffs for submodules

## Proposed changes

GE has a decent overview of changes in a submodule, but sometimes I want to see the actual changes in files or more than first/selected commit message. A git-diff --dir-diff will not work with all difftools, not show working dir (unstaged) changes and no intermediate commit messages.

The best difftool is GE itself, when a subrepo is currently opened only the selected commit is selected though. It can be difficult to find the first submodule commit. In the screenshot it was at least the same page, harder if there are more changes.

## Screenshots <!-- Remove this section if PR does not change UI -->

Open submodule in e9eff4bb646ccd355f221c81cbf98e1eeab5a3b4 (or doubleclick).
If the WorkTree was browsed (Commit, RevDiff, side panel later), OldCommit->Worktree would be displayed instead after the change.

![image](https://user-images.githubusercontent.com/6248932/103275158-d111ff00-49c3-11eb-912e-71550fff3e5b.png)

Before | After
-------|---------
![image](https://user-images.githubusercontent.com/6248932/103275284-24844d00-49c4-11eb-9f3d-f98805f40356.png) | ![image](https://user-images.githubusercontent.com/6248932/103275243-0fa7b980-49c4-11eb-93db-7c8afa1e3edc.png)

## Test methodology <!-- How did you ensure quality? -->

Test updated.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
