### PR TITLE
FileViewer: Return inapplicable hotkeys as unhandled

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1354,49 +1354,52 @@ namespace GitUI.Editor
         /// <summary>
         /// Use implementation matching the current viewItem
         /// </summary>
-        private void StageSelectedLines()
+        private bool StageSelectedLines()
         {
             if (!SupportLinePatching)
             {
                 // Hotkey executed when menu is disabled
-                return;
+                return false;
             }
 
             if (ViewItemIsWorkTree())
             {
                 StageSelectedLines(stage: true);
-                return;
+                return true;
             }
 
             ApplySelectedLines(allFile: false, reverse: false);
+            return true;
         }
 
-        private void UnstageSelectedLines()
+        private bool UnstageSelectedLines()
         {
             if (!ViewItemIsIndex())
             {
                 // Hotkey executed when menu is disabled
-                return;
+                return false;
             }
 
             StageSelectedLines(stage: false);
+            return true;
         }
 
-        private void ResetSelectedLines()
+        private bool ResetSelectedLines()
         {
             if (!SupportLinePatching)
             {
                 // Hotkey executed when menu is disabled
-                return;
+                return false;
             }
 
             if (ViewItemIsWorkTree() || ViewItemIsIndex())
             {
                 ResetNoncommittedSelectedLines();
-                return;
+                return true;
             }
 
             ApplySelectedLines(allFile: false, reverse: true);
+            return true;
         }
 
         /// <summary>
@@ -1901,9 +1904,9 @@ namespace GitUI.Editor
                 case Command.PreviousChange: PreviousChangeButtonClick(null, null); break;
                 case Command.NextOccurrence: internalFileViewer.GoToNextOccurrence(); break;
                 case Command.PreviousOccurrence: internalFileViewer.GoToPreviousOccurrence(); break;
-                case Command.StageLines: StageSelectedLines(); break;
-                case Command.UnstageLines: UnstageSelectedLines(); break;
-                case Command.ResetLines: ResetSelectedLines(); break;
+                case Command.StageLines: return StageSelectedLines();
+                case Command.UnstageLines: return UnstageSelectedLines();
+                case Command.ResetLines: return ResetSelectedLines();
                 default: return base.ExecuteCommand(cmd);
             }
 


### PR DESCRIPTION
Fixes #8752

## Proposed changes

- `FileViewer`: Return inapplicable hotkeys as unhandled
- 
## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 51e102316a622b2e372a7323bd9f9f59bb0e2b00
- Git 2.27.0.windows.1 (recommended: 2.28.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
