### PR TITLE
Fix high CPU usage of TeamCityAdapter

### DIFF
--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -110,9 +110,9 @@ namespace GitUI.BuildServerIntegration
                                                         anyRunningBuilds = true;
                                                         shouldLookForNewlyFinishedBuilds = true;
                                                     })
-                                               .Retry()
-                                               .Concat(delayObservable)
+                                               .OnErrorResumeNext(delayObservable)
                                                .Finally(() => anyRunningBuilds = false)
+                                               .Retry()
                                                .Repeat()
                                                .ObserveOn(MainThreadScheduler.Instance)
                                                .Subscribe(OnBuildInfoUpdate)

--- a/contributors.txt
+++ b/contributors.txt
@@ -146,3 +146,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/10/07, BrianFreemanAtlanta, Brian Freeman, freeman(at)carnegie.com
 2020/10/21, wischi-chr, Christian Wischenbart, christian.wischenbart@gmail.com
 2020/11/05, cristianst85, Cristian Stoica, cristianstoica85(at)gmail.com
+2021/01/02, matyasbach, Matyáš Bach, matyasbach(at)centrum.cz


### PR DESCRIPTION
Fixes #8281 and possibly also fixes #3646 and fixes #8167

Exceptions thrown from TeamCityAdapter caused immediate retry of failing operations -> spawning lot of new threads without any delay.

## Before
These cases caused high CPU usage:
- incorrect (nonexistent) TC build ID
- network or TC server outage

## After
CPU usage stays minimal. Build server is queried in defined time intervals even when responding errors or not communicating. 

## Test methodology <!-- How did you ensure quality? -->
Manually testing TeamCity integration and:
- simulating network/VPN outages
- set incorrect build ID

Other build server types could be affected and were not tested.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
