### PR TITLE
Link style was not applied to the dashboard

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -23,8 +23,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         private readonly TranslationString _openRepository = new("Open repository");
         private readonly TranslationString _translate = new("Translate");
 
-        private DashboardTheme _selectedTheme;
-
         public event EventHandler<GitModuleEventArgs> GitModuleChanged;
 
         public Dashboard()
@@ -63,31 +61,31 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         public void RefreshContent()
         {
+            DashboardTheme selectedTheme = ColorHelper.IsLightTheme() ? DashboardTheme.Light : DashboardTheme.Dark;
             InitDashboardLayout();
             ApplyTheme();
             userRepositoriesList.ShowRecentRepositories();
 
             void ApplyTheme()
             {
-                _selectedTheme = ColorHelper.IsLightTheme() ? DashboardTheme.Light : DashboardTheme.Dark;
-                BackgroundImage = _selectedTheme.BackgroundImage;
+                BackgroundImage = selectedTheme.BackgroundImage;
 
-                BackColor = _selectedTheme.Primary;
-                pnlLogo.BackColor = _selectedTheme.PrimaryVeryDark;
-                flpnlStart.BackColor = _selectedTheme.PrimaryLight;
-                flpnlContribute.BackColor = _selectedTheme.PrimaryVeryLight;
-                lblContribute.ForeColor = _selectedTheme.SecondaryHeadingText;
-                userRepositoriesList.BranchNameColor = _selectedTheme.SecondaryText;
-                userRepositoriesList.FavouriteColor = _selectedTheme.AccentedText;
-                userRepositoriesList.ForeColor = _selectedTheme.PrimaryText;
-                userRepositoriesList.HeaderColor = _selectedTheme.SecondaryHeadingText;
-                userRepositoriesList.HeaderBackColor = _selectedTheme.PrimaryDark;
-                userRepositoriesList.HoverColor = _selectedTheme.PrimaryLight;
-                userRepositoriesList.MainBackColor = _selectedTheme.Primary;
+                BackColor = selectedTheme.Primary;
+                pnlLogo.BackColor = selectedTheme.PrimaryVeryDark;
+                flpnlStart.BackColor = selectedTheme.PrimaryLight;
+                flpnlContribute.BackColor = selectedTheme.PrimaryVeryLight;
+                lblContribute.ForeColor = selectedTheme.SecondaryHeadingText;
+                userRepositoriesList.BranchNameColor = selectedTheme.SecondaryText;
+                userRepositoriesList.FavouriteColor = selectedTheme.AccentedText;
+                userRepositoriesList.ForeColor = selectedTheme.PrimaryText;
+                userRepositoriesList.HeaderColor = selectedTheme.SecondaryHeadingText;
+                userRepositoriesList.HeaderBackColor = selectedTheme.PrimaryDark;
+                userRepositoriesList.HoverColor = selectedTheme.PrimaryLight;
+                userRepositoriesList.MainBackColor = selectedTheme.Primary;
 
                 foreach (var item in flpnlContribute.Controls.OfType<LinkLabel>().Union(flpnlStart.Controls.OfType<LinkLabel>()))
                 {
-                    item.LinkColor = _selectedTheme.PrimaryText;
+                    item.LinkColor = selectedTheme.PrimaryText;
                 }
 
                 Invalidate(true);
@@ -177,8 +175,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                         Text = text,
                         TextAlign = ContentAlignment.MiddleLeft
                     };
-                    linkLabel.MouseHover += (s, e) => linkLabel.LinkColor = _selectedTheme.AccentedText;
-                    linkLabel.MouseLeave += (s, e) => linkLabel.LinkColor = _selectedTheme.PrimaryText;
+                    linkLabel.MouseHover += (s, e) => linkLabel.LinkColor = selectedTheme.AccentedText;
+                    linkLabel.MouseLeave += (s, e) => linkLabel.LinkColor = selectedTheme.PrimaryText;
 
                     if (handler is not null)
                     {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #


## Proposed changes

Apply theme to dashboard links.
theme is null when applying the link theme. No exception, but no effect.
This could be considered for 3.5 too.

An alternative to applying the theme is to remove the theme handling here.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/107990087-effc3d00-6fd3-11eb-847a-75f925c36be5.png)

![image](https://user-images.githubusercontent.com/6248932/107990238-49fd0280-6fd4-11eb-8303-e73199d848eb.png)

### After

![image](https://user-images.githubusercontent.com/6248932/107990038-d3600500-6fd3-11eb-8719-4f5a192debf7.png)

![image](https://user-images.githubusercontent.com/6248932/107990200-3487d880-6fd4-11eb-9538-c8543065d674.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
