### PR TITLE
ImageView: View failures as dump

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1046,7 +1046,16 @@ namespace GitUI.Editor
                                 if (image is null)
                                 {
                                     ResetView(ViewMode.Text, null);
-                                    internalFileViewer.SetText(string.Format(_cannotViewImage.Text, fileName), openWithDifftool);
+
+                                    var text = getFileText();
+                                    var summary = new StringBuilder()
+                                        .AppendLine(string.Format(_cannotViewImage.Text, fileName))
+                                        .AppendLine()
+                                        .AppendLine($"{text.Length:N0} bytes:")
+                                        .AppendLine();
+
+                                    ToHexDump(Encoding.ASCII.GetBytes(text), summary);
+                                    internalFileViewer.SetText(summary.ToString(), openWithDifftool);
                                     return;
                                 }
 


### PR DESCRIPTION
## Proposed changes

If an image cannot be viewed, an error message is shown but nothing of the file itself.
The user has has therefore no possibility to find the core problem.
If the file cannot be shown , this could be due to that the information the user has put in Git is corrupt, that the GE implementation cannot handle this type of image (like the GE hardcoded extension is used for another file) or that the image is stored with LFS. For LFS, GE (and most tools and web interfaces, but shown in GitHub) does not fetch the actual file but tries to display the LFS text as an image which obviously will fail. #6189 is WIP and has been that for some time....

Both GE not handling images and LFS will likely affect all "images"  in a certain repo and most users will not understand why.

This PR will therefore display a hexdump with the information. For LFS files, you can read the test and hopefully understand that this is really a LFS file, not corrupt.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/106336388-11002680-628f-11eb-9207-13136a003114.png)

### After

![image](https://user-images.githubusercontent.com/6248932/106336534-63d9de00-628f-11eb-8b48-8a8ce4776849.png)

![image](https://user-images.githubusercontent.com/6248932/106336889-21fd6780-6290-11eb-8168-fe7d87c477dc.png)

## Test methodology <!-- How did you ensure quality? -->

View images in LFS enabled repo, also with corrupted images.
The repo with the screenshots: https://github.com/gerhardol/tmp_test/tree/test/unicode

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
