### PR TITLE
Improve build times

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -85,10 +85,10 @@
     <None Include="Resources\ChangeLog.md" />
 
     <Content Include="Themes\*.css">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Themes\README.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 

--- a/UnitTests/GitCommands.Tests/GitCommands.Tests.csproj
+++ b/UnitTests/GitCommands.Tests/GitCommands.Tests.csproj
@@ -22,16 +22,16 @@
     <EmbeddedResource Include="MockData\Too_long_lines.txt" />
     <EmbeddedResource Include="MockData\Too_many_lines.txt" />
     <None Include="Patches\testdata\big.patch">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Patches\testdata\bigBin.patch">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Patches\testdata\rebase.diff">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="TestData\README.blame">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <EmbeddedResource Include="UserRepositoryHistory\Legacy\MockData\CategorisedRepositories01.xml" />
     <EmbeddedResource Include="UserRepositoryHistory\Legacy\MockData\CategorisedRepositories02.xml" />

--- a/UnitTests/Plugins/GitUIPluginInterfaces.Tests/GitUIPluginInterfaces.Tests.csproj
+++ b/UnitTests/Plugins/GitUIPluginInterfaces.Tests/GitUIPluginInterfaces.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <None Update="PathScanningData\**">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
When `CopyToOutputDirectory` has value `Always`, Visual Studio must build the project every time, which can trigger further builds. 

By changing these values to `PreserveNewest`, several project builds can be avoided, resulting in an improved inner dev loop.

To verify this, turn on minimal "up-to-date check" logging here:

![image](https://user-images.githubusercontent.com/350947/104921417-5ef27000-59ed-11eb-8d56-03104eceb134.png)
