### PR TITLE
Correct padding increase

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -279,6 +279,7 @@ namespace GitUI.CommandsDialogs
             ManageWorktreeSupport();
 
             WorkaroundToolbarLocationBug();
+            WorkaroundPaddingIncreaseBug();
 
             var toolBackColor = SystemColors.Window;
             var toolForeColor = SystemColors.WindowText;
@@ -530,6 +531,13 @@ namespace GitUI.CommandsDialogs
                     Debug.Assert(toolStrips[i].Left < toolStrips[i - 1].Left, $"{toolStrips[i - 1].Name} must be placed before {toolStrips[i].Name}");
                 }
 #endif
+            }
+
+            void WorkaroundPaddingIncreaseBug()
+            {
+                MainSplitContainer.Panel1.Padding = new Padding(1);
+                RevisionsSplitContainer.Panel1.Padding = new Padding(1);
+                RevisionsSplitContainer.Panel2.Padding = new Padding(1);
             }
         }
 


### PR DESCRIPTION
#8557 introduced new margins and borders, however those margins and borders are not correctly calculated in scaled environments, i.e. scale factor >100%.

@ivangrek in #8732 has provided probably a more "correct" fix, however this is a smaller and more targeted fix.

Resolves #8698
Closes #8732

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/106888378-96298680-673a-11eb-958d-b3c48d3341dc.png)


### After

![image](https://user-images.githubusercontent.com/4403806/106887929-f966e900-6739-11eb-8a3a-ac2b976f33ad.png)


## Test methodology <!-- How did you ensure quality? -->

- manual

![image](https://user-images.githubusercontent.com/4403806/106888550-d12bba00-673a-11eb-9cab-51c005d17235.png)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
