### PR TITLE
Improve display of exceptions 3.5

### DIFF
--- a/GitUI/NBugReports/BugReporter.cs
+++ b/GitUI/NBugReports/BugReporter.cs
@@ -18,123 +18,119 @@ namespace GitExtensions
         private static IntPtr OwnerFormHandle
             => OwnerForm?.Handle ?? IntPtr.Zero;
 
-        private static string FormatText(ExternalOperationException exception, bool canRaiseBug)
+        /// <summary>
+        /// Appends the exception data and gets the root error.
+        /// </summary>
+        /// <param name="text">A StringBuilder to which the exception data is appended.</param>
+        /// <param name="exception">An Exception to describe.</param>
+        /// <returns>The inner-most exception message.</returns>
+        internal static string Append(StringBuilder text, Exception exception)
         {
-            StringBuilder sb = new();
-
-            // Command: <command>
-            if (!string.IsNullOrWhiteSpace(exception.Command))
+            string rootError = exception.Message;
+            for (Exception innerException = exception.InnerException; innerException is not null; innerException = innerException.InnerException)
             {
-                sb.AppendLine($"{Strings.Command}: {exception.Command}");
+                if (!string.IsNullOrEmpty(innerException.Message))
+                {
+                    rootError = innerException.Message;
+                }
             }
 
-            // Arguments: <args>
-            if (!string.IsNullOrWhiteSpace(exception.Arguments))
+            if (exception is UserExternalOperationException userExternalOperationException && !string.IsNullOrWhiteSpace(userExternalOperationException.Context))
             {
-                sb.AppendLine($"{Strings.Arguments}: {exception.Arguments}");
+                // Context contains an error message as UserExternalOperationException is currently used. So append just "<context>"
+                text.AppendLine(userExternalOperationException.Context);
             }
 
-            // Working directory: <working dir>
-            sb.AppendLine($"{Strings.WorkingDirectory}: {exception.WorkingDirectory}");
-
-            if (canRaiseBug)
+            if (exception is ExternalOperationException externalOperationException)
             {
-                // Directions to raise a bug
-                sb.AppendLine();
-                sb.AppendLine(Strings.ReportBug);
+                // Command: <command>
+                AppendUnlessEmpty(externalOperationException.Command, GitUI.Strings.Command);
+
+                // Arguments: <args>
+                AppendUnlessEmpty(externalOperationException.Arguments, GitUI.Strings.Arguments);
+
+                // Directory: <dir>
+                AppendUnlessEmpty(externalOperationException.WorkingDirectory, GitUI.Strings.WorkingDirectory);
             }
 
-            return sb.ToString();
+            return rootError;
+
+            void AppendUnlessEmpty(string? value, string designation)
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    text.Append(designation).Append(": ").AppendLine(value);
+                }
+            }
         }
 
         public static void Report(Exception exception, bool isTerminating)
         {
-            if (exception is UserExternalOperationException userExternalException)
-            {
-                // Something happened that was likely caused by the user
-                ReportUserException(userExternalException, isTerminating);
-                return;
-            }
+            bool isUserExternalOperation = exception is UserExternalOperationException;
+            bool isExternalOperation = exception is ExternalOperationException;
 
-            if (exception is ExternalOperationException externalException)
-            {
-                // Something happened either in the app - can submit the bug to GitHub
-                ReportAppException(externalException, isTerminating);
-                return;
-            }
+            StringBuilder text = new();
+            string rootError = Append(text, exception);
 
-            // Report any other exceptions
-            ReportGenericException(exception, isTerminating);
-        }
-
-        private static void ReportAppException(ExternalOperationException exception, bool isTerminating)
-        {
-            // UserExternalOperationException wraps an actual exception, but be cautious just in case
-            string instructionText = exception.InnerException?.Message ?? Strings.InstructionOperationFailed;
-
-            ShowException(FormatText(exception, canRaiseBug: true), instructionText, exception, isTerminating);
-        }
-
-        private static void ReportGenericException(Exception exception, bool isTerminating)
-        {
-            // This exception is arbitrary, see if there's additional information
-            string? moreInfo = exception.InnerException?.Message;
-            if (moreInfo is not null)
-            {
-                moreInfo += Environment.NewLine + Environment.NewLine;
-            }
-
-            ShowException($"{moreInfo}{Strings.ReportBug}", exception.Message, exception, isTerminating);
-        }
-
-        private static void ReportUserException(UserExternalOperationException exception, bool isTerminating)
-            => ShowException(FormatText(exception, canRaiseBug: false), exception.Context, exception: null, isTerminating);
-
-        private static void ShowException(string text, string instructionText, Exception? exception, bool isTerminating)
-        {
-            using var dialog = new TaskDialog
+            using var taskDialog = new TaskDialog
             {
                 OwnerWindowHandle = OwnerFormHandle,
-                Text = text,
-                InstructionText = instructionText,
-                Caption = Strings.Error,
                 Icon = TaskDialogStandardIcon.Error,
+                Caption = GitUI.Strings.Error,
+                InstructionText = rootError,
                 Cancelable = true,
             };
 
-            if (exception is not null)
+            // prefer to ignore failed external operations
+            if (isExternalOperation)
             {
-                var btnReport = new TaskDialogCommandLink("Report", Strings.ButtonReportBug);
-                btnReport.Click += (s, e) =>
-                {
-                    dialog.Close();
-                    ShowNBug(OwnerForm, exception, isTerminating);
-                };
-
-                dialog.Controls.Add(btnReport);
+                AddIgnoreOrCloseButton();
             }
 
-            var btnIgnoreOrClose = new TaskDialogCommandLink("IgnoreOrClose", isTerminating ? Strings.ButtonCloseApp : Strings.ButtonIgnore);
-            btnIgnoreOrClose.Click += (s, e) =>
+            // no bug reports for user configured operations
+            if (!isUserExternalOperation)
             {
-                dialog.Close();
-            };
-            dialog.Controls.Add(btnIgnoreOrClose);
+                // directions and button to raise a bug
+                text.AppendLine().AppendLine(GitUI.Strings.ReportBug);
+            }
 
-            dialog.Show();
+            string buttonText = isUserExternalOperation ? GitUI.Strings.ButtonViewDetails : GitUI.Strings.ButtonReportBug;
+            TaskDialogCommandLink taskDialogCommandLink = new(buttonText, buttonText);
+            taskDialogCommandLink.Click += (s, e) =>
+                {
+                    taskDialog.Close();
+                    ShowNBug(OwnerForm, exception, isTerminating);
+                };
+            taskDialog.Controls.Add(taskDialogCommandLink);
+
+            // let the user decide whether to report the bug
+            if (!isExternalOperation)
+            {
+                AddIgnoreOrCloseButton();
+            }
+
+            taskDialog.Text = text.ToString().Trim();
+            taskDialog.Show();
+            return;
+
+            void AddIgnoreOrCloseButton()
+            {
+                string buttonText = isTerminating ? GitUI.Strings.ButtonCloseApp : GitUI.Strings.ButtonIgnore;
+                TaskDialogCommandLink taskDialogCommandLink = new(buttonText, buttonText);
+                taskDialogCommandLink.Click += (s, e) => taskDialog.Close();
+                taskDialog.Controls.Add(taskDialogCommandLink);
+            }
         }
 
         private static void ShowNBug(IWin32Window? owner, Exception exception, bool isTerminating)
         {
             var envInfo = UserEnvironmentInformation.GetInformation();
 
-            using (var form = new GitUI.NBugReports.BugReportForm())
+            using var form = new GitUI.NBugReports.BugReportForm();
+            var result = form.ShowDialog(owner, exception, envInfo);
+            if (isTerminating || result == DialogResult.Abort)
             {
-                var result = form.ShowDialog(owner, exception, envInfo);
-                if (isTerminating || result == DialogResult.Abort)
-                {
-                    Environment.Exit(-1);
-                }
+                Environment.Exit(-1);
             }
         }
     }

--- a/GitUI/NBugReports/BugReporter.cs
+++ b/GitUI/NBugReports/BugReporter.cs
@@ -44,18 +44,18 @@ namespace GitExtensions
             if (exception is ExternalOperationException externalOperationException)
             {
                 // Command: <command>
-                AppendUnlessEmpty(externalOperationException.Command, GitUI.Strings.Command);
+                AppendIfNotEmpty(externalOperationException.Command, GitUI.Strings.Command);
 
                 // Arguments: <args>
-                AppendUnlessEmpty(externalOperationException.Arguments, GitUI.Strings.Arguments);
+                AppendIfNotEmpty(externalOperationException.Arguments, GitUI.Strings.Arguments);
 
                 // Directory: <dir>
-                AppendUnlessEmpty(externalOperationException.WorkingDirectory, GitUI.Strings.WorkingDirectory);
+                AppendIfNotEmpty(externalOperationException.WorkingDirectory, GitUI.Strings.WorkingDirectory);
             }
 
             return rootError;
 
-            void AppendUnlessEmpty(string? value, string designation)
+            void AppendIfNotEmpty(string? value, string designation)
             {
                 if (!string.IsNullOrWhiteSpace(value))
                 {

--- a/GitUI/Strings.cs
+++ b/GitUI/Strings.cs
@@ -19,9 +19,7 @@ namespace GitUI
         private readonly TranslationString _buttonCreateBranch = new("Create branch");
         private readonly TranslationString _buttonIgnore = new("Ignore");
         private readonly TranslationString _buttonReportBug = new("Report bug!");
-
-        private readonly TranslationString _captionFailedExecute = new("Failed to execute");
-        private readonly TranslationString _instructionOperationFailed = new("Operation failed");
+        private readonly TranslationString _buttonViewDetails = new("View details");
 
         private readonly TranslationString _containedInCurrentCommitText = new("'{0}' is contained in the currently selected commit");
         private readonly TranslationString _containedInBranchesText = new("Contained in branches:");
@@ -132,9 +130,7 @@ namespace GitUI
         public static string ButtonCreateBranch => _instance.Value._buttonCreateBranch.Text;
         public static string ButtonIgnore => _instance.Value._buttonIgnore.Text;
         public static string ButtonReportBug => _instance.Value._buttonReportBug.Text;
-
-        public static string CaptionFailedExecute => _instance.Value._captionFailedExecute.Text;
-        public static string InstructionOperationFailed => _instance.Value._instructionOperationFailed.Text;
+        public static string ButtonViewDetails => _instance.Value._buttonViewDetails.Text;
 
         public static string ContainedInCurrentCommit => _instance.Value._containedInCurrentCommitText.Text;
         public static string ContainedInBranches => _instance.Value._containedInBranchesText.Text;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9549,12 +9549,12 @@ Select this commit to populate the full message.</source>
         <source>Report bug!</source>
         <target />
       </trans-unit>
-      <trans-unit id="_cancelText.Text">
-        <source>Cancel</source>
+      <trans-unit id="_buttonViewDetails.Text">
+        <source>View details</source>
         <target />
       </trans-unit>
-      <trans-unit id="_captionFailedExecute.Text">
-        <source>Failed to execute</source>
+      <trans-unit id="_cancelText.Text">
+        <source>Cancel</source>
         <target />
       </trans-unit>
       <trans-unit id="_childrenText.Text">
@@ -9699,10 +9699,6 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
         <source>Install git...</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_instructionOperationFailed.Text">
-        <source>Operation failed</source>
         <target />
       </trans-unit>
       <trans-unit id="_invisibleCommitText.Text">

--- a/UnitTests/GitUI.Tests/NBugReports/BugReporterTests.cs
+++ b/UnitTests/GitUI.Tests/NBugReports/BugReporterTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections;
+using System.Text;
+using FluentAssertions;
+using GitCommands;
+using GitExtensions;
+using GitUI.NBugReports;
+using NUnit.Framework;
+
+namespace GitUITests.NBugReports
+{
+    [TestFixture]
+    public sealed class BugReporterTests
+    {
+        [Test, TestCaseSource(typeof(TestExceptions), "TestCases")]
+        public void Append(Exception exception, string expectedRootError, string expectedText)
+        {
+            StringBuilder text = new();
+            string rootError = BugReporter.Append(text, exception);
+            rootError.Should().Be(expectedRootError);
+            text.ToString().Should().Be(expectedText);
+        }
+    }
+
+    public class TestExceptions
+    {
+        private const string _messageOuter = "outer";
+        private const string _messageMiddle = "middle";
+        private const string _messageInner = "inner";
+        private const string _context = "context";
+        private const string _command = "command";
+        private const string _arguments = "arguments";
+        private const string _directory = "directory";
+
+        public static IEnumerable TestCases
+        {
+            get
+            {
+                yield return new TestCaseData(new Exception(_messageOuter),
+                    _messageOuter,
+                    "");
+                yield return new TestCaseData(new Exception(_messageOuter, new Exception(_messageMiddle)),
+                    _messageMiddle,
+                    "");
+                yield return new TestCaseData(new Exception(_messageOuter, new Exception(_messageMiddle, new Exception(_messageInner))),
+                    _messageInner,
+                    "");
+                yield return new TestCaseData(new UserExternalOperationException(_context,
+                    new ExternalOperationException(_command, _arguments, _directory, new Exception(_messageOuter, new Exception(_messageInner)))),
+                    _messageInner,
+                    $"{_context}{Environment.NewLine}"
+                    + $"Command: {_command}{Environment.NewLine}"
+                    + $"Arguments: {_arguments}{Environment.NewLine}"
+                    + $"Working directory: {_directory}{Environment.NewLine}");
+                yield return new TestCaseData(new UserExternalOperationException(null,
+                    new ExternalOperationException(null, null, null, new Exception(_messageInner))),
+                    _messageInner,
+                    "");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #8718, parts of #8802 for release 3.5

## Proposed changes

- Display the error message of the inner-most exception
- Default to `Ignore` on `ExternalOperationException`
- Add `View details` on `UserExternalOperationException`, opens the `BugReportForm`, too

## Screenshots

Exception|Before|After
-|-|-
`throw`<br/>`new Exception("Wrapping exception.",`<br/>`new Exception("Intermediate error.",`<br/>`new Exception("Cannot access locked file 'xyz'.")));`|![grafik](https://user-images.githubusercontent.com/36601201/111054126-39706880-846a-11eb-9243-eb157b903c06.png)|![grafik](https://user-images.githubusercontent.com/36601201/111054023-5ce6e380-8469-11eb-98bb-34b3c40236ee.png)
`throw`<br/>`new ExternalOperationException("<command>", "<arguments>", "<workdir>",`<br/>`new Exception("Wrapping exception.",`<br/>`new Exception("Intermediate error.",`<br/>`new Exception("Cannot access locked file 'xyz'.")));`|![grafik](https://user-images.githubusercontent.com/36601201/111054196-dfbc6e00-846a-11eb-9356-40c7cd17215f.png)|![grafik](https://user-images.githubusercontent.com/36601201/111054049-899afb00-8469-11eb-9691-791af9a1f63e.png)
`UserExternalOperationException`<br/>due to locked file|![grafik](https://user-images.githubusercontent.com/36601201/111053725-88b49a00-8466-11eb-91a4-4e4c8602221a.png)|"Cannot access file '...' because used by another process"<br/>![grafik](https://user-images.githubusercontent.com/36601201/111053746-b7327500-8466-11eb-8dac-4a93c0c1466e.png)
`UserExternalOperationException`<br/>due to invalid executable in user script|![grafik](https://user-images.githubusercontent.com/36601201/111053809-45a6f680-8467-11eb-8cef-4448abd9a312.png)|"Cannot find file"<br/>![grafik](https://user-images.githubusercontent.com/36601201/111053847-94ed2700-8467-11eb-84a6-ec85b357e50c.png)

## Test methodology <!-- How did you ensure quality? -->

- added unit tests
- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build b4bd095f0b1223ab4e672e31226b8f0852ccc20e
- Git 2.27.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
