### PR TITLE
Dialogs layout alignment - `FormDeleteRemoteBranch`

### DIFF
--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.Designer.cs
@@ -28,126 +28,112 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormDeleteRemoteBranch));
             this.Delete = new System.Windows.Forms.Button();
             this.labelSelectBranches = new System.Windows.Forms.Label();
-            this.labelDeleteBranchWarning = new System.Windows.Forms.Label();
-            this.pictureBox1 = new System.Windows.Forms.PictureBox();
-            this.DeleteRemote = new System.Windows.Forms.CheckBox();
             this.Branches = new GitUI.BranchComboBox();
-            this.gotoUserManualControl1 = new GitUI.UserControls.GotoUserManualControl();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.tlpnlMain = new System.Windows.Forms.TableLayoutPanel();
+            this.DeleteRemote = new System.Windows.Forms.CheckBox();
+            this.MainPanel.SuspendLayout();
+            this.tlpnlMain.SuspendLayout();
             this.SuspendLayout();
+            // 
+            // MainPanel
+            // 
+            this.MainPanel.Controls.Add(this.tlpnlMain);
+            this.MainPanel.Padding = new System.Windows.Forms.Padding(9);
+            this.MainPanel.Size = new System.Drawing.Size(394, 82);
             // 
             // Delete
             // 
             this.Delete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.Delete.AutoSize = true;
+            this.Delete.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.Delete.Enabled = false;
             this.Delete.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.Delete.Image = global::GitUI.Properties.Images.BranchDelete;
-            this.Delete.Location = new System.Drawing.Point(553, 80);
-            this.Delete.Margin = new System.Windows.Forms.Padding(4);
+            this.Delete.Location = new System.Drawing.Point(310, 84);
+            this.Delete.MinimumSize = new System.Drawing.Size(75, 23);
             this.Delete.Name = "Delete";
-            this.Delete.Size = new System.Drawing.Size(150, 31);
-            this.Delete.TabIndex = 4;
-            this.Delete.Text = "Delete";
-            this.Delete.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.Delete.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
+            this.Delete.Size = new System.Drawing.Size(75, 23);
+            this.Delete.TabIndex = 2;
+            this.Delete.Text = "&Delete";
             this.Delete.UseVisualStyleBackColor = true;
-            this.Delete.Click += new System.EventHandler(this.OkClick);
+            this.Delete.Click += new System.EventHandler(this.Delete_Click);
             // 
             // labelSelectBranches
             // 
             this.labelSelectBranches.AutoSize = true;
+            this.labelSelectBranches.Dock = System.Windows.Forms.DockStyle.Fill;
             this.labelSelectBranches.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.labelSelectBranches.Location = new System.Drawing.Point(11, 11);
-            this.labelSelectBranches.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.labelSelectBranches.Location = new System.Drawing.Point(3, 0);
             this.labelSelectBranches.Name = "labelSelectBranches";
-            this.labelSelectBranches.Size = new System.Drawing.Size(104, 17);
-            this.labelSelectBranches.TabIndex = 1;
-            this.labelSelectBranches.Text = "Select branches";
+            this.labelSelectBranches.Size = new System.Drawing.Size(84, 29);
+            this.labelSelectBranches.TabIndex = 0;
+            this.labelSelectBranches.Text = "Select &branches";
+            this.labelSelectBranches.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // labelDeleteBranchWarning
+            // Branches
             // 
-            this.labelDeleteBranchWarning.AutoSize = true;
-            this.labelDeleteBranchWarning.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.labelDeleteBranchWarning.Location = new System.Drawing.Point(49, 145);
-            this.labelDeleteBranchWarning.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.labelDeleteBranchWarning.MaximumSize = new System.Drawing.Size(625, 0);
-            this.labelDeleteBranchWarning.Name = "labelDeleteBranchWarning";
-            this.labelDeleteBranchWarning.Size = new System.Drawing.Size(612, 68);
-            this.labelDeleteBranchWarning.TabIndex = 5;
-            this.labelDeleteBranchWarning.Text = resources.GetString("labelDeleteBranchWarning.Text");
+            this.Branches.BranchesToSelect = null;
+            this.Branches.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.Branches.Location = new System.Drawing.Point(90, 0);
+            this.Branches.Margin = new System.Windows.Forms.Padding(0);
+            this.Branches.Name = "Branches";
+            this.Branches.Size = new System.Drawing.Size(286, 28);
+            this.Branches.TabIndex = 1;
             // 
-            // pictureBox1
+            // tlpnlMain
             // 
-            this.pictureBox1.Image = global::GitUI.Properties.Images.Warning;
-            this.pictureBox1.InitialImage = global::GitUI.Properties.Images.Warning;
-            this.pictureBox1.Location = new System.Drawing.Point(15, 178);
-            this.pictureBox1.Margin = new System.Windows.Forms.Padding(4);
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(26, 25);
-            this.pictureBox1.TabIndex = 7;
-            this.pictureBox1.TabStop = false;
+            this.tlpnlMain.ColumnCount = 2;
+            this.tlpnlMain.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tlpnlMain.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tlpnlMain.Controls.Add(this.labelSelectBranches, 0, 0);
+            this.tlpnlMain.Controls.Add(this.Branches, 1, 0);
+            this.tlpnlMain.Controls.Add(this.DeleteRemote, 1, 1);
+            this.tlpnlMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tlpnlMain.Location = new System.Drawing.Point(9, 9);
+            this.tlpnlMain.Margin = new System.Windows.Forms.Padding(0);
+            this.tlpnlMain.Name = "tlpnlMain";
+            this.tlpnlMain.RowCount = 3;
+            this.tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlMain.Size = new System.Drawing.Size(370, 58);
+            this.tlpnlMain.TabIndex = 0;
             // 
             // DeleteRemote
             // 
             this.DeleteRemote.AutoSize = true;
-            this.DeleteRemote.Location = new System.Drawing.Point(15, 86);
-            this.DeleteRemote.Margin = new System.Windows.Forms.Padding(4);
+            this.DeleteRemote.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.DeleteRemote.Location = new System.Drawing.Point(93, 31);
+            this.DeleteRemote.Margin = new System.Windows.Forms.Padding(3);
             this.DeleteRemote.Name = "DeleteRemote";
-            this.DeleteRemote.Size = new System.Drawing.Size(176, 21);
+            this.DeleteRemote.Size = new System.Drawing.Size(280, 17);
             this.DeleteRemote.TabIndex = 3;
-            this.DeleteRemote.Text = "Delete branche(s) from remote repository";
+            this.DeleteRemote.Text = "Delete branch(es) from &remote repository";
             this.DeleteRemote.UseVisualStyleBackColor = true;
             this.DeleteRemote.CheckedChanged += new System.EventHandler(this.DeleteRemote_CheckedChanged);
-            // 
-            // Branches
-            // 
-            this.Branches.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.Branches.BranchesToSelect = null;
-            this.Branches.Location = new System.Drawing.Point(15, 44);
-            this.Branches.Margin = new System.Windows.Forms.Padding(0);
-            this.Branches.Name = "Branches";
-            this.Branches.Size = new System.Drawing.Size(688, 26);
-            this.Branches.TabIndex = 2;
-            // 
-            // gotoUserManualControl1
-            // 
-            this.gotoUserManualControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.gotoUserManualControl1.AutoSize = true;
-            this.gotoUserManualControl1.Location = new System.Drawing.Point(12, 264);
-            this.gotoUserManualControl1.ManualSectionAnchorName = "delete-branch";
-            this.gotoUserManualControl1.ManualSectionSubfolder = "branches";
-            this.gotoUserManualControl1.Margin = new System.Windows.Forms.Padding(4);
-            this.gotoUserManualControl1.MinimumSize = new System.Drawing.Size(88, 25);
-            this.gotoUserManualControl1.Name = "gotoUserManualControl1";
-            this.gotoUserManualControl1.Size = new System.Drawing.Size(88, 25);
-            this.gotoUserManualControl1.TabIndex = 8;
             // 
             // FormDeleteRemoteBranch
             // 
             this.AcceptButton = this.Delete;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(724, 295);
-            this.Controls.Add(this.gotoUserManualControl1);
-            this.Controls.Add(this.Branches);
-            this.Controls.Add(this.DeleteRemote);
-            this.Controls.Add(this.pictureBox1);
-            this.Controls.Add(this.labelDeleteBranchWarning);
+            this.ClientSize = new System.Drawing.Size(394, 114);
             this.Controls.Add(this.Delete);
-            this.Controls.Add(this.labelSelectBranches);
-            this.Margin = new System.Windows.Forms.Padding(4);
+            this.HelpButton = true;
+            this.ManualSectionAnchorName = "delete-branch";
+            this.ManualSectionSubfolder = "branches";
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(652, 326);
+            this.MinimumSize = new System.Drawing.Size(410, 129);
             this.Name = "FormDeleteRemoteBranch";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Delete branch";
-            this.Load += new System.EventHandler(this.FormDeleteRemoteBranchLoad);
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            this.Controls.SetChildIndex(this.Delete, 0);
+            this.Controls.SetChildIndex(this.MainPanel, 0);
+            this.MainPanel.ResumeLayout(false);
+            this.tlpnlMain.ResumeLayout(false);
+            this.tlpnlMain.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -157,10 +143,8 @@
 
         private System.Windows.Forms.Button Delete;
         private System.Windows.Forms.Label labelSelectBranches;
-        private System.Windows.Forms.Label labelDeleteBranchWarning;
-        private System.Windows.Forms.PictureBox pictureBox1;
         private System.Windows.Forms.CheckBox DeleteRemote;
         private BranchComboBox Branches;
-        private UserControls.GotoUserManualControl gotoUserManualControl1;
+        private System.Windows.Forms.TableLayoutPanel tlpnlMain;
     }
 }

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -1,11 +1,13 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git.Commands;
+using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
 using GitUI.Script;
 using GitUIPluginInterfaces;
@@ -13,7 +15,7 @@ using ResourceManager;
 
 namespace GitUI.CommandsDialogs
 {
-    public sealed partial class FormDeleteRemoteBranch : GitModuleForm
+    public sealed partial class FormDeleteRemoteBranch : GitExtensionsDialog
     {
         private readonly TranslationString _deleteRemoteBranchesCaption = new("Delete remote branches");
         private readonly TranslationString _confirmDeleteUnmergedRemoteBranchMessage =
@@ -31,15 +33,22 @@ namespace GitUI.CommandsDialogs
         }
 
         public FormDeleteRemoteBranch(GitUICommands commands, string defaultRemoteBranch)
-            : base(commands)
+            : base(commands, enablePositionRestore: false)
         {
             _defaultRemoteBranch = defaultRemoteBranch;
             InitializeComponent();
+
+            // work-around the designer bug that can't add controls to FlowLayoutPanel
+            ControlsPanel.Controls.Add(Delete);
+            AcceptButton = Delete;
+
             InitializeComplete();
         }
 
-        private void FormDeleteRemoteBranchLoad(object sender, EventArgs e)
+        protected override void OnRuntimeLoad(EventArgs e)
         {
+            base.OnRuntimeLoad(e);
+
             Branches.BranchesToSelect = Module.GetRefs(RefsFilter.Remotes).ToList();
             foreach (var branch in Module.GetMergedRemoteBranches())
             {
@@ -52,58 +61,74 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void OkClick(object sender, EventArgs e)
+        protected override void OnShown(EventArgs e)
         {
-            try
+            RecalculateSizeConstraints();
+            base.OnShown(e);
+            Branches.Focus();
+        }
+
+        private void RecalculateSizeConstraints()
+        {
+            SuspendLayout();
+            MinimumSize = MaximumSize = Size.Empty;
+
+            int height = ControlsPanel.Height + MainPanel.Padding.Top + MainPanel.Padding.Bottom
+                       + tlpnlMain.Height + tlpnlMain.Margin.Top + tlpnlMain.Margin.Bottom + DpiUtil.Scale(42);
+
+            MinimumSize = new Size(tlpnlMain.PreferredSize.Width + DpiUtil.Scale(70), height);
+            MaximumSize = new Size(Screen.PrimaryScreen.Bounds.Width, height);
+            Size = new Size(Width, height);
+            ResumeLayout();
+        }
+
+        private void Delete_Click(object sender, EventArgs e)
+        {
+            if (!DeleteRemote.Checked)
             {
-                if (!DeleteRemote.Checked)
+                return;
+            }
+
+            List<IGitRef> selectedBranches = Branches.GetSelectedBranches().ToList();
+
+            bool hasUnmergedBranches = selectedBranches.Any(branch => !_mergedBranches.Contains(branch.CompleteName));
+            if (hasUnmergedBranches)
+            {
+                if (MessageBox.Show(this,
+                                    _confirmDeleteUnmergedRemoteBranchMessage.Text,
+                                    _deleteRemoteBranchesCaption.Text,
+                                    MessageBoxButtons.YesNo,
+                                    MessageBoxIcon.Question,
+                                    MessageBoxDefaultButton.Button2) != DialogResult.Yes)
+                {
+                    return;
+                }
+            }
+
+            foreach ((string remote, IEnumerable<IGitRef> branches) in selectedBranches.GroupBy(b => b.Remote))
+            {
+                EnsurePageant(remote);
+
+                bool success = ScriptManager.RunEventScripts(this, ScriptEvent.BeforePush);
+                if (!success)
                 {
                     return;
                 }
 
-                List<IGitRef> selectedBranches = Branches.GetSelectedBranches().ToList();
-
-                var hasUnmergedBranches = selectedBranches.Any(branch => !_mergedBranches.Contains(branch.CompleteName));
-
-                if (hasUnmergedBranches)
+                GitDeleteRemoteBranchesCmd cmd = new(remote, branches.Select(x => x.LocalName));
+                using FormRemoteProcess form = new(UICommands, process: null, cmd.Arguments)
                 {
-                    if (MessageBox.Show(this, _confirmDeleteUnmergedRemoteBranchMessage.Text, _deleteRemoteBranchesCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
-                    {
-                        return;
-                    }
-                }
+                    Remote = remote
+                };
+                form.ShowDialog(Owner);
 
-                foreach (var (remote, branches) in selectedBranches.GroupBy(b => b.Remote))
+                if (!form.ErrorOccurred() && !Module.InTheMiddleOfAction())
                 {
-                    EnsurePageant(remote);
-
-                    GitDeleteRemoteBranchesCmd cmd = new(remote, branches.Select(x => x.LocalName));
-
-                    bool success = ScriptManager.RunEventScripts(this, ScriptEvent.BeforePush);
-                    if (!success)
-                    {
-                        return;
-                    }
-
-                    using FormRemoteProcess form = new(UICommands, process: null, cmd.Arguments)
-                    {
-                        Remote = remote
-                    };
-                    form.ShowDialog();
-
-                    if (!Module.InTheMiddleOfAction() && !form.ErrorOccurred())
-                    {
-                        ScriptManager.RunEventScripts(this, ScriptEvent.AfterPush);
-                    }
+                    ScriptManager.RunEventScripts(this, ScriptEvent.AfterPush);
                 }
-
-                UICommands.RepoChangedNotifier.Notify();
-            }
-            catch (Exception ex)
-            {
-                Trace.WriteLine(ex.Message);
             }
 
+            UICommands.RepoChangedNotifier.Notify();
             Close();
         }
 

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.resx
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.resx
@@ -117,11 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="labelDeleteBranchWarning.Text" xml:space="preserve">
-    <value>The commits referenced by the deleted branch will be lost
-if no other branch or tag references them. Make sure there
-is a branch or tag referencing the commits you wish to keep.
-If you have accidentally deleted a wrong branch, go to Commands | Show reflog form
-in order to recover the lost commits.</value>
-  </data>
 </root>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -4553,11 +4553,11 @@ Proceed?</source>
         <target />
       </trans-unit>
       <trans-unit id="Delete.Text">
-        <source>Delete</source>
+        <source>&amp;Delete</source>
         <target />
       </trans-unit>
       <trans-unit id="DeleteRemote.Text">
-        <source>Delete branche(s) from remote repository</source>
+        <source>Delete branch(es) from &amp;remote repository</source>
         <target />
       </trans-unit>
       <trans-unit id="_confirmDeleteUnmergedRemoteBranchMessage.Text">
@@ -4569,16 +4569,8 @@ Deleting a branch can cause commits to be deleted too!</source>
         <source>Delete remote branches</source>
         <target />
       </trans-unit>
-      <trans-unit id="labelDeleteBranchWarning.Text">
-        <source>The commits referenced by the deleted branch will be lost
-if no other branch or tag references them. Make sure there
-is a branch or tag referencing the commits you wish to keep.
-If you have accidentally deleted a wrong branch, go to Commands | Show reflog form
-in order to recover the lost commits.</source>
-        <target />
-      </trans-unit>
       <trans-unit id="labelSelectBranches.Text">
-        <source>Select branches</source>
+        <source>Select &amp;branches</source>
         <target />
       </trans-unit>
     </body>


### PR DESCRIPTION
Relates to #6183

## Proposed changes

* Apply the same design as for other updated dialogs
* Remove verbose "help" text, replaced with [?] button that links to the docs
* Set focus to the branches edit control

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/110279757-c0b67a00-802d-11eb-9626-37f47dcd2e60.png)


### After

![image](https://user-images.githubusercontent.com/4403806/110279770-c4e29780-802d-11eb-8059-5c05554c46f1.png)



## Test methodology <!-- How did you ensure quality? -->

- manual



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
