### PR TITLE
3.5 AppVeyor: Handle v2 tokens

### DIFF
--- a/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegration.Tests/AppVeyorAdapterTests.cs
+++ b/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegration.Tests/AppVeyorAdapterTests.cs
@@ -20,13 +20,12 @@ namespace AppVeyorIntegrationTests
     [TestFixture]
     public class AppVeyorAdapterTests
     {
-        private AppVeyorAdapter.Project _project = new AppVeyorAdapter.Project
-            { Id = "ProjectId", Name = "ProjectName", QueryUrl = "ProjectQueryUrl" };
+        private const string _projectId = "account/repo";
 
         [Test]
         public void Should_return_no_build_Info_When_Api_Json_is_empty()
         {
-            var buildInfo = new AppVeyorAdapter().ExtractBuildInfo(_project, string.Empty);
+            var buildInfo = new AppVeyorAdapter().ExtractBuildInfo(_projectId, string.Empty);
 
             buildInfo.Should().HaveCount(0);
         }
@@ -53,7 +52,7 @@ namespace AppVeyorIntegrationTests
             appVeyorAdapter.Initialize(Substitute.For<IBuildServerWatcher>(), Substitute.For<ISettingsSource>(), () => { },
                 id => true);
 
-            var buildInfo = appVeyorAdapter.ExtractBuildInfo(_project, resultString).ToList();
+            var buildInfo = appVeyorAdapter.ExtractBuildInfo(_projectId, resultString).ToList();
             return YamlSerialize(buildInfo);
         }
 

--- a/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegration.Tests/ApprovedFiles/AppVeyorAdapterTests.Should_return_a_build_Info_When_Json_content_is_the_one_of_a_master_build.approved.txt
+++ b/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegration.Tests/ApprovedFiles/AppVeyorAdapterTests.Should_return_a_build_Info_When_Json_content_is_the_one_of_a_master_build.approved.txt
@@ -1,9 +1,9 @@
 ﻿- BuildId: 22798682
   CommitId: d4295d591a45c67d812aa1c4fa17b6a0f2ea3114
-  AppVeyorBuildReportUrl: https://ci.appveyor.com/api/projects/ProjectId/build/3.1.0.5443
+  AppVeyorBuildReportUrl: https://ci.appveyor.com/api/projects/account/repo/build/3.1.0.5443
   Branch: master
-  BaseApiUrl: https://ci.appveyor.com/api/projects/ProjectId
-  BaseWebUrl: https://ci.appveyor.com/project/ProjectId/build/
+  BaseApiUrl: https://ci.appveyor.com/api/projects/account/repo/
+  BaseWebUrl: https://ci.appveyor.com/project/account/repo/build/
   PullRequestText: ''
   PullRequestTitle: ''
   TestsResultText: ''
@@ -13,5 +13,5 @@
   Status: Success
   CommitHashList:
   - d4295d591a45c67d812aa1c4fa17b6a0f2ea3114
-  Url: https://ci.appveyor.com/project/ProjectId/build/3.1.0.5443
+  Url: https://ci.appveyor.com/project/account/repo/build/3.1.0.5443
   ShowInBuildReportTab: true

--- a/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegration.Tests/ApprovedFiles/AppVeyorAdapterTests.Should_return_a_build_Info_When_Json_content_is_the_one_of_a_pull_request_build.approved.txt
+++ b/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegration.Tests/ApprovedFiles/AppVeyorAdapterTests.Should_return_a_build_Info_When_Json_content_is_the_one_of_a_pull_request_build.approved.txt
@@ -1,9 +1,9 @@
 ﻿- BuildId: 22800457
   CommitId: dfc541e7eda18a9eb620a0a352e1d6fe0141b34d
-  AppVeyorBuildReportUrl: https://ci.appveyor.com/api/projects/ProjectId/build/3.1.0.5444
+  AppVeyorBuildReportUrl: https://ci.appveyor.com/api/projects/account/repo/build/3.1.0.5444
   Branch: master
-  BaseApiUrl: https://ci.appveyor.com/api/projects/ProjectId
-  BaseWebUrl: https://ci.appveyor.com/project/ProjectId/build/
+  BaseApiUrl: https://ci.appveyor.com/api/projects/account/repo/
+  BaseWebUrl: https://ci.appveyor.com/project/account/repo/build/
   PullRequestText: PR#6326
   PullRequestTitle: Being able to navigate to a PR page of an AppVeyor build
   TestsResultText: ''
@@ -13,6 +13,6 @@
   Status: Success
   CommitHashList:
   - dfc541e7eda18a9eb620a0a352e1d6fe0141b34d
-  Url: https://ci.appveyor.com/project/ProjectId/build/3.1.0.5444
+  Url: https://ci.appveyor.com/project/account/repo/build/3.1.0.5444
   ShowInBuildReportTab: true
   PullRequestUrl: https://github.com/gitextensions/gitextensions/pull/6326


### PR DESCRIPTION
#8830 for 3.5

This is not a blocker, but something that should be included.

v2 tokens require that the account is prepended to the request..
This apparently is only required for quering repos for an account,
not normal info.

* Only query for project names for a configured account if no
account/repo at all is specified
Illegal repos will not report any builds anyway.
This allows a AppVeyor username/token at the same time as multiple
repos are used. For instance can gitextensions/gitextensions builds
be seen at the same time as user private builds

* Allow configuring of  account/repo also if accountName is set

* Less aggressive requery of running AppVeyor jobs

* Refactor
  * remove static variables/functions
  * Handle projectId/name as account/repo consistently
  * Use local functions (and inline code)
  * Remove internal data class Project (the module global is no longer needed)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
