### PR TITLE
range-diff: Incorrect limit when selecting four commits

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -788,23 +788,6 @@ namespace GitCommands
             return null;
         }
 
-        public int? GetCommitDiffCount(ObjectId baseId, ObjectId parentId)
-        {
-            var args = new GitArgumentBuilder("rev-list")
-            {
-                $"{baseId} {parentId}",
-                "--count"
-            };
-            var output = _gitExecutable.GetOutput(args);
-
-            if (int.TryParse(output, out var commitCount))
-            {
-                return commitCount;
-            }
-
-            return null;
-        }
-
         public (int? first, int? second) GetCommitRangeDiffCount(ObjectId firstId, ObjectId secondId)
         {
             if (firstId == secondId)

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -767,6 +767,11 @@ namespace GitCommands
 
         public int? GetCommitCount(string parent, string child, bool cache = false)
         {
+            if (parent == child)
+            {
+                return 0;
+            }
+
             var args = new GitArgumentBuilder("rev-list")
             {
                 parent,
@@ -802,6 +807,11 @@ namespace GitCommands
 
         public (int? first, int? second) GetCommitRangeDiffCount(ObjectId firstId, ObjectId secondId)
         {
+            if (firstId == secondId)
+            {
+                return (0, 0);
+            }
+
             var args = new GitArgumentBuilder("rev-list")
             {
                 $"{firstId}...{secondId}",
@@ -3620,6 +3630,11 @@ namespace GitCommands
 
         public ObjectId? GetMergeBase(ObjectId a, ObjectId b)
         {
+            if (a == b)
+            {
+                return a;
+            }
+
             var args = new GitArgumentBuilder("merge-base")
             {
                 a,

--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -200,8 +200,8 @@ namespace GitUI
             // to avoid that GE seem to hang when selecting the range diff
             int count = (baseA is null || baseB is null
                 ? baseToFirstCount + baseToSecondCount
-                : module.GetCommitDiffCount(baseA, firstRevHead)
-                + module.GetCommitDiffCount(baseB, selectedRevHead))
+                : module.GetCommitCount(firstRevHead.ToString(), baseA.ToString(), cache: true)
+                + module.GetCommitCount(selectedRevHead.ToString(), baseB.ToString(), cache: true))
                 ?? rangeDiffCommitLimit;
             if (!GitVersion.Current.SupportRangeDiffTool || count >= rangeDiffCommitLimit)
             {
@@ -222,7 +222,11 @@ namespace GitUI
             return fileStatusDescs;
 
             static ObjectId GetRevisionOrHead(GitRevision rev, Lazy<ObjectId> head)
-                => rev.IsArtificial ? head.Value : rev.ObjectId;
+                => rev.ObjectId == ObjectId.IndexId
+                ? rev.FirstParentId!
+                : rev.IsArtificial
+                ? head.Value
+                : rev.ObjectId;
 
             static string GetDescriptionForRevision(Func<ObjectId, string>? describeRevision, ObjectId objectId)
                 => describeRevision is not null ? describeRevision(objectId) : objectId.ToShortString();


### PR DESCRIPTION
Candidate for 3.5

## Proposed changes

* range-diff: Incorrect limit when selecting four commits

Git diff-range can be used to show the difference in 'slices' of branches.
This is advanced usage, my normal usage is just to select two heads.
But if you select baseA, A, baseB, B then range-diff shows the difference between the commits,
(see example after, just with one commit in each 'slice').
This is helpful in comparing a patchset in two separate branches (master and release for instance).

range-diff can be slow with many commits and is limited to 100 commit differences.
This calculation was incorrect and did not count the differences but the union for the "base" and the "head" why the command was normally refused.
With this, also a routine in GitModule could be removed.

* FileStatusList: avoid getRevision() for index commits

Just avoid some CPU cycles

* rev-list, merge-base: Avoid Git call when arguments are identical

No need to invoke Git in these situations, even if the commands are cached.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/110253050-8e067600-7f88-11eb-8ac5-658dfa513035.png)

### After

![image](https://user-images.githubusercontent.com/6248932/110253256-9c08c680-7f89-11eb-8368-444b98a44996.png)



## Test methodology <!-- How did you ensure quality? -->

manual

---

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
