### PR TITLE
fix: Select diff when there are staged and unstaged files

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1178,7 +1178,7 @@ namespace GitUI.CommandsDialogs
             {
                 var fc = this.FindFocusedControl();
 
-                if (fc == Ok)
+                if (fc is null || fc == Ok)
                 {
                     if (Unstaged.GitItemStatuses.Any())
                     {


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->


If there are both stages and unstaged files the commit dialog fails to select the first unstaged file, thus showing no diff. If there are only unstaged or staged files everything works as expected.
When the form opens it expects "Commit" button to have focus (i.e. be an active control), however it is not happening, and the active control remains null.

This appears as a regression form 3.4.3, but I was unable to see any changes that could lead to this bug. I haven't bisected due to limited available time.

## Proposed changes

Treat "no active control" the same way as "active control == Commit" to force the selection.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
![image](https://user-images.githubusercontent.com/4403806/104415951-0a06c200-55c7-11eb-87d6-fcf6d3ecb6dc.png)
![image](https://user-images.githubusercontent.com/4403806/104415961-0d9a4900-55c7-11eb-95b9-96196b1c46f5.png)


### After

<!-- TODO -->
![image](https://user-images.githubusercontent.com/4403806/104416131-5d791000-55c7-11eb-9286-fcc6c4fa6b73.png)


## Test methodology <!-- How did you ensure quality? -->

- manual

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
