### PR TITLE
ResolveConflicts: Incorrect evaluation of mergetool path

### DIFF
--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -259,7 +259,7 @@ namespace GitCommands
 
         [ContractAnnotation("=>false,fullPath:null")]
         [ContractAnnotation("=>true,fullPath:notnull")]
-        public static bool TryFindFullPath([NotNull] string fileName, out string fullPath)
+        public static bool TryFindFullPath([CanBeNull] string fileName, out string fullPath)
         {
             try
             {

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -662,17 +662,13 @@ namespace GitUI.CommandsDialogs
                     }
                 }
 
-                if (!string.IsNullOrEmpty(_mergetoolPath) && !PathUtil.TryFindFullPath(_mergetoolPath, out string fullPath))
+                if (!PathUtil.TryFindFullPath(_mergetoolPath, out string fullPath))
                 {
                     MessageBox.Show(this, _noMergeToolConfigured.Text, Strings.Warning, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     return false;
                 }
-                else
-                {
-                    fullPath = string.Empty;
-                }
 
-                _mergetoolPath = fullPath ?? string.Empty;
+                _mergetoolPath = fullPath;
             }
 
             return true;


### PR DESCRIPTION
Regression: https://github.com/gitextensions/gitextensions/pull/8690#issuecomment-756021266

## Proposed changes

Correct annotation for PathUtil.TryFindFullPath(), revert change to evaluate path in #8690

The mergetool path was always set to empty so the Git mergetool handling was used (not the GE special implementation to check results etc).

## Test methodology <!-- How did you ensure quality? -->

manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
