### PR TITLE
Left panel: Make "Expand all" and "Collapse all" based on selected node

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -50,8 +50,8 @@ namespace GitUI.BranchTreePanel
             if (contextMenu == menuMain)
             {
                 contextMenu.Items.Clear();
-                contextMenu.Items.Add(mnubtnCollapseAll);
-                contextMenu.Items.Add(mnubtnExpandAll);
+                contextMenu.Items.Add(mnubtnCollapse);
+                contextMenu.Items.Add(mnubtnExpand);
                 if (treeNode is not null)
                 {
                     AddMoveUpDownMenuItems();
@@ -65,14 +65,14 @@ namespace GitUI.BranchTreePanel
                 contextMenu.Items.Add(tsmiMainMenuSpacer1);
             }
 
-            if (!contextMenu.Items.Contains(mnubtnCollapseAll))
+            if (!contextMenu.Items.Contains(mnubtnCollapse))
             {
-                contextMenu.Items.Add(mnubtnCollapseAll);
+                contextMenu.Items.Add(mnubtnCollapse);
             }
 
-            if (!contextMenu.Items.Contains(mnubtnExpandAll))
+            if (!contextMenu.Items.Contains(mnubtnExpand))
             {
-                contextMenu.Items.Add(mnubtnExpandAll);
+                contextMenu.Items.Add(mnubtnExpand);
             }
 
             if (treeNode is not null)
@@ -276,8 +276,8 @@ namespace GitUI.BranchTreePanel
             _tagNodeMenuItems = new TagMenuItems<TagNode>(this);
             AddContextMenuItems(menuTag, _tagNodeMenuItems.Select(s => s.Item));
 
-            RegisterClick(mnubtnCollapseAll, () => treeMain.CollapseAll());
-            RegisterClick(mnubtnExpandAll, () => treeMain.ExpandAll());
+            RegisterClick(mnubtnCollapse, () => treeMain.SelectedNode?.Collapse());
+            RegisterClick(mnubtnExpand, () => treeMain.SelectedNode?.ExpandAll());
             RegisterClick(mnubtnMoveUp, () => ReorderTreeNode(treeMain.SelectedNode, up: true));
             RegisterClick(mnubtnMoveDown, () => ReorderTreeNode(treeMain.SelectedNode, up: false));
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -65,14 +65,14 @@ namespace GitUI.BranchTreePanel
                 contextMenu.Items.Add(tsmiMainMenuSpacer1);
             }
 
-            if (!contextMenu.Items.Contains(mnubtnCollapse))
-            {
-                contextMenu.Items.Add(mnubtnCollapse);
-            }
-
             if (!contextMenu.Items.Contains(mnubtnExpand))
             {
                 contextMenu.Items.Add(mnubtnExpand);
+            }
+
+            if (!contextMenu.Items.Contains(mnubtnCollapse))
+            {
+                contextMenu.Items.Add(mnubtnCollapse);
             }
 
             if (treeNode is not null)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -58,8 +58,8 @@ namespace GitUI.BranchTreePanel
             this.menuMain = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.tsmiMainMenuSpacer1 = new System.Windows.Forms.ToolStripSeparator();
             this.tsmiMainMenuSpacer2 = new System.Windows.Forms.ToolStripSeparator();
-            this.mnubtnCollapseAll = new System.Windows.Forms.ToolStripMenuItem();
-            this.mnubtnExpandAll = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnCollapse = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnExpand = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnMoveUp = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnMoveDown = new System.Windows.Forms.ToolStripMenuItem();
             this.menuBranch = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -141,8 +141,8 @@ namespace GitUI.BranchTreePanel
             // menuMain
             // 
             this.menuMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.mnubtnCollapseAll,
-            this.mnubtnExpandAll,
+            this.mnubtnCollapse,
+            this.mnubtnExpand,
             this.mnubtnMoveUp,
             this.mnubtnMoveDown});
             this.menuMain.Name = "menuMain";
@@ -151,19 +151,19 @@ namespace GitUI.BranchTreePanel
             // 
             // mnubtnCollapseAll
             // 
-            this.mnubtnCollapseAll.Image = global::GitUI.Properties.Images.CollapseAll;
-            this.mnubtnCollapseAll.Name = "mnubtnCollapseAll";
-            this.mnubtnCollapseAll.Size = new System.Drawing.Size(138, 22);
-            this.mnubtnCollapseAll.Text = "Collapse All";
-            this.mnubtnCollapseAll.ToolTipText = "Collapse all nodes";
+            this.mnubtnCollapse.Image = global::GitUI.Properties.Images.CollapseAll;
+            this.mnubtnCollapse.Name = "mnubtnCollapse";
+            this.mnubtnCollapse.Size = new System.Drawing.Size(138, 22);
+            this.mnubtnCollapse.Text = "Collapse";
+            this.mnubtnCollapse.ToolTipText = "Collapse all subnodes";
             // 
             // mnubtnExpandAll
             // 
-            this.mnubtnExpandAll.Image = global::GitUI.Properties.Images.ExpandAll;
-            this.mnubtnExpandAll.Name = "mnubtnExpandAll";
-            this.mnubtnExpandAll.Size = new System.Drawing.Size(138, 22);
-            this.mnubtnExpandAll.Text = "Expand All";
-            this.mnubtnExpandAll.ToolTipText = "Expand all nodes";
+            this.mnubtnExpand.Image = global::GitUI.Properties.Images.ExpandAll;
+            this.mnubtnExpand.Name = "mnubtnExpand";
+            this.mnubtnExpand.Size = new System.Drawing.Size(138, 22);
+            this.mnubtnExpand.Text = "Expand";
+            this.mnubtnExpand.ToolTipText = "Expand all subnodes";
             // 
             // mnubtnMoveUp
             // 
@@ -676,8 +676,8 @@ namespace GitUI.BranchTreePanel
         private ToolStripMenuItem mnubtnDeleteAllBranches;
         private ToolStripMenuItem mnubtnCreateBranch;
         private ContextMenuStrip menuMain;
-        private ToolStripMenuItem mnubtnCollapseAll;
-        private ToolStripMenuItem mnubtnExpandAll;
+        private ToolStripMenuItem mnubtnCollapse;
+        private ToolStripMenuItem mnubtnExpand;
         private ContextMenuStrip menuRemoteRepoNode;
         private ToolStripMenuItem mnubtnFetchOneBranch;
         private TableLayoutPanel repoTreePanel;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -59,9 +59,9 @@ namespace GitUI.BranchTreePanel
             btnSearch.PreviewKeyDown += OnPreviewKeyDown;
             PreviewKeyDown += OnPreviewKeyDown;
 
-            mnubtnCollapseAll.AdaptImageLightness();
+            mnubtnCollapse.AdaptImageLightness();
             tsbCollapseAll.AdaptImageLightness();
-            mnubtnExpandAll.AdaptImageLightness();
+            mnubtnExpand.AdaptImageLightness();
             mnubtnFetchAllBranchesFromARemote.AdaptImageLightness();
             mnuBtnPruneAllBranchesFromARemote.AdaptImageLightness();
             mnuBtnFetchAllRemotes.AdaptImageLightness();
@@ -76,7 +76,7 @@ namespace GitUI.BranchTreePanel
             treeMain.HideSelection = false;
 
             toolTip.SetToolTip(btnSearch, _searchTooltip.Text);
-            tsbCollapseAll.ToolTipText = mnubtnCollapseAll.ToolTipText;
+            tsbCollapseAll.ToolTipText = mnubtnCollapse.ToolTipText;
 
             tsbShowBranches.Checked = AppSettings.RepoObjectsTreeShowBranches;
             tsbShowRemotes.Checked = AppSettings.RepoObjectsTreeShowRemotes;

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
@@ -56,9 +56,8 @@
             this.assumeUnchangedTheFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparatorGitTrackingActions = new System.Windows.Forms.ToolStripSeparator();
             this.findToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.expandSubtreeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.expandAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.collapseAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.expandToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.collapseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.FileText = new GitUI.Editor.FileViewer();
             ((System.ComponentModel.ISupportInitialize)(this.FileTreeSplitContainer)).BeginInit();
             this.FileTreeSplitContainer.Panel1.SuspendLayout();
@@ -132,9 +131,8 @@
             this.assumeUnchangedTheFileToolStripMenuItem,
             this.toolStripSeparatorGitTrackingActions,
             this.findToolStripMenuItem,
-            this.expandSubtreeToolStripMenuItem,
-            this.expandAllToolStripMenuItem,
-            this.collapseAllToolStripMenuItem});
+            this.expandToolStripMenuItem,
+            this.collapseToolStripMenuItem});
             this.FileTreeContextMenu.Name = "FileTreeContextMenu";
             this.FileTreeContextMenu.Size = new System.Drawing.Size(326, 474);
             this.FileTreeContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.FileTreeContextMenu_Opening);
@@ -318,27 +316,19 @@
             // 
             // expandSubtreeToolStripMenuItem
             // 
-            this.expandSubtreeToolStripMenuItem.Image = global::GitUI.Properties.Images.TreeExpandSubtree;
-            this.expandSubtreeToolStripMenuItem.Name = "expandSubtreeToolStripMenuItem";
-            this.expandSubtreeToolStripMenuItem.Size = new System.Drawing.Size(325, 22);
-            this.expandSubtreeToolStripMenuItem.Text = "Expand subtree (takes a while on large subtrees)";
-            this.expandSubtreeToolStripMenuItem.Click += new System.EventHandler(this.expandSubtreeToolStripMenuItem_Click);
-            // 
-            // expandAllToolStripMenuItem
-            // 
-            this.expandAllToolStripMenuItem.Image = global::GitUI.Properties.Images.TreeExpandAll;
-            this.expandAllToolStripMenuItem.Name = "expandAllToolStripMenuItem";
-            this.expandAllToolStripMenuItem.Size = new System.Drawing.Size(325, 22);
-            this.expandAllToolStripMenuItem.Text = "Expand all (takes a while on large trees)";
-            this.expandAllToolStripMenuItem.Click += new System.EventHandler(this.expandAllStripMenuItem_Click);
+            this.expandToolStripMenuItem.Image = global::GitUI.Properties.Images.TreeExpandSubtree;
+            this.expandToolStripMenuItem.Name = "expandToolStripMenuItem";
+            this.expandToolStripMenuItem.Size = new System.Drawing.Size(325, 22);
+            this.expandToolStripMenuItem.Text = "Expand";
+            this.expandToolStripMenuItem.Click += new System.EventHandler(this.expandToolStripMenuItem_Click);
             // 
             // collapseAllToolStripMenuItem
             // 
-            this.collapseAllToolStripMenuItem.Image = global::GitUI.Properties.Images.TreeCollapseAll;
-            this.collapseAllToolStripMenuItem.Name = "collapseAllToolStripMenuItem";
-            this.collapseAllToolStripMenuItem.Size = new System.Drawing.Size(325, 22);
-            this.collapseAllToolStripMenuItem.Text = "Collapse all";
-            this.collapseAllToolStripMenuItem.Click += new System.EventHandler(this.collapseAllToolStripMenuItem_Click);
+            this.collapseToolStripMenuItem.Image = global::GitUI.Properties.Images.TreeCollapseAll;
+            this.collapseToolStripMenuItem.Name = "collapseToolStripMenuItem";
+            this.collapseToolStripMenuItem.Size = new System.Drawing.Size(325, 22);
+            this.collapseToolStripMenuItem.Text = "Collapse";
+            this.collapseToolStripMenuItem.Click += new System.EventHandler(this.collapseToolStripMenuItem_Click);
             // 
             // FileText
             // 
@@ -392,11 +382,10 @@
         private System.Windows.Forms.ToolStripMenuItem openFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openFileWithToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparatorGitTrackingActions;
-        private System.Windows.Forms.ToolStripMenuItem expandAllToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem collapseAllToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem collapseToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem assumeUnchangedTheFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparatorGitActions;
         private System.Windows.Forms.ToolStripMenuItem stopTrackingThisFileToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem expandSubtreeToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem expandToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
@@ -57,7 +57,7 @@
             this.toolStripSeparatorGitTrackingActions = new System.Windows.Forms.ToolStripSeparator();
             this.findToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.expandToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.collapseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.collapseAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.FileText = new GitUI.Editor.FileViewer();
             ((System.ComponentModel.ISupportInitialize)(this.FileTreeSplitContainer)).BeginInit();
             this.FileTreeSplitContainer.Panel1.SuspendLayout();
@@ -132,7 +132,7 @@
             this.toolStripSeparatorGitTrackingActions,
             this.findToolStripMenuItem,
             this.expandToolStripMenuItem,
-            this.collapseToolStripMenuItem});
+            this.collapseAllToolStripMenuItem});
             this.FileTreeContextMenu.Name = "FileTreeContextMenu";
             this.FileTreeContextMenu.Size = new System.Drawing.Size(326, 474);
             this.FileTreeContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.FileTreeContextMenu_Opening);
@@ -324,11 +324,11 @@
             // 
             // collapseAllToolStripMenuItem
             // 
-            this.collapseToolStripMenuItem.Image = global::GitUI.Properties.Images.TreeCollapseAll;
-            this.collapseToolStripMenuItem.Name = "collapseToolStripMenuItem";
-            this.collapseToolStripMenuItem.Size = new System.Drawing.Size(325, 22);
-            this.collapseToolStripMenuItem.Text = "Collapse";
-            this.collapseToolStripMenuItem.Click += new System.EventHandler(this.collapseToolStripMenuItem_Click);
+            this.collapseAllToolStripMenuItem.Image = global::GitUI.Properties.Images.TreeCollapseAll;
+            this.collapseAllToolStripMenuItem.Name = "collapseAllToolStripMenuItem";
+            this.collapseAllToolStripMenuItem.Size = new System.Drawing.Size(325, 22);
+            this.collapseAllToolStripMenuItem.Text = "Collapse All";
+            this.collapseAllToolStripMenuItem.Click += new System.EventHandler(this.collapseAllToolStripMenuItem_Click);
             // 
             // FileText
             // 
@@ -382,7 +382,7 @@
         private System.Windows.Forms.ToolStripMenuItem openFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openFileWithToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparatorGitTrackingActions;
-        private System.Windows.Forms.ToolStripMenuItem collapseToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem collapseAllToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem assumeUnchangedTheFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparatorGitActions;
         private System.Windows.Forms.ToolStripMenuItem stopTrackingThisFileToolStripMenuItem;

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -507,9 +507,9 @@ See the changes in the commit form.");
             tvGitTree.SelectedNode?.ExpandAll();
         }
 
-        private void collapseToolStripMenuItem_Click(object sender, EventArgs e)
+        private void collapseAllToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            tvGitTree.SelectedNode?.Collapse();
+            tvGitTree.CollapseAll();
         }
 
         private void fileTreeArchiveToolStripMenuItem_Click(object sender, EventArgs e)
@@ -618,7 +618,7 @@ See the changes in the commit form.");
 
             findToolStripMenuItem.Enabled = tvGitTree.Nodes.Count > 0;
             expandToolStripMenuItem.Visible = isFolder;
-            collapseToolStripMenuItem.Visible = isFolder;
+            collapseAllToolStripMenuItem.Visible = isFolder;
         }
 
         private void fileTreeOpenContainingFolderToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -153,6 +153,7 @@ See the changes in the commit form.");
             try
             {
                 tvGitTree.SuspendLayout();
+                tvGitTree.BeginUpdate();
 
                 // Save state only when there is selected node
                 if (tvGitTree.SelectedNode is not null)
@@ -215,6 +216,7 @@ See the changes in the commit form.");
             }
             finally
             {
+                tvGitTree.EndUpdate();
                 tvGitTree.ResumeLayout();
             }
         }

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -433,11 +433,6 @@ See the changes in the commit form.");
             }
         }
 
-        private void collapseAllToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            tvGitTree.CollapseAll();
-        }
-
         private void copyFilenameToClipboardToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (tvGitTree.SelectedNode?.Tag is GitItem gitItem)
@@ -507,14 +502,14 @@ See the changes in the commit form.");
             _refreshGitStatus?.Invoke();
         }
 
-        private void expandAllStripMenuItem_Click(object sender, EventArgs e)
-        {
-            tvGitTree.ExpandAll();
-        }
-
-        private void expandSubtreeToolStripMenuItem_Click(object sender, EventArgs e)
+        private void expandToolStripMenuItem_Click(object sender, EventArgs e)
         {
             tvGitTree.SelectedNode?.ExpandAll();
+        }
+
+        private void collapseToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            tvGitTree.SelectedNode?.Collapse();
         }
 
         private void fileTreeArchiveToolStripMenuItem_Click(object sender, EventArgs e)
@@ -622,7 +617,8 @@ See the changes in the commit form.");
             toolStripSeparatorGitTrackingActions.Visible = isFile;
 
             findToolStripMenuItem.Enabled = tvGitTree.Nodes.Count > 0;
-            expandSubtreeToolStripMenuItem.Visible = isFolder;
+            expandToolStripMenuItem.Visible = isFolder;
+            collapseToolStripMenuItem.Visible = isFolder;
         }
 
         private void fileTreeOpenContainingFolderToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8162,12 +8162,12 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <source>Fetch and prune all remotes</source>
         <target />
       </trans-unit>
-      <trans-unit id="mnubtnCollapseAll.Text">
-        <source>Collapse All</source>
+      <trans-unit id="mnubtnCollapse.Text">
+        <source>Collapse</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnCollapseAll.ToolTipText">
-        <source>Collapse all nodes</source>
+        <source>Collapse all subnodes</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnCommitSubmodule.Text">
@@ -8206,12 +8206,12 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <source>A&amp;ctivate and fetch</source>
         <target />
       </trans-unit>
-      <trans-unit id="mnubtnExpandAll.Text">
-        <source>Expand All</source>
+      <trans-unit id="mnubtnExpand.Text">
+        <source>Expand</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnExpandAll.ToolTipText">
-        <source>Expand all nodes</source>
+        <source>Expand all subnodes</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnFetchAllBranchesFromARemote.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8622,8 +8622,8 @@ See the changes in the commit form.</source>
         <source>Blame</source>
         <target />
       </trans-unit>
-      <trans-unit id="collapseToolStripMenuItem.Text">
-        <source>Collapse</source>
+      <trans-unit id="collapseAllToolStripMenuItem.Text">
+        <source>Collapse All</source>
         <target />
       </trans-unit>
       <trans-unit id="copyFilenameToClipboardToolStripMenuItem.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8166,7 +8166,7 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <source>Collapse</source>
         <target />
       </trans-unit>
-      <trans-unit id="mnubtnCollapseAll.ToolTipText">
+      <trans-unit id="mnubtnCollapse.ToolTipText">
         <source>Collapse all subnodes</source>
         <target />
       </trans-unit>
@@ -8210,7 +8210,7 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <source>Expand</source>
         <target />
       </trans-unit>
-      <trans-unit id="mnubtnExpandAll.ToolTipText">
+      <trans-unit id="mnubtnExpand.ToolTipText">
         <source>Expand all subnodes</source>
         <target />
       </trans-unit>
@@ -8357,7 +8357,7 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <target />
       </trans-unit>
       <trans-unit id="tsbCollapseAll.ToolTipText">
-        <source>Collapse all nodes</source>
+        <source>Collapse all subnodes</source>
         <target />
       </trans-unit>
       <trans-unit id="tsbShowBranches.Text">
@@ -8622,8 +8622,8 @@ See the changes in the commit form.</source>
         <source>Blame</source>
         <target />
       </trans-unit>
-      <trans-unit id="collapseAllToolStripMenuItem.Text">
-        <source>Collapse all</source>
+      <trans-unit id="collapseToolStripMenuItem.Text">
+        <source>Collapse</source>
         <target />
       </trans-unit>
       <trans-unit id="copyFilenameToClipboardToolStripMenuItem.Text">
@@ -8634,12 +8634,8 @@ See the changes in the commit form.</source>
         <source>Edit working directory file</source>
         <target />
       </trans-unit>
-      <trans-unit id="expandAllToolStripMenuItem.Text">
-        <source>Expand all (takes a while on large trees)</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="expandSubtreeToolStripMenuItem.Text">
-        <source>Expand subtree (takes a while on large subtrees)</source>
+      <trans-unit id="expandToolStripMenuItem.Text">
+        <source>Expand</source>
         <target />
       </trans-unit>
       <trans-unit id="fileHistoryToolStripMenuItem.Text">

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.cs
@@ -87,8 +87,8 @@ namespace GitExtensions.UITests.CommandsDialogs
                     int count = contextMenu.Items.Count;
 
                     // Assert items from bottom to the top
-                    contextMenu.Items[--count].Text.Should().Be("Expand All");
-                    contextMenu.Items[--count].Text.Should().Be("Collapse All");
+                    contextMenu.Items[--count].Text.Should().Be("Expand");
+                    contextMenu.Items[--count].Text.Should().Be("Collapse");
                     contextMenu.Items[--count].Should().BeOfType<ToolStripSeparator>();
                     contextMenu.Items[--count].Text.Should().Be(GitUI.Strings.SortOrder);
                     contextMenu.Items[--count].Text.Should().Be(GitUI.Strings.SortBy);

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.cs
@@ -87,8 +87,8 @@ namespace GitExtensions.UITests.CommandsDialogs
                     int count = contextMenu.Items.Count;
 
                     // Assert items from bottom to the top
-                    contextMenu.Items[--count].Text.Should().Be("Expand");
                     contextMenu.Items[--count].Text.Should().Be("Collapse");
+                    contextMenu.Items[--count].Text.Should().Be("Expand");
                     contextMenu.Items[--count].Should().BeOfType<ToolStripSeparator>();
                     contextMenu.Items[--count].Text.Should().Be(GitUI.Strings.SortOrder);
                     contextMenu.Items[--count].Text.Should().Be(GitUI.Strings.SortBy);


### PR DESCRIPTION
Fixes #8873

## Proposed changes

- "Expand all" and "Collapse all" now has an effect only on selected node (collapse all tree could still be made through menu icon)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![expand_all](https://user-images.githubusercontent.com/460196/108904357-af797080-761e-11eb-99d8-336819c0a31f.gif)

### After

![expand_all_fixed](https://user-images.githubusercontent.com/460196/108912965-a346e080-7629-11eb-88b1-7634e536cc91.gif)


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 873e9ed043f1d89064bae1bd4126c099c6da5410
- Git 2.28.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4311.0
- DPI 192dpi (200% scaling)
