### PR TITLE
Eliminate closure allocations

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -219,7 +219,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             }
 
             // Ensure all parents are loaded before adding it to the _nodes list. This is important for ordering.
-            ImmutableInterlocked.Update(ref _nodes, (list, rev) => list.Add(rev), revisionGraphRevision);
+            ImmutableInterlocked.Update(ref _nodes, (list, revision) => list.Add(revision), revisionGraphRevision);
         }
 
         /// <summary>

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -219,7 +219,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             }
 
             // Ensure all parents are loaded before adding it to the _nodes list. This is important for ordering.
-            ImmutableInterlocked.Update(ref _nodes, list => list.Add(revisionGraphRevision));
+            ImmutableInterlocked.Update(ref _nodes, (list, rev) => list.Add(rev), revisionGraphRevision);
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed changes

This change removes 427,688 bytes of closure allocations while loading GE with the gitextensions repo.

Passing the argument on the stack allows the delegate to be cached by the compiler, rather than allocating a new instance for each call.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
