### PR TITLE
RevDiff: Request GitStatus updates at file manipulations 3.5

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -199,7 +199,8 @@ namespace GitUI.CommandsDialogs
 
             repoObjectsTree.Initialize(_aheadBehindDataProvider, _filterBranchHelper, RevisionGrid, RevisionGrid, RevisionGrid);
             toolStripBranchFilterComboBox.DropDown += toolStripBranches_DropDown_ResizeDropDownWidth;
-            revisionDiff.Bind(RevisionGrid, fileTree);
+            revisionDiff.Bind(RevisionGrid, fileTree, () => RequestRefresh());
+            fileTree.Bind(() => RequestRefresh());
 
             var repositoryDescriptionProvider = new RepositoryDescriptionProvider(new GitDirectoryResolver());
             _appTitleGenerator = new AppTitleGenerator(repositoryDescriptionProvider);
@@ -806,7 +807,7 @@ namespace GitUI.CommandsDialogs
             }
 
             _gitStatusMonitor.InvalidateGitWorkingDirectoryStatus();
-            _gitStatusMonitor.RequestRefresh();
+            RequestRefresh();
 
             if (_dashboard is null || !_dashboard.Visible)
             {
@@ -817,6 +818,8 @@ namespace GitUI.CommandsDialogs
 
             toolStripButtonPush.DisplayAheadBehindInformation(Module.GetSelectedBranch());
         }
+
+        private void RequestRefresh() => _gitStatusMonitor?.RequestRefresh();
 
         private void RefreshSelection()
         {
@@ -1536,6 +1539,7 @@ namespace GitUI.CommandsDialogs
         private void ResetToolStripMenuItem_Click(object sender, EventArgs e)
         {
             UICommands.StartResetChangesDialog(this);
+            RequestRefresh();
             revisionDiff.RefreshArtificial();
         }
 
@@ -3218,6 +3222,7 @@ namespace GitUI.CommandsDialogs
                 var args = GitCommandHelpers.ResetCmd(ResetMode.Soft, "HEAD~1");
                 Module.GitExecutable.GetOutput(args);
                 refreshToolStripMenuItem.PerformClick();
+                RequestRefresh();
             }
         }
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -54,6 +54,7 @@ See the changes in the commit form.");
         [CanBeNull] private GitRevision _revision;
         private readonly RememberFileContextMenuController _rememberFileContextMenuController
             = RememberFileContextMenuController.Default;
+        private Action _refreshGitStatus;
 
         public RevisionFileTreeControl()
         {
@@ -65,6 +66,11 @@ See the changes in the commit form.");
             _revisionFileTreeController = new RevisionFileTreeController(() => Module.WorkingDir,
                                                                          new GitRevisionInfoProvider(() => Module),
                                                                          new FileAssociatedIconProvider());
+        }
+
+        public void Bind(Action refreshGitStatus)
+        {
+            _refreshGitStatus = refreshGitStatus;
         }
 
         public void ExpandToFile(string filePath)
@@ -489,11 +495,14 @@ See the changes in the commit form.");
 
         private void editCheckedOutFileToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (tvGitTree.SelectedNode?.Tag is GitItem gitItem && gitItem.ObjectType == GitObjectType.Blob)
+            if (tvGitTree.SelectedNode?.Tag is not GitItem gitItem || gitItem.ObjectType != GitObjectType.Blob)
             {
-                var fileName = _fullPathResolver.Resolve(gitItem.FileName);
-                UICommands.StartFileEditorDialog(fileName);
+                return;
             }
+
+            var fileName = _fullPathResolver.Resolve(gitItem.FileName);
+            UICommands.StartFileEditorDialog(fileName);
+            _refreshGitStatus?.Invoke();
         }
 
         private void expandAllStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
#8894 for 3.5

For (most) operations related to changes of worktree or index status
in Browse, request immediate git-status update, for the commit count
and artificial commit.
This will bypass the delay between updates. Also changes worktree<->index
would not trigger updates.

Note that operations to submodules in the sidepanel still requires file
system changes.

Should be merged if #8886 is merged in 3.5

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
