### PR TITLE
Increase the number of commit templates

### DIFF
--- a/GitUI/CommandsDialogs/CommitDialog/FormCommitTemplateSettings.cs
+++ b/GitUI/CommandsDialogs/CommitDialog/FormCommitTemplateSettings.cs
@@ -11,7 +11,7 @@ namespace GitUI.CommandsDialogs.CommitDialog
 
         private CommitTemplateItem[] _commitTemplates;
 
-        private const int _maxCommitTemplates = 5;
+        private const int _maxCommitTemplates = 10;
         private const int _maxShownCharsForName = 50;
         private const int _maxUsedCharsForName = 80;
 
@@ -41,6 +41,16 @@ namespace GitUI.CommandsDialogs.CommitDialog
                 for (int i = 0; i < _commitTemplates.Length; i++)
                 {
                     _commitTemplates[i] = new CommitTemplateItem();
+                }
+            }
+            else if (_commitTemplates.Length < _maxCommitTemplates)
+            {
+                // Migration: keep the one configured and complete with empty ones
+                var previousCommitTemplates = _commitTemplates;
+                _commitTemplates = new CommitTemplateItem[_maxCommitTemplates];
+                for (int i = 0; i < _commitTemplates.Length; i++)
+                {
+                    _commitTemplates[i] = i < previousCommitTemplates.Length ? previousCommitTemplates[i] : new CommitTemplateItem();
                 }
             }
 


### PR DESCRIPTION
## Proposed changes

- Increase to 10 the number of commit templates and migrate the existing ones when increasing the size

Reason behind the change:

- Because only the not empty lines are displayed in the menu, there is no drawback to allow more commit templates
- I need more lines 😉 (so perhaps someone else also...)


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

I can't produce it anymore (but there are only 5 lines 😉  )

### After

![image](https://user-images.githubusercontent.com/460196/106328781-b2cc4700-6280-11eb-8d40-a065a6fdd7e7.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual 


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 0ccc7fcedb2b3dab976368382a58fb43db18da78
- Git 2.28.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4261.0
- DPI 192dpi (200% scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
