### PR TITLE
Check if path exists before creating FileInfo

### DIFF
--- a/GitCommands/FileInfoExtensions.cs
+++ b/GitCommands/FileInfoExtensions.cs
@@ -11,14 +11,14 @@ namespace GitCommands
         /// </summary>
         public static void MakeFileTemporaryWritable(string fileName, Action<string> writableAction)
         {
-            var fileInfo = new FileInfo(fileName);
-            if (!fileInfo.Exists)
+            if (!File.Exists(fileName))
             {
                 // The file doesn't exist yet, no need to make it writable
                 writableAction(fileName);
                 return;
             }
 
+            var fileInfo = new FileInfo(fileName);
             var oldAttributes = fileInfo.Attributes;
             fileInfo.Attributes = FileAttributes.Normal;
             writableAction(fileName);

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseUtil.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseUtil.cs
@@ -6,8 +6,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
     {
         public static bool FileOrParentDirectoryExists(string path)
         {
-            var fileInfo = new FileInfo(path);
-            return fileInfo.Exists || (fileInfo.Directory is not null && fileInfo.Directory.Exists);
+            return File.Exists(path) || (Directory.Exists(path) && new FileInfo(path).Directory.Exists);
         }
 
         public static bool IsFileOrDirectory(string path)
@@ -17,13 +16,14 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         public static void ShowFileOrParentFolderInFileExplorer(string path)
         {
-            var fileInfo = new FileInfo(path);
-            if (fileInfo.Exists)
+            if (File.Exists(path))
             {
+                var fileInfo = new FileInfo(path);
                 OsShellUtil.SelectPathInFileExplorer(fileInfo.FullName);
             }
-            else if (fileInfo.Directory.Exists)
+            else if (Directory.Exists(path))
             {
+                var fileInfo = new FileInfo(path);
                 OsShellUtil.OpenWithFileExplorer(fileInfo.Directory.FullName);
             }
         }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2467,11 +2467,6 @@ namespace GitUI.CommandsDialogs
             foreach (var item in diffFiles.SelectedItems)
             {
                 string filePath = PathUtil.Combine(module.WorkingDir, item.Item.Name.ToNativePath());
-                if (string.IsNullOrWhiteSpace(filePath))
-                {
-                    continue;
-                }
-
                 FormBrowseUtil.ShowFileOrParentFolderInFileExplorer(filePath);
             }
         }

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -536,7 +536,7 @@ namespace GitUI.CommandsDialogs
             foreach (var item in DiffFiles.SelectedItems)
             {
                 string filePath = _fullPathResolver.Resolve(item.Item.Name);
-                if (filePath is not null && FormBrowseUtil.FileOrParentDirectoryExists(filePath))
+                if (FormBrowseUtil.FileOrParentDirectoryExists(filePath))
                 {
                     openContainingFolderToolStripMenuItem.Enabled = true;
                     break;


### PR DESCRIPTION
Will avoid exceptions for illegal characters etc

Fixes #8839

## Proposed changes

Use File.Exists(path) before FileInfo(path) to avoid exceptions.

Can be seen as a follow up to #8575 

## Test methodology <!-- How did you ensure quality? -->

review

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
