### PR TITLE
Include stash, bisect in grid if tags are shown

### DIFF
--- a/GitCommands/Git/Commands/GitRefsEnum.cs
+++ b/GitCommands/Git/Commands/GitRefsEnum.cs
@@ -1,0 +1,21 @@
+﻿using System.Diagnostics;
+using GitUIPluginInterfaces;
+
+namespace GitCommands.Git.Commands
+{
+    /// <summary>
+    /// Enums requestable in GitRefs() (multiple names can be appended)
+    /// Compare to <see ref="GitRefType"/> for actual values of parsed GitRefs
+    /// </summary>
+    public enum GetRefsEnum
+    {
+        None = 0,
+
+        Branches = 1 << 0,
+        Remotes = 1 << 1,
+        Tags = 1 << 2,
+
+        // All refs, including those abve but also (at least) stash, notes and bisect
+        All = 1 << 3
+    }
+}

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2902,7 +2902,26 @@ namespace GitCommands
             return result;
         }
 
+        /// <summary>
+        /// Get the Git refs.
+        /// </summary>
+        /// <param name="tags">Include tags.</param>
+        /// <param name="branches">Include local branches, also remote branches if <see paramref="tags"/> is set.</param>
+        /// <returns>All Git refs.</returns>
         public IReadOnlyList<IGitRef> GetRefs(bool tags = true, bool branches = true)
+        {
+            return GetRefs(
+                (tags ? GetRefsEnum.Tags : GetRefsEnum.None)
+                | (branches ? GetRefsEnum.Branches : GetRefsEnum.None)
+                | (tags && branches ? GetRefsEnum.Remotes : GetRefsEnum.None));
+        }
+
+        /// <summary>
+        /// Get the Git refs.
+        /// </summary>
+        /// <param name="getRef">Combined refs to search for.</param>
+        /// <returns>All Git refs.</returns>
+        public IReadOnlyList<IGitRef> GetRefs(GetRefsEnum getRef)
         {
             // We do not want to lock the repo for background operations.
             // The primary use of 'noLocks' is to run git-status the commit count as a background operation,
@@ -2911,7 +2930,7 @@ namespace GitCommands
             // Assume that all GetRefs() are done in the background, which may not be correct in the future.
             const bool noLocks = true;
 
-            var cmd = GitCommandHelpers.GetRefsCmd(tags: tags, branches: branches, noLocks, AppSettings.RefsSortBy, AppSettings.RefsSortOrder);
+            var cmd = GitCommandHelpers.GetRefsCmd(getRef, noLocks, AppSettings.RefsSortBy, AppSettings.RefsSortOrder);
             var refList = _gitExecutable.GetOutput(cmd);
             return ParseRefs(refList);
         }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -958,7 +958,7 @@ namespace GitUI
 
                 _revisionReader ??= new RevisionReader();
 
-                var refs = Module.GetRefs();
+                var refs = Module.GetRefs(GetRefsEnum.All);
                 _ambiguousRefs = GitRef.GetAmbiguousRefNames(refs);
 
                 _gridView.SuspendLayout();


### PR DESCRIPTION
Fixes #8879

## Proposed changes

Revert behavior to be same as in 3.4

If tag labels are shown, also show bisect, notes, stash etc

Note that the labels were orange in 3.4, changed in #8424

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

(slightly older than master)
![image](https://user-images.githubusercontent.com/6248932/111052110-79c6eb00-8458-11eb-8eb9-dae9a26ccdc7.png)

### After

![image](https://user-images.githubusercontent.com/6248932/111052089-45ebc580-8458-11eb-849b-b07f086d8694.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
