### PR TITLE
Support Bitbucket repos with dots in the name

### DIFF
--- a/Plugins/Bitbucket/Settings.cs
+++ b/Plugins/Bitbucket/Settings.cs
@@ -9,9 +9,9 @@ namespace GitExtensions.Plugins.Bitbucket
     public class Settings
     {
         private const string BitbucketHttpRegex =
-            @"https?:\/\/([\w\.\:]+\@)?(?<url>([a-zA-Z0-9\.\-\/]+?)):?(\d+)?\/scm\/(?<project>~?([\w\-]+?))\/(?<repo>([\w\-]+)).git";
+            @"https?:\/\/([\w\.\:]+\@)?(?<url>([a-zA-Z0-9\.\-\/]+?)):?(\d+)?\/scm\/(?<project>~?([^\/]+?))\/(?<repo>(.*?)).git";
         private const string BitbucketSshRegex =
-            @"ssh:\/\/([\w\.]+\@)(?<url>([a-zA-Z0-9\.\-]+)):?(\d+)?\/(?<project>~?([\w\-]+))\/(?<repo>([\w\-]+)).git";
+            @"ssh:\/\/([\w\.]+\@)(?<url>([a-zA-Z0-9\.\-]+)):?(\d+)?\/(?<project>~?([^\/]+))\/(?<repo>(.*?)).git";
 
         public static Settings? Parse(IGitModule gitModule, ISettingsSource settings, BitbucketPlugin plugin)
         {

--- a/contributors.txt
+++ b/contributors.txt
@@ -152,4 +152,5 @@ YYYY/MM/DD, github id, Full name, email
 2021/01/24, bcolaco, Bruno Colaço, bcolaco[@)gmail.com
 2021/01/25, guybark, Guy Barker, guybark(at)microsoft.com
 2021/02/10, mabako, Marcus Bauer, mabako(at)gmail.com
+2021/03/11, AntonKedrov, Anton Kedrov, a-k(at)gmx.com
 2021/03/16, JuPrgn, Julien Peyregne, julienprgn(at)gmail.com


### PR DESCRIPTION
Fixes #8965

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Changed HTTP and SSH regex patterns to match URLs, which might contain a dot in the repo name


## Test methodology <!-- How did you ensure quality? -->

- Manual testing


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
