### PR TITLE
Fix ownership of FormUpdates

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1008,7 +1008,7 @@ namespace GitUI.CommandsDialogs
                 {
                     AppSettings.LastUpdateCheck = DateTime.Now;
                     var updateForm = new FormUpdates(AppSettings.AppVersion);
-                    updateForm.SearchForUpdatesAndShow(Owner, false);
+                    updateForm.SearchForUpdatesAndShow(ownerWindow: this, alwaysShow: false);
                 }
 
                 bool hasWorkingDir = !string.IsNullOrEmpty(Module.WorkingDir);


### PR DESCRIPTION
`FormBrowse` is the main form, and hence it doesn't have `Owner` set. This leads to `FormUpdates` being created as an orphan modal form, that can be hidden behind `FormBrowse` and making the app look unresponsive.

![image](https://user-images.githubusercontent.com/4403806/108204159-8fa60080-7177-11eb-993c-81119cdf78be.png)

Correct the ownership and, thus, force the new form to show above the main form.


## Test methodology <!-- How did you ensure quality? -->

- manual



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
