### PR TITLE
Improve revision graph drawing

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -69,12 +69,9 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
         public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {
-            if (AppSettings.ShowRevisionGridGraphColumn &&
-                e.State.HasFlag(DataGridViewElementStates.Visible) &&
-                e.RowIndex >= 0 &&
-                _revisionGraph.Count != 0 &&
-                _revisionGraph.Count > e.RowIndex &&
-                PaintGraphCell(e.RowIndex, e.CellBounds, e.Graphics))
+            if (_revisionGraph.Count > e.RowIndex
+                && AppSettings.ShowRevisionGridGraphColumn // TODO: need to call setting in one redraw transaction
+                && PaintGraphCell(e.RowIndex, e.CellBounds, e.Graphics))
             {
                 e.Handled = true;
             }

--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitExtUtils.GitUI;
+using GitExtUtils.GitUI.Theming;
 using GitUI.UserControls.RevisionGrid.Graph;
 using GitUIPluginInterfaces;
 using Microsoft;
@@ -19,7 +20,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
         private static readonly int LaneLineWidth = DpiUtil.Scale(2);
         private static readonly int LaneWidth = DpiUtil.Scale(16);
-        private static readonly int NodeDimension = DpiUtil.Scale(10);
+        private static readonly int NodeDimension = DpiUtil.Scale(12);
 
         private readonly LaneInfoProvider _laneInfoProvider;
         private readonly RevisionGridControl _grid;
@@ -314,12 +315,33 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                             if (square)
                             {
                                 g.SmoothingMode = SmoothingMode.None;
+
                                 g.FillRectangle(brush, nodeRect);
+
+                                g.SmoothingMode = SmoothingMode.AntiAlias;
+
+                                nodeRect.Inflate(-3, -3);
+                                g.DrawRectangle(new Pen(Color.White.AdaptBackColor(), 2), nodeRect);
+                                nodeRect.Inflate(3, 3);
                             }
                             else //// Circle
                             {
                                 g.SmoothingMode = SmoothingMode.AntiAlias;
+
                                 g.FillEllipse(brush, nodeRect);
+
+                                if (currentRow.Revision.GitRevision?.IsArtificial is true)
+                                {
+                                    nodeRect.Inflate(-2, -2);
+                                    g.FillEllipse(new SolidBrush(Color.White.AdaptBackColor()), nodeRect);
+                                    nodeRect.Inflate(2, 2);
+                                }
+                                else
+                                {
+                                    nodeRect.Inflate(-3, -3);
+                                    g.DrawEllipse(new Pen(Color.White.AdaptBackColor(), 2), nodeRect);
+                                    nodeRect.Inflate(3, 3);
+                                }
                             }
 
                             if (hasOutline)
@@ -332,12 +354,18 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                                 if (square)
                                 {
                                     g.SmoothingMode = SmoothingMode.None;
-                                    g.DrawRectangle(pen, nodeRect);
+
+                                    nodeRect.Inflate(-2, -2);
+                                    g.FillRectangle(brush, nodeRect);
+                                    nodeRect.Inflate(2, 2);
                                 }
                                 else //// Circle
                                 {
                                     g.SmoothingMode = SmoothingMode.AntiAlias;
-                                    g.DrawEllipse(pen, nodeRect);
+
+                                    nodeRect.Inflate(-2, -2);
+                                    g.FillEllipse(brush, nodeRect);
+                                    nodeRect.Inflate(2, 2);
                                 }
                             }
                         }

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -281,7 +281,7 @@ namespace GitUI.UserControls.RevisionGrid
 
             if (e.RowIndex < 0 ||
                 e.RowIndex >= RowCount ||
-                !e.State.HasFlag(DataGridViewElementStates.Visible) ||
+                (e.State & DataGridViewElementStates.Visible) is not DataGridViewElementStates.Visible ||
                 revision is null)
             {
                 return;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

refers to #8941


## Proposed changes

- Remove dot filling to show that is not applied yet;
- Add a dot to the circle to indicate that it is done;
- Designate three states:  current, in progress, done;
- Remove redundant checks.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/3169265/110321344-39abd680-801a-11eb-93c4-b37a9b4c3785.png)

### After

![image](https://user-images.githubusercontent.com/3169265/110321076-dae65d00-8019-11eb-9bff-09c604b6a9b9.png)

![image](https://user-images.githubusercontent.com/3169265/110321212-0701de00-801a-11eb-8c84-142435597063.png)

![image](https://user-images.githubusercontent.com/3169265/110321109-e2a60180-8019-11eb-85b5-e5da1357bdc8.png)

![image](https://user-images.githubusercontent.com/3169265/110321139-ea65a600-8019-11eb-8458-3ae9695376e0.png)

## Test methodology <!-- How did you ensure quality? -->

- Manually
- Visually

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 3f977c1e31284d64d948328b5acca7bbfc8979ed
- Git 2.30.1.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
