### PR TITLE
Ugly hottrack color of tab header in dark theme

### DIFF
--- a/GitExtUtils/GitUI/ControlUtil.cs
+++ b/GitExtUtils/GitUI/ControlUtil.cs
@@ -8,9 +8,6 @@ namespace GitUI
 {
     public static class ControlUtil
     {
-        private static readonly MethodInfo SetStyleMethod = typeof(TabControl)
-            .GetMethod("SetStyle", BindingFlags.Instance | BindingFlags.NonPublic);
-
         /// <summary>
         /// Enumerates all descendant controls.
         /// </summary>
@@ -82,11 +79,5 @@ namespace GitUI
                 parent = parent.Parent;
             }
         }
-
-        /// <summary>
-        /// Calls protected method <see cref="Control.SetStyle"/>.
-        /// </summary>
-        public static void SetStyle(this Control control, ControlStyles styles, bool value) =>
-            SetStyleMethod.Invoke(control, new object[] { styles, value });
     }
 }

--- a/GitExtUtils/GitUI/Theming/ColorHelper.cs
+++ b/GitExtUtils/GitUI/Theming/ColorHelper.cs
@@ -325,5 +325,29 @@ namespace GitExtUtils.GitUI.Theming
             public static double Transform(double orig, double exampleOrig, double oppositeOrig, double example, double opposite) =>
                 ColorHelper.Transform(orig, exampleOrig, oppositeOrig, example, opposite);
         }
+
+        public static Color Lerp(Color colour, Color to, float amount)
+        {
+            // start colours as lerp-able floats
+            float sr = colour.R, sg = colour.G, sb = colour.B;
+
+            // end colours as lerp-able floats
+            float er = to.R, eg = to.G, eb = to.B;
+
+            // lerp the colours to get the difference
+            byte r = (byte)Lerp(sr, er),
+                g = (byte)Lerp(sg, eg),
+                b = (byte)Lerp(sb, eb);
+
+            // return the new colour
+            return Color.FromArgb(r, g, b);
+
+            float Lerp(float start, float end)
+            {
+                var difference = end - start;
+                var adjusted = difference * amount;
+                return start + adjusted;
+            }
+        }
     }
 }

--- a/GitUI/Theming/Renderers/TabRenderer.cs
+++ b/GitUI/Theming/Renderers/TabRenderer.cs
@@ -85,17 +85,20 @@ namespace GitUI.Theming
         private static Pen GetBorderPen() =>
             new Pen(Color.LightGray.AdaptBackColor());
 
-        private static Brush GetTabBackgroundBrush(States stateId) =>
-            stateId switch
+        private static Brush GetTabBackgroundBrush(States stateId)
+        {
+            switch (stateId)
             {
-                States.TIS_SELECTED => SystemBrushes.Window,
-                States.TIS_HOT => SystemBrushes.ControlDark,
-                States.TIS_DISABLED => SystemBrushes.ControlLight,
-
-                // States.TIS_NORMAL
-                // States.TIS_FOCUSED
-                _ => SystemBrushes.Control
-            };
+                case States.TIS_SELECTED:
+                    return SystemBrushes.Window;
+                case States.TIS_HOT:
+                    return new SolidBrush(ColorHelper.Lerp(SystemColors.Control, SystemColors.HotTrack, 64f / 255f));
+                case States.TIS_DISABLED:
+                    return SystemBrushes.ControlLight;
+                default:
+                    return SystemBrushes.Control;
+            }
+        }
 
         private static Color GetTextColor(States stateId) =>
             stateId switch

--- a/GitUI/UserControls/RevisionGrid/RevisionGridRefRenderer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridRefRenderer.cs
@@ -22,7 +22,7 @@ namespace GitUI
             var paddingTopBottom = DpiUtil.Scale(2);
             var marginRight = DpiUtil.Scale(7);
 
-            var textColor = fill ? headColor : Lerp(headColor, Color.White, 0.5f);
+            var textColor = fill ? headColor : ColorHelper.Lerp(headColor, Color.White, 0.5f);
 
             var textSize = TextRenderer.MeasureText(graphics, name, font, Size.Empty, TextFormatFlags.NoPadding);
 
@@ -70,8 +70,8 @@ namespace GitUI
                 using var path = CreateRoundRectPath(bounds, radius);
                 if (fill)
                 {
-                    var color1 = Lerp(color, SystemColors.Window, 0.92F);
-                    var color2 = Lerp(color1, SystemColors.Window, 0.9f);
+                    var color1 = ColorHelper.Lerp(color, SystemColors.Window, 0.92F);
+                    var color2 = ColorHelper.Lerp(color1, SystemColors.Window, 0.9f);
                     using var brush = new LinearGradientBrush(bounds, color1, color2, angle: 90);
                     graphics.FillPath(brush, path);
                 }
@@ -81,7 +81,7 @@ namespace GitUI
                 }
 
                 // frame
-                using var pen = new Pen(Lerp(color, SystemColors.Window, 0.83F));
+                using var pen = new Pen(ColorHelper.Lerp(color, SystemColors.Window, 0.83F));
                 if (dashedLine)
                 {
                     pen.DashPattern = _dashPattern;
@@ -186,30 +186,6 @@ namespace GitUI
             path.CloseFigure();
 
             return path;
-        }
-
-        private static Color Lerp(Color colour, Color to, float amount)
-        {
-            // start colours as lerp-able floats
-            float sr = colour.R, sg = colour.G, sb = colour.B;
-
-            // end colours as lerp-able floats
-            float er = to.R, eg = to.G, eb = to.B;
-
-            // lerp the colours to get the difference
-            byte r = (byte)Lerp(sr, er),
-                g = (byte)Lerp(sg, eg),
-                b = (byte)Lerp(sb, eb);
-
-            // return the new colour
-            return Color.FromArgb(r, g, b);
-
-            float Lerp(float start, float end)
-            {
-                var difference = end - start;
-                var adjusted = difference * amount;
-                return start + adjusted;
-            }
         }
     }
 }


### PR DESCRIPTION
Fix ugly hottrack color of tab header in dark theme introduced in #8815

https://github.com/gitextensions/gitextensions/pull/8815#issuecomment-773218652

### Before

![image](https://user-images.githubusercontent.com/4403806/106883012-82c6ed00-6733-11eb-96b6-e858baab9a53.png)

### After

![image](https://user-images.githubusercontent.com/12046452/107472408-f62b8d00-6b7f-11eb-8a8a-764dc305a990.png)

## Test environment(s)

Windows10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
