### PR TITLE
[3.5] Eliminate boxing allocation

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -888,9 +888,11 @@ namespace GitUI
 
                 SelectInitialRevision();
 
-                // NB: Build ref filter before updating the property to reduce the number of chage events.
+                const RefFilterOptions gitNotesOptions = RefFilterOptions.All | RefFilterOptions.Boundary;
+
+                // NB: Build ref filter before updating the property to reduce the number of change events.
                 RefFilterOptions refFilterOptions = RefFilterOptions;
-                if (!AppSettings.ShowGitNotes && refFilterOptions.HasFlag(RefFilterOptions.All | RefFilterOptions.Boundary))
+                if (!AppSettings.ShowGitNotes && (refFilterOptions & gitNotesOptions) == gitNotesOptions)
                 {
                     refFilterOptions |= RefFilterOptions.ShowGitNotes;
                 }


### PR DESCRIPTION
Port of #8888 for `release/3.5`.

This change removes 537,404 bytes of boxed enum allocations while loading GE with the gitextensions repo.