### PR TITLE
Fix SA1629 Documentation text should end with a period

### DIFF
--- a/GitCommands/FullPathResolver.cs
+++ b/GitCommands/FullPathResolver.cs
@@ -36,8 +36,7 @@ namespace GitCommands
         /// <remarks>
         /// Behaves similar to the .NET Core 2.1 version that do not throw on paths with illegal
         /// Windows characters (that could be OK in Git paths or for cross platform) but returns
-        /// null instead of an possible path.
-        /// but </remarks>
+        /// null instead of an possible path.</remarks>
         /// <param name="path">Folder or file path to resolve.</param>
         /// <returns>
         /// <paramref name="path" /> if <paramref name="path" /> is rooted; otherwise resolved path from working directory of the current repository.

--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -153,12 +153,12 @@ namespace GitCommands.Git.Commands
         }
 
         /// <summary>
-        /// The Git command line for reset
+        /// The Git command line for reset.
         /// </summary>
-        /// <param name="mode">Reset mode</param>
-        /// <param name="commit">Optional commit-ish (for reset-index this is tree-ish and mandatory)</param>
-        /// <param name="file">Optional file to reset</param>
-        /// <returns>Argument string</returns>
+        /// <param name="mode">Reset mode.</param>
+        /// <param name="commit">Optional commit-ish (for reset-index this is tree-ish and mandatory).</param>
+        /// <param name="file">Optional file to reset.</param>
+        /// <returns>Argument string.</returns>
         public static ArgumentString ResetCmd(ResetMode mode, string? commit = null, string? file = null)
         {
             if (mode == ResetMode.ResetIndex && string.IsNullOrWhiteSpace(commit))
@@ -177,13 +177,13 @@ namespace GitCommands.Git.Commands
 
         /// <summary>
         /// Push a local reference to a new commit
-        /// This is similar to "git branch --force "branch" "commit", except that you get a warning if commits are lost
+        /// This is similar to "git branch --force "branch" "commit", except that you get a warning if commits are lost.
         /// </summary>
-        /// <param name="repoPath">Full path to the repo</param>
-        /// <param name="gitRef">The branch to move</param>
-        /// <param name="targetId">The commit to move to</param>
-        /// <param name="force">Push the reference also if commits are lost</param>
-        /// <returns>The Git command to execute</returns>
+        /// <param name="repoPath">Full path to the repo.</param>
+        /// <param name="gitRef">The branch to move.</param>
+        /// <param name="targetId">The commit to move to.</param>
+        /// <param name="force">Push the reference also if commits are lost.</param>
+        /// <returns>The Git command to execute.</returns>
         public static ArgumentString PushLocalCmd(string repoPath, string gitRef, ObjectId targetId, bool force = false)
         {
             return new GitArgumentBuilder("push")
@@ -499,12 +499,12 @@ namespace GitCommands.Git.Commands
         }
 
         /// <summary>
-        /// Arguments for git-clean
+        /// Arguments for git-clean.
         /// </summary>
-        /// <param name="mode">The cleanup mode what to delete</param>
-        /// <param name="dryRun">Only show what would be deleted</param>
-        /// <param name="directories">Delete untracked directories too</param>
-        /// <param name="paths">Limit to specific paths</param>
+        /// <param name="mode">The cleanup mode what to delete.</param>
+        /// <param name="dryRun">Only show what would be deleted.</param>
+        /// <param name="directories">Delete untracked directories too.</param>
+        /// <param name="paths">Limit to specific paths.</param>
         public static ArgumentString CleanCmd(CleanMode mode, bool dryRun, bool directories, string? paths = null)
         {
             return new GitArgumentBuilder("clean")

--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -29,7 +29,7 @@ namespace GitCommands
         /// <see cref="GetOutputAsync"/>.
         /// </remarks>
         /// <param name="executable">The executable from which to launch a process.</param>
-        /// <param name="arguments">The arguments to pass to the executable</param>
+        /// <param name="arguments">The arguments to pass to the executable.</param>
         /// <param name="input">Bytes to be written to the process's standard input stream, or <c>null</c> if no input is required.</param>
         /// <param name="outputEncoding">The text encoding to use when decoding bytes read from the process's standard output and standard error streams, or <c>null</c> if the default encoding is to be used.</param>
         /// <param name="cache">A <see cref="CommandCache"/> to use if command results may be cached, otherwise <c>null</c>.</param>
@@ -55,7 +55,7 @@ namespace GitCommands
         /// This method uses <see cref="GetOutput"/> to get concatenated outputs of multiple commands in batch.
         /// </remarks>
         /// <param name="executable">The executable from which to launch processes.</param>
-        /// <param name="batchArguments">The array of batch arguments to pass to the executable</param>
+        /// <param name="batchArguments">The array of batch arguments to pass to the executable.</param>
         /// <param name="input">Bytes to be written to each process's standard input stream, or <c>null</c> if no input is required.</param>
         /// <param name="outputEncoding">The text encoding to use when decoding bytes read from each process's standard output and standard error streams, or <c>null</c> if the default encoding is to be used.</param>
         /// <param name="cache">A <see cref="CommandCache"/> to use if command results may be cached, otherwise <c>null</c>.</param>
@@ -83,7 +83,7 @@ namespace GitCommands
         /// Launches a process for the executable and returns its output.
         /// </summary>
         /// <param name="executable">The executable from which to launch a process.</param>
-        /// <param name="arguments">The arguments to pass to the executable</param>
+        /// <param name="arguments">The arguments to pass to the executable.</param>
         /// <param name="input">Bytes to be written to the process's standard input stream, or <c>null</c> if no input is required.</param>
         /// <param name="outputEncoding">The text encoding to use when decoding bytes read from the process's standard output and standard error streams, or <c>null</c> if the default encoding is to be used.</param>
         /// <param name="cache">A <see cref="CommandCache"/> to use if command results may be cached, otherwise <c>null</c>.</param>
@@ -154,7 +154,7 @@ namespace GitCommands
         /// <see cref="RunCommandAsync"/>.
         /// </remarks>
         /// <param name="executable">The executable from which to launch a process.</param>
-        /// <param name="arguments">The arguments to pass to the executable</param>
+        /// <param name="arguments">The arguments to pass to the executable.</param>
         /// <param name="input">Bytes to be written to the process's standard input stream, or <c>null</c> if no input is required.</param>
         /// <param name="createWindow">A flag indicating whether a console window should be created and bound to the process.</param>
         /// <returns><c>true</c> if the process's exit code was zero, otherwise <c>false</c>.</returns>
@@ -179,7 +179,7 @@ namespace GitCommands
         /// <see href="https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessa"/>.
         /// </remarks>
         /// <param name="executable">The executable from which to launch processes.</param>
-        /// <param name="batchArguments">The array of batch arguments to pass to the executable</param>
+        /// <param name="batchArguments">The array of batch arguments to pass to the executable.</param>
         /// <param name="input">Bytes to be written to each process's standard input stream, or <c>null</c> if no input is required.</param>
         /// <param name="createWindow">A flag indicating whether a console window should be created and bound to each process.</param>
         /// <returns><c>true</c> if all process exit codes were zero, otherwise <c>false</c>.</returns>
@@ -209,7 +209,7 @@ namespace GitCommands
         /// Launches a process for the executable and returns <c>true</c> if its exit code is zero.
         /// </summary>
         /// <param name="executable">The executable from which to launch a process.</param>
-        /// <param name="arguments">The arguments to pass to the executable</param>
+        /// <param name="arguments">The arguments to pass to the executable.</param>
         /// <param name="input">Bytes to be written to the process's standard input stream, or <c>null</c> if no input is required.</param>
         /// <param name="createWindow">A flag indicating whether a console window should be created and bound to the process.</param>
         /// <returns>A task that yields <c>true</c> if the process's exit code was zero, otherwise <c>false</c>.</returns>
@@ -233,7 +233,7 @@ namespace GitCommands
         /// Launches a process for the executable and returns output lines as they become available.
         /// </summary>
         /// <param name="executable">The executable from which to launch a process.</param>
-        /// <param name="arguments">The arguments to pass to the executable</param>
+        /// <param name="arguments">The arguments to pass to the executable.</param>
         /// <param name="input">Bytes to be written to the process's standard input stream, or <c>null</c> if no input is required.</param>
         /// <param name="outputEncoding">The text encoding to use when decoding bytes read from the process's standard output and standard error streams, or <c>null</c> if the default encoding is to be used.</param>
         /// <param name="stripAnsiEscapeCodes">A flag indicating whether ANSI escape codes should be removed from output strings.</param>
@@ -289,7 +289,7 @@ namespace GitCommands
         /// Launches a process for the executable and returns output lines as they become available.
         /// </summary>
         /// <param name="executable">The executable from which to launch a process.</param>
-        /// <param name="arguments">The arguments to pass to the executable</param>
+        /// <param name="arguments">The arguments to pass to the executable.</param>
         /// <param name="writeInput">A callback that writes bytes to the process's standard input stream, or <c>null</c> if no input is required.</param>
         /// <param name="outputEncoding">The text encoding to use when decoding bytes read from the process's standard output and standard error streams, or <c>null</c> if the default encoding is to be used.</param>
         /// <param name="stripAnsiEscapeCodes">A flag indicating whether ANSI escape codes should be removed from output strings.</param>
@@ -315,7 +315,7 @@ namespace GitCommands
         /// <see cref="ExecuteAsync"/>.
         /// </remarks>
         /// <param name="executable">The executable from which to launch a process.</param>
-        /// <param name="arguments">The arguments to pass to the executable</param>
+        /// <param name="arguments">The arguments to pass to the executable.</param>
         /// <param name="writeInput">A callback that writes bytes to the process's standard input stream, or <c>null</c> if no input is required.</param>
         /// <param name="outputEncoding">The text encoding to use when decoding bytes read from the process's standard output and standard error streams, or <c>null</c> if the default encoding is to be used.</param>
         /// <param name="stripAnsiEscapeCodes">A flag indicating whether ANSI escape codes should be removed from output strings.</param>
@@ -336,7 +336,7 @@ namespace GitCommands
         /// Launches a process for the executable and returns an object detailing exit code, standard output and standard error values.
         /// </summary>
         /// <param name="executable">The executable from which to launch a process.</param>
-        /// <param name="arguments">The arguments to pass to the executable</param>
+        /// <param name="arguments">The arguments to pass to the executable.</param>
         /// <param name="writeInput">A callback that writes bytes to the process's standard input stream, or <c>null</c> if no input is required.</param>
         /// <param name="outputEncoding">The text encoding to use when decoding bytes read from the process's standard output and standard error streams, or <c>null</c> if the default encoding is to be used.</param>
         /// <param name="stripAnsiEscapeCodes">A flag indicating whether ANSI escape codes should be removed from output strings.</param>

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -281,7 +281,7 @@ namespace GitCommands
         public Encoding CommitEncoding => EffectiveConfigFile.CommitEncoding ?? new UTF8Encoding(false);
 
         /// <summary>
-        /// Encoding for commit header (message, notes, author, committer, emails)
+        /// Encoding for commit header (message, notes, author, committer, emails).
         /// </summary>
         public Encoding LogOutputEncoding => EffectiveConfigFile.LogOutputEncoding ?? CommitEncoding;
 
@@ -313,11 +313,11 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// Asks git to resolve the given relativePath
-        /// git special folders are located in different directories depending on the kind of repo: submodule, worktree, main
-        /// See https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---git-pathltpathgt
+        /// Asks git to resolve the given relativePath.
+        /// git special folders are located in different directories depending on the kind of repo: submodule, worktree, main.
+        /// See https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---git-pathltpathgt.
         /// </summary>
-        /// <param name="relativePath">A path relative to the .git directory</param>
+        /// <param name="relativePath">A path relative to the .git directory.</param>
         public string ResolveGitInternalPath(string relativePath)
         {
             var args = new GitArgumentBuilder("rev-parse")
@@ -341,8 +341,8 @@ namespace GitCommands
         private readonly object _gitCommonLock = new object();
 
         /// <summary>
-        /// Returns git common directory
-        /// https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---git-common-dir
+        /// Returns git common directory.
+        /// https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---git-common-dir.
         /// </summary>
         public string GitCommonDirectory
         {
@@ -1800,11 +1800,11 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// Batch unstage files using <see cref="ExecutableExtensions.RunBatchCommand(IExecutable, ICollection{BatchArgumentItem}, Action{BatchProgressEventArgs}, byte[], bool)"/>
+        /// Batch unstage files using <see cref="ExecutableExtensions.RunBatchCommand(IExecutable, ICollection{BatchArgumentItem}, Action{BatchProgressEventArgs}, byte[], bool)"/>.
         /// </summary>
-        /// <param name="selectedItems">Selected file items</param>
-        /// <param name="action">Progress update callback</param>
-        /// <returns><see langword="true" /> if changes should be rescanned; otherwise <see langword="false" /></returns>.
+        /// <param name="selectedItems">Selected file items.</param>
+        /// <param name="action">Progress update callback.</param>
+        /// <returns><see langword="true" /> if changes should be rescanned; otherwise <see langword="false" />.</returns>.
         public bool BatchUnstageFiles(IEnumerable<GitItemStatus> selectedItems, Action<BatchProgressEventArgs>? action = null)
         {
             var files = new List<GitItemStatus>();
@@ -2431,11 +2431,11 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// If possible, find if files in a diff are index or worktree
+        /// If possible, find if files in a diff are index or worktree.
         /// </summary>
-        /// <param name="firstId">from revision string</param>
-        /// <param name="secondId">to revision</param>
-        /// <param name="parentToSecond">The parent for the second revision</param>
+        /// <param name="firstId">from revision string.</param>
+        /// <param name="secondId">to revision.</param>
+        /// <param name="parentToSecond">The parent for the second revision.</param>
         /// <remarks>Git revisions are required to determine if <see cref="StagedStatus"/> allows stage/unstage.</remarks>
         public static StagedStatus GetStagedStatus(ObjectId? firstId, ObjectId? secondId, ObjectId? parentToSecond)
         {
@@ -2709,11 +2709,11 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// Parse the output from git-diff --name-status
+        /// Parse the output from git-diff --name-status.
         /// </summary>
-        /// <param name="statusString">output from the git command</param>
+        /// <param name="statusString">output from the git command.</param>
         /// <param name="staged">required to determine if <see cref="StagedStatus"/> allows stage/unstage.</param>
-        /// <returns>list with the parsed GitItemStatus</returns>
+        /// <returns>list with the parsed GitItemStatus.</returns>
         /// <seealso href="https://git-scm.com/docs/git-diff"/>
         private List<GitItemStatus> GetDiffChangedFilesFromString(string statusString, StagedStatus staged)
         {
@@ -2864,10 +2864,10 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// Gets the current branch
+        /// Gets the current branch.
         /// </summary>
-        /// <param name="setDefaultIfEmpty">Return "(no branch)" if detached</param>
-        /// <returns>Current branchname</returns>
+        /// <param name="setDefaultIfEmpty">Return "(no branch)" if detached.</param>
+        /// <returns>Current branchname.</returns>
         public string GetSelectedBranch(bool setDefaultIfEmpty)
         {
             string head = GetSelectedBranchFast(WorkingDir, setDefaultIfEmpty);
@@ -3052,11 +3052,11 @@ namespace GitCommands
         /// <summary>
         /// Gets branches which contain the given commit.
         /// If both local and remote branches are requested, remote branches are prefixed with "remotes/"
-        /// (as returned by git branch -a)
+        /// (as returned by git branch -a).
         /// </summary>
         /// <param name="objectId">The sha1.</param>
-        /// <param name="getLocal">Pass true to include local branches</param>
-        /// <param name="getRemote">Pass true to include remote branches</param>
+        /// <param name="getLocal">Pass true to include local branches.</param>
+        /// <param name="getRemote">Pass true to include remote branches.</param>
         public IReadOnlyList<string> GetAllBranchesWhichContainGivenCommit(ObjectId objectId, bool getLocal, bool getRemote)
         {
             if (!getLocal && !getRemote)
@@ -3167,9 +3167,9 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// Returns list of file names which would be ignored
+        /// Returns list of file names which would be ignored.
         /// </summary>
-        /// <param name="ignorePatterns">Patterns to ignore (.gitignore syntax)</param>
+        /// <param name="ignorePatterns">Patterns to ignore (.gitignore syntax).</param>
         public IReadOnlyList<string> GetIgnoredFiles(IEnumerable<string> ignorePatterns)
         {
             var notEmptyPatterns = ignorePatterns
@@ -3590,10 +3590,10 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// Get a list of diff/merge tools known by Git
+        /// Get a list of diff/merge tools known by Git.
         /// </summary>
-        /// <param name="isDiff">diff or merge</param>
-        /// <returns>the list</returns>
+        /// <param name="isDiff">diff or merge.</param>
+        /// <returns>the list.</returns>
         public async Task<IEnumerable<string>> GetCustomDiffMergeTools(bool isDiff)
         {
             // Note that --gui has no effect here
@@ -3603,10 +3603,10 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// Parse the output from 'git difftool --tool-help'
+        /// Parse the output from 'git difftool --tool-help'.
         /// </summary>
-        /// <param name="output">The output string</param>
-        /// <returns>list with tool names</returns>
+        /// <param name="output">The output string.</param>
+        /// <returns>list with tool names.</returns>
         private static IEnumerable<string> ParseCustomDiffMergeTool(string output)
         {
             var tools = new List<string>();
@@ -3673,11 +3673,11 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// Compare two Git commitish; blob or rev:path
+        /// Compare two Git commitish; blob or rev:path.
         /// </summary>
-        /// <param name="firstGitCommit">commitish</param>
-        /// <param name="secondGitCommit">commitish</param>
-        /// <returns>empty string</returns>
+        /// <param name="firstGitCommit">commitish.</param>
+        /// <param name="secondGitCommit">commitish.</param>
+        /// <returns>empty string, or null if either input is null.</returns>
         public string? OpenFilesWithDifftool(string? firstGitCommit, string? secondGitCommit)
         {
             if (Strings.IsNullOrWhiteSpace(firstGitCommit) || Strings.IsNullOrWhiteSpace(secondGitCommit))
@@ -3999,7 +3999,7 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// Re-encodes string from GitCommandHelpers.LosslessEncoding to toEncoding
+        /// Re-encodes string from GitCommandHelpers.LosslessEncoding to toEncoding.
         /// </summary>
         [return: NotNullIfNotNull("s")]
         public static string? ReEncodeStringFromLossless(string? s, Encoding? toEncoding)
@@ -4069,9 +4069,9 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// header part of show result is encoded in logoutputencoding (including re-encoded commit message)
-        /// diff part is raw data in file's original encoding
-        /// s should be encoded in LosslessEncoding
+        /// header part of show result is encoded in logoutputencoding (including re-encoded commit message).
+        /// diff part is raw data in file's original encoding.
+        /// s should be encoded in LosslessEncoding.
         /// </summary>
         [return: NotNullIfNotNull("s")]
         public string? ReEncodeShowString(string? s)

--- a/GitCommands/Git/GitRefName.cs
+++ b/GitCommands/Git/GitRefName.cs
@@ -11,28 +11,28 @@ namespace GitCommands
         private static readonly Regex _remoteHeadRegex = new Regex("^refs/remotes/[^/]+/HEAD$", RegexOptions.Compiled);
         private static readonly Regex _remoteNameRegex = new Regex("^refs/remotes/([^/]+)", RegexOptions.Compiled);
 
-        /// <summary>"refs/tags/"</summary>
+        /// <summary>"refs/tags/".</summary>
         public static string RefsTagsPrefix { get; } = "refs/tags/";
 
-        /// <summary>"refs/heads/"</summary>
+        /// <summary>"refs/heads/".</summary>
         public static string RefsHeadsPrefix { get; } = "refs/heads/";
 
-        /// <summary>"refs/remotes/"</summary>
+        /// <summary>"refs/remotes/".</summary>
         public static string RefsRemotesPrefix { get; } = "refs/remotes/";
 
-        /// <summary>"refs/bisect/"</summary>
+        /// <summary>"refs/bisect/".</summary>
         public static string RefsBisectPrefix { get; } = "refs/bisect/";
 
-        /// <summary>"refs/bisect/good"</summary>
+        /// <summary>"refs/bisect/good".</summary>
         public static string RefsBisectGoodPrefix { get; } = "refs/bisect/good";
 
-        /// <summary>"refs/bisect/bad"</summary>
+        /// <summary>"refs/bisect/bad".</summary>
         public static string RefsBisectBadPrefix { get; } = "refs/bisect/bad";
 
-        /// <summary>"refs/stash"</summary>
+        /// <summary>"refs/stash".</summary>
         public static string RefsStashPrefix { get; } = "refs/stash";
 
-        /// <summary>"^{}"</summary>
+        /// <summary>"^{}".</summary>
         public static string TagDereferenceSuffix { get; } = "^{}";
 
         [Pure]

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -129,7 +129,7 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// Wrapper for Path.Combine
+        /// Wrapper for Path.Combine.
         /// </summary>
         /// <remark>
         /// Similar to the .NET Core 2.1 variant, except that null is returned if Windows
@@ -137,9 +137,9 @@ namespace GitCommands
         /// are in the paths instead of a possible path (the OS or file system will throw
         /// if the paths are invalid).
         /// </remark>
-        /// <param name="path1">initial part</param>
-        /// <param name="path2">second part</param>
-        /// <returns>path if it can be combined, null otherwise</returns>
+        /// <param name="path1">initial part.</param>
+        /// <param name="path2">second part.</param>
+        /// <returns>path if it can be combined, null otherwise.</returns>
         public static string? Combine(string path1, string path2)
         {
             try
@@ -153,13 +153,13 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// Wrapper for Path.GetExtension
+        /// Wrapper for Path.GetExtension.
         /// </summary>
         /// <remark>
         /// <see cref="Combine"/> for motivation.
         /// </remark>
-        /// <param name="path">path to check</param>
-        /// <returns>path if it can be combined, empty otherwise</returns>
+        /// <param name="path">path to check.</param>
+        /// <returns>path if it can be combined, empty otherwise.</returns>
         public static string GetExtension(string? path)
         {
             if (path == null)
@@ -190,7 +190,7 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// Special handling of on purpose invalid WSL machine name in Windows 10
+        /// Special handling of on purpose invalid WSL machine name in Windows 10.
         /// </summary>
         internal static string ResolveWsl(string path, string relativePath = "")
         {

--- a/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
+++ b/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
@@ -67,7 +67,7 @@ namespace GitCommands.Remotes
         void ToggleRemoteState(string remoteName, bool disabled);
 
         /// <summary>
-        /// Retrieves disabled remotes from .git/config file
+        /// Retrieves disabled remotes from .git/config file.
         /// </summary>
         IReadOnlyList<Remote> GetDisabledRemotes();
 
@@ -77,12 +77,12 @@ namespace GitCommands.Remotes
         IReadOnlyList<string> GetDisabledRemoteNames();
 
         /// <summary>
-        /// Retrieves enabled remote names
+        /// Retrieves enabled remote names.
         /// </summary>
         IReadOnlyList<string> GetEnabledRemoteNames();
 
         /// <summary>
-        /// Retrieves enabled remote names of remotes without branches (i.e. that require a fetch)
+        /// Retrieves enabled remote names of remotes without branches (i.e. that require a fetch).
         /// </summary>
         IReadOnlyList<string> GetEnabledRemoteNamesWithoutBranches();
     }
@@ -159,7 +159,7 @@ namespace GitCommands.Remotes
         }
 
         /// <summary>
-        /// Retrieves disabled remotes from .git/config file
+        /// Retrieves disabled remotes from .git/config file.
         /// </summary>
         public IReadOnlyList<Remote> GetDisabledRemotes()
         {
@@ -185,7 +185,7 @@ namespace GitCommands.Remotes
         }
 
         /// <summary>
-        /// Retrieves enabled remote names
+        /// Retrieves enabled remote names.
         /// </summary>
         public IReadOnlyList<string> GetEnabledRemoteNames()
         {
@@ -193,7 +193,7 @@ namespace GitCommands.Remotes
         }
 
         /// <summary>
-        /// Retrieves enabled remote names of remotes without branches (i.e. that require a fetch)
+        /// Retrieves enabled remote names of remotes without branches (i.e. that require a fetch).
         /// </summary>
         public IReadOnlyList<string> GetEnabledRemoteNamesWithoutBranches()
         {

--- a/GitCommands/Settings/RepoDistSettings.cs
+++ b/GitCommands/Settings/RepoDistSettings.cs
@@ -5,8 +5,8 @@ using GitUIPluginInterfaces;
 namespace GitCommands.Settings
 {
     /// <summary>
-    /// Settings that can be distributed with repository
-    /// they can be overridden for a particular repository
+    /// Settings that can be distributed with repository.
+    /// They can be overridden for a particular repository.
     /// </summary>
     public class RepoDistSettings : SettingsContainer<RepoDistSettings, GitExtSettingsCache>
     {

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -171,7 +171,7 @@ namespace System
         }
 
         /// <summary>
-        /// Quotes this string with the specified <paramref name="q"/>
+        /// Quotes this string with the specified <paramref name="q"/>.
         /// </summary>
         [Pure]
         public static string Quote(this string? s, string q = "\"")
@@ -185,7 +185,7 @@ namespace System
         }
 
         /// <summary>
-        /// Quotes this string if it is not null and not empty
+        /// Quotes this string if it is not null and not empty.
         /// </summary>
         [Pure]
         [return: NotNullIfNotNull("s")]
@@ -195,7 +195,7 @@ namespace System
         }
 
         /// <summary>
-        /// Adds parentheses if string is not null and not empty
+        /// Adds parentheses if string is not null and not empty.
         /// </summary>
         [Pure]
         [return: NotNullIfNotNull("s")]
@@ -207,7 +207,7 @@ namespace System
         /// <summary>
         /// Determines whether the beginning of this instance matches any of the specified strings.
         /// </summary>
-        /// <param name="starts">array of strings to compare</param>
+        /// <param name="starts">array of strings to compare.</param>
         /// <returns>true if any starts element matches the beginning of this string; otherwise, false.</returns>
         [Pure]
         public static bool StartsWithAny(this string? value, IEnumerable<string> starts)
@@ -278,7 +278,7 @@ namespace System
         /// Returns a value indicating whether the <paramref name="other"/> occurs within <paramref name="str"/>.
         /// </summary>
         /// <param name="other">The string to seek. </param>
-        /// <param name="stringComparison">The Comparison type</param>
+        /// <param name="stringComparison">The Comparison type.</param>
         /// <returns>
         /// true if the <paramref name="other"/> parameter occurs within <paramref name="str"/>,
         /// or if <paramref name="other"/> is the empty string (""); otherwise, false.

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -20,19 +20,19 @@ namespace GitCommands.Submodules
         void Init();
 
         /// <summary>
-        /// Update the submodule structure; find superprojects and submodules
+        /// Update the submodule structure; find superprojects and submodules.
         /// </summary>
-        /// <param name="workingDirectory">Current module working directory</param>
-        /// <param name="noBranchText">The text where no branch is checked out for the submodule</param>
-        /// <param name="updateStatus">Update the detailed submodule status (set when current module is not top project)</param>
+        /// <param name="workingDirectory">Current module working directory.</param>
+        /// <param name="noBranchText">The text where no branch is checked out for the submodule.</param>
+        /// <param name="updateStatus">Update the detailed submodule status (set when current module is not top project).</param>
         Task UpdateSubmodulesStructureAsync(string workingDirectory, string noBranchText, bool updateStatus);
 
         /// <summary>
-        /// Update the submodule status
+        /// Update the submodule status.
         /// </summary>
-        /// <param name="workingDirectory">Current module working directory</param>
-        /// <param name="gitStatus">The Git status for the changes (also other than submodules)</param>
-        /// <param name="forceUpdate">Suppress the usual delay of 15 seconds between consecutive updates</param>
+        /// <param name="workingDirectory">Current module working directory.</param>
+        /// <param name="gitStatus">The Git status for the changes (also other than submodules).</param>
+        /// <param name="forceUpdate">Suppress the usual delay of 15 seconds between consecutive updates.</param>
         Task UpdateSubmodulesStatusAsync(string workingDirectory, IReadOnlyList<GitItemStatus>? gitStatus, bool forceUpdate = false);
     }
 
@@ -177,10 +177,10 @@ namespace GitCommands.Submodules
         }
 
         /// <summary>
-        /// Get the result submodule structure
+        /// Get the result submodule structure.
         /// </summary>
-        /// <param name="currentModule">The current module</param>
-        /// <param name="noBranchText">text with no branches</param>
+        /// <param name="currentModule">The current module.</param>
+        /// <param name="noBranchText">text with no branches.</param>
         private SubmoduleInfoResult GetSuperProjectRepositorySubmodulesStructure(GitModule currentModule, string noBranchText)
         {
             var result = new SubmoduleInfoResult { Module = currentModule };
@@ -273,12 +273,12 @@ namespace GitCommands.Submodules
         }
 
         /// <summary>
-        /// Update the detailed status from the git status
+        /// Update the detailed status from the git status.
         /// </summary>
-        /// <param name="module">Current module</param>
-        /// <param name="gitStatus">git status</param>
-        /// <param name="cancelToken">Cancellation token</param>
-        /// <returns>The task</returns>
+        /// <param name="module">Current module.</param>
+        /// <param name="gitStatus">git status.</param>
+        /// <param name="cancelToken">Cancellation token.</param>
+        /// <returns>The task.</returns>
         private async Task UpdateSubmodulesStatusAsync(GitModule module, IReadOnlyList<GitItemStatus>? gitStatus, CancellationToken cancelToken)
         {
             _previousSubmoduleUpdateTime = DateTime.Now;
@@ -343,9 +343,9 @@ namespace GitCommands.Submodules
 
         /// <summary>
         /// Set the module (normally top module) as dirty (if changes in module or any submodule)
-        /// If status is already set, use that (so no change from changed commits to dirty)
+        /// If status is already set, use that (so no change from changed commits to dirty).
         /// </summary>
-        /// <param name="path">path to the module</param>
+        /// <param name="path">path to the module.</param>
         private void SetModuleAsDirty(string path, bool force = false)
         {
             if (!_submoduleInfos.ContainsKey(path) || _submoduleInfos[path] is null)
@@ -369,9 +369,9 @@ namespace GitCommands.Submodules
         }
 
         /// <summary>
-        /// Set the status to 'dirty' recursively to super projects
+        /// Set the status to 'dirty' recursively to super projects.
         /// </summary>
-        /// <param name="module">module</param>
+        /// <param name="module">module.</param>
         private void SetModuleAsDirtyUpwards(GitModule? module)
         {
             while (module is not null)
@@ -383,11 +383,11 @@ namespace GitCommands.Submodules
         }
 
         /// <summary>
-        /// Get the detailed submodule status submodules below 'module' (but not this module)
+        /// Get the detailed submodule status submodules below 'module' (but not this module).
         /// </summary>
-        /// <param name="module">Module to compare to</param>
-        /// <param name="cancelToken">Cancellation token</param>
-        /// <returns>The task</returns>
+        /// <param name="module">Module to compare to.</param>
+        /// <param name="cancelToken">Cancellation token.</param>
+        /// <returns>The task.</returns>
         private async Task GetSubmoduleDetailedStatusAsync(GitModule module, CancellationToken cancelToken)
         {
             if (!_submoduleInfos.ContainsKey(module.WorkingDir) || _submoduleInfos[module.WorkingDir] is null)
@@ -404,12 +404,12 @@ namespace GitCommands.Submodules
         }
 
         /// <summary>
-        /// Get the detailed submodule status for 'submoduleName' and below
+        /// Get the detailed submodule status for 'submoduleName' and below.
         /// </summary>
-        /// <param name="superModule">Module to compare to</param>
-        /// <param name="submoduleName">Name of the submodule</param>
-        /// <param name="cancelToken">Cancellation token</param>
-        /// <returns>the task</returns>
+        /// <param name="superModule">Module to compare to.</param>
+        /// <param name="submoduleName">Name of the submodule.</param>
+        /// <param name="cancelToken">Cancellation token.</param>
+        /// <returns>the task.</returns>
         private async Task GetSubmoduleDetailedStatusAsync(GitModule? superModule, string? submoduleName, CancellationToken cancelToken)
         {
             if (superModule is null || Strings.IsNullOrWhiteSpace(submoduleName))
@@ -459,10 +459,10 @@ namespace GitCommands.Submodules
         }
 
         /// <summary>
-        /// Set empty submodule status for 'submoduleName' and below
+        /// Set empty submodule status for 'submoduleName' and below.
         /// </summary>
-        /// <param name="superModule">The module to compare to</param>
-        /// <param name="submoduleName">Name of the submodule</param>
+        /// <param name="superModule">The module to compare to.</param>
+        /// <param name="submoduleName">Name of the submodule.</param>
         private void SetSubmoduleEmptyDetailedStatus(GitModule superModule, string submoduleName)
         {
             if (superModule is null || string.IsNullOrEmpty(submoduleName))

--- a/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
+++ b/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
@@ -14,7 +14,7 @@ namespace GitCommands.UserRepositoryHistory
         /// otherwise the last part of path is returned.
         /// </summary>
         /// <param name="repositoryDir">Path to repository.</param>
-        /// <returns>Short name for repository</returns>
+        /// <returns>Short name for repository.</returns>
         string Get(string repositoryDir);
     }
 
@@ -35,7 +35,7 @@ namespace GitCommands.UserRepositoryHistory
         /// otherwise the last part of path is returned.
         /// </summary>
         /// <param name="repositoryDir">Path to repository.</param>
-        /// <returns>Short name for repository</returns>
+        /// <returns>Short name for repository.</returns>
         public string Get(string repositoryDir)
         {
             var dirInfo = new DirectoryInfo(repositoryDir);

--- a/GitExtUtils/ArgumentBuilder.cs
+++ b/GitExtUtils/ArgumentBuilder.cs
@@ -64,9 +64,9 @@ namespace GitExtUtils
         }
 
         /// <summary>
-        /// Adds a range of arguments
+        /// Adds a range of arguments.
         /// </summary>
-        /// <param name="args">The arguments to add to this builder</param>
+        /// <param name="args">The arguments to add to this builder.</param>
         public void AddRange(IEnumerable<string> args)
         {
             args = args.Where(a => !string.IsNullOrEmpty(a));

--- a/GitExtUtils/FileUtility.cs
+++ b/GitExtUtils/FileUtility.cs
@@ -8,8 +8,8 @@ namespace GitUI
         /// <summary>
         /// Writes all text to a file. Works around issues with hidden files encountered by File.WriteAllText.
         /// </summary>
-        /// <param name="fileName">Destination file</param>
-        /// <param name="contents">Text to write as file contents</param>
+        /// <param name="fileName">Destination file.</param>
+        /// <param name="contents">Text to write as file contents.</param>
         public static void SafeWriteAllText(string fileName, string contents, Encoding encoding)
         {
             using (var fs = new FileStream(fileName, FileMode.Open))

--- a/GitExtUtils/GitArgumentBuilder.cs
+++ b/GitExtUtils/GitArgumentBuilder.cs
@@ -50,7 +50,7 @@ namespace GitExtUtils
         /// </summary>
         /// <param name="command">The git command this builder is compiling arguments for.</param>
         /// <param name="commandConfiguration">Optional source for default command configuration items. Pass <c>null</c> to use the Git Extensions defaults.</param>
-        /// <param name="gitOptions">Optional arguments that are for the git command.  EX: git --no-optional-locks status </param>
+        /// <param name="gitOptions">Optional arguments that are for the git command.  EX: git --no-optional-locks status.</param>
         /// <exception cref="ArgumentNullException"><paramref name="command"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException"><paramref name="command"/> is an invalid string.</exception>
         public GitArgumentBuilder([NotNull] string command, [CanBeNull] GitCommandConfiguration commandConfiguration = null, [CanBeNull] ArgumentString gitOptions = default)

--- a/GitExtUtils/GitUI/ControlHotkeyExtensions.cs
+++ b/GitExtUtils/GitUI/ControlHotkeyExtensions.cs
@@ -12,7 +12,7 @@ namespace GitUI
         /// Properly handle Ctrl + Backspace by removing the last word before the cursor.
         /// </summary>
         /// <remarks>
-        /// By default .NET TextBox inserts a strange special character instead
+        /// By default .NET TextBox inserts a strange special character instead.
         /// </remarks>
         public static void EnableRemoveWordHotkey(this Control control)
         {

--- a/GitExtUtils/GitUI/ControlUtil.cs
+++ b/GitExtUtils/GitUI/ControlUtil.cs
@@ -86,7 +86,7 @@ namespace GitUI
         }
 
         /// <summary>
-        /// Calls protected method <see cref="Control.SetStyle"/>
+        /// Calls protected method <see cref="Control.SetStyle"/>.
         /// </summary>
         public static void SetStyle(this Control control, ControlStyles styles, bool value) =>
             SetStyleMethod.Invoke(control, new object[] { styles, value });

--- a/GitExtUtils/GitUI/ListViewExtensions.cs
+++ b/GitExtUtils/GitUI/ListViewExtensions.cs
@@ -43,7 +43,7 @@ namespace GitUI
 
         /// <summary>
         /// <para>For practical purposes: The last <see cref="ListViewItem"/> added to selection.</para>
-        /// <para>Actually: Focused item if selected, otherwise last item in <see cref="SelectedItems"/> list</para>
+        /// <para>Actually: Focused item if selected, otherwise last item in <see cref="SelectedItems"/> list.</para>
         /// </summary>
         public static ListViewItem LastSelectedItem(this ListView listView)
         {
@@ -62,7 +62,7 @@ namespace GitUI
 
         /// <summary>
         /// A workaround for <see cref="ListViewItem.Bounds"/> which throws <see cref="ArgumentException"/>
-        /// on item from a collapsed <see cref="ListViewGroup"/>
+        /// on item from a collapsed <see cref="ListViewGroup"/>.
         /// </summary>
         public static Rectangle BoundsOrEmpty(this ListViewItem item) =>
             (Rectangle)_getItemRectOrEmptyMethod.Value.Invoke(item.ListView, new object[] { item.Index });

--- a/GitExtUtils/GitUI/Theming/AppColor.cs
+++ b/GitExtUtils/GitUI/Theming/AppColor.cs
@@ -1,11 +1,11 @@
 ﻿namespace GitExtUtils.GitUI.Theming
 {
     /// <summary>
-    /// GitExtensions' application specific color names
+    /// GitExtensions' application specific color names.
     /// </summary>
     /// <remarks>
     /// Values are stored in AppSettings class. Whenever new name is added here, add default value
-    /// to <see cref="AppColorDefaults"/> and \GitUI\Themes\invariant.css
+    /// to <see cref="AppColorDefaults"/> and \GitUI\Themes\invariant.css.
     /// </remarks>
     public enum AppColor
     {

--- a/GitExtUtils/GitUI/Theming/ColorHelper.cs
+++ b/GitExtUtils/GitUI/Theming/ColorHelper.cs
@@ -60,14 +60,14 @@ namespace GitExtUtils.GitUI.Theming
 
         /// <summary>
         /// Get a color to be used instead of SystemColors.GrayText
-        /// when background is SystemColors.Highlight or SystemColors.MenuHighlight
+        /// when background is SystemColors.Highlight or SystemColors.MenuHighlight.
         /// </summary>
         /// <remarks>
         /// Consider a transformation of color range [SystemColors.ControlText, SystemColors.Control] to
         /// [SystemColors.HighlightText, SystemColors.Highlight].
         /// What result would such transformation produce given SystemColors.GrayText as input?
-        /// First we calculate transformed GrayText color relative to InvariantTheme
-        /// Then we apply transformation from InvariantTheme to current theme by calling AdaptTextColor
+        /// First we calculate transformed GrayText color relative to InvariantTheme.
+        /// Then we apply transformation from InvariantTheme to current theme by calling AdaptTextColor.
         /// </remarks>
         public static Color GetHighlightGrayTextColor(
             KnownColor backgroundColorName,
@@ -94,7 +94,7 @@ namespace GitExtUtils.GitUI.Theming
 
         /// <summary>
         /// Get a color to be used instead of SystemColors.GrayText which is more ore less gray than
-        /// the usual SystemColors.GrayText
+        /// the usual SystemColors.GrayText.
         /// </summary>
         public static Color GetGrayTextColor(KnownColor textColorName, float degreeOfGrayness = 1f)
         {
@@ -137,7 +137,7 @@ namespace GitExtUtils.GitUI.Theming
         /// <summary>
         /// Roughly speaking makes a linear transformation of input orig 0 &lt; orig &lt; 1
         /// The transformation is specified by how it affected a pair of values
-        /// (exampleOrig, oppositeOrig) to (example, opposite)
+        /// (exampleOrig, oppositeOrig) to (example, opposite).
         /// </summary>
         private static double Transform(double orig,
             double exampleOrig, double oppositeOrig,

--- a/GitExtUtils/GitUI/Theming/HslColor.cs
+++ b/GitExtUtils/GitUI/Theming/HslColor.cs
@@ -31,8 +31,8 @@ namespace GitExtUtils.GitUI.Theming
         /// <summary>
         /// Creates an <see cref="HslColor"/> from an RGB <see cref="Color"/> object.
         /// </summary>
-        /// <param name="c">A Color to convert</param>
-        /// <returns>An HSL value</returns>
+        /// <param name="c">A Color to convert.</param>
+        /// <returns>An HSL value.</returns>
         public HslColor(in Color c)
         {
             double r = c.R / 255d;

--- a/GitExtUtils/GitUI/Theming/Theme.cs
+++ b/GitExtUtils/GitUI/Theming/Theme.cs
@@ -6,7 +6,7 @@ using System.Linq;
 namespace GitExtUtils.GitUI.Theming
 {
     /// <summary>
-    /// A set of values for .Net system colors and GitExtensions app-specific colors
+    /// A set of values for .Net system colors and GitExtensions app-specific colors.
     /// </summary>
     public class Theme
     {
@@ -39,7 +39,7 @@ namespace GitExtUtils.GitUI.Theming
 
         /// <summary>
         /// Get GitExtensions app-specific color value as defined by this instance. If not defined,
-        /// returns <see cref="Color.Empty"/>
+        /// returns <see cref="Color.Empty"/>.
         /// </summary>
         public Color GetColor(AppColor name) =>
             AppColorValues.TryGetValue(name, out var result)
@@ -47,7 +47,7 @@ namespace GitExtUtils.GitUI.Theming
                 : Color.Empty;
 
         /// <summary>
-        /// Get .Net system color value as defined by this instance
+        /// Get .Net system color value as defined by this instance.
         /// </summary>
         private Color GetSysColor(KnownColor name) =>
             SysColorValues.TryGetValue(name, out var result)
@@ -55,13 +55,13 @@ namespace GitExtUtils.GitUI.Theming
                 : Color.Empty;
 
         /// <summary>
-        /// GitExtension app-specific color identifiers
+        /// GitExtension app-specific color identifiers.
         /// </summary>
         public static IReadOnlyCollection<AppColor> AppColorNames { get; } =
             new HashSet<AppColor>(Enum.GetValues(typeof(AppColor)).Cast<AppColor>());
 
         /// <summary>
-        /// .Net system color identifiers
+        /// .Net system color identifiers.
         /// </summary>
         private static IReadOnlyCollection<KnownColor> SysColorNames { get; } =
             new HashSet<KnownColor>(
@@ -71,7 +71,7 @@ namespace GitExtUtils.GitUI.Theming
 
         /// <summary>
         /// Get .Net system color value as defined by this instance. If not defined, returns
-        /// <see cref="Color.Empty"/>
+        /// <see cref="Color.Empty"/>.
         /// </summary>
         public Color GetColor(KnownColor name)
         {
@@ -89,7 +89,7 @@ namespace GitExtUtils.GitUI.Theming
 
         /// <summary>
         /// Get .Net system color value as defined by this instance. If not defined, returns
-        /// actual .Net <see cref="SystemColors"/> color
+        /// actual .Net <see cref="SystemColors"/> color.
         /// </summary>
         public Color GetNonEmptyColor(KnownColor name)
         {
@@ -126,7 +126,7 @@ namespace GitExtUtils.GitUI.Theming
         /// <summary>
         /// Whether <see cref="KnownColor"/> represents Windows theme - defined color,
         /// produces same result as <see cref="Color.IsSystemColor"/> without the need to
-        /// create <see cref="Color"/> instance
+        /// create <see cref="Color"/> instance.
         /// </summary>
         private static bool IsSystemColor(KnownColor name) =>
             name < KnownColor.Transparent || name > KnownColor.YellowGreen;

--- a/GitExtUtils/GitUI/Win32ApiUtil.cs
+++ b/GitExtUtils/GitUI/Win32ApiUtil.cs
@@ -7,7 +7,7 @@ namespace GitUI
     public static class Win32ApiUtil
     {
         /// <summary>
-        /// Convert <see cref="Message.LParam"/> to <see cref="Point"/>
+        /// Convert <see cref="Message.LParam"/> to <see cref="Point"/>.
         /// </summary>
         public static Point ToPoint(this IntPtr lparam) =>
             new Point(unchecked((int)lparam.ToInt64()));


### PR DESCRIPTION
While making recent changes for nullable reference types (#8771, #8776) SA1629 started appearing in the error list.

Just adding some punctuation. Nothing exciting here.