### PR TITLE
Revert ability for move and show/hide toolbars

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -243,6 +243,7 @@ namespace GitUI.CommandsDialogs
             this.ToolStripMain.ClickThrough = true;
             this.ToolStripMain.Dock = System.Windows.Forms.DockStyle.None;
             this.ToolStripMain.GripMargin = new System.Windows.Forms.Padding(0);
+            this.ToolStripMain.GripStyle = ToolStripGripStyle.Hidden;
             this.ToolStripMain.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.ToolStripMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.RefreshButton,
@@ -276,6 +277,7 @@ namespace GitUI.CommandsDialogs
             this.ToolStripFilters.ClickThrough = true;
             this.ToolStripFilters.Dock = System.Windows.Forms.DockStyle.None;
             this.ToolStripFilters.GripMargin = new System.Windows.Forms.Padding(0);
+            this.ToolStripFilters.GripStyle = ToolStripGripStyle.Hidden;
             this.ToolStripFilters.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.ToolStripFilters.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripLabel1,

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -190,12 +190,14 @@ namespace GitUI.CommandsDialogs
             this.toolPanel = new System.Windows.Forms.ToolStripContainer();
             this._addUpstreamRemoteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolStripFilters = new GitUI.ToolStripEx();
+            this.ToolStripScripts = new GitUI.ToolStripEx();
             toolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
             toolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
             toolStripSeparator14 = new System.Windows.Forms.ToolStripSeparator();
             toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
             this.ToolStripMain.SuspendLayout();
             this.ToolStripFilters.SuspendLayout();
+            this.ToolStripScripts.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.MainSplitContainer)).BeginInit();
             this.MainSplitContainer.Panel1.SuspendLayout();
             this.MainSplitContainer.Panel2.SuspendLayout();
@@ -271,7 +273,7 @@ namespace GitUI.CommandsDialogs
             this.ToolStripMain.Size = new System.Drawing.Size(479, 25);
             this.ToolStripMain.TabIndex = 0;
             this.ToolStripMain.Text = "Standard";
-            //
+            // 
             // ToolStripFilters
             // 
             this.ToolStripFilters.ClickThrough = true;
@@ -992,7 +994,7 @@ namespace GitUI.CommandsDialogs
             // 
             this.fileExplorerToolStripMenuItem.Image = global::GitUI.Properties.Images.BrowseFileExplorer;
             this.fileExplorerToolStripMenuItem.Name = "fileExplorerToolStripMenuItem";
-            this.fileExplorerToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift)
+            this.fileExplorerToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.O)));
             this.fileExplorerToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
             this.fileExplorerToolStripMenuItem.Text = "File Explorer";
@@ -1759,13 +1761,29 @@ namespace GitUI.CommandsDialogs
             // 
             this.toolPanel.TopToolStripPanel.Controls.Add(this.ToolStripMain);
             this.toolPanel.TopToolStripPanel.Controls.Add(this.ToolStripFilters);
+            this.toolPanel.TopToolStripPanel.Controls.Add(this.ToolStripScripts);
             // 
             // addUpstreamRemoteToolStripMenuItem
-            //
+            // 
             this._addUpstreamRemoteToolStripMenuItem.Name = "_addUpstreamRemoteToolStripMenuItem";
             this._addUpstreamRemoteToolStripMenuItem.Size = new System.Drawing.Size(360, 38);
             this._addUpstreamRemoteToolStripMenuItem.Text = "Add upstream remote";
             this._addUpstreamRemoteToolStripMenuItem.Click += new System.EventHandler(this._addUpstreamRemoteToolStripMenuItem_Click);
+            // 
+            // toolStripScripts
+            // 
+            this.ToolStripScripts.ClickThrough = true;
+            this.ToolStripScripts.Dock = System.Windows.Forms.DockStyle.None;
+            this.ToolStripScripts.GripMargin = new System.Windows.Forms.Padding(0);
+            this.ToolStripScripts.GripStyle = ToolStripGripStyle.Hidden;
+            this.ToolStripScripts.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.ToolStripScripts.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
+            this.ToolStripScripts.Location = new System.Drawing.Point(3, 50);
+            this.ToolStripScripts.Name = "toolStripScripts";
+            this.ToolStripScripts.Padding = new System.Windows.Forms.Padding(0);
+            this.ToolStripScripts.Size = new System.Drawing.Size(43, 25);
+            this.ToolStripScripts.TabIndex = 2;
+            this.ToolStripScripts.Text = "Scripts";
             // 
             // FormBrowse
             // 
@@ -1807,6 +1825,8 @@ namespace GitUI.CommandsDialogs
             this.toolPanel.PerformLayout();
             this.ToolStripFilters.ResumeLayout(false);
             this.ToolStripFilters.PerformLayout();
+            this.ToolStripScripts.ResumeLayout(false);
+            this.ToolStripScripts.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
         }
@@ -1826,9 +1846,6 @@ namespace GitUI.CommandsDialogs
         private BindingSource gitRevisionBindingSource;
         private BindingSource gitItemBindingSource;
         private GitUI.RevisionGridControl RevisionGrid;
-        private MenuStripEx mainMenuStrip;
-        private ToolStripEx ToolStripMain;
-        private ToolStripEx ToolStripFilters;
         private CommitInfo.CommitInfo RevisionInfo;
         private GitUI.BranchTreePanel.RepoObjectsTree repoObjectsTree;
         private ToolTip FilterToolTip;
@@ -1836,6 +1853,11 @@ namespace GitUI.CommandsDialogs
         private RevisionDiffControl revisionDiff;
         private ToolStripContainer toolPanel;
         private RevisionGpgInfoControl revisionGpgInfo1;
+
+        private MenuStripEx mainMenuStrip;
+        private ToolStripEx ToolStripMain;
+        private ToolStripEx ToolStripFilters;
+        private ToolStripEx ToolStripScripts;
 
         private ToolStripButton toolStripButtonCommit;
         private ToolStripSplitButton _NO_TRANSLATE_WorkingDir;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -320,6 +320,7 @@ namespace GitUI.CommandsDialogs
                 // if the 1st one becomes longer than the 2nd toolbar's Location.X
                 // the layout engine will be place the 2nd toolbar first
                 toolPanel.TopToolStripPanel.Controls.Clear();
+                toolPanel.TopToolStripPanel.Controls.Add(ToolStripScripts);
                 toolPanel.TopToolStripPanel.Controls.Add(ToolStripFilters);
                 toolPanel.TopToolStripPanel.Controls.Add(ToolStripMain);
             }
@@ -452,6 +453,9 @@ namespace GitUI.CommandsDialogs
                 ToolStripMain.ForeColor = toolForeColor;
                 ToolStripFilters.BackColor = toolBackColor;
                 ToolStripFilters.ForeColor = toolForeColor;
+                ToolStripScripts.BackColor = toolBackColor;
+                ToolStripScripts.ForeColor = toolForeColor;
+
                 toolStripRevisionFilterDropDownButton.BackColor = toolBackColor;
                 toolStripRevisionFilterDropDownButton.ForeColor = toolForeColor;
 
@@ -627,7 +631,7 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnLoad(EventArgs e)
         {
-            _formBrowseMenus.CreateToolbarsMenus(ToolStripMain, ToolStripFilters, toolStripScripts);
+            _formBrowseMenus.CreateToolbarsMenus(ToolStripMain, ToolStripFilters, ToolStripScripts);
 
             HideVariableMainMenuItems();
             RefreshSplitViewLayout();
@@ -1110,11 +1114,11 @@ namespace GitUI.CommandsDialogs
                     .Where(script => script.Enabled && script.OnEvent == ScriptEvent.ShowInUserMenuBar)
                     .ToList();
 
-                for (int i = ToolStripMain.Items.Count - 1; i >= 0; i--)
+                for (int i = ToolStripScripts.Items.Count - 1; i >= 0; i--)
                 {
-                    if (ToolStripMain.Items[i].Tag as string == "userscript")
+                    if (ToolStripScripts.Items[i].Tag as string == "userscript")
                     {
-                        ToolStripMain.Items.RemoveAt(i);
+                        ToolStripScripts.Items.RemoveAt(i);
                     }
                 }
 
@@ -1122,8 +1126,6 @@ namespace GitUI.CommandsDialogs
                 {
                     return;
                 }
-
-                ToolStripMain.Items.Add(new ToolStripSeparator { Tag = "userscript" });
 
                 foreach (var script in scripts)
                 {
@@ -1147,7 +1149,7 @@ namespace GitUI.CommandsDialogs
                     };
 
                     // add to toolstrip
-                    ToolStripMain.Items.Add(button);
+                    ToolStripScripts.Items.Add(button);
                 }
             }
 

--- a/GitUI/CommandsDialogs/FormBrowse.resx
+++ b/GitUI/CommandsDialogs/FormBrowse.resx
@@ -147,6 +147,9 @@
   <metadata name="ToolStripFilters.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>711, 17</value>
   </metadata>
+  <metadata name="toolStripScripts.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>844, 17</value>
+  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>82</value>
   </metadata>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2101,6 +2101,10 @@ compare with first:</source>
         <source>Standard</source>
         <target />
       </trans-unit>
+      <trans-unit id="ToolStripScripts.Text">
+        <source>Scripts</source>
+        <target />
+      </trans-unit>
       <trans-unit id="TreeTabPage.Text">
         <source>File tree</source>
         <target />


### PR DESCRIPTION
Due to discovered layout and placement instability of toolbars
reverting most of the functionality added in #8572.

Closes #8680


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
