### PR TITLE
Fix submodule status loading error

### DIFF
--- a/GitCommands/Git/GitItemStatus.cs
+++ b/GitCommands/Git/GitItemStatus.cs
@@ -177,14 +177,17 @@ namespace GitCommands
 
         #endregion
 
-        public async Task<GitSubmoduleStatus?> GetSubmoduleStatusAsync()
+        /// <summary>
+        /// Gets a task whose result is the submodule status.
+        /// </summary>
+        /// <returns>
+        /// A null task when <see cref="SetSubmoduleStatus"/> has not been called on this object, or
+        /// a task whose result is the status. The task may also return null if the status could not be
+        /// determined.
+        /// </returns>
+        public Task<GitSubmoduleStatus?>? GetSubmoduleStatusAsync()
         {
-            if (_submoduleStatus is null)
-            {
-                return null;
-            }
-
-            return await _submoduleStatus.JoinAsync();
+            return _submoduleStatus?.JoinAsync();
         }
 
         internal void SetSubmoduleStatus(JoinableTask<GitSubmoduleStatus?> status)

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -112,10 +112,11 @@ namespace GitUI
                         : diffOfConflict;
                 }
 
-                if (file.IsSubmodule)
+                if (file.IsSubmodule
+                    && file.GetSubmoduleStatusAsync() is Task<GitSubmoduleStatus> task)
                 {
                     // Patch already evaluated
-                    var status = ThreadHelper.JoinableTaskFactory.Run(file.GetSubmoduleStatusAsync);
+                    var status = ThreadHelper.JoinableTaskFactory.Run(() => task);
                     return status is not null
                         ? LocalizationHelpers.ProcessSubmoduleStatus(fileViewer.Module, status)
                         : $"Failed to get status for submodule \"{file.Name}\"";

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -780,14 +780,13 @@ namespace GitUI
 
         private static string AppendItemSubmoduleStatus(string text, GitItemStatus item)
         {
-            if (item.IsSubmodule)
+            if (item.IsSubmodule
+                && item.GetSubmoduleStatusAsync() is Task<GitSubmoduleStatus> task
+                && task is not null
+                && task.IsCompleted
+                && task.CompletedResult() is not null)
             {
-                Task<GitSubmoduleStatus?> task = item.GetSubmoduleStatusAsync();
-
-                if (task.IsCompleted && task.CompletedResult() is not null)
-                {
-                    text += task.CompletedResult()!.AddedAndRemovedString();
-                }
+                text += task.CompletedResult()!.AddedAndRemovedString();
             }
 
             return text;
@@ -804,7 +803,11 @@ namespace GitUI
 
             var submoduleName = SelectedItem.Item.Name;
 
-            var status = await SelectedItem.Item.GetSubmoduleStatusAsync().ConfigureAwait(false);
+            Task<GitSubmoduleStatus?>? task = SelectedItem.Item.GetSubmoduleStatusAsync();
+            GitSubmoduleStatus? status = task is not null
+                ? await task.ConfigureAwait(false)
+                : null;
+
             ObjectId? selectedId = SelectedItem.SecondRevision?.ObjectId == ObjectId.WorkTreeId
                 ? ObjectId.WorkTreeId
                 : status?.Commit;
@@ -924,19 +927,21 @@ namespace GitUI
                         listItem.ImageIndex = GetItemImageIndex(item);
                     }
 
-                    if (item.GetSubmoduleStatusAsync() is not null && !item.GetSubmoduleStatusAsync().IsCompleted)
+                    if (item.IsSubmodule
+                        && item.GetSubmoduleStatusAsync() is Task<GitSubmoduleStatus> task
+                        && task is not null)
                     {
                         var capturedItem = item;
 
                         ThreadHelper.JoinableTaskFactory.RunAsync(
-                            async () =>
-                            {
-                                await capturedItem.GetSubmoduleStatusAsync();
+                        async () =>
+                        {
+                            await task;
 
-                                await this.SwitchToMainThreadAsync();
+                            await this.SwitchToMainThreadAsync();
 
-                                listItem.ImageIndex = GetItemImageIndex(capturedItem);
-                            });
+                            listItem.ImageIndex = GetItemImageIndex(capturedItem);
+                        });
                     }
 
                     if (previouslySelectedItems?.Contains(item) == true)
@@ -1017,14 +1022,11 @@ namespace GitUI
 
                 if (gitItemStatus.IsSubmodule)
                 {
-                    if (gitItemStatus.GetSubmoduleStatusAsync() is null ||
-                        !gitItemStatus.GetSubmoduleStatusAsync().IsCompleted)
-                    {
-                        return gitItemStatus.IsDirty ? nameof(Images.SubmoduleDirty) : nameof(Images.SubmodulesManage);
-                    }
-
-                    var status = gitItemStatus.GetSubmoduleStatusAsync().CompletedResult();
-                    if (status is null)
+                    if (gitItemStatus.GetSubmoduleStatusAsync() is not Task<GitSubmoduleStatus> task
+                        || task is null
+                        || !task.IsCompleted
+                        || task.CompletedResult() is not GitSubmoduleStatus status
+                        || status is null)
                     {
                         return gitItemStatus.IsDirty ? nameof(Images.SubmoduleDirty) : nameof(Images.SubmodulesManage);
                     }


### PR DESCRIPTION
Fixes @gerhardol's comments on #8875

## Proposed changes

Refactoring during annotation identified a potential issue here, but the change was not correct. This change allows the task itself to be null (an uncommon pattern) which indicates that `SetSubmoduleStatus` has not been called.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

To trigger the broken behaviour:
1. Open the GE repo
2. Select the "File Tree" tab
3. Select a submodule in the tree
4. Press H to open the history

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
