### PR TITLE
#8684 Avatars are misaligned in blame form

### DIFF
--- a/GitUI/Editor/BlameAuthorMargin.cs
+++ b/GitUI/Editor/BlameAuthorMargin.cs
@@ -15,7 +15,6 @@ namespace GitUI.Editor
     {
         private static readonly int AgeBucketMarkerWidth = Convert.ToInt32(4 * DpiUtil.ScaleX);
         private List<Image?>? _avatars;
-        private readonly int _lineHeight;
         private readonly Color _backgroundColor;
         private List<GitBlameEntry>? _blameLines;
         private readonly Dictionary<int, SolidBrush> _brushs = new Dictionary<int, SolidBrush>();
@@ -23,22 +22,13 @@ namespace GitUI.Editor
 
         public BlameAuthorMargin(TextArea textArea) : base(textArea)
         {
-            _lineHeight = GetFontHeight(textArea.Font);
             _backgroundColor = SystemColors.Window;
-            Width = _lineHeight + AgeBucketMarkerWidth + DpiUtil.Scale(2);
         }
 
-        public override int Width { get; }
+        public int LineHeight => textArea.TextView.FontHeight;
+        public override int Width => LineHeight + AgeBucketMarkerWidth + DpiUtil.Scale(2);
+
         public override bool IsVisible => _isVisible;
-
-        private static int GetFontHeight(Font font)
-        {
-            var max = Math.Max(
-                TextRenderer.MeasureText("_", font).Height,
-                (int)Math.Ceiling(font.GetHeight()));
-
-            return max + 1;
-        }
 
         public void Initialize(IEnumerable<GitBlameEntry> blameLines)
         {
@@ -84,9 +74,9 @@ namespace GitUI.Editor
             }
 
             var verticalOffset = textArea.VirtualTop.Y;
-            var lineStart = verticalOffset / _lineHeight;
-            var negativeOffset = (lineStart * _lineHeight) - verticalOffset;
-            var lineCount = (int)Math.Ceiling((double)(rect.Height - negativeOffset) / _lineHeight);
+            var lineStart = verticalOffset / LineHeight;
+            var negativeOffset = (lineStart * LineHeight) - verticalOffset;
+            var lineCount = (int)Math.Ceiling((double)(rect.Height - negativeOffset) / LineHeight);
 
             for (int i = 0; i < lineCount; i++)
             {
@@ -95,8 +85,8 @@ namespace GitUI.Editor
                     break;
                 }
 
-                int y = negativeOffset + (i * _lineHeight);
-                g.FillRectangle(_brushs[_blameLines[lineStart + i].AgeBucketIndex], 0, y, AgeBucketMarkerWidth, _lineHeight);
+                int y = negativeOffset + (i * LineHeight);
+                g.FillRectangle(_brushs[_blameLines[lineStart + i].AgeBucketIndex], 0, y, AgeBucketMarkerWidth, LineHeight);
 
                 if (_avatars[lineStart + i] is not null)
                 {


### PR DESCRIPTION
The font used to compute height of image could be out of date
if font of text view is changed by user preferences.

Fixes #8684


## Proposed changes

- The height of avatar is computed at startup. But the height of the textview can be updated by user preferences. So both size could be different.

In my case, font size used by blame author margin is "Consolas 10" and text view is "Consolas 9,75". The tiny difference of size explains why it affects randomly dpi windows parameter.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/9248729/111023770-32e6e000-83db-11eb-9458-dab82dd5e3d8.png)

### After

![image](https://user-images.githubusercontent.com/9248729/111023786-3d08de80-83db-11eb-9132-3da49f868238.png)


## Test methodology <!-- How did you ensure quality? -->

None :/


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 3c75c4b696788cf573c856795dca61485c351ad5
- Git 2.30.0.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
