### PR TITLE
Prevent exception when running unit tests

### DIFF
--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -104,7 +104,16 @@ namespace GitUI.AutoCompletion
                 return File.ReadLines(path);
             }
 
-            Stream? s = Assembly.GetEntryAssembly()?.GetManifestResourceStream("GitExtensions.AutoCompleteRegexes.txt");
+            var entryAssembly = Assembly.GetEntryAssembly();
+
+            if (entryAssembly is null)
+            {
+                // This will be null during integration tests, for example
+                return Enumerable.Empty<string>();
+            }
+
+            Stream? s = entryAssembly.GetManifestResourceStream("GitExtensions.AutoCompleteRegexes.txt");
+
             if (s is null)
             {
                 throw new NotImplementedException("Please add AutoCompleteRegexes.txt file into .csproj");


### PR DESCRIPTION
## Proposed changes

- Prevent exception when running unit tests when the entry assembly is null. This can make debugging smoother.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
