### PR TITLE
Submodule SidePanel updated too often

### DIFF
--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -153,12 +153,7 @@ namespace GitCommands.Submodules
 
             _submoduleInfoResult.CurrentSubmoduleStatus = gitStatus;
 
-            TimeSpan remaining = _previousSubmoduleUpdateTime - DateTime.Now.AddSeconds(-MinRefreshInterval);
-            const int extraStatusRefreshLimit = 1;
-            if (!forceUpdate && remaining.TotalSeconds > extraStatusRefreshLimit)
-            {
-                OnStatusUpdated(_submoduleInfoResult, cancelToken);
-            }
+            TimeSpan remaining = _previousSubmoduleUpdateTime.AddSeconds(MinRefreshInterval) - DateTime.Now;
 
             if (!forceUpdate && remaining > TimeSpan.Zero)
             {


### PR DESCRIPTION
Part of #8862

## Proposed changes

This PR handles the side panel for submodules being updated too often.
The PR has three parts that could be separated, but the discussion is easier if the combined result is presented.
Similarily, the results should be seen together with #8866 as that also improves the handling. That also reduces clutter to show what this PR really changes.

1. GitStatus updates were handled every 5th second

Regression in master after 3.4
The git-status updates are limited to at most every 5th second (or longer if git-status is really slow).
Submodule updates are limited even more, to every 15th second.
In 3.4 the extra updates were just thrown away.
In 3.5 some code to not require tests to wait these extra 15s were incorrect and updated the sidepanel too.
So the sidepanel as well as the menu dropdown were updated every 5th second, with two updates every 15th second.

2. Submodule tooltip were set twice

The sidepanel recreates the submodule tree at every status update (could be improved, not done here).
The status tooltip added in 3.5 were updated in both of these runs, just ms in between.
The tooltip is set to the default in the first *structure* update and the status update will set the specific status text only once.

3. Submodule tooltip were calculated in the UI thread

The actual diff is calculated by SubmoduleStatusProvider (and are cached by #8866), but *rev-parse --git-common-dir* must run to decode the Git output to present output. (This could maybe be guessed or the processed status changed, not done in this PR).
rev-parse requires about 40 ms on my PC, but at work this requires 200 ms or more. (Processing of the text requires an additional 10ms or so). As the job runs on the UI thread, the UI may get occasional slowdowns, especially if there are many submodules that are changed. The submodule list flicker when the list is refreshed.
The tooltip handling it therefore changed to be done on a worker thread.

Note: Part 1. and 2. are the most important here.
For 3. I tried to change the handling to calculate the tooltip on request too, but did not fully succeed. This solution is intended for 3.5, so I do not want to make it too complicated.

## Screenshots <!-- Remove this section if PR does not change UI -->

Two 15s cycles for each

### Before

Flicker when updating (more visible in real life)

![subm-flicker](https://user-images.githubusercontent.com/6248932/108611377-676c0b00-73de-11eb-9b44-88a70ba02fc0.gif)

<!--
master
Note: only 15s, all other have two cycles, 30s

![image](https://user-images.githubusercontent.com/6248932/108611167-1824db00-73dc-11eb-9f94-4ce6181c7709.png)

With #8866 
-->
![image](https://user-images.githubusercontent.com/6248932/108611038-c465c200-73da-11eb-9407-6493ef463f26.png)

### After

<!--
Without #8866 - hard to see differences
![image](https://user-images.githubusercontent.com/6248932/108610526-823a8180-73d6-11eb-9413-b4edd918b0ba.png)

With #8866 
-->
![image](https://user-images.githubusercontent.com/6248932/108610472-21ab4480-73d6-11eb-8061-c1012e4e5455.png)


## Test methodology <!-- How did you ensure quality? -->

Manual, inserting delays in the handling.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
