### PR TITLE
Review feedback on PR #8731 (StageAll,UnstageAll)

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -967,7 +967,6 @@ namespace GitUI.CommandsDialogs
             this.toolStageAllItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStageAllItem.Name = "toolStageAllItem";
             this.toolStageAllItem.Size = new System.Drawing.Size(23, 23);
-            this.toolStageAllItem.Text = "Stage all";
             this.toolStageAllItem.Click += new System.EventHandler(this.StageAllToolStripMenuItemClick);
             //
             // toolStripSeparator10
@@ -995,7 +994,6 @@ namespace GitUI.CommandsDialogs
             this.toolUnstageAllItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolUnstageAllItem.Name = "toolUnstageAllItem";
             this.toolUnstageAllItem.Size = new System.Drawing.Size(23, 23);
-            this.toolUnstageAllItem.Text = "Unstage all";
             this.toolUnstageAllItem.Click += new System.EventHandler(this.UnstageAllToolStripMenuItemClick);
             //
             // toolStripSeparator11

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3677,10 +3677,6 @@ You can unset the template:
         <source>Refresh</source>
         <target />
       </trans-unit>
-      <trans-unit id="toolStageAllItem.Text">
-        <source>Stage all</source>
-        <target />
-      </trans-unit>
       <trans-unit id="toolStageItem.Text">
         <source>&amp;Stage</source>
         <target />
@@ -3691,10 +3687,6 @@ You can unset the template:
       </trans-unit>
       <trans-unit id="toolStripMenuItem3.Text">
         <source>&amp;Options</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="toolUnstageAllItem.Text">
-        <source>Unstage all</source>
         <target />
       </trans-unit>
       <trans-unit id="toolUnstageItem.Text">

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1525,23 +1525,11 @@ namespace GitUI
         private readonly Subject<string> _filterSubject = new Subject<string>();
         [CanBeNull] private Regex _filter;
         private bool _filterVisible = false;
-        private bool _filterActive = false;
 
         public void SetFilter(string value)
         {
             FilterComboBox.Text = value;
             FilterFiles(value);
-        }
-
-        private void OnFilterChanged()
-        {
-            if (_filterActive == IsFilterActive)
-            {
-                return;
-            }
-
-            _filterActive = IsFilterActive;
-            FilterChanged?.Invoke(this, EventArgs.Empty);
         }
 
         private void DeleteFilterButton_Click(object sender, EventArgs e)
@@ -1554,7 +1542,7 @@ namespace GitUI
             StoreFilter(value);
 
             UpdateFileStatusListView(updateCausedByFilter: true);
-            OnFilterChanged();
+            FilterChanged?.Invoke(this, EventArgs.Empty);
             return FileStatusListView.Items.Count;
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

FollowUp on PR #8731

After implementing a minor improvement on FormCommit regarding StageAll and UnstageAll ToolStripButtons when the file-filter is active (PR #8731 / Issue #8596) @gerhardol highlighted 2 potential improvements in his review.
As the original PR has been already merged, I've opened this one.


## Proposed changes

Reason: Maintainablity
 * remove status variable _filterActive (as Gerhard mentioned: someone else may reuse the status variable for a slightly separate use case or add a parallel variable)
  Thus, FilterChanged will now fire on every character added/removed (instead of only when activated+deactivated) but this won't cause any issue.
 * Unset tool(Un)StageAllItem.Text : to avoid unecessary double translation text as this (in fact ToolTipText) is intialized anyway (in the constructor).


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
N/A 
<!-- TODO -->

### After
N/A (unchanged)
<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual and existing IntegrationTest


## Test environment(s) <!-- Remove any that don't apply -->

-    GitExtensions 33.33.33 (Build 8adeae7b)
-    GIT 2.30.0.windows.1
-    Windows 10 20H2


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
