### PR TITLE
Fix "Commit & push" button color when ameding is enabled

### DIFF
--- a/GitExtUtils/GitUI/Theming/OtherColors.cs
+++ b/GitExtUtils/GitUI/Theming/OtherColors.cs
@@ -7,5 +7,7 @@ namespace GitExtUtils.GitUI.Theming
         public static readonly Color BackgroundColor = Color.FromArgb(251, 251, 251).AdaptBackColor();
         public static readonly Color PanelBorderColor = Color.FromArgb(224, 224, 224).AdaptBackColor();
         public static readonly Color AmendButtonForcedColor = Color.FromArgb(230, 99, 99).AdaptBackColor();
+        public static readonly Color MergeConflictsColor = Color.FromArgb(230, 99, 99).AdaptBackColor();
+        public static readonly Color PanelMessageWarningColor = Color.FromArgb(230, 99, 99).AdaptBackColor();
     }
 }

--- a/GitExtUtils/GitUI/Theming/OtherColors.cs
+++ b/GitExtUtils/GitUI/Theming/OtherColors.cs
@@ -6,5 +6,6 @@ namespace GitExtUtils.GitUI.Theming
     {
         public static readonly Color BackgroundColor = Color.FromArgb(251, 251, 251).AdaptBackColor();
         public static readonly Color PanelBorderColor = Color.FromArgb(224, 224, 224).AdaptBackColor();
+        public static readonly Color AmendButtonForcedColor = Color.FromArgb(230, 99, 99).AdaptBackColor();
     }
 }

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -52,7 +52,7 @@ namespace GitUI.CommandsDialogs
 
             patchGrid1.SetSkipped(Skipped);
 
-            SolveMergeConflicts.BackColor = AppColor.Branch.GetThemeColor();
+            SolveMergeConflicts.BackColor = OtherColors.MergeConflictsColor;
             SolveMergeConflicts.SetForeColorForBackColor();
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -3221,8 +3221,8 @@ namespace GitUI.CommandsDialogs
             if (AppSettings.CommitAndPushForcedWhenAmend)
             {
                 CommitAndPush.BackColor = Amend.Checked
-                    ? AppColor.Branch.GetThemeColor()
-                    : SystemColors.ButtonFace;
+                    ? OtherColors.AmendButtonForcedColor
+                    : SystemColors.ButtonFace.AdaptBackColor();
 
                 CommitAndPush.SetForeColorForBackColor();
             }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -316,7 +316,7 @@ namespace GitUI.CommandsDialogs
             SelectedDiff.BottomScrollReached += FileViewer_BottomScrollReached;
             SelectedDiff.LinePatchingBlocksUntilReload = true;
 
-            SolveMergeconflicts.BackColor = AppColor.Branch.GetThemeColor();
+            SolveMergeconflicts.BackColor = OtherColors.MergeConflictsColor;
             SolveMergeconflicts.SetForeColorForBackColor();
 
             toolStripStatusBranchIcon.AdaptImageLightness();

--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -32,7 +32,7 @@ namespace GitUI.CommandsDialogs
         {
             _fileName = fileName;
             InitializeComponent();
-            panelMessage.BackColor = AppColor.Branch.GetThemeColor();
+            panelMessage.BackColor = OtherColors.PanelMessageWarningColor;
             panelMessage.SetForeColorForBackColor();
             InitializeComplete();
 

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -45,7 +45,7 @@ namespace GitUI.CommandsDialogs
         {
             _defaultBranch = defaultBranch;
             InitializeComponent();
-            SolveMergeconflicts.BackColor = AppColor.Branch.GetThemeColor();
+            SolveMergeconflicts.BackColor = OtherColors.MergeConflictsColor;
             SolveMergeconflicts.SetForeColorForBackColor();
             helpImageDisplayUserControl1.Image1 = Properties.Images.HelpCommandRebase.AdaptLightness();
             InitializeComplete();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8976


## Proposed changes

- Change color to red (same as remote branch)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/3169265/111063652-909d2a00-84b8-11eb-8d02-b0342e9ef1dd.png)


### After

![image](https://user-images.githubusercontent.com/3169265/111063657-94c94780-84b8-11eb-9255-cdfca581daa0.png)


## Test methodology <!-- How did you ensure quality? -->

- Manually
- Visually


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 89c85afd9db870026449dbb4167f6a9db268a0f1
- Git 2.30.2.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
