### PR TITLE
Jira plugin configuration - Password renamed to Password/API token

### DIFF
--- a/Plugins/GitUIPluginInterfaces/UserControls/CredentialsControl.Designer.cs
+++ b/Plugins/GitUIPluginInterfaces/UserControls/CredentialsControl.Designer.cs
@@ -98,7 +98,7 @@
             this.passwordLabel.Name = "passwordLabel";
             this.passwordLabel.Size = new System.Drawing.Size(53, 17);
             this.passwordLabel.TabIndex = 1;
-            this.passwordLabel.Text = "Password";
+            this.passwordLabel.Text = "Password/API token";
             // 
             // CredentialsControl
             // 

--- a/Plugins/GitUIPluginInterfaces/UserControls/CredentialsControl.Designer.cs
+++ b/Plugins/GitUIPluginInterfaces/UserControls/CredentialsControl.Designer.cs
@@ -98,7 +98,7 @@
             this.passwordLabel.Name = "passwordLabel";
             this.passwordLabel.Size = new System.Drawing.Size(53, 17);
             this.passwordLabel.TabIndex = 1;
-            this.passwordLabel.Text = "Password/API token";
+            this.passwordLabel.Text = "API token/Password";
             // 
             // CredentialsControl
             // 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8825.

## Proposed changes
API token is required instead of user password for Jira cloud and possibly for newer versions of Jira on-premise versions.
This PR only changes label from _Password_ to _Password/API token_ to make it clearer that token can (or must) be filled there.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/6107626/107351871-6debb000-6acb-11eb-8aa4-cbf7a518c1e0.png)

### After
![image](https://user-images.githubusercontent.com/6107626/107351734-3ed53e80-6acb-11eb-8020-a8131aa8aa4c.png)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
