### PR TITLE
3.5 Jenkins: requery new running jobs

### DIFF
--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -111,8 +111,8 @@ namespace GitUI.BuildServerIntegration
                                                         shouldLookForNewlyFinishedBuilds = true;
                                                     })
                                                .OnErrorResumeNext(delayObservable)
-                                               .Finally(() => anyRunningBuilds = false)
                                                .Retry()
+                                               .Finally(() => anyRunningBuilds = false)
                                                .Repeat()
                                                .ObserveOn(MainThreadScheduler.Instance)
                                                .Subscribe(OnBuildInfoUpdate)


### PR DESCRIPTION
#8833 for 3.5

Jenkins was not requeried since a1fb6669dc20b10d6b65fffebeea9b532e60be5a
This does not seem to be a problem for other buildservers,
AppVeyor requires a manual refresh anyway.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
