### PR TITLE
Focus ComboBox Branches of FormResetAnotherBranch

### DIFF
--- a/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -42,6 +42,8 @@ namespace GitUI.HelperDialogs
             Height = tableLayoutPanel1.Height + tableLayoutPanel1.Top;
             tableLayoutPanel1.Dock = DockStyle.Fill;
 
+            ActiveControl = Branches;
+
             InitializeComplete();
 
             labelResetBranchWarning.SetForeColorForBackColor();


### PR DESCRIPTION
## Proposed changes

- Set the initial focus of `FormResetAnotherBranch` to the (dropped down) ComboBox `Branches`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/110177090-b2d1e080-7e04-11eb-9f8d-5cbcc035b739.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/110177154-ca10ce00-7e04-11eb-9d66-821def9bc73e.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 87a45ff005cff65b736453d96a00d9250536ac85
- Git 2.27.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).