### PR TITLE
Pass 'skip' parameter

### DIFF
--- a/GitExtUtils/GitUI/ControlUtil.cs
+++ b/GitExtUtils/GitUI/ControlUtil.cs
@@ -65,7 +65,7 @@ namespace GitUI
         public static T FindDescendantOfType<T>(this Control control, Func<T, bool> predicate,
             Func<Control, bool> skip = null)
         {
-            return FindDescendants(control).OfType<T>().Where(predicate).FirstOrDefault();
+            return FindDescendants(control, skip).OfType<T>().Where(predicate).FirstOrDefault();
         }
 
         /// <summary>


### PR DESCRIPTION
Reading through the code I noticed that the `skip` parameter was unused. It should be passed to its overload.