### PR TITLE
Don't crash if GE can't check IsDarkTheme

### DIFF
--- a/GitUI/Theming/ThemeModule.cs
+++ b/GitUI/Theming/ThemeModule.cs
@@ -83,7 +83,7 @@ namespace GitUI.Theming
                 return CreateFallbackSettings(invariantTheme);
             }
 
-            IsDarkTheme = theme.SysColorValues[KnownColor.Window].GetBrightness() < 0.5;
+            IsDarkTheme = theme.GetNonEmptyColor(KnownColor.Window).GetBrightness() < 0.5;
 
             return new ThemeSettings(theme, invariantTheme, AppSettings.ThemeVariations, AppSettings.UseSystemVisualStyle);
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8904 


## Proposed changes

- Improve reading file theme.css

### Before

#8904 crashes at startup.

### After

Don't crash.

## Test methodology <!-- How did you ensure quality? -->

Can't write test without refactoring.

``GitUI.Theming.ThemeModule.Repository`` is private and statically initialized.

To test this class, ThemeModule should be refactored like ``GitUI.Theming.ThemeLoader`` to use interface and add a Load method to customize Repository field.

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.4.3.9999
- Build d4b0f48bbf3e39a71f5d7ff5231be5678d4aa0f1
- Git 2.30.0.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 120dpi (125% scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
