### PR TITLE
RevDiff: Show worktree/index changes similar to FormCommit

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2428,6 +2428,12 @@ namespace GitCommands
 
         public IReadOnlyList<GitItemStatus> GetDiffFilesWithUntracked(string? firstRevision, string? secondRevision, StagedStatus stagedStatus, bool noCache = false)
         {
+            if (stagedStatus is StagedStatus.WorkTree or StagedStatus.Index)
+            {
+                var status = GetAllChangedFilesWithSubmodulesStatus();
+                return status.Where(x => x.Staged == stagedStatus).ToList();
+            }
+
             var output = GetDiffFiles(firstRevision, secondRevision, noCache: noCache, nullSeparated: true);
             var result = GetDiffChangedFilesFromString(output, stagedStatus);
 


### PR DESCRIPTION
Fixes #8054

## Proposed changes

This PR has two purposes:
* Get the output in RevDiff panel to be the same as in the tool tip and in FormCommit (see #8054 for details, not much discussed here)
* Avoid unnecessary git-diff command for artificial commits

git-status is required to see new files, but git-diff was used to get other files. When selecting worktree or index only, the git-diff command is not needed, all info is in git-status. 
(Longer explanation: same as HEAD->Index and Index->Worktree, any other combination involving artificial diffs will require git-diff too.)

The git-diff can be considerably slower if viruses like Symantec are installed, delays showing the actual diff.

Note that git-status normally is slower than git-diff.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/110254360-2869b800-7f8f-11eb-96d7-031cf8b169c6.png)

![image](https://user-images.githubusercontent.com/6248932/110254517-cd849080-7f8f-11eb-8bd2-bab5026ebdcd.png)

### After

![image](https://user-images.githubusercontent.com/6248932/110254470-8f876c80-7f8f-11eb-9637-97a271e5e0c4.png)

![image](https://user-images.githubusercontent.com/6248932/110254544-ea20c880-7f8f-11eb-971d-d00b01bd5494.png)

## Test methodology <!-- How did you ensure quality? -->

Change just line endings for a file, for instance like:
`perl -pi -e 's/\r\n/\n/;' GitExtensions.settings`
The examples also used a dummy change to a file

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
