### PR TITLE
Eliminate boxing allocation

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -884,9 +884,11 @@ namespace GitUI
 
                 SelectInitialRevision(newCurrentCheckout);
 
-                // NB: Build ref filter before updating the property to reduce the number of chage events.
+                const RefFilterOptions gitNotesOptions = RefFilterOptions.All | RefFilterOptions.Boundary;
+
+                // NB: Build ref filter before updating the property to reduce the number of change events.
                 RefFilterOptions refFilterOptions = RefFilterOptions;
-                if (!AppSettings.ShowGitNotes && refFilterOptions.HasFlag(RefFilterOptions.All | RefFilterOptions.Boundary))
+                if (!AppSettings.ShowGitNotes && (refFilterOptions & gitNotesOptions) == gitNotesOptions)
                 {
                     refFilterOptions |= RefFilterOptions.ShowGitNotes;
                 }


### PR DESCRIPTION
## Proposed changes

This change removes 537,404 bytes of boxed enum allocations while loading GE with the gitextensions repo.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
 
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
