### PR TITLE
Fix borders when app run in >100% scaling factor

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -670,7 +670,7 @@ namespace GitUI.CommandsDialogs
             // MainSplitContainer.Panel1
             // 
             this.MainSplitContainer.Panel1.Controls.Add(this.repoObjectsTree);
-            this.MainSplitContainer.Panel1.Padding = new System.Windows.Forms.Padding(1);
+            this.MainSplitContainer.Panel1.Padding = new System.Windows.Forms.Padding(0);
             this.MainSplitContainer.Panel1MinSize = 192;
             // 
             // MainSplitContainer.Panel2
@@ -689,6 +689,7 @@ namespace GitUI.CommandsDialogs
             this.repoObjectsTree.Name = "repoObjectsTree";
             this.repoObjectsTree.Size = new System.Drawing.Size(267, 502);
             this.repoObjectsTree.TabIndex = 0;
+            this.repoObjectsTree.BorderStyle = BorderStyle.FixedSingle;
             // 
             // RightSplitContainer
             // 
@@ -719,8 +720,8 @@ namespace GitUI.CommandsDialogs
             this.RevisionsSplitContainer.Location = new System.Drawing.Point(0, 0);
             this.RevisionsSplitContainer.Margin = new System.Windows.Forms.Padding(0);
             this.RevisionsSplitContainer.Name = "RevisionsSplitContainer";
-            this.RevisionsSplitContainer.Panel1.Padding = new System.Windows.Forms.Padding(1);
-            this.RevisionsSplitContainer.Panel2.Padding = new System.Windows.Forms.Padding(1);
+            this.RevisionsSplitContainer.Panel1.Padding = new System.Windows.Forms.Padding(0);
+            this.RevisionsSplitContainer.Panel2.Padding = new System.Windows.Forms.Padding(0);
             // 
             // RevisionsSplitContainer.Panel1
             // 
@@ -747,6 +748,7 @@ namespace GitUI.CommandsDialogs
             this.RevisionGrid.Name = "RevisionGrid";
             this.RevisionGrid.Size = new System.Drawing.Size(350, 209);
             this.RevisionGrid.TabIndex = 0;
+            this.RevisionGrid.BorderStyle = BorderStyle.FixedSingle;
             // 
             // RevisionHeader
             // 
@@ -797,6 +799,7 @@ namespace GitUI.CommandsDialogs
             this.RevisionInfo.Size = new System.Drawing.Size(646, 264);
             this.RevisionInfo.TabIndex = 0;
             this.RevisionInfo.CommandClicked += new System.EventHandler<ResourceManager.CommandEventArgs>(this.RevisionInfo_CommandClicked);
+            this.RevisionInfo.BorderStyle = BorderStyle.FixedSingle;
             // 
             // TreeTabPage
             // 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -316,6 +316,10 @@ namespace GitUI.CommandsDialogs
 
             RevisionGrid.ToggledBetweenArtificialAndHeadCommits += (s, e) => FocusRevisionDiffFileStatusList();
 
+            repoObjectsTree.BorderColor = Color.LightGray.AdaptBackColor();
+            RevisionGrid.BorderColor = Color.LightGray.AdaptBackColor();
+            RevisionInfo.BorderColor = Color.LightGray.AdaptBackColor();
+
             return;
 
             void FocusRevisionDiffFileStatusList()
@@ -3108,6 +3112,7 @@ namespace GitUI.CommandsDialogs
                 RevisionInfo.Parent = CommitInfoTabPage;
                 RevisionGridContainer.Parent = RevisionsSplitContainer.Panel1;
                 RevisionsSplitContainer.Panel2Collapsed = true;
+                RevisionInfo.BorderStyle = BorderStyle.None;
             }
             else
             {
@@ -3135,14 +3140,11 @@ namespace GitUI.CommandsDialogs
                 }
 
                 RevisionsSplitContainer.Panel2Collapsed = false;
+                RevisionInfo.BorderStyle = BorderStyle.FixedSingle;
             }
 
             RevisionInfo.Parent.BackColor = RevisionInfo.BackColor;
             RevisionInfo.ResumeLayout(performLayout: true);
-
-            MainSplitContainer.Panel1.BackColor = Color.LightGray.AdaptBackColor();
-            RevisionsSplitContainer.Panel1.BackColor = Color.LightGray.AdaptBackColor();
-            RevisionsSplitContainer.Panel2.BackColor = Color.LightGray.AdaptBackColor();
 
             CommitInfoTabControl.ResumeLayout(performLayout: true);
             RevisionsSplitContainer.ResumeLayout(performLayout: true);

--- a/GitUI/Interops/Messages.cs
+++ b/GitUI/Interops/Messages.cs
@@ -46,6 +46,11 @@
         public const int WM_NULL = 0x0000;
 
         /// <summary>
+        /// The WM_SIZE message is sent to a window after its size has changed.
+        /// </summary>
+        public const int WM_SIZE = 0x0005;
+
+        /// <summary>
         /// The WM_PAINT message is sent when the system or another application makes a request to paint a portion of an application's window. The message is sent when the UpdateWindow or RedrawWindow function is called, or by the DispatchMessage function when the application obtains a WM_PAINT message by using the GetMessage or PeekMessage function.
         /// </summary>
         public const int WM_PAINT = 0x000F;
@@ -74,5 +79,10 @@
         /// The WM_NCMOUSELEAVE message is posted to a window when the cursor leaves the nonclient area of the window specified in a prior call to TrackMouseEvent.
         /// </summary>
         public const int WM_NCMOUSELEAVE = 0x02A2;
+
+        /// <summary>
+        /// Sent to a window whose size, position, or place in the Z order has changed as a result of a call to the SetWindowPos function or another window-management function.
+        /// </summary>
+        public const int WM_WINDOWPOSCHANGED = 0x0047;
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8698

## Proposed changes

- Use WndProc to draw borders

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

![image](https://user-images.githubusercontent.com/3169265/104087276-2de4a380-5267-11eb-83ab-3cffaa486cad.png)

## Test methodology <!-- How did you ensure quality? -->

- Visual
- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build a098b1ebba44b3325089e3e0639b4fc5e7e30957 (Dirty)
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4300.0
- DPI 144dpi (150% scaling)


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
