### PR TITLE
Remove IExecutable.GetOutput

### DIFF
--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -47,11 +47,6 @@ namespace GitCommands
             return new ProcessWrapper(fileName, args, _workingDir, createWindow, redirectInput, redirectOutput, outputEncoding, useShellExecute);
         }
 
-        public string GetOutput(ArgumentString arguments)
-        {
-            return this.GetOutput(arguments, null);
-        }
-
         #region ProcessWrapper
 
         /// <summary>

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using CommonTestUtils;
 using FluentAssertions;
+using GitCommands;
 using GitUI;
 using GitUI.CommandsDialogs;
 using ICSharpCode.TextEditor;

--- a/Plugins/GitUIPluginInterfaces/IExecutable.cs
+++ b/Plugins/GitUIPluginInterfaces/IExecutable.cs
@@ -31,13 +31,5 @@ namespace GitUIPluginInterfaces
                        bool redirectOutput = false,
                        Encoding? outputEncoding = null,
                        bool useShellExecute = false);
-
-        /// <summary>
-        /// Launches a process for the executable and returns its output.
-        /// </summary>
-        /// <param name="arguments">The arguments to pass to the executable</param>
-        /// <returns>The concatenation of standard output and standard error.</returns>
-        [MustUseReturnValue]
-        string GetOutput(ArgumentString arguments);
     }
 }

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -98,26 +98,6 @@ namespace CommonTestUtils
             throw new Exception("Unexpected arguments: " + arguments);
         }
 
-        public string GetOutput(ArgumentString arguments)
-        {
-            if (_outputStackByArguments.TryRemove(arguments, out var queue) && queue.TryPop(out var item))
-            {
-                if (queue.Count == 0)
-                {
-                    _outputStackByArguments.TryRemove(arguments, out _);
-                }
-
-                return item.output;
-            }
-
-            if (_commandArgumentsSet.TryRemove(arguments, out _))
-            {
-                return "";
-            }
-
-            throw new Exception("Unexpected arguments: " + arguments);
-        }
-
         private sealed class MockProcess : IProcess
         {
             public MockProcess([CanBeNull] string output, int? exitCode = 0)


### PR DESCRIPTION
## Proposed changes

- Remove `IExecutable.GetOutput`. This method simply delegated to an extension method anyway. It is not needed on the interface.

## Test methodology <!-- How did you ensure quality? -->

- It compiles. Letting CI run the tests as it takes forever on my machine.

---

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
