### PR TITLE
Add test accessors borrowed from https://github.com/dotnet/winforms/

### DIFF
--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -157,30 +157,5 @@ namespace GitUI
 
             ResumeLayout();
         }
-
-        // This is a base class for many forms, which have own GetTestAccessor() methods. This has to be unique
-        internal GitExtensionsFormTestAccessor GetGitExtensionsFormTestAccessor() => new GitExtensionsFormTestAccessor(this);
-
-        internal readonly struct GitExtensionsFormTestAccessor
-        {
-            private readonly GitExtensionsForm _form;
-
-            public GitExtensionsFormTestAccessor(GitExtensionsForm form)
-            {
-                _form = form;
-            }
-
-            public IWindowPositionManager WindowPositionManager
-            {
-                get => _form._windowPositionManager;
-                set => _form._windowPositionManager = value;
-            }
-
-            public Func<IReadOnlyList<Rectangle>> GetScreensWorkingArea
-            {
-                get => _form._getScreensWorkingArea;
-                set => _form._getScreensWorkingArea = value;
-            }
-        }
     }
 }

--- a/UnitTests/CommonTestUtils/ITestAccessor.cs
+++ b/UnitTests/CommonTestUtils/ITestAccessor.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// Borrowed from https://github.com/dotnet/winforms/
+
+#nullable enable
+
+namespace System
+{
+    /// <summary>
+    ///  Interface for accessing internals from tests.
+    /// </summary>
+    /// <remarks>
+    ///  A non generic representation of the acessor functionality is needed to
+    ///  allow dynamically creating arbitrary <see cref="TestAccessor{T}"/> from
+    ///  helper methods.
+    /// </remarks>
+    public interface ITestAccessor
+    {
+        /// <summary>
+        ///  Gets a dynamic accessor to internals on the test object.
+        /// </summary>
+        /// <remarks>
+        ///  This does not work for ref structs as they are not yet accessible via reflection.
+        ///  See https://github.com/dotnet/runtime/issues/10057.
+        /// </remarks>
+        dynamic Dynamic { get; }
+
+        /// <summary>
+        ///  Creates a delegate for the given non-public method.
+        /// </summary>
+        /// <param name="methodName">
+        ///  The method name. If null, uses the name of the delegate for the method.
+        /// </param>
+        /// <remarks>
+        ///  This provides a way to access methods that take ref structs.
+        /// </remarks>
+        /// <example>
+        ///  <![CDATA[
+        ///   // For ref structs you have to define a delegate as ref struct types
+        ///   // cannot be used as generic arguments (e.g. to Func/Span)
+        ///
+        ///   private delegate int GetDirectoryNameOffset(ReadOnlySpan<char> path);
+        ///
+        ///   public int InternalGetDirectoryNameOffset(ReadOnlySpan<char> path)
+        ///   {
+        ///       var accessor = typeof(System.IO.Path).TestAccessor();
+        ///       return accessor.CreateDelegate<GetDirectoryNameOffset>()(@"C:\Foo");
+        ///   }
+        ///
+        ///   // Without ref structs you can just use Func/Action
+        ///   var accessor = typeof(Color).TestAccessor();
+        ///   bool result = accessor.CreateDelegate<Func<KnownColor, bool>>("IsKnownColorSystem")(KnownColor.Window);
+        ///  ]]>
+        /// </example>
+        TDelegate CreateDelegate<TDelegate>(string? methodName = null)
+            where TDelegate : Delegate;
+    }
+}

--- a/UnitTests/CommonTestUtils/TestAccessor.cs
+++ b/UnitTests/CommonTestUtils/TestAccessor.cs
@@ -131,7 +131,7 @@ namespace System
                         break;
                     }
 
-                    // Walk up the heirarchy
+                    // Walk up the hierarchy
                     type = type.BaseType;
                 }
                 while (true);

--- a/UnitTests/CommonTestUtils/TestAccessor.cs
+++ b/UnitTests/CommonTestUtils/TestAccessor.cs
@@ -1,0 +1,226 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// Borrowed from https://github.com/dotnet/winforms/
+
+#nullable enable
+
+using System.Dynamic;
+using System.Linq;
+using System.Reflection;
+
+namespace System
+{
+    /// <summary>
+    ///  Internals (including privates) access wrapper for tests.
+    /// </summary>
+    /// <typeparam name="T">The type of the class being accessed.</typeparam>
+    /// <remarks>
+    ///  Does not allow access to public members- use the object directly.
+    ///
+    ///  One should strive to *not* access internal state where otherwise avoidable.
+    ///  Ask yourself if you can test the contract of the object in question
+    ///  *without* manipulating internals directly. Often you can.
+    ///
+    ///  Where internals access is more useful are testing building blocks of more
+    ///  complicated objects, such as internal helper methods or classes.
+    ///
+    ///  This can be used to access private/internal objects as well via
+    /// </remarks>
+    /// <example>
+    ///  This class can also be derived from to create a strongly typed wrapper
+    ///  that can then be associated via an extension method for the given type
+    ///  to provide consistent discovery and access.
+    ///
+    ///  <![CDATA[
+    ///   public class GuidTestAccessor : TestAccessor<Guid>
+    ///   {
+    ///     public TestAccessor(Guid instance) : base(instance) {}
+    ///
+    ///     public int A => Dynamic._a;
+    ///   }
+    ///
+    ///   public static partial class TestAccessors
+    ///   {
+    ///       public static GuidTestAccessor TestAccessor(this Guid guid)
+    ///           => new GuidTestAccessor(guid);
+    ///   }
+    ///  ]]>
+    /// </example>
+    public class TestAccessor<T> : ITestAccessor
+    {
+        private static readonly Type _type = typeof(T);
+        protected readonly T _instance;
+        private readonly DynamicWrapper _dynamicWrapper;
+
+        /// <param name="instance">The type instance, can be null for statics.</param>
+        public TestAccessor(T instance)
+        {
+            _instance = instance;
+            _dynamicWrapper = new DynamicWrapper(_instance!);
+        }
+
+        /// <inheritdoc/>
+        public TDelegate CreateDelegate<TDelegate>(string? methodName = null)
+            where TDelegate : Delegate
+        {
+            Type type = typeof(TDelegate);
+            Type[] types = type.GetMethod("Invoke").GetParameters().Select(pi => pi.ParameterType).ToArray();
+
+            // To make it easier to write a class wrapper with a number of delegates,
+            // we'll take the name from the delegate itself when unspecified.
+            if (methodName is null)
+            {
+                methodName = type.Name;
+            }
+
+            MethodInfo methodInfo = _type.GetMethod(
+                methodName,
+                BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static,
+                binder: null,
+                types,
+                modifiers: null);
+
+            if (methodInfo is null)
+            {
+                throw new ArgumentException($"Could not find non public method {methodName}.");
+            }
+
+            return (TDelegate)methodInfo.CreateDelegate(type, methodInfo.IsStatic ? (object?)null : _instance);
+        }
+
+        /// <inheritdoc/>
+        public dynamic Dynamic => _dynamicWrapper;
+
+        private class DynamicWrapper : DynamicObject
+        {
+            private readonly object _instance;
+
+            public DynamicWrapper(object instance)
+                => _instance = instance;
+
+            public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object? result)
+            {
+                result = null;
+
+                MethodInfo? methodInfo = null;
+                Type type = _type;
+
+                do
+                {
+                    try
+                    {
+                        methodInfo = type.GetMethod(
+                            binder.Name,
+                            BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+                    }
+                    catch (AmbiguousMatchException)
+                    {
+                        // More than one match for the name, specify the arguments
+                        methodInfo = type.GetMethod(
+                            binder.Name,
+                            BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static,
+                            binder: null,
+                            args.Select(a => a.GetType()).ToArray(),
+                            modifiers: null);
+                    }
+
+                    if (methodInfo != null || type == typeof(object))
+                    {
+                        // Found something, or already at the top of the type heirarchy
+                        break;
+                    }
+
+                    // Walk up the heirarchy
+                    type = type.BaseType;
+                }
+                while (true);
+
+                if (methodInfo is null)
+                {
+                    return false;
+                }
+
+                result = methodInfo.Invoke(_instance, args);
+                return true;
+            }
+
+            public override bool TrySetMember(SetMemberBinder binder, object value)
+            {
+                MemberInfo? info = GetFieldOrPropertyInfo(binder.Name);
+                if (info is null)
+                {
+                    return false;
+                }
+
+                SetValue(info, value);
+                return true;
+            }
+
+            public override bool TryGetMember(GetMemberBinder binder, out object? result)
+            {
+                result = null;
+
+                MemberInfo? info = GetFieldOrPropertyInfo(binder.Name);
+                if (info is null)
+                {
+                    return false;
+                }
+
+                result = GetValue(info);
+                return true;
+            }
+
+            private MemberInfo? GetFieldOrPropertyInfo(string memberName)
+            {
+                Type type = _type;
+                MemberInfo info;
+
+                do
+                {
+                    info = (MemberInfo)type.GetField(
+                        memberName,
+                        BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic)
+                        ?? type.GetProperty(
+                            memberName,
+                            BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic);
+
+                    if (info != null || type == typeof(object))
+                    {
+                        // Found something, or already at the top of the type heirarchy
+                        break;
+                    }
+
+                    // Walk up the type heirarchy
+                    type = type.BaseType;
+                }
+                while (true);
+
+                return info;
+            }
+
+            private object GetValue(MemberInfo memberInfo)
+                => memberInfo switch
+                {
+                    FieldInfo fieldInfo => fieldInfo.GetValue(_instance),
+                    PropertyInfo propertyInfo => propertyInfo.GetValue(_instance),
+                    _ => throw new InvalidOperationException()
+                };
+
+            private void SetValue(MemberInfo memberInfo, object value)
+            {
+                switch (memberInfo)
+                {
+                    case FieldInfo fieldInfo:
+                        fieldInfo.SetValue(_instance, value);
+                        break;
+                    case PropertyInfo propertyInfo:
+                        propertyInfo.SetValue(_instance, value);
+                        break;
+                    default:
+                        throw new InvalidOperationException();
+                }
+            }
+        }
+    }
+}

--- a/UnitTests/CommonTestUtils/TestAccessor.cs
+++ b/UnitTests/CommonTestUtils/TestAccessor.cs
@@ -127,7 +127,7 @@ namespace System
 
                     if (methodInfo != null || type == typeof(object))
                     {
-                        // Found something, or already at the top of the type heirarchy
+                        // Found something, or already at the top of the type hierarchy
                         break;
                     }
 

--- a/UnitTests/CommonTestUtils/TestAccessors.cs
+++ b/UnitTests/CommonTestUtils/TestAccessors.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// Borrowed from https://github.com/dotnet/winforms/
+
+#nullable enable
+
+namespace System
+{
+    /// <summary>
+    ///  Extension methods for associating internals test accessors with
+    ///  types being tested.
+    /// </summary>
+    /// <remarks>
+    ///  In the System namespace for implicit discovery.
+    /// </remarks>
+    public static partial class TestAccessors
+    {
+        // Need to pass a null parameter when constructing a static instance
+        // of TestAccessor. As this is pretty common and never changes, caching
+        // the array here.
+        private static object?[] _nullObjectParam = { null };
+
+        /// <summary>
+        ///  Extension that creates a generic internals test accessor for a
+        ///  given instance or Type class (if only accessing statics).
+        /// </summary>
+        /// <param name="instanceOrType">
+        ///  Instance or Type class (if only accessing statics).
+        /// </param>
+        /// <example>
+        /// <![CDATA[
+        ///  Version version = new Version(4, 1);
+        ///  Assert.Equal(4, version.TestAccessor().Dynamic._Major));
+        ///
+        ///  // Or
+        ///
+        ///  dynamic accessor = version.TestAccessor().Dynamic;
+        ///  Assert.Equal(4, accessor._Major));
+        /// ]]>
+        /// </example>
+        public static ITestAccessor TestAccessor(this object instanceOrType)
+        {
+            if (instanceOrType is Type type)
+            {
+                return (ITestAccessor)Activator.CreateInstance(
+                    typeof(TestAccessor<>).MakeGenericType(type),
+                    _nullObjectParam);
+            }
+            else
+            {
+                return (ITestAccessor)Activator.CreateInstance(
+                    typeof(TestAccessor<>).MakeGenericType(instanceOrType.GetType()),
+                    instanceOrType);
+            }
+        }
+    }
+}

--- a/UnitTests/GitUI.Tests/GitExtensionsFormTests.cs
+++ b/UnitTests/GitUI.Tests/GitExtensionsFormTests.cs
@@ -32,7 +32,7 @@ namespace GitUITests
                 Size = new Size(500, 500)
             };
 
-            form.TestAccessor().Dynamic._getScreensWorkingArea = (Func<IReadOnlyList<Rectangle>>)(() => throw new InvalidOperationException());
+            new GitExtensionsFormTestAccessor(form).GetScreensWorkingArea = () => throw new InvalidOperationException();
 
             form.InvokeRestorePosition();
 
@@ -50,7 +50,7 @@ namespace GitUITests
                 WindowState = FormWindowState.Minimized
             };
 
-            form.TestAccessor().Dynamic._getScreensWorkingArea = (Func<IReadOnlyList<Rectangle>>)(() => throw new InvalidOperationException());
+            new GitExtensionsFormTestAccessor(form).GetScreensWorkingArea = () => throw new InvalidOperationException();
 
             form.InvokeRestorePosition();
 
@@ -68,8 +68,9 @@ namespace GitUITests
                 Size = new Size(500, 500)
             };
 
-            form.TestAccessor().Dynamic._getScreensWorkingArea = (Func<IReadOnlyList<Rectangle>>)(() => throw new InvalidOperationException());
-            form.TestAccessor().Dynamic._windowPositionManager = _windowPositionManager;
+            GitExtensionsFormTestAccessor testAccessor = new(form);
+            testAccessor.GetScreensWorkingArea = () => throw new InvalidOperationException();
+            testAccessor.WindowPositionManager = _windowPositionManager;
 
             _windowPositionManager.LoadPosition(form).Returns(x => null);
 
@@ -99,8 +100,9 @@ namespace GitUITests
                 new Rectangle(0, 0, 1920, 1080)
             };
 
-            form.TestAccessor().Dynamic._getScreensWorkingArea = (Func<IReadOnlyList<Rectangle>>)(() => screens);
-            form.TestAccessor().Dynamic._windowPositionManager = _windowPositionManager;
+            GitExtensionsFormTestAccessor testAccessor = new(form);
+            testAccessor.GetScreensWorkingArea = () => screens;
+            testAccessor.WindowPositionManager = _windowPositionManager;
 
             _windowPositionManager.LoadPosition(form)
                 .Returns(x => new WindowPosition(new Rectangle(100, 100, 500, 500), 96, FormWindowState.Normal, "bla"));
@@ -133,8 +135,9 @@ namespace GitUITests
                 new Rectangle(0, 0, 1920, 1080)
             };
 
-            form.TestAccessor().Dynamic._getScreensWorkingArea = (Func<IReadOnlyList<Rectangle>>)(() => screens);
-            form.TestAccessor().Dynamic._windowPositionManager = _windowPositionManager;
+            GitExtensionsFormTestAccessor testAccessor = new(form);
+            testAccessor.GetScreensWorkingArea = () => screens;
+            testAccessor.WindowPositionManager = _windowPositionManager;
 
             _windowPositionManager.LoadPosition(form)
                 .Returns(x => new WindowPosition(new Rectangle(100, 100, 500, 500), savedDpi, FormWindowState.Normal, "bla"));
@@ -171,8 +174,9 @@ namespace GitUITests
                 new Rectangle(0, 0, 1920, 1080)
             };
 
-            form.TestAccessor().Dynamic._getScreensWorkingArea = (Func<IReadOnlyList<Rectangle>>)(() => screens);
-            form.TestAccessor().Dynamic._windowPositionManager = _windowPositionManager;
+            GitExtensionsFormTestAccessor testAccessor = new(form);
+            testAccessor.GetScreensWorkingArea = () => screens;
+            testAccessor.WindowPositionManager = _windowPositionManager;
 
             _windowPositionManager.LoadPosition(form)
                 .Returns(x => new WindowPosition(new Rectangle(100, 100, 300, 200), 96, FormWindowState.Normal, "bla"));
@@ -180,6 +184,26 @@ namespace GitUITests
             form.InvokeRestorePosition();
 
             form.Location.Should().Be(new Point(expectFormTop, expectedFormLeft));
+        }
+
+        private class GitExtensionsFormTestAccessor : TestAccessor<GitExtensionsForm>
+        {
+            public GitExtensionsFormTestAccessor(GitExtensionsForm instance)
+                : base(instance)
+            {
+            }
+
+            public Func<IReadOnlyList<Rectangle>> GetScreensWorkingArea
+            {
+                get => Dynamic._getScreensWorkingArea;
+                set => Dynamic._getScreensWorkingArea = value;
+            }
+
+            public IWindowPositionManager WindowPositionManager
+            {
+                get => Dynamic._windowPositionManager;
+                set => Dynamic._windowPositionManager = value;
+            }
         }
 
         private class MockForm : GitExtensionsForm

--- a/UnitTests/GitUI.Tests/GitExtensionsFormTests.cs
+++ b/UnitTests/GitUI.Tests/GitExtensionsFormTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Threading;
 using System.Windows.Forms;
@@ -31,8 +32,7 @@ namespace GitUITests
                 Size = new Size(500, 500)
             };
 
-            var test = form.GetGitExtensionsFormTestAccessor();
-            test.GetScreensWorkingArea = () => throw new InvalidOperationException();
+            form.TestAccessor().Dynamic._getScreensWorkingArea = (Func<IReadOnlyList<Rectangle>>)(() => throw new InvalidOperationException());
 
             form.InvokeRestorePosition();
 
@@ -50,8 +50,7 @@ namespace GitUITests
                 WindowState = FormWindowState.Minimized
             };
 
-            var test = form.GetGitExtensionsFormTestAccessor();
-            test.GetScreensWorkingArea = () => throw new InvalidOperationException();
+            form.TestAccessor().Dynamic._getScreensWorkingArea = (Func<IReadOnlyList<Rectangle>>)(() => throw new InvalidOperationException());
 
             form.InvokeRestorePosition();
 
@@ -69,9 +68,8 @@ namespace GitUITests
                 Size = new Size(500, 500)
             };
 
-            var test = form.GetGitExtensionsFormTestAccessor();
-            test.GetScreensWorkingArea = () => throw new InvalidOperationException();
-            test.WindowPositionManager = _windowPositionManager;
+            form.TestAccessor().Dynamic._getScreensWorkingArea = (Func<IReadOnlyList<Rectangle>>)(() => throw new InvalidOperationException());
+            form.TestAccessor().Dynamic._windowPositionManager = _windowPositionManager;
 
             _windowPositionManager.LoadPosition(form).Returns(x => null);
 
@@ -101,9 +99,8 @@ namespace GitUITests
                 new Rectangle(0, 0, 1920, 1080)
             };
 
-            var test = form.GetGitExtensionsFormTestAccessor();
-            test.GetScreensWorkingArea = () => screens;
-            test.WindowPositionManager = _windowPositionManager;
+            form.TestAccessor().Dynamic._getScreensWorkingArea = (Func<IReadOnlyList<Rectangle>>)(() => screens);
+            form.TestAccessor().Dynamic._windowPositionManager = _windowPositionManager;
 
             _windowPositionManager.LoadPosition(form)
                 .Returns(x => new WindowPosition(new Rectangle(100, 100, 500, 500), 96, FormWindowState.Normal, "bla"));
@@ -136,9 +133,8 @@ namespace GitUITests
                 new Rectangle(0, 0, 1920, 1080)
             };
 
-            var test = form.GetGitExtensionsFormTestAccessor();
-            test.GetScreensWorkingArea = () => screens;
-            test.WindowPositionManager = _windowPositionManager;
+            form.TestAccessor().Dynamic._getScreensWorkingArea = (Func<IReadOnlyList<Rectangle>>)(() => screens);
+            form.TestAccessor().Dynamic._windowPositionManager = _windowPositionManager;
 
             _windowPositionManager.LoadPosition(form)
                 .Returns(x => new WindowPosition(new Rectangle(100, 100, 500, 500), savedDpi, FormWindowState.Normal, "bla"));
@@ -175,9 +171,9 @@ namespace GitUITests
                 new Rectangle(0, 0, 1920, 1080)
             };
 
-            var test = form.GetGitExtensionsFormTestAccessor();
-            test.GetScreensWorkingArea = () => screens;
-            test.WindowPositionManager = _windowPositionManager;
+            form.TestAccessor().Dynamic._getScreensWorkingArea = (Func<IReadOnlyList<Rectangle>>)(() => screens);
+            form.TestAccessor().Dynamic._windowPositionManager = _windowPositionManager;
+
             _windowPositionManager.LoadPosition(form)
                 .Returns(x => new WindowPosition(new Rectangle(100, 100, 300, 200), 96, FormWindowState.Normal, "bla"));
 


### PR DESCRIPTION
Rework the test accessor pattern introduced by @sharwell, that requires creating an internal struct that exposes non-public API to tests, with a test accessor pattern used in dotent/winforms, that doesn't require additional changes to the production code. See https://github.com/dotnet/winforms/pull/3225

Added two examples of how a testaccessor can be used:
1. for a small number of tests using `Dynamic` object is totally ok,
2. when a number of tests become significant it is worth considering creating a specifc testaccessor type that provides a strongly typed facede.

Can be squash-merged.