### PR TITLE
Remove /en/latest from Doc links 3.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "GitExtensionsDoc"]
-	path = GitExtensionsDoc
-	url = ../../gitextensions/GitExtensionsDoc.git
 [submodule "Externals/Git.hub"]
 	path = Externals/Git.hub
 	url = ../../gitextensions/Git.hub.git

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -13,8 +13,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class AppearanceSettingsPage : SettingsPageWithHeader
     {
-        private const string _customAvatarTemplateURL = "https://git-extensions-documentation.readthedocs.io/en/latest/settings.html#git-extensions-appearance-author-images-avatar-provider";
-        private const string _gravatarDefaultImageURL = "https://git-extensions-documentation.readthedocs.io/en/latest/settings.html#git-extensions-appearance-author-images-avatar-fallback";
+        private const string _customAvatarTemplateURL = "https://git-extensions-documentation.readthedocs.io/settings.html#git-extensions-appearance-author-images-avatar-provider";
+        private const string _gravatarDefaultImageURL = "https://git-extensions-documentation.readthedocs.io/settings.html#git-extensions-appearance-author-images-avatar-fallback";
         private const string _spellingWikiURL = "https://github.com/gitextensions/gitextensions/wiki/Spelling";
         private const string _translationsWikiURL = "https://github.com/gitextensions/gitextensions/wiki/Translations";
 

--- a/GitUI/GitExtensionsDialog.cs
+++ b/GitUI/GitExtensionsDialog.cs
@@ -44,7 +44,7 @@ namespace GitUI
         /// </summary>
         /// <remarks>
         /// The URL structure:
-        /// https://git-extensions-documentation.readthedocs.io/en/latest/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}
+        /// https://git-extensions-documentation.readthedocs.io/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}.
         /// </remarks>
         public string ManualSectionAnchorName { get; set; }
 
@@ -53,7 +53,7 @@ namespace GitUI
         /// </summary>
         /// <remarks>
         /// The URL structure:
-        /// https://git-extensions-documentation.readthedocs.io/en/latest/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}
+        /// https://git-extensions-documentation.readthedocs.io/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}.
         /// </remarks>
         public string ManualSectionSubfolder { get; set; }
 

--- a/GitUI/UserManual/StandardHtmlUserManual.cs
+++ b/GitUI/UserManual/StandardHtmlUserManual.cs
@@ -4,7 +4,7 @@ namespace GitUI.UserManual
 {
     public class StandardHtmlUserManual : IProvideUserManual
     {
-        private const string _location = @"https://git-extensions-documentation.readthedocs.org/en/latest/";
+        private const string _location = @"https://git-extensions-documentation.readthedocs.org/";
 
         private readonly string _subFolder;
         private readonly string _anchorName;

--- a/README.md
+++ b/README.md
@@ -255,9 +255,9 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 
 # Useful Links
 
-* Website: [gitextensions.github.io](https://gitextensions.github.io/)
+* Website: [gitextensions.github.io](https://gitextensions.github.io/) [Git repo](https://github.com/gitextensions/gitextensions.github.io)
 * Source code: [github.com/gitextensions/gitextensions](https://github.com/gitextensions/gitextensions)
-* Online manual: [git-extensions-documentation.readthedocs.org](https://git-extensions-documentation.readthedocs.org/en/latest/)
+* Online manual: [git-extensions-documentation.readthedocs.org](https://git-extensions-documentation.readthedocs.org/) [Git repo](https://github.com/gitextensions/GitExtensionsDoc)
 * Issue tracker: [github.com/gitextensions/gitextensions/issues](https://github.com/gitextensions/gitextensions/issues)
 * Wiki: [github.com/gitextensions/gitextensions/wiki](https://github.com/gitextensions/gitextensions/wiki)
 * Gitter chat: [gitter.im/gitextensions/gitextensions](https://gitter.im/gitextensions/gitextensions?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/UnitTests/GitCommands.Tests/TestData/README.blame
+++ b/UnitTests/GitCommands.Tests/TestData/README.blame
@@ -323,7 +323,7 @@ e3268019c66da7534414e9562ececdee5d455b1b 63 73 2
 e3268019c66da7534414e9562ececdee5d455b1b 64 74
 	* Source code: [http://github.com/gitextensions/gitextensions](http://github.com/gitextensions/gitextensions)
 59f8cc5eb9d98621746300f0b289b5da7abaa13b 10 75 2
-	* Online manual: [https://git-extensions-documentation.readthedocs.org/en/latest/](https://git-extensions-documentation.readthedocs.org/en/latest/)
+	* Online manual: [https://git-extensions-documentation.readthedocs.org/](https://git-extensions-documentation.readthedocs.org/)
 59f8cc5eb9d98621746300f0b289b5da7abaa13b 11 76
 	* Issue tracker: [http://github.com/gitextensions/gitextensions/issues](http://github.com/gitextensions/gitextensions/issues)
 88bb86326419ee8dfa03c7fde9aae78b9b7fb961 15 77 1

--- a/UnitTests/GitUI.Tests/UserManual/StandardHtmlUserManualFixture.cs
+++ b/UnitTests/GitUI.Tests/UserManual/StandardHtmlUserManualFixture.cs
@@ -7,9 +7,9 @@ namespace GitUITests.UserManual
     [TestFixture]
     public class StandardHtmlUserManualFixture
     {
-        [TestCase(null, null, "https://git-extensions-documentation.readthedocs.org/en/latest/")] // both null makes no sense atm
-        [TestCase("merge_conflicts", null, "https://git-extensions-documentation.readthedocs.org/en/latest/merge_conflicts.html")]
-        [TestCase("merge_conflicts", "merge-conflicts", "https://git-extensions-documentation.readthedocs.org/en/latest/merge_conflicts.html#merge-conflicts")]
+        [TestCase(null, null, "https://git-extensions-documentation.readthedocs.org/")] // both null makes no sense atm
+        [TestCase("merge_conflicts", null, "https://git-extensions-documentation.readthedocs.org/merge_conflicts.html")]
+        [TestCase("merge_conflicts", "merge-conflicts", "https://git-extensions-documentation.readthedocs.org/merge_conflicts.html#merge-conflicts")]
         public void GetUrl(string subFolder, string anchor, string expected)
         {
             var sut = new StandardHtmlUserManual(subFolder, anchor);

--- a/scripts/set_version_to.py
+++ b/scripts/set_version_to.py
@@ -35,15 +35,6 @@ if __name__ == '__main__':
     if not args.text:
       args.text = args.version
     
-    filename = "..\GitUI\CommandsDialogs\FormBrowse.cs"
-    pattern = re.compile(r'(git-extensions-documentation.readthedocs.org/en)(/\w+)', re.IGNORECASE)
-    commonAssemblyInfo = open(filename, "r").readlines()
-    o = ""
-    for i in commonAssemblyInfo:
-        o += pattern.sub(r"\1/release-%s" % (short_version), i)
-    outfile = open(filename, "w")
-    outfile.writelines(o)
-
     submodules = glob.glob("..\Externals\**\AssemblyInfo.cs", recursive=True)
     filenames = [ "..\CommonAssemblyInfo.cs", "..\CommonAssemblyInfoExternals.cs" ]
     combined = filenames + submodules
@@ -119,20 +110,3 @@ if __name__ == '__main__':
     for i in range(1, len(verSplitted)):
         if len(verSplitted[i]) == 1:
             verSplitted[i] = "0" + verSplitted[i]
-
-    filename = "..\GitExtensionsDoc\source\conf.py"
-    docoConf = open(filename, "r").readlines()
-    o = ""
-    for i in docoConf:
-        line = i
-        if line.find("release = ") != -1:
-            data = line.split(' = ')
-            data[1] = '.'.join(verSplitted)
-            line = " = '".join(data) + "'\n"
-        elif line.find("version = ") != -1:
-            data = line.split(' = ')
-            data[1] = args.text
-            line = " = '".join(data) + "'\n"
-        o += line
-    outfile = open(filename, "w")
-    outfile.writelines(o)


### PR DESCRIPTION
Requests are directed to / anyway

Remove GitExtensionsDoc subrepo as it is not used in builds anyway.
Remove release script update of the subrepo, this must be handled manually since
signed builds must run in AppVeyor.

(cherry picked from commit c59fd847fc6c1879ead730b7da01104ac40d74e1)

#8838 for 3.5