### PR TITLE
readthedoc: use version specific links

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1879,7 +1879,7 @@ namespace GitUI.CommandsDialogs
         private void UserManualToolStripMenuItemClick(object sender, EventArgs e)
         {
             // Point to the default documentation, will work also if the old doc version is removed
-            OsShellUtil.OpenUrlInDefaultBrowser(@"https://git-extensions-documentation.readthedocs.org");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://git-extensions-documentation.readthedocs.org/en/master/");
         }
 
         private void CleanupToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -13,8 +13,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class AppearanceSettingsPage : SettingsPageWithHeader
     {
-        private const string _customAvatarTemplateURL = "https://git-extensions-documentation.readthedocs.io/settings.html#git-extensions-appearance-author-images-avatar-provider";
-        private const string _gravatarDefaultImageURL = "https://git-extensions-documentation.readthedocs.io/settings.html#git-extensions-appearance-author-images-avatar-fallback";
+        private const string _customAvatarTemplateURL = "https://git-extensions-documentation.readthedocs.io/en/master/settings.html#git-extensions-appearance-author-images-avatar-provider";
+        private const string _gravatarDefaultImageURL = "https://git-extensions-documentation.readthedocs.io/en/master/settings.html#git-extensions-appearance-author-images-avatar-fallback";
         private const string _spellingWikiURL = "https://github.com/gitextensions/gitextensions/wiki/Spelling";
         private const string _translationsWikiURL = "https://github.com/gitextensions/gitextensions/wiki/Translations";
 

--- a/GitUI/GitExtensionsDialog.cs
+++ b/GitUI/GitExtensionsDialog.cs
@@ -44,7 +44,7 @@ namespace GitUI
         /// </summary>
         /// <remarks>
         /// The URL structure:
-        /// https://git-extensions-documentation.readthedocs.io/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}.
+        /// https://git-extensions-documentation.readthedocs.io/en/master/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}.
         /// </remarks>
         public string? ManualSectionAnchorName { get; set; }
 
@@ -53,7 +53,7 @@ namespace GitUI
         /// </summary>
         /// <remarks>
         /// The URL structure:
-        /// https://git-extensions-documentation.readthedocs.io/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}.
+        /// https://git-extensions-documentation.readthedocs.io/en/master/{ManualSectionSubfolder}.html#{ManualSectionAnchorName}.
         /// </remarks>
         public string? ManualSectionSubfolder { get; set; }
 

--- a/GitUI/UserManual/StandardHtmlUserManual.cs
+++ b/GitUI/UserManual/StandardHtmlUserManual.cs
@@ -4,7 +4,7 @@ namespace GitUI.UserManual
 {
     public class StandardHtmlUserManual : IProvideUserManual
     {
-        private const string _location = @"https://git-extensions-documentation.readthedocs.org/";
+        private const string _location = @"https://git-extensions-documentation.readthedocs.org/en/master/";
 
         private readonly string _subFolder;
         private readonly string _anchorName;

--- a/UnitTests/GitCommands.Tests/TestData/README.blame
+++ b/UnitTests/GitCommands.Tests/TestData/README.blame
@@ -323,7 +323,7 @@ e3268019c66da7534414e9562ececdee5d455b1b 63 73 2
 e3268019c66da7534414e9562ececdee5d455b1b 64 74
 	* Source code: [http://github.com/gitextensions/gitextensions](http://github.com/gitextensions/gitextensions)
 59f8cc5eb9d98621746300f0b289b5da7abaa13b 10 75 2
-	* Online manual: [https://git-extensions-documentation.readthedocs.org/](https://git-extensions-documentation.readthedocs.org/)
+	* Online manual: [https://git-extensions-documentation.readthedocs.org/en/master/](https://git-extensions-documentation.readthedocs.org/en/master/)
 59f8cc5eb9d98621746300f0b289b5da7abaa13b 11 76
 	* Issue tracker: [http://github.com/gitextensions/gitextensions/issues](http://github.com/gitextensions/gitextensions/issues)
 88bb86326419ee8dfa03c7fde9aae78b9b7fb961 15 77 1

--- a/UnitTests/GitUI.Tests/UserManual/StandardHtmlUserManualFixture.cs
+++ b/UnitTests/GitUI.Tests/UserManual/StandardHtmlUserManualFixture.cs
@@ -7,9 +7,9 @@ namespace GitUITests.UserManual
     [TestFixture]
     public class StandardHtmlUserManualFixture
     {
-        [TestCase(null, null, "https://git-extensions-documentation.readthedocs.org/")] // both null makes no sense atm
-        [TestCase("merge_conflicts", null, "https://git-extensions-documentation.readthedocs.org/merge_conflicts.html")]
-        [TestCase("merge_conflicts", "merge-conflicts", "https://git-extensions-documentation.readthedocs.org/merge_conflicts.html#merge-conflicts")]
+        [TestCase(null, null, "https://git-extensions-documentation.readthedocs.org/en/master/")] // both null makes no sense atm
+        [TestCase("merge_conflicts", null, "https://git-extensions-documentation.readthedocs.org/en/master/merge_conflicts.html")]
+        [TestCase("merge_conflicts", "merge-conflicts", "https://git-extensions-documentation.readthedocs.org/en/master/merge_conflicts.html#merge-conflicts")]
         public void GetUrl(string subFolder, string anchor, string expected)
         {
             var sut = new StandardHtmlUserManual(subFolder, anchor);

--- a/scripts/set_version_to.py
+++ b/scripts/set_version_to.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
     parser.add_argument('-t', '--text', default=None,
                        help='text product version')
     args = parser.parse_args()
-    
+
     if not args.version:
         parser.print_help()
         exit(1)
@@ -34,7 +34,21 @@ if __name__ == '__main__':
 
     if not args.text:
       args.text = args.version
-    
+
+    filenames = [
+        "../GitUI/CommandsDialogs/FormBrowse.cs",
+        "../GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs",
+        "../GitUI/UserManual/StandardHtmlUserManual.cs"
+    ]
+    for filename in filenames:
+        pattern = re.compile(r'(git-extensions-documentation.readthedocs.org/en)(/\w+)', re.IGNORECASE)
+        commonAssemblyInfo = open(filename, "r").readlines()
+        o = ""
+        for i in commonAssemblyInfo:
+            o += pattern.sub(r"\1/release-%s" % (short_version), i)
+        outfile = open(filename, "w")
+        outfile.writelines(o)
+
     submodules = glob.glob("..\Externals\**\AssemblyInfo.cs", recursive=True)
     filenames = [ "..\CommonAssemblyInfo.cs", "..\CommonAssemblyInfoExternals.cs" ]
     combined = filenames + submodules
@@ -56,7 +70,7 @@ if __name__ == '__main__':
             o += line
         outfile = open(filename, "w")
         outfile.writelines(o)
-    
+
     filename = "..\GitExtensionsShellEx\GitExtensionsShellEx.rc"
     gitExtensionsShellEx = open(filename, "r").readlines()
     o = ""
@@ -81,7 +95,7 @@ if __name__ == '__main__':
         o += line
     outfile = open(filename, "w")
     outfile.writelines(o)
-    
+
     filename = "..\GitExtSshAskPass\SshAskPass.rc2"
     gitExtSshAskPass = open(filename, "r").readlines()
     o = ""


### PR DESCRIPTION
Fixes #8955

## Proposed changes

#8955 points to problem with redirecting in ReadTheDocs, this PR adds version specific links to all links in the application.
Links in README etc is still without version.

We need to maintain builds for ReadTheDocs separately anyway.
This has the benefit that links in the app will work also work when the structure changes.

When building a release, the links will need to be updated. (Before #8838 one of the files were changed.)

## Test methodology <!-- How did you ensure quality? -->

Review

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
