### PR TITLE
Handle external I/O exceptions that user can fix

### DIFF
--- a/GitCommands/Git/FileDeleteException.cs
+++ b/GitCommands/Git/FileDeleteException.cs
@@ -4,14 +4,6 @@ namespace GitCommands.Git
 {
     public class FileDeleteException : Exception
     {
-        private const string DefaultMessage = "Could not delete the file";
-
-        public FileDeleteException(string fileName)
-            : base(DefaultMessage)
-        {
-            FileName = fileName;
-        }
-
         public FileDeleteException(string fileName, Exception inner)
             : base(inner.Message, inner)
         {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -54,7 +54,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _superprojectModuleFormat = new TranslationString("Superproject: {0}");
         private readonly TranslationString _goToSuperProject = new TranslationString("Go to superproject");
 
-        private readonly TranslationString _indexLockCantDelete = new TranslationString("Failed to delete index.lock.");
+        private readonly TranslationString _indexLockCantDelete = new TranslationString("Failed to delete index.lock");
 
         private readonly TranslationString _loading = new TranslationString("Loading...");
 
@@ -2045,7 +2045,9 @@ namespace GitUI.CommandsDialogs
             }
             catch (FileDeleteException ex)
             {
-                MessageBox.Show(this, $@"{_indexLockCantDelete.Text}: {ex.FileName}{Environment.NewLine}{ex.Message}", Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                ThreadHelper.AssertOnUIThread();
+                throw new UserExternalOperationException(_indexLockCantDelete.Text,
+                    new ExternalOperationException(command: null, arguments: ex.FileName, Module.WorkingDir, ex));
             }
         }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -29,6 +29,7 @@ using GitUI.CommandsDialogs.WorktreeDialog;
 using GitUI.HelperDialogs;
 using GitUI.Hotkey;
 using GitUI.Infrastructure.Telemetry;
+using GitUI.NBugReports;
 using GitUI.Properties;
 using GitUI.Script;
 using GitUI.Shells;

--- a/GitUI/NBugReports/BugReporter.cs
+++ b/GitUI/NBugReports/BugReporter.cs
@@ -18,24 +18,24 @@ namespace GitExtensions
         private static IntPtr OwnerFormHandle
             => OwnerForm?.Handle ?? IntPtr.Zero;
 
-        private static string FormatText(ExternalOperationException ex, bool canRaiseBug)
+        private static string FormatText(ExternalOperationException exception, bool canRaiseBug)
         {
             StringBuilder sb = new StringBuilder();
 
             // Command: <command>
-            if (!string.IsNullOrWhiteSpace(ex.Command))
+            if (!string.IsNullOrWhiteSpace(exception.Command))
             {
-                sb.AppendLine($"{Strings.Command}: {ex.Command}");
+                sb.AppendLine($"{Strings.Command}: {exception.Command}");
             }
 
             // Arguments: <args>
-            if (!string.IsNullOrWhiteSpace(ex.Arguments))
+            if (!string.IsNullOrWhiteSpace(exception.Arguments))
             {
-                sb.AppendLine($"{Strings.Arguments}: {ex.Arguments}");
+                sb.AppendLine($"{Strings.Arguments}: {exception.Arguments}");
             }
 
             // Working directory: <working dir>
-            sb.AppendLine($"{Strings.WorkingDirectory}: {ex.WorkingDirectory}");
+            sb.AppendLine($"{Strings.WorkingDirectory}: {exception.WorkingDirectory}");
 
             if (canRaiseBug)
             {
@@ -47,16 +47,16 @@ namespace GitExtensions
             return sb.ToString();
         }
 
-        public static void Report(Exception ex, bool isTerminating)
+        public static void Report(Exception exception, bool isTerminating)
         {
-            if (ex is UserExternalOperationException userExternalException)
+            if (exception is UserExternalOperationException userExternalException)
             {
                 // Something happened that was likely caused by the user
                 ReportUserException(userExternalException, isTerminating);
                 return;
             }
 
-            if (ex is ExternalOperationException externalException)
+            if (exception is ExternalOperationException externalException)
             {
                 // Something happened either in the app - can submit the bug to GitHub
                 ReportAppException(externalException, isTerminating);
@@ -64,18 +64,33 @@ namespace GitExtensions
             }
 
             // Report any other exceptions
-            ReportGenericException(ex, isTerminating);
+            ReportGenericException(exception, isTerminating);
         }
 
-        private static void ReportAppException(ExternalOperationException ex, bool isTerminating)
+        private static void ReportAppException(ExternalOperationException exception, bool isTerminating)
         {
             // UserExternalOperationException wraps an actual exception, but be cautious just in case
-            string instructionText = ex.InnerException?.Message ?? Strings.InstructionOperationFailed;
+            string instructionText = exception.InnerException?.Message ?? Strings.InstructionOperationFailed;
 
-            ReportException(FormatText(ex, canRaiseBug: true), instructionText, ex, isTerminating);
+            ShowException(FormatText(exception, canRaiseBug: true), instructionText, exception, isTerminating);
         }
 
-        private static void ReportException(string text, string instructionText, Exception ex, bool isTerminating)
+        private static void ReportGenericException(Exception exception, bool isTerminating)
+        {
+            // This exception is arbitrary, see if there's additional information
+            string? moreInfo = exception.InnerException?.Message;
+            if (moreInfo != null)
+            {
+                moreInfo += Environment.NewLine + Environment.NewLine;
+            }
+
+            ShowException($"{moreInfo}{Strings.ReportBug}", exception.Message, exception, isTerminating);
+        }
+
+        private static void ReportUserException(UserExternalOperationException exception, bool isTerminating)
+            => ShowException(FormatText(exception, canRaiseBug: false), exception.Context, exception: null, isTerminating);
+
+        private static void ShowException(string text, string instructionText, Exception? exception, bool isTerminating)
         {
             using var dialog = new TaskDialog
             {
@@ -86,46 +101,19 @@ namespace GitExtensions
                 Icon = TaskDialogStandardIcon.Error,
                 Cancelable = true,
             };
-            var btnReport = new TaskDialogCommandLink("Report", Strings.ButtonReportBug);
-            btnReport.Click += (s, e) =>
-            {
-                dialog.Close();
-                ShowNBug(OwnerForm, ex, isTerminating);
-            };
-            var btnIgnoreOrClose = new TaskDialogCommandLink("IgnoreOrClose", isTerminating ? Strings.ButtonCloseApp : Strings.ButtonIgnore);
-            btnIgnoreOrClose.Click += (s, e) =>
-            {
-                dialog.Close();
-            };
-            dialog.Controls.Add(btnReport);
-            dialog.Controls.Add(btnIgnoreOrClose);
 
-            dialog.Show();
-        }
-
-        private static void ReportGenericException(Exception ex, bool isTerminating)
-        {
-            // This exception is arbitrary, see if there's additional information
-            string? moreInfo = ex.InnerException?.Message;
-            if (moreInfo != null)
+            if (exception != null)
             {
-                moreInfo += Environment.NewLine + Environment.NewLine;
+                var btnReport = new TaskDialogCommandLink("Report", Strings.ButtonReportBug);
+                btnReport.Click += (s, e) =>
+                {
+                    dialog.Close();
+                    ShowNBug(OwnerForm, exception, isTerminating);
+                };
+
+                dialog.Controls.Add(btnReport);
             }
 
-            ReportException($"{moreInfo}{Strings.ReportBug}", ex.Message, ex, isTerminating);
-        }
-
-        private static void ReportUserException(UserExternalOperationException ex, bool isTerminating)
-        {
-            using var dialog = new TaskDialog
-            {
-                OwnerWindowHandle = OwnerFormHandle,
-                Text = FormatText(ex, canRaiseBug: false),
-                InstructionText = ex.Context,
-                Caption = Strings.CaptionFailedExecute,
-                Icon = TaskDialogStandardIcon.Error,
-                Cancelable = true,
-            };
             var btnIgnoreOrClose = new TaskDialogCommandLink("IgnoreOrClose", isTerminating ? Strings.ButtonCloseApp : Strings.ButtonIgnore);
             btnIgnoreOrClose.Click += (s, e) =>
             {
@@ -136,13 +124,13 @@ namespace GitExtensions
             dialog.Show();
         }
 
-        private static void ShowNBug(IWin32Window? owner, Exception ex, bool isTerminating)
+        private static void ShowNBug(IWin32Window? owner, Exception exception, bool isTerminating)
         {
             var envInfo = UserEnvironmentInformation.GetInformation();
 
             using (var form = new GitUI.NBugReports.BugReportForm())
             {
-                var result = form.ShowDialog(owner, ex, envInfo);
+                var result = form.ShowDialog(owner, exception, envInfo);
                 if (isTerminating || result == DialogResult.Abort)
                 {
                     Environment.Exit(-1);

--- a/GitUI/NBugReports/BugReporter.cs
+++ b/GitUI/NBugReports/BugReporter.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Windows.Forms;
 using GitCommands;
 using GitUI;
+using GitUI.NBugReports;
 using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace GitExtensions

--- a/GitUI/NBugReports/UserExternalOperationException.cs
+++ b/GitUI/NBugReports/UserExternalOperationException.cs
@@ -1,6 +1,8 @@
 ﻿#nullable enable
 
-namespace GitCommands
+using GitCommands;
+
+namespace GitUI.NBugReports
 {
     /// <summary>
     /// Represents errors that occur during execution of user-configured operation, e.g. a script.

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitUI.HelperDialogs;
+using GitUI.NBugReports;
 using GitUIPluginInterfaces;
 
 namespace GitUI.Script

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2138,7 +2138,7 @@ compare with first:</source>
         <target />
       </trans-unit>
       <trans-unit id="_indexLockCantDelete.Text">
-        <source>Failed to delete index.lock.</source>
+        <source>Failed to delete index.lock</source>
         <target />
       </trans-unit>
       <trans-unit id="_loading.Text">

--- a/IntegrationTests/UI.IntegrationTests/Script/ScriptRunnerTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/Script/ScriptRunnerTests.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using GitCommands;
 using GitUI;
 using GitUI.CommandsDialogs;
+using GitUI.NBugReports;
 using GitUI.Script;
 using GitUIPluginInterfaces;
 using NSubstitute;


### PR DESCRIPTION
Relates to #8358

## Proposed changes

- Move user-facing exceptions to UI layer because these exceptions include localisable strings, that are only available at the UI layer.
- Handle non-app related I/O exceptions that a user can resolve


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/103474176-4c751580-4df5-11eb-9d85-91e418a5e408.png)


### After

![image](https://user-images.githubusercontent.com/4403806/103474140-0455f300-4df5-11eb-919b-5d1a992a8a2c.png)


NOTE: the current implementation of Task Dialog can't size itself to content, the .NET 5.0 version provided by Windows Forms SDK can.


## Test methodology <!-- How did you ensure quality? -->

Manually by:
- creating an index.lock file,
- locking the file (e.g. open in MS Excel)
- invoke the functionality through _Repository > Git Maintenance > Delete index.lock_
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
