### PR TITLE
Introduce new interface for named git refs

### DIFF
--- a/GitCommands/Git/GitItem.cs
+++ b/GitCommands/Git/GitItem.cs
@@ -4,7 +4,7 @@ using GitUIPluginInterfaces;
 namespace GitCommands.Git
 {
     [DebuggerDisplay("GitItem( {" + nameof(FileName) + "} )")]
-    public class GitItem : IGitItem
+    public class GitItem : INamedGitItem
     {
         public GitItem(int mode, GitObjectType objectType, ObjectId objectId, string name)
         {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3188,7 +3188,7 @@ namespace GitCommands
                 .Split('\0', '\n');
         }
 
-        public IEnumerable<IGitItem> GetTree(ObjectId commitId, bool full)
+        public IEnumerable<INamedGitItem> GetTree(ObjectId commitId, bool full)
         {
             var args = new GitArgumentBuilder("ls-tree")
             {

--- a/GitCommands/GitRevisionInfoProvider.cs
+++ b/GitCommands/GitRevisionInfoProvider.cs
@@ -11,7 +11,7 @@ namespace GitCommands
         /// Loads children item for the given <paramref name="item"/>.
         /// </summary>
         /// <returns>The item's children.</returns>
-        IEnumerable<IGitItem> LoadChildren(IGitItem item);
+        IEnumerable<INamedGitItem> LoadChildren(IGitItem item);
     }
 
     public sealed class GitRevisionInfoProvider : IGitRevisionInfoProvider
@@ -29,7 +29,7 @@ namespace GitCommands
         /// <returns>The item's children.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="item"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><see cref="IGitItem.Guid"/> is not supplied.</exception>
-        public IEnumerable<IGitItem> LoadChildren(IGitItem item)
+        public IEnumerable<INamedGitItem> LoadChildren(IGitItem item)
         {
             if (item is null)
             {
@@ -50,7 +50,7 @@ namespace GitCommands
 
             return YieldSubItems();
 
-            IEnumerable<IGitItem> YieldSubItems()
+            IEnumerable<INamedGitItem> YieldSubItems()
             {
                 var basePath = (item as GitItem)?.FileName ?? string.Empty;
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeController.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeController.cs
@@ -50,7 +50,7 @@ namespace GitUI.CommandsDialogs
         private readonly IFileAssociatedIconProvider _iconProvider;
         private readonly Func<string> _getWorkingDir;
         private readonly IGitRevisionInfoProvider _revisionInfoProvider;
-        private readonly ConcurrentDictionary<string, IEnumerable<IGitItem>> _cachedItems = new ConcurrentDictionary<string, IEnumerable<IGitItem>>();
+        private readonly ConcurrentDictionary<string, IEnumerable<INamedGitItem>> _cachedItems = new();
 
         public RevisionFileTreeController(Func<string> getWorkingDir, IGitRevisionInfoProvider revisionInfoProvider, IFileAssociatedIconProvider iconProvider)
         {

--- a/Plugins/GitUIPluginInterfaces/IGitItem.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitItem.cs
@@ -6,6 +6,10 @@ namespace GitUIPluginInterfaces
     {
         ObjectId? ObjectId { get; }
         string? Guid { get; }
+    }
+
+    public interface INamedGitItem : IGitItem
+    {
         string Name { get; }
     }
 }

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -14,7 +14,7 @@ namespace GitUIPluginInterfaces
         string AddRemote(string remoteName, string path);
         IReadOnlyList<IGitRef> GetRefs(bool tags = true, bool branches = true);
         IEnumerable<string> GetSettings(string setting);
-        IEnumerable<IGitItem> GetTree([CanBeNull] ObjectId commitId, bool full);
+        IEnumerable<INamedGitItem> GetTree([CanBeNull] ObjectId commitId, bool full);
 
         /// <summary>
         /// Removes the registered remote by running <c>git remote rm</c> command.

--- a/Plugins/GitUIPluginInterfaces/IGitRef.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitRef.cs
@@ -2,7 +2,7 @@
 
 namespace GitUIPluginInterfaces
 {
-    public interface IGitRef : IGitItem
+    public interface IGitRef : INamedGitItem
     {
         string CompleteName { get; }
         bool IsBisect { get; }

--- a/UnitTests/GitCommands.Tests/GitRevisionInfoProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/GitRevisionInfoProviderTests.cs
@@ -63,7 +63,7 @@ namespace GitCommandsTests
             item.ObjectId.Returns(objectId);
             item.Guid.Returns(objectId.ToString());
 
-            var items = new[] { Substitute.For<IGitItem>(), Substitute.For<IGitItem>(), Substitute.For<IGitItem>() };
+            var items = new[] { Substitute.For<INamedGitItem>(), Substitute.For<INamedGitItem>(), Substitute.For<INamedGitItem>() };
             _module.GetTree(objectId, full: false).Returns(items);
 
             var children = _provider.LoadChildren(item);
@@ -78,7 +78,7 @@ namespace GitCommandsTests
             var commitId = ObjectId.Random();
             var item = new GitItem(0, GitObjectType.Tree, commitId, "folder");
 
-            var items = new[] { Substitute.For<IGitItem>(), new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file2"), new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file3") };
+            var items = new[] { Substitute.For<INamedGitItem>(), new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file2"), new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file3") };
             _module.GetTree(commitId, false).Returns(items);
 
             var children = _provider.LoadChildren(item);

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RevisionFileTreeControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RevisionFileTreeControllerTests.cs
@@ -55,7 +55,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void LoadItemsInTreeView_should_add_all_none_GitItem_items_with_1st_level_nodes()
         {
-            var items = new IGitItem[] { new MockGitItem("file1"), new MockGitItem("file2") };
+            var items = new INamedGitItem[] { new MockGitItem("file1"), new MockGitItem("file2") };
             var item = new MockGitItem("folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
@@ -280,7 +280,7 @@ namespace GitUITests.CommandsDialogs
 
         [SuppressMessage("ReSharper", "UnusedMember.Local")]
         [SuppressMessage("ReSharper", "UnassignedGetOnlyAutoProperty")]
-        private class MockGitItem : IGitItem
+        private class MockGitItem : INamedGitItem
         {
             public MockGitItem(string name)
             {


### PR DESCRIPTION
## Proposed changes

This comes ahead of work to null-annotate these APIs. Not all implementations will populate this property, so in the old factoring it should be marked as nullable. However the Name property is used in many places where it is assumed non-null.

This factoring splits out those usages behind a new interface, making it easier to correctly annotate these APIs.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- It compiles

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
