### PR TITLE
Move ImpactLoader.cs from GitCommands.Statistics to GitExtensions.Plugins.GitImpact

### DIFF
--- a/Plugins/Statistics/GitImpact/FormImpact.cs
+++ b/Plugins/Statistics/GitImpact/FormImpact.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Windows.Forms;
-using GitCommands.Statistics;
 using GitUI;
 using GitUIPluginInterfaces;
 using ResourceManager;

--- a/Plugins/Statistics/GitImpact/GitExtensions.Plugins.GitImpact.csproj
+++ b/Plugins/Statistics/GitImpact/GitExtensions.Plugins.GitImpact.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\GitCommands\GitCommands.csproj" />
     <ProjectReference Include="..\..\..\GitExtUtils\GitExtUtils.csproj" />
     <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj" />
     <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />

--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -5,7 +5,6 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Windows.Forms;
-using GitCommands.Statistics;
 using GitExtUtils.GitUI;
 using GitUIPluginInterfaces;
 

--- a/Plugins/Statistics/GitImpact/ImpactLoader.cs
+++ b/Plugins/Statistics/GitImpact/ImpactLoader.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using GitCommands;
 using GitUI;
 using GitUIPluginInterfaces;
 using Microsoft.VisualStudio.Threading;
 
-namespace GitCommands.Statistics
+namespace GitExtensions.Plugins.GitImpact
 {
     public sealed class ImpactLoader : IDisposable
     {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Dependet on #8984


## Proposed changes

- Move ImpactLoader.cs from GitCommands.Statistics to GitExtensions.Plugins.GitImpact for incapsulation

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 11d61bfcc3394beaa50eca4d395a8ac12b778489 (Dirty)
- Git 2.30.1.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
