### PR TITLE
Hide theme fields for serialization from public interface

### DIFF
--- a/GitExtUtils/GitUI/Theming/IThemeSerializationData.cs
+++ b/GitExtUtils/GitUI/Theming/IThemeSerializationData.cs
@@ -3,7 +3,7 @@ using System.Drawing;
 
 namespace GitExtUtils.GitUI.Theming
 {
-    public interface IThemeSerializationFields
+    public interface IThemeSerializationData
     {
         IReadOnlyDictionary<AppColor, Color> AppColorValues { get; }
         IReadOnlyDictionary<KnownColor, Color> SysColorValues { get; }

--- a/GitExtUtils/GitUI/Theming/IThemeSerializationFields.cs
+++ b/GitExtUtils/GitUI/Theming/IThemeSerializationFields.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+
+namespace GitExtUtils.GitUI.Theming
+{
+    public interface IThemeSerializationFields
+    {
+        IReadOnlyDictionary<AppColor, Color> AppColorValues { get; }
+        IReadOnlyDictionary<KnownColor, Color> SysColorValues { get; }
+    }
+}

--- a/GitExtUtils/GitUI/Theming/Theme.cs
+++ b/GitExtUtils/GitUI/Theming/Theme.cs
@@ -8,7 +8,7 @@ namespace GitExtUtils.GitUI.Theming
     /// <summary>
     /// A set of values for .Net system colors and GitExtensions app-specific colors.
     /// </summary>
-    public class Theme : IThemeSerializationFields
+    public class Theme : IThemeSerializationData
     {
         private static readonly IReadOnlyDictionary<KnownColor, KnownColor> Duplicates =
             new Dictionary<KnownColor, KnownColor>
@@ -23,8 +23,8 @@ namespace GitExtUtils.GitUI.Theming
         private readonly IReadOnlyDictionary<AppColor, Color> _appColorValues;
         private readonly IReadOnlyDictionary<KnownColor, Color> _sysColorValues;
 
-        IReadOnlyDictionary<AppColor, Color> IThemeSerializationFields.AppColorValues => _appColorValues;
-        IReadOnlyDictionary<KnownColor, Color> IThemeSerializationFields.SysColorValues => _sysColorValues;
+        IReadOnlyDictionary<AppColor, Color> IThemeSerializationData.AppColorValues => _appColorValues;
+        IReadOnlyDictionary<KnownColor, Color> IThemeSerializationData.SysColorValues => _sysColorValues;
 
         public static Theme Default => _default ??= CreateDefaultTheme();
 

--- a/GitExtUtils/GitUI/Theming/Theme.cs
+++ b/GitExtUtils/GitUI/Theming/Theme.cs
@@ -8,7 +8,7 @@ namespace GitExtUtils.GitUI.Theming
     /// <summary>
     /// A set of values for .Net system colors and GitExtensions app-specific colors.
     /// </summary>
-    public class Theme
+    public class Theme : IThemeSerializationFields
     {
         private static readonly IReadOnlyDictionary<KnownColor, KnownColor> Duplicates =
             new Dictionary<KnownColor, KnownColor>
@@ -19,8 +19,12 @@ namespace GitExtUtils.GitUI.Theming
             };
 
         private static Theme? _default;
-        public IReadOnlyDictionary<AppColor, Color> AppColorValues { get; }
-        public IReadOnlyDictionary<KnownColor, Color> SysColorValues { get; }
+
+        private readonly IReadOnlyDictionary<AppColor, Color> _appColorValues;
+        private readonly IReadOnlyDictionary<KnownColor, Color> _sysColorValues;
+
+        IReadOnlyDictionary<AppColor, Color> IThemeSerializationFields.AppColorValues => _appColorValues;
+        IReadOnlyDictionary<KnownColor, Color> IThemeSerializationFields.SysColorValues => _sysColorValues;
 
         public static Theme Default => _default ??= CreateDefaultTheme();
 
@@ -30,8 +34,8 @@ namespace GitExtUtils.GitUI.Theming
             ThemeId id)
         {
             Id = id;
-            AppColorValues = appColors;
-            SysColorValues = sysColors;
+            _appColorValues = appColors;
+            _sysColorValues = sysColors;
         }
 
         public ThemeId Id { get; }
@@ -41,7 +45,7 @@ namespace GitExtUtils.GitUI.Theming
         /// returns <see cref="Color.Empty"/>.
         /// </summary>
         public Color GetColor(AppColor name) =>
-            AppColorValues.TryGetValue(name, out var result)
+            _appColorValues.TryGetValue(name, out var result)
                 ? result
                 : Color.Empty;
 
@@ -49,7 +53,7 @@ namespace GitExtUtils.GitUI.Theming
         /// Get .Net system color value as defined by this instance.
         /// </summary>
         private Color GetSysColor(KnownColor name) =>
-            SysColorValues.TryGetValue(name, out var result)
+            _sysColorValues.TryGetValue(name, out var result)
                 ? result
                 : Color.Empty;
 

--- a/GitUI/Theming/ThemeModule.cs
+++ b/GitUI/Theming/ThemeModule.cs
@@ -83,7 +83,7 @@ namespace GitUI.Theming
                 return CreateFallbackSettings(invariantTheme);
             }
 
-            IsDarkTheme = theme.SysColorValues[KnownColor.Window].GetBrightness() < 0.5;
+            IsDarkTheme = theme.GetNonEmptyColor(KnownColor.Window).GetBrightness() < 0.5;
 
             return new ThemeSettings(theme, invariantTheme, AppSettings.ThemeVariations, AppSettings.UseSystemVisualStyle);
         }

--- a/GitUI/Theming/ThemePersistence.cs
+++ b/GitUI/Theming/ThemePersistence.cs
@@ -30,12 +30,12 @@ namespace GitUI.Theming
 
         public void Save(Theme theme, string themeFileName)
         {
-            var serializationFields = (IThemeSerializationFields)theme;
+            var serializationData = (IThemeSerializationData)theme;
             string serialized = string.Join(
                 Environment.NewLine,
                 Enumerable.Concat(
-                    serializationFields.SysColorValues.Select(_ => string.Format(Format, _.Key, FormatColor(_.Value))),
-                    serializationFields.AppColorValues.Select(_ => string.Format(Format, _.Key, FormatColor(_.Value)))));
+                    serializationData.SysColorValues.Select(_ => string.Format(Format, _.Key, FormatColor(_.Value))),
+                    serializationData.AppColorValues.Select(_ => string.Format(Format, _.Key, FormatColor(_.Value)))));
 
             File.WriteAllText(themeFileName, serialized);
         }

--- a/GitUI/Theming/ThemePersistence.cs
+++ b/GitUI/Theming/ThemePersistence.cs
@@ -30,10 +30,12 @@ namespace GitUI.Theming
 
         public void Save(Theme theme, string themeFileName)
         {
+            var serializationFields = (IThemeSerializationFields)theme;
             string serialized = string.Join(
                 Environment.NewLine,
-                theme.SysColorValues.Select(_ => string.Format(Format, _.Key, FormatColor(_.Value))).Concat(
-                    theme.AppColorValues.Select(_ => string.Format(Format, _.Key, FormatColor(_.Value)))));
+                Enumerable.Concat(
+                    serializationFields.SysColorValues.Select(_ => string.Format(Format, _.Key, FormatColor(_.Value))),
+                    serializationFields.AppColorValues.Select(_ => string.Format(Format, _.Key, FormatColor(_.Value)))));
 
             File.WriteAllText(themeFileName, serialized);
         }


### PR DESCRIPTION
## Proposed changes

Hide theme data properties from its public interface, since they don't provide a behavior one would naturally expect from a public property with a given name.

The only intended usage for these properties is serialization.

#8904 discovered a problem which this PR would have prevented.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
