### PR TITLE
Use Executable for launching new GE instances

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowseController.cs
+++ b/GitUI/CommandsDialogs/FormBrowseController.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
@@ -107,17 +106,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var process = new Process
-            {
-                StartInfo =
-                {
-                    FileName = AppSettings.GetGitExtensionsFullPath(),
-                    Arguments = "browse",
-                    WorkingDirectory = repoPath,
-                    UseShellExecute = false
-                }
-            };
-            process.Start();
+            GitUICommands.LaunchBrowse(repoPath);
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormMergeSubmodule.cs
+++ b/GitUI/CommandsDialogs/FormMergeSubmodule.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Windows.Forms;
+using GitCommands;
 using GitExtUtils;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
@@ -72,17 +72,7 @@ namespace GitUI.CommandsDialogs
 
         private void btOpenSubmodule_Click(object sender, EventArgs e)
         {
-            var process = new Process
-            {
-                StartInfo =
-                {
-                    FileName = Application.ExecutablePath,
-                    Arguments = "browse",
-                    WorkingDirectory = Module.GetSubmoduleFullPath(_filename)
-                }
-            };
-
-            process.Start();
+            GitUICommands.LaunchBrowse(workingDir: Module.GetSubmoduleFullPath(_filename));
         }
 
         private void btCheckoutBranch_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -335,21 +334,7 @@ See the changes in the commit form.");
 
         private void SpawnCommitBrowser(GitItem item)
         {
-            var process = new Process
-            {
-                StartInfo =
-                {
-                    FileName = Application.ExecutablePath,
-                    Arguments = "browse",
-                    WorkingDirectory = _fullPathResolver.Resolve(item.FileName.EnsureTrailingPathSeparator())
-                }
-            };
-            if (item.ObjectId is not null)
-            {
-                process.StartInfo.Arguments += " -commit=" + item.Guid;
-            }
-
-            process.Start();
+            GitUICommands.LaunchBrowse(workingDir: _fullPathResolver.Resolve(item.FileName.EnsureTrailingPathSeparator()), selectedId: item.ObjectId);
         }
 
         private void tvGitTree_AfterSelect(object sender, TreeViewEventArgs e)

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -803,24 +803,12 @@ namespace GitUI
             var submoduleName = SelectedItem.Item.Name;
 
             var status = await SelectedItem.Item.GetSubmoduleStatusAsync().ConfigureAwait(false);
-            var selected = SelectedItem.SecondRevision.ObjectId == ObjectId.WorkTreeId
-                ? SelectedItem.SecondRevision.ObjectId.ToString()
-                : status?.Commit.ToString() ?? string.Empty;
-            var first = string.IsNullOrWhiteSpace(status?.OldCommit?.ToString())
-                ? string.Empty
-                : $",{status.OldCommit}";
+            ObjectId selectedId = SelectedItem.SecondRevision?.ObjectId == ObjectId.WorkTreeId
+                ? ObjectId.WorkTreeId
+                : status?.Commit;
+            ObjectId firstId = status?.OldCommit;
 
-            var process = new Process
-            {
-                StartInfo =
-                {
-                    FileName = Application.ExecutablePath,
-                    Arguments = $"browse -commit={selected}{first}",
-                    WorkingDirectory = _fullPathResolver.Resolve(submoduleName.EnsureTrailingPathSeparator())
-                }
-            };
-
-            process.Start();
+            GitUICommands.LaunchBrowse(workingDir: _fullPathResolver.Resolve(submoduleName.EnsureTrailingPathSeparator()), selectedId, firstId);
         }
 
         private void SelectItems(Func<ListViewItem, bool> predicate)

--- a/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using ApprovalTests.Utilities;
 using CommonTestUtils;
 using FluentAssertions;
 using GitCommands;


### PR DESCRIPTION
Contributes to #7795
Fixes https://github.com/gitextensions/gitextensions/pull/8726#discussion_r554511688

## Proposed changes

- Factor out `GitUICommands.Spawn` and `GitUICommands.SpawnBrowse` using `Executable` in order to throw `ExternalOperationException` on failure.

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build a5acbea9e7a67ce50156e1e4ff38f6b5d002e6e8
- Git 2.27.0.windows.1 (recommended: 2.28.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).