### PR TITLE
Process.Start with ExternalOperationException

### DIFF
--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -31,7 +31,12 @@ namespace GitCommands
 
         /// <inheritdoc />
         [PermissionSet(SecurityAction.Demand, Name = "FullTrust")]
-        public IProcess Start(ArgumentString arguments = default, bool createWindow = false, bool redirectInput = false, bool redirectOutput = false, Encoding outputEncoding = null)
+        public IProcess Start(ArgumentString arguments = default,
+                              bool createWindow = false,
+                              bool redirectInput = false,
+                              bool redirectOutput = false,
+                              Encoding outputEncoding = null,
+                              bool useShellExecute = false)
         {
             // TODO should we set these on the child process only?
             EnvironmentConfiguration.SetEnvironmentVariables();
@@ -40,7 +45,7 @@ namespace GitCommands
 
             var fileName = _fileNameProvider();
 
-            return new ProcessWrapper(fileName, args, _workingDir, createWindow, redirectInput, redirectOutput, outputEncoding);
+            return new ProcessWrapper(fileName, args, _workingDir, createWindow, redirectInput, redirectOutput, outputEncoding, useShellExecute);
         }
 
         public string GetOutput(ArgumentString arguments)
@@ -69,7 +74,14 @@ namespace GitCommands
             private bool _disposed;
 
             [SuppressMessage("ReSharper", "AssignNullToNotNullAttribute")]
-            public ProcessWrapper(string fileName, string arguments, string workDir, bool createWindow, bool redirectInput, bool redirectOutput, [CanBeNull] Encoding outputEncoding)
+            public ProcessWrapper(string fileName,
+                                  string arguments,
+                                  string workDir,
+                                  bool createWindow,
+                                  bool redirectInput,
+                                  bool redirectOutput,
+                                  [CanBeNull] Encoding outputEncoding,
+                                  bool useShellExecute)
             {
                 Debug.Assert(redirectOutput == (outputEncoding != null), "redirectOutput == (outputEncoding != null)");
                 _redirectInput = redirectInput;
@@ -80,7 +92,7 @@ namespace GitCommands
                     EnableRaisingEvents = true,
                     StartInfo =
                     {
-                        UseShellExecute = false,
+                        UseShellExecute = useShellExecute,
                         ErrorDialog = false,
                         CreateNoWindow = !createWindow,
                         RedirectStandardInput = redirectInput,

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -351,7 +351,7 @@ namespace GitExtensions
 
                 case 1:
                     {
-                        Process.Start(@"https://github.com/gitextensions/gitextensions/wiki/Application-Dependencies#git");
+                        OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/Application-Dependencies#git");
                         return false;
                     }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -319,7 +319,7 @@ namespace GitUI.BranchTreePanel
                     return;
                 }
 
-                Process.Start(_remote.FetchUrl);
+                OsShellUtil.OpenUrlInDefaultBrowser(_remote.FetchUrl);
             }
 
             public bool IsRemoteUrlUsingHttp => _remote.FetchUrl.IsUrlUsingHttp();

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
@@ -212,18 +211,18 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private static void TranslateItem_Click(object sender, EventArgs e)
         {
-            Process.Start("https://github.com/gitextensions/gitextensions/wiki/Translations");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/Translations");
         }
 
         private static void GitHubItem_Click(object sender, EventArgs e)
         {
-            Process.Start(@"https://github.com/gitextensions/gitextensions");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions");
         }
 
         private static void IssuesItem_Click(object sender, EventArgs e)
         {
             UserEnvironmentInformation.CopyInformation();
-            Process.Start(@"https://github.com/gitextensions/gitextensions/issues");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/issues");
         }
 
         private void openItem_Click(object sender, EventArgs e)
@@ -247,7 +246,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private static void DonateItem_Click(object sender, EventArgs e)
         {
-            Process.Start(FormDonate.DonationUrl);
+            OsShellUtil.OpenUrlInDefaultBrowser(FormDonate.DonationUrl);
         }
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -731,16 +730,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         }
 
         private void tsmiOpenFolder_Click(object sender, EventArgs e)
-        {
-            try
-            {
-                RepositoryContextAction(sender as ToolStripMenuItem, selectedRepositoryItem => Process.Start(selectedRepositoryItem.Repository.Path));
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(this, ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-        }
+            => RepositoryContextAction(sender as ToolStripMenuItem, selectedRepositoryItem => OsShellUtil.OpenWithFileExplorer(selectedRepositoryItem.Repository.Path));
 
         private void tsmiRemoveFromList_Click(object sender, EventArgs e)
         {

--- a/GitUI/CommandsDialogs/BrowseDialog/FormDonate.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormDonate.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Drawing;
 using ResourceManager;
 
@@ -27,7 +26,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void PictureBox1Click(object sender, EventArgs e)
         {
-            Process.Start(DonationUrl);
+            OsShellUtil.OpenUrlInDefaultBrowser(DonationUrl);
         }
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -71,7 +70,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void linkGitRevParse_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://git-scm.com/docs/git-rev-parse#_specifying_revisions");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://git-scm.com/docs/git-rev-parse#_specifying_revisions");
         }
 
         private Task LoadTagsAsync()

--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -165,10 +165,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             switch (launchType)
             {
                 case LaunchType.ChangeLog:
-                    Process.Start("https://github.com/gitextensions/gitextensions/blob/master/GitUI/Resources/ChangeLog.md");
+                    OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/blob/master/GitUI/Resources/ChangeLog.md");
                     break;
                 case LaunchType.DirectDownload:
-                    Process.Start(UpdateUrl);
+                    OsShellUtil.OpenUrlInDefaultBrowser(UpdateUrl);
                     break;
             }
         }

--- a/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
+++ b/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -39,7 +38,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (!string.IsNullOrWhiteSpace(_url))
                 {
-                    Process.Start(_url);
+                    OsShellUtil.OpenUrlInDefaultBrowser(_url);
                 }
             };
             _openReportLink.Font = new Font(_openReportLink.Font.Name, 16F);

--- a/GitUI/CommandsDialogs/FormAbout.cs
+++ b/GitUI/CommandsDialogs/FormAbout.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using GitCommands;
@@ -30,10 +29,10 @@ namespace GitUI.CommandsDialogs
             linkLabelIcons.LinkColor = clrLink;
 
             // Click handlers
-            _NO_TRANSLATE_labelProductName.LinkClicked += delegate { Process.Start("https://github.com/gitextensions/gitextensions"); };
+            _NO_TRANSLATE_labelProductName.LinkClicked += delegate { OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions"); };
             _NO_TRANSLATE_ThanksTo.LinkClicked += delegate { ShowContributorsForm(); };
-            pictureDonate.Click += delegate { Process.Start(FormDonate.DonationUrl); };
-            linkLabelIcons.LinkClicked += delegate { Process.Start("http://p.yusukekamiyamane.com/"); };
+            pictureDonate.Click += delegate { OsShellUtil.OpenUrlInDefaultBrowser(FormDonate.DonationUrl); };
+            linkLabelIcons.LinkClicked += delegate { OsShellUtil.OpenUrlInDefaultBrowser(@"http://p.yusukekamiyamane.com/"); };
 
             var contributorsList = GetContributorList();
             var thanksToContributorsText = string.Format(_thanksToContributors.Text, contributorsList.Count);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1829,14 +1829,8 @@ namespace GitUI.CommandsDialogs
 
         private void UserManualToolStripMenuItemClick(object sender, EventArgs e)
         {
-            try
-            {
-                // Point to the default documentation, will work also if the old doc version is removed
-                Process.Start("https://git-extensions-documentation.readthedocs.org");
-            }
-            catch (Win32Exception)
-            {
-            }
+            // Point to the default documentation, will work also if the old doc version is removed
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://git-extensions-documentation.readthedocs.org");
         }
 
         private void CleanupToolStripMenuItemClick(object sender, EventArgs e)
@@ -1990,19 +1984,12 @@ namespace GitUI.CommandsDialogs
 
         private void TranslateToolStripMenuItemClick(object sender, EventArgs e)
         {
-            Process.Start("https://github.com/gitextensions/gitextensions/wiki/Translations");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/Translations");
         }
 
         private void FileExplorerToolStripMenuItemClick(object sender, EventArgs e)
         {
-            try
-            {
-                Process.Start("explorer.exe", Module.WorkingDir);
-            }
-            catch (Exception ex)
-            {
-                MessageBoxes.ShowError(this, ex.Message);
-            }
+            OsShellUtil.OpenWithFileExplorer(Module.WorkingDir);
         }
 
         private void CreateBranchToolStripMenuItemClick(object sender, EventArgs e)
@@ -2891,7 +2878,7 @@ namespace GitUI.CommandsDialogs
         private void reportAnIssueToolStripMenuItem_Click(object sender, EventArgs e)
         {
             UserEnvironmentInformation.CopyInformation();
-            Process.Start(@"https://github.com/gitextensions/gitextensions/issues");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/issues");
         }
 
         private void checkForUpdatesToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2569,14 +2569,7 @@ namespace GitUI.CommandsDialogs
             var fileName = list.SelectedGitItem.Name;
             var path = _fullPathResolver.Resolve(fileName).ToNativePath();
 
-            try
-            {
-                Process.Start(path);
-            }
-            catch (System.ComponentModel.Win32Exception)
-            {
-                OsShellUtil.OpenAs(path);
-            }
+            OsShellUtil.Open(path);
         }
 
         private void OpenWithToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -241,12 +241,12 @@ namespace GitUI.CommandsDialogs
 
         private void lnkGitIgnorePatterns_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://github.com/github/gitignore");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/github/gitignore");
         }
 
         private void lnkGitIgnoreGenerate_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://www.gitignore.io/");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://www.gitignore.io/");
         }
 
         private void btnCancel_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -1448,7 +1447,7 @@ namespace GitUI.CommandsDialogs
         private void openToolStripMenuItem_Click(object sender, EventArgs e)
         {
             string fileName = GetFileName();
-            Process.Start(_fullPathResolver.Resolve(fileName));
+            OsShellUtil.Open(_fullPathResolver.Resolve(fileName));
         }
 
         private void openWithToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -340,7 +339,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             }
             else
             {
-                Process.Start(CurrentySelectedGitRepo.Homepage);
+                OsShellUtil.OpenUrlInDefaultBrowser(CurrentySelectedGitRepo.Homepage);
             }
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -767,7 +767,7 @@ namespace GitUI.CommandsDialogs
 
         private void diffOpenRevisionFileToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            SaveSelectedItemToTempFile(fileName => Process.Start(fileName));
+            SaveSelectedItemToTempFile(fileName => OsShellUtil.Open(fileName));
         }
 
         private void diffOpenRevisionFileWithToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -648,17 +648,10 @@ See the changes in the commit form.");
 
         private void openFileToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            try
+            var fileName = SaveSelectedItemToTempFile();
+            if (fileName != null)
             {
-                var fileName = SaveSelectedItemToTempFile();
-                if (fileName != null)
-                {
-                    Process.Start(fileName);
-                }
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(this, ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                OsShellUtil.Open(fileName);
             }
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -209,17 +208,17 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void helpTranslate_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://github.com/gitextensions/gitextensions/wiki/Translations");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/Translations");
         }
 
         private void downloadDictionary_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://github.com/gitextensions/gitextensions/wiki/Spelling");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/Spelling");
         }
 
         private void pictureAvatarHelp_Click(object sender, EventArgs e)
         {
-            Process.Start(@"http://en.gravatar.com/site/implement/images#default-image");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"http://en.gravatar.com/site/implement/images#default-image");
         }
 
         private void AvatarProvider_SelectedIndexChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -647,7 +647,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void GcmDetectedFix_Click(object sender, EventArgs e)
         {
-            Process.Start("https://github.com/gitextensions/gitextensions/wiki/How-To:-fix-GitCredentialWinStore-missing");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/How-To:-fix-GitCredentialWinStore-missing");
         }
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using GitCommands;
-using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Theming;
 using ResourceManager;
@@ -233,16 +230,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 ThemeId.Equals(other.ThemeId);
         }
 
-        private void tsmiApplicationFolder_Click(object sender, EventArgs e) => OpenFolder(_themePathProvider.AppThemesDirectory);
+        private void tsmiApplicationFolder_Click(object sender, EventArgs e)
+            => OsShellUtil.SelectPathInFileExplorer(_themePathProvider.AppThemesDirectory);
 
-        private void tsmiUserFolder_Click(object sender, EventArgs e) => OpenFolder(_themePathProvider.UserThemesDirectory);
-
-        private void OpenFolder(string folderPath)
-        {
-            if (Directory.Exists(folderPath))
-            {
-                Process.Start(folderPath);
-            }
-        }
+        private void tsmiUserFolder_Click(object sender, EventArgs e)
+            => OsShellUtil.SelectPathInFileExplorer(_themePathProvider.UserThemesDirectory);
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using GitCommands;
@@ -169,7 +168,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void LlblTelemetryPrivacyLink_LinkClicked(object sender, System.Windows.Forms.LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start("https://github.com/gitextensions/gitextensions/blob/master/PrivacyPolicy.md");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/blob/master/PrivacyPolicy.md");
         }
 
         private void lblCommitsLimit_CheckedChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Windows.Forms;
 using GitCommands;
 using ResourceManager;
@@ -86,7 +85,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void downloadGitForWindows_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://github.com/gitextensions/gitextensions/wiki/Application-Dependencies#git");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/Application-Dependencies#git");
         }
 
         private void ChangeHomeButton_Click(object sender, EventArgs e)

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git.Commands;
@@ -147,7 +146,7 @@ namespace GitUI.HelperDialogs
                 helpSection = "--hard";
             }
 
-            Process.Start($"https://git-scm.com/docs/git-reset#Documentation/git-reset.txt-{helpSection}");
+            OsShellUtil.OpenUrlInDefaultBrowser(@$"https://git-scm.com/docs/git-reset#Documentation/git-reset.txt-{helpSection}");
         }
     }
 }

--- a/GitUI/NBugReports/BugReportForm.cs
+++ b/GitUI/NBugReports/BugReportForm.cs
@@ -8,7 +8,6 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
-using System.Diagnostics;
 using System.Drawing;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
@@ -138,7 +137,7 @@ Send report anyway?");
             }
 
             string url = UrlBuilder.Build("https://github.com/gitextensions/gitextensions/issues/new", _lastException.OriginalException, _environmentInfo, descriptionTextBox.Text);
-            Process.Start(url);
+            OsShellUtil.OpenUrlInDefaultBrowser(url);
 
             DialogResult = DialogResult.Abort;
             Close();

--- a/GitUI/OsShellUtil.cs
+++ b/GitUI/OsShellUtil.cs
@@ -1,29 +1,44 @@
-﻿using System.Diagnostics;
+﻿using System;
 using System.Windows.Forms;
+using GitCommands;
 using Microsoft.WindowsAPICodePack.Dialogs;
 namespace GitUI
 {
     public static class OsShellUtil
     {
-        public static void OpenAs(string file)
+        /// <summary>
+        /// Open a file with its associated default application.
+        /// </summary>
+        /// <param name="filePath">Pathname of the file to open.</param>
+        public static void Open(string filePath)
         {
-            Process.Start(new ProcessStartInfo
+            try
             {
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                FileName = "rundll32.exe",
-                Arguments = "shell32.dll,OpenAs_RunDLL " + file
-            });
+                new Executable(filePath).Start(useShellExecute: true);
+            }
+            catch (Exception)
+            {
+                OpenAs(filePath);
+            }
+        }
+
+        /// <summary>
+        /// Let the user chose an application to open a file.
+        /// </summary>
+        /// <param name="filePath">Pathname of the file to open.</param>
+        public static void OpenAs(string filePath)
+        {
+            new Executable("rundll32.exe").Start("shell32.dll,OpenAs_RunDLL " + filePath, redirectOutput: true, outputEncoding: System.Text.Encoding.UTF8);
         }
 
         public static void SelectPathInFileExplorer(string filePath)
         {
-            Process.Start("explorer.exe", "/select, " + filePath);
+            OpenWithFileExplorer("/select, " + filePath);
         }
 
-        public static void OpenWithFileExplorer(string filePath)
+        public static void OpenWithFileExplorer(string arguments)
         {
-            Process.Start("explorer.exe", filePath);
+            new Executable("explorer.exe").Start(arguments);
         }
 
         /// <summary>
@@ -33,7 +48,7 @@ namespace GitUI
         {
             if (!string.IsNullOrWhiteSpace(url))
             {
-                Process.Start(url);
+                new Executable(url).Start(useShellExecute: true);
             }
         }
 

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -154,7 +154,7 @@ namespace GitUI.Script
             {
                 if (originalCommand.Equals("{openurl}", StringComparison.CurrentCultureIgnoreCase))
                 {
-                    Process.Start(argument);
+                    OsShellUtil.OpenUrlInDefaultBrowser(argument);
                 }
                 else
                 {

--- a/GitUI/UserControls/AvatarControl.cs
+++ b/GitUI/UserControls/AvatarControl.cs
@@ -179,14 +179,7 @@ namespace GitUI
 
         private void OnRegisterGravatarClick(object sender, EventArgs e)
         {
-            try
-            {
-                Process.Start("https://www.gravatar.com");
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(this, ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://www.gravatar.com");
         }
 
         private void OnDefaultImageDropDownOpening(object sender, EventArgs e)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Reactive.Concurrency;
@@ -2592,7 +2591,7 @@ namespace GitUI
 
             if (revision != null && !string.IsNullOrWhiteSpace(revision.BuildStatus?.Url))
             {
-                Process.Start(revision.BuildStatus.Url);
+                OsShellUtil.OpenUrlInDefaultBrowser(revision.BuildStatus.Url);
             }
         }
 
@@ -2602,7 +2601,7 @@ namespace GitUI
 
             if (revision != null && !string.IsNullOrWhiteSpace(revision.BuildStatus?.PullRequestUrl))
             {
-                Process.Start(revision.BuildStatus.PullRequestUrl);
+                OsShellUtil.OpenUrlInDefaultBrowser(revision.BuildStatus.PullRequestUrl);
             }
         }
 

--- a/Plugins/GitUIPluginInterfaces/IExecutable.cs
+++ b/Plugins/GitUIPluginInterfaces/IExecutable.cs
@@ -22,10 +22,16 @@ namespace GitUIPluginInterfaces
         /// <param name="redirectOutput">Whether the standard output stream of the process will be read from.</param>
         /// <param name="outputEncoding">The <see cref="Encoding"/> to use when interpreting standard output and standard
         /// error, or <c>null</c> if <paramref name="redirectOutput"/> is <c>false</c>.</param>
+        /// <param name="useShellExecute">The value for the flag <c>ProcessStartInfo.UseShellExecute</c>.</param>
         /// <returns>The started process.</returns>
         [NotNull]
         [MustUseReturnValue]
-        IProcess Start(ArgumentString arguments = default, bool createWindow = false, bool redirectInput = false, bool redirectOutput = false, [CanBeNull] Encoding outputEncoding = null);
+        IProcess Start(ArgumentString arguments = default,
+                       bool createWindow = false,
+                       bool redirectInput = false,
+                       bool redirectOutput = false,
+                       [CanBeNull] Encoding outputEncoding = null,
+                       bool useShellExecute = false);
 
         /// <summary>
         /// Launches a process for the executable and returns its output.

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -73,7 +73,7 @@ namespace CommonTestUtils
             }
         }
 
-        public IProcess Start(ArgumentString arguments, bool createWindow, bool redirectInput, bool redirectOutput, Encoding outputEncoding)
+        public IProcess Start(ArgumentString arguments, bool createWindow, bool redirectInput, bool redirectOutput, Encoding outputEncoding, bool useShellExecute = false)
         {
             if (_outputStackByArguments.TryRemove(arguments, out var queue) && queue.TryPop(out var item))
             {


### PR DESCRIPTION
Contributes to #7795, extracted from #8278

## Proposed changes

- Use class `Executable` for `OsShellUtil` implementation
- Use `OsShellUtil` functions instead of plain `Process.Start` where applicable

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build cca84cd8551e5be614bf215bd77d93664b69ece6
- Git 2.27.0.windows.1 (recommended: 2.28.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).