### PR TITLE
Notify of repo changes when unused branches were deleted

### DIFF
--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -211,6 +211,8 @@ namespace DeleteUnusedBranches
                     _gitCommands.GitExecutable.GetOutput(args);
                 }
 
+                _gitUiCommands.RepoChangedNotifier.Notify();
+
                 await this.SwitchToMainThreadAsync();
 
                 tableLayoutPanel2.Enabled = tableLayoutPanel3.Enabled = true;

--- a/contributors.txt
+++ b/contributors.txt
@@ -151,3 +151,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/01/17, thimmy687, Ricardo Krause, kaser23@gmx.de
 2021/01/24, bcolaco, Bruno Colaço, bcolaco[@)gmail.com
 2021/01/25, guybark, Guy Barker, guybark(at)microsoft.com
+2021/02/10, mabako, Marcus Bauer, mabako(at)gmail.com


### PR DESCRIPTION
With the existing behavior, you still see long-deleted branches after
closing the dialog until you either refresh the repo manually, or invoke
the notifier in some other location (e.g. through committing).

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Update the whole repository after obsolete branches were deleted

### Before

Deleting any branch through the "Delete obsolete branches" dialog will only update the revision grid, i.e. remove the branch label from the corresponding commits. The branch/remotes/submodules panel on the left side will continue to show outdated branches, double-clicking on them simply shows an error "No revision found".

### After

The branch/remotes/submodules panel is refreshed after you hit "Delete" within the dialog.

## Test methodology <!-- How did you ensure quality? -->

- Manual Testing

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.24.0.windows.2
- Windows 10 Version 2004

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
