### PR TITLE
Set one style (icon height and size) for Left Pane tree row and Grid row height

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -133,6 +133,7 @@ namespace GitUI.BranchTreePanel
             this.treeMain.ShowNodeToolTips = true;
             this.treeMain.Size = new System.Drawing.Size(300, 324);
             this.treeMain.TabIndex = 3;
+            this.treeMain.ShowLines = false;
             // 
             // menuMain
             // 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -71,6 +71,7 @@ namespace GitUI.BranchTreePanel
             mnuBtnPruneAllRemotes.AdaptImageLightness();
             mnubtnFetchCreateBranch.AdaptImageLightness();
             mnubtnPullFromRemoteBranch.AdaptImageLightness();
+            treeMain.ItemHeight = DpiUtil.Scale(24);
             InitializeComplete();
 
             RegisterContextActions();

--- a/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
@@ -46,7 +46,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
             Column.Width = e.CellBounds.Height;
 
-            var padding = DpiUtil.Scale(2);
+            var padding = DpiUtil.Scale(4);
             var imageSize = e.CellBounds.Height - padding - padding;
 
             Image image;
@@ -86,17 +86,10 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             e.Graphics.DrawImage(image, rect);
             e.Graphics.EndContainer(container);
 
-            e.Graphics.FillRectangle(style.BackBrush, rect.Left, rect.Top, 2, 1);
-            e.Graphics.FillRectangle(style.BackBrush, rect.Left, rect.Top, 1, 2);
-
-            e.Graphics.FillRectangle(style.BackBrush, rect.Right - 2, rect.Top, 2, 1);
-            e.Graphics.FillRectangle(style.BackBrush, rect.Right - 1, rect.Top, 1, 2);
-
-            e.Graphics.FillRectangle(style.BackBrush, rect.Left, rect.Bottom - 1, 2, 1);
-            e.Graphics.FillRectangle(style.BackBrush, rect.Left, rect.Bottom - 2, 1, 2);
-
-            e.Graphics.FillRectangle(style.BackBrush, rect.Right - 2, rect.Bottom - 1, 2, 1);
-            e.Graphics.FillRectangle(style.BackBrush, rect.Right - 1, rect.Bottom - 2, 1, 2);
+            e.Graphics.FillRectangle(style.BackBrush, rect.Left, rect.Top, 1, 1);
+            e.Graphics.FillRectangle(style.BackBrush, rect.Right - 1, rect.Top, 1, 1);
+            e.Graphics.FillRectangle(style.BackBrush, rect.Left, rect.Bottom - 1, 1, 1);
+            e.Graphics.FillRectangle(style.BackBrush, rect.Right - 1, rect.Bottom - 1, 1, 1);
         }
 
         public override bool TryGetToolTip(DataGridViewCellMouseEventArgs e, GitRevision revision, out string toolTip)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -181,6 +181,7 @@ namespace GitUI
             InitializeComponent();
             openPullRequestPageStripMenuItem.AdaptImageLightness();
             renameBranchToolStripMenuItem.AdaptImageLightness();
+            _gridView.RowTemplate.Height = DpiUtil.Scale(24);
             InitializeComplete();
 
             _loadingControlAsync = new Label


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Row height 24px: 16px icon + 2 * 4px paddings

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/3169265/104124372-403f0a00-5359-11eb-8622-9bbb6958a20a.png)

### After

![image](https://user-images.githubusercontent.com/3169265/104124378-46cd8180-5359-11eb-8d7d-df016eb54f97.png)

## Test methodology <!-- How did you ensure quality? -->

- Manually
- Visually

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build e361fdeae9305b54fe1458345c49b339d9629586
- Git 2.28.0.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
