### PR TITLE
Remove unused field from RevisionDiffController

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -38,7 +38,7 @@ namespace GitUI.CommandsDialogs
 
         private RevisionGridControl? _revisionGrid;
         private RevisionFileTreeControl? _revisionFileTree;
-        private IRevisionDiffController? _revisionDiffController;
+        private readonly IRevisionDiffController _revisionDiffController = new RevisionDiffController();
         private readonly IFileStatusListContextMenuController _revisionDiffContextMenuController;
         private readonly IFullPathResolver _fullPathResolver;
         private readonly IFindFilePredicateProvider _findFilePredicateProvider;
@@ -234,8 +234,6 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnRuntimeLoad()
         {
-            _revisionDiffController = new RevisionDiffController(_gitRevisionTester);
-
             DiffFiles.DescribeRevision = objectId => DescribeRevision(objectId);
             DiffText.SetFileLoader(GetNextPatchFile);
             DiffText.Font = AppSettings.FixedWidthFont;
@@ -517,8 +515,6 @@ namespace GitUI.CommandsDialogs
             fileHistoryDiffToolstripMenuItem.Font = (DiffFiles.SelectedItem?.Item.IsSubmodule ?? false) && AppSettings.OpenSubmoduleDiffInSeparateWindow
                 ? new Font(fileHistoryDiffToolstripMenuItem.Font, FontStyle.Regular)
                 : new Font(fileHistoryDiffToolstripMenuItem.Font, FontStyle.Bold);
-
-            Validates.NotNull(_revisionDiffController);
 
             diffUpdateSubmoduleMenuItem.Visible =
                 diffResetSubmoduleChanges.Visible =

--- a/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -75,13 +75,6 @@ namespace GitUI.CommandsDialogs
 
     public sealed class RevisionDiffController : IRevisionDiffController
     {
-        private readonly IGitRevisionTester _revisionTester;
-
-        public RevisionDiffController(IGitRevisionTester revisionTester)
-        {
-            _revisionTester = revisionTester;
-        }
-
         // The enabling of menu items is related to how the actions have been implemented
 
         public bool ShouldShowDifftoolMenus(ContextMenuSelectionInfo selectionInfo)

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
@@ -1,8 +1,6 @@
 ﻿using FluentAssertions;
-using GitCommands.Git;
 using GitUI.CommandsDialogs;
 using GitUIPluginInterfaces;
-using NSubstitute;
 using NUnit.Framework;
 
 namespace GitUITests.CommandsDialogs
@@ -10,18 +8,9 @@ namespace GitUITests.CommandsDialogs
     [TestFixture]
     public class RevisionDiffControllerTests
     {
-        private IGitRevisionTester _tester;
-        private RevisionDiffController _controller;
+        private readonly RevisionDiffController _controller = new();
 
-        [SetUp]
-        public void Setup()
-        {
-            _tester = Substitute.For<IGitRevisionTester>();
-
-            _controller = new RevisionDiffController(_tester);
-        }
-
-        private ContextMenuSelectionInfo CreateContextMenuSelectionInfo(GitRevision selectedRevision = null,
+        private static ContextMenuSelectionInfo CreateContextMenuSelectionInfo(GitRevision selectedRevision = null,
             bool isDisplayOnlyDiff = false,
             bool isStatusOnly = false,
             int selectedGitItemCount = 1,


### PR DESCRIPTION
## Proposed changes

Remove unused field from `RevisionDiffController`. This class is stateless. Update consuming code too.

## Test methodology <!-- How did you ensure quality? -->

- It compiles. CI will run tests.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
