### PR TITLE
Cache Git commands related to submodules

### DIFF
--- a/GitCommands/Git/CommandCache.cs
+++ b/GitCommands/Git/CommandCache.cs
@@ -41,7 +41,7 @@ namespace GitCommands
         /// Initialises a new instance of <see cref="CommandCache"/> with specified <paramref name="capacity"/>.
         /// </summary>
         /// <param name="capacity">The maximum number of commands to cache.</param>
-        public CommandCache(int capacity = 40)
+        public CommandCache(int capacity = 50)
         {
             _cache = new MruCache<string, (byte[] output, byte[] error)>(capacity: capacity);
         }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -790,15 +790,15 @@ namespace GitCommands
             return _gitTreeParser.ParseSingle(output);
         }
 
-        public int? GetCommitCount(string parentHash, string childHash)
+        public int? GetCommitCount(string parent, string child, bool cache = false)
         {
             var args = new GitArgumentBuilder("rev-list")
             {
-                parentHash,
-                $"^{childHash}",
+                parent,
+                $"^{child}",
                 "--count"
             };
-            var output = _gitExecutable.GetOutput(args);
+            var output = _gitExecutable.GetOutput(args, cache: cache ? GitCommandCache : null);
 
             if (int.TryParse(output, out var commitCount))
             {
@@ -833,7 +833,7 @@ namespace GitCommands
                 "--count",
                 "--left-right"
             };
-            var output = _gitExecutable.GetOutput(args);
+            var output = _gitExecutable.GetOutput(args, cache: GitCommandCache);
 
             var counts = output.Split('\t');
             if (counts.Length == 2 && int.TryParse(counts[0], out var first) && int.TryParse(counts[1], out var second))
@@ -3659,7 +3659,7 @@ namespace GitCommands
                 a,
                 b
             };
-            var output = _gitExecutable.GetOutput(args);
+            var output = _gitExecutable.GetOutput(args, cache: GitCommandCache);
 
             return ObjectId.TryParse(output, offset: 0, out var objectId)
                 ? objectId
@@ -3703,7 +3703,7 @@ namespace GitCommands
 
             if (loadData)
             {
-                oldData = _commitDataManager.GetCommitData(oldCommit.ToString(), out _);
+                oldData = _commitDataManager.GetCommitData(oldCommit.ToString(), out _, cache: true);
             }
 
             if (oldData is null)
@@ -3713,7 +3713,7 @@ namespace GitCommands
 
             if (loadData)
             {
-                data = _commitDataManager.GetCommitData(commit.ToString(), out _);
+                data = _commitDataManager.GetCommitData(commit.ToString(), out _, cache: true);
             }
 
             if (data is null)

--- a/GitCommands/Git/SubmoduleHelpers.cs
+++ b/GitCommands/Git/SubmoduleHelpers.cs
@@ -126,8 +126,8 @@ namespace GitCommands.Git
                 else
                 {
                     var submodule = module.GetSubmodule(fileName);
-                    addedCommits = submodule.GetCommitCount(commitId.ToString(), oldCommitId.ToString());
-                    removedCommits = submodule.GetCommitCount(oldCommitId.ToString(), commitId.ToString());
+                    addedCommits = submodule.GetCommitCount(commitId.ToString(), oldCommitId.ToString(), cache: true);
+                    removedCommits = submodule.GetCommitCount(oldCommitId.ToString(), commitId.ToString(), cache: true);
                 }
             }
 

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -541,7 +541,7 @@ namespace GitUI.Editor
                 isSubmodule,
                 getImage: GetImage,
                 getFileText: GetFileTextIfBlobExists,
-                getSubmoduleText: () => LocalizationHelpers.GetSubmoduleText(Module, file.Name.TrimEnd('/'), sha),
+                getSubmoduleText: () => LocalizationHelpers.GetSubmoduleText(Module, file.Name.TrimEnd('/'), sha, cache: true),
                 openWithDifftool: openWithDifftool);
 
             string GetFileTextIfBlobExists()
@@ -599,7 +599,7 @@ namespace GitUI.Editor
                     isSubmodule,
                     getImage: GetImage,
                     getFileText: GetFileText,
-                    getSubmoduleText: () => LocalizationHelpers.GetSubmoduleText(Module, fileName.TrimEnd('/'), ""),
+                    getSubmoduleText: () => LocalizationHelpers.GetSubmoduleText(Module, fileName.TrimEnd('/'), "", cache: false),
                     openWithDifftool));
 
             Image GetImage()

--- a/ResourceManager/LocalizationHelpers.cs
+++ b/ResourceManager/LocalizationHelpers.cs
@@ -78,7 +78,7 @@ namespace ResourceManager
             return datetime.LocalDateTime.ToString("G");
         }
 
-        public static string GetSubmoduleText(GitModule superproject, string name, string hash)
+        public static string GetSubmoduleText(GitModule superproject, string name, string hash, bool cache)
         {
             var sb = new StringBuilder();
             sb.AppendLine("Submodule " + name);
@@ -91,7 +91,7 @@ namespace ResourceManager
                 // TEMP, will be moved in the follow up refactor
                 ICommitDataManager commitDataManager = new CommitDataManager(() => module);
 
-                CommitData data = commitDataManager.GetCommitData(hash, out _);
+                CommitData data = commitDataManager.GetCommitData(hash, out _, cache);
                 if (data is null)
                 {
                     sb.AppendLine("Commit hash:\t" + hash);
@@ -152,7 +152,7 @@ namespace ResourceManager
                 {
                     if (status.OldCommit is not null)
                     {
-                        oldCommitData = commitDataManager.GetCommitData(status.OldCommit.ToString(), out _);
+                        oldCommitData = commitDataManager.GetCommitData(status.OldCommit.ToString(), out _, cache: true);
                     }
 
                     if (oldCommitData is not null)
@@ -184,7 +184,7 @@ namespace ResourceManager
             {
                 if (status.Commit is not null)
                 {
-                    commitData = commitDataManager.GetCommitData(status.Commit.ToString(), out _);
+                    commitData = commitDataManager.GetCommitData(status.Commit.ToString(), out _, cache: true);
                 }
 
                 if (commitData is not null)


### PR DESCRIPTION
Part of #8862 

## Proposed changes

* Cache Git commands related to submodules
Cache commands with sha input and no variable input like Git Notes
Only fetch Git Notes for commands that are not cached (Notes are not displayed in Submodule scenarios anyway).

* Cache GetCommitRangeDiffCount
Used when selecting multiple commits in RevDiff

*  Increase Git command cache to 50
Not strictly needed, 40 is OK also for my use after this, but it seems like a reasonable change.

## Screenshots <!-- Remove this section if PR does not change UI -->

Example with one submodule changed, on a relative fast PC (Git at work is 5 times slower).

Startup followed by refresh (similar to build), marked with red line.
Commands that are cached are marked with green (so cache have effect already at first display).

Note: The refresh was done a little early, a diff command will normally be required also after the update, but for current master four more commands would be required.

### Before

![image](https://user-images.githubusercontent.com/6248932/108597833-4928ef80-738b-11eb-94fa-04f0b057b63d.png)

### After

![image](https://user-images.githubusercontent.com/6248932/108597974-16332b80-738c-11eb-8887-49b0068ff5e8.png)

## Test methodology <!-- How did you ensure quality? -->

review and manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
