### PR TITLE
Graph: Ensure branch colors are not equal to branchs they are merged to

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/LaneInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Linq;
+
+namespace GitUI.UserControls.RevisionGrid.Graph
+{
+    public class LaneInfo
+    {
+        public LaneInfo(RevisionGraphSegment startSegment)
+        {
+            StartRevision = startSegment.Parent;
+            Color = StartRevision.Objectid.GetHashCode();
+        }
+
+        public int Color { get; private set; }
+
+        public RevisionGraphRevision StartRevision { get; private set; }
+
+        public int StartScore => StartRevision.Score;
+    }
+}

--- a/GitUI/UserControls/RevisionGrid/Graph/LaneInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneInfo.cs
@@ -4,10 +4,22 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 {
     public class LaneInfo
     {
-        public LaneInfo(RevisionGraphSegment startSegment)
+        public LaneInfo(RevisionGraphSegment startSegment, LaneInfo? derivedFrom)
         {
-            StartRevision = startSegment.Parent;
-            Color = StartRevision.Objectid.GetHashCode();
+            StartRevision = derivedFrom is null ? startSegment.Child : startSegment.Parent;
+
+            int colorSeed = StartRevision.Objectid.GetHashCode();
+            if (derivedFrom is null)
+            {
+                colorSeed ^= startSegment.Parent.Objectid.GetHashCode();
+            }
+
+            do
+            {
+                Color = RevisionGraphLaneColor.GetColorForLane(colorSeed);
+                ++colorSeed;
+            }
+            while (Color == derivedFrom?.Color);
         }
 
         public int Color { get; private set; }

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -282,7 +282,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
                     foreach (var startSegment in revision.StartSegments)
                     {
-                        startSegment.LaneInfo = new LaneInfo(startSegment);
+                        startSegment.LaneInfo = new LaneInfo(startSegment, derivedFrom: null);
                     }
                 }
                 else
@@ -321,7 +321,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                                 {
                                     if (startSegment.LaneInfo is null)
                                     {
-                                        startSegment.LaneInfo = new LaneInfo(startSegment);
+                                        startSegment.LaneInfo = new LaneInfo(startSegment, derivedFrom: segment.LaneInfo);
                                     }
                                 }
                             }
@@ -336,7 +336,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
                         foreach (var startSegment in revision.StartSegments)
                         {
-                            startSegment.LaneInfo = new LaneInfo(startSegment);
+                            startSegment.LaneInfo = new LaneInfo(startSegment, derivedFrom: null);
                         }
                     }
                 }

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -176,7 +176,6 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 // This revision is added from the log, but not seen before. This is probably a root node (new branch) OR the revisions
                 // are not in topo order. If this the case, we deal with it later.
                 revisionGraphRevision = new RevisionGraphRevision(revision.ObjectId, ++_maxScore);
-                revisionGraphRevision.LaneColor = revisionGraphRevision.IsCheckedOut ? 0 : _maxScore;
 
                 _nodeByObjectId.TryAdd(revision.ObjectId, revisionGraphRevision);
             }
@@ -280,6 +279,11 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 {
                     // This is the first row. Start with only the startsegments of this row
                     segments = new List<RevisionGraphSegment>(revision.StartSegments);
+
+                    foreach (var startSegment in revision.StartSegments)
+                    {
+                        startSegment.LaneInfo = new LaneInfo(startSegment);
+                    }
                 }
                 else
                 {
@@ -296,10 +300,31 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
                         // This segment that is copied from the previous row, connects to the node in this row.
                         // Copy all new segments that start from this node (revision) to this lane.
-                        if (revision == segment.Parent && !startSegmentsAdded)
+                        if (revision == segment.Parent)
                         {
-                            startSegmentsAdded = true;
-                            segments.AddRange(revision.StartSegments);
+                            if (!startSegmentsAdded)
+                            {
+                                startSegmentsAdded = true;
+                                segments.AddRange(revision.StartSegments);
+                            }
+
+                            foreach (var startSegment in revision.StartSegments)
+                            {
+                                if (startSegment == revision.StartSegments.First())
+                                {
+                                    if (startSegment.LaneInfo is null || startSegment.LaneInfo.StartScore > segment.LaneInfo?.StartScore)
+                                    {
+                                        startSegment.LaneInfo = segment.LaneInfo;
+                                    }
+                                }
+                                else
+                                {
+                                    if (startSegment.LaneInfo is null)
+                                    {
+                                        startSegment.LaneInfo = new LaneInfo(startSegment);
+                                    }
+                                }
+                            }
                         }
                     }
 
@@ -308,6 +333,11 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                     {
                         // Add new segments started by this revision to the end
                         segments.AddRange(revision.StartSegments);
+
+                        foreach (var startSegment in revision.StartSegments)
+                        {
+                            startSegment.LaneInfo = new LaneInfo(startSegment);
+                        }
                     }
                 }
 

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
@@ -19,6 +19,11 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             Color.FromArgb(231, 176, 15) // orange
         };
 
+        public static int GetColorForLane(int seed)
+        {
+            return Math.Abs(seed) % PresetGraphBrushes.Count;
+        }
+
         public static Color NonRelativeColor { get; } = Color.LightGray;
 
         internal static Brush NonRelativeBrush { get; }
@@ -37,7 +42,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
         public static Brush GetBrushForLane(int laneColor)
         {
-            return PresetGraphBrushes[Math.Abs(laneColor) % PresetGraphBrushes.Count];
+            return PresetGraphBrushes[laneColor];
         }
     }
 }

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -23,8 +23,6 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             StartSegments = new SynchronizedCollection<RevisionGraphSegment>();
 
             Score = guessScore;
-
-            LaneColor = -1;
         }
 
         public void ApplyFlags(RevisionNodeFlags types)
@@ -44,8 +42,6 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         /// to a revision with a higher score.
         /// </summary>
         public int Score { get; private set; }
-
-        public int LaneColor { get; set; }
 
         // This method is called to ensure that the score is higher than a given score.
         // E.g. the score needs to be higher that the score of its children.
@@ -136,19 +132,6 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
         public void AddParent(RevisionGraphRevision parent, out int maxScore)
         {
-            // Generate a LaneColor used for rendering
-            if (!Parents.IsEmpty)
-            {
-                parent.LaneColor = parent.Score;
-            }
-            else
-            {
-                if (parent.LaneColor == -1)
-                {
-                    parent.LaneColor = LaneColor;
-                }
-            }
-
             if (IsRelative)
             {
                 parent.MakeRelative();

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
@@ -26,6 +26,8 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             Child = child;
         }
 
+        public LaneInfo? LaneInfo { get; set; }
+
         public int StartScore => Child.Score;
 
         public int EndScore => Parent.Score;

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
@@ -71,13 +71,6 @@ namespace GitUITests.UserControls.RevisionGrid
         }
 
         [Test]
-        public void LaneColorTest()
-        {
-            _revisionGraph.CacheTo(_revisionGraph.Count, _revisionGraph.Count);
-            Assert.AreNotEqual(_revisionGraph.GetSegmentsForRow(2).GetSegmentsForIndex(0).First().Parent.LaneColor, _revisionGraph.GetSegmentsForRow(2).GetSegmentsForIndex(1).Last().Parent.LaneColor);
-        }
-
-        [Test]
         public void ShouldReorderInTopoOrder()
         {
             _revisionGraph.CacheTo(_revisionGraph.Count, _revisionGraph.Count);


### PR DESCRIPTION
First commits from #5783

## Proposed changes

- Ensure lane colors are not equal to lane they are merged to
- Add `LaneInfo` class

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/109416675-f9b47600-79bf-11eb-8425-3e67e67b997a.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/109416701-27012400-79c0-11eb-85b3-443e4037ca2d.png)

## Test methodology <!-- How did you ensure quality? -->

- manual and existing tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build d28d65a93206e789db25a24c9f926f1feb6e39ff
- Git 2.27.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).