### PR TITLE
FormCommit: remove context menu to copy to message

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -104,7 +104,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _stageFiles = new TranslationString("Stage {0} files");
         private readonly TranslationString _selectOnlyOneFile = new TranslationString("You must have only one file selected.");
 
-        private readonly TranslationString _addSelectionToCommitMessage = new TranslationString("Add selection to commit message");
         private readonly TranslationString _stageSelectedLines = new TranslationString("Stage selected line(s)");
         private readonly TranslationString _unstageSelectedLines = new TranslationString("Unstage selected line(s)");
         private readonly TranslationString _resetSelectedLines = new TranslationString("Reset selected line(s)");
@@ -156,7 +155,6 @@ namespace GitUI.CommandsDialogs
 
         private readonly ICommitTemplateManager _commitTemplateManager;
         [CanBeNull] private readonly GitRevision _editedCommit;
-        private readonly ToolStripMenuItem _addSelectionToCommitMessageToolStripMenuItem;
         private readonly ToolStripMenuItem _stageSelectedLinesToolStripMenuItem;
         private readonly ToolStripMenuItem _resetSelectedLinesToolStripMenuItem;
         private readonly AsyncLoader _unstagedLoader = new AsyncLoader();
@@ -262,8 +260,6 @@ namespace GitUI.CommandsDialogs
             _resetSelectedLinesToolStripMenuItem = SelectedDiff.AddContextMenuEntry(_resetSelectedLines.Text, ResetSelectedLinesToolStripMenuItemClick);
             _resetSelectedLinesToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.ResetSelectedFiles);
             _resetSelectedLinesToolStripMenuItem.Image = Reset.Image;
-            _addSelectionToCommitMessageToolStripMenuItem = SelectedDiff.AddContextMenuEntry(_addSelectionToCommitMessage.Text, (s, e) => AddSelectionToCommitMessage());
-            _addSelectionToCommitMessageToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.AddSelectionToCommitMessage);
             resetChanges.ShortcutKeyDisplayString = _resetSelectedLinesToolStripMenuItem.ShortcutKeyDisplayString;
             stagedResetChanges.ShortcutKeyDisplayString = _resetSelectedLinesToolStripMenuItem.ShortcutKeyDisplayString;
             deleteFileToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.DeleteSelectedFiles);
@@ -630,40 +626,12 @@ namespace GitUI.CommandsDialogs
             OpenWithDifftool = 12,
             OpenFile = 13,
             OpenFileWith = 14,
-            EditFile = 15,
-            AddSelectionToCommitMessage = 16
+            EditFile = 15
         }
 
         private string GetShortcutKeyDisplayString(Command cmd)
         {
             return GetShortcutKeys((int)cmd).ToShortcutKeyDisplayString();
-        }
-
-        private bool AddSelectionToCommitMessage()
-        {
-            if (!SelectedDiff.ContainsFocus)
-            {
-                return false;
-            }
-
-            var selectedText = SelectedDiff.GetSelectedText();
-            if (string.IsNullOrEmpty(selectedText))
-            {
-                return false;
-            }
-
-            if (Message.SelectionLength == 0)
-            {
-                selectedText += '\n';
-            }
-
-            int selectionStart = Message.SelectionStart;
-
-            Message.SelectedText = selectedText;
-
-            Message.SelectionStart = selectionStart + selectedText.Length;
-
-            return true;
         }
 
         private bool AddToGitIgnore()
@@ -832,7 +800,6 @@ namespace GitUI.CommandsDialogs
                 case Command.OpenFile: openToolStripMenuItem.PerformClick(); return true;
                 case Command.OpenFileWith: openWithToolStripMenuItem.PerformClick(); return true;
                 case Command.EditFile: editFileToolStripMenuItem.PerformClick(); return true;
-                case Command.AddSelectionToCommitMessage: return AddSelectionToCommitMessage();
                 default: return base.ExecuteCommand(cmd);
             }
         }

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -243,7 +243,6 @@ namespace GitUI.Hotkey
             {
                 new HotkeySettings(
                     FormCommit.HotkeySettingsName,
-                    Hk(FormCommit.Command.AddSelectionToCommitMessage, Keys.C),
                     Hk(FormCommit.Command.AddToGitIgnore, Keys.None),
                     Hk(FormCommit.Command.DeleteSelectedFiles, Keys.Delete),
                     Hk(FormCommit.Command.EditFile, EditFileHotkey),

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3136,10 +3136,6 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         <source>Stage &amp;in Superproject</source>
         <target />
       </trans-unit>
-      <trans-unit id="_addSelectionToCommitMessage.Text">
-        <source>Add selection to commit message</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_amendCommit.Text">
         <source>You are about to rewrite history.
 Only use amend if the commit is not published yet!

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -207,45 +207,6 @@ namespace GitExtensions.UITests.CommandsDialogs
             });
         }
 
-        [Test, TestCaseSource(typeof(CommitMessageTestData), "TestCases")]
-        public void AddSelectionToCommitMessage_shall_be_ignored_unless_diff_is_focused(
-            string message,
-            int selectionStart,
-            int selectionLength,
-            string expectedMessage,
-            int expectedSelectionStart)
-        {
-            TestAddSelectionToCommitMessage(focusSelectedDiff: false, CommitMessageTestData.SelectedText,
-                message, selectionStart, selectionLength,
-                expectedResult: false, expectedMessage: message, expectedSelectionStart: selectionStart);
-        }
-
-        [Test, TestCaseSource(typeof(CommitMessageTestData), "TestCases")]
-        public void AddSelectionToCommitMessage_shall_be_ignored_if_no_difftext_is_selected(
-            string message,
-            int selectionStart,
-            int selectionLength,
-            string expectedMessage,
-            int expectedSelectionStart)
-        {
-            TestAddSelectionToCommitMessage(focusSelectedDiff: true, selectedText: "",
-                message, selectionStart, selectionLength,
-                expectedResult: false, expectedMessage: message, expectedSelectionStart: selectionStart);
-        }
-
-        [Test, TestCaseSource(typeof(CommitMessageTestData), "TestCases")]
-        public void AddSelectionToCommitMessage_shall_modify_the_commit_message(
-            string message,
-            int selectionStart,
-            int selectionLength,
-            string expectedMessage,
-            int expectedSelectionStart)
-        {
-            TestAddSelectionToCommitMessage(focusSelectedDiff: true, CommitMessageTestData.SelectedText,
-                message, selectionStart, selectionLength,
-                expectedResult: true, expectedMessage, expectedSelectionStart);
-        }
-
         [Test]
         public void editFileToolStripMenuItem_Click_no_selection_should_not_throw()
         {
@@ -303,39 +264,6 @@ namespace GitExtensions.UITests.CommandsDialogs
             RunGeometryMemoryTest(
                 form => form.GetTestAccessor().SelectedDiff.Bounds,
                 (bounds1, bounds2) => bounds2.Should().Be(bounds1));
-        }
-
-        private void TestAddSelectionToCommitMessage(
-            bool focusSelectedDiff,
-            string selectedText,
-            string message,
-            int selectionStart,
-            int selectionLength,
-            bool expectedResult,
-            string expectedMessage,
-            int expectedSelectionStart)
-        {
-            RunFormTest(form =>
-            {
-                var ta = form.GetTestAccessor();
-
-                var selectedDiff = ta.SelectedDiff.GetTestAccessor().FileViewerInternal;
-                selectedDiff.SetText(selectedText, openWithDifftool: null);
-                selectedDiff.GetTestAccessor().TextEditor.ActiveTextAreaControl.SelectionManager.SetSelection(
-                    new TextLocation(0, 0), new TextLocation(selectedText.Length, 0));
-                if (focusSelectedDiff)
-                {
-                    selectedDiff.Focus();
-                }
-
-                ta.Message.Text = message;
-                ta.Message.SelectionStart = selectionStart;
-                ta.Message.SelectionLength = selectionLength;
-                ta.ExecuteCommand(FormCommit.Command.AddSelectionToCommitMessage).Should().Be((GitCommands.CommandStatus)expectedResult);
-                ta.Message.Text.Should().Be(expectedMessage);
-                ta.Message.SelectionStart.Should().Be(expectedSelectionStart);
-                ta.Message.SelectionLength.Should().Be(expectedResult ? 0 : selectionLength);
-            });
         }
 
         private void RunGeometryMemoryTest(Func<FormCommit, Rectangle> boundsAccessor, Action<Rectangle, Rectangle> testDriver)


### PR DESCRIPTION
## Proposed changes

The "Add selection to commit message" command is inserted to the
FileViewer menu, which is confusing.
Other inserted entries are removed in #7825.
A proper redesign could be done with enabling and eventhandlers,
but usage is considered low and workaround is to copy&paste.

Hotkey could be handled independent of the menu item.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/103409226-153d0500-4b66-11eb-8e87-39d5b533b752.png)

### After

![image](https://user-images.githubusercontent.com/6248932/103409158-b24b6e00-4b65-11eb-8921-375ed4db1256.png)

## Test methodology 

manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
