### PR TITLE
Remove double execution of GetSubmoduleStatusAsync

### DIFF
--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -112,7 +112,7 @@ namespace GitUI
                         : diffOfConflict;
                 }
 
-                if (file.IsSubmodule && file.GetSubmoduleStatusAsync() is not null)
+                if (file.IsSubmodule)
                 {
                     // Patch already evaluated
                     var status = ThreadHelper.JoinableTaskFactory.Run(file.GetSubmoduleStatusAsync);


### PR DESCRIPTION
## Proposed changes

The previous code would call `GetSubmoduleStatusAsync` twice, only using the second call's result.

As the returned task is never null, this check is redundant and does redundant work.

Checking the task's result occurs below.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
