### PR TITLE
Test to force same colors in AppColorDefaults and invariant.css

### DIFF
--- a/UnitTests/GitUI.Tests/Theming/AppColorDefaultsTests.cs
+++ b/UnitTests/GitUI.Tests/Theming/AppColorDefaultsTests.cs
@@ -42,16 +42,36 @@ namespace GitUITests.Theming
         [Test]
         public void Default_values_are_specified_in_invariant_theme()
         {
-            var themePathProvider = new ThemePathProvider();
-            var themeLoader = new ThemeLoader(new ThemeCssUrlResolver(themePathProvider), new ThemeFileReader());
-            var repository = new ThemeRepository(new ThemePersistence(themeLoader), themePathProvider);
-            var invariantTheme = repository.GetInvariantTheme();
+            Theme invariantTheme = GetInvariantTheme();
             invariantTheme.Should().NotBeNull();
             foreach (AppColor name in Enum.GetValues(typeof(AppColor)))
             {
                 Color value = invariantTheme.GetColor(name);
                 value.Should().NotBe(Color.Empty);
+
+                var defaultValue = AppColorDefaults.GetBy(name);
+                value.ToArgb().Should().Be(defaultValue.ToArgb());
             }
+        }
+
+        [Test]
+        public void Invariant_theme_colors_match_AppColorDefaults()
+        {
+            Theme invariantTheme = GetInvariantTheme();
+            foreach (AppColor name in Enum.GetValues(typeof(AppColor)))
+            {
+                Color value = invariantTheme.GetColor(name);
+                var defaultValue = AppColorDefaults.GetBy(name);
+                value.ToArgb().Should().Be(defaultValue.ToArgb());
+            }
+        }
+
+        private static Theme GetInvariantTheme()
+        {
+            var themePathProvider = new ThemePathProvider();
+            var themeLoader = new ThemeLoader(new ThemeCssUrlResolver(themePathProvider), new ThemeFileReader());
+            var repository = new ThemeRepository(new ThemePersistence(themeLoader), themePathProvider);
+            return repository.GetInvariantTheme();
         }
     }
 }

--- a/UnitTests/GitUI.Tests/Theming/AppColorDefaultsTests.cs
+++ b/UnitTests/GitUI.Tests/Theming/AppColorDefaultsTests.cs
@@ -68,9 +68,9 @@ namespace GitUITests.Theming
 
         private static Theme GetInvariantTheme()
         {
-            var themePathProvider = new ThemePathProvider();
-            var themeLoader = new ThemeLoader(new ThemeCssUrlResolver(themePathProvider), new ThemeFileReader());
-            var repository = new ThemeRepository(new ThemePersistence(themeLoader), themePathProvider);
+            ThemePathProvider themePathProvider = new();
+            ThemeLoader themeLoader = new(new ThemeCssUrlResolver(themePathProvider), new ThemeFileReader());
+            ThemeRepository repository = new(new ThemePersistence(themeLoader), themePathProvider);
             return repository.GetInvariantTheme();
         }
     }


### PR DESCRIPTION
The colors from `AppColorDefaults` should match those defined in invariant.css.

Turns out I somehow forgot to add a test to ensure this, which I realized while reviewing #8900 

`AppColorDefaults` class is obsolete, the only actual usage is `src\GitUI\Theming\ThemeMigration.cs : 37`

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
