### PR TITLE
Implemented F2 rename branch in RepoObjectsTree.

### DIFF
--- a/GitUI/BranchTreePanel/ContextMenu/MenuItemsGenerator.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/MenuItemsGenerator.cs
@@ -96,9 +96,10 @@ namespace GitUI.BranchTreePanel.ContextMenu
         {
             if (Implements<ICanRename>())
             {
-                yield return _menuItemFactory.CreateMenuItem<ToolStripMenuItem, TNode>(
-                    node => ((ICanRename)node).Rename(), Strings.Rename, GetTooltip(MenuItemKey.Rename), Properties.Images.Renamed.AdaptLightness())
-                    .WithKey(MenuItemKey.Rename);
+                ToolStripMenuItem item = _menuItemFactory.CreateMenuItem<ToolStripMenuItem, TNode>(
+                    node => ((ICanRename)node).Rename(), Strings.Rename, GetTooltip(MenuItemKey.Rename), Properties.Images.Renamed.AdaptLightness());
+                item.ShortcutKeys = Keys.F2;
+                yield return item.WithKey(MenuItemKey.Rename);
             }
         }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.LocalBranchNode.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.LocalBranchNode.cs
@@ -50,6 +50,11 @@ namespace GitUI.BranchTreePanel
                 SelectRevision();
             }
 
+            internal override void OnRename()
+            {
+                Rename();
+            }
+
             public bool Checkout()
             {
                 return UICommands.StartCheckoutBranch(ParentWindow(), branch: FullPath, remote: false);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -502,6 +502,10 @@ namespace GitUI.BranchTreePanel
             {
             }
 
+            internal virtual void OnRename()
+            {
+            }
+
             public static Node GetNode(TreeNode treeNode)
             {
                 return (Node)treeNode.Tag;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -523,9 +523,14 @@ namespace GitUI.BranchTreePanel
 
         private void OnPreviewKeyDown(object sender, PreviewKeyDownEventArgs e)
         {
-            if (e.KeyCode == Keys.F3)
+            switch (e.KeyCode)
             {
-                OnBtnSearchClicked(this, EventArgs.Empty);
+                case Keys.F2:
+                    Node.OnNode<Node>(treeMain.SelectedNode, node => node.OnRename());
+                    break;
+                case Keys.F3:
+                    OnBtnSearchClicked(this, EventArgs.Empty);
+                    break;
             }
         }
 


### PR DESCRIPTION
Fixes #8599


## Proposed changes

- Added listener for F2 key in RepoObjetsTree that fired the branch rename dialog.

# To do

- Unit tests (maybe). I think a some refactoring of the existing code is required to cover the added code with unit tests.
- Change de hard coded F2 with the configured key in `HotkeySettingsManager`.
- Add the configured hot key text to the context menu item.

## Test methodology

- Manual

## Test environment(s)

- GIT 2.29.2.windows.3
- Windows 10.0.17763.0

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
