### PR TITLE
Stop AsyncLoader passing null on cancellation

### DIFF
--- a/GitCommands/AsyncLoader.cs
+++ b/GitCommands/AsyncLoader.cs
@@ -30,20 +30,20 @@ namespace GitCommands
         public async Task LoadAsync(Action<CancellationToken> loadContent, Action onLoaded)
         {
             await LoadAsync(
-                (token) =>
+                token =>
                 {
                     loadContent(token);
-                    return string.Empty;
+                    return (object?)null;
                 },
                 _ => onLoaded());
         }
 
-        public Task<T?> LoadAsync<T>(Func<T> loadContent, Action<T?> onLoaded)
+        public Task<T?> LoadAsync<T>(Func<T> loadContent, Action<T> onLoaded)
         {
             return LoadAsync(token => loadContent(), onLoaded);
         }
 
-        public async Task<T?> LoadAsync<T>(Func<CancellationToken, T> loadContent, Action<T?> onLoaded)
+        public async Task<T?> LoadAsync<T>(Func<CancellationToken, T> loadContent, Action<T> onLoaded)
         {
             if (Volatile.Read(ref _disposed) != 0)
             {
@@ -73,13 +73,11 @@ namespace GitCommands
                 // Bail early if cancelled, returning default value for type
                 if (token.IsCancellationRequested)
                 {
-                    result = default;
+                    return default;
                 }
-                else
-                {
-                    // Load content
-                    result = loadContent(token);
-                }
+
+                // Load content
+                result = loadContent(token);
             }
             catch (Exception e)
             {

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -104,7 +104,7 @@ namespace GitUI.CommandsDialogs
             Close();
         }
 
-        private void UpdatePreviewPanel(IReadOnlyList<string>? ignoredFiles)
+        private void UpdatePreviewPanel(IReadOnlyList<string> ignoredFiles)
         {
             _NO_TRANSLATE_Preview.DataSource = ignoredFiles;
             _NO_TRANSLATE_filesWillBeIgnored.Text = string.Format(_matchingFilesString.Text, _NO_TRANSLATE_Preview.Items.Count);

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -407,15 +407,9 @@ namespace GitUI.CommandsDialogs
 
         private readonly AsyncLoader _branchListLoader = new();
 
-        private void UpdateBranches(RemoteActionResult<IReadOnlyList<IGitRef>>? branchList)
+        private void UpdateBranches(RemoteActionResult<IReadOnlyList<IGitRef>> branchList)
         {
             Cursor = Cursors.Default;
-
-            if (branchList is null)
-            {
-                // cancelled
-                return;
-            }
 
             if (branchList.HostKeyFail)
             {

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -826,7 +826,7 @@ namespace GitUI.CommandsDialogs
 
         #endregion
 
-        private void ComputeUnstagedFiles(Action<IReadOnlyList<GitItemStatus>?> onComputed, bool doAsync)
+        private void ComputeUnstagedFiles(Action<IReadOnlyList<GitItemStatus>> onComputed, bool doAsync)
         {
             IReadOnlyList<GitItemStatus> GetAllChangedFilesWithSubmodulesStatus()
             {
@@ -855,12 +855,6 @@ namespace GitUI.CommandsDialogs
         {
             ComputeUnstagedFiles(allChangedFiles =>
                 {
-                    if (allChangedFiles is null)
-                    {
-                        // cancelled
-                        return;
-                    }
-
                     if (allChangedFiles.Count > 0)
                     {
                         LoadUnstagedOutput(allChangedFiles);
@@ -982,14 +976,8 @@ namespace GitUI.CommandsDialogs
         ///   This method is passed in to the SetTextCallBack delegate
         ///   to set the Text property of textBox1.
         /// </summary>
-        private void LoadUnstagedOutput(IReadOnlyList<GitItemStatus>? allChangedFiles)
+        private void LoadUnstagedOutput(IReadOnlyList<GitItemStatus> allChangedFiles)
         {
-            if (allChangedFiles is null)
-            {
-                // cancelled
-                return;
-            }
-
             var lastSelection = _currentFilesList is not null
                 ? _currentSelection ?? Array.Empty<GitItemStatus>()
                 : Array.Empty<GitItemStatus>();

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -175,14 +175,8 @@ namespace GitUI.CommandsDialogs
             View.ScrollToTop();
         }
 
-        private void LoadGitItemStatuses(IReadOnlyList<GitItemStatus>? gitItemStatuses)
+        private void LoadGitItemStatuses(IReadOnlyList<GitItemStatus> gitItemStatuses)
         {
-            if (gitItemStatuses is null)
-            {
-                // cancelled
-                return;
-            }
-
             GitStash gitStash = (GitStash)Stashes.SelectedItem;
             if (gitStash == _currentWorkingDirStashItem)
             {

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -59,12 +59,6 @@ namespace GitUI.CommandsDialogs.RepoHosting
                 () => _hostedRemotes.Where(r => !r.IsOwnedByMe).ToArray(),
                 foreignHostedRemotes =>
                 {
-                    if (foreignHostedRemotes is null)
-                    {
-                        // cancelled
-                        return;
-                    }
-
                     if (foreignHostedRemotes.Length == 0)
                     {
                         MessageBox.Show(this, _strFailedToCreatePullRequest.Text + Environment.NewLine +

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -83,12 +83,6 @@ namespace GitUI.CommandsDialogs.RepoHosting
                 },
                 hostedRemotes =>
                 {
-                    if (hostedRemotes is null)
-                    {
-                        // cancelled
-                        return;
-                    }
-
                     _hostedRemotes = hostedRemotes;
                     _selectHostedRepoCB.Items.Clear();
                     foreach (var hostedRepo in _hostedRemotes)

--- a/GitUI/CommandsDialogs/SearchControl.cs
+++ b/GitUI/CommandsDialogs/SearchControl.cs
@@ -73,14 +73,8 @@ namespace GitUI.CommandsDialogs
             set => txtSearchBox.BorderFocusedColor = value;
         }
 
-        private void SearchForCandidates(IEnumerable<T>? candidates)
+        private void SearchForCandidates(IEnumerable<T> candidates)
         {
-            if (candidates is null)
-            {
-                // cancelled
-                return;
-            }
-
             var selectionStart = txtSearchBox.SelectionStart;
             var selectionLength = txtSearchBox.SelectionLength;
             listBoxSearchResult.BeginUpdate();

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1033,12 +1033,6 @@ namespace GitUI.Editor
                     getSubmoduleText,
                     text =>
                     {
-                        if (text is null)
-                        {
-                            // cancelled
-                            return;
-                        }
-
                         ThreadHelper.JoinableTaskFactory.Run(() => ViewTextAsync(fileName, text, openWithDifftool));
                     });
             }
@@ -1083,16 +1077,7 @@ namespace GitUI.Editor
                 return _async.LoadAsync(
                     getFileText,
                     text => ThreadHelper.JoinableTaskFactory.Run(
-                        () =>
-                        {
-                            if (text is null)
-                            {
-                                // cancelled
-                                return Task.CompletedTask;
-                            }
-
-                            return ViewTextAsync(fileName, text, openWithDifftool, checkGitAttributes: true);
-                        }));
+                        () => ViewTextAsync(fileName, text, openWithDifftool, checkGitAttributes: true)));
             }
         }
 


### PR DESCRIPTION
## Proposed changes

Stop AsyncLoader passing null on cancellation. This strange pattern was identified during recent annotation work. It isn't particularly useful to be called back with a default value when the original load action was cancelled.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
