### PR TITLE
Add UI improvements

### DIFF
--- a/GitExtUtils/GitUI/ControlDpiExtensions.cs
+++ b/GitExtUtils/GitUI/ControlDpiExtensions.cs
@@ -82,7 +82,7 @@ namespace GitUI
                             splitContainer.SplitterWidth = DpiUtil.Scale(splitterWidth);
                         }
 
-                        splitContainer.BackColor = ColorHelper.GetSplitterColor();
+                        splitContainer.BackColor = Color.Transparent;
                         break;
                     }
 

--- a/GitExtUtils/GitUI/Theming/OtherColors.cs
+++ b/GitExtUtils/GitUI/Theming/OtherColors.cs
@@ -1,0 +1,10 @@
+﻿using System.Drawing;
+
+namespace GitExtUtils.GitUI.Theming
+{
+    public static class OtherColors
+    {
+        public static readonly Color BackgroundColor = Color.FromArgb(251, 251, 251).AdaptBackColor();
+        public static readonly Color PanelBorderColor = Color.FromArgb(224, 224, 224).AdaptBackColor();
+    }
+}

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -326,6 +326,14 @@ namespace GitUI.CommandsDialogs
 
             RevisionGrid.ToggledBetweenArtificialAndHeadCommits += (s, e) => FocusRevisionDiffFileStatusList();
 
+            toolPanel.TopToolStripPanel.BackColor = Color.Transparent;
+            mainMenuStrip.BackColor = Color.Transparent;
+            ToolStripMain.BackColor = Color.Transparent;
+            ToolStripFilters.BackColor = Color.Transparent;
+            ToolStripScripts.BackColor = Color.Transparent;
+
+            BackColor = OtherColors.BackgroundColor;
+
             return;
 
             void FocusRevisionDiffFileStatusList()
@@ -3174,9 +3182,9 @@ namespace GitUI.CommandsDialogs
             RevisionInfo.Parent.BackColor = RevisionInfo.BackColor;
             RevisionInfo.ResumeLayout(performLayout: true);
 
-            MainSplitContainer.Panel1.BackColor = Color.LightGray.AdaptBackColor();
-            RevisionsSplitContainer.Panel1.BackColor = Color.LightGray.AdaptBackColor();
-            RevisionsSplitContainer.Panel2.BackColor = Color.LightGray.AdaptBackColor();
+            MainSplitContainer.Panel1.BackColor = OtherColors.PanelBorderColor;
+            RevisionsSplitContainer.Panel1.BackColor = OtherColors.PanelBorderColor;
+            RevisionsSplitContainer.Panel2.BackColor = OtherColors.PanelBorderColor;
 
             CommitInfoTabControl.ResumeLayout(performLayout: true);
             RevisionsSplitContainer.ResumeLayout(performLayout: true);

--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -82,8 +82,8 @@ namespace GitUI.CommitInfo
                 | System.Windows.Forms.AnchorStyles.Right)));
             this.pnlCommitMessage.BackColor = System.Drawing.SystemColors.Control;
             this.pnlCommitMessage.Controls.Add(this.rtbxCommitMessage);
-            this.pnlCommitMessage.Location = new System.Drawing.Point(8, 112);
-            this.pnlCommitMessage.Margin = new System.Windows.Forms.Padding(8, 0, 8, 0);
+            this.pnlCommitMessage.Location = new System.Drawing.Point(0, 112);
+            this.pnlCommitMessage.Margin = new System.Windows.Forms.Padding(0);
             this.pnlCommitMessage.Name = "pnlCommitMessage";
             this.pnlCommitMessage.Size = new System.Drawing.Size(456, 36);
             this.pnlCommitMessage.TabIndex = 0;


### PR DESCRIPTION
Follows to: https://github.com/gitextensions/gitextensions/pull/8849#issuecomment-783295170.

## Proposed changes

- Add darkening to the background for a softer color combination.
- Remove paddings for message block in CommitInfo panel to align text.
- Tone down the borders.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/3169265/109387616-1a6ec400-790b-11eb-961f-f18f228554dd.png)

### After

![image](https://user-images.githubusercontent.com/3169265/109387639-396d5600-790b-11eb-8872-a09b84515f64.png)




## Test methodology <!-- How did you ensure quality? -->

- Manually
- Visually


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 96278326503d1bb87ac6f58a3881e0de027ae298 (Dirty)
- Git 2.30.1.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
