### PR TITLE
GitStatusMonitor increase minimum time between updates

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -29,7 +29,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         /// <summary>
         /// Minimum interval between subsequent updates
         /// </summary>
-        private const int MinUpdateInterval = 5000;
+        private const int MinUpdateInterval = 30000;
 
         /// <summary>
         /// Update every 5min, just to make sure something didn't slip through the cracks.


### PR DESCRIPTION
Fixes #8871

## Proposed changes

Increase the time between git-status runs from 5s to 30s

So for instance when building, git-status runs every 30s

If there has been no changes and git-status has not run in 30s,
git-status will run in about one second as now

This affects:
* Commit button count
* artificial commit summary and tooltip
* left panel status and tooltips (added in 3.5)
* submodule menu drop down

The use case with most impact as I see it is if you save one file in the editor (git-status is triggered quickly), then you select another file in the editor already edited and save that, then the status will be updated in about 30s instead of about 5s.

## Test methodology <!-- How did you ensure quality? -->

manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
