### PR TITLE
Correct ownership of progress dialogs

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -85,12 +85,12 @@ namespace GitUI.BranchTreePanel
 
             public bool Rebase()
             {
-                return UICommands.StartRebaseDialog(TreeViewNode.TreeView, FullPath);
+                return UICommands.StartRebaseDialog(ParentWindow(), onto: FullPath);
             }
 
             public bool Reset()
             {
-                return UICommands.StartResetCurrentBranchDialog(TreeViewNode.TreeView, FullPath);
+                return UICommands.StartResetCurrentBranchDialog(ParentWindow(), branch: FullPath);
             }
 
             [CanBeNull]
@@ -233,27 +233,27 @@ namespace GitUI.BranchTreePanel
 
             public bool Checkout()
             {
-                return UICommands.StartCheckoutBranch(FullPath, false);
+                return UICommands.StartCheckoutBranch(ParentWindow(), branch: FullPath, remote: false);
             }
 
             public bool CreateBranch()
             {
-                return UICommands.StartCreateBranchDialog(TreeViewNode.TreeView, FullPath);
+                return UICommands.StartCreateBranchDialog(ParentWindow(), branch: FullPath);
             }
 
             public bool Merge()
             {
-                return UICommands.StartMergeBranchDialog(TreeViewNode.TreeView, FullPath);
+                return UICommands.StartMergeBranchDialog(ParentWindow(), branch: FullPath);
             }
 
             public bool Delete()
             {
-                return UICommands.StartDeleteBranchDialog(ParentWindow(), FullPath);
+                return UICommands.StartDeleteBranchDialog(ParentWindow(), branch: FullPath);
             }
 
             public bool Rename()
             {
-                return UICommands.StartRenameDialog(TreeViewNode.TreeView, FullPath);
+                return UICommands.StartRenameDialog(ParentWindow(), branch: FullPath);
             }
         }
 
@@ -294,7 +294,7 @@ namespace GitUI.BranchTreePanel
             public void CreateBranch()
             {
                 var newBranchNamePrefix = FullPath + PathSeparator;
-                UICommands.StartCreateBranchDialog(TreeViewNode.TreeView, null, newBranchNamePrefix);
+                UICommands.StartCreateBranchDialog(ParentWindow(), objectId: null, newBranchNamePrefix);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -171,7 +171,7 @@ namespace GitUI.CommandsDialogs
             if (!AppSettings.AlwaysShowCheckoutBranchDlg && localBranchSelected &&
                 (!HasUncommittedChanges || AppSettings.UseDefaultCheckoutBranchAction))
             {
-                return OkClick();
+                return PerformCheckout(owner);
             }
 
             return ShowDialog(owner);
@@ -267,14 +267,14 @@ namespace GitUI.CommandsDialogs
 
         private void OkClick(object sender, EventArgs e)
         {
-            DialogResult = OkClick();
+            DialogResult = PerformCheckout(this);
             if (DialogResult == DialogResult.OK)
             {
                 Close();
             }
         }
 
-        private DialogResult OkClick()
+        private DialogResult PerformCheckout(IWin32Window owner)
         {
             // Ok button set as the "AcceptButton" for the form
             // if the user hits [Enter] at any point, we need to trigger txtCustomBranchName Leave event
@@ -349,8 +349,6 @@ namespace GitUI.CommandsDialogs
             {
                 localChanges = LocalChangesAction.DontChange;
             }
-
-            IWin32Window owner = Visible ? this : Owner;
 
             bool stash = false;
             if (localChanges == LocalChangesAction.Stash)

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -344,11 +344,6 @@ namespace GitUI
             return StartCheckoutBranch(owner, "", false, containRevisions);
         }
 
-        public bool StartCheckoutBranch(string branch, bool remote)
-        {
-            return StartCheckoutBranch(null, branch, remote);
-        }
-
         public bool StartCheckoutRemoteBranch(IWin32Window owner, string branch)
         {
             return StartCheckoutBranch(owner, branch, true);

--- a/GitUI/HelperDialogs/FormProcess.cs
+++ b/GitUI/HelperDialogs/FormProcess.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Windows.Forms;
 using GitCommands;
 using GitUI.UserControls;
@@ -56,6 +57,8 @@ namespace GitUI.HelperDialogs
 
         public static bool ShowDialog([CanBeNull] IWin32Window owner, string process, ArgumentString arguments, string workingDirectory, string input, bool useDialogSettings)
         {
+            Debug.Assert(owner is not null, "Progress window must be owned by another window! This is a bug, please correct and send a pull request with a fix.");
+
             using (var formProcess = new FormProcess(commands: null, process, arguments, workingDirectory, input, useDialogSettings))
             {
                 formProcess.ShowDialog(owner);
@@ -65,6 +68,8 @@ namespace GitUI.HelperDialogs
 
         public static string ReadDialog([CanBeNull] IWin32Window owner, string process, ArgumentString arguments, string workingDirectory, string input, bool useDialogSettings)
         {
+            Debug.Assert(owner is not null, "Progress window must be owned by another window! This is a bug, please correct and send a pull request with a fix.");
+
             using (var formProcess = new FormProcess(commands: null, process, arguments, workingDirectory, input, useDialogSettings))
             {
                 formProcess.ShowDialog(owner);

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -410,7 +410,7 @@ namespace GitUI
             {
                 dlg.Init(actionLabel, refs);
                 dlg.Location = GetQuickItemSelectorLocation();
-                if (dlg.ShowDialog(this) != DialogResult.OK || dlg.SelectedRef is null)
+                if (dlg.ShowDialog(ParentForm) != DialogResult.OK || dlg.SelectedRef is null)
                 {
                     return;
                 }
@@ -1389,7 +1389,7 @@ namespace GitUI
                     {
                         InitiateRefAction(
                             new GitRefListsForRevision(selectedRevision).GetRenameableLocalBranches(),
-                            gitRef => UICommands.StartRenameDialog(this, gitRef.Name),
+                            gitRef => UICommands.StartRenameDialog(ParentForm, gitRef.Name),
                             FormQuickGitRefSelector.Action.Rename);
                         break;
                     }
@@ -1402,15 +1402,15 @@ namespace GitUI
                             {
                                 if (gitRef.IsTag)
                                 {
-                                    UICommands.StartDeleteTagDialog(this, gitRef.Name);
+                                    UICommands.StartDeleteTagDialog(ParentForm, gitRef.Name);
                                 }
                                 else if (gitRef.IsRemote)
                                 {
-                                    UICommands.StartDeleteRemoteBranchDialog(this, gitRef.Name);
+                                    UICommands.StartDeleteRemoteBranchDialog(ParentForm, gitRef.Name);
                                 }
                                 else
                                 {
-                                    UICommands.StartDeleteBranchDialog(this, gitRef.Name);
+                                    UICommands.StartDeleteBranchDialog(ParentForm, gitRef.Name);
                                 }
                             },
                             FormQuickGitRefSelector.Action.Delete);
@@ -1512,11 +1512,11 @@ namespace GitUI
                     return new FormCommitDiff(UICommands, selectedRevisions[0].ObjectId);
                 }
 
-                UICommands.ShowModelessForm(this, false, null, null, ProvideForm);
+                UICommands.ShowModelessForm(ParentForm, false, null, null, ProvideForm);
             }
             else if (!selectedRevisions.Any())
             {
-                UICommands.StartCompareRevisionsDialog(this);
+                UICommands.StartCompareRevisionsDialog(ParentForm);
             }
         }
 
@@ -1527,7 +1527,7 @@ namespace GitUI
             UICommands.DoActionOnRepo(() =>
             {
                 using var form = new FormCreateTag(UICommands, revision?.ObjectId);
-                return form.ShowDialog(this) == DialogResult.OK;
+                return form.ShowDialog(ParentForm) == DialogResult.OK;
             });
         }
 
@@ -1541,7 +1541,7 @@ namespace GitUI
             UICommands.DoActionOnRepo(() =>
             {
                 using var form = FormResetCurrentBranch.Create(UICommands, LatestSelectedRevision);
-                return form.ShowDialog(this) == DialogResult.OK;
+                return form.ShowDialog(ParentForm) == DialogResult.OK;
             });
         }
 
@@ -1555,7 +1555,7 @@ namespace GitUI
             UICommands.DoActionOnRepo(() =>
             {
                 using var form = FormResetAnotherBranch.Create(UICommands, LatestSelectedRevision);
-                return form.ShowDialog(this) == DialogResult.OK;
+                return form.ShowDialog(ParentForm) == DialogResult.OK;
             });
         }
 
@@ -1566,7 +1566,7 @@ namespace GitUI
             UICommands.DoActionOnRepo(() =>
             {
                 using var form = new FormCreateBranch(UICommands, revision?.ObjectId);
-                return form.ShowDialog(this) == DialogResult.OK;
+                return form.ShowDialog(ParentForm) == DialogResult.OK;
             });
         }
 
@@ -1643,7 +1643,7 @@ namespace GitUI
 
         internal void ShowRevisionFilterDialog()
         {
-            _revisionFilter.ShowDialog(this);
+            _revisionFilter.ShowDialog(ParentForm);
             ForceRefreshRevisions();
         }
 
@@ -1673,11 +1673,11 @@ namespace GitUI
 
             foreach (var head in gitRefListsForRevision.AllTags)
             {
-                AddBranchMenuItem(deleteTagDropDown, head, delegate { UICommands.StartDeleteTagDialog(this, head.Name); });
+                AddBranchMenuItem(deleteTagDropDown, head, delegate { UICommands.StartDeleteTagDialog(ParentForm, head.Name); });
 
                 var refUnambiguousName = GetRefUnambiguousName(head);
                 var mergeItem = AddBranchMenuItem(mergeBranchDropDown, head,
-                    delegate { UICommands.StartMergeBranchDialog(this, refUnambiguousName); });
+                    delegate { UICommands.StartMergeBranchDialog(ParentForm, refUnambiguousName); });
                 mergeItem.Tag = refUnambiguousName;
             }
 
@@ -1695,7 +1695,7 @@ namespace GitUI
                 else
                 {
                     var toolStripItem = AddBranchMenuItem(mergeBranchDropDown, head,
-                        delegate { UICommands.StartMergeBranchDialog(this, GetRefUnambiguousName(head)); });
+                        delegate { UICommands.StartMergeBranchDialog(ParentForm, GetRefUnambiguousName(head)); });
 
                     if (_rebaseOnTopOf is null)
                     {
@@ -1714,7 +1714,7 @@ namespace GitUI
             if (mergeBranchDropDown.Items.Count == 0 && !currentBranchPointsToRevision)
             {
                 var toolStripItem = new ToolStripMenuItem(revision.Guid);
-                toolStripItem.Click += delegate { UICommands.StartMergeBranchDialog(this, revision.Guid); };
+                toolStripItem.Click += delegate { UICommands.StartMergeBranchDialog(ParentForm, revision.Guid); };
                 mergeBranchDropDown.Items.Add(toolStripItem);
                 if (_rebaseOnTopOf is null)
                 {
@@ -1736,10 +1736,10 @@ namespace GitUI
                     }
                     else
                     {
-                        AddBranchMenuItem(deleteBranchDropDown, head, delegate { UICommands.StartDeleteBranchDialog(this, head.Name); });
+                        AddBranchMenuItem(deleteBranchDropDown, head, delegate { UICommands.StartDeleteBranchDialog(ParentForm, head.Name); });
                     }
 
-                    AddBranchMenuItem(renameDropDown, head, delegate { UICommands.StartRenameDialog(this, head.Name); });
+                    AddBranchMenuItem(renameDropDown, head, delegate { UICommands.StartRenameDialog(ParentForm, head.Name); });
                 }
 
                 if (head.CompleteName != currentBranchRef)
@@ -1758,11 +1758,11 @@ namespace GitUI
                     {
                         if (head.IsRemote)
                         {
-                            UICommands.StartCheckoutRemoteBranch(this, head.Name);
+                            UICommands.StartCheckoutRemoteBranch(ParentForm, head.Name);
                         }
                         else
                         {
-                            UICommands.StartCheckoutBranch(this, head.Name);
+                            UICommands.StartCheckoutBranch(ParentForm, head.Name);
                         }
                     });
                 }
@@ -1782,7 +1782,7 @@ namespace GitUI
                         }
                     }
 
-                    AddBranchMenuItem(deleteBranchDropDown, head, delegate { UICommands.StartDeleteRemoteBranchDialog(this, head.Name); });
+                    AddBranchMenuItem(deleteBranchDropDown, head, delegate { UICommands.StartDeleteRemoteBranchDialog(ParentForm, head.Name); });
                 }
             }
 
@@ -1889,7 +1889,7 @@ namespace GitUI
 
             if (AppSettings.DontConfirmRebase)
             {
-                UICommands.StartRebase(this, _rebaseOnTopOf);
+                UICommands.StartRebase(ParentForm, _rebaseOnTopOf);
                 return;
             }
 
@@ -1915,7 +1915,7 @@ namespace GitUI
 
             if (result == TaskDialogResult.Yes)
             {
-                UICommands.StartRebase(this, _rebaseOnTopOf);
+                UICommands.StartRebase(ParentForm, _rebaseOnTopOf);
             }
         }
 
@@ -1928,7 +1928,7 @@ namespace GitUI
 
             if (AppSettings.DontConfirmRebase)
             {
-                UICommands.StartInteractiveRebase(this, _rebaseOnTopOf);
+                UICommands.StartInteractiveRebase(ParentForm, _rebaseOnTopOf);
                 return;
             }
 
@@ -1954,7 +1954,7 @@ namespace GitUI
 
             if (result == TaskDialogResult.Yes)
             {
-                UICommands.StartInteractiveRebase(this, _rebaseOnTopOf);
+                UICommands.StartInteractiveRebase(ParentForm, _rebaseOnTopOf);
             }
         }
 
@@ -1962,7 +1962,7 @@ namespace GitUI
         {
             if (_rebaseOnTopOf is not null)
             {
-                UICommands.StartRebaseDialogWithAdvOptions(this, _rebaseOnTopOf);
+                UICommands.StartRebaseDialogWithAdvOptions(ParentForm, _rebaseOnTopOf);
             }
         }
 
@@ -1970,7 +1970,7 @@ namespace GitUI
         {
             if (LatestSelectedRevision is not null)
             {
-                UICommands.StartCheckoutRevisionDialog(this, LatestSelectedRevision.Guid);
+                UICommands.StartCheckoutRevisionDialog(ParentForm, LatestSelectedRevision.Guid);
             }
         }
 
@@ -1990,7 +1990,7 @@ namespace GitUI
                 diffRevision = selectedRevisions.Last();
             }
 
-            UICommands.StartArchiveDialog(this, mainRevision, diffRevision);
+            UICommands.StartArchiveDialog(ParentForm, mainRevision, diffRevision);
         }
 
         internal void ToggleShowAuthorDate()
@@ -2048,14 +2048,14 @@ namespace GitUI
             var revisions = GetSelectedRevisions(SortDirection.Ascending);
             foreach (var rev in revisions)
             {
-                UICommands.StartRevertCommitDialog(this, rev);
+                UICommands.StartRevertCommitDialog(ParentForm, rev);
             }
         }
 
         private void CherryPickCommitToolStripMenuItemClick(object sender, EventArgs e)
         {
             var revisions = GetSelectedRevisions(SortDirection.Descending);
-            UICommands.StartCherryPickDialog(this, revisions);
+            UICommands.StartCherryPickDialog(ParentForm, revisions);
         }
 
         private void FixupCommitToolStripMenuItemClick(object sender, EventArgs e)
@@ -2065,7 +2065,7 @@ namespace GitUI
                 return;
             }
 
-            UICommands.StartFixupCommitDialog(this, LatestSelectedRevision);
+            UICommands.StartFixupCommitDialog(ParentForm, LatestSelectedRevision);
         }
 
         private void SquashCommitToolStripMenuItemClick(object sender, EventArgs e)
@@ -2075,7 +2075,7 @@ namespace GitUI
                 return;
             }
 
-            UICommands.StartSquashCommitDialog(this, LatestSelectedRevision);
+            UICommands.StartSquashCommitDialog(ParentForm, LatestSelectedRevision);
         }
 
         internal void ToggleShowRelativeDate(EventArgs e)
@@ -2179,13 +2179,13 @@ namespace GitUI
             }
 
             string command = GitCommandHelpers.ContinueBisectCmd(bisectOption, LatestSelectedRevision.ObjectId);
-            FormProcess.ShowDialog(this, process: null, arguments: command, Module.WorkingDir, input: null, useDialogSettings: false);
+            FormProcess.ShowDialog(ParentForm, process: null, arguments: command, Module.WorkingDir, input: null, useDialogSettings: false);
             RefreshRevisions();
         }
 
         private void StopBisectToolStripMenuItemClick(object sender, EventArgs e)
         {
-            FormProcess.ShowDialog(this, process: null, arguments: GitCommandHelpers.StopBisectCmd(), Module.WorkingDir, input: null, useDialogSettings: true);
+            FormProcess.ShowDialog(ParentForm, process: null, arguments: GitCommandHelpers.StopBisectCmd(), Module.WorkingDir, input: null, useDialogSettings: true);
             RefreshRevisions();
         }
 
@@ -2453,7 +2453,7 @@ namespace GitUI
             }
             else if (showNoRevisionMsg)
             {
-                MessageBox.Show(ParentForm as IWin32Window ?? this, _noRevisionFoundError.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _noRevisionFoundError.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -2488,7 +2488,7 @@ namespace GitUI
 
             using (var form = new FormCompareToBranch(UICommands, headCommit.ObjectId))
             {
-                if (form.ShowDialog(this) == DialogResult.OK)
+                if (form.ShowDialog(ParentForm) == DialogResult.OK)
                 {
                     var baseCommit = Module.RevParse(form.BranchName);
                     UICommands.ShowFormDiff(baseCommit, headCommit.ObjectId,
@@ -2630,7 +2630,7 @@ namespace GitUI
             using (var formProcess = new FormProcess(UICommands, process: null, arguments: rebaseCmd, Module.WorkingDir, input: null, useDialogSettings: true))
             {
                 formProcess.ProcessEnvVariables.Add("GIT_SEQUENCE_EDITOR", string.Format("sed -i -re '0,/pick/s//{0}/'", command));
-                formProcess.ShowDialog(this);
+                formProcess.ShowDialog(ParentForm);
             }
 
             RefreshRevisions();
@@ -2656,7 +2656,7 @@ namespace GitUI
                     if (!string.IsNullOrEmpty(fileName) && fileName.EndsWith(".patch", StringComparison.InvariantCultureIgnoreCase))
                     {
                         // Start apply patch dialog for each dropped patch file...
-                        UICommands.StartApplyPatchDialog(this, fileName);
+                        UICommands.StartApplyPatchDialog(ParentForm, fileName);
                     }
                 }
             }


### PR DESCRIPTION
In multi monitor scenarios, where the main form is on a 2ndary monitor, checking out a branch without showing the checkout dialog could lead to situations where the checkout progress dialog would be shown on the primary screen.

This was caused by setting the progress dialog's owner to `null`.

Ensure the correct owner is passed to the progress dialog in the checkout branch sequence.

Also correct various callsites in the revision grid and the left panel to pass the form as the owner instead of respective controls.



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
