### PR TITLE
Improve RevisionDataGridView responsiveness

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.BackgroundUpdater.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.BackgroundUpdater.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace GitUI.UserControls.RevisionGrid
+{
+    public sealed partial class RevisionDataGridView
+    {
+        /// <summary>
+        /// Coordinates background update executions. Requested reruns only "queue up" upto one.
+        /// </summary>
+        private class BackgroundUpdater
+        {
+            private readonly Func<Task> _operation;
+            private readonly int _cooldownMilliseconds;
+            private readonly object _sync = new();
+
+            private volatile bool _executing;
+            private volatile bool _rerunRequested;
+
+            public BackgroundUpdater(Func<Task> operation, int cooldownMilliseconds)
+            {
+                _operation = operation ?? throw new ArgumentNullException(nameof(operation));
+                _cooldownMilliseconds = cooldownMilliseconds;
+            }
+
+            public void ScheduleExcecution()
+            {
+                lock (_sync)
+                {
+                    if (!_executing)
+                    {
+                        // if not running, start it
+                        _executing = true;
+                        Task.Run(WrappedOperation);
+                    }
+                    else
+                    {
+                        // if currently running make sure it runs again
+                        _rerunRequested = true;
+                    }
+                }
+            }
+
+            private async Task WrappedOperation()
+            {
+                await _operation();
+
+                if (_rerunRequested)
+                {
+                    await Task.Delay(_cooldownMilliseconds);
+                }
+
+                lock (_sync)
+                {
+                    if (_rerunRequested)
+                    {
+                        Task.Run(WrappedOperation);
+                        _rerunRequested = false;
+                    }
+                    else
+                    {
+                        _executing = false;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
If one rapidly scrolls through the revision data grid, the datagrid is no longer updated/painted, so I took a closer look at
`./gitextensions/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs` and found a few things that should probably be changed.

Currently `RunBackgroundAsync` always runs in the background, uses exceptions for control flow in a tight loop (basically throwing an exception 5 times per second) and using a queue to process `BackgroundUpdateAsync`, which causes it to be a lot more executed than really needed.

## Proposed changes
1. Don't use exceptions for control flow
2. Get rid of the background task
3. Replace queue with a mechanism that only updates when needed.
4. Make sure the DataGridView is redrawn even with massive amounts of scroll events.

Let's start with point three. I added a new nested class called `BackgroundUpdater` that is similar to the [rx debounce operator](http://reactivex.io/documentation/operators/debounce.html). It allows background updates to be skipped if there is already one in progress, and also makes sure that the update runs again if a request comes in while the background update is in progress. Multiple requests (while the update is running) don't queue up, the update is just flagged for a rerun. This change also fixes point 1 and 2.

Sadly at that point, point 4 is still not fixed, when scrolling really fast (for example with a mouse that supports free mouse-wheel spinning), because the message pump from the application is flooded with [WM_CTLCOLORSCROLLBAR](https://docs.microsoft.com/en-us/windows/win32/controls/wm-ctlcolorscrollbar) messages which prevent redrawing the control.

To fix that we track the last time the DataGrid was painted and injecting a WM_PAINT message if needed - forcing the control to repaint.

The changes can be tested by rapidly scrolling through the RevisionDataGridView with the current master and with this PR.

## Test methodology

- Manual testing (without rx it would probably be pretty hard to test the current `RevisionDataGridView` implementation automatically
- Manual performance comparison against the current master branch (cbc8c05efeae68786ba7db2cad2ed24daebaeb6f)

## Test environment(s)

- git 2.30.0.windows.1
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
