### PR TITLE
FileViewer: Consistently use Stage/Reset  Lines

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -94,8 +94,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _onlyStageChunkOfSingleFileError =
             new TranslationString("You can only use this option when selecting a single file");
 
-        private readonly TranslationString _resetChangesCaption = new TranslationString("Reset changes");
-
         private readonly TranslationString _resetSelectedChangesText =
             new TranslationString("Are you sure you want to reset all selected files?");
 
@@ -105,10 +103,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _selectOnlyOneFile = new TranslationString("You must have only one file selected.");
 
         private readonly TranslationString _addSelectionToCommitMessage = new TranslationString("Add selection to commit message");
-        private readonly TranslationString _stageSelectedLines = new TranslationString("Stage selected line(s)");
-        private readonly TranslationString _unstageSelectedLines = new TranslationString("Unstage selected line(s)");
-        private readonly TranslationString _resetSelectedLines = new TranslationString("Reset selected line(s)");
-        private readonly TranslationString _resetSelectedLinesConfirmation = new TranslationString("Are you sure you want to reset the changes to the selected lines?");
 
         private readonly TranslationString _formTitle = new TranslationString("Commit to {0} ({1})");
 
@@ -257,9 +251,9 @@ namespace GitUI.CommandsDialogs
             stagedEditFileToolStripMenuItem11.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.EditFile);
 
             SelectedDiff.AddContextMenuSeparator();
-            _stageSelectedLinesToolStripMenuItem = SelectedDiff.AddContextMenuEntry(_stageSelectedLines.Text, StageSelectedLinesToolStripMenuItemClick);
+            _stageSelectedLinesToolStripMenuItem = SelectedDiff.AddContextMenuEntry(Strings.StageSelectedLines, StageSelectedLinesToolStripMenuItemClick);
             _stageSelectedLinesToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.StageSelectedFile);
-            _resetSelectedLinesToolStripMenuItem = SelectedDiff.AddContextMenuEntry(_resetSelectedLines.Text, ResetSelectedLinesToolStripMenuItemClick);
+            _resetSelectedLinesToolStripMenuItem = SelectedDiff.AddContextMenuEntry(Strings.ResetSelectedLines, ResetSelectedLinesToolStripMenuItemClick);
             _resetSelectedLinesToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.ResetSelectedFiles);
             _resetSelectedLinesToolStripMenuItem.Image = Reset.Image;
             _addSelectionToCommitMessageToolStripMenuItem = SelectedDiff.AddContextMenuEntry(_addSelectionToCommitMessage.Text, (s, e) => AddSelectionToCommitMessage());
@@ -962,7 +956,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            if (MessageBox.Show(this, _resetSelectedLinesConfirmation.Text, _resetChangesCaption.Text,
+            if (MessageBox.Show(this, Strings.ResetSelectedLinesConfirmation, Strings.ResetChangesCaption,
                 MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.No)
             {
                 return;
@@ -1257,7 +1251,7 @@ namespace GitUI.CommandsDialogs
                 _selectedDiffReloaded = true;
             }).FileAndForget();
 
-            _stageSelectedLinesToolStripMenuItem.Text = staged ? _unstageSelectedLines.Text : _stageSelectedLines.Text;
+            _stageSelectedLinesToolStripMenuItem.Text = staged ? Strings.UnstageSelectedLines : Strings.StageSelectedLines;
             _stageSelectedLinesToolStripMenuItem.Image = staged ? toolUnstageItem.Image : toolStageItem.Image;
             _stageSelectedLinesToolStripMenuItem.ShortcutKeyDisplayString =
                 GetShortcutKeyDisplayString(staged ? Command.UnStageSelectedFile : Command.StageSelectedFile);
@@ -2167,7 +2161,7 @@ namespace GitUI.CommandsDialogs
 
                 if (!string.IsNullOrEmpty(output.ToString()))
                 {
-                    MessageBox.Show(this, output.ToString(), _resetChangesCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, output.ToString(), Strings.ResetChangesCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
             finally
@@ -2247,7 +2241,7 @@ namespace GitUI.CommandsDialogs
 
         private void ResetSelectedFilesToolStripMenuItemClick(object sender, EventArgs e)
         {
-            if (MessageBox.Show(this, _resetSelectedChangesText.Text, _resetChangesCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) !=
+            if (MessageBox.Show(this, _resetSelectedChangesText.Text, Strings.ResetChangesCaption, MessageBoxButtons.YesNo, MessageBoxIcon.Question) !=
                 DialogResult.Yes)
             {
                 return;

--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -99,7 +99,7 @@ namespace GitUI.Editor
             this.cherrypickSelectedLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.CherryPick;
             this.cherrypickSelectedLinesToolStripMenuItem.Name = "cherrypickSelectedLinesToolStripMenuItem";
             this.cherrypickSelectedLinesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.cherrypickSelectedLinesToolStripMenuItem.Text = "Cherry pick selected lines";
+            this.cherrypickSelectedLinesToolStripMenuItem.Text = Strings.StageSelectedLines;
             this.cherrypickSelectedLinesToolStripMenuItem.Click += new System.EventHandler(this.cherrypickSelectedLinesToolStripMenuItem_Click);
             // 
             // copyPatchToolStripMenuItem
@@ -379,7 +379,7 @@ namespace GitUI.Editor
             this.revertSelectedLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.ResetFileTo;
             this.revertSelectedLinesToolStripMenuItem.Name = "revertSelectedLinesToolStripMenuItem";
             this.revertSelectedLinesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.revertSelectedLinesToolStripMenuItem.Text = "Revert selected lines";
+            this.revertSelectedLinesToolStripMenuItem.Text = Strings.ResetSelectedLines;
             this.revertSelectedLinesToolStripMenuItem.Click += new System.EventHandler(this.revertSelectedLinesToolStripMenuItem_Click);
             //
             // llShowPreview

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -90,6 +90,12 @@ namespace GitUI
 - For multiple selected commits (up to four), show the difference for all the first selected with the last selected commit.
 - For more than four selected commits, show the difference from the first to the last selected commit.");
 
+        private readonly TranslationString _stageSelectedLines = new TranslationString("Stage selected line(s)");
+        private readonly TranslationString _unstageSelectedLines = new TranslationString("Unstage selected line(s)");
+        private readonly TranslationString _resetSelectedLines = new TranslationString("Reset selected line(s)");
+        private readonly TranslationString _resetSelectedLinesConfirmation = new TranslationString("Are you sure you want to reset the changes to the selected lines?");
+        private readonly TranslationString _resetChangesCaption = new TranslationString("Reset changes");
+
         private readonly TranslationString _rotInactive = new TranslationString("[ Inactive ]");
 
         private readonly TranslationString _argumentsText = new TranslationString("Arguments");
@@ -192,6 +198,12 @@ namespace GitUI
         public static string CombinedDiff => _instance.Value._combinedDiff.Text;
         public static string ShowDiffForAllParentsText => _instance.Value._showDiffForAllParentsText.Text;
         public static string ShowDiffForAllParentsTooltip => _instance.Value._showDiffForAllParentsTooltip.Text;
+
+        public static string StageSelectedLines => _instance.Value._stageSelectedLines.Text;
+        public static string UnstageSelectedLines => _instance.Value._unstageSelectedLines.Text;
+        public static string ResetSelectedLines => _instance.Value._resetSelectedLines.Text;
+        public static string ResetSelectedLinesConfirmation => _instance.Value._resetSelectedLinesConfirmation.Text;
+        public static string ResetChangesCaption => _instance.Value._resetChangesCaption.Text;
 
         public static string Inactive => _instance.Value._rotInactive.Text;
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1337,7 +1337,7 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <target />
       </trans-unit>
       <trans-unit id="cherrypickSelectedLinesToolStripMenuItem.Text">
-        <source>Cherry pick selected lines</source>
+        <source>Stage selected line(s)</source>
         <target />
       </trans-unit>
       <trans-unit id="copyNewVersionToolStripMenuItem.Text">
@@ -1413,7 +1413,7 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <target />
       </trans-unit>
       <trans-unit id="revertSelectedLinesToolStripMenuItem.Text">
-        <source>Revert selected lines</source>
+        <source>Reset selected line(s)</source>
         <target />
       </trans-unit>
       <trans-unit id="settingsButton.ToolTipText">
@@ -3284,20 +3284,8 @@ Do you want to continue?</source>
         <source>You can only use this option when selecting a single file</source>
         <target />
       </trans-unit>
-      <trans-unit id="_resetChangesCaption.Text">
-        <source>Reset changes</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_resetSelectedChangesText.Text">
         <source>Are you sure you want to reset all selected files?</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_resetSelectedLines.Text">
-        <source>Reset selected line(s)</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_resetSelectedLinesConfirmation.Text">
-        <source>Are you sure you want to reset the changes to the selected lines?</source>
         <target />
       </trans-unit>
       <trans-unit id="_resetStageChunkOfFileCaption.Text">
@@ -3329,10 +3317,6 @@ Suitable for some config files modified locally.</source>
         <source>Stage {0} files</source>
         <target />
       </trans-unit>
-      <trans-unit id="_stageSelectedLines.Text">
-        <source>Stage selected line(s)</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_statusBarBranchWithoutRemote.Text">
         <source>(remote not configured)</source>
         <target />
@@ -3356,10 +3340,6 @@ You can unset the template:
       </trans-unit>
       <trans-unit id="_templateNotFoundCaption.Text">
         <source>Template Error</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_unstageSelectedLines.Text">
-        <source>Unstage selected line(s)</source>
         <target />
       </trans-unit>
       <trans-unit id="_untrackedRemote.Text">
@@ -9533,6 +9513,18 @@ Select this commit to populate the full message.</source>
         <source>If you think this was caused by Git Extensions, you can report a bug for the team to investigate.</source>
         <target />
       </trans-unit>
+      <trans-unit id="_resetChangesCaption.Text">
+        <source>Reset changes</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_resetSelectedLines.Text">
+        <source>Reset selected line(s)</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_resetSelectedLinesConfirmation.Text">
+        <source>Are you sure you want to reset the changes to the selected lines?</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_rotInactive.Text">
         <source>[ Inactive ]</source>
         <target />
@@ -9598,6 +9590,10 @@ Select this commit to populate the full message.</source>
         <source>&amp;Sort order...</source>
         <target />
       </trans-unit>
+      <trans-unit id="_stageSelectedLines.Text">
+        <source>Stage selected line(s)</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_submodulesText.Text">
         <source>Submodules</source>
         <target />
@@ -9625,6 +9621,10 @@ Yes, I allow telemetry!</source>
       </trans-unit>
       <trans-unit id="_uninterestingDiffOmitted.Text">
         <source>Uninteresting diff hunks are omitted.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_unstageSelectedLines.Text">
+        <source>Unstage selected line(s)</source>
         <target />
       </trans-unit>
       <trans-unit id="_viewPullRequest.Text">


### PR DESCRIPTION
## Proposed changes

Current text when staging changes for specific lines is cherry picking and reverting for normal commits, for worktree (index) staging (unstaging) and resetting is used. The Git commands are slightly different but this is unknown for the user, the action is the same.
Especially, the hotkey must be the same. It is very confusing to identify the view as a "reset" or "revert" with separate hotkeys.

It is possible to have separate menu items with separate texts for e.g. reset/revert, but if the hotkey is to be the same, the hotkey handler must be identical so the action in the menu and hotkey will differ.

The names are currently chosen in analogy with cherry-picking/reverting commits, giving the "different name for the same action" for the line manipulation.

See also #7825 that updates the context menu for stage/unstage (including hotkeys not yet available for revert/cherry-pick) as well as #8707

Current usage of cherry-picking and reverting is expected to be relative limited, it is more important when staging commits. 

This PR also moves a few other strings to Strings.cs, preparing for #7825 (but still an improvement if #7825 would be rejected).
The printouts are slightly changed, to be consistent.

## Screenshots 

### Before

![image](https://user-images.githubusercontent.com/6248932/103414623-fe56dc80-4b7e-11eb-843f-27ef6b9f943b.png)

![image](https://user-images.githubusercontent.com/6248932/103414654-19c1e780-4b7f-11eb-9588-002d1e9d1431.png)

### After

![image](https://user-images.githubusercontent.com/6248932/103415143-26dfd600-4b81-11eb-9b25-1664242150ea.png)

![image](https://user-images.githubusercontent.com/6248932/103415087-ee3ffc80-4b80-11eb-9742-c1592218a566.png)

## Test methodology 

UI changes only, screenshots

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
