### PR TITLE
FormBrowse Toolbar: Being able to hide each control separately

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
@@ -106,12 +106,148 @@ namespace GitUI.CommandsDialogs
                     CheckOnClick = true,
                     Tag = senderToolStrip
                 };
+
+                toolStripItem.DropDown.Closing += (sender, e) =>
+                {
+                    if (e.CloseReason == ToolStripDropDownCloseReason.ItemClicked)
+                    {
+                        // Cancel closing menu to allow selecting/unselecting multiple items.
+                        e.Cancel = true;
+                    }
+                };
+
+                CreateToolStripSubMenus(senderToolStrip, toolStripItem);
+
                 toolStripItem.Click += (s, e) =>
                 {
                     senderToolStrip.Visible = !senderToolStrip.Visible;
                 };
 
                 return toolStripItem;
+            }
+        }
+
+        private static void CreateToolStripSubMenus(ToolStrip senderToolStrip, ToolStripMenuItem toolStripItem)
+        {
+            const string toolbarSettingsPrefix = "formbrowse_toolbar_visibility_";
+            string? currentGroup = null;
+            foreach (ToolStripItem toolbarItem in senderToolStrip.Items)
+            {
+                if (toolbarItem is ToolStripSeparator)
+                {
+                    toolStripItem.DropDownItems.Add(new ToolStripSeparator());
+                    continue;
+                }
+
+                bool belongToAGroup = BelongToAGroup(toolbarItem, out string groupName);
+                string key;
+                if (belongToAGroup)
+                {
+                    if (currentGroup == groupName)
+                    {
+                        toolbarItem.Visible = LoadVisibilitySetting(groupName);
+                        continue;
+                    }
+
+                    currentGroup = (string)toolbarItem.Tag;
+                    key = groupName;
+                }
+                else
+                {
+                    key = toolbarItem.Name;
+                }
+
+                toolbarItem.Visible = LoadVisibilitySetting(key);
+
+                ToolStripMenuItem menuToolbarItem = new(toolbarItem.ToolTipText)
+                {
+                    Checked = toolbarItem.Visible,
+                    CheckOnClick = true,
+                    Tag = toolbarItem,
+                    Image = toolbarItem.Image
+                };
+
+                menuToolbarItem.Click += (s, e) =>
+                {
+                    toolbarItem.Visible = !toolbarItem.Visible;
+
+                    if (!BelongToAGroup(toolbarItem, out var group))
+                    {
+                        SaveVisibilitySetting(toolbarItem.Name, toolbarItem.Visible);
+                    }
+                    else
+                    {
+                        SaveVisibilitySetting(group, toolbarItem.Visible);
+                        foreach (ToolStripItem item in senderToolStrip.Items)
+                        {
+                            if (item.Tag == (object)group)
+                            {
+                                item.Visible = toolbarItem.Visible;
+                            }
+                        }
+                    }
+
+                    AdaptSeparatorsVisibility(senderToolStrip);
+                };
+
+                toolStripItem.DropDownItems.Add(menuToolbarItem);
+            }
+
+            AdaptSeparatorsVisibility(senderToolStrip);
+
+            return;
+
+            static void SaveVisibilitySetting(string key, bool visible) => AppSettings.SetBool(toolbarSettingsPrefix + key, visible ? null : false);
+            static bool LoadVisibilitySetting(string key) => AppSettings.GetBool(toolbarSettingsPrefix + key, true);
+
+            static bool BelongToAGroup(ToolStripItem toolbarItem, out string groupName)
+            {
+                const string groupPrefix = "ToolBar_group:";
+                if (toolbarItem.Tag is string group && group.StartsWith(groupPrefix))
+                {
+                    groupName = group;
+                    return true;
+                }
+
+                groupName = string.Empty;
+                return false;
+            }
+        }
+
+        private static void AdaptSeparatorsVisibility(ToolStrip senderToolStrip)
+        {
+            // First pass: toolbar items from left to right
+            bool shouldHideNextSeparator = true;
+            foreach (ToolStripItem item in senderToolStrip.Items)
+            {
+                HandleCurrentItem(item);
+            }
+
+            // Second pass: toolbar items from right to left
+            shouldHideNextSeparator = true;
+            for (int i = senderToolStrip.Items.Count - 1; i >= 0; i--)
+            {
+                var item = senderToolStrip.Items[i];
+
+                if (item is ToolStripSeparator { Visible: false })
+                {
+                    continue;
+                }
+
+                HandleCurrentItem(item);
+            }
+
+            void HandleCurrentItem(ToolStripItem toolStripItem)
+            {
+                if (toolStripItem is ToolStripSeparator separator)
+                {
+                    separator.Visible = !shouldHideNextSeparator;
+                    shouldHideNextSeparator = true;
+                }
+                else
+                {
+                    shouldHideNextSeparator &= !toolStripItem.Visible;
+                }
             }
         }
 

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -378,12 +378,12 @@ namespace GitUI.CommandsDialogs
             // 
             // toolStripButtonLevelUp
             // 
-            this.toolStripButtonLevelUp.AutoToolTip = false;
             this.toolStripButtonLevelUp.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.toolStripButtonLevelUp.Image = global::GitUI.Properties.Images.SubmodulesManage;
             this.toolStripButtonLevelUp.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripButtonLevelUp.Name = "toolStripButtonLevelUp";
             this.toolStripButtonLevelUp.Size = new System.Drawing.Size(32, 22);
+            this.toolStripButtonLevelUp.ToolTipText = "Submodules";
             this.toolStripButtonLevelUp.ButtonClick += new System.EventHandler(this.toolStripButtonLevelUp_ButtonClick);
             this.toolStripButtonLevelUp.DropDownOpening += new System.EventHandler(this.toolStripButtonLevelUp_DropDownOpening);
             // 
@@ -611,7 +611,9 @@ namespace GitUI.CommandsDialogs
             // 
             this.toolStripLabel1.Name = "toolStripLabel1";
             this.toolStripLabel1.Size = new System.Drawing.Size(58, 22);
+            this.toolStripLabel1.Tag = "ToolBar_group:Branch filter";
             this.toolStripLabel1.Text = "Branches:";
+            this.toolStripLabel1.ToolTipText = "Branch filter";
             // 
             // toolStripBranchFilterComboBox
             // 
@@ -621,6 +623,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripBranchFilterComboBox.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.toolStripBranchFilterComboBox.Name = "toolStripBranchFilterComboBox";
             this.toolStripBranchFilterComboBox.Size = new System.Drawing.Size(100, 23);
+            this.toolStripBranchFilterComboBox.Tag = "ToolBar_group:Branch filter";
             this.toolStripBranchFilterComboBox.Click += new System.EventHandler(this.toolStripBranchFilterComboBox_Click);
             // 
             // toolStripBranchFilterDropDownButton
@@ -629,6 +632,8 @@ namespace GitUI.CommandsDialogs
             this.toolStripBranchFilterDropDownButton.Image = global::GitUI.Properties.Images.EditFilter;
             this.toolStripBranchFilterDropDownButton.Name = "toolStripBranchFilterDropDownButton";
             this.toolStripBranchFilterDropDownButton.Size = new System.Drawing.Size(29, 22);
+            this.toolStripBranchFilterDropDownButton.Tag = "ToolBar_group:Branch filter";
+            this.toolStripBranchFilterDropDownButton.Text = "Branch type";
             // 
             // toolStripSeparator19
             // 
@@ -639,7 +644,9 @@ namespace GitUI.CommandsDialogs
             // 
             this.toolStripRevisionFilterLabel.Name = "toolStripRevisionFilterLabel";
             this.toolStripRevisionFilterLabel.Size = new System.Drawing.Size(36, 22);
+            this.toolStripRevisionFilterLabel.Tag = "ToolBar_group:Text filter";
             this.toolStripRevisionFilterLabel.Text = "Filter:";
+            this.toolStripRevisionFilterLabel.ToolTipText = "Text filter";
             // 
             // toolStripRevisionFilterTextBox
             // 
@@ -648,6 +655,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripRevisionFilterTextBox.ForeColor = System.Drawing.SystemColors.ControlText;
             this.toolStripRevisionFilterTextBox.Name = "toolStripRevisionFilterTextBox";
             this.toolStripRevisionFilterTextBox.Size = new System.Drawing.Size(100, 25);
+            this.toolStripRevisionFilterTextBox.Tag = "ToolBar_group:Text filter";
             // 
             // toolStripRevisionFilterDropDownButton
             // 
@@ -656,6 +664,8 @@ namespace GitUI.CommandsDialogs
             this.toolStripRevisionFilterDropDownButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripRevisionFilterDropDownButton.Name = "toolStripRevisionFilterDropDownButton";
             this.toolStripRevisionFilterDropDownButton.Size = new System.Drawing.Size(29, 22);
+            this.toolStripRevisionFilterDropDownButton.Tag = "ToolBar_group:Text filter";
+            this.toolStripRevisionFilterDropDownButton.Text = "Filter type";
             // 
             // ShowFirstParent
             // 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2633,8 +2633,16 @@ Do you want to continue?</source>
         <source>Toggle split view layout</source>
         <target />
       </trans-unit>
+      <trans-unit id="toolStripBranchFilterDropDownButton.Text">
+        <source>Branch type</source>
+        <target />
+      </trans-unit>
       <trans-unit id="toolStripButtonCommit.Text">
         <source>Commit</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="toolStripButtonLevelUp.ToolTipText">
+        <source>Submodules</source>
         <target />
       </trans-unit>
       <trans-unit id="toolStripButtonPull.Text">
@@ -2653,6 +2661,10 @@ Do you want to continue?</source>
         <source>Branches:</source>
         <target />
       </trans-unit>
+      <trans-unit id="toolStripLabel1.ToolTipText">
+        <source>Branch filter</source>
+        <target />
+      </trans-unit>
       <trans-unit id="toolStripMenuItemReflog.Text">
         <source>Show reflog...</source>
         <target />
@@ -2661,8 +2673,16 @@ Do you want to continue?</source>
         <source>Worktrees</source>
         <target />
       </trans-unit>
+      <trans-unit id="toolStripRevisionFilterDropDownButton.Text">
+        <source>Filter type</source>
+        <target />
+      </trans-unit>
       <trans-unit id="toolStripRevisionFilterLabel.Text">
         <source>Filter:</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="toolStripRevisionFilterLabel.ToolTipText">
+        <source>Text filter</source>
         <target />
       </trans-unit>
       <trans-unit id="toolStripSplitStash.ToolTipText">


### PR DESCRIPTION
Fixes "One or two comment asking for this feature but that I can't find anymore..."

Follow up of #8572

## Proposed changes

- Being able to choose the buttons in the browse form toolbar
- Preventing the closing of the menu to easily unselect multiple items


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/110222195-c8acd780-7ed0-11eb-969d-a13db07c6a56.png)


### After

![image](https://user-images.githubusercontent.com/4403806/110271331-eaff3c00-801b-11eb-9937-cc96352d38df.png) 
![image](https://user-images.githubusercontent.com/460196/110400067-4874a680-8077-11eb-8ab8-283ae72bdb59.png)

Gif (with not updated with last separator handling. See screenshot above)
![toolbar_configuration](https://user-images.githubusercontent.com/460196/110222292-70c2a080-7ed1-11eb-9ee5-7f27936baf7a.gif)

## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 132668ee18374ce1ddccb8640e717ae8b70087a3 (Dirty)
- Git 2.28.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4311.0
- DPI 192dpi (200% scaling)
