### PR TITLE
Fixup the initial view menu item state of #8942

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
@@ -157,11 +157,12 @@ namespace GitUI.CommandsDialogs
                     key = toolbarItem.Name;
                 }
 
-                toolbarItem.Visible = LoadVisibilitySetting(key);
+                bool visible = LoadVisibilitySetting(key);
+                toolbarItem.Visible = visible;
 
                 ToolStripMenuItem menuToolbarItem = new(toolbarItem.ToolTipText)
                 {
-                    Checked = toolbarItem.Visible,
+                    Checked = visible,
                     CheckOnClick = true,
                     Tag = toolbarItem,
                     Image = toolbarItem.Image


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/pull/8942#pullrequestreview-605798471

## Proposed changes

- avoid using the property `Visible`

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 072518e5b13b465ef0ce466fc28435565bd14441
- Git 2.27.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
