### PR TITLE
Reset Another branch: prevent special characters in path to fail command

### DIFF
--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -179,16 +179,15 @@ namespace GitCommands.Git.Commands
         /// Push a local reference to a new commit
         /// This is similar to "git branch --force "branch" "commit", except that you get a warning if commits are lost.
         /// </summary>
-        /// <param name="repoPath">Full path to the repo.</param>
         /// <param name="gitRef">The branch to move.</param>
         /// <param name="targetId">The commit to move to.</param>
         /// <param name="force">Push the reference also if commits are lost.</param>
         /// <returns>The Git command to execute.</returns>
-        public static ArgumentString PushLocalCmd(string repoPath, string gitRef, ObjectId targetId, bool force = false)
+        public static ArgumentString PushLocalCmd(string gitRef, ObjectId targetId, bool force = false)
         {
             return new GitArgumentBuilder("push")
             {
-                $"file://{repoPath}".RemoveTrailingPathSeparator().QuoteNE(),
+                ".",
                 $"{targetId}:{gitRef}".QuoteNE(),
                 { force, "--force" }
             };

--- a/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -91,8 +91,7 @@ namespace GitUI.HelperDialogs
                 return;
             }
 
-            var repoPath = Path.GetFullPath(Module.WorkingDir);
-            var command = GitCommandHelpers.PushLocalCmd(repoPath, gitRefToReset.CompleteName, _revision.ObjectId, ForceReset.Checked);
+            var command = GitCommandHelpers.PushLocalCmd(gitRefToReset.CompleteName, _revision.ObjectId, ForceReset.Checked);
             bool success = FormProcess.ShowDialog(this, process: null, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
             if (success)
             {

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -496,12 +496,11 @@ namespace GitCommandsTests.Git.Commands
                 () => GitCommandHelpers.ResetCmd(ResetMode.ResetIndex, commit: hash, file: "file.txt"));
         }
 
-        [TestCase(@"a path with spaces\", "mybranch", false, ExpectedResult = @"push ""file://a path with spaces"" ""1111111111111111111111111111111111111111:mybranch""")]
-        [TestCase(@"c:\path2\", "branch2", true, ExpectedResult = @"push ""file://c:\path2"" ""1111111111111111111111111111111111111111:branch2"" --force")]
-        [TestCase(@"/c/path3/", "branch3", true, ExpectedResult = @"push ""file:///c/path3"" ""1111111111111111111111111111111111111111:branch3"" --force")]
-        public string PushLocalCmd(string repoPath, string gitRef, bool force)
+        [TestCase("mybranch", false, ExpectedResult = @"push . ""1111111111111111111111111111111111111111:mybranch""")]
+        [TestCase("branch2", true, ExpectedResult = @"push . ""1111111111111111111111111111111111111111:branch2"" --force")]
+        public string PushLocalCmd(string gitRef, bool force)
         {
-            return GitCommandHelpers.PushLocalCmd(repoPath, gitRef, ObjectId.WorkTreeId, force).Arguments;
+            return GitCommandHelpers.PushLocalCmd(gitRef, ObjectId.WorkTreeId, force).Arguments;
         }
 
         [TestCase(ResetMode.ResetIndex, "tree-ish", null, @"reset ""tree-ish"" --")]


### PR DESCRIPTION
by using a relative path "." instead...

This is possible because the Working directory of the command run
is the repository folder

Fixes #8822

## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build f0e6f1b5aad2d765050c319931422057eab29f38
- Git 2.28.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4261.0
- DPI 192dpi (200% scaling)
