### PR TITLE
Correct FormCherryPick ownership

### DIFF
--- a/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -66,7 +66,7 @@ namespace GitUI.CommandsDialogs
             this.Pick.TabIndex = 10;
             this.Pick.Text = "Cherry pick";
             this.Pick.UseVisualStyleBackColor = true;
-            this.Pick.Click += new System.EventHandler(this.Revert_Click);
+            this.Pick.Click += new System.EventHandler(this.Pick_Click);
             // 
             // btnChooseRevision
             // 

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -97,7 +97,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void Revert_Click(object sender, EventArgs e)
+        private void Pick_Click(object sender, EventArgs e)
         {
             var args = new ArgumentBuilder();
             var canExecute = true;
@@ -126,9 +126,9 @@ namespace GitUI.CommandsDialogs
 
                 // Don't verify whether the command is successful.
                 // If it fails, likely there is a conflict that needs to be resolved.
-                FormProcess.ShowDialog(this, process: null, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
+                FormProcess.ShowDialog(Owner, process: null, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
 
-                MergeConflictHandler.HandleMergeConflicts(UICommands, this, AutoCommit.Checked);
+                MergeConflictHandler.HandleMergeConflicts(UICommands, Owner, AutoCommit.Checked);
                 DialogResult = DialogResult.OK;
                 Close();
             }


### PR DESCRIPTION
Still trying to figure out intermittent flakiness reported in #6220. Very subjective, but this little tweak _seems_ to make some difference in local tests. 
Obviously a sweep across the codebase would be ideal but I don't have enough cycles to perform it, hence the piecemeal approach.


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
