### PR TITLE
Sidepanel submodule improvements

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2635,15 +2635,8 @@ namespace GitCommands
                     var localItem = item;
                     localItem.SetSubmoduleStatus(ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                     {
-                        var submoduleStatus = await SubmoduleHelpers.GetCurrentSubmoduleChangesAsync(this, localItem.Name, localItem.OldName, localItem.Staged == StagedStatus.Index)
-                        .ConfigureAwait(false);
-                        if (submoduleStatus is not null && submoduleStatus.Commit != submoduleStatus.OldCommit)
-                        {
-                            var submodule = submoduleStatus.GetSubmodule(this);
-                            submoduleStatus.CheckSubmoduleStatus(submodule);
-                        }
-
-                        return submoduleStatus;
+                        return await SubmoduleHelpers.GetCurrentSubmoduleChangesAsync(this, localItem.Name, localItem.OldName, localItem.Staged == StagedStatus.Index)
+                            .ConfigureAwait(false);
                     }));
                 }
             }
@@ -2658,17 +2651,7 @@ namespace GitCommands
                         async () =>
                         {
                             await TaskScheduler.Default.SwitchTo(alwaysYield: true);
-
-                            Patch? patch = GetSingleDiff(firstId, secondId, item.Name, item.OldName, "", SystemEncoding, true);
-                            string? text = patch is not null ? patch.Text : "";
-                            var submoduleStatus = SubmoduleHelpers.ParseSubmoduleStatus(text, this, item.Name);
-                            if (submoduleStatus is not null && submoduleStatus.Commit != submoduleStatus.OldCommit)
-                            {
-                                var submodule = submoduleStatus.GetSubmodule(this);
-                                submoduleStatus.CheckSubmoduleStatus(submodule);
-                            }
-
-                            return submoduleStatus;
+                            return SubmoduleHelpers.GetCurrentSubmoduleChangesAsync(this, item.Name, item.OldName, firstId, secondId);
                         }));
             }
         }

--- a/GitCommands/Submodules/DetailedSubmoduleInfo.cs
+++ b/GitCommands/Submodules/DetailedSubmoduleInfo.cs
@@ -5,7 +5,10 @@ namespace GitCommands.Submodules
     public class DetailedSubmoduleInfo
     {
         public bool IsDirty { get; set; }
-        public SubmoduleStatus? Status { get; set; }
-        public string? AddedAndRemovedText { get; set; }
+        public SubmoduleStatus? Status
+            => RawStatus?.Status ?? SubmoduleStatus.Unknown;
+        public string? AddedAndRemovedText
+            => RawStatus?.AddedAndRemovedString() ?? string.Empty;
+        public GitSubmoduleStatus? RawStatus { get; set; }
     }
 }

--- a/GitCommands/Submodules/SubmoduleInfoResult.cs
+++ b/GitCommands/Submodules/SubmoduleInfoResult.cs
@@ -26,5 +26,10 @@ namespace GitCommands.Submodules
 
         // Name of current module, if it is a submodule. If current module is TopProject, will be null.
         public string? CurrentSubmoduleName { get; internal set; }
+
+        /// <summary>
+        /// GitItemStatus for the current submodule
+        /// </summary>
+        public IReadOnlyList<GitItemStatus>? CurrentSubmoduleStatus { get; internal set; }
     }
 }

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -357,9 +357,8 @@ namespace GitCommands.Submodules
             {
                 _submoduleInfos[path].Detailed = new DetailedSubmoduleInfo
                 {
-                    Status = SubmoduleStatus.Unknown,
                     IsDirty = true,
-                    AddedAndRemovedText = ""
+                    RawStatus = null
                 };
             }
             else
@@ -434,9 +433,8 @@ namespace GitCommands.Submodules
                 null :
                 new DetailedSubmoduleInfo
                 {
-                    Status = submoduleStatus.Status,
                     IsDirty = submoduleStatus.IsDirty,
-                    AddedAndRemovedText = submoduleStatus.AddedAndRemovedString()
+                    RawStatus = submoduleStatus
                 };
 
             // Recursively update submodules

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -427,13 +427,9 @@ namespace GitCommands.Submodules
             cancelToken.ThrowIfCancellationRequested();
 
             var submoduleStatus = await SubmoduleHelpers.GetCurrentSubmoduleChangesAsync(superModule, submoduleName, noLocks: true)
-            .ConfigureAwait(false);
-            if (submoduleStatus is not null && submoduleStatus.Commit != submoduleStatus.OldCommit)
-            {
-                submoduleStatus.CheckSubmoduleStatus(submoduleStatus.GetSubmodule(superModule));
-            }
+                .ConfigureAwait(false);
 
-            // If no changes, set info.Detailed set to null
+            // If no changes, set info.Detailed to null
             info.Detailed = submoduleStatus is null ?
                 null :
                 new DetailedSubmoduleInfo

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -152,7 +152,15 @@ namespace GitCommands.Submodules
                 cancelToken.ThrowIfCancellationRequested();
             }
 
+            _submoduleInfoResult.CurrentSubmoduleStatus = gitStatus;
+
             TimeSpan remaining = _previousSubmoduleUpdateTime - DateTime.Now.AddSeconds(-MinRefreshInterval);
+            const int extraStatusRefreshLimit = 1;
+            if (!forceUpdate && remaining.TotalSeconds > extraStatusRefreshLimit)
+            {
+                OnStatusUpdated(_submoduleInfoResult, cancelToken);
+            }
+
             if (!forceUpdate && remaining > TimeSpan.Zero)
             {
                 await Task.Delay(remaining, cancelToken);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -231,9 +231,13 @@ namespace GitUI.BranchTreePanel
 
                 bool bareRepository = Module.IsBareRepository();
                 mnubtnOpenSubmodule.Visible = submoduleNode.CanOpen;
+                mnubtnOpenGESubmodule.Visible = submoduleNode.CanOpen;
                 mnubtnUpdateSubmodule.Visible = true;
                 mnubtnManageSubmodules.Visible = !bareRepository && submoduleNode.IsCurrent;
                 mnubtnSynchronizeSubmodules.Visible = !bareRepository && submoduleNode.IsCurrent;
+                mnubtnResetSubmodule.Visible = !bareRepository;
+                mnubtnStashSubmodule.Visible = !bareRepository;
+                mnubtnCommitSubmodule.Visible = !bareRepository;
             }
         }
 
@@ -317,7 +321,11 @@ namespace GitUI.BranchTreePanel
             RegisterClick<SubmoduleNode>(mnubtnManageSubmodules, _ => _submoduleTree.ManageSubmodules(this));
             RegisterClick<SubmoduleNode>(mnubtnSynchronizeSubmodules, _ => _submoduleTree.SynchronizeSubmodules(this));
             RegisterClick<SubmoduleNode>(mnubtnOpenSubmodule, node => _submoduleTree.OpenSubmodule(this, node));
+            RegisterClick<SubmoduleNode>(mnubtnOpenGESubmodule, node => _submoduleTree.OpenSubmoduleInGitExtensions(this, node));
             RegisterClick<SubmoduleNode>(mnubtnUpdateSubmodule, node => _submoduleTree.UpdateSubmodule(this, node));
+            RegisterClick<SubmoduleNode>(mnubtnResetSubmodule, node => _submoduleTree.ResetSubmodule(this, node));
+            RegisterClick<SubmoduleNode>(mnubtnStashSubmodule, node => _submoduleTree.StashSubmodule(this, node));
+            RegisterClick<SubmoduleNode>(mnubtnCommitSubmodule, node => _submoduleTree.CommitSubmodule(this, node));
             Node.RegisterContextMenu(typeof(SubmoduleNode), menuSubmodule);
         }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -105,8 +105,12 @@ namespace GitUI.BranchTreePanel
             this.menuSubmodule = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.mnubtnManageSubmodules = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnOpenSubmodule = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnOpenGESubmodule = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnUpdateSubmodule = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnSynchronizeSubmodules = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnResetSubmodule = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnStashSubmodule = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnCommitSubmodule = new System.Windows.Forms.ToolStripMenuItem();
             this.menuAllSubmodules = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.menuMain.SuspendLayout();
             this.menuBranch.SuspendLayout();
@@ -550,8 +554,12 @@ namespace GitUI.BranchTreePanel
             this.menuSubmodule.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mnubtnManageSubmodules,
             this.mnubtnOpenSubmodule,
+            this.mnubtnOpenGESubmodule,
             this.mnubtnUpdateSubmodule,
-            this.mnubtnSynchronizeSubmodules});
+            this.mnubtnSynchronizeSubmodules,
+            this.mnubtnResetSubmodule,
+            this.mnubtnStashSubmodule,
+            this.mnubtnCommitSubmodule});
             this.menuSubmodule.Name = "contextmenuSubmodule";
             this.menuSubmodule.Size = new System.Drawing.Size(139, 92);
             this.menuSubmodule.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
@@ -572,6 +580,14 @@ namespace GitUI.BranchTreePanel
             this.mnubtnOpenSubmodule.Text = "&Open";
             this.mnubtnOpenSubmodule.ToolTipText = "Open selected submodule";
             // 
+            // mnubtnOpenGESubmodule
+            // 
+            this.mnubtnOpenGESubmodule.Image = global::GitUI.Properties.Images.GitExtensionsLogo16;
+            this.mnubtnOpenGESubmodule.Name = "mnubtnOpenGESubmodule";
+            this.mnubtnOpenGESubmodule.Size = new System.Drawing.Size(138, 22);
+            this.mnubtnOpenGESubmodule.Text = "O&pen";
+            this.mnubtnOpenGESubmodule.ToolTipText = "Open selected submodule in a new instance";
+            // 
             // mnubtnUpdateSubmodule
             // 
             this.mnubtnUpdateSubmodule.Image = global::GitUI.Properties.Images.SubmodulesUpdate;
@@ -587,6 +603,30 @@ namespace GitUI.BranchTreePanel
             this.mnubtnSynchronizeSubmodules.Size = new System.Drawing.Size(138, 22);
             this.mnubtnSynchronizeSubmodules.Text = "Synchronize";
             this.mnubtnSynchronizeSubmodules.ToolTipText = "Synchronize selected submodule recursively";
+            // 
+            // mnubtnResetSubmodule
+            // 
+            this.mnubtnResetSubmodule.Image = global::GitUI.Properties.Images.ResetWorkingDirChanges;
+            this.mnubtnResetSubmodule.Name = "mnubtnResetSubmodule";
+            this.mnubtnResetSubmodule.Size = new System.Drawing.Size(138, 22);
+            this.mnubtnResetSubmodule.Text = "&Reset";
+            this.mnubtnResetSubmodule.ToolTipText = "Reset selected submodule";
+            // 
+            // mnubtnStashSubmodule
+            // 
+            this.mnubtnStashSubmodule.Image = global::GitUI.Properties.Images.Stash;
+            this.mnubtnStashSubmodule.Name = "mnubtnStashSubmodule";
+            this.mnubtnStashSubmodule.Size = new System.Drawing.Size(138, 22);
+            this.mnubtnStashSubmodule.Text = "&Stash";
+            this.mnubtnStashSubmodule.ToolTipText = "Stash changes in selected submodule";
+            // 
+            // mnubtnCommitSubmodule
+            // 
+            this.mnubtnCommitSubmodule.Image = global::GitUI.Properties.Images.RepoStateDirtySubmodules;
+            this.mnubtnCommitSubmodule.Name = "mnubtnCommitSubmodule";
+            this.mnubtnCommitSubmodule.Size = new System.Drawing.Size(138, 22);
+            this.mnubtnCommitSubmodule.Text = "&Commit";
+            this.mnubtnCommitSubmodule.ToolTipText = "Commit changes in selected submodule";
             // 
             // menuAllSubmodules
             // 
@@ -663,6 +703,10 @@ namespace GitUI.BranchTreePanel
         private ToolStripMenuItem mnubtnSynchronizeSubmodules;
         private ToolStripMenuItem mnubtnUpdateSubmodule;
         private ToolStripMenuItem mnubtnOpenSubmodule;
+        private ToolStripMenuItem mnubtnOpenGESubmodule;
+        private ToolStripMenuItem mnubtnResetSubmodule;
+        private ToolStripMenuItem mnubtnStashSubmodule;
+        private ToolStripMenuItem mnubtnCommitSubmodule;
         private ToolStripMenuItem runScriptToolStripMenuItem;
         private ToolStripMenuItem mnubtnMoveUp;
         private ToolStripMenuItem mnubtnMoveDown;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -11,6 +11,7 @@ using GitCommands;
 using GitCommands.Git;
 using GitCommands.Submodules;
 using GitUI.Properties;
+using GitUIPluginInterfaces;
 using Microsoft.VisualStudio.Threading;
 
 namespace GitUI.BranchTreePanel
@@ -91,6 +92,12 @@ namespace GitUI.BranchTreePanel
 
             public void Open()
             {
+                if (Info?.Detailed?.RawStatus != null)
+                {
+                    UICommands.BrowseSetWorkingDir(Info.Path, ObjectId.WorkTreeId, Info.Detailed.RawStatus.OldCommit);
+                    return;
+                }
+
                 UICommands.BrowseSetWorkingDir(Info.Path);
             }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -143,6 +143,12 @@ namespace GitUI.BranchTreePanel
                         moduleIsParent: false,
                         limitOutput: true);
                 }
+                else if (GitStatus is not null)
+                {
+                    var changeCount = new ArtificialCommitChangeCount();
+                    changeCount.Update(GitStatus);
+                    TreeViewNode.ToolTipText = changeCount.GetSummary();
+                }
                 else
                 {
                     TreeViewNode.ToolTipText = DisplayText();

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -140,7 +140,8 @@ namespace GitUI.BranchTreePanel
                     TreeViewNode.ToolTipText = LocalizationHelpers.ProcessSubmoduleStatus(
                         new GitModule(Info.Path),
                         Info.Detailed.RawStatus,
-                        moduleIsParent: false);
+                        moduleIsParent: false,
+                        limitOutput: true);
                 }
                 else
                 {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -134,6 +134,19 @@ namespace GitUI.BranchTreePanel
                     TreeViewNode.NodeFont = new Font(AppSettings.Font, FontStyle.Bold);
                 }
 
+                if (Info.Detailed?.RawStatus is not null)
+                {
+                    // Prefer submodule status, shows ahead/behind
+                    TreeViewNode.ToolTipText = LocalizationHelpers.ProcessSubmoduleStatus(
+                        new GitModule(Info.Path),
+                        Info.Detailed.RawStatus,
+                        moduleIsParent: false);
+                }
+                else
+                {
+                    TreeViewNode.ToolTipText = DisplayText();
+                }
+
                 TreeViewNode.ImageKey = GetSubmoduleItemImage(Info.Detailed);
                 TreeViewNode.SelectedImageKey = TreeViewNode.ImageKey;
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1939,8 +1939,10 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        public void SetWorkingDir(string path)
+        public void SetWorkingDir(string path, ObjectId selectedId = null, ObjectId firstId = null)
         {
+            RevisionGrid.SelectedId = selectedId;
+            RevisionGrid.FirstId = firstId;
             SetGitModule(this, new GitModuleEventArgs(new GitModule(path)));
         }
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1931,9 +1931,9 @@ namespace GitUI
             BrowseRepo?.GoToRef(refName, showNoRevisionMsg, toggleSelection);
         }
 
-        public void BrowseSetWorkingDir(string path)
+        public void BrowseSetWorkingDir(string path, ObjectId selectedId = null, ObjectId firstId = null)
         {
-            BrowseRepo?.SetWorkingDir(path);
+            BrowseRepo?.SetWorkingDir(path, selectedId, firstId);
         }
 
         public IGitRemoteCommand CreateRemoteCommand()

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8131,6 +8131,14 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <source>Collapse all nodes</source>
         <target />
       </trans-unit>
+      <trans-unit id="mnubtnCommitSubmodule.Text">
+        <source>&amp;Commit</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnCommitSubmodule.ToolTipText">
+        <source>Commit changes in selected submodule</source>
+        <target />
+      </trans-unit>
       <trans-unit id="mnubtnCreateBranch.Text">
         <source>Create Branch...</source>
         <target />
@@ -8245,6 +8253,14 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <source>Move node up</source>
         <target />
       </trans-unit>
+      <trans-unit id="mnubtnOpenGESubmodule.Text">
+        <source>O&amp;pen</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnOpenGESubmodule.ToolTipText">
+        <source>Open selected submodule in a new instance</source>
+        <target />
+      </trans-unit>
       <trans-unit id="mnubtnOpenSubmodule.Text">
         <source>&amp;Open</source>
         <target />
@@ -8263,6 +8279,22 @@ To show all branches, right click the revision grid, select 'view' and then the 
       </trans-unit>
       <trans-unit id="mnubtnRemoteBranchFetchAndCheckout.ToolTipText">
         <source>Checkout this branch</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnResetSubmodule.Text">
+        <source>&amp;Reset</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnResetSubmodule.ToolTipText">
+        <source>Reset selected submodule</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnStashSubmodule.Text">
+        <source>&amp;Stash</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnStashSubmodule.ToolTipText">
+        <source>Stash changes in selected submodule</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnSynchronizeSubmodules.Text">

--- a/GitUI/UserControls/RevisionGrid/ArtificialCommitChangeCount.cs
+++ b/GitUI/UserControls/RevisionGrid/ArtificialCommitChangeCount.cs
@@ -6,15 +6,38 @@ using GitCommands;
 
 namespace GitUI
 {
-    public class ChangeCount
+    public sealed class ArtificialCommitChangeCount
     {
-        // Count for artificial commits
+        /// <summary>
+        /// Number of changed files
+        /// </summary>
         public IReadOnlyList<GitItemStatus> Changed { get; set; }
+
+        /// <summary>
+        ///  Number of new files
+        /// </summary>
         public IReadOnlyList<GitItemStatus> New { get; set; }
+
+        /// <summary>
+        /// Number of deleted files
+        /// </summary>
         public IReadOnlyList<GitItemStatus> Deleted { get; set; }
+
+        /// <summary>
+        /// Number of submodules where the commit has changed
+        /// (regardless if they are dirty or not)
+        /// </summary>
         public IReadOnlyList<GitItemStatus> SubmodulesChanged { get; set; }
+
+        /// <summary>
+        /// Number of dirty submodules (with changes that are not committed)
+        /// (regardless if the commit is changed or not)
+        /// </summary>
         public IReadOnlyList<GitItemStatus> SubmodulesDirty { get; set; }
 
+        /// <summary>
+        /// Any change in any category
+        /// </summary>
         public bool HasChanges
             => (Changed?.Count ?? 0) > 0
                || (New?.Count ?? 0) > 0
@@ -22,7 +45,11 @@ namespace GitUI
                || (SubmodulesChanged?.Count ?? 0) > 0
                || (SubmodulesDirty?.Count ?? 0) > 0;
 
-        public void UpdateChangeCount(IReadOnlyList<GitItemStatus> items)
+        /// <summary>
+        /// Update the change count
+        /// </summary>
+        /// <param name="items">Git items</param>
+        public void Update(IReadOnlyList<GitItemStatus> items)
         {
             Changed = items.Where(item => !item.IsNew && !item.IsDeleted && !item.IsSubmodule).ToList();
             New = items.Where(item => item.IsNew && !item.IsSubmodule).ToList();
@@ -31,7 +58,11 @@ namespace GitUI
             SubmodulesDirty = items.Where(item => item.IsSubmodule && item.IsDirty).ToList();
         }
 
-        public StringBuilder GetSummary()
+        /// <summary>
+        /// Summary for the changes, limited if too big
+        /// </summary>
+        /// <returns>string with changes</returns>
+        public string GetSummary()
         {
             StringBuilder builder = new StringBuilder();
 
@@ -42,7 +73,7 @@ namespace GitUI
             Append(SubmodulesChanged, "changed submodule");
             Append(SubmodulesDirty, "dirty submodule");
 
-            return builder;
+            return builder.ToString();
 
             void Append(IReadOnlyList<GitItemStatus> items, string singular)
             {
@@ -56,16 +87,8 @@ namespace GitUI
                     builder.AppendLine();
                 }
 
-                builder.Append(items.Count).Append(' ');
-
-                if (items.Count == 1)
-                {
-                    builder.AppendLine(singular);
-                }
-                else
-                {
-                    builder.Append(singular).AppendLine("s");
-                }
+                builder.Append($"{items.Count} {singular}{(items.Count == 1 ? "" : "s")}")
+                    .AppendLine();
 
                 const int maxItems = 5;
 

--- a/GitUI/UserControls/RevisionGrid/ChangeCount.cs
+++ b/GitUI/UserControls/RevisionGrid/ChangeCount.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using GitCommands;
+
+namespace GitUI
+{
+    public class ChangeCount
+    {
+        // Count for artificial commits
+        public IReadOnlyList<GitItemStatus> Changed { get; set; }
+        public IReadOnlyList<GitItemStatus> New { get; set; }
+        public IReadOnlyList<GitItemStatus> Deleted { get; set; }
+        public IReadOnlyList<GitItemStatus> SubmodulesChanged { get; set; }
+        public IReadOnlyList<GitItemStatus> SubmodulesDirty { get; set; }
+
+        public bool HasChanges
+            => (Changed?.Count ?? 0) > 0
+               || (New?.Count ?? 0) > 0
+               || (Deleted?.Count ?? 0) > 0
+               || (SubmodulesChanged?.Count ?? 0) > 0
+               || (SubmodulesDirty?.Count ?? 0) > 0;
+
+        public void UpdateChangeCount(IReadOnlyList<GitItemStatus> items)
+        {
+            Changed = items.Where(item => !item.IsNew && !item.IsDeleted && !item.IsSubmodule).ToList();
+            New = items.Where(item => item.IsNew && !item.IsSubmodule).ToList();
+            Deleted = items.Where(item => item.IsDeleted && !item.IsSubmodule).ToList();
+            SubmodulesChanged = items.Where(item => item.IsSubmodule && item.IsChanged).ToList();
+            SubmodulesDirty = items.Where(item => item.IsSubmodule && item.IsDirty).ToList();
+        }
+
+        public StringBuilder GetSummary()
+        {
+            StringBuilder builder = new StringBuilder();
+
+            // TODO use translation strings here
+            Append(Changed, "changed file");
+            Append(Deleted, "deleted file");
+            Append(New, "new file");
+            Append(SubmodulesChanged, "changed submodule");
+            Append(SubmodulesDirty, "dirty submodule");
+
+            return builder;
+
+            void Append(IReadOnlyList<GitItemStatus> items, string singular)
+            {
+                if (items is null || items.Count == 0)
+                {
+                    return;
+                }
+
+                if (builder.Length != 0)
+                {
+                    builder.AppendLine();
+                }
+
+                builder.Append(items.Count).Append(' ');
+
+                if (items.Count == 1)
+                {
+                    builder.AppendLine(singular);
+                }
+                else
+                {
+                    builder.Append(singular).AppendLine("s");
+                }
+
+                const int maxItems = 5;
+
+                for (var i = 0; i < maxItems && i < items.Count; i++)
+                {
+                    builder.Append("- ").AppendLine(items[i].Name);
+                }
+
+                if (items.Count > maxItems)
+                {
+                    var unlistedCount = items.Count - maxItems;
+                    builder.Append("- (").Append(unlistedCount).Append(" more file");
+                    if (unlistedCount != 1)
+                    {
+                        builder.Append('s');
+                    }
+
+                    builder.Append(')').AppendLine();
+                }
+            }
+        }
+    }
+}

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -141,57 +141,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
                 if (stats is not null)
                 {
-                    void Append(IReadOnlyList<GitItemStatus> items, string singular)
-                    {
-                        if (items is null || items.Count == 0)
-                        {
-                            return;
-                        }
-
-                        if (_toolTipBuilder.Length != 0)
-                        {
-                            _toolTipBuilder.AppendLine();
-                        }
-
-                        _toolTipBuilder.Append(items.Count).Append(' ');
-
-                        if (items.Count == 1)
-                        {
-                            _toolTipBuilder.AppendLine(singular);
-                        }
-                        else
-                        {
-                            _toolTipBuilder.Append(singular).AppendLine("s");
-                        }
-
-                        const int maxItems = 5;
-
-                        for (var i = 0; i < maxItems && i < items.Count; i++)
-                        {
-                            _toolTipBuilder.Append("- ").AppendLine(items[i].Name);
-                        }
-
-                        if (items.Count > maxItems)
-                        {
-                            var unlistedCount = items.Count - maxItems;
-                            _toolTipBuilder.Append("- (").Append(unlistedCount).Append(" more file");
-                            if (unlistedCount != 1)
-                            {
-                                _toolTipBuilder.Append('s');
-                            }
-
-                            _toolTipBuilder.Append(')').AppendLine();
-                        }
-                    }
-
-                    // TODO use translation strings here
-                    Append(stats.Changed, "changed file");
-                    Append(stats.Deleted, "deleted file");
-                    Append(stats.New, "new file");
-                    Append(stats.SubmodulesChanged, "changed submodule");
-                    Append(stats.SubmodulesDirty, "dirty submodule");
-
-                    toolTip = _toolTipBuilder.ToString();
+                    toolTip = _toolTipBuilder.Append(stats.GetSummary()).ToString();
                     return true;
                 }
             }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Reactive.Concurrency;
@@ -1049,8 +1050,8 @@ namespace GitUI
 
                 void AddArtificialRevisions(ObjectId filteredCurrentCheckout)
                 {
-                    _indexChangeCount = new ChangeCount();
-                    _workTreeChangeCount = new ChangeCount();
+                    _indexChangeCount = new ArtificialCommitChangeCount();
+                    _workTreeChangeCount = new ArtificialCommitChangeCount();
 
                     var userName = Module.GetEffectiveSetting(SettingKeyString.UserName);
                     var userEmail = Module.GetEffectiveSetting(SettingKeyString.UserEmail);
@@ -2092,7 +2093,7 @@ namespace GitUI
         #region Artificial commit change counters
 
         [CanBeNull]
-        public ChangeCount GetChangeCount(ObjectId objectId)
+        public ArtificialCommitChangeCount GetChangeCount(ObjectId objectId)
         {
             return objectId == ObjectId.WorkTreeId
                 ? _workTreeChangeCount
@@ -2101,8 +2102,8 @@ namespace GitUI
                     : null;
         }
 
-        private ChangeCount _workTreeChangeCount = new ChangeCount();
-        private ChangeCount _indexChangeCount = new ChangeCount();
+        private ArtificialCommitChangeCount _workTreeChangeCount = new ArtificialCommitChangeCount();
+        private ArtificialCommitChangeCount _indexChangeCount = new ArtificialCommitChangeCount();
 
         public void UpdateArtificialCommitCount(
             [CanBeNull] IReadOnlyList<GitItemStatus> status,
@@ -2140,7 +2141,7 @@ namespace GitUI
                 var changeCount = GetChangeCount(objectId);
                 var staged = objectId == ObjectId.WorkTreeId ? StagedStatus.WorkTree : StagedStatus.Index;
                 var items = status.Where(item => item.Staged == staged).ToList();
-                changeCount.UpdateChangeCount(items);
+                changeCount.Update(items);
             }
         }
 

--- a/Plugins/GitUIPluginInterfaces/IBrowseRepo.cs
+++ b/Plugins/GitUIPluginInterfaces/IBrowseRepo.cs
@@ -3,6 +3,6 @@
     public interface IBrowseRepo
     {
         void GoToRef(string refName, bool showNoRevisionMsg, bool toggleSelection = false);
-        void SetWorkingDir(string path);
+        void SetWorkingDir(string path, ObjectId selectedId = null, ObjectId firstId = null);
     }
 }

--- a/ResourceManager/LocalizationHelpers.cs
+++ b/ResourceManager/LocalizationHelpers.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using GitCommands;
 using GitCommands.Git;
@@ -120,7 +122,7 @@ namespace ResourceManager
             return ProcessSubmoduleStatus(module, status);
         }
 
-        public static string ProcessSubmoduleStatus([NotNull] GitModule module, [NotNull] GitSubmoduleStatus status, bool moduleIsParent = true)
+        public static string ProcessSubmoduleStatus([NotNull] GitModule module, [NotNull] GitSubmoduleStatus status, bool moduleIsParent = true, bool limitOutput = false)
         {
             if (module is null)
             {
@@ -261,12 +263,23 @@ namespace ResourceManager
 
             if (status.Commit is not null && status.OldCommit is not null)
             {
+                const int maxLimitedLines = 5;
                 if (status.IsDirty)
                 {
                     string statusText = gitModule.GetStatusText(untracked: false);
                     if (!string.IsNullOrEmpty(statusText))
                     {
                         sb.AppendLine("\nStatus:");
+                        if (limitOutput)
+                        {
+                            var txt = statusText.SplitLines();
+                            if (txt.Length > maxLimitedLines)
+                            {
+                                statusText = new List<string>(txt).Take(maxLimitedLines).Join(Environment.NewLine) +
+                                    $"{Environment.NewLine} {txt.Length - maxLimitedLines} more changes";
+                            }
+                        }
+
                         sb.Append(statusText);
                     }
                 }
@@ -275,6 +288,16 @@ namespace ResourceManager
                 if (!string.IsNullOrEmpty(diffs))
                 {
                     sb.AppendLine("\nDifferences:");
+                    if (limitOutput)
+                    {
+                        var txt = diffs.SplitLines();
+                        if (txt.Length > maxLimitedLines)
+                        {
+                            diffs = new List<string>(txt).Take(maxLimitedLines).Join(Environment.NewLine) +
+                                $"{Environment.NewLine} {txt.Length - maxLimitedLines} more differences";
+                        }
+                    }
+
                     sb.Append(diffs);
                 }
             }

--- a/ResourceManager/LocalizationHelpers.cs
+++ b/ResourceManager/LocalizationHelpers.cs
@@ -111,8 +111,7 @@ namespace ResourceManager
 
         public static string ProcessSubmodulePatch(GitModule module, string fileName, Patch patch)
         {
-            string text = patch?.Text;
-            var status = SubmoduleHelpers.ParseSubmoduleStatus(text, module, fileName);
+            var status = SubmoduleHelpers.ParseSubmoduleStatus(patch?.Text, module, fileName);
             if (status is null)
             {
                 return "";

--- a/ResourceManager/LocalizationHelpers.cs
+++ b/ResourceManager/LocalizationHelpers.cs
@@ -120,7 +120,7 @@ namespace ResourceManager
             return ProcessSubmoduleStatus(module, status);
         }
 
-        public static string ProcessSubmoduleStatus([NotNull] GitModule module, [NotNull] GitSubmoduleStatus status)
+        public static string ProcessSubmoduleStatus([NotNull] GitModule module, [NotNull] GitSubmoduleStatus status, bool moduleIsParent = true)
         {
             if (module is null)
             {
@@ -132,7 +132,7 @@ namespace ResourceManager
                 throw new ArgumentNullException(nameof(status));
             }
 
-            GitModule gitModule = module.GetSubmodule(status.Name);
+            GitModule gitModule = moduleIsParent ? module.GetSubmodule(status.Name) : module;
             var sb = new StringBuilder();
             sb.AppendLine("Submodule " + status.Name + " Change");
 


### PR DESCRIPTION
Closes #8714 
Second part of #8703
Based on #8703 that is set to automerge so not to be merged yet. Fully reviewable.

Best reviewed commit by commit

## Proposed changes

* Open submodule in left panel selects first/selected commit as in #8703
* Add actions in Commit/RevDiff worktree to submodules: Reset/Stash/Commit
* Add Open in new instance for submodules
* Tooltip with details for changed submodules. This adds extra git-diff for modules that are dirty only (for others the command were executed anyway). The number of changes reported are limited to five changes (similar to how the RevGrid tooltip is limited already)
* For topmodule there is no submodule status message available, display the same tooltip as for the RevGrid WorkTree commit.
* A few minor refactorings were required

Review commit by commit.
Several of the changes will be squashed at approval.

## Screenshots

Using a testrepo with GE modules recursively added (originally to test performance)

Before | After
------ | -----
![image](https://user-images.githubusercontent.com/6248932/103831649-cbc84a80-507c-11eb-9d0b-e796b3581cc9.png) | ![image](https://user-images.githubusercontent.com/6248932/103831723-fa462580-507c-11eb-950d-8288ce6c6260.png)
![image](https://user-images.githubusercontent.com/6248932/103831813-337e9580-507d-11eb-8875-271155edf3ce.png) | ![image](https://user-images.githubusercontent.com/6248932/103831886-56a94500-507d-11eb-92ef-e30d4cf285a5.png)
(all submodules do not have tooltips) | ![image](https://user-images.githubusercontent.com/6248932/103831942-80626c00-507d-11eb-824a-8ace8ec3fe1d.png)
Commits selected when opening a submodule from left panel
![image](https://user-images.githubusercontent.com/6248932/103832583-e56a9180-507e-11eb-9864-3b488fe9500a.png) | ![image](https://user-images.githubusercontent.com/6248932/103832633-07641400-507f-11eb-8c7e-99040c803178.png)

## Test methodology <!-- How did you ensure quality? -->

Manual
Mostly UI changes, using already existing 

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
