### PR TITLE
Optimise string split operations

### DIFF
--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -74,7 +74,7 @@ namespace GitCommands
             // commit message
             // ...
 
-            var lines = data.Split('\n');
+            var lines = data.Split(Delimiters.Newline);
 
             var guid = lines[0];
             var commitEncoding = lines[1];
@@ -134,7 +134,7 @@ namespace GitCommands
             // diff notes
             // ...
 
-            var lines = data.Split('\n');
+            var lines = data.Split(Delimiters.Newline);
 
             var guid = ObjectId.Parse(lines[0]);
 
@@ -142,7 +142,7 @@ namespace GitCommands
             var treeGuid = ObjectId.Parse(lines[1]);
 
             // TODO: we can use this to add more relationship info like gitk does if wanted
-            var parentIds = lines[2].Split(' ').Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => ObjectId.Parse(id)).ToList();
+            var parentIds = lines[2].LazySplit(' ').Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => ObjectId.Parse(id)).ToList();
             var author = module.ReEncodeStringFromLossless(lines[3]);
             var authorDate = DateTimeUtils.ParseUnixTime(lines[4]);
             var committer = module.ReEncodeStringFromLossless(lines[5]);

--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -74,7 +74,7 @@ namespace GitCommands
             // commit message
             // ...
 
-            var lines = data.Split(Delimiters.Newline);
+            var lines = data.Split(Delimiters.LineFeed);
 
             var guid = lines[0];
             var commitEncoding = lines[1];
@@ -134,7 +134,7 @@ namespace GitCommands
             // diff notes
             // ...
 
-            var lines = data.Split(Delimiters.Newline);
+            var lines = data.Split(Delimiters.LineFeed);
 
             var guid = ObjectId.Parse(lines[0]);
 

--- a/GitCommands/CommitMessageManager.cs
+++ b/GitCommands/CommitMessageManager.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Text;
 using System.Windows.Forms;
+using GitExtUtils;
 
 namespace GitCommands
 {
@@ -175,23 +176,21 @@ namespace GitCommands
             var formattedCommitMessage = new StringBuilder();
 
             var lineNumber = 1;
-            foreach (var line in commitMessage.Split('\n'))
+            foreach (var line in commitMessage.LazySplit('\n'))
             {
-                string nonNullLine = line ?? string.Empty;
-
                 // When a committemplate is used, skip comments and do not count them as line.
                 // otherwise: "#" is probably not used for comment but for issue number
-                if (usingCommitTemplate && nonNullLine.StartsWith("#"))
+                if (usingCommitTemplate && line.StartsWith("#"))
                 {
                     continue;
                 }
 
-                if (ensureCommitMessageSecondLineEmpty && lineNumber == 2 && !string.IsNullOrEmpty(nonNullLine))
+                if (ensureCommitMessageSecondLineEmpty && lineNumber == 2 && !string.IsNullOrEmpty(line))
                 {
                     formattedCommitMessage.AppendLine();
                 }
 
-                formattedCommitMessage.AppendLine(nonNullLine);
+                formattedCommitMessage.AppendLine(line);
 
                 lineNumber++;
             }

--- a/GitCommands/CustomDiffMergeToolCache.cs
+++ b/GitCommands/CustomDiffMergeToolCache.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using GitCommands.Config;
+using GitExtUtils;
 using GitUI;
 using Microsoft.VisualStudio.Threading;
 
@@ -95,7 +96,7 @@ namespace GitCommands
 
             // The sections to parse in the text has a 'header', then break parsing at first non match
 
-            foreach (var l in output.Split('\n'))
+            foreach (var l in output.LazySplit('\n'))
             {
                 if (l == "The following tools are valid, but not currently available:")
                 {

--- a/GitCommands/EnvironmentPathsProvider.cs
+++ b/GitCommands/EnvironmentPathsProvider.cs
@@ -44,7 +44,7 @@ namespace GitCommands
                 yield break;
             }
 
-            foreach (string rawDir in pathVariable.Split(EnvUtils.EnvVariableSeparator))
+            foreach (string rawDir in pathVariable.LazySplit(EnvUtils.EnvVariableSeparator))
             {
                 string dir = rawDir;
 

--- a/GitCommands/FileHelper.cs
+++ b/GitCommands/FileHelper.cs
@@ -76,7 +76,7 @@ namespace GitCommands
                 fileName.Quote()
             };
             string result = module.GitExecutable.GetOutput(cmd);
-            var lines = result.Split(Delimiters.NullAndNewline);
+            var lines = result.Split(Delimiters.NullAndLineFeed);
             var attributes = new Dictionary<string, string>();
             for (int i = 0; i < lines.Length - 2; i += 3)
             {

--- a/GitCommands/FileHelper.cs
+++ b/GitCommands/FileHelper.cs
@@ -76,7 +76,7 @@ namespace GitCommands
                 fileName.Quote()
             };
             string result = module.GitExecutable.GetOutput(cmd);
-            var lines = result.Split('\n', '\0');
+            var lines = result.Split(Delimiters.NullAndNewline);
             var attributes = new Dictionary<string, string>();
             for (int i = 0; i < lines.Length - 2; i += 3)
             {

--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -298,7 +298,7 @@ namespace GitCommands
             bool stripAnsiEscapeCodes = true)
         {
             var result = await executable.ExecuteAsync(arguments, writeInput, outputEncoding, cache, stripAnsiEscapeCodes);
-            return result.StandardOutput.SplitLines().Concat(result.StandardError.SplitLines());
+            return result.StandardOutput.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries).Concat(result.StandardError.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries));
         }
 
         /// <summary>

--- a/GitCommands/Git/GetAllChangedFilesOutputParser.cs
+++ b/GitCommands/Git/GetAllChangedFilesOutputParser.cs
@@ -61,7 +61,7 @@ namespace GitCommands.Git
             var submodules = GetModule().GetSubmodulesLocalPaths();
 
             // Split all files on '\0' (WE NEED ALL COMMANDS TO BE RUN WITH -z! THIS IS ALSO IMPORTANT FOR ENCODING ISSUES!)
-            var files = trimmedStatus.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
+            var files = trimmedStatus.Split(Delimiters.Null, StringSplitOptions.RemoveEmptyEntries);
             for (int n = 0; n < files.Length; n++)
             {
                 if (string.IsNullOrEmpty(files[n]))
@@ -77,8 +77,7 @@ namespace GitCommands.Git
                 else
                 {
                     // Note that this fails for files with spaces (git-status --porcelain=1 is deprecated)
-                    var splitChars = new[] { '\t', ' ' };
-                    splitIndex = files[n].IndexOfAny(splitChars, 1);
+                    splitIndex = files[n].IndexOfAny(Delimiters.TabAndSpace, 1);
                 }
 
                 string status;
@@ -182,7 +181,7 @@ namespace GitCommands.Git
             string trimmedStatus = RemoveWarnings(getAllChangedFilesCommandOutput);
 
             // Split all files on '\0'
-            var files = trimmedStatus.Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
+            var files = trimmedStatus.Split(Delimiters.Null, StringSplitOptions.RemoveEmptyEntries);
             for (int n = 0; n < files.Length; n++)
             {
                 string line = files[n];
@@ -221,7 +220,7 @@ namespace GitCommands.Git
                         Debug.Assert(line.Length > 2 && n + 1 < files.Length, "Cannot parse renamed:" + line);
 
                         // Find renamed files...
-                        string[] renames = line.Substring(114).Split(new[] { ' ' }, 2);
+                        string[] renames = line.Substring(114).Split(Delimiters.Space, 2);
                         renamePercent = renames[0];
                         fileName = renames[1];
                         oldFileName = files[++n];

--- a/GitCommands/Git/GitBranchNameNormaliser.cs
+++ b/GitCommands/Git/GitBranchNameNormaliser.cs
@@ -122,8 +122,8 @@ namespace GitCommands.Git
         /// <returns>Normalised branch name.</returns>
         internal string Rule01(string branchName, GitBranchNameOptions options)
         {
-            var tokens = branchName.Split('/').ToList();
-            for (int i = 0; i < tokens.Count; i++)
+            var tokens = branchName.Split(Delimiters.ForwardSlash);
+            for (int i = 0; i < tokens.Length; i++)
             {
                 if (tokens[i].StartsWith("."))
                 {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -536,7 +536,7 @@ namespace GitCommands
             }
 
             // Parse temporary file name from command line result
-            var splitResult = output.Split(Delimiters.TabAndNewlineAndCarriageReturn, StringSplitOptions.RemoveEmptyEntries);
+            var splitResult = output.Split(Delimiters.TabAndLineFeedAndCarriageReturn, StringSplitOptions.RemoveEmptyEntries);
             if (splitResult.Length != 2)
             {
                 return false;
@@ -696,7 +696,7 @@ namespace GitCommands
             var unmerged = (await _gitExecutable
                 .GetOutputAsync(args)
                 .ConfigureAwait(false))
-                .Split(Delimiters.NullAndNewline, StringSplitOptions.RemoveEmptyEntries);
+                .Split(Delimiters.NullAndLineFeed, StringSplitOptions.RemoveEmptyEntries);
 
             var item = new ConflictedFileData[3];
 
@@ -928,7 +928,7 @@ namespace GitCommands
             var revInfo = _gitExecutable.GetOutput(args, cache: GitCommandCache, outputEncoding: LosslessEncoding);
 
             // TODO improve parsing to reduce temporary string (see similar code in RevisionReader)
-            string[] lines = revInfo.Split(Delimiters.Newline);
+            string[] lines = revInfo.Split(Delimiters.LineFeed);
 
             var revision = new GitRevision(ObjectId.Parse(lines[0]))
             {
@@ -1088,7 +1088,7 @@ namespace GitCommands
                 SubmodulePath.Quote()
             };
             var output = await SuperprojectModule.GitExecutable.GetOutputAsync(args).ConfigureAwait(false);
-            var lines = output.Split(Delimiters.Newline);
+            var lines = output.Split(Delimiters.LineFeed);
 
             if (lines.Length == 0)
             {
@@ -1903,7 +1903,7 @@ namespace GitCommands
         public IReadOnlyList<PatchFile> GetInteractiveRebasePatchFiles()
         {
             string todoFile = RebaseTodoFilePath;
-            string[]? todoCommits = File.Exists(todoFile) ? File.ReadAllText(todoFile).Trim().Split(Delimiters.NewlineAndCarriageReturn, StringSplitOptions.RemoveEmptyEntries) : null;
+            string[]? todoCommits = File.Exists(todoFile) ? File.ReadAllText(todoFile).Trim().Split(Delimiters.LineFeedAndCarriageReturn, StringSplitOptions.RemoveEmptyEntries) : null;
 
             var patchFiles = new List<PatchFile>();
 
@@ -2251,7 +2251,7 @@ namespace GitCommands
         public IReadOnlyList<GitStash> GetStashes(bool noLocks = false)
         {
             var args = GetStashesCmd(noLocks);
-            var lines = _gitExecutable.GetOutput(args).Split(Delimiters.Newline);
+            var lines = _gitExecutable.GetOutput(args).Split(Delimiters.LineFeed);
 
             var stashes = new List<GitStash>(lines.Length);
 
@@ -2944,7 +2944,7 @@ namespace GitCommands
             => (await _gitExecutable
                 .GetOutputAsync(GitCommandHelpers.MergedBranchesCmd(includeRemote, fullRefname, commit))
                 .ConfigureAwait(false))
-                .Split(Delimiters.Newline, StringSplitOptions.RemoveEmptyEntries);
+                .Split(Delimiters.LineFeed, StringSplitOptions.RemoveEmptyEntries);
 
         public IEnumerable<string> GetMergedBranches(bool includeRemote = false)
         {
@@ -3157,7 +3157,7 @@ namespace GitCommands
                 // filter duplicates out of the result because options -c and -m may return
                 // same files at times
                 return _gitExecutable.GetOutput($"ls-files -z -o -m -c -i {excludeParams}")
-                    .Split(Delimiters.NullAndNewline, StringSplitOptions.RemoveEmptyEntries)
+                    .Split(Delimiters.NullAndLineFeed, StringSplitOptions.RemoveEmptyEntries)
                     .Distinct()
                     .ToList();
             }
@@ -3172,7 +3172,7 @@ namespace GitCommands
             return _gitExecutable.GetOutput(
                     $"ls-tree -z -r --name-only {id}",
                     cache: GitCommandCache)
-                .Split(Delimiters.NullAndNewline);
+                .Split(Delimiters.NullAndLineFeed);
         }
 
         public IEnumerable<INamedGitItem> GetTree(ObjectId? commitId, bool full)
@@ -3799,7 +3799,7 @@ namespace GitCommands
 
             // Get processes by "ps" command.
             var cmd = Path.Combine(AppSettings.GitBinDir, "ps");
-            var lines = new Executable(cmd).GetOutput("x").Split(Delimiters.Newline);
+            var lines = new Executable(cmd).GetOutput("x").Split(Delimiters.LineFeed);
 
             if (lines.Length <= 2)
             {

--- a/GitCommands/Git/GitTreeParser.cs
+++ b/GitCommands/Git/GitTreeParser.cs
@@ -38,7 +38,7 @@ namespace GitCommands.Git
             // 100644 blob 5b0965cd097b8c48b66dd456337852640fa429c8    stylecop.json
 
             // Split on \0 too, as GitModule.GetTree uses `ls-tree -z` which uses null terminators
-            var items = tree.Split('\0', '\n');
+            var items = tree.Split(Delimiters.NullAndNewline);
 
             return items.Select(ParseSingle).Where(item => item is not null)!;
         }

--- a/GitCommands/Git/GitTreeParser.cs
+++ b/GitCommands/Git/GitTreeParser.cs
@@ -38,7 +38,7 @@ namespace GitCommands.Git
             // 100644 blob 5b0965cd097b8c48b66dd456337852640fa429c8    stylecop.json
 
             // Split on \0 too, as GitModule.GetTree uses `ls-tree -z` which uses null terminators
-            var items = tree.Split(Delimiters.NullAndNewline);
+            var items = tree.Split(Delimiters.NullAndLineFeed);
 
             return items.Select(ParseSingle).Where(item => item is not null)!;
         }

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using GitExtUtils;
 
 namespace GitCommands
 {
@@ -81,7 +82,7 @@ namespace GitCommands
 
                 IEnumerable<int> ParseNumbers()
                 {
-                    foreach (var number in Full.Split('.'))
+                    foreach (var number in Full.LazySplit('.'))
                     {
                         if (int.TryParse(number, out var value))
                         {

--- a/GitCommands/GitCommands.csproj
+++ b/GitCommands/GitCommands.csproj
@@ -7,6 +7,8 @@
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
     <Compile Include="..\GitExtUtils\Annotations.cs" Link="Annotations.cs" />
+    <Compile Include="..\GitExtUtils\Delimiters.cs" Link="Utils\Delimiters.cs" />
+    <Compile Include="..\GitExtUtils\LazyStringSplit.cs" Link="Utils\LazyStringSplit.cs" />
     <Compile Include="..\GitExtUtils\Strings.cs" Link="Strings.cs" />
     <Compile Include="..\GitExtUtils\Validates.cs" Link="Validates.cs" />
 

--- a/GitCommands/Patches/PatchManager.cs
+++ b/GitCommands/Patches/PatchManager.cs
@@ -512,7 +512,7 @@ namespace GitCommands.Patches
 
         public static Chunk? ParseChunk(string chunkStr, int currentPos, int selectionPosition, int selectionLength)
         {
-            string[] lines = chunkStr.Split('\n');
+            string[] lines = chunkStr.Split(Delimiters.Newline);
             if (lines.Length < 2)
             {
                 return null;

--- a/GitCommands/Patches/PatchManager.cs
+++ b/GitCommands/Patches/PatchManager.cs
@@ -512,7 +512,7 @@ namespace GitCommands.Patches
 
         public static Chunk? ParseChunk(string chunkStr, int currentPos, int selectionPosition, int selectionLength)
         {
-            string[] lines = chunkStr.Split(Delimiters.Newline);
+            string[] lines = chunkStr.Split(Delimiters.LineFeed);
             if (lines.Length < 2)
             {
                 return null;

--- a/GitCommands/Patches/PatchProcessor.cs
+++ b/GitCommands/Patches/PatchProcessor.cs
@@ -37,7 +37,7 @@ namespace GitCommands.Patches
         {
             // TODO encoding for each file in patch should be obtained separately from .gitattributes
 
-            string[] lines = patchText.Split('\n');
+            string[] lines = patchText.Split(Delimiters.Newline);
             int i = 0;
 
             // skip email header

--- a/GitCommands/Patches/PatchProcessor.cs
+++ b/GitCommands/Patches/PatchProcessor.cs
@@ -37,7 +37,7 @@ namespace GitCommands.Patches
         {
             // TODO encoding for each file in patch should be obtained separately from .gitattributes
 
-            string[] lines = patchText.Split(Delimiters.Newline);
+            string[] lines = patchText.Split(Delimiters.LineFeed);
             int i = 0;
 
             // skip email header

--- a/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
+++ b/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
@@ -150,7 +150,7 @@ namespace GitCommands.Remotes
             }
 
             var remoteHead = remote.Push
-                                   .Select(s => s.Split(':'))
+                                   .Select(s => s.Split(Delimiters.Colon))
                                    .Where(t => t.Length == 2)
                                    .Where(t => IsSettingForBranch(t[0], branch))
                                    .Select(t => new GitRef(module, null, t[1]))

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -12,6 +12,7 @@ using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using GitCommands.Settings;
 using GitCommands.Utils;
+using GitExtUtils;
 using GitExtUtils.GitUI.Theming;
 using GitUIPluginInterfaces;
 using Microsoft;
@@ -1375,7 +1376,7 @@ namespace GitCommands
         {
             get
             {
-                return GetString("uithemevariations", string.Empty).Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                return GetString("uithemevariations", string.Empty).Split(Delimiters.Comma, StringSplitOptions.RemoveEmptyEntries);
             }
             set
             {
@@ -2027,7 +2028,7 @@ namespace GitCommands
             else
             {
                 var utf8 = new UTF8Encoding(false);
-                foreach (var encodingName in availableEncodings.Split(';'))
+                foreach (var encodingName in availableEncodings.LazySplit(';'))
                 {
                     if (encodingName == Encoding.UTF7.HeaderName)
                     {

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -11,9 +11,6 @@ namespace System
 {
     public static class StringExtensions
     {
-        private static readonly char[] _newLine = { '\n' };
-        private static readonly char[] _space = { ' ' };
-
         // NOTE ordinal string comparison is the default as most string comparison in GE is against static ASCII output from git.exe
 
         /// <summary>
@@ -231,7 +228,7 @@ namespace System
 
             var sb = new StringBuilder(capacity: value.Length);
 
-            foreach (var line in value.Split('\n'))
+            foreach (var line in value.LazySplit('\n'))
             {
                 if (!shouldRemoveLine(line))
                 {
@@ -241,14 +238,6 @@ namespace System
 
             return sb.ToString();
         }
-
-        /// <summary>Split a string, delimited by line-breaks, excluding empty entries.</summary>
-        [Pure]
-        public static string[] SplitLines(this string value) => value.Split(_newLine, StringSplitOptions.RemoveEmptyEntries);
-
-        /// <summary>Split a string, delimited by the space character, excluding empty entries.</summary>
-        [Pure]
-        public static string[] SplitBySpace(this string value) => value.Split(_space, StringSplitOptions.RemoveEmptyEntries);
 
         /// <summary>
         /// Shortens <paramref name="str"/> if necessary, so that the resulting string has fewer than <paramref name="maxLength"/> characters.

--- a/GitExtUtils/Delimiters.cs
+++ b/GitExtUtils/Delimiters.cs
@@ -2,16 +2,23 @@ using System.IO;
 
 namespace System
 {
+    /// <summary>
+    /// Singleton instances of commonly used character arrays.
+    /// </summary>
+    /// <remarks>
+    /// Using these instances avoids allocating an array for each invocation of methods
+    /// such as <c>string.Split</c>.
+    /// </remarks>
     internal static class Delimiters
     {
-        public static readonly char[] Newline = { '\n' };
+        public static readonly char[] LineFeed = { '\n' };
         public static readonly char[] Space = { ' ' };
         public static readonly char[] Tab = { '\t' };
         public static readonly char[] Null = { '\0' };
         public static readonly char[] TabAndSpace = { '\t', ' ' };
-        public static readonly char[] TabAndNewlineAndCarriageReturn = { '\t', '\n', '\r' };
-        public static readonly char[] NullAndNewline = { '\0', '\n' };
-        public static readonly char[] NewlineAndCarriageReturn = { '\n', '\r' };
+        public static readonly char[] TabAndLineFeedAndCarriageReturn = { '\t', '\n', '\r' };
+        public static readonly char[] NullAndLineFeed = { '\0', '\n' };
+        public static readonly char[] LineFeedAndCarriageReturn = { '\n', '\r' };
         public static readonly char[] ForwardSlash = { '/' };
         public static readonly char[] Colon = { ':' };
         public static readonly char[] Comma = { ',' };

--- a/GitExtUtils/Delimiters.cs
+++ b/GitExtUtils/Delimiters.cs
@@ -1,0 +1,22 @@
+using System.IO;
+
+namespace System
+{
+    internal static class Delimiters
+    {
+        public static readonly char[] Newline = { '\n' };
+        public static readonly char[] Space = { ' ' };
+        public static readonly char[] Tab = { '\t' };
+        public static readonly char[] Null = { '\0' };
+        public static readonly char[] TabAndSpace = { '\t', ' ' };
+        public static readonly char[] TabAndNewlineAndCarriageReturn = { '\t', '\n', '\r' };
+        public static readonly char[] NullAndNewline = { '\0', '\n' };
+        public static readonly char[] NewlineAndCarriageReturn = { '\n', '\r' };
+        public static readonly char[] ForwardSlash = { '/' };
+        public static readonly char[] Colon = { ':' };
+        public static readonly char[] Comma = { ',' };
+        public static readonly char[] Period = { '.' };
+        public static readonly char[] Hash = { '#' };
+        public static readonly char[] PathSeparators = { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+    }
+}

--- a/GitExtUtils/LazyStringSplit.cs
+++ b/GitExtUtils/LazyStringSplit.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft;
+
+namespace GitExtUtils
+{
+    /// <summary>
+    /// Splits a string by a delimiter, producing substrings lazily during enumeration.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="string.Split(char[])"/> and overloads, <see cref="LazyStringSplit"/>
+    /// does not allocate an array for the return, and allocates strings on demand during
+    /// enumeration. A custom enumerator type is used so that the only allocations made are
+    /// the substrings themselves. We also avoid the large internal arrays assigned by the
+    /// methods on <see cref="string"/>.
+    /// </remarks>
+    internal readonly struct LazyStringSplit : IEnumerable<string>
+    {
+        private readonly string _input;
+        private readonly char _delimiter;
+        private readonly StringSplitOptions _options;
+
+        public LazyStringSplit(string input, char delimiter, StringSplitOptions options = StringSplitOptions.None)
+        {
+            Requires.NotNull(input, nameof(input));
+
+            _input = input;
+            _delimiter = delimiter;
+            _options = options;
+        }
+
+        public Enumerator GetEnumerator() => new(this, _options);
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        IEnumerator<string> IEnumerable<string>.GetEnumerator() => GetEnumerator();
+
+        public struct Enumerator : IEnumerator<string>
+        {
+            private readonly StringSplitOptions _options;
+            private readonly string _input;
+            private readonly char _delimiter;
+            private int _index;
+
+            internal Enumerator(in LazyStringSplit split, StringSplitOptions options)
+            {
+                _options = options;
+                _index = 0;
+                _input = split._input;
+                _delimiter = split._delimiter;
+                Current = null!;
+            }
+
+            public string Current { get; private set; }
+
+            public bool MoveNext()
+            {
+                while (_index < _input.Length)
+                {
+                    int delimiterIndex = _input.IndexOf(_delimiter, _index);
+
+                    if (delimiterIndex == -1)
+                    {
+                        Current = _input.Substring(_index);
+                        _index = _input.Length + 1;
+                        return true;
+                    }
+
+                    int length = delimiterIndex - _index;
+
+                    if (length == 0)
+                    {
+                        _index++;
+                        if (_options == StringSplitOptions.RemoveEmptyEntries)
+                        {
+                            continue;
+                        }
+                        else
+                        {
+                            Current = "";
+                            return true;
+                        }
+                    }
+
+                    Current = _input.Substring(_index, length);
+                    _index = delimiterIndex + 1;
+
+                    return true;
+                }
+
+                if (_options == StringSplitOptions.None && _index == _input.Length)
+                {
+                    _index++;
+                    Current = "";
+                    return true;
+                }
+
+                return false;
+            }
+
+            object IEnumerator.Current => Current;
+
+            void IEnumerator.Reset()
+            {
+                _index = 0;
+                Current = null!;
+            }
+
+            void IDisposable.Dispose()
+            {
+            }
+        }
+    }
+
+    internal static class LazyStringSplitExtensions
+    {
+        public static LazyStringSplit LazySplit(this string s, char delimiter, StringSplitOptions options = StringSplitOptions.None)
+        {
+            return new(s, delimiter, options);
+        }
+
+        public static IEnumerable<T> Select<T>(this LazyStringSplit split, Func<string, T> func)
+        {
+            foreach (string value in split)
+            {
+                yield return func(value);
+            }
+        }
+
+        public static string First(this LazyStringSplit split)
+        {
+            return split.FirstOrDefault() ?? throw new InvalidOperationException("Sequence is empty.");
+        }
+
+        public static string? FirstOrDefault(this LazyStringSplit split)
+        {
+            using var enumerator = split.GetEnumerator();
+            return enumerator.MoveNext() ? enumerator.Current : null;
+        }
+
+        public static string? LastOrDefault(this LazyStringSplit split)
+        {
+            using var enumerator = split.GetEnumerator();
+
+            if (!enumerator.MoveNext())
+            {
+                return null;
+            }
+
+            while (true)
+            {
+                string last = enumerator.Current;
+
+                if (!enumerator.MoveNext())
+                {
+                    return last;
+                }
+            }
+        }
+
+        public static IEnumerable<string> Where(this LazyStringSplit split, Func<string, bool> predicate)
+        {
+            foreach (string s in split)
+            {
+                if (predicate(s))
+                {
+                    yield return s;
+                }
+            }
+        }
+    }
+}

--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -120,7 +120,7 @@ namespace GitUI.AutoCompletion
             }
 
             using var sr = new StreamReader(s);
-            return sr.ReadToEnd().Split(Delimiters.NewlineAndCarriageReturn, StringSplitOptions.RemoveEmptyEntries);
+            return sr.ReadToEnd().Split(Delimiters.LineFeedAndCarriageReturn, StringSplitOptions.RemoveEmptyEntries);
         }
 
         private static Dictionary<string, Regex> ParseRegexes()

--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -120,7 +120,7 @@ namespace GitUI.AutoCompletion
             }
 
             using var sr = new StreamReader(s);
-            return sr.ReadToEnd().Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
+            return sr.ReadToEnd().Split(Delimiters.NewlineAndCarriageReturn, StringSplitOptions.RemoveEmptyEntries);
         }
 
         private static Dictionary<string, Regex> ParseRegexes()
@@ -135,7 +135,7 @@ namespace GitUI.AutoCompletion
                 var extensionStr = line.Substring(0, i);
                 var regexStr = line.Substring(i + 1).Trim();
 
-                var extensions = extensionStr.Split(',').Select(s => s.Trim()).Distinct();
+                var extensions = extensionStr.LazySplit(',').Select(s => s.Trim()).Distinct();
                 var regex = new Regex(regexStr, RegexOptions.Compiled);
 
                 foreach (var extension in extensions)

--- a/GitUI/Avatars/CustomAvatarProvider.cs
+++ b/GitUI/Avatars/CustomAvatarProvider.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Linq;
 using System.Threading.Tasks;
 using GitCommands;
+using GitExtUtils;
 
 namespace GitUI.Avatars
 {
@@ -60,7 +61,7 @@ namespace GitUI.Avatars
             }
 
             var providerParts = customProviderTemplates
-                .Split(';')
+                .LazySplit(';')
                 .Select(p => p.Trim())
                 .Select(p => FromTemplateSegment(downloader, p))
                 .WhereNotNull()

--- a/GitUI/Avatars/InitialsAvatarProvider.cs
+++ b/GitUI/Avatars/InitialsAvatarProvider.cs
@@ -52,7 +52,7 @@ namespace GitUI.Avatars
 
             if (!Strings.IsNullOrWhiteSpace(email))
             {
-                var withoutDomain = email.Split('@')[0].TrimStart();
+                var withoutDomain = email.LazySplit('@').First().TrimStart();
                 return (withoutDomain, _emailInitialSeparator);
             }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Remotes;
+using GitExtUtils;
 using GitUI.BranchTreePanel.Interfaces;
 using GitUI.Properties;
 using GitUI.UserControls.RevisionGrid;
@@ -218,7 +219,7 @@ namespace GitUI.BranchTreePanel
 
             private RemoteBranchInfo GetRemoteBranchInfo()
             {
-                var remote = FullPath.Split('/').First();
+                var remote = FullPath.LazySplit('/').First();
                 var branch = FullPath.Substring(remote.Length + 1);
                 return new RemoteBranchInfo(remote, branch);
             }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -68,7 +68,7 @@ namespace GitUI.BranchTreePanel
                 // Extract submodule name and branch
                 // e.g. Info.Text = "Externals/conemu-inside [no branch]"
                 // Note that the branch portion won't be there if the user hasn't yet init'd + updated the submodule.
-                var pathAndBranch = Info.Text.Split(new char[] { ' ' }, 2);
+                var pathAndBranch = Info.Text.Split(Delimiters.Space, 2);
                 Trace.Assert(pathAndBranch.Length >= 1);
                 SubmoduleName = pathAndBranch[0].SubstringAfterLast('/'); // Remove path
                 BranchText = pathAndBranch.Length == 2 ? " " + pathAndBranch[1] : "";
@@ -477,7 +477,7 @@ namespace GitUI.BranchTreePanel
                 // Create and add missing SubmoduleFolderNodes
                 foreach (var node in submoduleNodes)
                 {
-                    var parts = GetNodeRelativePath(topModule, node).Split('/');
+                    var parts = GetNodeRelativePath(topModule, node).Split(Delimiters.ForwardSlash);
                     for (int i = 0; i < parts.Length - 1; ++i)
                     {
                         var path = string.Join("/", parts.Take(i + 1));
@@ -494,7 +494,7 @@ namespace GitUI.BranchTreePanel
                 foreach (var node in submoduleNodes)
                 {
                     Node parentNode = rootNode;
-                    var parts = GetNodeRelativePath(topModule, node).Split('/');
+                    var parts = GetNodeRelativePath(topModule, node).Split(Delimiters.ForwardSlash);
                     for (int i = 0; i < parts.Length; ++i)
                     {
                         var path = string.Join("/", parts.Take(i + 1));

--- a/GitUI/CommandsDialogs/FormAbout.cs
+++ b/GitUI/CommandsDialogs/FormAbout.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using GitCommands;
+using GitExtUtils;
 using GitUI.CommandsDialogs.AboutBoxDialog;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.Properties;
@@ -66,7 +67,7 @@ namespace GitUI.CommandsDialogs
             {
                 return new[] { Resources.Team, Resources.Coders, Resources.Translators, Resources.Designers }
                     .Select(c => c.Replace(Environment.NewLine, ""))
-                    .SelectMany(line => line.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries))
+                    .SelectMany(line => line.LazySplit(',', StringSplitOptions.RemoveEmptyEntries))
                     .Select(contributor => contributor.Trim())
                     .ToList();
             }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2428,7 +2428,7 @@ namespace GitUI.CommandsDialogs
                     name.QuoteNE()
                 };
                 string diff = Module.GitExecutable.GetOutput(args);
-                var lines = diff.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                var lines = diff.Split(Delimiters.Newline, StringSplitOptions.RemoveEmptyEntries);
                 const string subprojectCommit = "Subproject commit ";
                 var from = lines.Single(s => s.StartsWith("-" + subprojectCommit)).Substring(subprojectCommit.Length + 1);
                 var to = lines.Single(s => s.StartsWith("+" + subprojectCommit)).Substring(subprojectCommit.Length + 1);

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2428,7 +2428,7 @@ namespace GitUI.CommandsDialogs
                     name.QuoteNE()
                 };
                 string diff = Module.GitExecutable.GetOutput(args);
-                var lines = diff.Split(Delimiters.Newline, StringSplitOptions.RemoveEmptyEntries);
+                var lines = diff.Split(Delimiters.LineFeed, StringSplitOptions.RemoveEmptyEntries);
                 const string subprojectCommit = "Subproject commit ";
                 var from = lines.Single(s => s.StartsWith("-" + subprojectCommit)).Substring(subprojectCommit.Length + 1);
                 var to = lines.Single(s => s.StartsWith("+" + subprojectCommit)).Substring(subprojectCommit.Length + 1);

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -84,7 +84,7 @@ namespace GitUI.CommandsDialogs
                 gridReflog.DataSource = refLines;
 
                 IEnumerable<RefLine> ConvertReflogOutput()
-                    => from line in output.Split('\n')
+                    => from line in output.LazySplit('\n')
                         where line.Length != 0
                         select _regexReflog.Match(line)
                         into match

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Windows.Forms;
 
 using GitCommands;
+using GitExtUtils;
 using GitUI.HelperDialogs;
 
 namespace GitUI.CommandsDialogs
@@ -215,7 +216,7 @@ namespace GitUI.CommandsDialogs
             }
 
             // Now check the rules, the well-known recommendation is to have the single "/*" rule active
-            List<string> rulelines = RulesText.SplitLines().Select(l => l.Trim()).Where(l => (!string.IsNullOrEmpty(l)) && (l[0] != '#')).ToList(); // All nonempty and non-comment lines
+            List<string> rulelines = RulesText.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries).Select(l => l.Trim()).Where(l => (!string.IsNullOrEmpty(l)) && (l[0] != '#')).ToList(); // All nonempty and non-comment lines
             if (rulelines.All(l => l == "/*"))
             {
                 return; // Rules OK for turning off
@@ -231,7 +232,7 @@ namespace GitUI.CommandsDialogs
 
             // Adjust the rules
             // Comment out all existing nonempty lines, add the single “/*” line to make a total pass filter
-            RulesText = new[] { "/*" }.Concat(RulesText.SplitLines().Select(l => (string.IsNullOrWhiteSpace(l) || (l[0] == '#')) ? l : "#" + l)).Join(Environment.NewLine);
+            RulesText = new[] { "/*" }.Concat(RulesText.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries).Select(l => (string.IsNullOrWhiteSpace(l) || (l[0] == '#')) ? l : "#" + l)).Join(Environment.NewLine);
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/FormVerify.LostObject.cs
+++ b/GitUI/CommandsDialogs/FormVerify.LostObject.cs
@@ -117,7 +117,7 @@ namespace GitUI.CommandsDialogs
                         result.Date = DateTimeUtils.ParseUnixTime(logPatternMatch.Groups[4].Value);
                         if (logPatternMatch.Groups.Count >= 5)
                         {
-                            var parentId = logPatternMatch.Groups[5].Value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+                            var parentId = logPatternMatch.Groups[5].Value.LazySplit(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
                             if (parentId is not null)
                             {
                                 result.Parent = ObjectId.Parse(parentId);

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -80,7 +80,7 @@ See the changes in the commit form.");
                 return;
             }
 
-            var pathParts = filePath.Split('/');
+            var pathParts = filePath.Split(Delimiters.ForwardSlash);
 
             var currentNodes = tvGitTree.Nodes;
             TreeNode? foundNode = null;
@@ -467,7 +467,7 @@ See the changes in the commit form.");
                 return;
             }
 
-            var items = selectedItem.Split('/');
+            var items = selectedItem.Split(Delimiters.ForwardSlash);
             var nodes = tvGitTree.Nodes;
 
             for (var i = 0; i < items.Length - 1; i++)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
@@ -122,7 +122,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 return null;
             }
 
-            var defaultProjectName = Module.WorkingDir.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries).Last();
+            var defaultProjectName = Module.WorkingDir.Split(Delimiters.PathSeparators, StringSplitOptions.RemoveEmptyEntries).Last();
 
             var exports = ManagedExtensibility.GetExports<IBuildServerSettingsUserControl, IBuildServerTypeMetadata>();
             var selectedExport = exports.SingleOrDefault(export => export.Metadata.BuildServerType == GetSelectedBuildServerType());

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.Properties;
 using Microsoft;
@@ -141,7 +142,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 }
 
                 // search for keywords (space combines as 'and')
-                var andKeywords = searchFor.Split(' ');
+                var andKeywords = searchFor.LazySplit(' ');
                 if (andKeywords.All(keyword => settingsPage.GetSearchKeywords().Any(k => k.Contains(keyword))))
                 {
                     // only part of a keyword must match to have a match

--- a/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
+++ b/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
@@ -104,7 +104,7 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
 
             var gitArguments = new GitArgumentBuilder("ls-remote") { "--heads", url.ToPosixPath().Quote() };
             var heads = gitExecutable.GetOutput(gitArguments);
-            return heads.SplitLines()
+            return heads.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries)
                         .Select(head =>
                         {
                             int branchIndex = head.IndexOf(GitRefName.RefsHeadsPrefix);

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Properties;
@@ -63,22 +64,21 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         private void Initialize()
         {
-            var lines = Module.GitExecutable.GetOutput("worktree list --porcelain").Split('\n').GetEnumerator();
+            var lines = Module.GitExecutable.GetOutput("worktree list --porcelain");
 
             _worktrees = new List<WorkTree>();
             WorkTree? currentWorktree = null;
-            while (lines.MoveNext())
+            foreach (var line in lines.LazySplit('\n'))
             {
-                var current = (string)lines.Current;
-                if (string.IsNullOrWhiteSpace(current))
+                if (string.IsNullOrWhiteSpace(line))
                 {
                     continue;
                 }
 
-                var strings = current.Split(' ');
+                var strings = line.Split(' ');
                 if (strings[0] == "worktree")
                 {
-                    currentWorktree = new WorkTree { Path = current.Substring(9) };
+                    currentWorktree = new WorkTree { Path = line.Substring(9) };
                     currentWorktree.IsDeleted = !Directory.Exists(currentWorktree.Path);
                     _worktrees.Add(currentWorktree);
                 }

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -222,12 +222,12 @@ namespace GitUI.CommitInfo
             int warningPos = tree.IndexOf("warning:");
             if (warningPos >= 0)
             {
-                throw new RefsWarningException(tree.Substring(warningPos).SplitLines()[0]);
+                throw new RefsWarningException(tree.Substring(warningPos).LazySplit('\n', StringSplitOptions.RemoveEmptyEntries).First());
             }
 
             int i = 0;
             var dict = new Dictionary<string, int>();
-            foreach (var entry in tree.Split('\n'))
+            foreach (var entry in tree.LazySplit('\n'))
             {
                 if (dict.ContainsKey(entry))
                 {

--- a/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
+++ b/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Text.RegularExpressions;
 using GitCommands;
 using GitCommands.Patches;
 
@@ -18,7 +19,7 @@ namespace GitUI.Editor.Diff
             var leftLineNum = DiffLineInfo.NotApplicableLineNum;
             var rightLineNum = DiffLineInfo.NotApplicableLineNum;
             var isHeaderLineLocated = false;
-            string[] lines = diffContent.Split('\n');
+            string[] lines = diffContent.Split(Delimiters.Newline);
             for (int i = 0; i < lines.Length; i++)
             {
                 string line = lines[i];

--- a/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
+++ b/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
@@ -19,7 +19,7 @@ namespace GitUI.Editor.Diff
             var leftLineNum = DiffLineInfo.NotApplicableLineNum;
             var rightLineNum = DiffLineInfo.NotApplicableLineNum;
             var isHeaderLineLocated = false;
-            string[] lines = diffContent.Split(Delimiters.Newline);
+            string[] lines = diffContent.Split(Delimiters.LineFeed);
             for (int i = 0; i < lines.Length; i++)
             {
                 string line = lines[i];

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -774,7 +774,7 @@ namespace GitUI.Editor
                     code = " " + code;
                 }
 
-                var lines = code.Split('\n')
+                var lines = code.LazySplit('\n')
                     .Where(s => s.Length == 0 || s[0] != startChar || (s.Length > 2 && s[1] == s[0] && s[2] == s[0]));
                 var hpos = fileText.IndexOf("\n@@");
 
@@ -1637,9 +1637,7 @@ namespace GitUI.Editor
                         }
                     }
 
-                    string[] lines = code.Split('\n');
-                    lines.Transform(RemovePrefix);
-                    code = string.Join("\n", lines);
+                    code = string.Join("\n", code.LazySplit('\n').Select(RemovePrefix));
                 }
             }
 

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -638,7 +638,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static string GetUrl(this LinkClickedEventArgs e)
         {
-            var v = e.LinkText.Split(new[] { '#' }, 2);
+            var v = e.LinkText.Split(Delimiters.Hash, 2);
             return v.Length switch
             {
                 0 => "",
@@ -649,7 +649,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static void GetLinkText(this LinkClickedEventArgs e, out string url, out string text)
         {
-            var v = e.LinkText.Split(new[] { '#' }, 2);
+            var v = e.LinkText.Split(Delimiters.Hash, 2);
             if (v.Length == 0)
             {
                 url = "";

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -8,6 +8,8 @@
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
     <Compile Include="..\GitExtUtils\Annotations.cs" Link="Utils\Annotations.cs" />
+    <Compile Include="..\GitExtUtils\Delimiters.cs" Link="Utils\Delimiters.cs" />
+    <Compile Include="..\GitExtUtils\LazyStringSplit.cs" Link="Utils\LazyStringSplit.cs" />
     <Compile Include="..\GitExtUtils\Strings.cs" Link="Utils\Strings.cs" />
     <Compile Include="..\GitExtUtils\Validates.cs" Link="Utils\Validates.cs" />
   </ItemGroup>

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1557,7 +1557,7 @@ namespace GitUI
             {
                 selectedId = null;
                 firstId = null;
-                foreach (string part in arg.Split(','))
+                foreach (string part in arg.LazySplit(','))
                 {
                     if (!module.TryResolvePartialCommitId(part, out var objectId))
                     {
@@ -1604,7 +1604,7 @@ namespace GitUI
             {
                 if (File.Exists(args[2]))
                 {
-                    string path = File.ReadAllText(args[2]).Trim().Split(new[] { '\n' }, 1).FirstOrDefault();
+                    string? path = File.ReadAllText(args[2]).Trim().LazySplit('\n').FirstOrDefault();
                     if (Directory.Exists(path))
                     {
                         c = new GitUICommands(path);

--- a/GitUI/UserControls/BranchComboBox.cs
+++ b/GitUI/UserControls/BranchComboBox.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
 using Microsoft;
@@ -46,7 +47,7 @@ namespace GitUI
 
         public IEnumerable<IGitRef> GetSelectedBranches()
         {
-            foreach (string branch in branches.Text.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries))
+            foreach (string branch in branches.Text.LazySplit(' ', StringSplitOptions.RemoveEmptyEntries))
             {
                 var gitHead = _branchesToSelect.FirstOrDefault(g => g.Name == branch);
                 if (gitHead is null)

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -484,6 +484,6 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         }
 
         private static string[] GetCommitMessageLines(GitRevision revision) =>
-            (revision.Body?.Trim() ?? revision.Subject).SplitLines();
+            (revision.Body?.Trim() ?? revision.Subject).Split(Delimiters.Newline, StringSplitOptions.RemoveEmptyEntries);
     }
 }

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -484,6 +484,6 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         }
 
         private static string[] GetCommitMessageLines(GitRevision revision) =>
-            (revision.Body?.Trim() ?? revision.Subject).Split(Delimiters.Newline, StringSplitOptions.RemoveEmptyEntries);
+            (revision.Body?.Trim() ?? revision.Subject).Split(Delimiters.LineFeed, StringSplitOptions.RemoveEmptyEntries);
     }
 }

--- a/GitUI/WebBrowserEmulationMode.cs
+++ b/GitUI/WebBrowserEmulationMode.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using GitExtUtils;
 using Microsoft.Win32;
 
 namespace GitUI
@@ -58,7 +59,7 @@ namespace GitUI
                         }
                     }
 
-                    int.TryParse(version.ToString().Split('.')[0], out browserVersion);
+                    int.TryParse(version.ToString().LazySplit('.').First(), out browserVersion);
                 }
 
                 emulationMode = browserVersion switch

--- a/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
+++ b/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
@@ -117,7 +117,7 @@ namespace GitExtensions.Plugins.BackgroundFetch
                                           }
                                       }
 
-                                      var gitCmd = _gitCommand.ValueOrDefault(Settings).Trim().SplitBySpace();
+                                      var gitCmd = _gitCommand.ValueOrDefault(Settings).Trim().Split(Delimiters.Space, StringSplitOptions.RemoveEmptyEntries);
                                       args = new GitArgumentBuilder(gitCmd[0]) { gitCmd.Skip(1) };
                                       string msg;
                                       try

--- a/Plugins/BackgroundFetch/GitExtensions.Plugins.BackgroundFetch.csproj
+++ b/Plugins/BackgroundFetch/GitExtensions.Plugins.BackgroundFetch.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\GitExtUtils\Delimiters.cs" Link="Delimiters.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\..\GitExtUtils\Annotations.cs" Link="Annotations.cs" />

--- a/Plugins/Statistics/GitImpact/GitExtensions.Plugins.GitImpact.csproj
+++ b/Plugins/Statistics/GitImpact/GitExtensions.Plugins.GitImpact.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <Compile Include="..\..\..\GitExtUtils\Delimiters.cs" Link="Delimiters.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\GitExtUtils\GitExtUtils.csproj" />
     <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj" />
     <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />

--- a/Plugins/Statistics/GitImpact/ImpactLoader.cs
+++ b/Plugins/Statistics/GitImpact/ImpactLoader.cs
@@ -200,7 +200,7 @@ namespace GitExtensions.Plugins.GitImpact
                         continue;
                     }
 
-                    string[] fileLine = line.Split('\t');
+                    string[] fileLine = line.Split(Delimiters.Tab);
                     if (fileLine.Length >= 2)
                     {
                         if (fileLine[0] != "-")

--- a/ResourceManager/LocalizationHelpers.cs
+++ b/ResourceManager/LocalizationHelpers.cs
@@ -159,7 +159,7 @@ namespace ResourceManager
                         sb.AppendLine("\t\t\t\t\t" + GetRelativeDateString(DateTime.UtcNow, oldCommitData.CommitDate.UtcDateTime) + " (" +
                                       GetFullDateString(oldCommitData.CommitDate) + ")");
                         var delimiter = new[] { '\n', '\r' };
-                        var lines = oldCommitData.Body.Trim(delimiter).Split(new[] { "\r\n" }, 0);
+                        var lines = oldCommitData.Body.Trim(delimiter).Split(new[] { "\r\n" }, StringSplitOptions.None);
                         foreach (var line in lines)
                         {
                             sb.AppendLine("\t\t" + line);
@@ -191,7 +191,7 @@ namespace ResourceManager
                     sb.AppendLine("\t\t\t\t\t" + GetRelativeDateString(DateTime.UtcNow, commitData.CommitDate.UtcDateTime) + " (" +
                                   GetFullDateString(commitData.CommitDate) + ")");
                     var delimiter = new[] { '\n', '\r' };
-                    var lines = commitData.Body.Trim(delimiter).Split(new[] { "\r\n" }, 0);
+                    var lines = commitData.Body.Trim(delimiter).Split(new[] { "\r\n" }, StringSplitOptions.None);
                     foreach (var line in lines)
                     {
                         sb.AppendLine("\t\t" + line);
@@ -271,7 +271,7 @@ namespace ResourceManager
                         sb.AppendLine("\nStatus:");
                         if (limitOutput)
                         {
-                            var txt = statusText.SplitLines();
+                            var txt = statusText.Split(Delimiters.Newline, StringSplitOptions.RemoveEmptyEntries);
                             if (txt.Length > maxLimitedLines)
                             {
                                 statusText = new List<string>(txt).Take(maxLimitedLines).Join(Environment.NewLine) +
@@ -298,7 +298,7 @@ namespace ResourceManager
                     sb.AppendLine("\nDifferences:");
                     if (limitOutput)
                     {
-                        var txt = diffs.SplitLines();
+                        var txt = diffs.Split(Delimiters.Newline, StringSplitOptions.RemoveEmptyEntries);
                         if (txt.Length > maxLimitedLines)
                         {
                             diffs = new List<string>(txt).Take(maxLimitedLines).Join(Environment.NewLine) +

--- a/ResourceManager/LocalizationHelpers.cs
+++ b/ResourceManager/LocalizationHelpers.cs
@@ -271,7 +271,7 @@ namespace ResourceManager
                         sb.AppendLine("\nStatus:");
                         if (limitOutput)
                         {
-                            var txt = statusText.Split(Delimiters.Newline, StringSplitOptions.RemoveEmptyEntries);
+                            var txt = statusText.Split(Delimiters.LineFeed, StringSplitOptions.RemoveEmptyEntries);
                             if (txt.Length > maxLimitedLines)
                             {
                                 statusText = new List<string>(txt).Take(maxLimitedLines).Join(Environment.NewLine) +
@@ -298,7 +298,7 @@ namespace ResourceManager
                     sb.AppendLine("\nDifferences:");
                     if (limitOutput)
                     {
-                        var txt = diffs.Split(Delimiters.Newline, StringSplitOptions.RemoveEmptyEntries);
+                        var txt = diffs.Split(Delimiters.LineFeed, StringSplitOptions.RemoveEmptyEntries);
                         if (txt.Length > maxLimitedLines)
                         {
                             diffs = new List<string>(txt).Take(maxLimitedLines).Join(Environment.NewLine) +

--- a/ResourceManager/ResourceManager.csproj
+++ b/ResourceManager/ResourceManager.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
     <Compile Include="..\GitExtUtils\Annotations.cs" Link="Utils\Annotations.cs" />
+    <Compile Include="..\GitExtUtils\Delimiters.cs" Link="Utils\Delimiters.cs" />
     <Compile Include="..\GitExtUtils\Strings.cs" Link="Utils\Strings.cs" />
     <Compile Include="..\GitExtUtils\Validates.cs" Link="Utils\Validates.cs" />
   </ItemGroup>

--- a/ResourceManager/Xliff/TranslationItem.cs
+++ b/ResourceManager/Xliff/TranslationItem.cs
@@ -38,7 +38,7 @@ namespace ResourceManager.Xliff
             get => Name + "." + Property;
             set
             {
-                var values = value.Split(new[] { '.' }, 2);
+                var values = value.Split(Delimiters.Period, 2);
                 Name = values[0];
                 Property = values.Length > 1 ? values[1] : "";
             }

--- a/UnitTests/CommonTestUtils/AssertEx.cs
+++ b/UnitTests/CommonTestUtils/AssertEx.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
@@ -11,9 +15,9 @@ namespace CommonTestUtils
 {
     public static class AssertEx
     {
-        public static async Task<Exception> ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code, string message, params object[] args)
+        public static async Task<Exception?> ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code, string message, params object?[]? args)
         {
-            Exception caughtException = null;
+            Exception? caughtException = null;
             try
             {
                 await code();
@@ -27,31 +31,86 @@ namespace CommonTestUtils
             return caughtException;
         }
 
-        public static async Task<Exception> ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code)
+        public static async Task<Exception?> ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code)
         {
             return await ThrowsAsync(expression, code, string.Empty, null);
         }
 
-        public static async Task<Exception> ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code, string message, params object[] args)
+        public static async Task<Exception?> ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code, string message, params object?[]? args)
         {
             return await ThrowsAsync(new ExceptionTypeConstraint(expectedExceptionType), code, message, args);
         }
 
-        public static async Task<Exception> ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code)
+        public static async Task<Exception?> ThrowsAsync(Type expectedExceptionType, AsyncTestDelegate code)
         {
             return await ThrowsAsync(new ExceptionTypeConstraint(expectedExceptionType), code, string.Empty, null);
         }
 
-        public static async Task<TActual> ThrowsAsync<TActual>(AsyncTestDelegate code, string message, params object[] args)
+        public static async Task<TActual?> ThrowsAsync<TActual>(AsyncTestDelegate code, string message, params object?[]? args)
             where TActual : Exception
         {
-            return (TActual)(await ThrowsAsync(typeof(TActual), code, message, args));
+            return (TActual?)(await ThrowsAsync(typeof(TActual), code, message, args));
         }
 
-        public static async Task<TActual> ThrowsAsync<TActual>(AsyncTestDelegate code)
+        public static async Task<TActual?> ThrowsAsync<TActual>(AsyncTestDelegate code)
             where TActual : Exception
         {
             return await ThrowsAsync<TActual>(code, string.Empty, null);
+        }
+
+        public static void SequenceEqual<T>(
+            IEnumerable<T> expected,
+            IEnumerable<T> actual,
+            IEqualityComparer<T>? comparer = null)
+        {
+            comparer ??= EqualityComparer<T>.Default;
+
+            if (expected is ICollection c1 && actual is ICollection c2)
+            {
+                Assert.AreEqual(c1.Count, c2.Count, "Invalid collection count");
+            }
+
+            int index = 0;
+
+            using var expectedEnumerator = expected.GetEnumerator();
+            using var actualEnumerator = actual.GetEnumerator();
+
+            while (true)
+            {
+                var expectedHasNext = expectedEnumerator.MoveNext();
+                var actualHasNext = actualEnumerator.MoveNext();
+
+                switch (expectedHasNext, actualHasNext)
+                {
+                    case (false, false):
+                    {
+                        // Both sequences end at the same point. We are finished.
+                        return;
+                    }
+
+                    case (false, true):
+                    {
+                        throw new($"Expected sequence ended at index {index} while actual sequence has more items.");
+                    }
+
+                    case (true, false):
+                    {
+                        throw new($"Actual sequence ended at index {index} while expected sequence has more items.");
+                    }
+
+                    case (true, true):
+                    {
+                        if (!comparer.Equals(expectedEnumerator.Current, actualEnumerator.Current))
+                        {
+                            throw new($"Sequences differ at index {index}.\nExpect: {expectedEnumerator.Current}\nActual: {actualEnumerator.Current}");
+                        }
+
+                        break;
+                    }
+                }
+
+                index++;
+            }
         }
     }
 }

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -802,7 +802,7 @@ namespace GitCommandsTests
 
             // Commit in submodule
             moduleSub.GitExecutable.GetOutput(@"commit --allow-empty -am ""First commit""");
-            string commitRef = moduleSub.GitExecutable.GetOutput("show HEAD").Split('\n')[0].Split(' ')[1];
+            string commitRef = moduleSub.GitExecutable.GetOutput("show HEAD").LazySplit('\n').First().LazySplit(' ').Skip(1).First();
 
             // Update ref in superproject
             moduleTestHelperSuper.Module.GitExecutable.GetOutput(@"add ""sub repo""");

--- a/UnitTests/GitCommands.Tests/Remote/ConfigFileRemoteSettingsManagerTests.cs
+++ b/UnitTests/GitCommands.Tests/Remote/ConfigFileRemoteSettingsManagerTests.cs
@@ -5,6 +5,7 @@ using CommonTestUtils;
 using FluentAssertions;
 using GitCommands.Config;
 using GitCommands.Remotes;
+using GitExtUtils;
 using GitUIPluginInterfaces;
 using NSubstitute;
 using NUnit.Framework;
@@ -338,7 +339,7 @@ namespace GitCommandsTests.Remote
         private IGitRef CreateSubstituteRef(string guid, string completeName, string remote)
         {
             var isRemote = !string.IsNullOrEmpty(remote);
-            var name = (isRemote ? remote + "/" : "") + completeName.Split('/').LastOrDefault();
+            var name = (isRemote ? remote + "/" : "") + completeName.LazySplit('/').LastOrDefault();
             var isTag = completeName.StartsWith("refs/tags/", StringComparison.InvariantCultureIgnoreCase);
             var gitRef = Substitute.For<IGitRef>();
             gitRef.Module.Returns(_module);

--- a/UnitTests/GitExtUtils.Tests/ArgumentBuilderTests.cs
+++ b/UnitTests/GitExtUtils.Tests/ArgumentBuilderTests.cs
@@ -61,7 +61,7 @@ namespace GitExtUtilsTests
 
             var args = "Lorem ipsum dolor sit amet, solet soleat option mel no.";
             var expectedLength = args.Length;
-            builder.AddRange(args.Split(' '));
+            builder.AddRange(args.LazySplit(' '));
             builder.GetTestAccessor().Arguments.Length.Should().Be(expectedLength + /* 'test ' */5);
         }
 

--- a/UnitTests/GitExtUtils.Tests/LazyStringSplitTests.cs
+++ b/UnitTests/GitExtUtils.Tests/LazyStringSplitTests.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using CommonTestUtils;
+using GitExtUtils;
+using NUnit.Framework;
+
+namespace GitExtUtilsTests
+{
+    [TestFixture]
+    public sealed class LazyStringSplitTests
+    {
+        [TestCase("a;b;c", ';', new[] { "a", "b", "c" })]
+        [TestCase("a_b_c", '_', new[] { "a", "b", "c" })]
+        [TestCase("aa;bb;cc", ';', new[] { "aa", "bb", "cc" })]
+        [TestCase("aaa;bbb;ccc", ';', new[] { "aaa", "bbb", "ccc" })]
+        [TestCase(";a", ';', new[] { "", "a" })]
+        [TestCase("a;", ';', new[] { "a", "" })]
+        [TestCase(";a;b;c", ';', new[] { "", "a", "b", "c" })]
+        [TestCase("a;b;c;", ';', new[] { "a", "b", "c", "" })]
+        [TestCase(";a;b;c;", ';', new[] { "", "a", "b", "c", "" })]
+        [TestCase(";;a;;b;;c;;", ';', new[] { "", "", "a", "", "b", "", "c", "", "" })]
+        [TestCase("", ';', new[] { "" })]
+        [TestCase(";", ';', new[] { "", "" })]
+        [TestCase(";;", ';', new[] { "", "", "" })]
+        [TestCase(";;;", ';', new[] { "", "", "", "" })]
+        [TestCase(";;;a", ';', new[] { "", "", "", "a" })]
+        [TestCase("a;;;", ';', new[] { "a", "", "", "" })]
+        [TestCase(";a;;", ';', new[] { "", "a", "", "" })]
+        [TestCase(";;a;", ';', new[] { "", "", "a", "" })]
+        [TestCase("a", ';', new[] { "a" })]
+        [TestCase("aa", ';', new[] { "aa" })]
+        public void None(string input, char delimiter, string[] expected)
+        {
+            // This boxes
+            IEnumerable<string> actual = new LazyStringSplit(input, delimiter, StringSplitOptions.None);
+
+            AssertEx.SequenceEqual(expected, actual);
+
+            // Non boxing foreach
+            var list = new List<string>();
+
+            foreach (var s in new LazyStringSplit(input, delimiter, StringSplitOptions.None))
+            {
+                list.Add(s);
+            }
+
+            AssertEx.SequenceEqual(expected, list);
+
+            // Equivalence with string.Split
+            AssertEx.SequenceEqual(expected, input.Split(new[] { delimiter }, StringSplitOptions.None));
+        }
+
+        [TestCase("a;b;c", ';', new[] { "a", "b", "c" })]
+        [TestCase("a_b_c", '_', new[] { "a", "b", "c" })]
+        [TestCase("aa;bb;cc", ';', new[] { "aa", "bb", "cc" })]
+        [TestCase("aaa;bbb;ccc", ';', new[] { "aaa", "bbb", "ccc" })]
+        [TestCase(";a", ';', new[] { "a" })]
+        [TestCase("a;", ';', new[] { "a" })]
+        [TestCase(";a;b;c", ';', new[] { "a", "b", "c" })]
+        [TestCase("a;b;c;", ';', new[] { "a", "b", "c" })]
+        [TestCase(";a;b;c;", ';', new[] { "a", "b", "c" })]
+        [TestCase(";;a;;b;;c;;", ';', new[] { "a", "b", "c" })]
+        [TestCase("", ';', new string[0])]
+        [TestCase(";", ';', new string[0])]
+        [TestCase(";;", ';', new string[0])]
+        [TestCase(";;;", ';', new string[0])]
+        [TestCase(";;;a", ';', new[] { "a" })]
+        [TestCase("a;;;", ';', new[] { "a" })]
+        [TestCase(";a;;", ';', new[] { "a" })]
+        [TestCase(";;a;", ';', new[] { "a" })]
+        [TestCase("a", ';', new[] { "a" })]
+        [TestCase("aa", ';', new[] { "aa" })]
+        public void RemoveEmptyEntries(string input, char delimiter, string[] expected)
+        {
+            // This boxes
+            IEnumerable<string> actual = new LazyStringSplit(input, delimiter, StringSplitOptions.RemoveEmptyEntries);
+
+            AssertEx.SequenceEqual(expected, actual);
+
+            // Non boxing foreach
+            var list = new List<string>();
+
+            foreach (var s in new LazyStringSplit(input, delimiter, StringSplitOptions.RemoveEmptyEntries))
+            {
+                list.Add(s);
+            }
+
+            AssertEx.SequenceEqual(expected, list);
+
+            // Equivalence with string.Split
+            AssertEx.SequenceEqual(expected, input.Split(new[] { delimiter }, StringSplitOptions.RemoveEmptyEntries));
+        }
+
+        [Test]
+        public void Constructor_WithNullInput_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => _ = new LazyStringSplit(null!, ' ', StringSplitOptions.RemoveEmptyEntries));
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

- Optimise string split operations
  - Avoid allocating a params array for most calls by keeping cached instances on `Delimiters` class.
  - Use `LazySplit` where possible to do so, to avoid allocating array for the result and internal arrays during the split operation.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
