### PR TITLE
Fix hang when requesting submodule status

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2253,7 +2253,7 @@ namespace GitCommands
             return stashes;
         }
 
-        public Patch? GetSingleDiff(
+        public async Task<Patch?> GetSingleDiffAsync(
             ObjectId? firstId, ObjectId? secondId,
             string? fileName, string? oldFileName,
             string extraDiffArguments, Encoding encoding,
@@ -2284,7 +2284,7 @@ namespace GitCommands
                 ? GitCommandCache
                 : null;
 
-            var patch = _gitExecutable.GetOutput(
+            var patch = await _gitExecutable.GetOutputAsync(
                 args,
                 cache: cache,
                 outputEncoding: LosslessEncoding);
@@ -2602,7 +2602,8 @@ namespace GitCommands
                         async () =>
                         {
                             await TaskScheduler.Default.SwitchTo(alwaysYield: true);
-                            return SubmoduleHelpers.GetCurrentSubmoduleChanges(this, item.Name, item.OldName, firstId, secondId);
+                            return await SubmoduleHelpers.GetCurrentSubmoduleChangesAsync(this, item.Name, item.OldName, firstId, secondId)
+                                .ConfigureAwait(false);
                         }));
             }
         }

--- a/GitCommands/Git/SubmoduleHelpers.cs
+++ b/GitCommands/Git/SubmoduleHelpers.cs
@@ -10,9 +10,9 @@ namespace GitCommands.Git
 {
     public static class SubmoduleHelpers
     {
-        public static GitSubmoduleStatus? GetCurrentSubmoduleChanges(GitModule module, string? fileName, string? oldFileName, ObjectId? firstId, ObjectId? secondId)
+        public static async Task<GitSubmoduleStatus?> GetCurrentSubmoduleChangesAsync(GitModule module, string? fileName, string? oldFileName, ObjectId? firstId, ObjectId? secondId)
         {
-            Patch? patch = module.GetSingleDiff(firstId, secondId, fileName, oldFileName, "", GitModule.SystemEncoding, true);
+            Patch? patch = await module.GetSingleDiffAsync(firstId, secondId, fileName, oldFileName, "", GitModule.SystemEncoding, cacheResult: true).ConfigureAwait(false);
             return ParseSubmodulePatchStatus(patch, module, fileName);
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -164,6 +164,7 @@ namespace GitUI.CommandsDialogs
         private readonly AsyncLoader _unstagedLoader = new();
         private readonly bool _useFormCommitMessage = AppSettings.UseFormCommitMessage;
         private readonly CancellationTokenSequence _interactiveAddSequence = new();
+        private readonly CancellationTokenSequence _viewChangesSequence = new();
         private readonly SplitterManager _splitterManager = new(new AppSettingsPath("CommitDialog"));
         private readonly Subject<string> _selectionFilterSubject = new();
         private readonly IFullPathResolver _fullPathResolver;
@@ -417,6 +418,7 @@ namespace GitUI.CommandsDialogs
             {
                 _unstagedLoader.Dispose();
                 _interactiveAddSequence.Dispose();
+                _viewChangesSequence.Dispose();
                 components?.Dispose();
             }
 
@@ -1140,7 +1142,8 @@ namespace GitUI.CommandsDialogs
 
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                await SelectedDiff.ViewChangesAsync(item, openWithDiffTool: () => OpenWithDiffTool());
+                await SelectedDiff.ViewChangesAsync(item, openWithDiffTool: () => OpenWithDiffTool(),
+                    cancellationToken: _viewChangesSequence.Next());
             }).FileAndForget();
 
             return;

--- a/GitUI/CommandsDialogs/FormDiff.Designer.cs
+++ b/GitUI/CommandsDialogs/FormDiff.Designer.cs
@@ -9,19 +9,6 @@ namespace GitUI.CommandsDialogs
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components is not null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         #region Windows Form Designer generated code
 
         /// <summary>

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -26,6 +26,7 @@ namespace GitUI.CommandsDialogs
         private readonly IFileStatusListContextMenuController _revisionDiffContextMenuController;
         private readonly IFullPathResolver _fullPathResolver;
         private readonly IFindFilePredicateProvider _findFilePredicateProvider;
+        private readonly CancellationTokenSequence _viewChangesSequence = new();
 
         private readonly ToolTip _toolTipControl = new();
 
@@ -97,6 +98,21 @@ namespace GitUI.CommandsDialogs
             Load += delegate { PopulateDiffFiles(); };
         }
 
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _viewChangesSequence.Dispose();
+                components?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
         private void FileViewer_TopScrollReached(object sender, EventArgs e)
         {
             DiffFiles.SelectPreviousVisibleItem();
@@ -137,7 +153,8 @@ namespace GitUI.CommandsDialogs
 
         private void ShowSelectedFileDiff()
         {
-            DiffText.ViewChangesAsync(DiffFiles.SelectedItem);
+            _ = DiffText.ViewChangesAsync(DiffFiles.SelectedItem,
+                cancellationToken: _viewChangesSequence.Next());
         }
 
         private void btnSwap_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormLog.Designer.cs
+++ b/GitUI/CommandsDialogs/FormLog.Designer.cs
@@ -9,19 +9,6 @@ namespace GitUI.CommandsDialogs
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components is not null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         #region Windows Form Designer generated code
 
         /// <summary>

--- a/GitUI/CommandsDialogs/FormLog.cs
+++ b/GitUI/CommandsDialogs/FormLog.cs
@@ -4,6 +4,8 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormLog : GitModuleForm
     {
+        private readonly CancellationTokenSequence _viewChangesSequence = new();
+
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormLog()
         {
@@ -20,6 +22,21 @@ namespace GitUI.CommandsDialogs
             InitializeComplete();
         }
 
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _viewChangesSequence.Dispose();
+                components?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
         private void FormDiffLoad(object sender, EventArgs e)
         {
             RevisionGrid.Load();
@@ -34,7 +51,8 @@ namespace GitUI.CommandsDialogs
         {
             using (WaitCursorScope.Enter())
             {
-                diffViewer.ViewChangesAsync(DiffFiles.SelectedItem);
+                _ = diffViewer.ViewChangesAsync(DiffFiles.SelectedItem,
+                    cancellationToken: _viewChangesSequence.Next());
             }
         }
 

--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -11,20 +11,6 @@ namespace GitUI.CommandsDialogs
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            _asyncLoader.Dispose();
-            if (disposing && (components is not null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         #region Windows Form Designer generated code
 
         /// <summary>

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -24,6 +24,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _areYouSure = new("Are you sure you want to drop the stash? This action cannot be undone.");
         private readonly TranslationString _dontShowAgain = new("Don't show me this message again.");
 
+        private readonly CancellationTokenSequence _viewChangesSequence = new();
         private readonly AsyncLoader _asyncLoader = new();
 
         public bool ManageStashes { get; set; }
@@ -91,6 +92,22 @@ namespace GitUI.CommandsDialogs
             }
 
             base.OnKeyUp(e);
+        }
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            _asyncLoader.Dispose();
+            if (disposing)
+            {
+                _viewChangesSequence.Dispose();
+                components?.Dispose();
+            }
+
+            base.Dispose(disposing);
         }
 
         private void FormStashFormClosing(object sender, FormClosingEventArgs e)
@@ -227,7 +244,8 @@ namespace GitUI.CommandsDialogs
 
         private void StashedSelectedIndexChanged(object sender, EventArgs e)
         {
-            View.ViewChangesAsync(Stashed.SelectedItem);
+            _ = View.ViewChangesAsync(Stashed.SelectedItem,
+                cancellationToken: _viewChangesSequence.Next());
             EnablePartialStash();
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
@@ -9,19 +9,6 @@ namespace GitUI.CommandsDialogs
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary> 
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components is not null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         #region Component Designer generated code
 
         /// <summary> 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -43,6 +43,7 @@ namespace GitUI.CommandsDialogs
         private readonly IFullPathResolver _fullPathResolver;
         private readonly IFindFilePredicateProvider _findFilePredicateProvider;
         private readonly IGitRevisionTester _gitRevisionTester;
+        private readonly CancellationTokenSequence _viewChangesSequence = new();
         private readonly RememberFileContextMenuController _rememberFileContextMenuController
             = RememberFileContextMenuController.Default;
         private Action? _refreshGitStatus;
@@ -243,6 +244,21 @@ namespace GitUI.CommandsDialogs
             base.OnRuntimeLoad();
         }
 
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _viewChangesSequence.Dispose();
+                components?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
         private string DescribeRevision(ObjectId? objectId, int maxLength = 0)
         {
             if (objectId is null)
@@ -436,7 +452,8 @@ namespace GitUI.CommandsDialogs
         private async Task ShowSelectedFileDiffAsync()
         {
             await DiffText.ViewChangesAsync(DiffFiles.SelectedItem,
-                openWithDiffTool: () => firstToSelectedToolStripMenuItem.PerformClick());
+                openWithDiffTool: () => firstToSelectedToolStripMenuItem.PerformClick(),
+                cancellationToken: _viewChangesSequence.Next());
         }
 
         private void DiffFiles_SelectedIndexChanged(object sender, EventArgs e)

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -27,26 +27,29 @@ namespace GitUI
         /// <param name="defaultText">default text if no diff is possible.</param>
         /// <param name="openWithDiffTool">The difftool command to open with.</param>
         /// <returns>Task to view.</returns>
-        public static Task ViewChangesAsync(this FileViewer fileViewer,
+        public static async Task ViewChangesAsync(this FileViewer fileViewer,
             FileStatusItem? item,
+            CancellationToken cancellationToken,
             string defaultText = "",
             Action? openWithDiffTool = null)
         {
             if (item?.Item.IsStatusOnly ?? false)
             {
                 // Present error (e.g. parsing Git)
-                return fileViewer.ViewTextAsync(item.Item.Name, item.Item.ErrorMessage ?? "");
+                await fileViewer.ViewTextAsync(item.Item.Name, item.Item.ErrorMessage ?? "");
+                return;
             }
 
             if (item?.Item is null || item.SecondRevision?.ObjectId is null)
             {
                 if (!string.IsNullOrWhiteSpace(defaultText))
                 {
-                    return fileViewer.ViewTextAsync(item?.Item?.Name, defaultText);
+                    await fileViewer.ViewTextAsync(item?.Item?.Name, defaultText);
+                    return;
                 }
 
                 fileViewer.Clear();
-                return Task.CompletedTask;
+                return;
             }
 
             var firstId = item.FirstRevision?.ObjectId ?? item.SecondRevision.FirstParentId;
@@ -56,14 +59,19 @@ namespace GitUI
             if (item.Item.IsNew || firstId is null || (!item.Item.IsDeleted && FileHelper.IsImage(item.Item.Name)))
             {
                 // View blob guid from revision, or file for worktree
-                return fileViewer.ViewGitItemRevisionAsync(item.Item, item.SecondRevision.ObjectId, openWithDiffTool);
+                await fileViewer.ViewGitItemRevisionAsync(item.Item, item.SecondRevision.ObjectId, openWithDiffTool);
+                return;
             }
 
             if (item.Item.IsRangeDiff)
             {
-                // This command may take time, give an indication of what is going on
-                // The sha are incorrect if baseA/baseB is set, to simplify the presentation
-                fileViewer.ViewText("range-diff.sh", $"git range-diff {firstId}...{item.SecondRevision.ObjectId}");
+                // Git range-diff has cubic runtime complexity and can be slow and memory consuming,
+                // give an indication of what is going on
+                string range = item.BaseA is null || item.BaseB is null
+                    ? $"{firstId}...{item.SecondRevision.ObjectId}"
+                    : $"{item.BaseA}..{firstId} {item.BaseB}..{item.SecondRevision.ObjectId}";
+
+                await fileViewer.ViewTextAsync("range-diff.sh", $"git range-diff {range}");
 
                 string output = fileViewer.Module.GetRangeDiff(
                         firstId,
@@ -74,17 +82,29 @@ namespace GitUI
 
                 // Try set highlighting from first found filename
                 Match match = new Regex(@"\n\s*(@@|##)\s+(?<file>[^#:\n]+)").Match(output ?? "");
-                var filename = match.Groups["file"].Success ? match.Groups["file"].Value : item.Item.Name;
+                string filename = match.Groups["file"].Success ? match.Groups["file"].Value : item.Item.Name;
 
-                return fileViewer.ViewRangeDiffAsync(filename, output ?? defaultText);
+                cancellationToken.ThrowIfCancellationRequested();
+
+                await fileViewer.ViewRangeDiffAsync(filename, output ?? defaultText);
+                return;
             }
 
-            string selectedPatch = GetSelectedPatch(fileViewer, firstId, item.SecondRevision.ObjectId, item.Item)
+            string selectedPatch = (await GetSelectedPatchAsync(fileViewer, firstId, item.SecondRevision.ObjectId, item.Item))
                 ?? defaultText;
 
-            return item.Item.IsSubmodule
-                ? fileViewer.ViewTextAsync(item.Item.Name, text: selectedPatch, openWithDifftool: openWithDiffTool)
-                : fileViewer.ViewPatchAsync(item, text: selectedPatch, openWithDifftool: openWithDiffTool);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (item.Item.IsSubmodule)
+            {
+                await fileViewer.ViewTextAsync(item.Item.Name, text: selectedPatch, openWithDifftool: openWithDiffTool);
+            }
+            else
+            {
+                await fileViewer.ViewPatchAsync(item, text: selectedPatch, openWithDifftool: openWithDiffTool);
+            }
+
+            return;
 
             void OpenWithDiffTool()
             {
@@ -96,7 +116,7 @@ namespace GitUI
                     isTracked: item.Item.IsTracked);
             }
 
-            static string? GetSelectedPatch(
+            static async Task<string?> GetSelectedPatchAsync(
                 FileViewer fileViewer,
                 ObjectId firstId,
                 ObjectId selectedId,
@@ -112,24 +132,26 @@ namespace GitUI
                         : diffOfConflict;
                 }
 
-                if (file.IsSubmodule)
+                var task = file.GetSubmoduleStatusAsync();
+
+                if (file.IsSubmodule && task is not null)
                 {
-#pragma warning disable VSTHRD103 // Call async methods when in an async method
-                    var status = ThreadHelper.JoinableTaskFactory.Run(file.GetSubmoduleStatusAsync!);
-#pragma warning restore VSTHRD103 // Call async methods when in an async method
+                    // Patch already evaluated
+                    var status = await task;
+
                     return status is not null
                         ? LocalizationHelpers.ProcessSubmoduleStatus(fileViewer.Module, status)
                         : $"Failed to get status for submodule \"{file.Name}\"";
                 }
 
-                var patch = GetItemPatch(fileViewer.Module, file, firstId, selectedId,
+                var patch = await GetItemPatchAsync(fileViewer.Module, file, firstId, selectedId,
                     fileViewer.GetExtraDiffArguments(), fileViewer.Encoding);
 
                 return file.IsSubmodule
                     ? LocalizationHelpers.ProcessSubmodulePatch(fileViewer.Module, file.Name, patch)
                     : patch?.Text;
 
-                static Patch? GetItemPatch(
+                static async Task<Patch?> GetItemPatchAsync(
                     GitModule module,
                     GitItemStatus file,
                     ObjectId? firstId,
@@ -140,7 +162,7 @@ namespace GitUI
                     // Files with tree guid should be presented with normal diff
                     var isTracked = file.IsTracked || (file.TreeGuid is not null && secondId is not null);
 
-                    return module.GetSingleDiff(firstId, secondId, file.Name, file.OldName, diffArgs, encoding, true, isTracked);
+                    return await module.GetSingleDiffAsync(firstId, secondId, file.Name, file.OldName, diffArgs, encoding, true, isTracked);
                 }
             }
         }

--- a/GitUI/UserControls/CommitDiff.Designer.cs
+++ b/GitUI/UserControls/CommitDiff.Designer.cs
@@ -7,19 +7,6 @@
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary> 
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components is not null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         #region Component Designer generated code
 
         /// <summary> 

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -8,6 +8,8 @@ namespace GitUI.UserControls
 {
     public partial class CommitDiff : GitModuleControl
     {
+        private readonly CancellationTokenSequence _viewChangesSequence = new();
+
         /// <summary>
         /// Raised when the Escape key is pressed (and only when no selection exists, as the default behaviour of escape is to clear the selection).
         /// </summary>
@@ -66,6 +68,21 @@ namespace GitUI.UserControls
             }
         }
 
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _viewChangesSequence.Dispose();
+                components?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
         private void DiffFiles_SelectedIndexChanged(object sender, EventArgs e)
         {
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
@@ -84,7 +101,8 @@ namespace GitUI.UserControls
 
         private async Task ViewSelectedDiffAsync()
         {
-            await DiffText.ViewChangesAsync(DiffFiles.SelectedItem);
+            await DiffText.ViewChangesAsync(DiffFiles.SelectedItem,
+                cancellationToken: _viewChangesSequence.Next());
         }
     }
 }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -483,6 +483,9 @@ namespace GitExtensions.UITests.CommandsDialogs
                         CommitKind.Fixup => _commands.StartFixupCommitDialog(owner: null, _referenceRepository.Module.GetRevision()),
                         _ => throw new ArgumentException($"Unsupported commit kind: {commitKind}", nameof(commitKind))
                     });
+
+                    // Await updated FileViewer
+                    ThreadHelper.JoinPendingOperations();
                 },
                 testDriverAsync);
         }


### PR DESCRIPTION
- Fixes #8914 so that the application doesn't hang when submodule results have not completed at the time they're requested.
- Makes the UI responsive while the submodule operation is underway.
- Discards some unawaited tasks, as these triggered compiler diagnostics after making the above changes (unsure why).

This required making methods `GitModule.GetSingleDiff` and `SubmoduleHelpers.GetCurrentSubmoduleChanges` async.

## Test methodology

- Manual testing

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
