### PR TITLE
Remove redundant property setters

### DIFF
--- a/GitCommands/Config/ConfigSection.cs
+++ b/GitCommands/Config/ConfigSection.cs
@@ -63,7 +63,7 @@ namespace GitCommands.Config
 
         public string SectionName { get; set; }
         public string? SubSection { get; set; }
-        public bool SubSectionCaseSensitive { get; set; }
+        public bool SubSectionCaseSensitive { get; }
 
         public IDictionary<string, IReadOnlyList<string>> AsDictionary()
         {

--- a/GitCommands/CustomDiffMergeTool.cs
+++ b/GitCommands/CustomDiffMergeTool.cs
@@ -1,16 +1,17 @@
-﻿using System.Windows.Forms;
+﻿using System;
+using System.Windows.Forms;
 
 namespace GitCommands
 {
     public class CustomDiffMergeTool
     {
-        public CustomDiffMergeTool(ToolStripMenuItem menuItem, System.EventHandler click)
+        public CustomDiffMergeTool(ToolStripMenuItem menuItem, EventHandler click)
         {
             MenuItem = menuItem;
             Click = click;
         }
 
-        public ToolStripMenuItem MenuItem { get; set; }
-        public System.EventHandler Click;
+        public ToolStripMenuItem MenuItem { get; }
+        public EventHandler Click { get; }
     }
 }

--- a/GitCommands/CustomDiffMergeToolCache.cs
+++ b/GitCommands/CustomDiffMergeToolCache.cs
@@ -16,9 +16,10 @@ namespace GitCommands
             _isDiff = isDiff;
         }
 
-        private bool _isDiff { get; set; }
-        private SemaphoreSlim _mutex = new(1);
-        private IEnumerable<string>? _tools = null;
+        private readonly bool _isDiff;
+        private readonly SemaphoreSlim _mutex = new(1);
+
+        private IEnumerable<string>? _tools;
 
         public static CustomDiffMergeToolCache DiffToolCache { get; } = new(true);
         public static CustomDiffMergeToolCache MergeToolCache { get; } = new(false);

--- a/GitCommands/UserRepositoryHistory/RecentRepoInfo.cs
+++ b/GitCommands/UserRepositoryHistory/RecentRepoInfo.cs
@@ -8,12 +8,12 @@ namespace GitCommands.UserRepositoryHistory
 {
     public class RecentRepoInfo
     {
-        public Repository Repo { get; set; }
+        public Repository Repo { get; }
         public string? Caption { get; set; }
         public bool MostRecent { get; set; }
         public DirectoryInfo? DirInfo { get; set; }
-        public string? ShortName { get; set; }
-        public string DirName { get; set; }
+        public string? ShortName { get; }
+        public string DirName { get; }
 
         public RecentRepoInfo(Repository repo, bool mostRecent)
         {

--- a/GitExtUtils/GitUI/Theming/BmpTransformation.cs
+++ b/GitExtUtils/GitUI/Theming/BmpTransformation.cs
@@ -15,7 +15,7 @@ namespace GitExtUtils.GitUI.Theming
         private const int BytesPerPixel = 4;
         private const PixelFormat PixelFormat = System.Drawing.Imaging.PixelFormat.Format32bppArgb;
 
-        protected Rectangle Rect { get; private set; }
+        protected Rectangle Rect { get; }
         protected byte[]? BgraValues { get; private set; }
         protected bool ImageChanged { get; set; }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -46,7 +46,7 @@ namespace GitUI.BranchTreePanel
             /// <summary>
             /// Short name of the branch/branch path. <example>"issue1344"</example>.
             /// </summary>
-            public string Name { get; protected set; }
+            public string Name { get; }
 
             protected string ParentPath { get; }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -301,7 +301,7 @@ namespace GitUI.BranchTreePanel
                 _remotesManager = remotesManager;
             }
 
-            public bool Enabled { get; private set; }
+            public bool Enabled { get; }
 
             public bool Fetch()
             {

--- a/GitUI/CommandsDialogs/FormBlame.cs
+++ b/GitUI/CommandsDialogs/FormBlame.cs
@@ -5,7 +5,7 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormBlame : GitModuleForm
     {
-        public string FileName { get; set; }
+        public string FileName { get; }
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/GitUI/CommandsDialogs/FormRevertCommit.cs
+++ b/GitUI/CommandsDialogs/FormRevertCommit.cs
@@ -31,7 +31,7 @@ namespace GitUI.CommandsDialogs
             InitializeComplete();
         }
 
-        public GitRevision Revision { get; set; }
+        public GitRevision Revision { get; }
 
         private void FormRevertCommit_Load(object sender, EventArgs e)
         {

--- a/GitUI/CommandsDialogs/SettingsDialog/GroupSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/GroupSettingsPage.cs
@@ -10,7 +10,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
     /// </summary>
     public abstract class GroupSettingsPage : Translate, ISettingsPage
     {
-        public string Title { get; set; }
+        public string Title { get; }
 
         protected GroupSettingsPage(string title)
         {

--- a/GitUI/HelperDialogs/FormProcess.cs
+++ b/GitUI/HelperDialogs/FormProcess.cs
@@ -16,9 +16,9 @@ namespace GitUI.HelperDialogs
     public class FormProcess : FormStatus
     {
         public string Remote { get; set; }
-        public string ProcessString { get; set; }
+        public string ProcessString { get; }
         public string ProcessArguments { get; set; }
-        public string? ProcessInput { get; set; }
+        public string? ProcessInput { get; }
         public readonly string WorkingDirectory;
         public HandleOnExit? HandleOnExitCallback { get; set; }
         public readonly Dictionary<string, string> ProcessEnvVariables = new Dictionary<string, string>();

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -67,7 +67,7 @@ namespace GitUI.HelperDialogs
             }
         }
 
-        public GitRevision Revision { get; set; }
+        public GitRevision Revision { get; }
 
         private void FormResetCurrentBranch_Load(object sender, EventArgs e)
         {

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
@@ -21,7 +21,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
         public static Color NonRelativeColor { get; } = Color.LightGray;
 
-        internal static Brush NonRelativeBrush { get; private set; }
+        internal static Brush NonRelativeBrush { get; }
 
         internal static readonly List<Brush> PresetGraphBrushes = new List<Brush>();
 

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -91,7 +91,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
         public GitRevision? GitRevision { get; set; }
 
-        public ObjectId Objectid { get; set; }
+        public ObjectId Objectid { get; }
 
         public ImmutableStack<RevisionGraphRevision> Parents => _parents;
         public ImmutableStack<RevisionGraphRevision> Children => _children;

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -25,8 +25,8 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             Segments = segments;
         }
 
-        public RevisionGraphRevision Revision { get; private set; }
-        public IReadOnlyList<RevisionGraphSegment> Segments { get; private set; }
+        public RevisionGraphRevision Revision { get; }
+        public IReadOnlyList<RevisionGraphSegment> Segments { get; }
 
         // This dictonary contains a cached list of all segments and the lane index the segment is in for this row.
         private IReadOnlyDictionary<RevisionGraphSegment, int>? _segmentLanes;

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
@@ -27,7 +27,7 @@
 
         public int EndScore => Parent.Score;
 
-        public RevisionGraphRevision Parent { get; private set; }
-        public RevisionGraphRevision Child { get; private set; }
+        public RevisionGraphRevision Parent { get; }
+        public RevisionGraphRevision Child { get; }
     }
 }

--- a/GitUI/WindowsThumbnailToolbarButton.cs
+++ b/GitUI/WindowsThumbnailToolbarButton.cs
@@ -13,8 +13,8 @@ namespace GitUI
             Click = click;
         }
 
-        public EventHandler<ThumbnailButtonClickedEventArgs> Click { get; set; }
-        public Image Image { get; set; }
-        public string Text { get; set; }
+        public EventHandler<ThumbnailButtonClickedEventArgs> Click { get; }
+        public Image Image { get; }
+        public string Text { get; }
     }
 }

--- a/Plugins/FindLargeFiles/GitObject.cs
+++ b/Plugins/FindLargeFiles/GitObject.cs
@@ -16,13 +16,13 @@ namespace FindLargeFiles
 
         public string SHA { get; set; }
         public string Path { get; set; }
-        internal int SizeInBytes { get; set; }
+        internal int SizeInBytes { get; }
         public string Size => string.Format("{0:F2} Mb", SizeInBytes / 1024.0f / 1024);
         internal int CompressedSizeInBytes { get; set; }
         public string CompressedSize => CompressedSizeInBytes >= 0 ? string.Format("{0:F2} Mb", CompressedSizeInBytes / 1024.0f / 1024) : "<Unknown>";
         public int CommitCount => Commit.Count;
         public DateTime LastCommitDate { get; set; }
         public bool Delete { get; set; }
-        internal HashSet<string> Commit { get; set; }
+        internal HashSet<string> Commit { get; }
     }
 }

--- a/Plugins/GitUIPluginInterfaces/IGitRemoteCommand.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitRemoteCommand.cs
@@ -20,9 +20,9 @@ namespace GitUIPluginInterfaces
     {
         public IGitRemoteCommand Command { get; }
 
-        public bool IsError { get; set; }
+        public bool IsError { get; }
 
-        public bool Handled { get; set; }
+        public bool Handled { get; }
 
         public GitRemoteCommandCompletedEventArgs(IGitRemoteCommand command, bool isError, bool handled)
         {

--- a/Plugins/GitUIPluginInterfaces/Settings/BoolSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/BoolSetting.cs
@@ -19,7 +19,7 @@ namespace GitUIPluginInterfaces
 
         public string Name { get; }
         public string Caption { get; }
-        public bool DefaultValue { get; set; }
+        public bool DefaultValue { get; }
         public CheckBox CustomControl { get; set; }
 
         public ISettingControlBinding CreateControlBinding()

--- a/Plugins/GitUIPluginInterfaces/Settings/ChoiceSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/ChoiceSetting.cs
@@ -25,8 +25,8 @@ namespace GitUIPluginInterfaces
 
         public string Name { get; }
         public string Caption { get; }
-        public string DefaultValue { get; set; }
-        public IList<string> Values { get; set; }
+        public string DefaultValue { get; }
+        public IList<string> Values { get; }
         public ComboBox CustomControl { get; set; }
 
         public ISettingControlBinding CreateControlBinding()

--- a/Plugins/GitUIPluginInterfaces/Settings/NumberSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/NumberSetting.cs
@@ -19,7 +19,7 @@ namespace GitUIPluginInterfaces
 
         public string Name { get; }
         public string Caption { get; }
-        public T DefaultValue { get; set; }
+        public T DefaultValue { get; }
         public TextBox CustomControl { get; set; }
 
         public ISettingControlBinding CreateControlBinding()

--- a/Plugins/GitUIPluginInterfaces/Settings/PasswordSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/PasswordSetting.cs
@@ -18,7 +18,7 @@ namespace GitUIPluginInterfaces
 
         public string Name { get; }
         public string Caption { get; }
-        public string DefaultValue { get; set; }
+        public string DefaultValue { get; }
         public TextBox CustomControl { get; set; }
 
         public ISettingControlBinding CreateControlBinding()

--- a/Plugins/GitUIPluginInterfaces/Settings/StringSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/StringSetting.cs
@@ -20,9 +20,9 @@ namespace GitUIPluginInterfaces
 
         public string Name { get; }
         public string Caption { get; }
-        public string DefaultValue { get; set; }
+        public string DefaultValue { get; }
         public TextBox CustomControl { get; set; }
-        public bool UseDefaultValueIfBlank { get; set; }
+        public bool UseDefaultValueIfBlank { get; }
 
         public ISettingControlBinding CreateControlBinding()
         {

--- a/Plugins/Statistics/GitStatistics/PieChart/PieChart3D.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/PieChart3D.cs
@@ -255,13 +255,13 @@ namespace GitStatistics.PieChart
         ///   Gets or sets the x-coordinate of the upper-left corner of the
         ///   bounding rectangle.
         /// </summary>
-        public float X { get; set; }
+        public float X { get; }
 
         /// <summary>
         ///   Gets or sets the y-coordinate of the upper-left corner of the
         ///   bounding rectangle.
         /// </summary>
-        public float Y { get; set; }
+        public float Y { get; }
 
         /// <summary>
         ///   Sets the shadowing style used.

--- a/ResourceManager/CommandEventArgs.cs
+++ b/ResourceManager/CommandEventArgs.cs
@@ -10,7 +10,7 @@ namespace ResourceManager
             Data = data;
         }
 
-        public string Command { get; set; }
-        public string Data { get; set; }
+        public string Command { get; }
+        public string Data { get; }
     }
 }

--- a/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
+++ b/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
@@ -58,7 +58,7 @@ namespace CommonTestUtils
         /// <summary>
         /// Gets the module.
         /// </summary>
-        public GitModule Module { get; private set; }
+        public GitModule Module { get; }
 
         /// <summary>
         /// Gets the temporary path where test repositories will be created for integration tests.

--- a/UnitTests/GitUI.Tests/BranchTreePanel/GitRefMenuItemsTest.cs
+++ b/UnitTests/GitUI.Tests/BranchTreePanel/GitRefMenuItemsTest.cs
@@ -119,7 +119,7 @@ namespace GitUITests.BranchTreePanel
         // can't use a substitute here because of class constraint on INode
         public class TestBranchNode : INode, IGitRefActions, ICanDelete, ICanRename
         {
-            public Stack<string> CallStatck { get; set; } = new Stack<string>();
+            public Stack<string> CallStatck { get; } = new Stack<string>();
 
             public bool Checkout()
             {


### PR DESCRIPTION
## Proposed changes

Remove redundant property setters. Read only properties have the stronger guarantee that their value will not change over time, making reasoning about the containing type's behaviour easier.

## Test methodology <!-- How did you ensure quality? -->

- Manual review. Couldn't find any late binding to these properties. CI will run tests.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
