### PR TITLE
Rename translation strings to avoid conflict

### DIFF
--- a/GitCommands/ExternalLinks/ExternalLinksStorage.cs
+++ b/GitCommands/ExternalLinks/ExternalLinksStorage.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Xml;
 using System.Xml.Serialization;
 using GitCommands.Settings;
+using GitExtUtils;
 
 namespace GitCommands.ExternalLinks
 {
@@ -75,7 +76,7 @@ namespace GitCommands.ExternalLinks
         // TODO: refactor and outsource to the centralised SettingsSerialiser implementations.
         private static IReadOnlyList<ExternalLinkDefinition>? LoadFromXmlString(string? xmlString)
         {
-            if (GitExtUtils.Strings.IsNullOrWhiteSpace(xmlString))
+            if (Strings.IsNullOrWhiteSpace(xmlString))
             {
                 return Array.Empty<ExternalLinkDefinition>();
             }

--- a/GitExtUtils/Linq/LinqExtensions.cs
+++ b/GitExtUtils/Linq/LinqExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using GitExtUtils;
 using JetBrains.Annotations;
 
 // ReSharper disable once CheckNamespace
@@ -228,7 +229,7 @@ namespace System.Linq
         {
             foreach (var item in source)
             {
-                if (!GitExtUtils.Strings.IsNullOrWhiteSpace(item))
+                if (!Strings.IsNullOrWhiteSpace(item))
                 {
                     yield return item;
                 }

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -118,8 +118,8 @@ namespace GitExtensions
 
             AppSettings.TelemetryEnabled ??= MessageBox.Show(
                 null,
-                ResourceManager.Strings.TelemetryPermissionMessage,
-                ResourceManager.Strings.TelemetryPermissionCaption,
+                ResourceManager.TranslatedStrings.TelemetryPermissionMessage,
+                ResourceManager.TranslatedStrings.TelemetryPermissionCaption,
                 MessageBoxButtons.YesNo,
                 MessageBoxIcon.Question) == DialogResult.Yes;
 
@@ -313,18 +313,18 @@ namespace GitExtensions
 
             using var dialog1 = new TaskDialog
             {
-                InstructionText = ResourceManager.Strings.GitExecutableNotFound,
+                InstructionText = ResourceManager.TranslatedStrings.GitExecutableNotFound,
                 Icon = TaskDialogStandardIcon.Error,
                 StandardButtons = TaskDialogStandardButtons.Cancel,
                 Cancelable = true,
             };
-            var btnFindGitExecutable = new TaskDialogCommandLink("FindGitExecutable", null, ResourceManager.Strings.FindGitExecutable);
+            var btnFindGitExecutable = new TaskDialogCommandLink("FindGitExecutable", null, ResourceManager.TranslatedStrings.FindGitExecutable);
             btnFindGitExecutable.Click += (s, e) =>
             {
                 dialogResult = 0;
                 dialog1.Close();
             };
-            var btnInstallGitInstructions = new TaskDialogCommandLink("InstallGitInstructions", null, ResourceManager.Strings.InstallGitInstructions);
+            var btnInstallGitInstructions = new TaskDialogCommandLink("InstallGitInstructions", null, ResourceManager.TranslatedStrings.InstallGitInstructions);
             btnInstallGitInstructions.Click += (s, e) =>
             {
                 dialogResult = 1;

--- a/GitUI/Avatars/GithubAvatarProvider.cs
+++ b/GitUI/Avatars/GithubAvatarProvider.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
+using GitExtUtils;
 using JetBrains.Annotations;
 
 namespace GitUI.Avatars
@@ -88,7 +89,7 @@ namespace GitUI.Avatars
                     var client = new Git.hub.Client();
                     var userProfile = await client.GetUserAsync(username);
 
-                    if (GitExtUtils.Strings.IsNullOrEmpty(userProfile?.AvatarUrl))
+                    if (Strings.IsNullOrEmpty(userProfile?.AvatarUrl))
                     {
                         return null;
                     }

--- a/GitUI/Avatars/InitialsAvatarProvider.cs
+++ b/GitUI/Avatars/InitialsAvatarProvider.cs
@@ -5,6 +5,7 @@ using System.Drawing.Text;
 using System.Linq;
 using System.Threading.Tasks;
 using GitCommands;
+using GitExtUtils;
 
 namespace GitUI.Avatars
 {
@@ -44,12 +45,12 @@ namespace GitUI.Avatars
 
         private static (string? name, char[]? separator) NameSelector(string? name, string? email)
         {
-            if (!GitExtUtils.Strings.IsNullOrWhiteSpace(name))
+            if (!Strings.IsNullOrWhiteSpace(name))
             {
                 return (name.Trim(), null);
             }
 
-            if (!GitExtUtils.Strings.IsNullOrWhiteSpace(email))
+            if (!Strings.IsNullOrWhiteSpace(email))
             {
                 var withoutDomain = email.Split('@')[0].TrimStart();
                 return (withoutDomain, _emailInitialSeparator);

--- a/GitUI/BranchTreePanel/ContextMenu/GitRefsSortByContextMenuItem.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/GitRefsSortByContextMenuItem.cs
@@ -17,7 +17,7 @@ namespace GitUI.BranchTreePanel.ContextMenu
             _onSortByChanged = onSortByChanged;
 
             Image = Images.SortBy;
-            Text = Strings.SortBy;
+            Text = TranslatedStrings.SortBy;
 
             foreach (var option in EnumHelper.GetValues<GitRefsSortBy>().Select(e => (Text: e.GetDescription(), Value: e)))
             {

--- a/GitUI/BranchTreePanel/ContextMenu/GitRefsSortOrderContextMenuItem.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/GitRefsSortOrderContextMenuItem.cs
@@ -18,7 +18,7 @@ namespace GitUI.BranchTreePanel.ContextMenu
             _onSortOrderChanged = onSortOrderChanged;
 
             Image = Images.SortBy;
-            Text = Strings.SortOrder;
+            Text = TranslatedStrings.SortOrder;
             Name = MenuItemName;
 
             foreach (var option in EnumHelper.GetValues<GitRefsSortOrder>().Select(e => (Text: e.GetDescription(), Value: e)))

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -165,7 +165,7 @@ namespace GitUI.BranchTreePanel
 
                     if (_isMerged && Visible)
                     {
-                        TreeViewNode.ToolTipText = string.Format(Strings.ContainedInCurrentCommit, Name);
+                        TreeViewNode.ToolTipText = string.Format(TranslatedStrings.ContainedInCurrentCommit, Name);
                     }
                 }
             }
@@ -182,7 +182,7 @@ namespace GitUI.BranchTreePanel
                         : nameof(Images.EyeClosed);
                 if (!Visible)
                 {
-                    TreeViewNode.ToolTipText = string.Format(Strings.InvisibleCommit, FullPath);
+                    TreeViewNode.ToolTipText = string.Format(TranslatedStrings.InvisibleCommit, FullPath);
                 }
             }
         }
@@ -266,7 +266,7 @@ namespace GitUI.BranchTreePanel
                 base.ApplyStyle();
 
                 TreeViewNode.ImageKey = TreeViewNode.SelectedImageKey =
-                    FullPath == Strings.Inactive ? nameof(Images.EyeClosed) : nameof(Images.BranchFolder);
+                    FullPath == TranslatedStrings.Inactive ? nameof(Images.EyeClosed) : nameof(Images.BranchFolder);
             }
         }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -132,7 +132,7 @@ namespace GitUI.BranchTreePanel
                         disabledRemoteRepoNodes.Add(node);
                     }
 
-                    var disabledFolderNode = new RemoteRepoFolderNode(this, Strings.Inactive);
+                    var disabledFolderNode = new RemoteRepoFolderNode(this, TranslatedStrings.Inactive);
                     disabledRemoteRepoNodes
                         .OrderBy(node => node.FullPath)
                         .ForEach(node => disabledFolderNode.Nodes.AddNode(node));

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -327,9 +327,9 @@ namespace GitUI.BranchTreePanel
 
         private void CreateBranches()
         {
-            var rootNode = new TreeNode(Strings.Branches)
+            var rootNode = new TreeNode(TranslatedStrings.Branches)
             {
-                Name = Strings.Branches,
+                Name = TranslatedStrings.Branches,
                 ImageKey = nameof(Images.BranchLocalRoot),
                 SelectedImageKey = nameof(Images.BranchLocalRoot),
             };
@@ -338,9 +338,9 @@ namespace GitUI.BranchTreePanel
 
         private void CreateRemotes()
         {
-            var rootNode = new TreeNode(Strings.Remotes)
+            var rootNode = new TreeNode(TranslatedStrings.Remotes)
             {
-                Name = Strings.Remotes,
+                Name = TranslatedStrings.Remotes,
                 ImageKey = nameof(Images.BranchRemoteRoot),
                 SelectedImageKey = nameof(Images.BranchRemoteRoot),
             };
@@ -355,9 +355,9 @@ namespace GitUI.BranchTreePanel
 
         private void CreateTags()
         {
-            var rootNode = new TreeNode(Strings.Tags)
+            var rootNode = new TreeNode(TranslatedStrings.Tags)
             {
-                Name = Strings.Tags,
+                Name = TranslatedStrings.Tags,
                 ImageKey = nameof(Images.TagHorizontal),
                 SelectedImageKey = nameof(Images.TagHorizontal),
             };
@@ -366,9 +366,9 @@ namespace GitUI.BranchTreePanel
 
         private void CreateSubmodules()
         {
-            var rootNode = new TreeNode(Strings.Submodules)
+            var rootNode = new TreeNode(TranslatedStrings.Submodules)
             {
-                Name = Strings.Submodules,
+                Name = TranslatedStrings.Submodules,
                 ImageKey = nameof(Images.FolderSubmodule),
                 SelectedImageKey = nameof(Images.FolderSubmodule),
             };

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -830,7 +830,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
                     if (!module.IsValidGitWorkingDir())
                     {
-                        MessageBox.Show(this, Strings.DirectoryInvalidRepository,
+                        MessageBox.Show(this, TranslatedStrings.DirectoryInvalidRepository,
                             _cannotOpenTheFolder.Text, MessageBoxButtons.OK,
                             MessageBoxIcon.Exclamation, MessageBoxDefaultButton.Button1);
                         return;

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -73,7 +73,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private Task LoadTagsAsync()
         {
-            comboBoxTags.Text = Strings.LoadingData;
+            comboBoxTags.Text = TranslatedStrings.LoadingData;
             return _tagsLoader.LoadAsync(
                 () => Module.GetRefs(tags: true, branches: false).ToList(),
                 list =>
@@ -87,7 +87,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private Task LoadBranchesAsync()
         {
-            comboBoxBranches.Text = Strings.LoadingData;
+            comboBoxBranches.Text = TranslatedStrings.LoadingData;
             return _branchesLoader.LoadAsync(
                 () => Module.GetRefs(tags: false, branches: true).ToList(),
                 list =>

--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.UserRepositoryHistory;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using ResourceManager;
 
@@ -52,7 +53,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 directories.Add(AppSettings.DefaultCloneDestinationPath.EnsureTrailingPathSeparator());
             }
 
-            if (!GitExtUtils.Strings.IsNullOrWhiteSpace(currentModule?.WorkingDir))
+            if (!Strings.IsNullOrWhiteSpace(currentModule?.WorkingDir))
             {
                 var di = new DirectoryInfo(currentModule.WorkingDir);
                 if (di.Parent is not null)
@@ -65,7 +66,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             if (directories.Count == 0)
             {
-                if (!GitExtUtils.Strings.IsNullOrWhiteSpace(AppSettings.RecentWorkingDir))
+                if (!Strings.IsNullOrWhiteSpace(AppSettings.RecentWorkingDir))
                 {
                     directories.Add(AppSettings.RecentWorkingDir.EnsureTrailingPathSeparator());
                 }
@@ -98,7 +99,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 return;
             }
 
-            MessageBox.Show(this, _warningOpenFailed.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBox.Show(this, _warningOpenFailed.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
         private void DirectoryKeyPress(object sender, KeyPressEventArgs e)

--- a/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
@@ -46,7 +46,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 }
                 else
                 {
-                    MessageBox.Show("No ExecuteAction assigned to this MenuCommand. Please submit a bug report.", Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show("No ExecuteAction assigned to this MenuCommand. Please submit a bug report.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             };
 

--- a/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
+++ b/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
@@ -23,7 +23,7 @@ namespace GitUI.CommandsDialogs
         private WebBrowserControl? _buildReportWebBrowser;
         private GitRevision? _selectedGitRevision;
         private string? _url;
-        private readonly LinkLabel _openReportLink = new LinkLabel { AutoSize = false, Text = Strings.OpenReport, TextAlign = ContentAlignment.MiddleCenter, Dock = DockStyle.Fill };
+        private readonly LinkLabel _openReportLink = new LinkLabel { AutoSize = false, Text = TranslatedStrings.OpenReport, TextAlign = ContentAlignment.MiddleCenter, Dock = DockStyle.Fill };
 
         public Control? Control { get; private set; } // for focusing
 

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -98,7 +98,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, ex.ToString(), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, ex.ToString(), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             Close();

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -173,7 +173,7 @@ namespace GitUI.CommandsDialogs
 
             if (string.IsNullOrEmpty(patchFile) && string.IsNullOrEmpty(dirText))
             {
-                MessageBox.Show(this, _noFileSelectedText.Text, Strings.Error, MessageBoxButtons.OK,  MessageBoxIcon.Error);
+                MessageBox.Show(this, _noFileSelectedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK,  MessageBoxIcon.Error);
                 return;
             }
 

--- a/GitUI/CommandsDialogs/FormArchive.cs
+++ b/GitUI/CommandsDialogs/FormArchive.cs
@@ -45,14 +45,14 @@ namespace GitUI.CommandsDialogs
                 if (_diffSelectedRevision is null)
                 {
                     const string defaultString = "...";
-                    labelDateCaption.Text = $"{ResourceManager.Strings.CommitDate}:";
+                    labelDateCaption.Text = $"{ResourceManager.TranslatedStrings.CommitDate}:";
                     labelAuthor.Text = defaultString;
                     gbDiffRevision.Text = defaultString;
                     labelMessage.Text = defaultString;
                 }
                 else
                 {
-                    labelDateCaption.Text = $"{ResourceManager.Strings.CommitDate}: {_diffSelectedRevision.CommitDate}";
+                    labelDateCaption.Text = $"{ResourceManager.TranslatedStrings.CommitDate}: {_diffSelectedRevision.CommitDate}";
                     labelAuthor.Text = _diffSelectedRevision.Author;
                     gbDiffRevision.Text = _diffSelectedRevision.ObjectId.ToShortString();
                     labelMessage.Text = _diffSelectedRevision.Subject;
@@ -113,7 +113,7 @@ namespace GitUI.CommandsDialogs
         {
             if (checkboxRevisionFilter.Checked && DiffSelectedRevision is null)
             {
-                MessageBox.Show(this, _noRevisionSelected.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                MessageBox.Show(this, _noRevisionSelected.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 return;
             }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -889,7 +889,7 @@ namespace GitUI.CommandsDialogs
                 toolPanel.ContentPanel.Controls.Add(_dashboard);
             }
 
-            Text = _appTitleGenerator.Generate(branchName: Strings.NoBranch);
+            Text = _appTitleGenerator.Generate(branchName: TranslatedStrings.NoBranch);
 
             _dashboard.RefreshContent();
             _dashboard.Visible = true;
@@ -1114,7 +1114,7 @@ namespace GitUI.CommandsDialogs
                 }
 
                 RefreshWorkingDirComboText();
-                var branchName = !string.IsNullOrEmpty(branchSelect.Text) ? branchSelect.Text : Strings.NoBranch;
+                var branchName = !string.IsNullOrEmpty(branchSelect.Text) ? branchSelect.Text : TranslatedStrings.NoBranch;
                 Text = _appTitleGenerator.Generate(Module.WorkingDir, validBrowseDir, branchName);
 
                 OnActivate();
@@ -2162,7 +2162,7 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-                MessageBox.Show(this, _noReposHostPluginLoaded.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _noReposHostPluginLoaded.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -2208,7 +2208,7 @@ namespace GitUI.CommandsDialogs
             repoHost = PluginRegistry.TryGetGitHosterForModule(Module);
             if (repoHost is null)
             {
-                MessageBox.Show(this, _noReposHostFound.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _noReposHostFound.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
@@ -2482,7 +2482,7 @@ namespace GitUI.CommandsDialogs
             {
                 string? filePath = PathUtil.Combine(module.WorkingDir, item.Item.Name.ToNativePath());
 
-                if (!GitExtUtils.Strings.IsNullOrWhiteSpace(filePath))
+                if (!Strings.IsNullOrWhiteSpace(filePath))
                 {
                     FormBrowseUtil.ShowFileOrParentFolderInFileExplorer(filePath);
                 }
@@ -2796,7 +2796,7 @@ namespace GitUI.CommandsDialogs
                 try
                 {
                     await TaskScheduler.Default;
-                    await _submoduleStatusProvider.UpdateSubmodulesStructureAsync(Module.WorkingDir, Strings.NoBranch, updateStatus);
+                    await _submoduleStatusProvider.UpdateSubmodulesStructureAsync(Module.WorkingDir, TranslatedStrings.NoBranch, updateStatus);
                 }
                 catch (GitConfigurationException ex)
                 {
@@ -3049,7 +3049,7 @@ namespace GitUI.CommandsDialogs
                 catch (InvalidOperationException)
                 {
 #if DEBUG
-                    MessageBox.Show(@"ConEmu appears to be missing. Please perform a full rebuild and try again.", Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(@"ConEmu appears to be missing. Please perform a full rebuild and try again.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
 #else
                     throw;
 #endif

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -104,7 +104,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (ParentsList.SelectedItems.Count == 0)
                 {
-                    MessageBox.Show(this, _noneParentSelectedText.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, _noneParentSelectedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     canExecute = false;
                 }
                 else

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1256,25 +1256,25 @@ namespace GitUI.CommandsDialogs
                     {
                         OwnerWindowHandle = Handle,
                         Text = _notOnBranch.Text,
-                        InstructionText = Strings.ErrorInstructionNotOnBranch,
-                        Caption = Strings.ErrorCaptionNotOnBranch,
+                        InstructionText = TranslatedStrings.ErrorInstructionNotOnBranch,
+                        Caption = TranslatedStrings.ErrorCaptionNotOnBranch,
                         StandardButtons = TaskDialogStandardButtons.Cancel,
                         Icon = TaskDialogStandardIcon.Error,
                         Cancelable = true,
                     };
-                    var btnCheckout = new TaskDialogCommandLink("Checkout", null, Strings.ButtonCheckoutBranch);
+                    var btnCheckout = new TaskDialogCommandLink("Checkout", null, TranslatedStrings.ButtonCheckoutBranch);
                     btnCheckout.Click += (s, e) =>
                     {
                         dialogResult = 0;
                         dialog.Close();
                     };
-                    var btnCreate = new TaskDialogCommandLink("Create", null, Strings.ButtonCreateBranch);
+                    var btnCreate = new TaskDialogCommandLink("Create", null, TranslatedStrings.ButtonCreateBranch);
                     btnCreate.Click += (s, e) =>
                     {
                         dialogResult = 1;
                         dialog.Close();
                     };
-                    var btnContinue = new TaskDialogCommandLink("Continue", null, Strings.ButtonContinue);
+                    var btnContinue = new TaskDialogCommandLink("Continue", null, TranslatedStrings.ButtonContinue);
                     btnContinue.Click += (s, e) =>
                     {
                         dialogResult = 2;
@@ -1364,7 +1364,7 @@ namespace GitUI.CommandsDialogs
 
                     if (pushCompleted && Module.SuperprojectModule is not null &&
                         AppSettings.StageInSuperprojectAfterCommit &&
-                        !GitExtUtils.Strings.IsNullOrWhiteSpace(Module.SubmodulePath))
+                        !Strings.IsNullOrWhiteSpace(Module.SubmodulePath))
                     {
                         Module.SuperprojectModule.StageFile(Module.SubmodulePath);
                     }
@@ -1392,7 +1392,7 @@ namespace GitUI.CommandsDialogs
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show(this, $"Exception: {e.Message}", Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, $"Exception: {e.Message}", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
                 return;
@@ -2103,7 +2103,7 @@ namespace GitUI.CommandsDialogs
 
                 if (!string.IsNullOrEmpty(output.ToString()))
                 {
-                    MessageBox.Show(this, output.ToString(), Strings.ResetChangesCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, output.ToString(), TranslatedStrings.ResetChangesCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
             finally
@@ -2146,7 +2146,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, _deleteFailed.Text + Environment.NewLine + ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _deleteFailed.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -2175,7 +2175,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, _deleteFailed.Text + Environment.NewLine + ex, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _deleteFailed.Text + Environment.NewLine + ex, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             Initialize();
@@ -2183,7 +2183,7 @@ namespace GitUI.CommandsDialogs
 
         private void ResetSelectedFilesToolStripMenuItemClick(object sender, EventArgs e)
         {
-            if (MessageBox.Show(this, _resetSelectedChangesText.Text, Strings.ResetChangesCaption, MessageBoxButtons.YesNo, MessageBoxIcon.Question) !=
+            if (MessageBox.Show(this, _resetSelectedChangesText.Text, TranslatedStrings.ResetChangesCaption, MessageBoxButtons.YesNo, MessageBoxIcon.Question) !=
                 DialogResult.Yes)
             {
                 return;
@@ -2743,7 +2743,7 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-                MessageBox.Show(this, _selectOnlyOneFile.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _selectOnlyOneFile.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -3288,7 +3288,7 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-                MessageBox.Show(string.Format(_stopTrackingFail.Text, filename), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(string.Format(_stopTrackingFail.Text, filename), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -82,7 +82,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -70,7 +70,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, _cannotOpenFile.Text + Environment.NewLine + ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _cannotOpenFile.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 Close();
             }
         }
@@ -91,7 +91,7 @@ namespace GitUI.CommandsDialogs
                         }
                         catch (Exception ex)
                         {
-                            if (MessageBox.Show(this, $"{_cannotSaveFile.Text}{Environment.NewLine}{ex.Message}", Strings.Error, MessageBoxButtons.OKCancel, MessageBoxIcon.Error) == DialogResult.Cancel)
+                            if (MessageBox.Show(this, $"{_cannotSaveFile.Text}{Environment.NewLine}{ex.Message}", TranslatedStrings.Error, MessageBoxButtons.OKCancel, MessageBoxIcon.Error) == DialogResult.Cancel)
                             {
                                 e.Cancel = true;
                                 return;
@@ -133,7 +133,7 @@ namespace GitUI.CommandsDialogs
 
         private void SaveChanges()
         {
-            if (!GitExtUtils.Strings.IsNullOrEmpty(_fileName))
+            if (!Strings.IsNullOrEmpty(_fileName))
             {
                 if (fileViewer.FilePreamble is null || Module.FilesEncoding.GetPreamble().SequenceEqual(fileViewer.FilePreamble))
                 {

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -271,7 +271,7 @@ namespace GitUI.CommandsDialogs
 
                     foreach (var line in lines.Select(GitModule.ReEncodeFileNameFromLossless))
                     {
-                        if (!GitExtUtils.Strings.IsNullOrEmpty(line) && setOfFileNames.Add(line))
+                        if (!Strings.IsNullOrEmpty(line) && setOfFileNames.Add(line))
                         {
                             listOfFileNames.Append(" \"");
                             listOfFileNames.Append(line);
@@ -356,7 +356,7 @@ namespace GitUI.CommandsDialogs
 
             var fileName = revision.Name;
 
-            if (GitExtUtils.Strings.IsNullOrEmpty(fileName))
+            if (Strings.IsNullOrEmpty(fileName))
             {
                 fileName = FileName;
             }
@@ -472,13 +472,13 @@ namespace GitUI.CommandsDialogs
             {
                 string? orgFileName = selectedRows[0].Name;
 
-                if (GitExtUtils.Strings.IsNullOrEmpty(orgFileName))
+                if (Strings.IsNullOrEmpty(orgFileName))
                 {
                     orgFileName = FileName;
                 }
 
                 string? fullName = _fullPathResolver.Resolve(orgFileName);
-                if (GitExtUtils.Strings.IsNullOrWhiteSpace(fullName))
+                if (Strings.IsNullOrWhiteSpace(fullName))
                 {
                     return;
                 }

--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -86,25 +86,25 @@ namespace GitUI.CommandsDialogs
         {
             if (SaveToDir.Checked && string.IsNullOrEmpty(OutputPath.Text))
             {
-                MessageBox.Show(this, _noOutputPathEnteredText.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _noOutputPathEnteredText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             if (!SaveToDir.Checked && string.IsNullOrEmpty(MailTo.Text))
             {
-                MessageBox.Show(this, _noEmailEnteredText.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _noEmailEnteredText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             if (!SaveToDir.Checked && string.IsNullOrEmpty(MailSubject.Text))
             {
-                MessageBox.Show(this, _noSubjectEnteredText.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _noSubjectEnteredText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             if (!SaveToDir.Checked && string.IsNullOrEmpty(AppSettings.SmtpServer))
             {
-                MessageBox.Show(this, _wrongSmtpSettingsText.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _wrongSmtpSettingsText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -207,7 +207,7 @@ namespace GitUI.CommandsDialogs
 
                 if (string.IsNullOrEmpty(from))
                 {
-                    MessageBox.Show(this, _noGitMailConfigured.Text, Strings.Warning, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    MessageBox.Show(this, _noGitMailConfigured.Text, TranslatedStrings.Warning, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 }
 
                 string to = MailTo.Text;
@@ -240,7 +240,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 

--- a/GitUI/CommandsDialogs/FormInit.cs
+++ b/GitUI/CommandsDialogs/FormInit.cs
@@ -61,7 +61,7 @@ namespace GitUI.CommandsDialogs
 
             if (File.Exists(directoryPath))
             {
-                MessageBox.Show(this, _chooseDirectoryNotFile.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _chooseDirectoryNotFile.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -213,7 +213,7 @@ namespace GitUI.CommandsDialogs
             _NO_TRANSLATE_Remotes.SelectedIndex = -1;
             _NO_TRANSLATE_Remotes.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
 
-            if (GitExtUtils.Strings.IsNullOrEmpty(selectedRemoteName))
+            if (Strings.IsNullOrEmpty(selectedRemoteName))
             {
                 selectedRemoteName = Module.GetSetting(string.Format(SettingKeyString.BranchRemote, _branch));
             }
@@ -242,7 +242,7 @@ namespace GitUI.CommandsDialogs
             if (pullAction == AppSettings.PullAction.FetchPruneAll)
             {
                 string messageBoxTitle;
-                if (GitExtUtils.Strings.IsNullOrEmpty(remote))
+                if (Strings.IsNullOrEmpty(remote))
                 {
                     messageBoxTitle = string.Format(_pruneFromCaption.Text, AllRemotes);
                 }
@@ -378,19 +378,19 @@ namespace GitUI.CommandsDialogs
                 {
                     OwnerWindowHandle = owner?.Handle ?? default,
                     Text = _notOnBranch.Text,
-                    InstructionText = Strings.ErrorInstructionNotOnBranch,
-                    Caption = Strings.ErrorCaptionNotOnBranch,
+                    InstructionText = TranslatedStrings.ErrorInstructionNotOnBranch,
+                    Caption = TranslatedStrings.ErrorCaptionNotOnBranch,
                     StandardButtons = TaskDialogStandardButtons.Cancel,
                     Icon = TaskDialogStandardIcon.Error,
                     Cancelable = true,
                 };
-                var btnCheckout = new TaskDialogCommandLink("Checkout", null, Strings.ButtonCheckoutBranch);
+                var btnCheckout = new TaskDialogCommandLink("Checkout", null, TranslatedStrings.ButtonCheckoutBranch);
                 btnCheckout.Click += (s, e) =>
                 {
                     dialogResult = 0;
                     dialog.Close();
                 };
-                var btnContinue = new TaskDialogCommandLink("Continue", null, Strings.ButtonContinue);
+                var btnContinue = new TaskDialogCommandLink("Continue", null, TranslatedStrings.ButtonContinue);
                 btnContinue.Click += (s, e) =>
                 {
                     dialogResult = 1;
@@ -481,19 +481,19 @@ namespace GitUI.CommandsDialogs
             {
                 if (PullFromUrl.Checked && string.IsNullOrEmpty(comboBoxPullSource.Text))
                 {
-                    MessageBox.Show(this, _selectSourceDirectory.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, _selectSourceDirectory.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return false;
                 }
 
                 if (PullFromRemote.Checked && string.IsNullOrEmpty(_NO_TRANSLATE_Remotes.Text) && !IsPullAll())
                 {
-                    MessageBox.Show(this, _selectRemoteRepository.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, _selectRemoteRepository.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return false;
                 }
 
                 if (!Fetch.Checked && Branches.Text == "*")
                 {
-                    MessageBox.Show(this, _fetchAllBranchesCanOnlyWithFetch.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, _fetchAllBranchesCanOnlyWithFetch.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return false;
                 }
 
@@ -934,7 +934,7 @@ namespace GitUI.CommandsDialogs
                 {
                     foreach (var remote in (IEnumerable<ConfigFileRemote>)_NO_TRANSLATE_Remotes.DataSource)
                     {
-                        if (!GitExtUtils.Strings.IsNullOrWhiteSpace(remote.Name) && remote.Name != AllRemotes)
+                        if (!Strings.IsNullOrWhiteSpace(remote.Name) && remote.Name != AllRemotes)
                         {
                             yield return remote.Name;
                         }

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -13,6 +13,7 @@ using GitCommands.Git;
 using GitCommands.Git.Commands;
 using GitCommands.Remotes;
 using GitCommands.UserRepositoryHistory;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
 using GitUI.Script;
@@ -239,7 +240,7 @@ namespace GitUI.CommandsDialogs
             _NO_TRANSLATE_Remotes.SelectedIndexChanged += RemotesUpdated;
             _NO_TRANSLATE_Remotes.TextUpdate += RemotesUpdated;
 
-            if (GitExtUtils.Strings.IsNullOrEmpty(selectedRemoteName))
+            if (Strings.IsNullOrEmpty(selectedRemoteName))
             {
                 selectedRemoteName = Module.GetSetting(string.Format(SettingKeyString.BranchRemote, _currentBranchName));
             }
@@ -288,7 +289,7 @@ namespace GitUI.CommandsDialogs
             ErrorOccurred = false;
             if (PushToUrl.Checked && !PathUtil.IsUrl(PushDestination.Text))
             {
-                MessageBox.Show(owner, _selectDestinationDirectory.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(owner, _selectDestinationDirectory.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
@@ -302,7 +303,7 @@ namespace GitUI.CommandsDialogs
             var selectedRemoteName = _selectedRemote.Name;
             if (TabControlTagBranch.SelectedTab == TagTab && string.IsNullOrEmpty(TagComboBox.Text))
             {
-                MessageBox.Show(owner, _selectTag.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(owner, _selectTag.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -273,7 +273,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (string.IsNullOrEmpty(Branches.Text))
                 {
-                    MessageBox.Show(this, _noBranchSelectedText.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, _noBranchSelectedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -511,7 +511,7 @@ Inactive remote is completely invisible to git.");
         {
             if (string.IsNullOrEmpty(PuttySshKey.Text))
             {
-                MessageBox.Show(this, _errorNoKeyEntered.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _errorNoKeyEntered.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else
             {
@@ -532,7 +532,7 @@ Inactive remote is completely invisible to git.");
         {
             MessageBox.Show(this,
                             string.Format(_remoteBranchDataError.Text, RemoteBranches.Rows[e.RowIndex].Cells[0].Value, RemoteBranches.Columns[e.ColumnIndex].HeaderText),
-                            Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                            TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             RemoteBranches.Rows[e.RowIndex].Cells[e.ColumnIndex].Value = "";
         }
 

--- a/GitUI/CommandsDialogs/FormRemotesController.cs
+++ b/GitUI/CommandsDialogs/FormRemotesController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using GitCommands.UserRepositoryHistory;
+using GitExtUtils;
 
 namespace GitUI.CommandsDialogs
 {
@@ -23,7 +24,7 @@ namespace GitUI.CommandsDialogs
 
         public void RemoteUpdate(IList<Repository> remotes, string? oldRemoteUrl, string? newRemoteUrl)
         {
-            if (GitExtUtils.Strings.IsNullOrWhiteSpace(newRemoteUrl))
+            if (Strings.IsNullOrWhiteSpace(newRemoteUrl))
             {
                 return;
             }

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -352,7 +352,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, "Merge using script failed.\n" + ex, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, "Merge using script failed.\n" + ex, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             return false;
@@ -508,7 +508,7 @@ namespace GitUI.CommandsDialogs
                     if (FileHelper.IsBinaryFileName(Module, item.Local.Filename))
                     {
                         if (MessageBox.Show(this, string.Format(_fileIsBinary.Text, _mergetool),
-                                Strings.Warning, MessageBoxButtons.YesNo, MessageBoxIcon.Warning,
+                                TranslatedStrings.Warning, MessageBoxButtons.YesNo, MessageBoxIcon.Warning,
                                 MessageBoxDefaultButton.Button2) == DialogResult.No)
                         {
                             BinaryFilesChooseLocalBaseRemote(item);
@@ -516,7 +516,7 @@ namespace GitUI.CommandsDialogs
                         }
                     }
 
-                    if (GitExtUtils.Strings.IsNullOrWhiteSpace(_mergetoolCmd) || GitExtUtils.Strings.IsNullOrWhiteSpace(_mergetoolPath))
+                    if (Strings.IsNullOrWhiteSpace(_mergetoolCmd) || Strings.IsNullOrWhiteSpace(_mergetoolPath))
                     {
                         // mergetool is set, but arguments cannot be manipulated
                         Module.RunMergeTool(item.Filename);
@@ -625,7 +625,7 @@ namespace GitUI.CommandsDialogs
 
             if (string.IsNullOrEmpty(_mergetool))
             {
-                MessageBox.Show(this, _noMergeTool.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _noMergeTool.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
@@ -662,7 +662,7 @@ namespace GitUI.CommandsDialogs
 
                 if (!PathUtil.TryFindFullPath(_mergetoolPath, out string? fullPath))
                 {
-                    MessageBox.Show(this, _noMergeToolConfigured.Text, Strings.Warning, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    MessageBox.Show(this, _noMergeToolConfigured.Text, TranslatedStrings.Warning, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     return false;
                 }
 
@@ -836,7 +836,7 @@ namespace GitUI.CommandsDialogs
         {
             if (!Module.HandleConflictSelectSide(fileName, "BASE"))
             {
-                MessageBox.Show(this, _chooseBaseFileFailedText.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _chooseBaseFileFailedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -865,7 +865,7 @@ namespace GitUI.CommandsDialogs
         {
             if (!Module.HandleConflictSelectSide(fileName, "LOCAL"))
             {
-                MessageBox.Show(this, _chooseLocalFileFailedText.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _chooseLocalFileFailedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -894,7 +894,7 @@ namespace GitUI.CommandsDialogs
         {
             if (!Module.HandleConflictSelectSide(fileName, "REMOTE"))
             {
-                MessageBox.Show(this, _chooseRemoteFileFailedText.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _chooseRemoteFileFailedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -1297,7 +1297,7 @@ namespace GitUI.CommandsDialogs
 
                 if (!Module.HandleConflictsSaveSide(conflictData.Filename, fileName, side))
                 {
-                    MessageBox.Show(this, _failureWhileOpenFile.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, _failureWhileOpenFile.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
                 OsShellUtil.OpenAs(fileName);
@@ -1352,7 +1352,7 @@ namespace GitUI.CommandsDialogs
                 {
                     if (!Module.HandleConflictsSaveSide(conflictData.Filename, fileDialog.FileName, side))
                     {
-                        MessageBox.Show(this, _failureWhileSaveFile.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show(this, _failureWhileSaveFile.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 }
             }

--- a/GitUI/CommandsDialogs/FormRevertCommit.cs
+++ b/GitUI/CommandsDialogs/FormRevertCommit.cs
@@ -72,7 +72,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (ParentsList.SelectedItems.Count != 1)
                 {
-                    MessageBox.Show(this, _noneParentSelectedText.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, _noneParentSelectedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
                 else

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -261,7 +261,7 @@ namespace GitUI.CommandsDialogs
                     OwnerWindowHandle = Handle,
                     Text = ex.InnerException.Message,
                     InstructionText = _cantSaveSettings.Text,
-                    Caption = Strings.Error,
+                    Caption = TranslatedStrings.Error,
                     StandardButtons = TaskDialogStandardButtons.Ok,
                     Icon = TaskDialogStandardIcon.Error,
                     Cancelable = true,

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -195,7 +195,7 @@ namespace GitUI.CommandsDialogs
                 };
                 var indexItems = gitItemStatuses.Where(item => item.Staged == StagedStatus.Index).ToList();
                 var workTreeItems = gitItemStatuses.Where(item => item.Staged != StagedStatus.Index).ToList();
-                Stashed.SetStashDiffs(headRev, indexRev, ResourceManager.Strings.Index, indexItems, workTreeRev, ResourceManager.Strings.Workspace, workTreeItems);
+                Stashed.SetStashDiffs(headRev, indexRev, ResourceManager.TranslatedStrings.Index, indexItems, workTreeRev, ResourceManager.TranslatedStrings.Workspace, workTreeItems);
             }
             else
             {

--- a/GitUI/CommandsDialogs/InvalidRepositoryRemover.cs
+++ b/GitUI/CommandsDialogs/InvalidRepositoryRemover.cs
@@ -27,13 +27,13 @@ namespace GitUI.CommandsDialogs
 
             using var dialog = new TaskDialog
             {
-                InstructionText = Strings.DirectoryInvalidRepository,
-                Caption = Strings.Open,
+                InstructionText = TranslatedStrings.DirectoryInvalidRepository,
+                Caption = TranslatedStrings.Open,
                 Icon = TaskDialogStandardIcon.Error,
                 StandardButtons = TaskDialogStandardButtons.Cancel,
                 Cancelable = true,
             };
-            var btnRemoveSelectedInvalidRepository = new TaskDialogCommandLink("RemoveSelectedInvalidRepository", null, Strings.RemoveSelectedInvalidRepository);
+            var btnRemoveSelectedInvalidRepository = new TaskDialogCommandLink("RemoveSelectedInvalidRepository", null, TranslatedStrings.RemoveSelectedInvalidRepository);
             btnRemoveSelectedInvalidRepository.Click += (s, e) =>
             {
                 dialogResult = 0;
@@ -42,7 +42,7 @@ namespace GitUI.CommandsDialogs
             dialog.Controls.Add(btnRemoveSelectedInvalidRepository);
             if (invalidPathCount > 1)
             {
-                var btnRemoveAllInvalidRepositories = new TaskDialogCommandLink("RemoveAllInvalidRepositories", null, string.Format(Strings.RemoveAllInvalidRepositories, invalidPathCount));
+                var btnRemoveAllInvalidRepositories = new TaskDialogCommandLink("RemoveAllInvalidRepositories", null, string.Format(TranslatedStrings.RemoveAllInvalidRepositories, invalidPathCount));
                 btnRemoveAllInvalidRepositories.Click += (s, e) =>
                 {
                     dialogResult = 1;

--- a/GitUI/CommandsDialogs/RememberFileContextMenuController.cs
+++ b/GitUI/CommandsDialogs/RememberFileContextMenuController.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Diagnostics.Contracts;
 using GitCommands;
+using GitExtUtils;
 using GitUI.UserControls;
 using GitUIPluginInterfaces;
 
@@ -95,7 +96,7 @@ namespace GitUI.CommandsDialogs
                     : item.Item.Name)
                 ?.ToPosixPath();
             var id = (isSecondRevision ? item.SecondRevision : item.FirstRevision)?.ObjectId;
-            if (GitExtUtils.Strings.IsNullOrWhiteSpace(name) || id is null)
+            if (Strings.IsNullOrWhiteSpace(name) || id is null)
             {
                 return null;
             }

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -182,7 +182,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             var body = _bodyTB.Text.Trim();
             if (title.Length == 0)
             {
-                MessageBox.Show(this, _strYouMustSpecifyATitle.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _strYouMustSpecifyATitle.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -197,7 +197,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             catch (Exception ex)
             {
                 MessageBox.Show(this, _strFailedToCreatePullRequest.Text + Environment.NewLine +
-                    ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -8,6 +8,7 @@ using GitCommands;
 using GitCommands.Git;
 using GitCommands.Git.Commands;
 using GitCommands.UserRepositoryHistory;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces.RepositoryHosts;
@@ -79,7 +80,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
                     await this.SwitchToMainThreadAsync();
                     var lastRepo = repositoryHistory.FirstOrDefault();
-                    if (!GitExtUtils.Strings.IsNullOrEmpty(lastRepo?.Path))
+                    if (!Strings.IsNullOrEmpty(lastRepo?.Path))
                     {
                         string p = lastRepo.Path.Trim('/', '\\');
                         destinationTB.Text = Path.GetDirectoryName(p);
@@ -119,9 +120,9 @@ namespace GitUI.CommandsDialogs.RepoHosting
                                 Text = repo.Name,
                                 SubItems =
                                 {
-                                    repo.IsAFork ? Strings.Yes : Strings.No,
+                                    repo.IsAFork ? TranslatedStrings.Yes : TranslatedStrings.No,
                                     repo.Forks.ToString(),
-                                    repo.IsPrivate ? Strings.Yes : Strings.No
+                                    repo.IsPrivate ? TranslatedStrings.Yes : TranslatedStrings.No
                                 }
                             });
                         }
@@ -178,7 +179,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     {
                         await this.SwitchToMainThreadAsync();
 
-                        MessageBox.Show(this, _strSearchFailed.Text + Environment.NewLine + ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show(this, _strSearchFailed.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         searchBtn.Enabled = true;
                     }
                 })
@@ -214,12 +215,12 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
                         if (ex.Message.Contains("404"))
                         {
-                            MessageBox.Show(this, _strUserNotFound.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                            MessageBox.Show(this, _strUserNotFound.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
                         else
                         {
                             MessageBox.Show(this, _strCouldNotFetchReposOfUser.Text + Environment.NewLine +
-                                                  ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                                                  ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
 
                         searchBtn.Enabled = true;
@@ -249,7 +250,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     SubItems =
                     {
                         repo.Owner,
-                        repo.IsAFork ? Strings.Yes : Strings.No,
+                        repo.IsAFork ? TranslatedStrings.Yes : TranslatedStrings.No,
                         repo.Forks.ToString()
                     }
                 });
@@ -265,7 +266,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         {
             if (searchResultsLV.SelectedItems.Count != 1)
             {
-                MessageBox.Show(this, _strSelectOneItem.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _strSelectOneItem.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -276,7 +277,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, _strFailedToFork.Text + Environment.NewLine + ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _strFailedToFork.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             tabControl.SelectedTab = myReposPage;
@@ -340,7 +341,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             string hp = CurrentySelectedGitRepo.Homepage;
             if (string.IsNullOrEmpty(hp) || (!hp.StartsWith("http://") && !hp.StartsWith("https://")))
             {
-                MessageBox.Show(this, _strNoHomepageDefined.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _strNoHomepageDefined.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else
             {
@@ -409,7 +410,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
             var module = new GitModule(targetDir);
 
-            if (addUpstreamRemoteAsCB.Text.Trim().Length > 0 && !GitExtUtils.Strings.IsNullOrEmpty(repo.ParentReadOnlyUrl))
+            if (addUpstreamRemoteAsCB.Text.Trim().Length > 0 && !Strings.IsNullOrEmpty(repo.ParentReadOnlyUrl))
             {
                 var error = module.AddRemote(addUpstreamRemoteAsCB.Text.Trim(), repo.ParentReadOnlyUrl);
                 if (!string.IsNullOrEmpty(error))
@@ -524,7 +525,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             string targetDir = destinationTB.Text.Trim();
             if (targetDir.Length == 0)
             {
-                MessageBox.Show(this, _strCloneFolderCanNotBeEmpty.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _strCloneFolderCanNotBeEmpty.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return null;
             }
 

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -54,7 +54,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             _diffViewer.ExtraDiffArgumentsChanged += _fileStatusList_SelectedIndexChanged;
             _loader.LoadingError += (sender, ex) =>
             {
-                MessageBox.Show(this, ex.Exception.ToString(), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, ex.Exception.ToString(), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 this.UnMask();
             };
             _diffViewer.TopScrollReached += FileViewer_TopScrollReached;
@@ -124,7 +124,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     }
                     catch (Exception ex) when (ex is not OperationCanceledException)
                     {
-                        MessageBox.Show(this, _strFailedToFetchPullData.Text + Environment.NewLine + ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show(this, _strFailedToFetchPullData.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 })
                 .FileAndForget();
@@ -308,7 +308,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     }
                     catch (Exception ex) when (ex is not OperationCanceledException)
                     {
-                        MessageBox.Show(this, _strCouldNotLoadDiscussion.Text + Environment.NewLine + ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show(this, _strCouldNotLoadDiscussion.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         LoadDiscussion(null);
                     }
                 })
@@ -346,7 +346,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     }
                     catch (Exception ex) when (ex is not OperationCanceledException)
                     {
-                        MessageBox.Show(this, _strFailedToLoadDiffData.Text + Environment.NewLine + ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show(this, _strFailedToLoadDiffData.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 })
                 .FileAndForget();
@@ -364,7 +364,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             GitRevision? secondRev = ObjectId.TryParse(secondSha, out ObjectId? secondId) ? new GitRevision(secondId) : null;
             if (secondRev is null)
             {
-                MessageBox.Show(this, _strUnableUnderstandPatch.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _strUnableUnderstandPatch.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -373,7 +373,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                 var match = Regex.Match(part, @"^a/([^\n]+) b/([^\n]+)\s*(.*)$", RegexOptions.Singleline);
                 if (!match.Success)
                 {
-                    MessageBox.Show(this, _strUnableUnderstandPatch.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, _strUnableUnderstandPatch.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 
@@ -436,7 +436,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     if (hostedRepository.CloneReadOnlyUrl != remoteUrl)
                     {
                         MessageBox.Show(this, string.Format(_strRemoteAlreadyExist.Text, remoteName, hostedRepository.CloneReadOnlyUrl, remoteUrl),
-                            Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                            TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         return;
                     }
                 }
@@ -511,7 +511,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, _strFailedToClosePullRequest.Text + Environment.NewLine + ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _strFailedToClosePullRequest.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -9,6 +9,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git;
 using GitCommands.Git.Commands;
+using GitExtUtils;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.HelperDialogs;
 using GitUI.Hotkey;
@@ -248,7 +249,7 @@ namespace GitUI.CommandsDialogs
             if (objectId is null)
             {
                 // No parent at all, present as working directory
-                return ResourceManager.Strings.Workspace;
+                return ResourceManager.TranslatedStrings.Workspace;
             }
 
             Validates.NotNull(_revisionGrid);
@@ -534,7 +535,7 @@ namespace GitUI.CommandsDialogs
             saveAsToolStripMenuItem1.Visible = _revisionDiffController.ShouldShowMenuSaveAs(selectionInfo);
             openContainingFolderToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuShowInFolder(selectionInfo);
             diffEditWorkingDirectoryFileToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuEditWorkingDirectoryFile(selectionInfo);
-            diffDeleteFileToolStripMenuItem.Text = ResourceManager.Strings.GetDeleteFile(selectionInfo.SelectedGitItemCount);
+            diffDeleteFileToolStripMenuItem.Text = ResourceManager.TranslatedStrings.GetDeleteFile(selectionInfo.SelectedGitItemCount);
             diffDeleteFileToolStripMenuItem.Enabled = _revisionDiffController.ShouldShowMenuDeleteFile(selectionInfo);
             diffDeleteFileToolStripMenuItem.Visible = diffDeleteFileToolStripMenuItem.Enabled;
 
@@ -764,7 +765,7 @@ namespace GitUI.CommandsDialogs
                 firstRev: DiffFiles.SelectedItem.SecondRevision,
                 secondRev: DiffFiles.SelectedItem.FirstRevision,
                 item: DiffFiles.SelectedItem.Item);
-            if (!GitExtUtils.Strings.IsNullOrWhiteSpace(DiffFiles.SelectedItem.Item.OldName))
+            if (!Strings.IsNullOrWhiteSpace(DiffFiles.SelectedItem.Item.OldName))
             {
                 var name = DiffFiles.SelectedItem.Item.OldName;
                 DiffFiles.SelectedItem.Item.OldName = DiffFiles.SelectedItem.Item.Name;
@@ -905,7 +906,7 @@ namespace GitUI.CommandsDialogs
                 && _rememberFileContextMenuController.ShouldEnableSecondItemDiff(diffFiles[0]);
             diffWithRememberedDifftoolToolStripMenuItem.Text =
                 _rememberFileContextMenuController.RememberedDiffFileItem is not null
-                    ? string.Format(Strings.DiffSelectedWithRememberedFile, _rememberFileContextMenuController.RememberedDiffFileItem.Item.Name)
+                    ? string.Format(TranslatedStrings.DiffSelectedWithRememberedFile, _rememberFileContextMenuController.RememberedDiffFileItem.Item.Name)
                     : string.Empty;
 
             rememberSecondRevDiffToolStripMenuItem.Visible = diffFiles.Count == 1;
@@ -1033,7 +1034,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, _deleteFailed.Text + Environment.NewLine + ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _deleteFailed.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
@@ -184,7 +184,7 @@
             this.openSubmoduleMenuItem.Image = global::GitUI.Properties.Images.GitExtensionsLogo16;
             this.openSubmoduleMenuItem.Name = "openSubmoduleMenuItem";
             this.openSubmoduleMenuItem.Size = new System.Drawing.Size(325, 22);
-            this.openSubmoduleMenuItem.Text = Strings.OpenWithGitExtensions;
+            this.openSubmoduleMenuItem.Text = TranslatedStrings.OpenWithGitExtensions;
             this.openSubmoduleMenuItem.Click += new System.EventHandler(this.openSubmoduleMenuItem_Click);
             // 
             // copyFilenameToClipboardToolStripMenuItem

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -122,7 +122,7 @@ See the changes in the commit form.");
             {
                 if (isIncompleteMatch)
                 {
-                    MessageBox.Show(_nodeNotFoundNextAvailableParentSelected.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(_nodeNotFoundNextAvailableParentSelected.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
                 tvGitTree.SelectedNode = foundNode;
@@ -130,7 +130,7 @@ See the changes in the commit form.");
             }
             else
             {
-                MessageBox.Show(_nodeNotFoundSelectionNotChanged.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(_nodeNotFoundSelectionNotChanged.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -462,7 +462,7 @@ See the changes in the commit form.");
                 selectedItem = searchWindow.SelectedItem;
             }
 
-            if (GitExtUtils.Strings.IsNullOrEmpty(selectedItem))
+            if (Strings.IsNullOrEmpty(selectedItem))
             {
                 return;
             }
@@ -585,7 +585,7 @@ See the changes in the commit form.");
                                                                          && _rememberFileContextMenuController.ShouldEnableSecondItemDiff(fsi);
             diffWithRememberedFileToolStripMenuItem.Text =
                 _rememberFileContextMenuController.RememberedDiffFileItem is not null
-                    ? string.Format(Strings.DiffSelectedWithRememberedFile, _rememberFileContextMenuController.RememberedDiffFileItem.Item.Name)
+                    ? string.Format(TranslatedStrings.DiffSelectedWithRememberedFile, _rememberFileContextMenuController.RememberedDiffFileItem.Item.Name)
                     : string.Empty;
 
             rememberFileStripMenuItem.Visible = isFile;
@@ -777,7 +777,7 @@ See the changes in the commit form.");
 
             if (wereErrors)
             {
-                MessageBox.Show(string.Format(_assumeUnchangedFail.Text, itemStatus.Name), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(string.Format(_assumeUnchangedFail.Text, itemStatus.Name), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else
             {
@@ -806,7 +806,7 @@ See the changes in the commit form.");
             }
             else
             {
-                MessageBox.Show(string.Format(_stopTrackingFail.Text, filename), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(string.Format(_stopTrackingFail.Text, filename), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -4,6 +4,7 @@ using System.IO;
 using GitCommands;
 using GitCommands.Settings;
 using GitCommands.Utils;
+using GitExtUtils;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;
 using Microsoft.Win32;
 
@@ -59,7 +60,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             }
 
             string gitpath = AppSettings.GitCommandValue;
-            if (!GitExtUtils.Strings.IsNullOrWhiteSpace(possibleNewPath))
+            if (!Strings.IsNullOrWhiteSpace(possibleNewPath))
             {
                 gitpath = possibleNewPath.Trim();
             }

--- a/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
@@ -83,7 +83,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             }
             catch (UnauthorizedAccessException)
             {
-                MessageBox.Show(_cantReadRegistry.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(_cantReadRegistry.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             return value ?? "";

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -154,8 +154,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.RefsSortBy = (GitRefsSortBy)_NO_TRANSLATE_cmbBranchesSortBy.SelectedIndex;
 
             AppSettings.Translation = Language.Text;
-            ResourceManager.Strings.Reinitialize();
-            Strings.Reinitialize();
+            ResourceManager.TranslatedStrings.Reinitialize();
+            TranslatedStrings.Reinitialize();
 
             AppSettings.AvatarProvider = (AvatarProvider)AvatarProvider.SelectedValue;
 
@@ -204,7 +204,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
             catch
             {
-                MessageBox.Show(this, string.Format(_noDictFilesFound.Text, AppSettings.GetDictionaryDir()), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, string.Format(_noDictFilesFound.Text, AppSettings.GetDictionaryDir()), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -9,6 +9,7 @@ using GitCommands;
 using GitCommands.Config;
 using GitCommands.DiffMergeTools;
 using GitCommands.Utils;
+using GitExtUtils;
 using Microsoft;
 using Microsoft.Win32;
 using ResourceManager;
@@ -258,7 +259,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                         }
                         else
                         {
-                            MessageBox.Show(this, string.Format(_cantRegisterShellExtension.Text, CommonLogic.GitExtensionsShellEx64Name), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                            MessageBox.Show(this, string.Format(_cantRegisterShellExtension.Text, CommonLogic.GitExtensionsShellEx64Name), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
                     }
                 }
@@ -269,7 +270,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
             else
             {
-                MessageBox.Show(this, string.Format(_cantRegisterShellExtension.Text, CommonLogic.GitExtensionsShellEx32Name), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, string.Format(_cantRegisterShellExtension.Text, CommonLogic.GitExtensionsShellEx32Name), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             CheckSettings();
@@ -363,7 +364,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     }
                     catch (Exception e)
                     {
-                        MessageBox.Show(this, e.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show(this, e.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 }
 
@@ -592,7 +593,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             var installDir = AppSettings.GetInstallDir();
 
-            if (GitExtUtils.Strings.IsNullOrEmpty(installDir))
+            if (Strings.IsNullOrEmpty(installDir))
             {
                 RenderSettingUnset(GitExtensionsInstall, GitExtensionsInstall_Fix, _registryKeyGitExtensionsMissing.Text);
                 return false;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
@@ -11,9 +11,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Text = "Diff Viewer";
             InitializeComplete();
 
-            chkShowDiffForAllParents.Text = Strings.ShowDiffForAllParentsText;
-            chkShowDiffForAllParents.ToolTipText = Strings.ShowDiffForAllParentsTooltip;
-            chkContScrollToNextFileOnlyWithAlt.Text = Strings.ContScrollToNextFileOnlyWithAlt;
+            chkShowDiffForAllParents.Text = TranslatedStrings.ShowDiffForAllParentsText;
+            chkShowDiffForAllParents.ToolTipText = TranslatedStrings.ShowDiffForAllParentsTooltip;
+            chkContScrollToNextFileOnlyWithAlt.Text = TranslatedStrings.ContScrollToNextFileOnlyWithAlt;
         }
 
         protected override void SettingsToPage()

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -210,7 +210,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             {
                 if (string.IsNullOrEmpty(otherHomeDir.Text))
                 {
-                    MessageBox.Show(this, _noHomeDirectorySpecified.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, _noHomeDirectorySpecified.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 
@@ -227,7 +227,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             string path = Environment.GetEnvironmentVariable("HOME");
             if (!Directory.Exists(path) || string.IsNullOrEmpty(path))
             {
-                MessageBox.Show(this, string.Format(_homeNotAccessible.Text, path), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, string.Format(_homeNotAccessible.Text, path), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
 
                 return;
             }

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -48,7 +48,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             {
                 var selectedBranch = UICommands.GitModule.GetSelectedBranch();
                 ExistingBranches = Module.GetRefs(false);
-                comboBoxBranches.Text = Strings.LoadingData;
+                comboBoxBranches.Text = TranslatedStrings.LoadingData;
                 ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     await _branchesLoader.LoadAsync(

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -251,7 +251,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
                     }
                     else
                     {
-                        MessageBox.Show(this, $@"{_deleteWorktreeFailedText.Text}: {workTree.Path}{Environment.NewLine}{errorMessage}", Strings.Error,
+                        MessageBox.Show(this, $@"{_deleteWorktreeFailedText.Text}: {workTree.Path}{Environment.NewLine}{errorMessage}", TranslatedStrings.Error,
                             MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 }

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -169,7 +169,7 @@ namespace GitUI.CommitInfo
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -125,7 +125,7 @@ namespace GitUI.CommitInfo
             }
             catch (Exception ex)
             {
-                MessageBox.Show(this, ex.Message, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/GitUI/CommitInfo/RefsFormatter.cs
+++ b/GitUI/CommitInfo/RefsFormatter.cs
@@ -38,7 +38,7 @@ namespace GitUI.CommitInfo
             }
 
             var (formattedBranches, truncated) = FilterAndFormatBranches(branches, showAsLinks, limit);
-            return ToString(formattedBranches, Strings.ContainedInBranches, Strings.ContainedInNoBranch, "branches", truncated);
+            return ToString(formattedBranches, TranslatedStrings.ContainedInBranches, TranslatedStrings.ContainedInNoBranch, "branches", truncated);
         }
 
         public string FormatTags(IReadOnlyList<string> tags, bool showAsLinks, bool limit)
@@ -50,7 +50,7 @@ namespace GitUI.CommitInfo
 
             bool truncate = limit && tags.Count > MaximumDisplayedLinesIfLimited;
             var formattedTags = FormatTags(truncate ? tags.Take(MaximumDisplayedRefsIfLimited) : tags);
-            return ToString(formattedTags, Strings.ContainedInTags, Strings.ContainedInNoTag, "tags", truncate);
+            return ToString(formattedTags, TranslatedStrings.ContainedInTags, TranslatedStrings.ContainedInNoTag, "tags", truncate);
 
             IEnumerable<string> FormatTags(IEnumerable<string> selectedTags)
             {

--- a/GitUI/CustomDiffMergeToolProvider.cs
+++ b/GitUI/CustomDiffMergeToolProvider.cs
@@ -85,7 +85,7 @@ namespace GitUI
                         menu.MenuItem.DropDown.Items.Add(new ToolStripSeparator());
                         var disableItem = new ToolStripMenuItem
                         {
-                            Text = ResourceManager.Strings.DisableMenuItem
+                            Text = ResourceManager.TranslatedStrings.DisableMenuItem
                         };
 
                         disableItem.Click += (o, s) =>

--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -93,7 +93,7 @@ namespace GitUI.Editor
             this.stageSelectedLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.Stage;
             this.stageSelectedLinesToolStripMenuItem.Name = "stageSelectedLinesToolStripMenuItem";
             this.stageSelectedLinesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.stageSelectedLinesToolStripMenuItem.Text = Strings.StageSelectedLines;
+            this.stageSelectedLinesToolStripMenuItem.Text = TranslatedStrings.StageSelectedLines;
             this.stageSelectedLinesToolStripMenuItem.Click += new System.EventHandler(this.stageSelectedLinesToolStripMenuItem_Click);
             // 
             // unstageSelectedLinesToolStripMenuItem
@@ -101,7 +101,7 @@ namespace GitUI.Editor
             this.unstageSelectedLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.Unstage;
             this.unstageSelectedLinesToolStripMenuItem.Name = "chunstageSelectedLinesToolStripMenuItemerrypickSelectedLinesToolStripMenuItem";
             this.unstageSelectedLinesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.unstageSelectedLinesToolStripMenuItem.Text = Strings.UnstageSelectedLines;
+            this.unstageSelectedLinesToolStripMenuItem.Text = TranslatedStrings.UnstageSelectedLines;
             this.unstageSelectedLinesToolStripMenuItem.Click += new System.EventHandler(this.unstageSelectedLinesToolStripMenuItem_Click);
             // 
             // resetSelectedLinesToolStripMenuItem
@@ -109,7 +109,7 @@ namespace GitUI.Editor
             this.resetSelectedLinesToolStripMenuItem.Image = global::GitUI.Properties.Images.ResetWorkingDirChanges;
             this.resetSelectedLinesToolStripMenuItem.Name = "resetSelectedLinesToolStripMenuItem";
             this.resetSelectedLinesToolStripMenuItem.Size = new System.Drawing.Size(243, 22);
-            this.resetSelectedLinesToolStripMenuItem.Text = Strings.ResetSelectedLines;
+            this.resetSelectedLinesToolStripMenuItem.Text = TranslatedStrings.ResetSelectedLines;
             this.resetSelectedLinesToolStripMenuItem.Click += new System.EventHandler(this.resetSelectedLinesToolStripMenuItem_Click);
             // 
             // copyToolStripMenuItem

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -153,7 +153,7 @@ namespace GitUI.Editor
             ShowSyntaxHighlightingInDiff = AppSettings.ShowSyntaxHighlightingInDiff;
             showSyntaxHighlighting.Image = Resources.SyntaxHighlighting.AdaptLightness();
             showSyntaxHighlighting.Checked = ShowSyntaxHighlightingInDiff;
-            automaticContinuousScrollToolStripMenuItem.Text = Strings.ContScrollToNextFileOnlyWithAlt;
+            automaticContinuousScrollToolStripMenuItem.Text = TranslatedStrings.ContScrollToNextFileOnlyWithAlt;
 
             IsReadOnly = true;
 
@@ -876,7 +876,7 @@ namespace GitUI.Editor
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show(this, $"{ex.Message}{Environment.NewLine}{fileName}", Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, $"{ex.Message}{Environment.NewLine}{fileName}", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
                 // If the file does not exist, it doesn't matter what size we
@@ -977,7 +977,7 @@ namespace GitUI.Editor
             _viewMode = viewMode;
             _viewItem = item;
             if (_viewMode == ViewMode.Text
-                && !GitExtUtils.Strings.IsNullOrEmpty(fileName)
+                && !Strings.IsNullOrEmpty(fileName)
                 && (fileName.EndsWith(".diff", StringComparison.OrdinalIgnoreCase)
                     || fileName.EndsWith(".patch", StringComparison.OrdinalIgnoreCase)))
             {
@@ -1470,7 +1470,7 @@ namespace GitUI.Editor
                 return;
             }
 
-            if (MessageBox.Show(this, Strings.ResetSelectedLinesConfirmation, Strings.ResetChangesCaption,
+            if (MessageBox.Show(this, TranslatedStrings.ResetSelectedLinesConfirmation, TranslatedStrings.ResetChangesCaption,
                 MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.No)
             {
                 return;
@@ -1592,7 +1592,7 @@ namespace GitUI.Editor
             {
                 if (patchUpdateDiff || !MergeConflictHandler.HandleMergeConflicts(UICommands, this, false, false))
                 {
-                    MessageBox.Show(this, output + "\n\n" + Encoding.GetString(patch), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, output + "\n\n" + Encoding.GetString(patch), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
 

--- a/GitUI/FilterBranchHelper.cs
+++ b/GitUI/FilterBranchHelper.cs
@@ -20,7 +20,7 @@ namespace GitUI
         private readonly ToolStripMenuItem _remoteToolStripMenuItem;
         private GitModule Module => _NO_TRANSLATE_RevisionGrid.Module;
 
-        private static readonly string[] _noResultsFound = { Strings.NoResultsFound };
+        private static readonly string[] _noResultsFound = { TranslatedStrings.NoResultsFound };
 
         public FilterBranchHelper(ToolStripComboBox toolStripBranches, ToolStripDropDownButton toolStripDropDownButton2, RevisionGridControl revisionGrid)
         {
@@ -32,7 +32,7 @@ namespace GitUI
                 Checked = true,
                 CheckOnClick = true,
                 Name = "localToolStripMenuItem",
-                Text = Strings.Local
+                Text = TranslatedStrings.Local
             };
 
             //
@@ -42,7 +42,7 @@ namespace GitUI
             {
                 CheckOnClick = true,
                 Name = "tagToolStripMenuItem",
-                Text = Strings.Tag
+                Text = TranslatedStrings.Tag
             };
 
             //
@@ -53,7 +53,7 @@ namespace GitUI
                 CheckOnClick = true,
                 Name = "remoteToolStripMenuItem",
                 Size = new System.Drawing.Size(115, 22),
-                Text = Strings.Remote
+                Text = TranslatedStrings.Remote
             };
 
             _NO_TRANSLATE_toolStripBranches = toolStripBranches;
@@ -190,7 +190,7 @@ namespace GitUI
             {
                 string filter = _NO_TRANSLATE_toolStripBranches.Items.Count > 0 ? _NO_TRANSLATE_toolStripBranches.Text : string.Empty;
 
-                if (filter == Strings.NoResultsFound)
+                if (filter == TranslatedStrings.NoResultsFound)
                 {
                     filter = string.Empty;
                 }

--- a/GitUI/GitExtensionsDialog.cs
+++ b/GitUI/GitExtensionsDialog.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
+using GitExtUtils;
 using GitExtUtils.GitUI.Theming;
 
 namespace GitUI
@@ -59,7 +60,7 @@ namespace GitUI
         protected override void OnHelpButtonClicked(CancelEventArgs e)
         {
             // If we show the Help button but we have failed to specify where the docs are -> hide the button, and exit
-            if (GitExtUtils.Strings.IsNullOrWhiteSpace(ManualSectionAnchorName) || GitExtUtils.Strings.IsNullOrWhiteSpace(ManualSectionSubfolder))
+            if (Strings.IsNullOrWhiteSpace(ManualSectionAnchorName) || Strings.IsNullOrWhiteSpace(ManualSectionSubfolder))
             {
                 HelpButton = false;
                 e.Cancel = true;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -178,7 +178,7 @@ namespace GitUI
             var objectId = Module.RevParse(branch);
             if (objectId is null)
             {
-                MessageBox.Show($"Branch \"{branch}\" could not be resolved.", Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show($"Branch \"{branch}\" could not be resolved.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
@@ -404,7 +404,7 @@ namespace GitUI
             var objectId = Module.RevParse(branch);
             if (objectId is null)
             {
-                MessageBox.Show($"Branch \"{branch}\" could not be resolved.", Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show($"Branch \"{branch}\" could not be resolved.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
@@ -587,7 +587,7 @@ namespace GitUI
             bool Action()
             {
                 using var viewPatch = new FormViewPatch(this);
-                if (!GitExtUtils.Strings.IsNullOrEmpty(patchFile))
+                if (!Strings.IsNullOrEmpty(patchFile))
                 {
                     viewPatch.LoadPatch(patchFile);
                 }
@@ -736,13 +736,13 @@ namespace GitUI
                         }
                         catch (Exception ex)
                         {
-                            errorCaption = Strings.ErrorCaptionFailedDeleteFile;
+                            errorCaption = TranslatedStrings.ErrorCaptionFailedDeleteFile;
                             errorMessage = ex.Message;
                         }
                     }
                     else
                     {
-                        errorCaption = Strings.ErrorCaptionFailedDeleteFolder;
+                        errorCaption = TranslatedStrings.ErrorCaptionFailedDeleteFolder;
                         path.TryDeleteDirectory(out errorMessage);
                     }
 
@@ -1143,14 +1143,14 @@ namespace GitUI
 
             if (!RevisionDiffInfoProvider.TryGet(revisions, diffKind, out var firstRevision, out var secondRevision, out var error))
             {
-                MessageBox.Show(owner, error, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(owner, error, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else
             {
                 string output = Module.OpenWithDifftool(fileName, oldFileName, firstRevision, secondRevision, isTracked: isTracked, customTool: customTool);
                 if (!string.IsNullOrEmpty(output))
                 {
-                    MessageBox.Show(owner, output, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(owner, output, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
         }
@@ -1285,7 +1285,7 @@ namespace GitUI
 
         public void StartCloneForkFromHoster(IWin32Window? owner, IRepositoryHostPlugin gitHoster, EventHandler<GitModuleEventArgs>? gitModuleChanged)
         {
-            WrapRepoHostingCall(Strings.ForkCloneRepo, gitHoster, gh =>
+            WrapRepoHostingCall(TranslatedStrings.ForkCloneRepo, gitHoster, gh =>
             {
                 using var frm = new ForkAndCloneForm(gitHoster, gitModuleChanged);
                 frm.ShowDialog(owner);
@@ -1294,7 +1294,7 @@ namespace GitUI
 
         internal void StartPullRequestsDialog(IWin32Window? owner, IRepositoryHostPlugin gitHoster)
         {
-            WrapRepoHostingCall(Strings.ViewPullRequest, gitHoster,
+            WrapRepoHostingCall(TranslatedStrings.ViewPullRequest, gitHoster,
                                 gh =>
                                 {
                                     var frm = new ViewPullRequestsForm(this, gitHoster) { ShowInTaskbar = true };
@@ -1309,7 +1309,7 @@ namespace GitUI
 
             if (relevantHosts.Count == 0)
             {
-                MessageBox.Show(owner, "Could not find any repo hosts for current working directory", Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(owner, "Could not find any repo hosts for current working directory", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else if (relevantHosts.Count == 1)
             {
@@ -1317,14 +1317,14 @@ namespace GitUI
             }
             else
             {
-                MessageBox.Show("StartCreatePullRequest:Selection not implemented!", Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show("StartCreatePullRequest:Selection not implemented!", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
         public void StartCreatePullRequest(IWin32Window? owner, IRepositoryHostPlugin gitHoster, string? chooseRemote = null, string? chooseBranch = null)
         {
             WrapRepoHostingCall(
-                Strings.CreatePullRequest,
+                TranslatedStrings.CreatePullRequest,
                 gitHoster,
                 gh =>
                 {

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Patches;
+using GitExtUtils;
 using GitUI.Editor;
 using GitUI.UserControls;
 using GitUI.UserControls.RevisionGrid;
@@ -107,8 +108,8 @@ namespace GitUI
                     var diffOfConflict = fileViewer.Module.GetCombinedDiffContent(selectedId, file.Name,
                         fileViewer.GetExtraDiffArguments(), fileViewer.Encoding);
 
-                    return GitExtUtils.Strings.IsNullOrWhiteSpace(diffOfConflict)
-                        ? Strings.UninterestingDiffOmitted
+                    return Strings.IsNullOrWhiteSpace(diffOfConflict)
+                        ? TranslatedStrings.UninterestingDiffOmitted
                         : diffOfConflict;
                 }
 

--- a/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -18,7 +18,7 @@ namespace GitUI.HelperDialogs
         private readonly TranslationString _localRefInvalid = new("The entered value '{0}' is not the name of an existing local branch.");
 
         public static FormResetAnotherBranch Create(GitUICommands gitUiCommands, GitRevision revision)
-            => new FormResetAnotherBranch(gitUiCommands, revision ?? throw new NotSupportedException(Strings.NoRevision));
+            => new FormResetAnotherBranch(gitUiCommands, revision ?? throw new NotSupportedException(TranslatedStrings.NoRevision));
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -90,7 +90,7 @@ namespace GitUI.HelperDialogs
             var gitRefToReset = _localGitRefs.FirstOrDefault(b => b.Name == Branches.Text);
             if (gitRefToReset is null)
             {
-                MessageBox.Show(string.Format(_localRefInvalid.Text, Branches.Text), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(string.Format(_localRefInvalid.Text, Branches.Text), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -24,7 +24,7 @@ namespace GitUI.HelperDialogs
         }
 
         public static FormResetCurrentBranch Create(GitUICommands commands, GitRevision revision, ResetType resetType = ResetType.Mixed)
-            => new FormResetCurrentBranch(commands, revision ?? throw new NotSupportedException(Strings.NoRevision), resetType);
+            => new FormResetCurrentBranch(commands, revision ?? throw new NotSupportedException(TranslatedStrings.NoRevision), resetType);
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Windows.Forms;
 using System.Xml.Serialization;
 using GitCommands;
+using GitExtUtils;
 using GitUI.CommandsDialogs;
 using GitUI.Editor;
 using GitUI.Script;
@@ -162,7 +163,7 @@ namespace GitUI.Hotkey
         {
             MigrateSettings();
 
-            if (!GitExtUtils.Strings.IsNullOrWhiteSpace(AppSettings.SerializedHotkeys))
+            if (!Strings.IsNullOrWhiteSpace(AppSettings.SerializedHotkeys))
             {
                 return LoadSerializedSettings(AppSettings.SerializedHotkeys);
             }

--- a/GitUI/MessageBoxes.cs
+++ b/GitUI/MessageBoxes.cs
@@ -64,9 +64,9 @@ namespace GitUI
 
         public static void ShowGitConfigurationExceptionMessage(IWin32Window? owner, GitConfigurationException exception)
             => Show(owner,
-                    string.Format(ResourceManager.Strings.GeneralGitConfigExceptionMessage,
+                    string.Format(ResourceManager.TranslatedStrings.GeneralGitConfigExceptionMessage,
                                   exception.ConfigPath, Environment.NewLine, (exception.InnerException ?? exception).Message),
-                    ResourceManager.Strings.GeneralGitConfigExceptionCaption,
+                    ResourceManager.TranslatedStrings.GeneralGitConfigExceptionCaption,
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Warning);
 
@@ -120,7 +120,7 @@ namespace GitUI
             => ShowError(owner, Instance._shellNotFound.Text, Instance._shellNotFoundCaption.Text);
 
         public static void ShowError(IWin32Window? owner, string text, string? caption = null)
-            => Show(owner, text, caption ?? Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            => Show(owner, text, caption ?? TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
 
         private static bool Confirm(IWin32Window? owner, string text, string caption)
             => Show(owner, text, caption, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes;

--- a/GitUI/NBugReports/BugReporter.cs
+++ b/GitUI/NBugReports/BugReporter.cs
@@ -23,23 +23,23 @@ namespace GitExtensions
             // Command: <command>
             if (!string.IsNullOrWhiteSpace(exception.Command))
             {
-                sb.AppendLine($"{GitUI.Strings.Command}: {exception.Command}");
+                sb.AppendLine($"{TranslatedStrings.Command}: {exception.Command}");
             }
 
             // Arguments: <args>
             if (!string.IsNullOrWhiteSpace(exception.Arguments))
             {
-                sb.AppendLine($"{GitUI.Strings.Arguments}: {exception.Arguments}");
+                sb.AppendLine($"{TranslatedStrings.Arguments}: {exception.Arguments}");
             }
 
             // Working directory: <working dir>
-            sb.AppendLine($"{GitUI.Strings.WorkingDirectory}: {exception.WorkingDirectory}");
+            sb.AppendLine($"{TranslatedStrings.WorkingDirectory}: {exception.WorkingDirectory}");
 
             if (canRaiseBug)
             {
                 // Directions to raise a bug
                 sb.AppendLine();
-                sb.AppendLine(GitUI.Strings.ReportBug);
+                sb.AppendLine(TranslatedStrings.ReportBug);
             }
 
             return sb.ToString();
@@ -68,7 +68,7 @@ namespace GitExtensions
         private static void ReportAppException(ExternalOperationException exception, bool isTerminating)
         {
             // UserExternalOperationException wraps an actual exception, but be cautious just in case
-            string instructionText = exception.InnerException?.Message ?? GitUI.Strings.InstructionOperationFailed;
+            string instructionText = exception.InnerException?.Message ?? TranslatedStrings.InstructionOperationFailed;
 
             ShowException(FormatText(exception, canRaiseBug: true), instructionText, exception, isTerminating);
         }
@@ -82,7 +82,7 @@ namespace GitExtensions
                 moreInfo += Environment.NewLine + Environment.NewLine;
             }
 
-            ShowException($"{moreInfo}{GitUI.Strings.ReportBug}", exception.Message, exception, isTerminating);
+            ShowException($"{moreInfo}{TranslatedStrings.ReportBug}", exception.Message, exception, isTerminating);
         }
 
         private static void ReportUserException(UserExternalOperationException exception, bool isTerminating)
@@ -95,14 +95,14 @@ namespace GitExtensions
                 OwnerWindowHandle = OwnerFormHandle,
                 Text = text,
                 InstructionText = instructionText,
-                Caption = GitUI.Strings.Error,
+                Caption = TranslatedStrings.Error,
                 Icon = TaskDialogStandardIcon.Error,
                 Cancelable = true,
             };
 
             if (exception is not null)
             {
-                var btnReport = new TaskDialogCommandLink("Report", GitUI.Strings.ButtonReportBug);
+                var btnReport = new TaskDialogCommandLink("Report", TranslatedStrings.ButtonReportBug);
                 btnReport.Click += (s, e) =>
                 {
                     dialog.Close();
@@ -112,7 +112,7 @@ namespace GitExtensions
                 dialog.Controls.Add(btnReport);
             }
 
-            var btnIgnoreOrClose = new TaskDialogCommandLink("IgnoreOrClose", isTerminating ? GitUI.Strings.ButtonCloseApp : GitUI.Strings.ButtonIgnore);
+            var btnIgnoreOrClose = new TaskDialogCommandLink("IgnoreOrClose", isTerminating ? TranslatedStrings.ButtonCloseApp : TranslatedStrings.ButtonIgnore);
             btnIgnoreOrClose.Click += (s, e) =>
             {
                 dialog.Close();

--- a/GitUI/NBugReports/ErrorReportMarkDownBodyBuilder.cs
+++ b/GitUI/NBugReports/ErrorReportMarkDownBodyBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using GitExtUtils;
 
 namespace GitUI.NBugReports
 {
@@ -45,7 +46,7 @@ namespace GitUI.NBugReports
             sb.AppendLine();
             sb.AppendLine();
 
-            if (!GitExtUtils.Strings.IsNullOrWhiteSpace(additionalInfo))
+            if (!Strings.IsNullOrWhiteSpace(additionalInfo))
             {
                 sb.AppendLine("## Additional information");
                 sb.AppendLine(additionalInfo.Trim());
@@ -57,7 +58,7 @@ namespace GitUI.NBugReports
             {
                 sb.AppendLine("## Environment");
 
-                if (!GitExtUtils.Strings.IsNullOrWhiteSpace(environmentInfo))
+                if (!Strings.IsNullOrWhiteSpace(environmentInfo))
                 {
                     sb.AppendLine(environmentInfo);
                 }

--- a/GitUI/OsShellUtil.cs
+++ b/GitUI/OsShellUtil.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils;
 using Microsoft.WindowsAPICodePack.Dialogs;
 namespace GitUI
 {
@@ -46,7 +47,7 @@ namespace GitUI
         /// </summary>
         public static void OpenUrlInDefaultBrowser(string? url)
         {
-            if (!GitExtUtils.Strings.IsNullOrWhiteSpace(url))
+            if (!Strings.IsNullOrWhiteSpace(url))
             {
                 new Executable(url).Start(useShellExecute: true);
             }

--- a/GitUI/RepositoryCurrentBranchNameProvider.cs
+++ b/GitUI/RepositoryCurrentBranchNameProvider.cs
@@ -20,7 +20,7 @@ namespace GitUI
             string branchName = GitModule.GetSelectedBranchFast(repositoryPath);
             if (string.IsNullOrWhiteSpace(branchName) || branchName == DetachedHeadParser.DetachedBranch)
             {
-                branchName = $"({Strings.NoBranch})";
+                branchName = $"({TranslatedStrings.NoBranch})";
             }
 
             return branchName;

--- a/GitUI/Script/ScriptManager.cs
+++ b/GitUI/Script/ScriptManager.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Xml;
 using System.Xml.Serialization;
 using GitCommands;
+using GitExtUtils;
 
 namespace GitUI.Script
 {
@@ -78,7 +79,7 @@ namespace GitUI.Script
         private static BindingList<ScriptInfo> DeserializeFromXml(string? xml)
         {
             // When there is nothing to deserialize, add default scripts
-            if (GitExtUtils.Strings.IsNullOrEmpty(xml))
+            if (Strings.IsNullOrEmpty(xml))
             {
                 return GetDefaultScripts();
             }

--- a/GitUI/Script/ScriptOptionsParser.cs
+++ b/GitUI/Script/ScriptOptionsParser.cs
@@ -6,6 +6,7 @@ using System.Windows.Forms;
 using GitCommands.Config;
 using GitCommands.Git;
 using GitCommands.UserRepositoryHistory;
+using GitExtUtils;
 using GitUI.UserControls.RevisionGrid;
 using GitUIPluginInterfaces;
 
@@ -88,7 +89,7 @@ namespace GitUI.Script
 
         public static (string? arguments, bool abort) Parse(string? arguments, IGitModule module, IWin32Window owner, IScriptHostControl? scriptHostControl)
         {
-            if (GitExtUtils.Strings.IsNullOrWhiteSpace(arguments))
+            if (Strings.IsNullOrWhiteSpace(arguments))
             {
                 return (arguments, abort: false);
             }

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -41,13 +41,13 @@ namespace GitUI.Script
             catch (ExternalOperationException ex) when (ex is not UserExternalOperationException)
             {
                 ThreadHelper.AssertOnUIThread();
-                throw new UserExternalOperationException($"{Strings.ScriptErrorFailedToExecute}: '{scriptKey}'", ex);
+                throw new UserExternalOperationException($"{TranslatedStrings.ScriptErrorFailedToExecute}: '{scriptKey}'", ex);
             }
         }
 
         private static CommandStatus RunScriptInternal(IWin32Window owner, IGitModule module, string? scriptKey, IGitUICommands uiCommands, RevisionGridControl? revisionGrid)
         {
-            if (GitExtUtils.Strings.IsNullOrEmpty(scriptKey))
+            if (Strings.IsNullOrEmpty(scriptKey))
             {
                 return false;
             }
@@ -56,17 +56,17 @@ namespace GitUI.Script
             if (scriptInfo is null)
             {
                 ThreadHelper.AssertOnUIThread();
-                throw new UserExternalOperationException($"{Strings.ScriptErrorCantFind}: '{scriptKey}'",
+                throw new UserExternalOperationException($"{TranslatedStrings.ScriptErrorCantFind}: '{scriptKey}'",
                     new ExternalOperationException(command: null, arguments: null, module.WorkingDir, innerException: null));
             }
 
-            if (GitExtUtils.Strings.IsNullOrEmpty(scriptInfo.Command))
+            if (Strings.IsNullOrEmpty(scriptInfo.Command))
             {
                 return false;
             }
 
             string? arguments = scriptInfo.Arguments;
-            if (!GitExtUtils.Strings.IsNullOrEmpty(arguments) && revisionGrid is null)
+            if (!Strings.IsNullOrEmpty(arguments) && revisionGrid is null)
             {
                 string? optionDependingOnSelectedRevision
                     = ScriptOptionsParser.Options.FirstOrDefault(option => ScriptOptionsParser.DependsOnSelectedRevision(option)
@@ -74,13 +74,13 @@ namespace GitUI.Script
                 if (optionDependingOnSelectedRevision is not null)
                 {
                     ThreadHelper.AssertOnUIThread();
-                    throw new UserExternalOperationException($"{Strings.ScriptText}: '{scriptKey}'{Environment.NewLine}'{optionDependingOnSelectedRevision}' {Strings.ScriptErrorOptionWithoutRevisionGridText}",
+                    throw new UserExternalOperationException($"{TranslatedStrings.ScriptText}: '{scriptKey}'{Environment.NewLine}'{optionDependingOnSelectedRevision}' {TranslatedStrings.ScriptErrorOptionWithoutRevisionGridText}",
                         new ExternalOperationException(scriptInfo.Command, arguments, module.WorkingDir, innerException: null));
                 }
             }
 
             if (scriptInfo.AskConfirmation &&
-                MessageBox.Show(owner, $"{Strings.ScriptConfirmExecute}: '{scriptInfo.Name}'?", Strings.ScriptText,
+                MessageBox.Show(owner, $"{TranslatedStrings.ScriptConfirmExecute}: '{scriptInfo.Name}'?", TranslatedStrings.ScriptText,
                                 MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
             {
                 return false;
@@ -91,7 +91,7 @@ namespace GitUI.Script
             if (abort)
             {
                 ThreadHelper.AssertOnUIThread();
-                throw new UserExternalOperationException($"{Strings.ScriptText}: '{scriptKey}'{Environment.NewLine}{Strings.ScriptErrorOptionWithoutRevisionText}",
+                throw new UserExternalOperationException($"{TranslatedStrings.ScriptText}: '{scriptKey}'{Environment.NewLine}{TranslatedStrings.ScriptErrorOptionWithoutRevisionText}",
                     new ExternalOperationException(scriptInfo.Command, arguments, module.WorkingDir, innerException: null));
             }
 
@@ -136,7 +136,7 @@ namespace GitUI.Script
                 }
 
                 command = command.Replace(NavigateToPrefix, string.Empty);
-                if (!GitExtUtils.Strings.IsNullOrEmpty(command))
+                if (!Strings.IsNullOrEmpty(command))
                 {
                     var revisionRef = new Executable(command, module.WorkingDir).GetOutputLines(argument).FirstOrDefault();
 

--- a/GitUI/Shells/ConEmuControlExtensions.cs
+++ b/GitUI/Shells/ConEmuControlExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using ConEmu.WinForms;
+using GitExtUtils;
 
 namespace GitUI.Shells
 {
@@ -7,7 +8,7 @@ namespace GitUI.Shells
     {
         public static void ChangeFolder(this ConEmuControl? terminal, IShellDescriptor? shell, string? path)
         {
-            if (terminal?.RunningSession is null || shell is null || GitExtUtils.Strings.IsNullOrWhiteSpace(path))
+            if (terminal?.RunningSession is null || shell is null || Strings.IsNullOrWhiteSpace(path))
             {
                 return;
             }

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -4,7 +4,7 @@ using ResourceManager;
 
 namespace GitUI
 {
-    internal sealed class Strings : Translate
+    internal sealed class TranslatedStrings : Translate
     {
         private readonly TranslationString _error = new("Error");
         private readonly TranslationString _warning = new("Warning");
@@ -104,18 +104,18 @@ namespace GitUI
         private readonly TranslationString _reportBugText = new("If you think this was caused by Git Extensions, you can report a bug for the team to investigate.");
 
         // public only because of FormTranslate
-        public Strings()
+        public TranslatedStrings()
         {
             Translator.Translate(this, AppSettings.CurrentTranslation);
         }
 
-        private static Lazy<Strings> _instance = new Lazy<Strings>();
+        private static Lazy<TranslatedStrings> _instance = new Lazy<TranslatedStrings>();
 
         public static void Reinitialize()
         {
             if (_instance.IsValueCreated)
             {
-                _instance = new Lazy<Strings>();
+                _instance = new Lazy<TranslatedStrings>();
             }
         }
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9468,7 +9468,35 @@ When OpenSSH is used, command line dialogs are shown!
       </trans-unit>
     </body>
   </file>
-  <file datatype="plaintext" original="Strings" source-language="en">
+  <file datatype="plaintext" original="TagMenuItemsStrings" source-language="en">
+    <body>
+      <trans-unit id="CheckoutTooltip.Text">
+        <source>Checkout this tag</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="CreateTooltip.Text">
+        <source>Create a local branch from this tag</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="DeleteTooltip.Text">
+        <source>Delete this tag</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="MergeTooltip.Text">
+        <source>Merge this tag into current branch</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="RebaseTooltip.Text">
+        <source>Rebase current branch to this tag</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="ResetTooltip.Text">
+        <source>Reset current branch to here</source>
+        <target />
+      </trans-unit>
+    </body>
+  </file>
+  <file datatype="plaintext" original="TranslatedStrings" source-language="en">
     <body>
       <trans-unit id="_argumentsText.Text">
         <source>Arguments</source>
@@ -9917,34 +9945,6 @@ Yes, I allow telemetry!</source>
       </trans-unit>
       <trans-unit id="_yes.Text">
         <source>Yes</source>
-        <target />
-      </trans-unit>
-    </body>
-  </file>
-  <file datatype="plaintext" original="TagMenuItemsStrings" source-language="en">
-    <body>
-      <trans-unit id="CheckoutTooltip.Text">
-        <source>Checkout this tag</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="CreateTooltip.Text">
-        <source>Create a local branch from this tag</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="DeleteTooltip.Text">
-        <source>Delete this tag</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="MergeTooltip.Text">
-        <source>Merge this tag into current branch</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="RebaseTooltip.Text">
-        <source>Rebase current branch to this tag</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="ResetTooltip.Text">
-        <source>Reset current branch to here</source>
         <target />
       </trans-unit>
     </body>

--- a/GitUI/UserControls/AvatarControl.cs
+++ b/GitUI/UserControls/AvatarControl.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Utils;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.Avatars;
 using GitUI.Properties;
@@ -129,7 +130,7 @@ namespace GitUI
 
             var email = Email;
 
-            if (!AppSettings.ShowAuthorAvatarInCommitInfo || GitExtUtils.Strings.IsNullOrWhiteSpace(email))
+            if (!AppSettings.ShowAuthorAvatarInCommitInfo || Strings.IsNullOrWhiteSpace(email))
             {
                 RefreshImage(Images.User80);
                 return;

--- a/GitUI/UserControls/BranchComboBox.cs
+++ b/GitUI/UserControls/BranchComboBox.cs
@@ -51,7 +51,7 @@ namespace GitUI
                 var gitHead = _branchesToSelect.FirstOrDefault(g => g.Name == branch);
                 if (gitHead is null)
                 {
-                    MessageBox.Show(string.Format(_branchCheckoutError.Text, branch), Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(string.Format(_branchCheckoutError.Text, branch), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
                 else
                 {

--- a/GitUI/UserControls/CommitPickerSmallControl.cs
+++ b/GitUI/UserControls/CommitPickerSmallControl.cs
@@ -38,7 +38,7 @@ namespace GitUI.UserControls
             if (SelectedObjectId is null && !string.IsNullOrWhiteSpace(commitHash))
             {
                 SelectedObjectId = oldCommitHash;
-                MessageBox.Show("The given commit hash is not valid for this repository and was therefore discarded.", Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show("The given commit hash is not valid for this repository and was therefore discarded.", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else
             {

--- a/GitUI/UserControls/CommitSummaryUserControl.cs
+++ b/GitUI/UserControls/CommitSummaryUserControl.cs
@@ -52,8 +52,8 @@ namespace GitUI.UserControls
             {
                 _revision = value;
 
-                labelAuthorCaption.Text = ResourceManager.Strings.Author + ":";
-                labelDateCaption.Text = ResourceManager.Strings.CommitDate + ":";
+                labelAuthorCaption.Text = ResourceManager.TranslatedStrings.Author + ":";
+                labelDateCaption.Text = ResourceManager.TranslatedStrings.CommitDate + ":";
                 labelTagsCaption.Text = _tagsCaption;
                 labelBranchesCaption.Text = _branchesCaption;
 

--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -52,7 +52,7 @@ namespace GitUI
                             new FileStatusWithDescription(
                                 firstRev: new GitRevision(parentId),
                                 secondRev: selectedRev,
-                                summary: Strings.DiffWithParent + GetDescriptionForRevision(describeRevision, parentId),
+                                summary: TranslatedStrings.DiffWithParent + GetDescriptionForRevision(describeRevision, parentId),
                                 statuses: module.GetDiffFilesWithSubmodulesStatus(parentId, selectedRev.ObjectId, selectedRev.FirstParentId))));
                 }
 
@@ -65,7 +65,7 @@ namespace GitUI
                     {
                         // Create an artificial commit
                         fileStatusDescs.Add(new FileStatusWithDescription(
-                            firstRev: new GitRevision(ObjectId.CombinedDiffId), secondRev: selectedRev, summary: Strings.CombinedDiff, statuses: conflicts));
+                            firstRev: new GitRevision(ObjectId.CombinedDiffId), secondRev: selectedRev, summary: TranslatedStrings.CombinedDiff, statuses: conflicts));
                     }
                 }
 
@@ -85,7 +85,7 @@ namespace GitUI
             fileStatusDescs.Add(new FileStatusWithDescription(
                 firstRev: firstRev,
                 secondRev: selectedRev,
-                summary: Strings.DiffWithParent + GetDescriptionForRevision(describeRevision, firstRev.ObjectId),
+                summary: TranslatedStrings.DiffWithParent + GetDescriptionForRevision(describeRevision, firstRev.ObjectId),
                 statuses: module.GetDiffFilesWithSubmodulesStatus(firstRev.ObjectId, selectedRev.ObjectId, selectedRev.FirstParentId)));
 
             if (!AppSettings.ShowDiffForAllParents || revisions.Count > maxMultiCompare)
@@ -146,7 +146,7 @@ namespace GitUI
                         .Select(rev => new FileStatusWithDescription(
                             firstRev: rev,
                             secondRev: selectedRev,
-                            summary: Strings.DiffWithParent + GetDescriptionForRevision(describeRevision, rev.ObjectId),
+                            summary: TranslatedStrings.DiffWithParent + GetDescriptionForRevision(describeRevision, rev.ObjectId),
                             statuses: module.GetDiffFilesWithSubmodulesStatus(rev.ObjectId, selectedRev.ObjectId, selectedRev.FirstParentId))));
 
                 return fileStatusDescs;
@@ -166,26 +166,26 @@ namespace GitUI
             fileStatusDescs.Add(new FileStatusWithDescription(
                 firstRev: revBase,
                 secondRev: selectedRev,
-                summary: Strings.DiffBaseToB + GetDescriptionForRevision(describeRevision, selectedRev.ObjectId),
+                summary: TranslatedStrings.DiffBaseToB + GetDescriptionForRevision(describeRevision, selectedRev.ObjectId),
                 statuses: allBaseToB.Except(commonBaseToAandB, comparer).ToList()));
             fileStatusDescs.Add(new FileStatusWithDescription(
                 firstRev: revBase,
                 secondRev: firstRev,
-                summary: Strings.DiffBaseToB + GetDescriptionForRevision(describeRevision, firstRev.ObjectId),
+                summary: TranslatedStrings.DiffBaseToB + GetDescriptionForRevision(describeRevision, firstRev.ObjectId),
                 statuses: allBaseToA.Except(commonBaseToAandB, comparer).ToList()));
             fileStatusDescs.Add(new FileStatusWithDescription(
                 firstRev: revBase,
                 secondRev: selectedRev,
-                summary: Strings.DiffCommonBase + GetDescriptionForRevision(describeRevision, baseRevGuid),
+                summary: TranslatedStrings.DiffCommonBase + GetDescriptionForRevision(describeRevision, baseRevGuid),
                 statuses: commonBaseToAandB));
 
             // Add rangeDiff as a separate group (range is not the same as diff with artificial commits)
-            var statuses = new List<GitItemStatus> { new GitItemStatus(name: Strings.DiffRange) { IsRangeDiff = true } };
+            var statuses = new List<GitItemStatus> { new GitItemStatus(name: TranslatedStrings.DiffRange) { IsRangeDiff = true } };
             var first = firstRev.ObjectId == firstRevHead ? firstRev : new GitRevision(firstRevHead);
             var selected = selectedRev.ObjectId == selectedRevHead ? selectedRev : new GitRevision(selectedRevHead);
             var (baseToFirstCount, baseToSecondCount) = module.GetCommitRangeDiffCount(first.ObjectId, selected.ObjectId);
             const int rangeDiffCommitLimit = 100;
-            var desc = $"{Strings.DiffRange} {baseToFirstCount ?? rangeDiffCommitLimit}↓ {baseToSecondCount ?? rangeDiffCommitLimit}↑";
+            var desc = $"{TranslatedStrings.DiffRange} {baseToFirstCount ?? rangeDiffCommitLimit}↓ {baseToSecondCount ?? rangeDiffCommitLimit}↑";
 
             var rangeDiff = new FileStatusWithDescription(
                 firstRev: first,

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Properties;
@@ -683,7 +684,7 @@ namespace GitUI
                 new FileStatusWithDescription(
                     firstRev: firstRev,
                     secondRev: secondRev,
-                    summary: Strings.DiffWithParent + GetDescriptionForRevision(firstRev?.ObjectId),
+                    summary: TranslatedStrings.DiffWithParent + GetDescriptionForRevision(firstRev?.ObjectId),
                     statuses: items)
             };
         }
@@ -769,7 +770,7 @@ namespace GitUI
             {
                 Name = "openSubmoduleMenuItem",
                 Tag = "1",
-                Text = Strings.OpenWithGitExtensions,
+                Text = TranslatedStrings.OpenWithGitExtensions,
                 Image = Images.GitExtensionsLogo16
             };
             item.Click += (s, ea) => { ThreadHelper.JoinableTaskFactory.RunAsync(() => OpenSubmoduleAsync()); };
@@ -1240,10 +1241,10 @@ namespace GitUI
                     Name = separatorKey,
                     Visible = mayBeMultipleRevs
                 });
-                var showAllDiferencesItem = new ToolStripMenuItem(Strings.ShowDiffForAllParentsText)
+                var showAllDiferencesItem = new ToolStripMenuItem(TranslatedStrings.ShowDiffForAllParentsText)
                 {
                     Checked = AppSettings.ShowDiffForAllParents,
-                    ToolTipText = Strings.ShowDiffForAllParentsTooltip,
+                    ToolTipText = TranslatedStrings.ShowDiffForAllParentsTooltip,
                     Name = showAllDifferencesItemName,
                     CheckOnClick = true,
                     Visible = mayBeMultipleRevs
@@ -1324,7 +1325,7 @@ namespace GitUI
                     ? SystemColors.HighlightText
                     : SystemColors.WindowText;
 
-                if (!GitExtUtils.Strings.IsNullOrEmpty(prefix))
+                if (!Strings.IsNullOrEmpty(prefix))
                 {
                     DrawString(textRect, prefix, grayTextColor);
                     var prefixSize = formatter.MeasureString(prefix);
@@ -1333,7 +1334,7 @@ namespace GitUI
 
                 DrawString(textRect, text, textColor);
 
-                if (!GitExtUtils.Strings.IsNullOrEmpty(suffix))
+                if (!Strings.IsNullOrEmpty(suffix))
                 {
                     var textSize = formatter.MeasureString(text);
                     textRect.Offset(textSize.Width, 0);

--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands.Patches;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using Microsoft;
@@ -140,9 +141,9 @@ namespace GitUI
                 return;
             }
 
-            if (GitExtUtils.Strings.IsNullOrEmpty(patchFile.FullName))
+            if (Strings.IsNullOrEmpty(patchFile.FullName))
             {
-                MessageBox.Show(_unableToShowPatchDetails.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(_unableToShowPatchDetails.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 

--- a/GitUI/UserControls/RevisionGrid/AuthorRevisionHighlighting.cs
+++ b/GitUI/UserControls/RevisionGrid/AuthorRevisionHighlighting.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using GitCommands.Config;
+using GitExtUtils;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 
@@ -36,7 +37,7 @@ namespace GitUI.UserControls
 
         public bool IsHighlighted(GitRevision? revision)
         {
-            if (GitExtUtils.Strings.IsNullOrWhiteSpace(revision?.AuthorEmail))
+            if (Strings.IsNullOrWhiteSpace(revision?.AuthorEmail))
             {
                 return false;
             }

--- a/GitUI/UserControls/RevisionGrid/Columns/AuthorNameColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/AuthorNameColumnProvider.cs
@@ -64,13 +64,13 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             string toolTip;
             if (revision.Author == revision.Committer && revision.AuthorEmail == revision.CommitterEmail)
             {
-                toolTip = $"{revision.Author} <{revision.AuthorEmail}> {Strings.AuthoredAndCommitted}";
+                toolTip = $"{revision.Author} <{revision.AuthorEmail}> {TranslatedStrings.AuthoredAndCommitted}";
             }
             else
             {
                 toolTip =
-                    $"{revision.Author} <{revision.AuthorEmail}> {Strings.Authored}\n" +
-                    $"{revision.Committer} <{revision.CommitterEmail}> {Strings.Committed}";
+                    $"{revision.Author} <{revision.AuthorEmail}> {TranslatedStrings.Authored}\n" +
+                    $"{revision.Committer} <{revision.CommitterEmail}> {TranslatedStrings.Committed}";
             }
 
             return toolTip;

--- a/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using GitUIPluginInterfaces;
@@ -174,7 +175,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
         public override void OnCellFormatting(DataGridViewCellFormattingEventArgs e, GitRevision revision)
         {
-            e.Value = !GitExtUtils.Strings.IsNullOrEmpty(revision.BuildStatus?.Description)
+            e.Value = !Strings.IsNullOrEmpty(revision.BuildStatus?.Description)
                 ? revision.BuildStatus.Description
                 : "";
             e.FormattingApplied = true;

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -105,7 +105,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 var initialLength = (bodySummary?.Length ?? 50) + 10;
                 _toolTipBuilder.EnsureCapacity(initialLength);
 
-                _toolTipBuilder.Append(bodySummary ?? revision.Subject + Strings.BodyNotLoaded);
+                _toolTipBuilder.Append(bodySummary ?? revision.Subject + TranslatedStrings.BodyNotLoaded);
 
                 if (revision.Refs.Count != 0)
                 {
@@ -119,11 +119,11 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                     {
                         if (gitRef.IsBisectGood)
                         {
-                            _toolTipBuilder.AppendLine(Strings.MarkBisectAsGood);
+                            _toolTipBuilder.AppendLine(TranslatedStrings.MarkBisectAsGood);
                         }
                         else if (gitRef.IsBisectBad)
                         {
-                            _toolTipBuilder.AppendLine(Strings.MarkBisectAsBad);
+                            _toolTipBuilder.AppendLine(TranslatedStrings.MarkBisectAsBad);
                         }
                         else
                         {
@@ -172,8 +172,8 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 dashedLine: false);
 
             var max = Math.Max(
-                TextRenderer.MeasureText(ResourceManager.Strings.Workspace, style.NormalFont).Width,
-                TextRenderer.MeasureText(ResourceManager.Strings.Index, style.NormalFont).Width);
+                TextRenderer.MeasureText(ResourceManager.TranslatedStrings.Workspace, style.NormalFont).Width,
+                TextRenderer.MeasureText(ResourceManager.TranslatedStrings.Index, style.NormalFont).Width);
 
             offset = baseOffset + max + DpiUtil.Scale(6);
 

--- a/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
@@ -116,7 +116,7 @@ namespace GitUI.UserControls.RevisionGrid
             // Add items for branches
             if (branchNames.Any())
             {
-                var caption = new ToolStripMenuItem { Text = Strings.Branches };
+                var caption = new ToolStripMenuItem { Text = TranslatedStrings.Branches };
                 MenuUtil.SetAsCaptionMenuItem(caption, Owner);
                 DropDownItems.Add(caption);
 
@@ -131,7 +131,7 @@ namespace GitUI.UserControls.RevisionGrid
             // Add items for tags
             if (tagNames.Any())
             {
-                var caption = new ToolStripMenuItem { Text = Strings.Tags };
+                var caption = new ToolStripMenuItem { Text = TranslatedStrings.Tags };
                 MenuUtil.SetAsCaptionMenuItem(caption, Owner);
                 DropDownItems.Add(caption);
 
@@ -145,18 +145,18 @@ namespace GitUI.UserControls.RevisionGrid
 
             // Add other items
             int count = revisions.Count();
-            AddItem(ResourceManager.Strings.GetCommitHash(count), r => r.Guid, Images.CommitId, 'C');
-            AddItem(ResourceManager.Strings.GetMessage(count), r => r.Body ?? r.Subject, Images.Message, 'M');
-            AddItem(ResourceManager.Strings.GetAuthor(count), r => $"{r.Author} <{r.AuthorEmail}>", Images.Author, 'A');
+            AddItem(ResourceManager.TranslatedStrings.GetCommitHash(count), r => r.Guid, Images.CommitId, 'C');
+            AddItem(ResourceManager.TranslatedStrings.GetMessage(count), r => r.Body ?? r.Subject, Images.Message, 'M');
+            AddItem(ResourceManager.TranslatedStrings.GetAuthor(count), r => $"{r.Author} <{r.AuthorEmail}>", Images.Author, 'A');
 
             if (count == 1 && revisions.First().AuthorDate == revisions.First().CommitDate)
             {
-                AddItem(ResourceManager.Strings.Date, r => r.AuthorDate.ToString(), Images.Date, 'D');
+                AddItem(ResourceManager.TranslatedStrings.Date, r => r.AuthorDate.ToString(), Images.Date, 'D');
             }
             else
             {
-                AddItem(ResourceManager.Strings.GetAuthorDate(count), r => r.AuthorDate.ToString(), Images.Date, 'T');
-                AddItem(ResourceManager.Strings.GetCommitDate(count), r => r.CommitDate.ToString(), Images.Date, 'D');
+                AddItem(ResourceManager.TranslatedStrings.GetAuthorDate(count), r => r.AuthorDate.ToString(), Images.Date, 'T');
+                AddItem(ResourceManager.TranslatedStrings.GetCommitDate(count), r => r.CommitDate.ToString(), Images.Date, 'D');
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
@@ -45,7 +45,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 var branch = new BranchFinder(node);
                 if (!string.IsNullOrWhiteSpace(branch.CommittedTo))
                 {
-                    laneInfoText.AppendFormat("\n{0}: {1}", Strings.Branch, branch.CommittedTo);
+                    laneInfoText.AppendFormat("\n{0}: {1}", TranslatedStrings.Branch, branch.CommittedTo);
                     if (!string.IsNullOrWhiteSpace(branch.MergedWith))
                     {
                         laneInfoText.AppendFormat(MergedWithText.Text, branch.MergedWith);
@@ -64,7 +64,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 laneInfoText.Append(node.GitRevision.Subject);
                 if (node.GitRevision.HasMultiLineMessage)
                 {
-                    laneInfoText.Append(Strings.BodyNotLoaded);
+                    laneInfoText.Append(TranslatedStrings.BodyNotLoaded);
                 }
             }
 

--- a/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
@@ -118,7 +118,7 @@ namespace GitUI
         {
             _label.Visible = true;
             _label.BringToFront();
-            _label.Text = Strings.SearchingFor + _quickSearchString;
+            _label.Text = TranslatedStrings.SearchingFor + _quickSearchString;
             _label.AutoSize = true;
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.RevisionGridInMemFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.RevisionGridInMemFilter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.RegularExpressions;
+using GitExtUtils;
 using GitUIPluginInterfaces;
 
 namespace GitUI
@@ -66,7 +67,7 @@ namespace GitUI
             {
                 if (string.IsNullOrEmpty(authorFilter) &&
                     string.IsNullOrEmpty(committerFilter) &&
-                    (GitExtUtils.Strings.IsNullOrEmpty(messageFilter) ||
+                    (Strings.IsNullOrEmpty(messageFilter) ||
                      !ObjectId.IsValidPartial(messageFilter, minLength: 5)))
                 {
                     return null;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1069,7 +1069,7 @@ namespace GitUI
                         Committer = userName,
                         CommitDate = DateTime.MaxValue,
                         CommitterEmail = userEmail,
-                        Subject = ResourceManager.Strings.Workspace,
+                        Subject = ResourceManager.TranslatedStrings.Workspace,
                         ParentIds = new[] { ObjectId.IndexId },
                         HasNotes = true
                     };
@@ -1084,7 +1084,7 @@ namespace GitUI
                         Committer = userName,
                         CommitDate = DateTime.MaxValue,
                         CommitterEmail = userEmail,
-                        Subject = ResourceManager.Strings.Index,
+                        Subject = ResourceManager.TranslatedStrings.Index,
                         ParentIds = new[] { filteredCurrentCheckout },
                         HasNotes = true
                     };
@@ -2322,7 +2322,7 @@ namespace GitUI
         {
             if (_revisionReader is not null)
             {
-                MessageBox.Show(_cannotHighlightSelectedBranch.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(_cannotHighlightSelectedBranch.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -2394,7 +2394,7 @@ namespace GitUI
             var mergeBaseCommitId = UICommands.GitModule.GitExecutable.GetOutput(args).TrimEnd('\n');
             if (string.IsNullOrWhiteSpace(mergeBaseCommitId))
             {
-                MessageBox.Show(_noMergeBaseCommit.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(_noMergeBaseCommit.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -2421,7 +2421,7 @@ namespace GitUI
 
         public void GoToRef(string? refName, bool showNoRevisionMsg, bool toggleSelection = false)
         {
-            if (GitExtUtils.Strings.IsNullOrEmpty(refName))
+            if (Strings.IsNullOrEmpty(refName))
             {
                 return;
             }
@@ -2442,7 +2442,7 @@ namespace GitUI
             }
             else if (showNoRevisionMsg)
             {
-                MessageBox.Show(this, _noRevisionFoundError.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _noRevisionFoundError.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -2490,7 +2490,7 @@ namespace GitUI
             var headBranch = Module.GetSelectedBranch(setDefaultIfEmpty: false);
             if (string.IsNullOrWhiteSpace(headBranch))
             {
-                MessageBox.Show(this, "No branch is currently selected", Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, "No branch is currently selected", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -2518,7 +2518,7 @@ namespace GitUI
         {
             if (_baseCommitToCompare is null)
             {
-                MessageBox.Show(this, _baseForCompareNotSelectedError.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, _baseForCompareNotSelectedError.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -2541,7 +2541,7 @@ namespace GitUI
 
             if (baseCommit.ObjectId == ObjectId.WorkTreeId)
             {
-                MessageBox.Show(this, "Cannot diff working directory to itself", Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, "Cannot diff working directory to itself", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -2562,7 +2562,7 @@ namespace GitUI
             }
             else
             {
-                MessageBox.Show(this, "You must have two commits selected to compare", Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(this, "You must have two commits selected to compare", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -2598,7 +2598,7 @@ namespace GitUI
         {
             var revision = GetSelectedRevisions().FirstOrDefault();
 
-            if (revision is not null && !GitExtUtils.Strings.IsNullOrWhiteSpace(revision.BuildStatus?.Url))
+            if (revision is not null && !Strings.IsNullOrWhiteSpace(revision.BuildStatus?.Url))
             {
                 OsShellUtil.OpenUrlInDefaultBrowser(revision.BuildStatus.Url);
             }
@@ -2608,7 +2608,7 @@ namespace GitUI
         {
             var revision = GetSelectedRevisions().FirstOrDefault();
 
-            if (revision is not null && !GitExtUtils.Strings.IsNullOrWhiteSpace(revision.BuildStatus?.PullRequestUrl))
+            if (revision is not null && !Strings.IsNullOrWhiteSpace(revision.BuildStatus?.PullRequestUrl))
             {
                 OsShellUtil.OpenUrlInDefaultBrowser(revision.BuildStatus.PullRequestUrl);
             }
@@ -2653,7 +2653,7 @@ namespace GitUI
                 if (fileNameArray.Length > 10)
                 {
                     // Some users need to be protected against themselves!
-                    MessageBox.Show(this, _droppingFilesBlocked.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, _droppingFilesBlocked.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 
@@ -2661,7 +2661,7 @@ namespace GitUI
                 {
                     var fileName = fileNameObject as string;
 
-                    if (!GitExtUtils.Strings.IsNullOrEmpty(fileName) && fileName.EndsWith(".patch", StringComparison.InvariantCultureIgnoreCase))
+                    if (!Strings.IsNullOrEmpty(fileName) && fileName.EndsWith(".patch", StringComparison.InvariantCultureIgnoreCase))
                     {
                         // Start apply patch dialog for each dropped patch file...
                         UICommands.StartApplyPatchDialog(ParentForm, fileName);
@@ -2678,7 +2678,7 @@ namespace GitUI
                 {
                     var fileName = fileNameObject as string;
 
-                    if (!GitExtUtils.Strings.IsNullOrEmpty(fileName) && fileName.EndsWith(".patch", StringComparison.InvariantCultureIgnoreCase))
+                    if (!Strings.IsNullOrEmpty(fileName) && fileName.EndsWith(".patch", StringComparison.InvariantCultureIgnoreCase))
                     {
                         // Allow drop (copy, not move) patch files
                         e.Effect = DragDropEffects.Copy;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -424,7 +424,7 @@ namespace GitUI.UserControls.RevisionGrid
             }
             else
             {
-                MessageBox.Show(_revisionGrid, _noRevisionFoundError.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(_revisionGrid, _noRevisionFoundError.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
     }

--- a/GitUI/UserControls/SortDiffListContextMenuItem.cs
+++ b/GitUI/UserControls/SortDiffListContextMenuItem.cs
@@ -22,7 +22,7 @@ namespace GitUI.UserControls
         {
             _sortService = sortService ?? throw new ArgumentNullException(nameof(sortService));
             Image = Images.SortBy;
-            Text = Strings.SortBy;
+            Text = TranslatedStrings.SortBy;
 
             _filePathSortItem = new ToolStripMenuItem()
             {

--- a/GitUI/UserEnvironmentInformation.cs
+++ b/GitUI/UserEnvironmentInformation.cs
@@ -49,7 +49,7 @@ namespace GitUI
 
         public static string GetGitVersionInfo(string? gitVersion, GitVersion lastSupportedVersion, GitVersion recommendedVersion)
         {
-            if (GitExtUtils.Strings.IsNullOrWhiteSpace(gitVersion))
+            if (Strings.IsNullOrWhiteSpace(gitVersion))
             {
                 return $"- (minimum: {lastSupportedVersion}, recommended: {recommendedVersion})";
             }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.Remotes.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.Remotes.cs
@@ -127,7 +127,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                     // no-op: by the virtue of loading the form, the left panel has loaded its content
 
                     // assert
-                    remotesNode.Nodes.OfType<TreeNode>().Any(n => n.Text == GitUI.Strings.Inactive).Should().BeFalse();
+                    remotesNode.Nodes.OfType<TreeNode>().Any(n => n.Text == TranslatedStrings.Inactive).Should().BeFalse();
                 });
         }
 
@@ -144,7 +144,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                     // no-op: by the virtue of loading the form, the left panel has loaded its content
 
                     // assert
-                    remotesNode.Nodes.OfType<TreeNode>().Count(n => n.Text == GitUI.Strings.Inactive).Should().Be(1);
+                    remotesNode.Nodes.OfType<TreeNode>().Count(n => n.Text == TranslatedStrings.Inactive).Should().Be(1);
                 });
         }
 
@@ -161,7 +161,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                     // no-op: by the virtue of loading the form, the left panel has loaded its content
 
                     // assert
-                    remotesNode.Nodes.OfType<TreeNode>().Last().Text.Should().Be(GitUI.Strings.Inactive);
+                    remotesNode.Nodes.OfType<TreeNode>().Last().Text.Should().Be(TranslatedStrings.Inactive);
                 });
         }
 
@@ -195,7 +195,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         private TreeNode GetRemoteNode(FormBrowse form)
         {
             var treeView = form.GetTestAccessor().RepoObjectsTree.GetTestAccessor().TreeView;
-            var remotesNode = treeView.Nodes.OfType<TreeNode>().FirstOrDefault(n => n.Text == GitUI.Strings.Remotes);
+            var remotesNode = treeView.Nodes.OfType<TreeNode>().FirstOrDefault(n => n.Text == TranslatedStrings.Remotes);
             remotesNode.Should().NotBeNull();
             return remotesNode;
         }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.Submodules.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.Submodules.cs
@@ -119,7 +119,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         private TreeNode GetSubmoduleNode(FormBrowse form)
         {
             var treeView = form.GetTestAccessor().RepoObjectsTree.GetTestAccessor().TreeView;
-            var remotesNode = treeView.Nodes.OfType<TreeNode>().FirstOrDefault(n => n.Text == GitUI.Strings.Submodules);
+            var remotesNode = treeView.Nodes.OfType<TreeNode>().FirstOrDefault(n => n.Text == TranslatedStrings.Submodules);
             remotesNode.Should().NotBeNull();
             return remotesNode;
         }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.cs
@@ -96,8 +96,8 @@ namespace GitExtensions.UITests.CommandsDialogs
                     contextMenu.Items[--count].Text.Should().Be("Collapse");
                     contextMenu.Items[--count].Text.Should().Be("Expand");
                     contextMenu.Items[--count].Should().BeOfType<ToolStripSeparator>();
-                    contextMenu.Items[--count].Text.Should().Be(GitUI.Strings.SortOrder);
-                    contextMenu.Items[--count].Text.Should().Be(GitUI.Strings.SortBy);
+                    contextMenu.Items[--count].Text.Should().Be(TranslatedStrings.SortOrder);
+                    contextMenu.Items[--count].Text.Should().Be(TranslatedStrings.SortBy);
                     contextMenu.Items[--count].Should().BeOfType<ToolStripSeparator>();
                 });
         }

--- a/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/CopyContextMenuItemTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/CopyContextMenuItemTests.cs
@@ -62,10 +62,10 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
 
             _copyContextMenuItem.DropDownItems.Count.Should().Be(4);
 
-            _copyContextMenuItem.DropDownItems[0].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetCommitHash(1), 'C'));
-            _copyContextMenuItem.DropDownItems[1].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetMessage(1), 'M'));
-            _copyContextMenuItem.DropDownItems[2].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetAuthor(1), 'A'));
-            _copyContextMenuItem.DropDownItems[3].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.Date, 'D'));
+            _copyContextMenuItem.DropDownItems[0].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetCommitHash(1), 'C'));
+            _copyContextMenuItem.DropDownItems[1].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetMessage(1), 'M'));
+            _copyContextMenuItem.DropDownItems[2].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetAuthor(1), 'A'));
+            _copyContextMenuItem.DropDownItems[3].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.Date, 'D'));
         }
 
         [Test]
@@ -84,14 +84,14 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
             _copyContextMenuItem.ShowDropDown();
 
             _copyContextMenuItem.DropDownItems.Count.Should().Be(8);
-            _copyContextMenuItem.DropDownItems[0].Text.Should().Be(GitUI.Strings.Branches);
+            _copyContextMenuItem.DropDownItems[0].Text.Should().Be(TranslatedStrings.Branches);
             _copyContextMenuItem.DropDownItems[1].Text.Should().EndWith("branch1");
             _copyContextMenuItem.DropDownItems[2].Text.Should().EndWith("branch2");
             _copyContextMenuItem.DropDownItems[3].Should().BeOfType<ToolStripSeparator>();
-            _copyContextMenuItem.DropDownItems[4].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetCommitHash(1), 'C'));
-            _copyContextMenuItem.DropDownItems[5].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetMessage(1), 'M'));
-            _copyContextMenuItem.DropDownItems[6].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetAuthor(1), 'A'));
-            _copyContextMenuItem.DropDownItems[7].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.Date, 'D'));
+            _copyContextMenuItem.DropDownItems[4].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetCommitHash(1), 'C'));
+            _copyContextMenuItem.DropDownItems[5].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetMessage(1), 'M'));
+            _copyContextMenuItem.DropDownItems[6].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetAuthor(1), 'A'));
+            _copyContextMenuItem.DropDownItems[7].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.Date, 'D'));
         }
 
         [Test]
@@ -110,14 +110,14 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
             _copyContextMenuItem.ShowDropDown();
 
             _copyContextMenuItem.DropDownItems.Count.Should().Be(8);
-            _copyContextMenuItem.DropDownItems[0].Text.Should().Be(GitUI.Strings.Tags);
+            _copyContextMenuItem.DropDownItems[0].Text.Should().Be(TranslatedStrings.Tags);
             _copyContextMenuItem.DropDownItems[1].Text.Should().EndWith("tag1");
             _copyContextMenuItem.DropDownItems[2].Text.Should().EndWith("tag2");
             _copyContextMenuItem.DropDownItems[3].Should().BeOfType<ToolStripSeparator>();
-            _copyContextMenuItem.DropDownItems[4].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetCommitHash(1), 'C'));
-            _copyContextMenuItem.DropDownItems[5].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetMessage(1), 'M'));
-            _copyContextMenuItem.DropDownItems[6].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetAuthor(1), 'A'));
-            _copyContextMenuItem.DropDownItems[7].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.Date, 'D'));
+            _copyContextMenuItem.DropDownItems[4].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetCommitHash(1), 'C'));
+            _copyContextMenuItem.DropDownItems[5].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetMessage(1), 'M'));
+            _copyContextMenuItem.DropDownItems[6].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetAuthor(1), 'A'));
+            _copyContextMenuItem.DropDownItems[7].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.Date, 'D'));
         }
 
         [Test]
@@ -138,18 +138,18 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
             _copyContextMenuItem.ShowDropDown();
 
             _copyContextMenuItem.DropDownItems.Count.Should().Be(12);
-            _copyContextMenuItem.DropDownItems[0].Text.Should().Be(GitUI.Strings.Branches);
+            _copyContextMenuItem.DropDownItems[0].Text.Should().Be(TranslatedStrings.Branches);
             _copyContextMenuItem.DropDownItems[1].Text.Should().EndWith("branch1");
             _copyContextMenuItem.DropDownItems[2].Text.Should().EndWith("branch2");
             _copyContextMenuItem.DropDownItems[3].Should().BeOfType<ToolStripSeparator>();
-            _copyContextMenuItem.DropDownItems[4].Text.Should().Be(GitUI.Strings.Tags);
+            _copyContextMenuItem.DropDownItems[4].Text.Should().Be(TranslatedStrings.Tags);
             _copyContextMenuItem.DropDownItems[5].Text.Should().EndWith("tag1");
             _copyContextMenuItem.DropDownItems[6].Text.Should().EndWith("tag2");
             _copyContextMenuItem.DropDownItems[7].Should().BeOfType<ToolStripSeparator>();
-            _copyContextMenuItem.DropDownItems[8].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetCommitHash(1), 'C'));
-            _copyContextMenuItem.DropDownItems[9].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetMessage(1), 'M'));
-            _copyContextMenuItem.DropDownItems[10].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetAuthor(1), 'A'));
-            _copyContextMenuItem.DropDownItems[11].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.Date, 'D'));
+            _copyContextMenuItem.DropDownItems[8].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetCommitHash(1), 'C'));
+            _copyContextMenuItem.DropDownItems[9].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetMessage(1), 'M'));
+            _copyContextMenuItem.DropDownItems[10].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetAuthor(1), 'A'));
+            _copyContextMenuItem.DropDownItems[11].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.Date, 'D'));
         }
 
         [Test]
@@ -181,11 +181,11 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
 
             _copyContextMenuItem.DropDownItems.Count.Should().Be(5);
 
-            _copyContextMenuItem.DropDownItems[0].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetCommitHash(revisions.Length), 'C'));
-            _copyContextMenuItem.DropDownItems[1].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetMessage(revisions.Length), 'M'));
-            _copyContextMenuItem.DropDownItems[2].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetAuthor(revisions.Length), 'A'));
-            _copyContextMenuItem.DropDownItems[3].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetAuthorDate(revisions.Length), 'T'));
-            _copyContextMenuItem.DropDownItems[4].Text.Should().StartWith(AddHotKey(ResourceManager.Strings.GetCommitDate(revisions.Length), 'D'));
+            _copyContextMenuItem.DropDownItems[0].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetCommitHash(revisions.Length), 'C'));
+            _copyContextMenuItem.DropDownItems[1].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetMessage(revisions.Length), 'M'));
+            _copyContextMenuItem.DropDownItems[2].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetAuthor(revisions.Length), 'A'));
+            _copyContextMenuItem.DropDownItems[3].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetAuthorDate(revisions.Length), 'T'));
+            _copyContextMenuItem.DropDownItems[4].Text.Should().StartWith(AddHotKey(ResourceManager.TranslatedStrings.GetCommitDate(revisions.Length), 'D'));
         }
 
         private string AddHotKey(string label, char? hotkey)

--- a/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
+++ b/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
@@ -77,38 +77,38 @@ namespace ResourceManager.CommitDataRenders
             Validates.NotNull(_linkFactory);
 
             var header = new StringBuilder();
-            header.AppendLine(_labelFormatter.FormatLabel(ResourceManager.Strings.Author, padding) + _linkFactory.CreateLink(commitData.Author, "mailto:" + authorEmail));
+            header.AppendLine(_labelFormatter.FormatLabel(TranslatedStrings.Author, padding) + _linkFactory.CreateLink(commitData.Author, "mailto:" + authorEmail));
 
             if (!isArtificial)
             {
-                header.AppendLine(_labelFormatter.FormatLabel(datesEqual ? ResourceManager.Strings.Date : ResourceManager.Strings.AuthorDate, padding) + WebUtility.HtmlEncode(_dateFormatter.FormatDateAsRelativeLocal(commitData.AuthorDate)));
+                header.AppendLine(_labelFormatter.FormatLabel(datesEqual ? TranslatedStrings.Date : TranslatedStrings.AuthorDate, padding) + WebUtility.HtmlEncode(_dateFormatter.FormatDateAsRelativeLocal(commitData.AuthorDate)));
             }
 
             if (!authorIsCommitter)
             {
                 string committerEmail = GetEmail(commitData.Committer);
-                header.AppendLine(_labelFormatter.FormatLabel(ResourceManager.Strings.Committer, padding) + _linkFactory.CreateLink(commitData.Committer, "mailto:" + committerEmail));
+                header.AppendLine(_labelFormatter.FormatLabel(TranslatedStrings.Committer, padding) + _linkFactory.CreateLink(commitData.Committer, "mailto:" + committerEmail));
             }
 
             if (!isArtificial)
             {
                 if (!datesEqual)
                 {
-                    header.AppendLine(_labelFormatter.FormatLabel(ResourceManager.Strings.CommitDate, padding) + WebUtility.HtmlEncode(_dateFormatter.FormatDateAsRelativeLocal(commitData.CommitDate)));
+                    header.AppendLine(_labelFormatter.FormatLabel(TranslatedStrings.CommitDate, padding) + WebUtility.HtmlEncode(_dateFormatter.FormatDateAsRelativeLocal(commitData.CommitDate)));
                 }
 
-                header.AppendLine(_labelFormatter.FormatLabel(ResourceManager.Strings.CommitHash, padding) + WebUtility.HtmlEncode(commitData.ObjectId.ToString()));
+                header.AppendLine(_labelFormatter.FormatLabel(TranslatedStrings.CommitHash, padding) + WebUtility.HtmlEncode(commitData.ObjectId.ToString()));
             }
 
             if (commitData.ChildIds is not null && commitData.ChildIds.Count != 0)
             {
-                header.AppendLine(_labelFormatter.FormatLabel(ResourceManager.Strings.GetChildren(commitData.ChildIds.Count), padding) + RenderObjectIds(commitData.ChildIds, showRevisionsAsLinks));
+                header.AppendLine(_labelFormatter.FormatLabel(TranslatedStrings.GetChildren(commitData.ChildIds.Count), padding) + RenderObjectIds(commitData.ChildIds, showRevisionsAsLinks));
             }
 
             var parentIds = commitData.ParentIds;
             if (parentIds.Count != 0)
             {
-                header.AppendLine(_labelFormatter.FormatLabel(ResourceManager.Strings.GetParents(parentIds.Count), padding) + RenderObjectIds(parentIds, showRevisionsAsLinks));
+                header.AppendLine(_labelFormatter.FormatLabel(TranslatedStrings.GetParents(parentIds.Count), padding) + RenderObjectIds(parentIds, showRevisionsAsLinks));
             }
 
             // remove the trailing newline character
@@ -132,19 +132,19 @@ namespace ResourceManager.CommitDataRenders
             var padding = _headerRendererStyleProvider.GetMaxWidth();
 
             var header = new StringBuilder();
-            header.AppendLine(_labelFormatter.FormatLabel(ResourceManager.Strings.Author, padding) + commitData.Author);
-            header.AppendLine(_labelFormatter.FormatLabel(datesEqual ? ResourceManager.Strings.Date : ResourceManager.Strings.AuthorDate, padding) + _dateFormatter.FormatDateAsRelativeLocal(commitData.AuthorDate));
+            header.AppendLine(_labelFormatter.FormatLabel(TranslatedStrings.Author, padding) + commitData.Author);
+            header.AppendLine(_labelFormatter.FormatLabel(datesEqual ? TranslatedStrings.Date : TranslatedStrings.AuthorDate, padding) + _dateFormatter.FormatDateAsRelativeLocal(commitData.AuthorDate));
             if (!authorIsCommitter)
             {
-                header.AppendLine(_labelFormatter.FormatLabel(ResourceManager.Strings.Committer, padding) + commitData.Committer);
+                header.AppendLine(_labelFormatter.FormatLabel(TranslatedStrings.Committer, padding) + commitData.Committer);
             }
 
             if (!datesEqual)
             {
-                header.AppendLine(_labelFormatter.FormatLabel(ResourceManager.Strings.CommitDate, padding) + _dateFormatter.FormatDateAsRelativeLocal(commitData.CommitDate));
+                header.AppendLine(_labelFormatter.FormatLabel(TranslatedStrings.CommitDate, padding) + _dateFormatter.FormatDateAsRelativeLocal(commitData.CommitDate));
             }
 
-            header.Append(_labelFormatter.FormatLabel(ResourceManager.Strings.CommitHash, padding) + commitData.ObjectId);
+            header.Append(_labelFormatter.FormatLabel(TranslatedStrings.CommitHash, padding) + commitData.ObjectId);
 
             return header.ToString();
         }

--- a/ResourceManager/CommitDataRenders/MonospacedHeaderRenderStyleProvider.cs
+++ b/ResourceManager/CommitDataRenders/MonospacedHeaderRenderStyleProvider.cs
@@ -17,13 +17,13 @@ namespace ResourceManager.CommitDataRenders
         {
             var strings = new[]
             {
-                ResourceManager.Strings.Author,
-                ResourceManager.Strings.AuthorDate,
-                ResourceManager.Strings.Committer,
-                ResourceManager.Strings.CommitDate,
-                ResourceManager.Strings.CommitHash,
-                ResourceManager.Strings.GetChildren(10), // assume text for plural case is longer
-                ResourceManager.Strings.GetParents(10)
+                TranslatedStrings.Author,
+                TranslatedStrings.AuthorDate,
+                TranslatedStrings.Committer,
+                TranslatedStrings.CommitDate,
+                TranslatedStrings.CommitHash,
+                TranslatedStrings.GetChildren(10), // assume text for plural case is longer
+                TranslatedStrings.GetParents(10)
             };
 
             _maxLength = strings.Select(s => s.Length).Max() + 2;

--- a/ResourceManager/CommitDataRenders/TabbedHeaderRenderStyleProvider.cs
+++ b/ResourceManager/CommitDataRenders/TabbedHeaderRenderStyleProvider.cs
@@ -14,13 +14,13 @@ namespace ResourceManager.CommitDataRenders
         {
             var strings = new[]
             {
-                ResourceManager.Strings.Author,
-                ResourceManager.Strings.AuthorDate,
-                ResourceManager.Strings.Committer,
-                ResourceManager.Strings.CommitDate,
-                ResourceManager.Strings.CommitHash,
-                ResourceManager.Strings.GetChildren(10), // assume text for plural case is longer
-                ResourceManager.Strings.GetParents(10)
+                TranslatedStrings.Author,
+                TranslatedStrings.AuthorDate,
+                TranslatedStrings.Committer,
+                TranslatedStrings.CommitDate,
+                TranslatedStrings.CommitHash,
+                TranslatedStrings.GetChildren(10), // assume text for plural case is longer
+                TranslatedStrings.GetParents(10)
             };
 
             var tabStop = strings

--- a/ResourceManager/LinkFactory.cs
+++ b/ResourceManager/LinkFactory.cs
@@ -81,11 +81,11 @@ namespace ResourceManager
             {
                 if (objectId == ObjectId.WorkTreeId)
                 {
-                    linkText = ResourceManager.Strings.Workspace;
+                    linkText = TranslatedStrings.Workspace;
                 }
                 else if (objectId == ObjectId.IndexId)
                 {
-                    linkText = ResourceManager.Strings.Index;
+                    linkText = TranslatedStrings.Index;
                 }
                 else if (preserveGuidInLinkText)
                 {
@@ -101,7 +101,7 @@ namespace ResourceManager
         }
 
         public string CreateShowAllLink(string what)
-            => AddLink($"[ {Strings.ShowAll} ]", $"{InternalScheme}://{ShowAll}/{what}");
+            => AddLink($"[ {TranslatedStrings.ShowAll} ]", $"{InternalScheme}://{ShowAll}/{what}");
 
         public void ExecuteLink(string linkText, Action<CommandEventArgs>? handleInternalLink = null, Action<string?>? showAll = null)
         {

--- a/ResourceManager/LocalizationHelpers.cs
+++ b/ResourceManager/LocalizationHelpers.cs
@@ -35,40 +35,40 @@ namespace ResourceManager
 
             if (delta < 60)
             {
-                return ResourceManager.Strings.GetNSecondsAgoText(ts.Seconds);
+                return TranslatedStrings.GetNSecondsAgoText(ts.Seconds);
             }
 
             if (delta < 45 * 60)
             {
-                return ResourceManager.Strings.GetNMinutesAgoText(ts.Minutes);
+                return TranslatedStrings.GetNMinutesAgoText(ts.Minutes);
             }
 
             if (delta < 24 * 60 * 60)
             {
                 int hours = delta < 60 * 60 ? Math.Sign(ts.Minutes) * 1 : ts.Hours;
-                return ResourceManager.Strings.GetNHoursAgoText(hours);
+                return TranslatedStrings.GetNHoursAgoText(hours);
             }
 
             // 30.417 = 365 days / 12 months - note that the if statement only bothers with 30 days for "1 month ago" because ts.Days is int
             if (delta < (displayWeeks ? 7 : 30) * 24 * 60 * 60)
             {
-                return ResourceManager.Strings.GetNDaysAgoText(ts.Days);
+                return TranslatedStrings.GetNDaysAgoText(ts.Days);
             }
 
             if (displayWeeks && delta < 30 * 24 * 60 * 60)
             {
                 int weeks = Convert.ToInt32(ts.Days / 7.0);
-                return ResourceManager.Strings.GetNWeeksAgoText(weeks);
+                return TranslatedStrings.GetNWeeksAgoText(weeks);
             }
 
             if (delta < 365 * 24 * 60 * 60)
             {
                 int months = Convert.ToInt32(ts.Days / 30.0);
-                return ResourceManager.Strings.GetNMonthsAgoText(months);
+                return TranslatedStrings.GetNMonthsAgoText(months);
             }
 
             int years = Convert.ToInt32(ts.Days / 365.0);
-            return ResourceManager.Strings.GetNYearsAgoText(years);
+            return TranslatedStrings.GetNYearsAgoText(years);
         }
 
         public static string GetFullDateString(DateTimeOffset datetime)

--- a/ResourceManager/TranslatedStrings.cs
+++ b/ResourceManager/TranslatedStrings.cs
@@ -5,7 +5,7 @@ using SmartFormat;
 namespace ResourceManager
 {
     /// <summary>Contains common string literals which are translated.</summary>
-    public sealed class Strings : Translate
+    public sealed class TranslatedStrings : Translate
     {
         private readonly TranslationString _secondsAgo = new("{0} {1:second|seconds} ago");
         private readonly TranslationString _minutesAgo = new("{0} {1:minute|minutes} ago");
@@ -49,18 +49,18 @@ Yes, I allow telemetry!");
         private readonly TranslationString _disableMenuItem = new TranslationString("Disable this dropdown");
 
         // public only because of FormTranslate
-        public Strings()
+        public TranslatedStrings()
         {
             Translator.Translate(this, AppSettings.CurrentTranslation);
         }
 
-        private static Lazy<Strings> _instance = new Lazy<Strings>();
+        private static Lazy<TranslatedStrings> _instance = new Lazy<TranslatedStrings>();
 
         public static void Reinitialize()
         {
             if (_instance.IsValueCreated)
             {
-                _instance = new Lazy<Strings>();
+                _instance = new Lazy<TranslatedStrings>();
             }
         }
 

--- a/ResourceManager/TranslationUtils.cs
+++ b/ResourceManager/TranslationUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using GitExtUtils;
 
 namespace ResourceManager
 {
@@ -16,7 +17,7 @@ namespace ResourceManager
 
         public static void AddTranslationItemsFromFields(string? category, object obj, ITranslation translation)
         {
-            if (!GitExtUtils.Strings.IsNullOrEmpty(category))
+            if (!Strings.IsNullOrEmpty(category))
             {
                 Xliff.TranslationUtil.AddTranslationItemsFromFields(category, obj, translation);
             }
@@ -39,7 +40,7 @@ namespace ResourceManager
 
         public static void TranslateItemsFromFields(string? category, object obj, ITranslation translation)
         {
-            if (!GitExtUtils.Strings.IsNullOrEmpty(category))
+            if (!Strings.IsNullOrEmpty(category))
             {
                 Xliff.TranslationUtil.TranslateItemsFromFields(category, obj, translation);
             }

--- a/ResourceManager/Xliff/TranslationBody.cs
+++ b/ResourceManager/Xliff/TranslationBody.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Xml.Serialization;
+using GitExtUtils;
 
 namespace ResourceManager.Xliff
 {
@@ -27,7 +28,7 @@ namespace ResourceManager.Xliff
 
         public void AddTranslationItemIfNotExist(TranslationItem translationItem)
         {
-            if (GitExtUtils.Strings.IsNullOrEmpty(translationItem.Name))
+            if (Strings.IsNullOrEmpty(translationItem.Name))
             {
                 throw new InvalidOperationException($"Cannot add {nameof(TranslationItem)} without name");
             }

--- a/UnitTests/GitUI.Tests/UserControls/CommitInfo/RefsFormatterTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/CommitInfo/RefsFormatterTests.cs
@@ -46,10 +46,10 @@ namespace GitUITests.UserControls.CommitInfo
             IReadOnlyList<string> refs = new List<string>();
 
             _refsFormatter.FormatBranches(refs, showAsLinks, limit)
-                .Should().Be(GitUI.Strings.ContainedInNoBranch);
+                .Should().Be(GitUI.TranslatedStrings.ContainedInNoBranch);
 
             _refsFormatter.FormatTags(refs, showAsLinks, limit)
-                .Should().Be(GitUI.Strings.ContainedInNoTag);
+                .Should().Be(GitUI.TranslatedStrings.ContainedInNoTag);
         }
 
         [Test]
@@ -61,12 +61,12 @@ namespace GitUITests.UserControls.CommitInfo
             IEnumerable<string> formattedTags = refs.Select(r => FormatRef(r, "tag", showAsLinks));
 
             _refsFormatter.FormatBranches(refs, showAsLinks, limit)
-                .Should().Be(GitUI.Strings.ContainedInBranches
+                .Should().Be(GitUI.TranslatedStrings.ContainedInBranches
                              + Environment.NewLine
                              + formattedBranches.Join(Environment.NewLine));
 
             _refsFormatter.FormatTags(refs, showAsLinks, limit)
-                .Should().Be(GitUI.Strings.ContainedInTags
+                .Should().Be(GitUI.TranslatedStrings.ContainedInTags
                              + Environment.NewLine
                              + formattedTags.Join(Environment.NewLine));
         }
@@ -78,13 +78,13 @@ namespace GitUITests.UserControls.CommitInfo
             IEnumerable<string> formattedTags = _refs.Take(10).Select(r => FormatRef(r, "tag", showAsLinks));
 
             _refsFormatter.FormatBranches(_refs, showAsLinks, limit: true)
-                .Should().Be(GitUI.Strings.ContainedInBranches
+                .Should().Be(GitUI.TranslatedStrings.ContainedInBranches
                              + Environment.NewLine
                              + formattedBranches.Join(Environment.NewLine)
                              + GetShowAllLink("branches"));
 
             _refsFormatter.FormatTags(_refs, showAsLinks, limit: true)
-                .Should().Be(GitUI.Strings.ContainedInTags
+                .Should().Be(GitUI.TranslatedStrings.ContainedInTags
                              + Environment.NewLine
                              + formattedTags.Join(Environment.NewLine)
                              + GetShowAllLink("tags"));
@@ -97,7 +97,7 @@ namespace GitUITests.UserControls.CommitInfo
 
         private string GetShowAllLink(string type)
         {
-            return $"{Environment.NewLine}<a href='gitext://showall/{type}'>[ {Strings.ShowAll} ]</a>{Environment.NewLine}";
+            return $"{Environment.NewLine}<a href='gitext://showall/{type}'>[ {TranslatedStrings.ShowAll} ]</a>{Environment.NewLine}";
         }
     }
 }

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
@@ -173,7 +173,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
                     prefix,
                     node.GitRevision.Guid,
                     Environment.NewLine,
-                    Strings.Branch,
+                    TranslatedStrings.Branch,
                     branch,
                     mergedWith is null ? "" : string.Format(LaneInfoProvider.TestAccessor.MergedWithText.Text, mergedWith),
                     node.GitRevision.Body,
@@ -244,7 +244,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
             _realCommitNode.GitRevision.HasMultiLineMessage = true;
             _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
 
-            GetLaneInfo_should_display(_realCommitNode, suffix: _realCommitNode.GitRevision.Subject + Strings.BodyNotLoaded);
+            GetLaneInfo_should_display(_realCommitNode, suffix: _realCommitNode.GitRevision.Subject + TranslatedStrings.BodyNotLoaded);
         }
 
         [Test]

--- a/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererTests.cs
+++ b/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererTests.cs
@@ -40,16 +40,16 @@ namespace ResourceManagerTests.CommitDataRenders
         public void Setup()
         {
             _labelFormatter = Substitute.For<IHeaderLabelFormatter>();
-            _labelFormatter.FormatLabel(ResourceManager.Strings.Author, Arg.Any<int>()).Returns(x => "Author:        ");
-            _labelFormatter.FormatLabel(ResourceManager.Strings.Committer, Arg.Any<int>()).Returns(x => "Committer:     ");
-            _labelFormatter.FormatLabel(ResourceManager.Strings.Date, Arg.Any<int>()).Returns(x => "Date:          ");
-            _labelFormatter.FormatLabel(ResourceManager.Strings.AuthorDate, Arg.Any<int>()).Returns(x => "Author date:   ");
-            _labelFormatter.FormatLabel(ResourceManager.Strings.CommitDate, Arg.Any<int>()).Returns(x => "Commit date:   ");
-            _labelFormatter.FormatLabel(ResourceManager.Strings.CommitHash, Arg.Any<int>()).Returns(x => "Commit hash:   ");
-            _labelFormatter.FormatLabel(ResourceManager.Strings.GetParents(1), Arg.Any<int>()).Returns(x => "Parent:        ");
-            _labelFormatter.FormatLabel(ResourceManager.Strings.GetParents(Arg.Any<int>()), Arg.Any<int>()).Returns(x => "Parents:       ");
-            _labelFormatter.FormatLabel(ResourceManager.Strings.GetChildren(1), Arg.Any<int>()).Returns(x => "Child:         ");
-            _labelFormatter.FormatLabel(ResourceManager.Strings.GetChildren(Arg.Any<int>()), Arg.Any<int>()).Returns(x => "Children:      ");
+            _labelFormatter.FormatLabel(TranslatedStrings.Author, Arg.Any<int>()).Returns(x => "Author:        ");
+            _labelFormatter.FormatLabel(TranslatedStrings.Committer, Arg.Any<int>()).Returns(x => "Committer:     ");
+            _labelFormatter.FormatLabel(TranslatedStrings.Date, Arg.Any<int>()).Returns(x => "Date:          ");
+            _labelFormatter.FormatLabel(TranslatedStrings.AuthorDate, Arg.Any<int>()).Returns(x => "Author date:   ");
+            _labelFormatter.FormatLabel(TranslatedStrings.CommitDate, Arg.Any<int>()).Returns(x => "Commit date:   ");
+            _labelFormatter.FormatLabel(TranslatedStrings.CommitHash, Arg.Any<int>()).Returns(x => "Commit hash:   ");
+            _labelFormatter.FormatLabel(TranslatedStrings.GetParents(1), Arg.Any<int>()).Returns(x => "Parent:        ");
+            _labelFormatter.FormatLabel(TranslatedStrings.GetParents(Arg.Any<int>()), Arg.Any<int>()).Returns(x => "Parents:       ");
+            _labelFormatter.FormatLabel(TranslatedStrings.GetChildren(1), Arg.Any<int>()).Returns(x => "Child:         ");
+            _labelFormatter.FormatLabel(TranslatedStrings.GetChildren(Arg.Any<int>()), Arg.Any<int>()).Returns(x => "Children:      ");
 
             _headerRendererStyleProvider = Substitute.For<IHeaderRenderStyleProvider>();
             _linkFactory = Substitute.For<ILinkFactory>();
@@ -102,12 +102,12 @@ namespace ResourceManagerTests.CommitDataRenders
             var result = _renderer.Render(data, false);
 
             result.Should().Be($"Author:        John Doe (Acme Inc) <John.Doe@test.com>{Environment.NewLine}Date:          6 months ago (06/17/2017 23:38:40){Environment.NewLine}Commit hash:   7fa3109989e0523aeacb178995a2a3aa6c302a2c");
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Author, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Date, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.CommitHash, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.AuthorDate, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.Committer, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.CommitDate, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Author, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Date, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.CommitHash, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.AuthorDate, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.Committer, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.CommitDate, Arg.Any<int>());
         }
 
         [Test]
@@ -131,12 +131,12 @@ namespace ResourceManagerTests.CommitDataRenders
             var result = _renderer.Render(data, false);
 
             result.Should().Be($"Author:        John Doe (Acme Inc) <John.Doe@test.com>{Environment.NewLine}Date:          6 months ago (06/17/2017 23:38:40){Environment.NewLine}Committer:     John Doe <John.Doe@test.com>{Environment.NewLine}Commit hash:   7fa3109989e0523aeacb178995a2a3aa6c302a2c");
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Author, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Date, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Committer, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.CommitHash, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.AuthorDate, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.CommitDate, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Author, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Date, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Committer, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.CommitHash, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.AuthorDate, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.CommitDate, Arg.Any<int>());
         }
 
         [Test]
@@ -160,12 +160,12 @@ namespace ResourceManagerTests.CommitDataRenders
             var result = _renderer.Render(data, false);
 
             result.Should().Be($"Author:        John Doe (Acme Inc) <John.Doe@test.com>{Environment.NewLine}Author date:   6 months ago (06/17/2017 23:38:40){Environment.NewLine}Commit date:   2 months ago (10/23/2017 12:17:11){Environment.NewLine}Commit hash:   7fa3109989e0523aeacb178995a2a3aa6c302a2c");
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Author, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.AuthorDate, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.CommitDate, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.CommitHash, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.Date, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.Committer, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Author, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.AuthorDate, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.CommitDate, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.CommitHash, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.Date, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.Committer, Arg.Any<int>());
         }
 
         [Test]
@@ -192,12 +192,12 @@ namespace ResourceManagerTests.CommitDataRenders
                 $"Children:      {_childrenHashes[0].ToShortString()} " +
                 $"{_childrenHashes[1].ToShortString()} " +
                 $"{_childrenHashes[2].ToShortString()}");
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Author, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Date, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.CommitHash, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.AuthorDate, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.Committer, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.CommitDate, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Author, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Date, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.CommitHash, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.AuthorDate, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.Committer, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.CommitDate, Arg.Any<int>());
         }
 
         [Test]
@@ -221,12 +221,12 @@ namespace ResourceManagerTests.CommitDataRenders
 
             result.Should().Be($"Author:        John Doe (Acme Inc) <John.Doe@test.com>{Environment.NewLine}Date:          6 months ago (06/17/2017 23:38:40){Environment.NewLine}Commit hash:   7fa3109989e0523aeacb178995a2a3aa6c302a2c{Environment.NewLine}" +
                 $"Parents:       {_parentHashes[0].ToShortString()} {_parentHashes[1].ToShortString()} {_parentHashes[2].ToShortString()}");
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Author, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Date, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.CommitHash, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.AuthorDate, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.Committer, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.CommitDate, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Author, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Date, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.CommitHash, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.AuthorDate, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.Committer, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.CommitDate, Arg.Any<int>());
         }
 
         [TestCase(GitRevision.IndexGuid)]
@@ -250,12 +250,12 @@ namespace ResourceManagerTests.CommitDataRenders
 
             result.Should().Be($"Author:        John Doe (Acme Inc) <John.Doe@test.com>{Environment.NewLine}" +
                                $"Parents:       {_parentHashes[0].ToShortString()} {_parentHashes[1].ToShortString()} {_parentHashes[2].ToShortString()}");
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Author, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.Date, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.CommitHash, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.AuthorDate, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.Committer, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.CommitDate, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Author, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.Date, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.CommitHash, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.AuthorDate, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.Committer, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.CommitDate, Arg.Any<int>());
         }
 
         [Test]
@@ -284,12 +284,12 @@ namespace ResourceManagerTests.CommitDataRenders
             var result = _renderer.RenderPlain(data);
 
             result.Should().Be($"Author:        John Doe (Acme Inc) <John.Doe@test.com>{Environment.NewLine}Date:          6 months ago (06/17/2017 23:38:40){Environment.NewLine}Commit hash:   7fa3109989e0523aeacb178995a2a3aa6c302a2c");
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Author, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Date, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.CommitHash, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.AuthorDate, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.Committer, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.CommitDate, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Author, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Date, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.CommitHash, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.AuthorDate, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.Committer, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.CommitDate, Arg.Any<int>());
         }
 
         [Test]
@@ -313,12 +313,12 @@ namespace ResourceManagerTests.CommitDataRenders
             var result = _renderer.RenderPlain(data);
 
             result.Should().Be($"Author:        John Doe (Acme Inc) <John.Doe@test.com>{Environment.NewLine}Date:          6 months ago (06/17/2017 23:38:40){Environment.NewLine}Committer:     John Doe <John.Doe@test.com>{Environment.NewLine}Commit hash:   7fa3109989e0523aeacb178995a2a3aa6c302a2c");
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Author, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Date, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Committer, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.CommitHash, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.AuthorDate, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.CommitDate, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Author, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Date, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Committer, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.CommitHash, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.AuthorDate, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.CommitDate, Arg.Any<int>());
         }
 
         [Test]
@@ -342,12 +342,12 @@ namespace ResourceManagerTests.CommitDataRenders
             var result = _renderer.RenderPlain(data);
 
             result.Should().Be($"Author:        John Doe (Acme Inc) <John.Doe@test.com>{Environment.NewLine}Author date:   6 months ago (06/17/2017 23:38:40){Environment.NewLine}Commit date:   2 months ago (10/23/2017 12:17:11){Environment.NewLine}Commit hash:   7fa3109989e0523aeacb178995a2a3aa6c302a2c");
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.Author, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.AuthorDate, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.CommitDate, Arg.Any<int>());
-            _labelFormatter.Received(1).FormatLabel(ResourceManager.Strings.CommitHash, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.Date, Arg.Any<int>());
-            _labelFormatter.DidNotReceive().FormatLabel(ResourceManager.Strings.Committer, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.Author, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.AuthorDate, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.CommitDate, Arg.Any<int>());
+            _labelFormatter.Received(1).FormatLabel(TranslatedStrings.CommitHash, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.Date, Arg.Any<int>());
+            _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.Committer, Arg.Any<int>());
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

Rename translation strings to avoid conflict.

So long as we target .NET Framework, we do not have annotated versions of `string.IsNullOrEmpty` and friends. We've worked around this by introducing a `Strings` class that has annotated versions of these, but that class had a naming conflict with existing translation string resources.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
