### PR TITLE
Disable CodeCov integration

### DIFF
--- a/scripts/tools/NUnit/NUnit.targets
+++ b/scripts/tools/NUnit/NUnit.targets
@@ -22,7 +22,7 @@
 
     <PropertyGroup>
       <_UseOpenCover>true</_UseOpenCover>
-      <_UseCodeCov>true</_UseCodeCov>
+      <_UseCodeCov>false</_UseCodeCov>
       <_NUnitConsoleExe>nunit3-console.exe</_NUnitConsoleExe>
       <_NUnitRunnerCommand Condition="$(ContinuousIntegrationBuild) != true">$(PkgNUnit_ConsoleRunner)\tools\$(_NUnitConsoleExe)</_NUnitRunnerCommand>
       <_NUnitRunnerCommand Condition="$(ContinuousIntegrationBuild) == true">$(_NUnitConsoleExe)</_NUnitRunnerCommand>
@@ -72,13 +72,13 @@
           LogStandardErrorAsError="false"
           WorkingDirectory="$(OutDir)"
           IgnoreExitCode="true"
-          Condition="$(ContinuousIntegrationBuild) == true">
+          Condition="$(ContinuousIntegrationBuild) == true and $(_UseCodeCov) == true">
     </Exec>
     <Exec Command='$(_CodeCovProdCommand)'
           LogStandardErrorAsError="false"
           WorkingDirectory="$(OutDir)"
           IgnoreExitCode="true"
-          Condition="$(ContinuousIntegrationBuild) == true">
+          Condition="$(ContinuousIntegrationBuild) == true and $(_UseCodeCov) == true">
     </Exec>
 
     <!--


### PR DESCRIPTION
Submitting test coverage to CodeCov adds extra time to CI builds, it can be sometimes flaky, and it doesn't appear to be adding a great deal of value (At least currently).

![image](https://user-images.githubusercontent.com/4403806/110237036-c2c8fc00-7f8d-11eb-9ba2-d28b11ca170b.png)
