### PR TITLE
fix crash on refresh when submodule nodes selected

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -319,14 +319,9 @@ namespace GitUI.BranchTreePanel
                     var node = TreeViewNode.GetNodeFromPath(originalSelectedNodeFullNamePath);
                     if (node != null)
                     {
-                        if (((BaseBranchNode)node.Tag).Visible)
-                        {
-                            TreeViewNode.TreeView.SelectedNode = node;
-                        }
-                        else
-                        {
-                            TreeViewNode.TreeView.SelectedNode = null;
-                        }
+                        TreeViewNode.TreeView.SelectedNode = !(node.Tag is BaseBranchNode branchNode) || branchNode.Visible
+                            ? node
+                            : null;
                     }
                 }
 


### PR DESCRIPTION
Submodule nodes have a different base class, and if a submodule
tree node is selected while the tree is refreshed, the app would
crash with an `InvalidCastException`

```
System.InvalidCastException: Unable to cast object of type 'SubmoduleNode' to type 'BaseBranchNode'.
   at void GitUI.BranchTreePanel.RepoObjectsTree+Tree.FillTreeViewNode(string originalSelectedNodeFullNamePath, bool firstTime)
   at async Task GitUI.BranchTreePanel.RepoObjectsTree+Tree.ReloadNodesAsync(Func<CancellationToken, Task<Nodes>> loadNodesTask)
   at void GitUI.BranchTreePanel.RepoObjectsTree+SubmoduleTree+<>c__DisplayClass4_0+<<OnStatusUpdated>b__0>d.MoveNext()
   at void GitUI.ThreadHelper+<>c__DisplayClass13_0+<<FileAndForget>b__0>d.MoveNext()
```

Resolves #8658


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
