### PR TITLE
Sidepanel submodule: Recreate tree only at structure changes

### DIFF
--- a/GitCommands/Submodules/SubmoduleStatusEventArgs.cs
+++ b/GitCommands/Submodules/SubmoduleStatusEventArgs.cs
@@ -7,12 +7,18 @@ namespace GitCommands.Submodules
     {
         public SubmoduleInfoResult Info { get; }
 
+        /// <summary>
+        /// First update of the submodule structure. Status of the submodule will be updated asynchronously.
+        /// </summary>
+        public bool StructureUpdated { get; }
+
         public CancellationToken Token { get; }
 
-        public SubmoduleStatusEventArgs(SubmoduleInfoResult info, CancellationToken token)
+        public SubmoduleStatusEventArgs(SubmoduleInfoResult info, bool structureUpdated, CancellationToken token)
         {
             Info = info;
             Token = token;
+            StructureUpdated = structureUpdated;
         }
     }
 }

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -99,7 +99,7 @@ namespace GitCommands.Submodules
             }
 
             // Structure is updated
-            OnStatusUpdated(result, cancelToken);
+            OnStatusUpdated(result, structureUpdated: true, cancelToken);
 
             if (updateStatus && currentModule.SuperprojectModule is not null)
             {
@@ -126,7 +126,7 @@ namespace GitCommands.Submodules
                 // Ignore if possible or at least delay the pending git-status trigger
                 _previousSubmoduleUpdateTime = DateTime.Now;
                 _submodulesStatusSequence.Next();
-                OnStatusUpdated(result, cancelToken);
+                OnStatusUpdated(result, structureUpdated: false, cancelToken);
             }
 
             _submoduleInfoResult = result;
@@ -164,7 +164,7 @@ namespace GitCommands.Submodules
             var currentModule = new GitModule(workingDirectory);
             await UpdateSubmodulesStatusAsync(currentModule, gitStatus, cancelToken);
 
-            OnStatusUpdated(_submoduleInfoResult, cancelToken);
+            OnStatusUpdated(_submoduleInfoResult, structureUpdated: false, cancelToken);
         }
 
         private void OnStatusUpdating()
@@ -172,10 +172,10 @@ namespace GitCommands.Submodules
             StatusUpdating?.Invoke(this, EventArgs.Empty);
         }
 
-        private void OnStatusUpdated(SubmoduleInfoResult info, CancellationToken token)
+        private void OnStatusUpdated(SubmoduleInfoResult info, bool structureUpdated, CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
-            StatusUpdated?.Invoke(this, new SubmoduleStatusEventArgs(info, token));
+            StatusUpdated?.Invoke(this, new SubmoduleStatusEventArgs(info, structureUpdated, token));
         }
 
         /// <summary>

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -48,7 +48,7 @@ namespace GitUI.BranchTreePanel
         // Node representing a submodule
         private class SubmoduleNode : Node
         {
-            public SubmoduleInfo Info { get; }
+            public SubmoduleInfo Info { get; set; }
             public bool IsCurrent { get; }
             public IReadOnlyList<GitItemStatus>? GitStatus { get; }
             public string LocalPath { get; }
@@ -76,10 +76,7 @@ namespace GitUI.BranchTreePanel
 
             public void RefreshDetails()
             {
-                if (Info.Detailed is not null && Tree.TreeViewNode.TreeView is not null)
-                {
-                    ApplyStatus();
-                }
+                ApplyStatus();
             }
 
             public bool CanOpen => !IsCurrent;
@@ -134,15 +131,14 @@ namespace GitUI.BranchTreePanel
                     TreeViewNode.NodeFont = new Font(AppSettings.Font, FontStyle.Bold);
                 }
 
-                TreeViewNode.ToolTipText = DisplayText();
-
                 // Note that status is applied also after the tree is created, when status is applied
                 ApplyStatus();
             }
 
             private void ApplyStatus()
             {
-                TreeViewNode.ImageKey = GetSubmoduleItemImage(Info.Detailed);
+                TreeViewNode.ToolTipText = DisplayText();
+                TreeViewNode.ImageKey = GetSubmoduleItemImage(Info?.Detailed);
                 TreeViewNode.SelectedImageKey = TreeViewNode.ImageKey;
 
                 return;
@@ -208,10 +204,12 @@ namespace GitUI.BranchTreePanel
         private sealed class SubmoduleTree : Tree
         {
             private SubmoduleStatusEventArgs? _currentSubmoduleInfo;
+            private Nodes? _currentNodes = null;
 
             public SubmoduleTree(TreeNode treeNode, IGitUICommandsSource uiCommands)
                 : base(treeNode, uiCommands)
             {
+                SubmoduleStatusProvider.Default.StatusUpdating += Provider_StatusUpdating;
                 SubmoduleStatusProvider.Default.StatusUpdated += Provider_StatusUpdated;
             }
 
@@ -231,6 +229,11 @@ namespace GitUI.BranchTreePanel
                 return Task.FromResult(new Nodes(null));
             }
 
+            private void Provider_StatusUpdating(object sender, EventArgs e)
+            {
+                _currentNodes = null;
+            }
+
             private void Provider_StatusUpdated(object sender, SubmoduleStatusEventArgs e)
             {
                 _currentSubmoduleInfo = e;
@@ -247,23 +250,66 @@ namespace GitUI.BranchTreePanel
                 {
                     CancellationTokenSource? cts = null;
                     Task<Nodes>? loadNodesTask = null;
-                    await ReloadNodesAsync(token =>
+                    if (e.StructureUpdated)
                     {
-                        cts = CancellationTokenSource.CreateLinkedTokenSource(e.Token, token);
-                        loadNodesTask = LoadNodesAsync(e.Info, cts.Token);
-                        return loadNodesTask;
-                    }).ConfigureAwait(false);
+                        _currentNodes = null;
+                    }
+
+                    if (_currentNodes is not null)
+                    {
+                        // Structure is up-to-date, update status
+                        var infos = e.Info.AllSubmodules.ToDictionary(info => info.Path, info => info);
+                        Validates.NotNull(e.Info.TopProject);
+                        infos[e.Info.TopProject.Path] = e.Info.TopProject;
+                        var nodes = _currentNodes.DepthEnumerator<SubmoduleNode>().ToList();
+                        foreach (var node in nodes)
+                        {
+                            if (infos.ContainsKey(node.Info.Path))
+                            {
+                                node.Info = infos[node.Info.Path];
+                                infos.Remove(node.Info.Path);
+                            }
+                            else
+                            {
+                                // structure no longer matching
+                                Debug.Assert(true, $"Status info with {1 + e.Info.AllSubmodules.Count} records do not match current nodes ({nodes.Count})");
+                                _currentNodes = null;
+                                break;
+                            }
+                        }
+
+                        if (infos.Count > 0)
+                        {
+                            Debug.Fail($"{infos.Count} status info records remains after matching current nodes, structure seem to mismatch ({nodes.Count}/{e.Info.AllSubmodules.Count})");
+                            _currentNodes = null;
+                        }
+                    }
+
+                    if (_currentNodes is null)
+                    {
+                        await ReloadNodesAsync(token =>
+                        {
+                            cts = CancellationTokenSource.CreateLinkedTokenSource(e.Token, token);
+                            loadNodesTask = LoadNodesAsync(e.Info, cts.Token);
+                            return loadNodesTask;
+                        }).ConfigureAwait(false);
+                    }
 
                     if (cts is not null && loadNodesTask is not null)
                     {
-                        var loadedNodes = await loadNodesTask;
-                        await LoadNodeDetailsAsync(loadedNodes, cts.Token).ConfigureAwaitRunInline();
-                        LoadNodeToolTips(loadedNodes, cts.Token);
+                        _currentNodes = await loadNodesTask;
+                    }
+
+                    if (_currentNodes is not null)
+                    {
+                        var token = cts?.Token ?? e.Token;
+                        await LoadNodeDetailsAsync(_currentNodes, token).ConfigureAwaitRunInline();
+                        LoadNodeToolTips(_currentNodes, token);
                     }
 
                     Interlocked.CompareExchange(ref _currentSubmoduleInfo, null, e);
-                }).FileAndForget();
-            }
+            }).FileAndForget();
+        }
 
             private async Task<Nodes> LoadNodesAsync(SubmoduleInfoResult info, CancellationToken token)
             {


### PR DESCRIPTION
Fixes #8871
Related to #8886

## Proposed changes

The submodules in the sidepanel are recreated every time git-status is updated.
Before #8867, that occurred every 5th second. A gif show the behavior there.
#8867 restores the behavior to 3.4 and refreshing every 15th second.
#8886 proposes increasing the time further to 30 seconds.

This PR only recreate the submodule structure when there are structure changes.

No screenshot - but not much to see.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 10df80cb1fe2ff8c07a30be3525635161f04c42c
- Git 2.30.1.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
