### PR TITLE
Restore/expose IGitUICommands.StartRemotesDialog

### DIFF
--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1043,8 +1043,7 @@ namespace GitUI
             return DoActionOnRepo(owner, Action);
         }
 
-        /// <param name="preselectRemote">makes the FormRemotes initially select the given remote</param>
-        /// <param name="preselectLocal">makes the FormRemotes initially show tab "Default push behavior" and select the given local</param>
+        /// <inheritdoc/>
         public bool StartRemotesDialog(IWin32Window owner, string preselectRemote = null, string preselectLocal = null)
         {
             bool Action()

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -30,6 +30,13 @@ namespace GitUIPluginInterfaces
         bool StartCommandLineProcessDialog(IWin32Window owner, IGitCommand command);
         void StartBatchFileProcessDialog(string batchFile);
 
+        /// <summary>
+        /// Opens the FormRemotes.
+        /// </summary>
+        /// <param name="preselectRemote">Makes the FormRemotes initially select the given remote.</param>
+        /// <param name="preselectLocal">Makes the FormRemotes initially show the tab "Default push behavior" and select the given local.</param>
+        bool StartRemotesDialog(IWin32Window owner, string preselectRemote = null, string preselectLocal = null);
+
         bool StartSettingsDialog(Type pageType);
         bool StartSettingsDialog(IGitPlugin gitPlugin);
         void AddCommitTemplate(string key, Func<string> addingText, Image icon);


### PR DESCRIPTION
## Proposed changes

- Expose `IGitUICommands.StartRemotesDialog` again (https://github.com/gitextensions/GitExtensions.GerritPlugin/pull/16#discussion_r570168180)
  including all arguments (`owner` window is a must, the other two with default value `null` should not hurt)

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- run existing tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 7c1f1bb77ed149b369d09423143b5bea5545b445
- Git 2.27.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
