### PR TITLE
GitStatusMonitor increase minimum time between updates

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -28,7 +28,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         /// <summary>
         /// Minimum interval between subsequent updates
         /// </summary>
-        private const int MinUpdateInterval = 5000;
+        private const int MinUpdateInterval = 30000;
 
         /// <summary>
         /// Update every 5min, just to make sure something didn't slip through the cracks.


### PR DESCRIPTION
(cherry picked from commit acddf0669ab4fe7c6191f56b2aded4e8fbe961a5)

#8886 for 3.5

Since #8902 I expect the interactive response updating the commit counter is as expected, so this should be OK