### PR TITLE
Verb "open" for ShellExecute

### DIFF
--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -93,6 +93,7 @@ namespace GitCommands
                     StartInfo =
                     {
                         UseShellExecute = useShellExecute,
+                        Verb = useShellExecute ? "open" : string.Empty,
                         ErrorDialog = false,
                         CreateNoWindow = !createWindow,
                         RedirectStandardInput = redirectInput,


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/pull/8721#discussion_r552306228

## Proposed changes

- Use verb "open" in case of UseShellExecute in preparation for .NET Core

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 20514e62f05b7b334fe2db2ee2720ca83297561c
- Git 2.27.0.windows.1 (recommended: 2.28.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).