### PR TITLE
C#9 pattern enhancements

### DIFF
--- a/GitCommands/Git/GitItemStatus.cs
+++ b/GitCommands/Git/GitItemStatus.cs
@@ -219,7 +219,7 @@ namespace GitCommands
                 str.Append(" (Conflict)");
             }
 
-            if (Staged != StagedStatus.None && Staged != StagedStatus.Unset)
+            if (Staged is not (StagedStatus.None or StagedStatus.Unset))
             {
                 str.Append($" {Staged}");
             }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -736,7 +736,7 @@ namespace GitCommands
                 string hash = findSecondWhitespace >= 0 ? fileStage.Substring(0, findSecondWhitespace).Trim() : "";
                 fileStage = findSecondWhitespace >= 0 ? fileStage.Substring(findSecondWhitespace).Trim() : "";
 
-                if (fileStage.Length > 2 && int.TryParse(fileStage[0].ToString(), out var stage) && stage >= 1 && stage <= 3)
+                if (fileStage.Length > 2 && int.TryParse(fileStage[0].ToString(), out var stage) && stage is (>= 1 and <= 3))
                 {
                     var itemName = fileStage.Substring(2);
                     if (prevItemName != itemName && prevItemName is not null)

--- a/GitCommands/StringPool.cs
+++ b/GitCommands/StringPool.cs
@@ -178,44 +178,46 @@ namespace GitCommands
             }
 
             fixed (char* pc = comparand)
-            fixed (char* ps = source)
             {
-                // Create writeable pointers to equivalent positions in each string
-                var c = pc;
-                var s = &ps[index];
-
-                // Loop every 10 characters (20 bytes each loop)
-                while (len >= 10)
+                fixed (char* ps = source)
                 {
-                    // Compare an int by int, 5 times
-                    if (*(int*)c != *(int*)s ||
-                        *(int*)(c + 2) != *(int*)(s + 2) ||
-                        *(int*)(c + 4) != *(int*)(s + 4) ||
-                        *(int*)(c + 6) != *(int*)(s + 6) ||
-                        *(int*)(c + 8) != *(int*)(s + 8))
+                    // Create writeable pointers to equivalent positions in each string
+                    var c = pc;
+                    var s = &ps[index];
+
+                    // Loop every 10 characters (20 bytes each loop)
+                    while (len >= 10)
                     {
-                        return false;
+                        // Compare an int by int, 5 times
+                        if (*(int*)c != *(int*)s ||
+                            *(int*)(c + 2) != *(int*)(s + 2) ||
+                            *(int*)(c + 4) != *(int*)(s + 4) ||
+                            *(int*)(c + 6) != *(int*)(s + 6) ||
+                            *(int*)(c + 8) != *(int*)(s + 8))
+                        {
+                            return false;
+                        }
+
+                        // Update the pointers.
+                        // We delay this (rather than using ++ inline) to avoid
+                        // CPU stall on flushing writes.
+                        c += 10;
+                        s += 10;
+                        len -= 10;
                     }
 
-                    // Update the pointers.
-                    // We delay this (rather than using ++ inline) to avoid
-                    // CPU stall on flushing writes.
-                    c += 10;
-                    s += 10;
-                    len -= 10;
-                }
+                    // Loop every 2 characters (4 bytes)
+                    while (len > 1 && *(int*)c == *(int*)s)
+                    {
+                        // Compare int by int (4 bytes each loop)
+                        c += 2;
+                        s += 2;
+                        len -= 2;
+                    }
 
-                // Loop every 2 characters (4 bytes)
-                while (len > 1 && *(int*)c == *(int*)s)
-                {
-                    // Compare int by int (4 bytes each loop)
-                    c += 2;
-                    s += 2;
-                    len -= 2;
+                    // If last byte has odd index, check it too
+                    return len == 0 || (len == 1 && *c == *s);
                 }
-
-                // If last byte has odd index, check it too
-                return len == 0 || (len == 1 && *c == *s);
             }
         }
 

--- a/GitCommands/Utils/WeakRefCache.cs
+++ b/GitCommands/Utils/WeakRefCache.cs
@@ -39,7 +39,7 @@ namespace GitCommands.Utils
                 }
                 else
                 {
-                    if (!(cached is T))
+                    if (cached is not T)
                     {
                         throw new InvalidCastException("Incompatible class for object: " + objectUniqueKey + ". Expected: " + typeof(T).FullName + ", found: " + cached.GetType().FullName);
                     }

--- a/GitExtUtils/GitUI/Theming/Theme.cs
+++ b/GitExtUtils/GitUI/Theming/Theme.cs
@@ -129,7 +129,7 @@ namespace GitExtUtils.GitUI.Theming
         /// create <see cref="Color"/> instance.
         /// </summary>
         private static bool IsSystemColor(KnownColor name) =>
-            name < KnownColor.Transparent || name > KnownColor.YellowGreen;
+            name is (< KnownColor.Transparent or > KnownColor.YellowGreen);
 
         internal static class TestAccessor
         {

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -563,7 +563,7 @@ namespace GitUI.CommandsDialogs
                     return false;
                 }
 
-                if (onRejectedPullAction != AppSettings.PullAction.Merge && onRejectedPullAction != AppSettings.PullAction.Rebase)
+                if (onRejectedPullAction is not (AppSettings.PullAction.Merge or AppSettings.PullAction.Rebase))
                 {
                     form.AppendOutput(Environment.NewLine +
                         "Automatical pull can only be performed, when the default pull action is either set to Merge or Rebase." +

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -128,7 +128,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
                         ResizeColumnToFitContent(myReposLV.Columns[0]);
                     }
-                    catch (Exception ex) when (!(ex is OperationCanceledException))
+                    catch (Exception ex) when (ex is not OperationCanceledException)
                     {
                         await this.SwitchToMainThreadAsync();
 
@@ -174,7 +174,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
                         HandleSearchResult(repositories);
                     }
-                    catch (Exception ex) when (!(ex is OperationCanceledException))
+                    catch (Exception ex) when (ex is not OperationCanceledException)
                     {
                         await this.SwitchToMainThreadAsync();
 
@@ -208,7 +208,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
                         HandleSearchResult(repositories);
                     }
-                    catch (Exception ex) when (!(ex is OperationCanceledException))
+                    catch (Exception ex) when (ex is not OperationCanceledException)
                     {
                         await this.SwitchToMainThreadAsync();
 

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -125,7 +125,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                         SetPullRequestsData(pullRequests);
                         _selectHostedRepoCB.Enabled = true;
                     }
-                    catch (Exception ex) when (!(ex is OperationCanceledException))
+                    catch (Exception ex) when (ex is not OperationCanceledException)
                     {
                         MessageBox.Show(this, _strFailedToFetchPullData.Text + Environment.NewLine + ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
@@ -307,7 +307,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
                         LoadDiscussion(discussion);
                     }
-                    catch (Exception ex) when (!(ex is OperationCanceledException))
+                    catch (Exception ex) when (ex is not OperationCanceledException)
                     {
                         MessageBox.Show(this, _strCouldNotLoadDiscussion.Text + Environment.NewLine + ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         LoadDiscussion(null);
@@ -346,7 +346,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
                         SplitAndLoadDiff(content, _currentPullRequestInfo.BaseSha, _currentPullRequestInfo.HeadSha);
                     }
-                    catch (Exception ex) when (!(ex is OperationCanceledException))
+                    catch (Exception ex) when (ex is not OperationCanceledException)
                     {
                         MessageBox.Show(this, _strFailedToLoadDiffData.Text + Environment.NewLine + ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.cs
@@ -40,7 +40,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             diffFontDialog.Font = _diffFont;
             DialogResult result = diffFontDialog.ShowDialog(this);
 
-            if (result == DialogResult.OK || result == DialogResult.Yes)
+            if (result is (DialogResult.OK or DialogResult.Yes))
             {
                 SetCurrentDiffFont(diffFontDialog.Font);
             }
@@ -51,7 +51,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             applicationDialog.Font = _applicationFont;
             DialogResult result = applicationDialog.ShowDialog(this);
 
-            if (result == DialogResult.OK || result == DialogResult.Yes)
+            if (result is (DialogResult.OK or DialogResult.Yes))
             {
                 SetCurrentApplicationFont(applicationDialog.Font);
             }
@@ -62,7 +62,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             commitFontDialog.Font = _commitFont;
             DialogResult result = commitFontDialog.ShowDialog(this);
 
-            if (result == DialogResult.OK || result == DialogResult.Yes)
+            if (result is (DialogResult.OK or DialogResult.Yes))
             {
                 SetCurrentCommitFont(commitFontDialog.Font);
             }
@@ -73,7 +73,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             monospaceFontDialog.Font = _monospaceFont;
             DialogResult result = monospaceFontDialog.ShowDialog(this);
 
-            if (result == DialogResult.OK || result == DialogResult.Yes)
+            if (result is (DialogResult.OK or DialogResult.Yes))
             {
                 SetCurrentMonospaceFont(monospaceFontDialog.Font);
             }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -740,9 +740,7 @@ namespace GitUI.Editor
 
         private static bool IsDiffView(ViewMode viewMode)
         {
-            return viewMode == ViewMode.Diff
-                   || viewMode == ViewMode.FixedDiff
-                   || viewMode == ViewMode.RangeDiff;
+            return viewMode is (ViewMode.Diff or ViewMode.FixedDiff or ViewMode.RangeDiff);
         }
 
         private async Task ViewPrivateAsync(string fileName, string text, Action openWithDifftool, ViewMode viewMode = ViewMode.Diff)
@@ -835,29 +833,29 @@ namespace GitUI.Editor
             resetSelectedLinesToolStripMenuItem.Visible = SupportLinePatching;
 
             // RangeDiff patch is undefined, could be new/old commit or to parents
-            copyPatchToolStripMenuItem.Visible = viewMode == ViewMode.Diff || viewMode == ViewMode.FixedDiff;
-            copyNewVersionToolStripMenuItem.Visible = viewMode == ViewMode.Diff || viewMode == ViewMode.FixedDiff;
-            copyOldVersionToolStripMenuItem.Visible = viewMode == ViewMode.Diff || viewMode == ViewMode.FixedDiff;
+            copyPatchToolStripMenuItem.Visible = viewMode is (ViewMode.Diff or ViewMode.FixedDiff);
+            copyNewVersionToolStripMenuItem.Visible = viewMode is (ViewMode.Diff or ViewMode.FixedDiff);
+            copyOldVersionToolStripMenuItem.Visible = viewMode is (ViewMode.Diff or ViewMode.FixedDiff);
 
-            ignoreWhitespaceAtEolToolStripMenuItem.Visible = viewMode == ViewMode.Diff || viewMode == ViewMode.RangeDiff;
-            ignoreWhitespaceChangesToolStripMenuItem.Visible = viewMode == ViewMode.Diff || viewMode == ViewMode.RangeDiff;
-            ignoreAllWhitespaceChangesToolStripMenuItem.Visible = viewMode == ViewMode.Diff || viewMode == ViewMode.RangeDiff;
-            increaseNumberOfLinesToolStripMenuItem.Visible = viewMode == ViewMode.Diff || viewMode == ViewMode.RangeDiff;
-            decreaseNumberOfLinesToolStripMenuItem.Visible = viewMode == ViewMode.Diff || viewMode == ViewMode.RangeDiff;
-            showEntireFileToolStripMenuItem.Visible = viewMode == ViewMode.Diff || viewMode == ViewMode.RangeDiff;
+            ignoreWhitespaceAtEolToolStripMenuItem.Visible = viewMode is (ViewMode.Diff or ViewMode.RangeDiff);
+            ignoreWhitespaceChangesToolStripMenuItem.Visible = viewMode is (ViewMode.Diff or ViewMode.RangeDiff);
+            ignoreAllWhitespaceChangesToolStripMenuItem.Visible = viewMode is (ViewMode.Diff or ViewMode.RangeDiff);
+            increaseNumberOfLinesToolStripMenuItem.Visible = viewMode is (ViewMode.Diff or ViewMode.RangeDiff);
+            decreaseNumberOfLinesToolStripMenuItem.Visible = viewMode is (ViewMode.Diff or ViewMode.RangeDiff);
+            showEntireFileToolStripMenuItem.Visible = viewMode is (ViewMode.Diff or ViewMode.RangeDiff);
             toolStripSeparator2.Visible = IsDiffView(viewMode);
             treatAllFilesAsTextToolStripMenuItem.Visible = IsDiffView(viewMode);
 
             // toolbar
             nextChangeButton.Visible = IsDiffView(viewMode);
             previousChangeButton.Visible = IsDiffView(viewMode);
-            increaseNumberOfLines.Visible = viewMode == ViewMode.Diff || viewMode == ViewMode.RangeDiff;
-            decreaseNumberOfLines.Visible = viewMode == ViewMode.Diff || viewMode == ViewMode.RangeDiff;
-            showEntireFileButton.Visible = viewMode == ViewMode.Diff || viewMode == ViewMode.RangeDiff;
+            increaseNumberOfLines.Visible = viewMode is (ViewMode.Diff or ViewMode.RangeDiff);
+            decreaseNumberOfLines.Visible = viewMode is (ViewMode.Diff or ViewMode.RangeDiff);
+            showEntireFileButton.Visible = viewMode is (ViewMode.Diff or ViewMode.RangeDiff);
             showSyntaxHighlighting.Visible = IsDiffView(viewMode);
-            ignoreWhitespaceAtEol.Visible = viewMode == ViewMode.Diff || viewMode == ViewMode.RangeDiff;
-            ignoreWhiteSpaces.Visible = viewMode == ViewMode.Diff || viewMode == ViewMode.RangeDiff;
-            ignoreAllWhitespaces.Visible = viewMode == ViewMode.Diff || viewMode == ViewMode.RangeDiff;
+            ignoreWhitespaceAtEol.Visible = viewMode is (ViewMode.Diff or ViewMode.RangeDiff);
+            ignoreWhiteSpaces.Visible = viewMode is (ViewMode.Diff or ViewMode.RangeDiff);
+            ignoreAllWhitespaces.Visible = viewMode is (ViewMode.Diff or ViewMode.RangeDiff);
         }
 
         private void OnExtraDiffArgumentsChanged()

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1459,7 +1459,7 @@ namespace GitUI
                 return false;
             }
 
-            if ((command == BlameHistoryCommand || command == FileHistoryCommand) && args.Count <= 2)
+            if (command is (BlameHistoryCommand or FileHistoryCommand) && args.Count <= 2)
             {
                 MessageBox.Show("Cannot open blame / file history, there is no file selected.", "Blame / file history", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;

--- a/GitUI/Interops/UxTheme/SetWindowTheme.cs
+++ b/GitUI/Interops/UxTheme/SetWindowTheme.cs
@@ -10,9 +10,11 @@ namespace System
         public static unsafe int SetWindowTheme(IntPtr hWnd, string subAppName, string subIdList)
         {
             fixed (char* pszSubAppName = subAppName)
-            fixed (char* pszSubIdList = subIdList)
             {
-                return SetWindowTheme(hWnd, pszSubAppName, pszSubIdList);
+                fixed (char* pszSubIdList = subIdList)
+                {
+                    return SetWindowTheme(hWnd, pszSubAppName, pszSubIdList);
+                }
             }
         }
     }

--- a/GitUI/MouseWheelRedirector.cs
+++ b/GitUI/MouseWheelRedirector.cs
@@ -62,7 +62,7 @@ namespace GitUI
                 return false;
             }
 
-            while (control is not null && !(control is GitExtensionsControl))
+            while (control is not (null or GitExtensionsControl))
             {
                 bool nonScrollableRtbx = isNonScrollableRichTextBox(control);
 

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -37,7 +37,7 @@ namespace GitUI.Script
             {
                 return RunScriptInternal(owner, module, scriptKey, uiCommands, revisionGrid);
             }
-            catch (ExternalOperationException ex) when (!(ex is UserExternalOperationException))
+            catch (ExternalOperationException ex) when (ex is not UserExternalOperationException)
             {
                 ThreadHelper.AssertOnUIThread();
                 throw new UserExternalOperationException($"{Strings.ScriptErrorFailedToExecute}: '{scriptKey}'", ex);

--- a/GitUI/Script/SplitButton.cs
+++ b/GitUI/Script/SplitButton.cs
@@ -321,7 +321,7 @@ namespace GitUI.Script
                               bounds.Width - _dropDownRectangle.Width - internalBorder,
                               bounds.Height - (internalBorder * 2) + 2);
 
-            bool drawSplitLine = State == PushButtonState.Hot || State == PushButtonState.Pressed || !Application.RenderWithVisualStyles;
+            bool drawSplitLine = State is (PushButtonState.Hot or PushButtonState.Pressed) || !Application.RenderWithVisualStyles;
 
             if (RightToLeft == RightToLeft.Yes)
             {
@@ -619,7 +619,7 @@ namespace GitUI.Script
             {
                 offset = excess_width;
             }
-            else if (h_image == HorizontalAlignment.Center && (h_text == HorizontalAlignment.Left || h_text == HorizontalAlignment.Center))
+            else if (h_image == HorizontalAlignment.Center && h_text is (HorizontalAlignment.Left or HorizontalAlignment.Center))
             {
                 offset += excess_width / 3;
             }
@@ -682,7 +682,7 @@ namespace GitUI.Script
             {
                 offset = excess_height;
             }
-            else if (v_image == VerticalAlignment.Center && (v_text == VerticalAlignment.Top || v_text == VerticalAlignment.Center))
+            else if (v_image == VerticalAlignment.Center && v_text is (VerticalAlignment.Top or VerticalAlignment.Center))
             {
                 offset += excess_height / 3;
             }
@@ -758,28 +758,28 @@ namespace GitUI.Script
             int x = 0;
             int y = 0;
 
-            if (align == ContentAlignment.BottomLeft || align == ContentAlignment.MiddleLeft || align == ContentAlignment.TopLeft)
+            if (align is (ContentAlignment.BottomLeft or ContentAlignment.MiddleLeft or ContentAlignment.TopLeft))
             {
                 x = outer.X;
             }
-            else if (align == ContentAlignment.BottomCenter || align == ContentAlignment.MiddleCenter || align == ContentAlignment.TopCenter)
+            else if (align is (ContentAlignment.BottomCenter or ContentAlignment.MiddleCenter or ContentAlignment.TopCenter))
             {
                 x = Math.Max(outer.X + ((outer.Width - inner.Width) / 2), outer.Left);
             }
-            else if (align == ContentAlignment.BottomRight || align == ContentAlignment.MiddleRight || align == ContentAlignment.TopRight)
+            else if (align is (ContentAlignment.BottomRight or ContentAlignment.MiddleRight or ContentAlignment.TopRight))
             {
                 x = outer.Right - inner.Width;
             }
 
-            if (align == ContentAlignment.TopCenter || align == ContentAlignment.TopLeft || align == ContentAlignment.TopRight)
+            if (align is (ContentAlignment.TopCenter or ContentAlignment.TopLeft or ContentAlignment.TopRight))
             {
                 y = outer.Y;
             }
-            else if (align == ContentAlignment.MiddleCenter || align == ContentAlignment.MiddleLeft || align == ContentAlignment.MiddleRight)
+            else if (align is (ContentAlignment.MiddleCenter or ContentAlignment.MiddleLeft or ContentAlignment.MiddleRight))
             {
                 y = outer.Y + ((outer.Height - inner.Height) / 2);
             }
-            else if (align == ContentAlignment.BottomCenter || align == ContentAlignment.BottomRight || align == ContentAlignment.BottomLeft)
+            else if (align is (ContentAlignment.BottomCenter or ContentAlignment.BottomRight or ContentAlignment.BottomLeft))
             {
                 y = outer.Bottom - inner.Height;
             }

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -898,7 +898,7 @@ namespace GitUI.SpellChecker
         {
             if (AutoComplete.Visible)
             {
-                if (keyData == Keys.Tab || keyData == Keys.Enter)
+                if (keyData is (Keys.Tab or Keys.Enter))
                 {
                     AcceptAutoComplete();
                     return true;

--- a/GitUI/UserControls/InteractiveGitActionControl.cs
+++ b/GitUI/UserControls/InteractiveGitActionControl.cs
@@ -236,7 +236,7 @@ namespace GitUI.UserControls
             switch (_action)
             {
                 case GitAction.Bisect:
-                    if (!(Form is FormBrowse))
+                    if (Form is not FormBrowse)
                     {
                         return;
                     }

--- a/GitUI/UserControls/NativeTreeViewDoubleClickDecorator.cs
+++ b/GitUI/UserControls/NativeTreeViewDoubleClickDecorator.cs
@@ -81,7 +81,7 @@ namespace GitUI.UserControls
         private bool IsDoubleClickStateSet()
         {
             int delta = (int)DateTime.Now.Subtract(_lastMouseDown).TotalMilliseconds;
-            return delta >= 0 && delta < 200;
+            return delta is (>= 0 and < 200);
         }
 
         private void ResetDoubleClickState()

--- a/GitUI/UserControls/NativeTreeViewExplorerNavigationDecorator.cs
+++ b/GitUI/UserControls/NativeTreeViewExplorerNavigationDecorator.cs
@@ -64,7 +64,7 @@ namespace GitUI.UserControls
         {
             // If arrow key was used to navigate to this node, don't send OnSelected
             int delta = (int)_getCurrentTime().Subtract(_lastKeyNavigateTime).TotalMilliseconds;
-            if (delta >= 0 && delta < 500)
+            if (delta is (>= 0 and < 500))
             {
                 return;
             }

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -260,7 +260,7 @@ namespace AppVeyorIntegration
                     var version = b["version"].ToObject<string>();
                     var status = ParseBuildStatus(b["status"].ToObject<string>());
                     long? duration = null;
-                    if (status == BuildInfo.BuildStatus.Success || status == BuildInfo.BuildStatus.Failure)
+                    if (status is (BuildInfo.BuildStatus.Success or BuildInfo.BuildStatus.Failure))
                     {
                         duration = GetBuildDuration(b);
                     }

--- a/Plugins/Statistics/GitStatistics/PieChart/EdgeColor.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/EdgeColor.cs
@@ -16,7 +16,7 @@ namespace GitStatistics.PieChart
         public static Color GetRenderingColor(EdgeColorType edgeColorType, Color color)
         {
             Debug.Assert(color != Color.Empty, "color != Color.Empty");
-            if (edgeColorType == EdgeColorType.Contrast || edgeColorType == EdgeColorType.EnhancedContrast)
+            if (edgeColorType is (EdgeColorType.Contrast or EdgeColorType.EnhancedContrast))
             {
                 edgeColorType = GetContrastColorType(color, edgeColorType);
             }
@@ -51,7 +51,7 @@ namespace GitStatistics.PieChart
 
         private static EdgeColorType GetContrastColorType(Color color, EdgeColorType colorType)
         {
-            Debug.Assert(colorType == EdgeColorType.Contrast || colorType == EdgeColorType.EnhancedContrast, "colorType == EdgeColorType.Contrast || colorType == EdgeColorType.EnhancedContrast");
+            Debug.Assert(colorType is (EdgeColorType.Contrast or EdgeColorType.EnhancedContrast), "colorType is(EdgeColorType.Contrast or EdgeColorType.EnhancedContrast)");
             if (color.GetBrightness() > BrightnessThreshold)
             {
                 return colorType ==

--- a/Plugins/Statistics/GitStatistics/PieChart/PieChart3D.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/PieChart3D.cs
@@ -851,7 +851,7 @@ namespace GitStatistics.PieChart
         /// </returns>
         protected SizeF GetSliceDisplacement(float angle, float displacementFactor)
         {
-            Debug.Assert(displacementFactor > 0F && displacementFactor <= 1F, "displacementFactor > 0F && displacementFactor <= 1F");
+            Debug.Assert(IsDisplacementValid(displacementFactor), "displacementFactor is (>= 0F and <= 1F)");
             if (displacementFactor == 0F)
             {
                 return SizeF.Empty;
@@ -995,7 +995,7 @@ namespace GitStatistics.PieChart
         /// </returns>
         private static bool IsDisplacementValid(float value)
         {
-            return value >= 0F && value <= 1F;
+            return value is (>= 0F and <= 1F);
         }
     }
 }

--- a/Plugins/Statistics/GitStatistics/PieChart/PieSlice.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/PieSlice.cs
@@ -953,28 +953,17 @@ namespace GitStatistics.PieChart
         /// </summary>
         private void InitializeSides()
         {
-            if (StartAngle > 90 && StartAngle < 270)
-            {
-                StartSide =
-                    new Quadrilateral(
+            StartSide = StartAngle is (> 90 and < 270)
+                ? new Quadrilateral(
                         Center, PointStart, PointStartBelow, CenterBelow,
-                        SweepAngle != 180);
-            }
-            else
-            {
-                StartSide = Quadrilateral.Empty;
-            }
+                        SweepAngle != 180)
+                : Quadrilateral.Empty;
 
-            if (EndAngle > 270 || EndAngle < 90)
-            {
-                EndSide = new Quadrilateral(
+            EndSide = EndAngle is (> 270 or < 90)
+                ? new Quadrilateral(
                     Center, PointEnd, PointEndBelow, CenterBelow,
-                    SweepAngle != 180);
-            }
-            else
-            {
-                EndSide = Quadrilateral.Empty;
-            }
+                    SweepAngle != 180)
+                : Quadrilateral.Empty;
         }
 
         /// <summary>

--- a/ResourceManager/GitExtensionsControl.cs
+++ b/ResourceManager/GitExtensionsControl.cs
@@ -123,7 +123,10 @@ namespace ResourceManager
             keys &= ~Keys.Shift; // ignore the SHIFT key as modifier
             switch (keys)
             {
-                case Keys key when (key >= Keys.A && key <= Keys.Z) || (key >= Keys.D0 && key <= Keys.D9) || (key >= Keys.Oem1 && key <= Keys.Oem102):
+                case Keys key when key is
+                    (>= Keys.A and <= Keys.Z)
+                    or (>= Keys.D0 and <= Keys.D9)
+                    or (>= Keys.Oem1 and <= Keys.Oem102):
                 case Keys.Space:
                 case Keys.Back:
                 case Keys.Delete:

--- a/Solution.Versions.props
+++ b/Solution.Versions.props
@@ -12,7 +12,7 @@
     <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>
     <RestSharpVersion>106.11.4</RestSharpVersion>
     <SmartFormatNETVersion>2.0.0</SmartFormatNETVersion>
-    <StyleCopAnalyzersVersion>1.2.0-beta.113</StyleCopAnalyzersVersion>
+    <StyleCopAnalyzersVersion>1.2.0-beta.321</StyleCopAnalyzersVersion>
     <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
     <SystemIOAbstractionsVersion>2.0.0.144</SystemIOAbstractionsVersion>
     <SystemIOAbstractionsTestingHelpersVersion>2.0.0.143</SystemIOAbstractionsTestingHelpersVersion>

--- a/UnitTests/GitCommands.Tests/Git/GitBranchNameNormaliserTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitBranchNameNormaliserTest.cs
@@ -126,11 +126,18 @@ namespace GitCommandsTests.Git
             _gitBranchNameNormaliser.Rule08(input, _gitBranchNameOptions).Should().Be(expected);
         }
 
-        // Branch name cannot contain a '\'.
-        [TestCase(@"test\foo\\bar\", "test_foo_bar_")]
+        // Branch name cannot be the single character '@'.
+        [TestCase(@"@", "_")]
         public void Normalise_rule09(string input, string expected)
         {
             _gitBranchNameNormaliser.Rule09(input, _gitBranchNameOptions).Should().Be(expected);
+        }
+
+        // Branch name cannot contain a '\'.
+        [TestCase(@"test\foo\\bar\", "test_foo_bar_")]
+        public void Normalise_rule10(string input, string expected)
+        {
+            _gitBranchNameNormaliser.Rule10(input, _gitBranchNameOptions).Should().Be(expected);
         }
     }
 }


### PR DESCRIPTION
Fixes #8728
Separated from #8734 (based on this)

## Proposed changes

Enable C#9 'syntactic sugar' for pattern matching.
Mostly changed with intellicode suggestions and a few manual changes.

Separated from #8734 to merge that quickly and discuss the changes here.
I would like to apply the changes in FileViewer.cs at least.
Maybe StyleCop changes are required toadd parenthesis to improve readability to merge this.

## Test methodology 

manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
