### PR TITLE
Show both bisect and git operation notifications

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -71,7 +71,8 @@ namespace GitUI.CommandsDialogs
             this.RevisionsSplitContainer = new System.Windows.Forms.SplitContainer();
             this.RevisionGridContainer = new System.Windows.Forms.Panel();
             this.RevisionGrid = new GitUI.RevisionGridControl();
-            this.RevisionHeader = new GitUI.UserControls.InteractiveGitActionControl();
+            this.notificationBarBisectInProgress = new GitUI.UserControls.InteractiveGitActionControl();
+            this.notificationBarGitActionInProgress = new GitUI.UserControls.InteractiveGitActionControl();
             this.CommitInfoTabControl = new GitUI.CommandsDialogs.FullBleedTabControl();
             this.CommitInfoTabPage = new System.Windows.Forms.TabPage();
             this.RevisionInfo = new GitUI.CommitInfo.CommitInfo();
@@ -733,7 +734,8 @@ namespace GitUI.CommandsDialogs
             // RevisionGridContainer
             // 
             this.RevisionGridContainer.Controls.Add(this.RevisionGrid);
-            this.RevisionGridContainer.Controls.Add(this.RevisionHeader);
+            this.RevisionGridContainer.Controls.Add(this.notificationBarBisectInProgress);
+            this.RevisionGridContainer.Controls.Add(this.notificationBarGitActionInProgress);
             this.RevisionGridContainer.Dock = System.Windows.Forms.DockStyle.Fill;
             this.RevisionGridContainer.Location = new System.Drawing.Point(0, 0);
             this.RevisionGridContainer.Name = "RevisionGridContainer";
@@ -746,17 +748,27 @@ namespace GitUI.CommandsDialogs
             this.RevisionGrid.Location = new System.Drawing.Point(0, 0);
             this.RevisionGrid.Name = "RevisionGrid";
             this.RevisionGrid.Size = new System.Drawing.Size(350, 209);
-            this.RevisionGrid.TabIndex = 0;
+            this.RevisionGrid.TabIndex = 2;
             // 
-            // RevisionHeader
+            // notificationBarBisectInProgress
             // 
-            this.RevisionHeader.Dock = System.Windows.Forms.DockStyle.Top;
-            this.RevisionHeader.Location = new System.Drawing.Point(0, 0);
-            this.RevisionHeader.MinimumSize = new System.Drawing.Size(0, 33);
-            this.RevisionHeader.Name = "RevisionHeader";
-            this.RevisionHeader.Size = new System.Drawing.Size(561, 33);
-            this.RevisionHeader.TabIndex = 1;
-            this.RevisionHeader.Visible = false;
+            this.notificationBarBisectInProgress.Dock = System.Windows.Forms.DockStyle.Top;
+            this.notificationBarBisectInProgress.Location = new System.Drawing.Point(0, 33);
+            this.notificationBarBisectInProgress.MinimumSize = new System.Drawing.Size(0, 33);
+            this.notificationBarBisectInProgress.Name = "notificationBarBisectInProgress";
+            this.notificationBarBisectInProgress.Size = new System.Drawing.Size(561, 33);
+            this.notificationBarBisectInProgress.TabIndex = 1;
+            this.notificationBarBisectInProgress.Visible = false;
+            // 
+            // notificationBarGitActionInProgress
+            // 
+            this.notificationBarGitActionInProgress.Dock = System.Windows.Forms.DockStyle.Top;
+            this.notificationBarGitActionInProgress.Location = new System.Drawing.Point(0, 0);
+            this.notificationBarGitActionInProgress.MinimumSize = new System.Drawing.Size(0, 33);
+            this.notificationBarGitActionInProgress.Name = "notificationBarGitActionInProgress";
+            this.notificationBarGitActionInProgress.Size = new System.Drawing.Size(561, 33);
+            this.notificationBarGitActionInProgress.TabIndex = 0;
+            this.notificationBarGitActionInProgress.Visible = false;
             // 
             // CommitInfoTabControl
             // 
@@ -1980,6 +1992,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem commitInfoRightwardMenuItem;
         private ToolStripMenuItem tsmiTelemetryEnabled;
         private Panel RevisionGridContainer;
-        private UserControls.InteractiveGitActionControl RevisionHeader;
+        private UserControls.InteractiveGitActionControl notificationBarBisectInProgress;
+        private UserControls.InteractiveGitActionControl notificationBarGitActionInProgress;
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1173,8 +1173,11 @@ namespace GitUI.CommandsDialogs
 
         private void OnActivate()
         {
-            // check if we are in the middle of an action (merge/rebase/bisect)
-            RevisionHeader.RefreshGitAction();
+            // check if we are in the middle of bisect
+            notificationBarBisectInProgress.RefreshBisect();
+
+            // check if we are in the middle of an action (merge/rebase/etc.)
+            notificationBarGitActionInProgress.RefreshGitAction();
         }
 
         private void UpdateStashCount()

--- a/GitUI/UserControls/InteractiveGitActionControl.cs
+++ b/GitUI/UserControls/InteractiveGitActionControl.cs
@@ -42,10 +42,11 @@ namespace GitUI.UserControls
             InitializeComplete();
         }
 
-        public void RefreshGitAction()
+        // It is possible for a repo to be in a middle of a bisect operation and
+        // be in a conflicted state. Hence detect bisect separately from the rest
+        // of git actions
+        public void RefreshBisect()
         {
-            // get the current state of the repo
-
             if (!Module.IsValidGitWorkingDir())
             {
                 return;
@@ -54,6 +55,18 @@ namespace GitUI.UserControls
             if (Module.InTheMiddleOfBisect())
             {
                 SetGitAction(GitAction.Bisect, false);
+                return;
+            }
+
+            SetGitAction(GitAction.None, false);
+        }
+
+        public void RefreshGitAction()
+        {
+            // get the current state of the repo
+
+            if (!Module.IsValidGitWorkingDir())
+            {
                 return;
             }
 


### PR DESCRIPTION




## Proposed changes

 It is possible for a repo to be in a middle of a bisect operation and be in a conflicted state. Hence detect bisect separately from the rest of git actions.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/104533348-548b4b80-5666-11eb-9879-4a6dad8f6590.png)


### After

![image](https://user-images.githubusercontent.com/4403806/104533361-594fff80-5666-11eb-971a-189025ad25c2.png)



## Test methodology <!-- How did you ensure quality? -->

- manual




----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
