### PR TITLE
Browse: Avoid extra git-rev-parse at start

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2652,7 +2652,7 @@ namespace GitCommands
                         async () =>
                         {
                             await TaskScheduler.Default.SwitchTo(alwaysYield: true);
-                            return SubmoduleHelpers.GetCurrentSubmoduleChangesAsync(this, item.Name, item.OldName, firstId, secondId);
+                            return SubmoduleHelpers.GetCurrentSubmoduleChanges(this, item.Name, item.OldName, firstId, secondId);
                         }));
             }
         }

--- a/GitCommands/Git/SubmoduleHelpers.cs
+++ b/GitCommands/Git/SubmoduleHelpers.cs
@@ -11,7 +11,7 @@ namespace GitCommands.Git
 {
     public static class SubmoduleHelpers
     {
-        public static GitSubmoduleStatus? GetCurrentSubmoduleChangesAsync(GitModule module, string? fileName, string? oldFileName, ObjectId? firstId, ObjectId? secondId)
+        public static GitSubmoduleStatus? GetCurrentSubmoduleChanges(GitModule module, string? fileName, string? oldFileName, ObjectId? firstId, ObjectId? secondId)
         {
             Patch? patch = module.GetSingleDiff(firstId, secondId, fileName, oldFileName, "", GitModule.SystemEncoding, true);
             return ParseSubmodulePatchStatus(patch, module, fileName);

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -21,21 +21,6 @@ namespace GitUI
 {
     public static class GitUIExtensions
     {
-        [CanBeNull]
-        private static Patch GetItemPatch(
-            [NotNull] GitModule module,
-            [NotNull] GitItemStatus file,
-            [CanBeNull] ObjectId firstId,
-            [CanBeNull] ObjectId secondId,
-            [NotNull] string diffArgs,
-            [NotNull] Encoding encoding)
-        {
-            // Files with tree guid should be presented with normal diff
-            var isTracked = file.IsTracked || (file.TreeGuid is not null && secondId is not null);
-
-            return module.GetSingleDiff(firstId, secondId, file.Name, file.OldName, diffArgs, encoding, true, isTracked);
-        }
-
         /// <summary>
         /// View the changes between the revisions, if possible as a diff
         /// </summary>
@@ -144,6 +129,20 @@ namespace GitUI
                 return file.IsSubmodule
                     ? LocalizationHelpers.ProcessSubmodulePatch(fileViewer.Module, file.Name, patch)
                     : patch?.Text;
+
+                static Patch GetItemPatch(
+                    [NotNull] GitModule module,
+                    [NotNull] GitItemStatus file,
+                    [CanBeNull] ObjectId firstId,
+                    [CanBeNull] ObjectId secondId,
+                    [NotNull] string diffArgs,
+                    [NotNull] Encoding encoding)
+                {
+                    // Files with tree guid should be presented with normal diff
+                    var isTracked = file.IsTracked || (file.TreeGuid is not null && secondId is not null);
+
+                    return module.GetSingleDiff(firstId, secondId, file.Name, file.OldName, diffArgs, encoding, true, isTracked);
+                }
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -886,7 +886,7 @@ namespace GitUI
 
                 IndexWatcher.Reset();
 
-                SelectInitialRevision();
+                SelectInitialRevision(newCurrentCheckout);
 
                 // NB: Build ref filter before updating the property to reduce the number of chage events.
                 RefFilterOptions refFilterOptions = RefFilterOptions;
@@ -1222,7 +1222,7 @@ namespace GitUI
         /// The SelectedId is the last selected commit in the grid (with related CommitInfo in Browse)
         /// The FirstId is first selected, the first commit in a diff
         /// </summary>
-        private void SelectInitialRevision()
+        private void SelectInitialRevision(ObjectId currentCheckout)
         {
             var toBeSelectedObjectIds = _selectedObjectIds;
 
@@ -1244,7 +1244,7 @@ namespace GitUI
                 }
                 else
                 {
-                    toBeSelectedObjectIds = new ObjectId[] { Module.GetCurrentCheckout() };
+                    toBeSelectedObjectIds = currentCheckout is null ? Array.Empty<ObjectId>() : new ObjectId[] { currentCheckout };
                 }
             }
 


### PR DESCRIPTION
Remains from #8851

## Proposed changes

- Browse: Avoid extra git-rev-parse at start

There are two calls to `git ls-files -z --unmerged` due to OnActivate()  called from both OnActivated() and InternalInitialize().
This is hard to get around as OnActivated() is needed when the form is activated (from backround, modal window closed)
and InternalInitialize is needed after the module is loaded.

Refactorings:
* GitUIExtensions: GetItemPatch to local function
* Remove Async suffix for GetCurrentSubmoduleChangesAsync

## Screenshots <!-- Remove this section if PR does not change UI -->

See #8851, two calls to `git rev-parse HEAD` quite early.

## Test methodology <!-- How did you ensure quality? -->

manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
