### PR TITLE
RevDiff: Request GitStatus updates at file manipulations

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -201,7 +201,8 @@ namespace GitUI.CommandsDialogs
 
             repoObjectsTree.Initialize(_aheadBehindDataProvider, _filterBranchHelper, RevisionGrid, RevisionGrid, RevisionGrid);
             toolStripBranchFilterComboBox.DropDown += toolStripBranches_DropDown_ResizeDropDownWidth;
-            revisionDiff.Bind(RevisionGrid, fileTree);
+            revisionDiff.Bind(RevisionGrid, fileTree, () => RequestRefresh());
+            fileTree.Bind(() => RequestRefresh());
 
             var repositoryDescriptionProvider = new RepositoryDescriptionProvider(new GitDirectoryResolver());
             _appTitleGenerator = new AppTitleGenerator(repositoryDescriptionProvider);
@@ -813,7 +814,7 @@ namespace GitUI.CommandsDialogs
             }
 
             _gitStatusMonitor.InvalidateGitWorkingDirectoryStatus();
-            _gitStatusMonitor.RequestRefresh();
+            RequestRefresh();
 
             if (_dashboard is null || !_dashboard.Visible)
             {
@@ -824,6 +825,8 @@ namespace GitUI.CommandsDialogs
 
             toolStripButtonPush.DisplayAheadBehindInformation(Module.GetSelectedBranch());
         }
+
+        private void RequestRefresh() => _gitStatusMonitor?.RequestRefresh();
 
         private void RefreshSelection()
         {
@@ -1541,6 +1544,7 @@ namespace GitUI.CommandsDialogs
         private void ResetToolStripMenuItem_Click(object sender, EventArgs e)
         {
             UICommands.StartResetChangesDialog(this);
+            RequestRefresh();
             revisionDiff.RefreshArtificial();
         }
 
@@ -3223,6 +3227,7 @@ namespace GitUI.CommandsDialogs
                 var args = GitCommandHelpers.ResetCmd(ResetMode.Soft, "HEAD~1");
                 Module.GitExecutable.GetOutput(args);
                 refreshToolStripMenuItem.PerformClick();
+                RequestRefresh();
             }
         }
 


### PR DESCRIPTION
https://github.com/gitextensions/gitextensions/pull/8886#issuecomment-786868520

## Proposed changes

Whenever files are manipulated in RevDiff, request GitStatusMonitor refresh
- If the change was just worktree <-> index, git-status is not triggered at all (until next file system change or every fifth minute)
- If the change is throttled (#8886 increases the minimal time for updates to 30 s), an interactive request is done (delayed 200 ms to possibly bundle changes)

I considered to request the update only at (likely) worktree <-> index changes, but that got more complicated and a faster update is desired after manual changes.
If you stage files one by one, if may cause git-status to run more or less continously (where Git is slow). I do not believe this is a problem, but the request could be done with some delay too.
@mstv?

Note that FormCommit is not affected, it always rescans (not directly with git-status) when a change is done.

Candidate for 3.5 too 

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
