### PR TITLE
Jenkins: requery new running jobs

### DIFF
--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -111,8 +111,8 @@ namespace GitUI.BuildServerIntegration
                                                         shouldLookForNewlyFinishedBuilds = true;
                                                     })
                                                .OnErrorResumeNext(delayObservable)
-                                               .Finally(() => anyRunningBuilds = false)
                                                .Retry()
+                                               .Finally(() => anyRunningBuilds = false)
                                                .Repeat()
                                                .ObserveOn(MainThreadScheduler.Instance)
                                                .Subscribe(OnBuildInfoUpdate)


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8829

## Proposed changes

Jenkins was not requeried since a1fb6669dc20b10d6b65fffebeea9b532e60be5a
This does not seem to be a problem for other buildservers,
AppVeyor requires a manual refresh anyway.

This is not an issue if the build starts immediately after a push, but there could be a queue to start the build, then refresh is needed.

## Test methodology <!-- How did you ensure quality? -->

* Create a new commit, refresh grid but do not push it
* push the commit from command line
* check that the build status is updated

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
