### PR TITLE
Dialogs layout alignment - `FormDeleteBranch`

### DIFF
--- a/GitCommands/Git/Commands/GitDeleteBranchCmd.cs
+++ b/GitCommands/Git/Commands/GitDeleteBranchCmd.cs
@@ -14,6 +14,11 @@ namespace GitCommands.Git.Commands
         public GitDeleteBranchCmd(IReadOnlyCollection<IGitRef> branches, bool force)
         {
             _branches = branches ?? throw new ArgumentNullException(nameof(branches));
+            if (_branches.Count == 0)
+            {
+                throw new ArgumentException("At least one branch is required.", nameof(branches));
+            }
+
             _force = force;
         }
 
@@ -22,14 +27,15 @@ namespace GitCommands.Git.Commands
 
         protected override ArgumentString BuildArguments()
         {
-            var hasRemoteBranch = _branches.Any(branch => branch.IsRemote);
-            var hasNonRemoteBranch = _branches.Any(branch => !branch.IsRemote);
+            bool hasRemoteBranch = _branches.Any(branch => branch.IsRemote);
+            bool hasNonRemoteBranch = _branches.Any(branch => !branch.IsRemote);
 
             return new GitArgumentBuilder("branch")
             {
-                { _force, "-D", "-d" },
-                { hasRemoteBranch && hasNonRemoteBranch, "-a" },
-                { hasRemoteBranch && !hasNonRemoteBranch, "-r" },
+                { "--delete" },
+                { _force, "--force" },
+                { hasRemoteBranch && hasNonRemoteBranch, "--all" },
+                { hasRemoteBranch && !hasNonRemoteBranch, "--remotes" },
                 _branches.Select(branch => branch.Name.Quote())
             };
         }

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -986,6 +986,12 @@ namespace GitCommands
             set => SetBool("DontConfirmAmend", value);
         }
 
+        public static bool DontConfirmDeleteUnmergedBranch
+        {
+            get => GetBool("DontConfirmDeleteUnmergedBranch", false);
+            set => SetBool("DontConfirmDeleteUnmergedBranch", value);
+        }
+
         public static bool DontConfirmCommitIfNoBranch
         {
             get => GetBool("DontConfirmCommitIfNoBranch", false);

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -31,9 +31,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _applyStashedItemsAgain =
             new("Apply stashed items to working directory again?");
 
-        private readonly TranslationString _dontShowAgain =
-            new("Don't show me this message again.");
-
         private readonly TranslationString _resetNonFastForwardBranch =
             new("You are going to reset the “{0}” branch to a new location discarding ALL the commited changes since the {1} revision.\n\nAre you sure?");
         private readonly TranslationString _resetCaption = new("Reset branch");
@@ -393,7 +390,7 @@ namespace GitUI.CommandsDialogs
                             Buttons = { TaskDialogButton.Yes, TaskDialogButton.No },
                             Verification = new TaskDialogVerificationCheckBox
                             {
-                                Text = _dontShowAgain.Text
+                                Text = TranslatedStrings.DontShowAgain
                             },
                             SizeToContent = true
                         };

--- a/GitUI/CommandsDialogs/FormDeleteBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.Designer.cs
@@ -28,117 +28,95 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormDeleteBranch));
             this.Delete = new System.Windows.Forms.Button();
             this.labelSelectBranches = new System.Windows.Forms.Label();
-            this.labelDeleteBranchWarning = new System.Windows.Forms.Label();
-            this.pictureBox1 = new System.Windows.Forms.PictureBox();
-            this.ForceDelete = new System.Windows.Forms.CheckBox();
             this.Branches = new GitUI.BranchComboBox();
-            this.gotoUserManualControl1 = new GitUI.UserControls.GotoUserManualControl();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.tlpnlMain = new System.Windows.Forms.TableLayoutPanel();
+            this.MainPanel.SuspendLayout();
+            this.tlpnlMain.SuspendLayout();
             this.SuspendLayout();
+            // 
+            // MainPanel
+            // 
+            this.MainPanel.Controls.Add(this.tlpnlMain);
+            this.MainPanel.Padding = new System.Windows.Forms.Padding(9);
+            this.MainPanel.Size = new System.Drawing.Size(394, 58);
             // 
             // Delete
             // 
             this.Delete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.Delete.AutoSize = true;
+            this.Delete.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.Delete.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.Delete.Image = global::GitUI.Properties.Images.BranchDelete;
-            this.Delete.Location = new System.Drawing.Point(439, 65);
+            this.Delete.Location = new System.Drawing.Point(310, 65);
+            this.Delete.MinimumSize = new System.Drawing.Size(75, 23);
             this.Delete.Name = "Delete";
-            this.Delete.Size = new System.Drawing.Size(120, 25);
-            this.Delete.TabIndex = 4;
-            this.Delete.Text = "Delete";
-            this.Delete.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.Delete.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
+            this.Delete.Size = new System.Drawing.Size(75, 23);
+            this.Delete.TabIndex = 2;
+            this.Delete.Text = "&Delete";
             this.Delete.UseVisualStyleBackColor = true;
-            this.Delete.Click += new System.EventHandler(this.OkClick);
+            this.Delete.Click += new System.EventHandler(this.Delete_Click);
             // 
             // labelSelectBranches
             // 
             this.labelSelectBranches.AutoSize = true;
+            this.labelSelectBranches.Dock = System.Windows.Forms.DockStyle.Fill;
             this.labelSelectBranches.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.labelSelectBranches.Location = new System.Drawing.Point(9, 9);
+            this.labelSelectBranches.Location = new System.Drawing.Point(3, 0);
             this.labelSelectBranches.Name = "labelSelectBranches";
-            this.labelSelectBranches.Size = new System.Drawing.Size(99, 16);
-            this.labelSelectBranches.TabIndex = 1;
-            this.labelSelectBranches.Text = "Select branches";
-            // 
-            // labelDeleteBranchWarning
-            // 
-            this.labelDeleteBranchWarning.AutoSize = true;
-            this.labelDeleteBranchWarning.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.labelDeleteBranchWarning.Location = new System.Drawing.Point(39, 116);
-            this.labelDeleteBranchWarning.MaximumSize = new System.Drawing.Size(500, 0);
-            this.labelDeleteBranchWarning.Name = "labelDeleteBranchWarning";
-            this.labelDeleteBranchWarning.Size = new System.Drawing.Size(490, 64);
-            this.labelDeleteBranchWarning.TabIndex = 5;
-            this.labelDeleteBranchWarning.Text = resources.GetString("labelDeleteBranchWarning.Text");
-            // 
-            // pictureBox1
-            // 
-            this.pictureBox1.Image = global::GitUI.Properties.Images.Warning;
-            this.pictureBox1.InitialImage = global::GitUI.Properties.Images.Warning;
-            this.pictureBox1.Location = new System.Drawing.Point(12, 142);
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(21, 20);
-            this.pictureBox1.TabIndex = 7;
-            this.pictureBox1.TabStop = false;
-            // 
-            // ForceDelete
-            // 
-            this.ForceDelete.AutoSize = true;
-            this.ForceDelete.Location = new System.Drawing.Point(12, 69);
-            this.ForceDelete.Name = "ForceDelete";
-            this.ForceDelete.Size = new System.Drawing.Size(98, 20);
-            this.ForceDelete.TabIndex = 3;
-            this.ForceDelete.Text = "Force delete";
-            this.ForceDelete.UseVisualStyleBackColor = true;
+            this.labelSelectBranches.Size = new System.Drawing.Size(84, 28);
+            this.labelSelectBranches.TabIndex = 0;
+            this.labelSelectBranches.Text = "Select &branches";
+            this.labelSelectBranches.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // Branches
             // 
-            this.Branches.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.Branches.BranchesToSelect = null;
-            this.Branches.Location = new System.Drawing.Point(12, 35);
+            this.Branches.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.Branches.Location = new System.Drawing.Point(90, 0);
             this.Branches.Margin = new System.Windows.Forms.Padding(0);
             this.Branches.Name = "Branches";
-            this.Branches.Size = new System.Drawing.Size(550, 21);
-            this.Branches.TabIndex = 2;
+            this.Branches.Size = new System.Drawing.Size(286, 28);
+            this.Branches.TabIndex = 1;
             // 
-            // gotoUserManualControl1
+            // tlpnlMain
             // 
-            this.gotoUserManualControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.gotoUserManualControl1.AutoSize = true;
-            this.gotoUserManualControl1.Location = new System.Drawing.Point(10, 211);
-            this.gotoUserManualControl1.ManualSectionAnchorName = "delete-branch";
-            this.gotoUserManualControl1.ManualSectionSubfolder = "branches";
-            this.gotoUserManualControl1.MinimumSize = new System.Drawing.Size(70, 20);
-            this.gotoUserManualControl1.Name = "gotoUserManualControl1";
-            this.gotoUserManualControl1.Size = new System.Drawing.Size(70, 20);
-            this.gotoUserManualControl1.TabIndex = 8;
+            this.tlpnlMain.ColumnCount = 2;
+            this.tlpnlMain.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tlpnlMain.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tlpnlMain.Controls.Add(this.labelSelectBranches, 0, 0);
+            this.tlpnlMain.Controls.Add(this.Branches, 1, 0);
+            this.tlpnlMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tlpnlMain.Location = new System.Drawing.Point(9, 9);
+            this.tlpnlMain.Margin = new System.Windows.Forms.Padding(0);
+            this.tlpnlMain.Name = "tlpnlMain";
+            this.tlpnlMain.RowCount = 2;
+            this.tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tlpnlMain.Size = new System.Drawing.Size(376, 40);
+            this.tlpnlMain.TabIndex = 0;
             // 
             // FormDeleteBranch
             // 
             this.AcceptButton = this.Delete;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(579, 236);
-            this.Controls.Add(this.gotoUserManualControl1);
-            this.Controls.Add(this.Branches);
-            this.Controls.Add(this.ForceDelete);
-            this.Controls.Add(this.pictureBox1);
-            this.Controls.Add(this.labelDeleteBranchWarning);
+            this.ClientSize = new System.Drawing.Size(394, 90);
             this.Controls.Add(this.Delete);
-            this.Controls.Add(this.labelSelectBranches);
+            this.HelpButton = true;
+            this.ManualSectionAnchorName = "delete-branch";
+            this.ManualSectionSubfolder = "branches";
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(525, 270);
+            this.MinimumSize = new System.Drawing.Size(410, 129);
             this.Name = "FormDeleteBranch";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Delete branch";
-            this.Load += new System.EventHandler(this.FormDeleteBranchLoad);
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            this.Controls.SetChildIndex(this.Delete, 0);
+            this.Controls.SetChildIndex(this.MainPanel, 0);
+            this.MainPanel.ResumeLayout(false);
+            this.tlpnlMain.ResumeLayout(false);
+            this.tlpnlMain.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -148,10 +126,7 @@
 
         private System.Windows.Forms.Button Delete;
         private System.Windows.Forms.Label labelSelectBranches;
-        private System.Windows.Forms.Label labelDeleteBranchWarning;
-        private System.Windows.Forms.PictureBox pictureBox1;
-        private System.Windows.Forms.CheckBox ForceDelete;
         private BranchComboBox Branches;
-        private UserControls.GotoUserManualControl gotoUserManualControl1;
+        private System.Windows.Forms.TableLayoutPanel tlpnlMain;
     }
 }

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -1,24 +1,24 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using GitCommands;
 using GitCommands.Git;
 using GitCommands.Git.Commands;
+using GitExtUtils.GitUI;
 using GitUIPluginInterfaces;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs
 {
-    public sealed partial class FormDeleteBranch : GitModuleForm
+    public sealed partial class FormDeleteBranch : GitExtensionsDialog
     {
-        private readonly TranslationString _deleteBranchCaption = new("Delete branches");
-        private readonly TranslationString _deleteBranchQuestion = new(
-            "Are you sure you want to delete selected branches?" + Environment.NewLine + "Deleting a branch can cause commits to be deleted too!");
-        private readonly TranslationString _deleteUnmergedBranchForcingSuggestion =
-            new("You cannot delete unmerged branch until you set “force delete” mode.");
-        private readonly TranslationString _cannotDeleteCurrentBranchMessage =
-            new("Cannot delete the branch “{0}” which you are currently on.");
+        private readonly TranslationString _deleteBranchCaption = new("Delete Branches");
+        private readonly TranslationString _cannotDeleteCurrentBranchMessage = new("Cannot delete the branch “{0}” which you are currently on.");
+        private readonly TranslationString _deleteBranchConfirmTitle = new("Delete Confirmation");
+        private readonly TranslationString _deleteBranchQuestion = new("The selected branch(es) have not been merged into HEAD.\r\nProceed?");
+        private readonly TranslationString _useReflogHint = new("Did you know you can use reflog to restore deleted branches?");
 
         private readonly IEnumerable<string> _defaultBranches;
         private readonly HashSet<string> _mergedBranches = new();
@@ -33,24 +33,31 @@ namespace GitUI.CommandsDialogs
         }
 
         public FormDeleteBranch(GitUICommands commands, IEnumerable<string> defaultBranches)
-            : base(commands)
+            : base(commands, enablePositionRestore: false)
         {
             _defaultBranches = defaultBranches;
 
             InitializeComponent();
+
+            // work-around the designer bug that can't add controls to FlowLayoutPanel
+            ControlsPanel.Controls.Add(Delete);
+            AcceptButton = Delete;
+
             InitializeComplete();
         }
 
-        private void FormDeleteBranchLoad(object sender, EventArgs e)
+        protected override void OnRuntimeLoad(EventArgs e)
         {
+            base.OnRuntimeLoad(e);
+
             Branches.BranchesToSelect = Module.GetRefs(RefsFilter.Heads).ToList();
-            foreach (var branch in Module.GetMergedBranches())
+            foreach (string branch in Module.GetMergedBranches())
             {
                 if (!branch.StartsWith("* "))
                 {
                     _mergedBranches.Add(branch.Trim());
                 }
-                else if (!branch.StartsWith("* ") || !DetachedHeadParser.IsDetachedHead(branch.Substring(2)))
+                else if (!branch.StartsWith("* ") || !DetachedHeadParser.IsDetachedHead(branch[2..]))
                 {
                     _currentBranch = branch.Trim('*', ' ');
                 }
@@ -62,50 +69,69 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void OkClick(object sender, EventArgs e)
+        protected override void OnShown(EventArgs e)
         {
-            try
+            RecalculateSizeConstraints();
+            base.OnShown(e);
+            Branches.Focus();
+        }
+
+        private void RecalculateSizeConstraints()
+        {
+            SuspendLayout();
+            MinimumSize = MaximumSize = Size.Empty;
+
+            int height = ControlsPanel.Height + MainPanel.Padding.Top + MainPanel.Padding.Bottom
+                       + tlpnlMain.Height + tlpnlMain.Margin.Top + tlpnlMain.Margin.Bottom + DpiUtil.Scale(42);
+
+            MinimumSize = new Size(tlpnlMain.PreferredSize.Width + DpiUtil.Scale(70), height);
+            MaximumSize = new Size(Screen.PrimaryScreen.Bounds.Width, height);
+            Size = new Size(Width, height);
+            ResumeLayout();
+        }
+
+        private void Delete_Click(object sender, EventArgs e)
+        {
+            var selectedBranches = Branches.GetSelectedBranches().ToArray();
+            if (!selectedBranches.Any())
             {
-                var selectedBranches = Branches.GetSelectedBranches().ToArray();
-
-                if (!selectedBranches.Any())
-                {
-                    return;
-                }
-
-                if (_currentBranch is not null && selectedBranches.Any(branch => branch.Name == _currentBranch))
-                {
-                    MessageBox.Show(this, string.Format(_cannotDeleteCurrentBranchMessage.Text, _currentBranch), _deleteBranchCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    return;
-                }
-
-                // always treat branches as unmerged if there is no current branch (HEAD is detached)
-                var hasUnmergedBranches = _currentBranch is null || selectedBranches.Any(branch => !_mergedBranches.Contains(branch.Name));
-
-                // we could show yes/no dialog and set forcing checkbox automatically, but more safe way is asking user to do it himself
-                if (hasUnmergedBranches && !ForceDelete.Checked)
-                {
-                    MessageBox.Show(this, _deleteUnmergedBranchForcingSuggestion.Text, _deleteBranchCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    return;
-                }
-
-                // ask for confirmation to delete unmerged branch that may cause loosing commits
-                // (actually we could check if there are another branches pointing to that commit)
-                if (hasUnmergedBranches
-                    && MessageBox.Show(this, _deleteBranchQuestion.Text, _deleteBranchCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
-                {
-                    return;
-                }
-
-                GitDeleteBranchCmd cmd = new(selectedBranches, ForceDelete.Checked);
-                UICommands.StartCommandLineProcessDialog(this, cmd);
-            }
-            catch (Exception ex)
-            {
-                Trace.WriteLine(ex.Message);
+                return;
             }
 
-            Close();
+            if (_currentBranch is not null && selectedBranches.Any(branch => branch.Name == _currentBranch))
+            {
+                MessageBox.Show(this, string.Format(_cannotDeleteCurrentBranchMessage.Text, _currentBranch), _deleteBranchCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            // always treat branches as unmerged if there is no current branch (HEAD is detached)
+            bool hasUnmergedBranches = _currentBranch is null || selectedBranches.Any(branch => !_mergedBranches.Contains(branch.Name));
+            if (hasUnmergedBranches && !AppSettings.DontConfirmDeleteUnmergedBranch)
+            {
+                TaskDialogPage page = new()
+                {
+                    Text = _deleteBranchQuestion.Text,
+                    Caption = _deleteBranchConfirmTitle.Text,
+                    Icon = TaskDialogIcon.Warning,
+                    Buttons = { TaskDialogButton.Yes, TaskDialogButton.No },
+                    DefaultButton = TaskDialogButton.No,
+                    Footnote = _useReflogHint.Text,
+                    SizeToContent = true,
+                };
+
+                bool isConfirmed = TaskDialog.ShowDialog(Handle, page) == TaskDialogButton.Yes;
+                if (!isConfirmed)
+                {
+                    return;
+                }
+            }
+
+            GitDeleteBranchCmd cmd = new(selectedBranches, force: hasUnmergedBranches);
+            bool success = UICommands.StartCommandLineProcessDialog(Owner, cmd);
+            if (success)
+            {
+                Close();
+            }
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormDeleteBranch.resx
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.resx
@@ -1,64 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -117,10 +57,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="labelDeleteBranchWarning.Text" xml:space="preserve">
-    <value>You can only delete branches when they are fully merged in HEAD. 
-When you delete a branch the commits can get lost because nothing points to them.
-When you want to delete a not-fully merged branch, you can override this using the 'Force delete' option.
-</value>
-  </data>
 </root>

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -81,8 +81,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _noRemoteBranchForFetchButton = new("Fetch from {0}");
         private readonly TranslationString _noRemoteBranchCaption = new("Remote branch not specified");
 
-        private readonly TranslationString _dontShowAgain = new("Don't show me this message again.");
-
         private readonly TranslationString _pruneBranchesCaption = new("Pull was rejected");
         private readonly TranslationString _pruneBranchesMainInstruction = new("Remote branch no longer exist");
         private readonly TranslationString _pruneBranchesBranch =
@@ -566,7 +564,7 @@ namespace GitUI.CommandsDialogs
                         Icon = TaskDialogIcon.Information,
                         Verification = new TaskDialogVerificationCheckBox
                         {
-                            Text = _dontShowAgain.Text
+                            Text = TranslatedStrings.DontShowAgain
                         },
                         SizeToContent = true
                     };
@@ -767,7 +765,7 @@ namespace GitUI.CommandsDialogs
                     Icon = TaskDialogIcon.Information,
                     Verification = new TaskDialogVerificationCheckBox
                     {
-                        Text = _dontShowAgain.Text
+                        Text = TranslatedStrings.DontShowAgain
                     },
                     AllowCancel = false,
                     SizeToContent = true

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -84,7 +84,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _pullActionRebase = new("rebase");
         private readonly TranslationString _pullActionMerge = new("merge");
         private readonly TranslationString _pullRepositoryCaption = new("Push was rejected from \"{0}\"");
-        private readonly TranslationString _dontShowAgain = new("Remember my decision.");
         private readonly TranslationString _useForceWithLeaseInstead =
             new("Force push may overwrite changes since your last fetch. Do you want to use the safer force with lease instead?");
         private readonly TranslationString _forceWithLeaseTooltips =
@@ -650,7 +649,7 @@ namespace GitUI.CommandsDialogs
                     Icon = TaskDialogIcon.Error,
                     Verification = new TaskDialogVerificationCheckBox
                     {
-                        Text = _dontShowAgain.Text
+                        Text = TranslatedStrings.DontShowAgain
                     },
                     AllowCancel = true,
                     SizeToContent = true

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -22,7 +22,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _stashDropConfirmTitle = new("Drop Stash Confirmation");
         private readonly TranslationString _cannotBeUndone = new("This action cannot be undone.");
         private readonly TranslationString _areYouSure = new("Are you sure you want to drop the stash? This action cannot be undone.");
-        private readonly TranslationString _dontShowAgain = new("Don't show me this message again.");
 
         private readonly CancellationTokenSequence _viewChangesSequence = new();
         private readonly AsyncLoader _asyncLoader = new();
@@ -353,7 +352,7 @@ namespace GitUI.CommandsDialogs
                         Icon = TaskDialogIcon.Information,
                         Verification = new TaskDialogVerificationCheckBox
                         {
-                            Text = _dontShowAgain.Text
+                            Text = TranslatedStrings.DontShowAgain
                         },
                         SizeToContent = true
                     };

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
@@ -52,6 +52,7 @@
             this.chkSecondAbortConfirmation = new System.Windows.Forms.CheckBox();
             this.chkUpdateModules = new System.Windows.Forms.CheckBox();
             this.chkSwitchWorktree = new System.Windows.Forms.CheckBox();
+            this.chkBranchDeleteUnmerged = new System.Windows.Forms.CheckBox();
             this.tlpnlMain.SuspendLayout();
             this.gbConfirmations.SuspendLayout();
             this.tlpnlConfirmations.SuspendLayout();
@@ -63,43 +64,43 @@
             this.lblGroupBranches.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lblGroupBranches.Location = new System.Drawing.Point(3, 127);
             this.lblGroupBranches.Name = "lblGroupBranches";
-            this.lblGroupBranches.Size = new System.Drawing.Size(1331, 15);
+            this.lblGroupBranches.Size = new System.Drawing.Size(1589, 15);
             this.lblGroupBranches.Text = "Branches:";
             // 
             // lblGroupStashes
             // 
             this.lblGroupStashes.AutoSize = true;
             this.lblGroupStashes.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblGroupStashes.Location = new System.Drawing.Point(3, 229);
+            this.lblGroupStashes.Location = new System.Drawing.Point(3, 254);
             this.lblGroupStashes.Name = "lblGroupStashes";
-            this.lblGroupStashes.Size = new System.Drawing.Size(1331, 15);
+            this.lblGroupStashes.Size = new System.Drawing.Size(1589, 15);
             this.lblGroupStashes.Text = "Stash:";
             // 
             // lblGroupConflictResolution
             // 
             this.lblGroupConflictResolution.AutoSize = true;
             this.lblGroupConflictResolution.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblGroupConflictResolution.Location = new System.Drawing.Point(3, 331);
+            this.lblGroupConflictResolution.Location = new System.Drawing.Point(3, 356);
             this.lblGroupConflictResolution.Name = "lblGroupConflictResolution";
-            this.lblGroupConflictResolution.Size = new System.Drawing.Size(1331, 15);
+            this.lblGroupConflictResolution.Size = new System.Drawing.Size(1589, 15);
             this.lblGroupConflictResolution.Text = "Rebase / conflict resolution:";
             // 
             // lblGroupSubmodules
             // 
             this.lblGroupSubmodules.AutoSize = true;
             this.lblGroupSubmodules.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblGroupSubmodules.Location = new System.Drawing.Point(3, 433);
+            this.lblGroupSubmodules.Location = new System.Drawing.Point(3, 458);
             this.lblGroupSubmodules.Name = "lblGroupSubmodules";
-            this.lblGroupSubmodules.Size = new System.Drawing.Size(1331, 15);
+            this.lblGroupSubmodules.Size = new System.Drawing.Size(1589, 15);
             this.lblGroupSubmodules.Text = "Submodules:";
             // 
             // lblGroupWorktrees
             // 
             this.lblGroupWorktrees.AutoSize = true;
             this.lblGroupWorktrees.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblGroupWorktrees.Location = new System.Drawing.Point(3, 485);
+            this.lblGroupWorktrees.Location = new System.Drawing.Point(3, 510);
             this.lblGroupWorktrees.Name = "lblGroupWorktrees";
-            this.lblGroupWorktrees.Size = new System.Drawing.Size(1331, 15);
+            this.lblGroupWorktrees.Size = new System.Drawing.Size(1589, 15);
             this.lblGroupWorktrees.Text = "Worktrees:";
             // 
             // lblGroupCommits
@@ -108,7 +109,7 @@
             this.lblGroupCommits.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lblGroupCommits.Location = new System.Drawing.Point(3, 0);
             this.lblGroupCommits.Name = "lblGroupCommits";
-            this.lblGroupCommits.Size = new System.Drawing.Size(1331, 15);
+            this.lblGroupCommits.Size = new System.Drawing.Size(1589, 15);
             this.lblGroupCommits.Text = "Commits:";
             // 
             // tlpnlMain
@@ -123,7 +124,7 @@
             this.tlpnlMain.RowCount = 2;
             this.tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlMain.Size = new System.Drawing.Size(1359, 693);
+            this.tlpnlMain.Size = new System.Drawing.Size(1617, 1273);
             // 
             // gbConfirmations
             // 
@@ -134,7 +135,7 @@
             this.gbConfirmations.Location = new System.Drawing.Point(3, 3);
             this.gbConfirmations.Name = "gbConfirmations";
             this.gbConfirmations.Padding = new System.Windows.Forms.Padding(8);
-            this.gbConfirmations.Size = new System.Drawing.Size(1353, 557);
+            this.gbConfirmations.Size = new System.Drawing.Size(1611, 582);
             this.gbConfirmations.TabStop = false;
             this.gbConfirmations.Text = "Confirm actions";
             // 
@@ -152,23 +153,30 @@
             this.tlpnlConfirmations.Controls.Add(this.lblGroupBranches, 0, 6);
             this.tlpnlConfirmations.Controls.Add(this.chkFetchAndPruneAllConfirmation, 0, 7);
             this.tlpnlConfirmations.Controls.Add(this.chkPushNewBranch, 0, 8);
+            this.tlpnlConfirmations.Controls.Add(this.chkBranchDeleteUnmerged, 0, 10);
             this.tlpnlConfirmations.Controls.Add(this.chkAddTrackingRef, 0, 9);
-            this.tlpnlConfirmations.Controls.Add(this.lblGroupStashes, 0, 11);
-            this.tlpnlConfirmations.Controls.Add(this.chkAutoPopStashAfterCheckout, 0, 12);
-            this.tlpnlConfirmations.Controls.Add(this.chkAutoPopStashAfterPull, 0, 13);
-            this.tlpnlConfirmations.Controls.Add(this.chkConfirmStashDrop, 0, 14);
-            this.tlpnlConfirmations.Controls.Add(this.lblGroupConflictResolution, 0, 16);
-            this.tlpnlConfirmations.Controls.Add(this.chkResolveConflicts, 0, 17);
-            this.tlpnlConfirmations.Controls.Add(this.chkCommitAfterConflictsResolved, 0, 18);
-            this.tlpnlConfirmations.Controls.Add(this.chkSecondAbortConfirmation, 0, 19);
-            this.tlpnlConfirmations.Controls.Add(this.lblGroupSubmodules, 0, 21);
-            this.tlpnlConfirmations.Controls.Add(this.chkUpdateModules, 0, 22);
-            this.tlpnlConfirmations.Controls.Add(this.lblGroupWorktrees, 0, 24);
-            this.tlpnlConfirmations.Controls.Add(this.chkSwitchWorktree, 0, 25);
+            this.tlpnlConfirmations.Controls.Add(this.lblGroupStashes, 0, 12);
+            this.tlpnlConfirmations.Controls.Add(this.chkAutoPopStashAfterCheckout, 0, 13);
+            this.tlpnlConfirmations.Controls.Add(this.chkAutoPopStashAfterPull, 0, 14);
+            this.tlpnlConfirmations.Controls.Add(this.chkConfirmStashDrop, 0, 15);
+            this.tlpnlConfirmations.Controls.Add(this.lblGroupConflictResolution, 0, 17);
+            this.tlpnlConfirmations.Controls.Add(this.chkResolveConflicts, 0, 18);
+            this.tlpnlConfirmations.Controls.Add(this.chkCommitAfterConflictsResolved, 0, 19);
+            this.tlpnlConfirmations.Controls.Add(this.chkSecondAbortConfirmation, 0, 20);
+            this.tlpnlConfirmations.Controls.Add(this.lblGroupSubmodules, 0, 22);
+            this.tlpnlConfirmations.Controls.Add(this.chkUpdateModules, 0, 23);
+            this.tlpnlConfirmations.Controls.Add(this.lblGroupWorktrees, 0, 25);
+            this.tlpnlConfirmations.Controls.Add(this.chkSwitchWorktree, 0, 26);
             this.tlpnlConfirmations.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tlpnlConfirmations.Location = new System.Drawing.Point(8, 24);
             this.tlpnlConfirmations.Name = "tlpnlConfirmations";
-            this.tlpnlConfirmations.RowCount = 26;
+            this.tlpnlConfirmations.RowCount = 27;
+            this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 12F));
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -187,15 +195,10 @@
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 12F));
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 12F));
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 12F));
-            this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlConfirmations.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlConfirmations.Size = new System.Drawing.Size(1337, 525);
+            this.tlpnlConfirmations.Size = new System.Drawing.Size(1595, 550);
             // 
             // chkAmend
             // 
@@ -265,7 +268,7 @@
             // chkAutoPopStashAfterCheckout
             // 
             this.chkAutoPopStashAfterCheckout.AutoSize = true;
-            this.chkAutoPopStashAfterCheckout.Location = new System.Drawing.Point(3, 247);
+            this.chkAutoPopStashAfterCheckout.Location = new System.Drawing.Point(3, 272);
             this.chkAutoPopStashAfterCheckout.Name = "chkAutoPopStashAfterCheckout";
             this.chkAutoPopStashAfterCheckout.Size = new System.Drawing.Size(500, 19);
             this.chkAutoPopStashAfterCheckout.Text = "Apply stashed changes after successful checkout (else stash will be popped automatically)";
@@ -275,7 +278,7 @@
             // chkAutoPopStashAfterPull
             // 
             this.chkAutoPopStashAfterPull.AutoSize = true;
-            this.chkAutoPopStashAfterPull.Location = new System.Drawing.Point(3, 272);
+            this.chkAutoPopStashAfterPull.Location = new System.Drawing.Point(3, 297);
             this.chkAutoPopStashAfterPull.Name = "chkAutoPopStashAfterPull";
             this.chkAutoPopStashAfterPull.Size = new System.Drawing.Size(471, 19);
             this.chkAutoPopStashAfterPull.Text = "Apply stashed changes after successful pull (else stash will be popped automatically)";
@@ -285,7 +288,7 @@
             // chkConfirmStashDrop
             // 
             this.chkConfirmStashDrop.AutoSize = true;
-            this.chkConfirmStashDrop.Location = new System.Drawing.Point(3, 297);
+            this.chkConfirmStashDrop.Location = new System.Drawing.Point(3, 322);
             this.chkConfirmStashDrop.Name = "chkConfirmStashDrop";
             this.chkConfirmStashDrop.Size = new System.Drawing.Size(82, 19);
             this.chkConfirmStashDrop.Text = "Drop stash";
@@ -294,7 +297,7 @@
             // chkResolveConflicts
             // 
             this.chkResolveConflicts.AutoSize = true;
-            this.chkResolveConflicts.Location = new System.Drawing.Point(3, 349);
+            this.chkResolveConflicts.Location = new System.Drawing.Point(3, 374);
             this.chkResolveConflicts.Name = "chkResolveConflicts";
             this.chkResolveConflicts.Size = new System.Drawing.Size(114, 19);
             this.chkResolveConflicts.Text = "Resolve conflicts";
@@ -304,7 +307,7 @@
             // chkCommitAfterConflictsResolved
             // 
             this.chkCommitAfterConflictsResolved.AutoSize = true;
-            this.chkCommitAfterConflictsResolved.Location = new System.Drawing.Point(3, 374);
+            this.chkCommitAfterConflictsResolved.Location = new System.Drawing.Point(3, 399);
             this.chkCommitAfterConflictsResolved.Name = "chkCommitAfterConflictsResolved";
             this.chkCommitAfterConflictsResolved.Size = new System.Drawing.Size(296, 19);
             this.chkCommitAfterConflictsResolved.Text = "Commit changes after conflicts have been resolved";
@@ -314,7 +317,7 @@
             // chkSecondAbortConfirmation
             // 
             this.chkSecondAbortConfirmation.AutoSize = true;
-            this.chkSecondAbortConfirmation.Location = new System.Drawing.Point(3, 399);
+            this.chkSecondAbortConfirmation.Location = new System.Drawing.Point(3, 424);
             this.chkSecondAbortConfirmation.Name = "chkSecondAbortConfirmation";
             this.chkSecondAbortConfirmation.Size = new System.Drawing.Size(267, 19);
             this.chkSecondAbortConfirmation.Text = "Confirm for the second time to abort a merge";
@@ -324,7 +327,7 @@
             // chkUpdateModules
             // 
             this.chkUpdateModules.AutoSize = true;
-            this.chkUpdateModules.Location = new System.Drawing.Point(3, 451);
+            this.chkUpdateModules.Location = new System.Drawing.Point(3, 476);
             this.chkUpdateModules.Name = "chkUpdateModules";
             this.chkUpdateModules.Size = new System.Drawing.Size(201, 19);
             this.chkUpdateModules.Text = "Update submodules on checkout";
@@ -334,11 +337,20 @@
             // chkSwitchWorktree
             // 
             this.chkSwitchWorktree.AutoSize = true;
-            this.chkSwitchWorktree.Location = new System.Drawing.Point(3, 503);
+            this.chkSwitchWorktree.Location = new System.Drawing.Point(3, 528);
             this.chkSwitchWorktree.Name = "chkSwitchWorktree";
             this.chkSwitchWorktree.Size = new System.Drawing.Size(110, 19);
             this.chkSwitchWorktree.Text = "Switch worktree";
             this.chkSwitchWorktree.UseVisualStyleBackColor = true;
+            // 
+            // chkBranchDeleteUnmerged
+            // 
+            this.chkBranchDeleteUnmerged.AutoSize = true;
+            this.chkBranchDeleteUnmerged.Location = new System.Drawing.Point(3, 220);
+            this.chkBranchDeleteUnmerged.Name = "chkBranchDeleteUnmerged";
+            this.chkBranchDeleteUnmerged.Size = new System.Drawing.Size(168, 19);
+            this.chkBranchDeleteUnmerged.Text = "Delete unmerged branches";
+            this.chkBranchDeleteUnmerged.UseVisualStyleBackColor = true;
             // 
             // ConfirmationsSettingsPage
             // 
@@ -347,7 +359,7 @@
             this.Controls.Add(this.tlpnlMain);
             this.Name = "ConfirmationsSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
-            this.Size = new System.Drawing.Size(1375, 709);
+            this.Size = new System.Drawing.Size(1633, 1289);
             this.tlpnlMain.ResumeLayout(false);
             this.tlpnlMain.PerformLayout();
             this.gbConfirmations.ResumeLayout(false);
@@ -384,5 +396,6 @@
         private System.Windows.Forms.Label lblGroupConflictResolution;
         private System.Windows.Forms.Label lblGroupSubmodules;
         private System.Windows.Forms.Label lblGroupWorktrees;
+        private System.Windows.Forms.CheckBox chkBranchDeleteUnmerged;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
@@ -25,6 +25,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkFetchAndPruneAllConfirmation.Checked = !AppSettings.DontConfirmFetchAndPruneAll;
             chkPushNewBranch.Checked = !AppSettings.DontConfirmPushNewBranch;
             chkAddTrackingRef.Checked = !AppSettings.DontConfirmAddTrackingRef;
+            chkBranchDeleteUnmerged.Checked = !AppSettings.DontConfirmDeleteUnmergedBranch;
 
             // Stashes:
             chkAutoPopStashAfterPull.CheckState = ToCheckboxStateInverted(AppSettings.AutoPopStashAfterPull);
@@ -55,6 +56,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.DontConfirmFetchAndPruneAll = !chkFetchAndPruneAllConfirmation.Checked;
             AppSettings.DontConfirmPushNewBranch = !chkPushNewBranch.Checked;
             AppSettings.DontConfirmAddTrackingRef = !chkAddTrackingRef.Checked;
+            AppSettings.DontConfirmDeleteUnmergedBranch = !chkBranchDeleteUnmerged.Checked;
 
             // Stashes:
             AppSettings.AutoPopStashAfterPull = ToBooleanInverted(chkAutoPopStashAfterPull.CheckState);

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -116,16 +116,16 @@ namespace GitUI
 
         public bool StartCommandLineProcessDialog(IWin32Window? owner, IGitCommand command)
         {
-            var executed = command.AccessesRemote
+            bool success = command.AccessesRemote
                 ? FormRemoteProcess.ShowDialog(owner, this, command.Arguments)
                 : FormProcess.ShowDialog(owner, process: null, arguments: command.Arguments, Module.WorkingDir, input: null, useDialogSettings: true);
 
-            if (executed && command.ChangesRepoState)
+            if (success && command.ChangesRepoState)
             {
                 RepoChangedNotifier.Notify();
             }
 
-            return executed;
+            return success;
         }
 
         public void StartCommandLineProcessDialog(IWin32Window? owner, string command, ArgumentString arguments)

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -13,6 +13,7 @@ namespace GitUI
         private readonly TranslationString _okText = new("OK");
         private readonly TranslationString _cancelText = new("Cancel");
         private readonly TranslationString _closeText = new("Close");
+        private readonly TranslationString _dontShowAgain = new("Don't show me this message again");
 
         private readonly TranslationString _buttonCheckoutBranch = new("Checkout branch");
         private readonly TranslationString _buttonContinue = new("Continue");
@@ -133,6 +134,7 @@ namespace GitUI
         public static string OK => _instance.Value._okText.Text;
         public static string Cancel => _instance.Value._cancelText.Text;
         public static string Close => _instance.Value._closeText.Text;
+        public static string DontShowAgain => _instance.Value._dontShowAgain.Text;
 
         public static string ButtonContinue => _instance.Value._buttonContinue.Text;
         public static string ButtonCheckoutBranch => _instance.Value._buttonCheckoutBranch.Text;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1195,6 +1195,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Apply stashed changes after successful pull (else stash will be popped automatically)</source>
         <target />
       </trans-unit>
+      <trans-unit id="chkBranchDeleteUnmerged.Text">
+        <source>Delete unmerged branches</source>
+        <target />
+      </trans-unit>
       <trans-unit id="chkCommitAfterConflictsResolved.Text">
         <source>Commit changes after conflicts have been resolved</source>
         <target />
@@ -3276,10 +3280,6 @@ Enter valid branch name or select predefined value.</source>
 Enter valid branch name or select predefined value.</source>
         <target />
       </trans-unit>
-      <trans-unit id="_dontShowAgain.Text">
-        <source>Don't show me this message again.</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_invalidBranchName.Text">
         <source>An existing branch must be selected.</source>
         <target />
@@ -4484,11 +4484,7 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="Delete.Text">
-        <source>Delete</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="ForceDelete.Text">
-        <source>Force delete</source>
+        <source>&amp;Delete</source>
         <target />
       </trans-unit>
       <trans-unit id="_cannotDeleteCurrentBranchMessage.Text">
@@ -4496,27 +4492,24 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="_deleteBranchCaption.Text">
-        <source>Delete branches</source>
+        <source>Delete Branches</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_deleteBranchConfirmTitle.Text">
+        <source>Delete Confirmation</source>
         <target />
       </trans-unit>
       <trans-unit id="_deleteBranchQuestion.Text">
-        <source>Are you sure you want to delete selected branches?
-Deleting a branch can cause commits to be deleted too!</source>
+        <source>The selected branch(es) have not been merged into HEAD.
+Proceed?</source>
         <target />
       </trans-unit>
-      <trans-unit id="_deleteUnmergedBranchForcingSuggestion.Text">
-        <source>You cannot delete unmerged branch until you set “force delete” mode.</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="labelDeleteBranchWarning.Text">
-        <source>You can only delete branches when they are fully merged in HEAD. 
-When you delete a branch the commits can get lost because nothing points to them.
-When you want to delete a not-fully merged branch, you can override this using the 'Force delete' option.
-</source>
+      <trans-unit id="_useReflogHint.Text">
+        <source>Did you know you can use reflog to restore deleted branches?</source>
         <target />
       </trans-unit>
       <trans-unit id="labelSelectBranches.Text">
-        <source>Select branches</source>
+        <source>Select &amp;branches</source>
         <target />
       </trans-unit>
     </body>
@@ -5836,10 +5829,6 @@ Are you sure you want to rebase this merge?</source>
         <source>&amp;Pull</source>
         <target />
       </trans-unit>
-      <trans-unit id="_dontShowAgain.Text">
-        <source>Don't show me this message again.</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_fetchAllBranchesCanOnlyWithFetch.Text">
         <source>You can only fetch all remote branches (*) without merge or rebase.
 If you want to fetch all remote branches, choose fetch.
@@ -6067,10 +6056,6 @@ Would you like to do it now?</source>
       </trans-unit>
       <trans-unit id="_createPullRequestCB.Text">
         <source>&amp;Create pull request after push</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_dontShowAgain.Text">
-        <source>Remember my decision.</source>
         <target />
       </trans-unit>
       <trans-unit id="_errorPushToRemoteCaption.Text">
@@ -7472,10 +7457,6 @@ Therefore the Cancel button does NOT revert any changes made.</source>
       </trans-unit>
       <trans-unit id="_currentWorkingDirChanges.Text">
         <source>Current working directory changes</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_dontShowAgain.Text">
-        <source>Don't show me this message again.</source>
         <target />
       </trans-unit>
       <trans-unit id="_noStashes.Text">
@@ -10677,6 +10658,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_disableMenuItem.Text">
         <source>Disable this dropdown</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_dontShowAgain.Text">
+        <source>Don't show me this message again</source>
         <target />
       </trans-unit>
       <trans-unit id="_error.Text">

--- a/GitUI/UserControls/BranchComboBox.Designer.cs
+++ b/GitUI/UserControls/BranchComboBox.Designer.cs
@@ -40,32 +40,30 @@
             this.branches.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.branches.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.branches.FormattingEnabled = true;
-            this.branches.Location = new System.Drawing.Point(0, 0);
+            this.branches.Location = new System.Drawing.Point(0, 3);
             this.branches.Name = "branches";
             this.branches.Size = new System.Drawing.Size(304, 23);
-            this.branches.TabIndex = 0;
             // 
             // selectMultipleBranchesButton
             // 
             this.selectMultipleBranchesButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.selectMultipleBranchesButton.Image = global::GitUI.Properties.Images.Select;
-            this.selectMultipleBranchesButton.Location = new System.Drawing.Point(308, 0);
+            this.selectMultipleBranchesButton.Location = new System.Drawing.Point(308, 1);
             this.selectMultipleBranchesButton.Margin = new System.Windows.Forms.Padding(0);
             this.selectMultipleBranchesButton.Name = "selectMultipleBranchesButton";
             this.selectMultipleBranchesButton.Size = new System.Drawing.Size(23, 23);
-            this.selectMultipleBranchesButton.TabIndex = 1;
             this.selectMultipleBranchesButton.UseVisualStyleBackColor = true;
             this.selectMultipleBranchesButton.Click += new System.EventHandler(this.selectMultipleBranchesButton_Click);
             // 
             // BranchComboBox
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
-            this.Controls.Add(this.selectMultipleBranchesButton);
             this.Controls.Add(this.branches);
+            this.Controls.Add(this.selectMultipleBranchesButton);
             this.Margin = new System.Windows.Forms.Padding(0);
             this.Name = "BranchComboBox";
-            this.Size = new System.Drawing.Size(331, 24);
+            this.Size = new System.Drawing.Size(331, 26);
             this.ResumeLayout(false);
 
         }

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitDeleteBranchCmdTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitDeleteBranchCmdTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using GitCommands;
+using GitCommands.Git.Commands;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Git.Commands
+{
+    [TestFixture]
+    public sealed class GitDeleteBranchCmdTests
+    {
+        [Test]
+        public void ctor_should_throw_if_branches_is_null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GitDeleteBranchCmd(branches: null, force: false));
+        }
+
+        [Test]
+        public void ctor_should_throw_if_branches_is_empty()
+        {
+            Assert.Throws<ArgumentException>(() => new GitDeleteBranchCmd(Array.Empty<IGitRef>(), force: false));
+        }
+
+        [Test]
+        public void ctor_should_have_expected_values()
+        {
+            const string remoteName = "origin";
+            string completeName = $"refs/remotes/{remoteName}/branch_name";
+            GitRef remoteBranchRef = SetupRawRemoteRef(remoteName, completeName);
+
+            GitDeleteBranchCmd cmd = new(new IGitRef[] { remoteBranchRef }, force: false);
+
+            Assert.IsFalse(cmd.AccessesRemote);
+            Assert.IsTrue(cmd.ChangesRepoState);
+        }
+
+        private static IEnumerable<TestCaseData> GetRefsCommandTestData
+        {
+            get
+            {
+                const string name = "local_branch";
+
+                // Test local branches only
+                List<IGitRef> localRefs = new();
+                var localGitModule = Substitute.For<IGitModule>();
+                var localConfigFileSettings = Substitute.For<IConfigFileSettings>();
+                localConfigFileSettings.GetValue($"branch.local_branch.merge").Returns(string.Empty);
+                localConfigFileSettings.GetValue($"branch.local_branch.remote").Returns(string.Empty);
+                localGitModule.LocalConfigFile.Returns(localConfigFileSettings);
+                GitRef localBranchRef = new(localGitModule, ObjectId.Random(), $"refs/heads/{name}");
+
+                localRefs.Add(localBranchRef);
+
+                yield return new TestCaseData(localRefs, /* force */ false, /* expected */ $"branch --delete \"{name}\"");
+                yield return new TestCaseData(localRefs, /* force */ true, /* expected */ $"branch --delete --force \"{name}\"");
+
+                // Test local and remote branches
+                const string remoteName = "origin";
+                string completeName = $"refs/remotes/{remoteName}/{name}";
+                GitRef remoteBranchRef = SetupRawRemoteRef(remoteName, completeName);
+
+                List<IGitRef> mixedRefs = new();
+                mixedRefs.Add(localBranchRef);
+                mixedRefs.Add(remoteBranchRef);
+
+                yield return new TestCaseData(mixedRefs, /* force */ false, /* expected */ $"branch --delete --all \"{name}\" \"origin/{name}\"");
+                yield return new TestCaseData(mixedRefs, /* force */ true, /* expected */ $"branch --delete --force --all \"{name}\" \"origin/{name}\"");
+
+                // Test remote branches only
+                List<IGitRef> remoteRefs = new();
+                remoteRefs.Add(remoteBranchRef);
+
+                yield return new TestCaseData(remoteRefs, /* force */ false, /* expected */ $"branch --delete --remotes \"origin/{name}\"");
+                yield return new TestCaseData(remoteRefs, /* force */ true, /* expected */ $"branch --delete --force --remotes \"origin/{name}\"");
+            }
+        }
+
+        [TestCaseSource(nameof(GetRefsCommandTestData))]
+        public void Arguments_are_Expected(IReadOnlyCollection<IGitRef> branches, bool force, string expected)
+        {
+            GitDeleteBranchCmd cmd = new(branches, force);
+            Assert.AreEqual(expected, cmd.Arguments);
+        }
+
+        private static GitRef SetupRawRemoteRef(string remoteName, string completeName)
+        {
+            var localGitModule = Substitute.For<IGitModule>();
+            var localConfigFileSettings = Substitute.For<IConfigFileSettings>();
+            localConfigFileSettings.GetValue($"branch.local_branch.merge").Returns(completeName);
+            localConfigFileSettings.GetValue($"branch.local_branch.remote").Returns(remoteName);
+            localGitModule.LocalConfigFile.Returns(localConfigFileSettings);
+            GitRef remoteBranchRef = new(localGitModule, ObjectId.Random(), completeName, remoteName);
+            return remoteBranchRef;
+        }
+    }
+}


### PR DESCRIPTION
Relates to #6183

## Proposed changes

- Apply the same design as for other updated dialogs
- Remove verbose "help" text, replaced with [?] button that links to [the docs](https://git-extensions-documentation.readthedocs.io/en/release-3.4/branches.html#delete-branch) (the link is currently broken, see: https://github.com/gitextensions/gitextensions/issues/8955)
- Remove nagging confirmations - this is NOT a data loss situation, local branches can be easily restored
- Set focus to the branches edit control


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/110276266-e12f0600-8026-11eb-8424-33dce38b9635.png)
![image](https://user-images.githubusercontent.com/4403806/110276291-ec823180-8026-11eb-9e67-e02e9ce1ff04.png)
![image](https://user-images.githubusercontent.com/4403806/110276303-f441d600-8026-11eb-81e4-13dd69d7a832.png)


### After

![image](https://user-images.githubusercontent.com/4403806/110390499-323c0a00-80ba-11eb-9dba-f95464ae4c0f.png)
![image](https://user-images.githubusercontent.com/4403806/126071780-7efccb88-3413-4973-b79c-52352703c97a.png)


## Test methodology <!-- How did you ensure quality? -->

- manual



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
