### PR TITLE
Resolve PluginSettings key names issue

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -126,7 +126,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
                             foreach (var gitHoster in PluginRegistry.GitHosters)
                             {
-                                lastControl = CreateLink(panel, string.Format(_cloneFork.Text, gitHoster.Description), Images.CloneRepoGitHub,
+                                lastControl = CreateLink(panel, string.Format(_cloneFork.Text, gitHoster.Name), Images.CloneRepoGitHub,
                                     (repoSender, eventArgs) => UICommands.StartCloneForkFromHoster(this, gitHoster, GitModuleChanged));
                             }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -949,7 +949,7 @@ namespace GitUI.CommandsDialogs
 
                     var item = new ToolStripMenuItem
                     {
-                        Text = plugin.Description,
+                        Text = plugin.Name,
                         Image = plugin.Icon,
                         Tag = plugin
                     };
@@ -990,7 +990,7 @@ namespace GitUI.CommandsDialogs
             _repositoryHostsToolStripMenuItem.Visible = PluginRegistry.GitHosters.Count > 0;
             if (PluginRegistry.GitHosters.Count == 1)
             {
-                _repositoryHostsToolStripMenuItem.Text = PluginRegistry.GitHosters[0].Description;
+                _repositoryHostsToolStripMenuItem.Text = PluginRegistry.GitHosters[0].Name;
             }
 
             UpdatePluginMenu(Module.IsValidGitWorkingDir());

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -88,7 +88,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                 });
             }
 
-            Text = _gitHoster.Description + ": " + Text;
+            Text = $"{_gitHoster.Name}: {Text}";
 
             UpdateCloneInfo();
             UpdateMyRepos();
@@ -134,7 +134,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                         await this.SwitchToMainThreadAsync();
 
                         myReposLV.Items.Clear();
-                        helpTextLbl.Text = string.Format(_strFailedToGetRepos.Text, _gitHoster.Description) +
+                        helpTextLbl.Text = string.Format(_strFailedToGetRepos.Text, _gitHoster.Name) +
                                             "\r\n\r\nException: " + ex.Message + "\r\n\r\n" + helpTextLbl.Text;
                     }
                 })

--- a/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
@@ -52,7 +52,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Plugins
 
         public override string GetTitle()
         {
-            return _gitPlugin?.Description ?? string.Empty;
+            return _gitPlugin?.Name ?? string.Empty;
         }
 
         private IEnumerable<ISetting> GetSettings()

--- a/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
@@ -27,10 +27,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Plugins
 
         private void Init(IGitPlugin gitPlugin)
         {
-            Validates.NotNull(gitPlugin.Name);
+            Validates.NotNull(gitPlugin.Description);
 
             _gitPlugin = gitPlugin;
-            _settingsContainer = new GitPluginSettingsContainer(gitPlugin.Name);
+
+            // Description for old plugin setting processing as key
+            _settingsContainer = new GitPluginSettingsContainer(gitPlugin.Id, gitPlugin.Description);
             CreateSettingsControls();
             InitializeComplete();
         }

--- a/GitUI/Plugin/PluginRegistry.cs
+++ b/GitUI/Plugin/PluginRegistry.cs
@@ -33,8 +33,10 @@ namespace GitUI
 
                     foreach (var plugin in ManagedExtensibility.GetExports<IGitPlugin>().Select(lazy => lazy.Value))
                     {
-                        Validates.NotNull(plugin.Name);
-                        plugin.SettingsContainer = new GitPluginSettingsContainer(plugin.Name);
+                        Validates.NotNull(plugin.Description);
+
+                        // Description for old plugin setting processing as key
+                        plugin.SettingsContainer = new GitPluginSettingsContainer(plugin.Id, plugin.Description);
 
                         if (plugin is IRepositoryHostPlugin repositoryHostPlugin)
                         {

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -117,7 +117,7 @@ namespace GitUI.Script
                 {
                     foreach (var plugin in PluginRegistry.Plugins)
                     {
-                        if (string.Equals(plugin.Description, command, StringComparison.CurrentCultureIgnoreCase))
+                        if (string.Equals(plugin.Name, command, StringComparison.CurrentCultureIgnoreCase))
                         {
                             var eventArgs = new GitUIEventArgs(owner, uiCommands);
                             return new CommandStatus(executed: true, needsGridRefresh: plugin.Execute(eventArgs));

--- a/GitUI/Translation/Czech.Plugins.xlf
+++ b/GitUI/Translation/Czech.Plugins.xlf
@@ -10,7 +10,7 @@
   </file>
   <file datatype="plaintext" original="AutoCompileSubModulesPlugin" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Auto compile SubModules</source>
         <target>Automaticky přeložit podmoduly</target>
         
@@ -48,7 +48,7 @@
   </file>
   <file datatype="plaintext" original="BackgroundFetchPlugin" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Periodic background fetch</source>
         <target>Pravidelné přenášení na pozadí</target>
         
@@ -97,7 +97,7 @@
         <target>Uživatelské jméno na Bitbucket</target>
         
       </trans-unit>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Bitbucket Server</source>
         <target>Bitbucket server</target>
         
@@ -296,7 +296,7 @@
   </file>
   <file datatype="plaintext" original="CreateLocalBranchesPlugin" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Create local tracking branches</source>
         <target>Vytvořit místní sledovací větve</target>
         
@@ -458,7 +458,7 @@ Opravdu chcete pokračovat?</target>
   </file>
   <file datatype="plaintext" original="DeleteUnusedBranchesPlugin" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Delete obsolete branches</source>
         <target>Smazat zastaralé větve</target>
         
@@ -577,7 +577,7 @@ Opravdu chcete pokračovat?</target>
   </file>
   <file datatype="plaintext" original="FindLargeFilesPlugin" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Find large files</source>
         <target>Najít velké soubory</target>
         
@@ -1022,7 +1022,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GerritPlugin" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gerrit Code Review</source>
         <target>Gerrit - Revize kódu</target>
         
@@ -1230,7 +1230,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitFlowPlugin" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitFlow</source>
         <target>GitFlow</target>
         
@@ -1239,7 +1239,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitHub3Plugin" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitHub</source>
         <target>GitHub</target>
         
@@ -1265,7 +1265,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitImpactPlugin" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Impact Graph</source>
         <target>Graf vlivu</target>
         
@@ -1274,7 +1274,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitStatisticsPlugin" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Statistics</source>
         <target>Statistiky</target>
         
@@ -1298,7 +1298,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GourcePlugin" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gource</source>
         <target>Gource</target>
         
@@ -1445,7 +1445,7 @@ Chcete znovu nastavit cestu?</target>
   </file>
   <file datatype="plaintext" original="JiraCommitHintPlugin" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Jira Commit Hint</source>
         
       </trans-unit>
@@ -1553,7 +1553,7 @@ Chcete znovu nastavit cestu?</target>
   </file>
   <file datatype="plaintext" original="ProxySwitcherPlugin" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Proxy Switcher</source>
         <target>Přepínač proxy serverů</target>
         
@@ -1708,7 +1708,7 @@ název větve, nebo značky)</target>
   </file>
   <file datatype="plaintext" original="ReleaseNotesGeneratorPlugin" source-language="en" target-language="cs">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Release Notes Generator</source>
         <target>Generátor poznámek k vydání</target>
         

--- a/GitUI/Translation/Dutch.Plugins.xlf
+++ b/GitUI/Translation/Dutch.Plugins.xlf
@@ -10,7 +10,7 @@
   </file>
   <file datatype="plaintext" original="AutoCompileSubModulesPlugin" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Auto compile SubModules</source>
         <target>Compileer SubModules automatisch</target>
         
@@ -48,7 +48,7 @@
   </file>
   <file datatype="plaintext" original="BackgroundFetchPlugin" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Periodic background fetch</source>
         <target>Fetch periodiek op de achtergrond</target>
         
@@ -97,7 +97,7 @@
         <target>Btibucket Gebruikersnaam</target>
         
       </trans-unit>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Bitbucket Server</source>
         <target>Bitbucket Server</target>
         
@@ -296,7 +296,7 @@
   </file>
   <file datatype="plaintext" original="CreateLocalBranchesPlugin" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Create local tracking branches</source>
         <target>Maak lokale tracking branches</target>
         
@@ -458,7 +458,7 @@ Weet u zeker dat u door wilt gaan?</target>
   </file>
   <file datatype="plaintext" original="DeleteUnusedBranchesPlugin" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Delete obsolete branches</source>
         <target>Verwijder achterhaalde branches</target>
         
@@ -580,7 +580,7 @@ Weet u zeker dat u door wilt gaan?</target>
   </file>
   <file datatype="plaintext" original="FindLargeFilesPlugin" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Find large files</source>
         <target>Zoek grote bestanden</target>
         
@@ -1020,7 +1020,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GerritPlugin" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gerrit Code Review</source>
         <target>Gerrit Code Review</target>
         
@@ -1228,7 +1228,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitFlowPlugin" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitFlow</source>
         <target>GitFlow</target>
         
@@ -1237,7 +1237,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitHub3Plugin" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitHub</source>
         <target>GitHub</target>
         
@@ -1263,7 +1263,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitImpactPlugin" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Impact Graph</source>
         <target>Impact Grafiek</target>
         
@@ -1272,7 +1272,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitStatisticsPlugin" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Statistics</source>
         <target>Statistieken</target>
         
@@ -1296,7 +1296,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GourcePlugin" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gource</source>
         <target>Gource</target>
         
@@ -1444,7 +1444,7 @@ Wilt het het pad opnieuw instellen?</target>
   </file>
   <file datatype="plaintext" original="JiraCommitHintPlugin" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Jira Commit Hint</source>
         <target>Jira Commit Hint</target>
         
@@ -1556,7 +1556,7 @@ Wilt het het pad opnieuw instellen?</target>
   </file>
   <file datatype="plaintext" original="ProxySwitcherPlugin" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Proxy Switcher</source>
         <target>Proxy Switcher</target>
         
@@ -1713,7 +1713,7 @@ branch namen of tag namen zijn)</target>
   </file>
   <file datatype="plaintext" original="ReleaseNotesGeneratorPlugin" source-language="en" target-language="nl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Release Notes Generator</source>
         <target>Release Notes Generator</target>
         

--- a/GitUI/Translation/English.Plugins.xlf
+++ b/GitUI/Translation/English.Plugins.xlf
@@ -10,7 +10,7 @@
   </file>
   <file datatype="plaintext" original="AutoCompileSubModulesPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Auto compile SubModules</source>
         <target />
       </trans-unit>
@@ -40,7 +40,7 @@
   </file>
   <file datatype="plaintext" original="BackgroundFetchPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Periodic background fetch</source>
         <target />
       </trans-unit>
@@ -80,7 +80,7 @@
         <source>Bitbucket Username</source>
         <target />
       </trans-unit>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Bitbucket Server</source>
         <target />
       </trans-unit>
@@ -241,7 +241,7 @@
   </file>
   <file datatype="plaintext" original="CreateLocalBranchesPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Create local tracking branches</source>
         <target />
       </trans-unit>
@@ -371,7 +371,7 @@ Are you sure you want to continue?</source>
   </file>
   <file datatype="plaintext" original="DeleteUnusedBranchesPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Delete obsolete branches</source>
         <target />
       </trans-unit>
@@ -471,7 +471,7 @@ Are you sure you want to continue?</source>
   </file>
   <file datatype="plaintext" original="FindLargeFilesPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Find large files</source>
         <target />
       </trans-unit>
@@ -829,7 +829,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GerritPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gerrit Code Review</source>
         <target />
       </trans-unit>
@@ -985,7 +985,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
         <source>ref/...</source>
         <target />
       </trans-unit>
-      <trans-unit id="lblPrefixName.Text">
+      <trans-unit id="lblPrefixDescription.Text">
         <source>[prefix]/</source>
         <target />
       </trans-unit>
@@ -1001,7 +1001,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitFlowPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitFlow</source>
         <target />
       </trans-unit>
@@ -1009,7 +1009,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitHub3Plugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitHub</source>
         <target />
       </trans-unit>
@@ -1033,7 +1033,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitImpactPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Impact Graph</source>
         <target />
       </trans-unit>
@@ -1041,7 +1041,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitStatisticsPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Statistics</source>
         <target />
       </trans-unit>
@@ -1061,7 +1061,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GourcePlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gource</source>
         <target />
       </trans-unit>
@@ -1177,7 +1177,7 @@ Do you want to reset the configured path?</source>
   </file>
   <file datatype="plaintext" original="JiraCommitHintPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Jira Commit Hint</source>
         <target />
       </trans-unit>
@@ -1265,7 +1265,7 @@ Do you want to reset the configured path?</source>
         <source>There is no proxy configured. Please set the proxy host in the plugin settings.</source>
         <target />
       </trans-unit>
-      <trans-unit id="_pluginDescription.Text">
+      <trans-unit id="_pluginName.Text">
         <source>Proxy Switcher</source>
         <target />
       </trans-unit>
@@ -1273,7 +1273,7 @@ Do you want to reset the configured path?</source>
   </file>
   <file datatype="plaintext" original="ProxySwitcherPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Proxy Switcher</source>
         <target />
       </trans-unit>
@@ -1399,7 +1399,7 @@ branch names, tag names)</source>
   </file>
   <file datatype="plaintext" original="ReleaseNotesGeneratorPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Release Notes Generator</source>
         <target />
       </trans-unit>

--- a/GitUI/Translation/French.Plugins.xlf
+++ b/GitUI/Translation/French.Plugins.xlf
@@ -10,7 +10,7 @@
   </file>
   <file datatype="plaintext" original="AutoCompileSubModulesPlugin" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Auto compile SubModules</source>
         <target>Compilation automatique des sous modules</target>
         
@@ -48,7 +48,7 @@
   </file>
   <file datatype="plaintext" original="BackgroundFetchPlugin" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Periodic background fetch</source>
         <target>Effectuer une récupération (fetch) périodique en arrière-plan</target>
         
@@ -97,7 +97,7 @@
         <target>Utilisateur Bitbucket</target>
         
       </trans-unit>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Bitbucket Server</source>
         <target>Serveur Bitbucket</target>
         
@@ -296,7 +296,7 @@
   </file>
   <file datatype="plaintext" original="CreateLocalBranchesPlugin" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Create local tracking branches</source>
         <target>Créer des branches de suivie locales</target>
         
@@ -458,7 +458,7 @@ Les branches distantes seront supprimées '{0}'. On ne peut pas annuler.
   </file>
   <file datatype="plaintext" original="DeleteUnusedBranchesPlugin" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Delete obsolete branches</source>
         <target>Supprimer les branches obsolètes</target>
         
@@ -581,7 +581,7 @@ Les branches distantes seront supprimées '{0}'. On ne peut pas annuler.
   </file>
   <file datatype="plaintext" original="FindLargeFilesPlugin" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Find large files</source>
         <target>Chercher des grands fichiers</target>
         
@@ -1027,7 +1027,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GerritPlugin" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gerrit Code Review</source>
         <target>Revue de code Gerrit</target>
         
@@ -1238,7 +1238,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitFlowPlugin" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitFlow</source>
         <target>GitFlow</target>
         
@@ -1247,7 +1247,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitHub3Plugin" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitHub</source>
         <target>GitHub</target>
         
@@ -1275,7 +1275,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitImpactPlugin" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Impact Graph</source>
         <target>Impact Graph</target>
         
@@ -1284,7 +1284,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitStatisticsPlugin" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Statistics</source>
         <target>Statistiques</target>
         
@@ -1308,7 +1308,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GourcePlugin" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gource</source>
         <target>Gource</target>
         
@@ -1456,7 +1456,7 @@ Voulez-vous réinitialiser le chemin configuré?</target>
   </file>
   <file datatype="plaintext" original="JiraCommitHintPlugin" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Jira Commit Hint</source>
         <target>Lien commit-Jira</target>
         
@@ -1574,7 +1574,7 @@ Voulez-vous réinitialiser le chemin configuré?</target>
   </file>
   <file datatype="plaintext" original="ProxySwitcherPlugin" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Proxy Switcher</source>
         <target>Changeur de proxy</target>
         
@@ -1731,7 +1731,7 @@ noms de branche, noms de tag)</target>
   </file>
   <file datatype="plaintext" original="ReleaseNotesGeneratorPlugin" source-language="en" target-language="fr">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Release Notes Generator</source>
         <target>Générateur de Notes de Release</target>
         

--- a/GitUI/Translation/German.Plugins.xlf
+++ b/GitUI/Translation/German.Plugins.xlf
@@ -10,7 +10,7 @@
   </file>
   <file datatype="plaintext" original="AutoCompileSubModulesPlugin" source-language="en" target-language="de">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Auto compile SubModules</source>
         <target>Untermodule automatisch kompilieren</target>
         
@@ -48,7 +48,7 @@
   </file>
   <file datatype="plaintext" original="BackgroundFetchPlugin" source-language="en" target-language="de">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Periodic background fetch</source>
         <target>Periodischer fetch im Hintergrund</target>
         
@@ -97,7 +97,7 @@
         <target>Bitbucket Benutzername</target>
         
       </trans-unit>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Bitbucket Server</source>
         <target>Bitbucket Server</target>
         
@@ -296,7 +296,7 @@
   </file>
   <file datatype="plaintext" original="CreateLocalBranchesPlugin" source-language="en" target-language="de">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Create local tracking branches</source>
         <target>Erzeuge lokale Branches zur Verfolgung</target>
         
@@ -458,7 +458,7 @@ Sind Sie sich sicher und wollen damit fortfahren?</target>
   </file>
   <file datatype="plaintext" original="DeleteUnusedBranchesPlugin" source-language="en" target-language="de">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Delete obsolete branches</source>
         <target>Obsolete Branches löschen</target>
         
@@ -581,7 +581,7 @@ Sind Sie sich sicher und wollen damit fortfahren?</target>
   </file>
   <file datatype="plaintext" original="FindLargeFilesPlugin" source-language="en" target-language="de">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Find large files</source>
         <target>Finde große Dateien</target>
         
@@ -1031,7 +1031,7 @@ Um die Gerrit Unterstützung für ein Repository zu aktivieren, muss eine .gitre
   </file>
   <file datatype="plaintext" original="GerritPlugin" source-language="en" target-language="de">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gerrit Code Review</source>
         <target>Gerrit Code Review</target>
         
@@ -1243,7 +1243,7 @@ Um die Gerrit Unterstützung für ein Repository zu aktivieren, muss eine .gitre
   </file>
   <file datatype="plaintext" original="GitFlowPlugin" source-language="en" target-language="de">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitFlow</source>
         <target>GitFlow</target>
         
@@ -1252,7 +1252,7 @@ Um die Gerrit Unterstützung für ein Repository zu aktivieren, muss eine .gitre
   </file>
   <file datatype="plaintext" original="GitHub3Plugin" source-language="en" target-language="de">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitHub</source>
         <target>GitHub</target>
         
@@ -1281,7 +1281,7 @@ Um die Gerrit Unterstützung für ein Repository zu aktivieren, muss eine .gitre
   </file>
   <file datatype="plaintext" original="GitImpactPlugin" source-language="en" target-language="de">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Impact Graph</source>
         <target>Darstellung der Abhängigkeiten</target>
         
@@ -1290,7 +1290,7 @@ Um die Gerrit Unterstützung für ein Repository zu aktivieren, muss eine .gitre
   </file>
   <file datatype="plaintext" original="GitStatisticsPlugin" source-language="en" target-language="de">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Statistics</source>
         <target>Statistiken</target>
         
@@ -1314,7 +1314,7 @@ Um die Gerrit Unterstützung für ein Repository zu aktivieren, muss eine .gitre
   </file>
   <file datatype="plaintext" original="GourcePlugin" source-language="en" target-language="de">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gource</source>
         <target>Gource</target>
         
@@ -1462,7 +1462,7 @@ Wollen Sie den konfigurierten Pfad zurücksetzen?</target>
   </file>
   <file datatype="plaintext" original="JiraCommitHintPlugin" source-language="en" target-language="de">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Jira Commit Hint</source>
         <target>JIRA Commit Hinweis</target>
         
@@ -1580,7 +1580,7 @@ Wollen Sie den konfigurierten Pfad zurücksetzen?</target>
   </file>
   <file datatype="plaintext" original="ProxySwitcherPlugin" source-language="en" target-language="de">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Proxy Switcher</source>
         <target>Proxy Wechsler</target>
         
@@ -1737,7 +1737,7 @@ Branchnamen oder Tag-Namen sein.)</target>
   </file>
   <file datatype="plaintext" original="ReleaseNotesGeneratorPlugin" source-language="en" target-language="de">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Release Notes Generator</source>
         <target>Release Notes Generator</target>
         

--- a/GitUI/Translation/Japanese.Plugins.xlf
+++ b/GitUI/Translation/Japanese.Plugins.xlf
@@ -10,7 +10,7 @@
   </file>
   <file datatype="plaintext" original="AutoCompileSubModulesPlugin" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Auto compile SubModules</source>
         <target>サブモジュールの自動コンパイル</target>
         
@@ -48,7 +48,7 @@
   </file>
   <file datatype="plaintext" original="BackgroundFetchPlugin" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Periodic background fetch</source>
         <target>バックグラウンドで定期的にフェッチ</target>
         
@@ -97,7 +97,7 @@
         <target>Bitbucketユーザ名</target>
         
       </trans-unit>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Bitbucket Server</source>
         <target>Bitbucketサーバ</target>
         
@@ -295,7 +295,7 @@
   </file>
   <file datatype="plaintext" original="CreateLocalBranchesPlugin" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Create local tracking branches</source>
         <target>ローカルの追跡ブランチを作成</target>
         
@@ -457,7 +457,7 @@ Are you sure you want to continue?</source>
   </file>
   <file datatype="plaintext" original="DeleteUnusedBranchesPlugin" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Delete obsolete branches</source>
         <target>不要なブランチを削除</target>
         
@@ -580,7 +580,7 @@ Are you sure you want to continue?</source>
   </file>
   <file datatype="plaintext" original="FindLargeFilesPlugin" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Find large files</source>
         <target>巨大なファイルを発見する</target>
         
@@ -1029,7 +1029,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GerritPlugin" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gerrit Code Review</source>
         <target>Gerrit コードレビュー</target>
         
@@ -1241,7 +1241,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitFlowPlugin" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitFlow</source>
         <target>GitFlow</target>
         
@@ -1250,7 +1250,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitHub3Plugin" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitHub</source>
         <target>GitHub</target>
         
@@ -1279,7 +1279,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitImpactPlugin" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Impact Graph</source>
         <target>インパクトグラフ</target>
         
@@ -1288,7 +1288,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitStatisticsPlugin" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Statistics</source>
         <target>統計情報</target>
         
@@ -1312,7 +1312,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GourcePlugin" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gource</source>
         <target>Gource</target>
         
@@ -1460,7 +1460,7 @@ Do you want to reset the configured path?</source>
   </file>
   <file datatype="plaintext" original="JiraCommitHintPlugin" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Jira Commit Hint</source>
         <target>Jiraコミットヒント</target>
         
@@ -1578,7 +1578,7 @@ Do you want to reset the configured path?</source>
   </file>
   <file datatype="plaintext" original="ProxySwitcherPlugin" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Proxy Switcher</source>
         <target>プロキシスイッチャ</target>
         
@@ -1734,7 +1734,7 @@ branch names, tag names)</source>
   </file>
   <file datatype="plaintext" original="ReleaseNotesGeneratorPlugin" source-language="en" target-language="ja">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Release Notes Generator</source>
         <target>リリースノートジェネレータ</target>
         

--- a/GitUI/Translation/Polish.Plugins.xlf
+++ b/GitUI/Translation/Polish.Plugins.xlf
@@ -9,7 +9,7 @@
   </file>
   <file datatype="plaintext" original="AutoCompileSubModulesPlugin" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Auto compile SubModules</source>
         <target>Automatycznie kompiluj moduły zależne</target>
         
@@ -47,7 +47,7 @@
   </file>
   <file datatype="plaintext" original="BackgroundFetchPlugin" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Periodic background fetch</source>
         <target>Okresowe pobieranie w tle</target>
         
@@ -96,7 +96,7 @@
         <target>Nazwa użytkownika Bitbucket</target>
         
       </trans-unit>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Bitbucket Server</source>
         <target>Serwer Bitbucket</target>
         
@@ -295,7 +295,7 @@ zatwierdzono przez {0}</target>
   </file>
   <file datatype="plaintext" original="CreateLocalBranchesPlugin" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Create local tracking branches</source>
         <target>Stwórz lokalne śledzenie gałęzi</target>
         
@@ -457,7 +457,7 @@ Na pewno chcesz kontynuować?</target>
   </file>
   <file datatype="plaintext" original="DeleteUnusedBranchesPlugin" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Delete obsolete branches</source>
         <target>Usuwanie przestarzałych gałęzi</target>
         
@@ -580,7 +580,7 @@ Na pewno chcesz kontynuować?</target>
   </file>
   <file datatype="plaintext" original="FindLargeFilesPlugin" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Find large files</source>
         <target>Znajdź duże pliki</target>
         
@@ -1024,7 +1024,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GerritPlugin" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gerrit Code Review</source>
         <target>Przegląd kodu Gerrit</target>
         
@@ -1235,7 +1235,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitFlowPlugin" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitFlow</source>
         <target>GitFlow</target>
         
@@ -1244,7 +1244,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitHub3Plugin" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitHub</source>
         <target>GitHub</target>
         
@@ -1272,7 +1272,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitImpactPlugin" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Impact Graph</source>
         <target>Wykres wkładu</target>
         
@@ -1281,7 +1281,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitStatisticsPlugin" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Statistics</source>
         <target>Statystyki</target>
         
@@ -1305,7 +1305,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GourcePlugin" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gource</source>
         <target>Gource</target>
         
@@ -1453,7 +1453,7 @@ Chcesz zresetować skonfigurowaną ścieżkę?</target>
   </file>
   <file datatype="plaintext" original="JiraCommitHintPlugin" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Jira Commit Hint</source>
         
       </trans-unit>
@@ -1569,7 +1569,7 @@ Chcesz zresetować skonfigurowaną ścieżkę?</target>
   </file>
   <file datatype="plaintext" original="ProxySwitcherPlugin" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Proxy Switcher</source>
         <target>Zmiana proxy</target>
         
@@ -1726,7 +1726,7 @@ zatwierdzeń, nazwami gałęzi lub tagów)</target>
   </file>
   <file datatype="plaintext" original="ReleaseNotesGeneratorPlugin" source-language="en" target-language="pl">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Release Notes Generator</source>
         <target>Generator informacji o wydaniu</target>
         

--- a/GitUI/Translation/Russian.Plugins.xlf
+++ b/GitUI/Translation/Russian.Plugins.xlf
@@ -10,7 +10,7 @@
   </file>
   <file datatype="plaintext" original="AutoCompileSubModulesPlugin" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Auto compile SubModules</source>
         <target>Автоматическая сборка субмодулей</target>
         
@@ -48,7 +48,7 @@
   </file>
   <file datatype="plaintext" original="BackgroundFetchPlugin" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Periodic background fetch</source>
         <target>Периодически забирать в фоне</target>
         
@@ -97,7 +97,7 @@
         <target>Bitbucket имя пользователя</target>
         
       </trans-unit>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Bitbucket Server</source>
         <target>Сервер Bitbucket</target>
         
@@ -296,7 +296,7 @@
   </file>
   <file datatype="plaintext" original="CreateLocalBranchesPlugin" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Create local tracking branches</source>
         <target>Создать локальные отслеживающие ветки</target>
         
@@ -458,7 +458,7 @@ Are you sure you want to continue?</source>
   </file>
   <file datatype="plaintext" original="DeleteUnusedBranchesPlugin" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Delete obsolete branches</source>
         <target>Удалить устаревшие ветки</target>
         
@@ -581,7 +581,7 @@ Are you sure you want to continue?</source>
   </file>
   <file datatype="plaintext" original="FindLargeFilesPlugin" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Find large files</source>
         <target>Найти большие файлы</target>
         
@@ -1030,7 +1030,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GerritPlugin" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gerrit Code Review</source>
         <target>Рецензирование кода в Gerrit</target>
         
@@ -1242,7 +1242,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitFlowPlugin" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitFlow</source>
         <target>GitFlow</target>
         
@@ -1251,7 +1251,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitHub3Plugin" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitHub</source>
         <target>GitHub</target>
         
@@ -1280,7 +1280,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitImpactPlugin" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Impact Graph</source>
         <target>Граф воздействия</target>
         
@@ -1289,7 +1289,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitStatisticsPlugin" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Statistics</source>
         <target>Статистика</target>
         
@@ -1313,7 +1313,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GourcePlugin" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gource</source>
         <target>Gource</target>
         
@@ -1461,7 +1461,7 @@ Do you want to reset the configured path?</source>
   </file>
   <file datatype="plaintext" original="JiraCommitHintPlugin" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Jira Commit Hint</source>
         <target>Подсказка коммита Jira</target>
         
@@ -1579,7 +1579,7 @@ Do you want to reset the configured path?</source>
   </file>
   <file datatype="plaintext" original="ProxySwitcherPlugin" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Proxy Switcher</source>
         <target>Переключение прокси</target>
         
@@ -1735,7 +1735,7 @@ branch names, tag names)</source>
   </file>
   <file datatype="plaintext" original="ReleaseNotesGeneratorPlugin" source-language="en" target-language="ru">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Release Notes Generator</source>
         <target>Генератор примечаний к выпуску</target>
         

--- a/GitUI/Translation/Simplified Chinese.Plugins.xlf
+++ b/GitUI/Translation/Simplified Chinese.Plugins.xlf
@@ -10,7 +10,7 @@
   </file>
   <file datatype="plaintext" original="AutoCompileSubModulesPlugin" source-language="en" target-language="zh-Hans">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Auto compile SubModules</source>
         <target>自动编译子模块</target>
         
@@ -48,7 +48,7 @@
   </file>
   <file datatype="plaintext" original="BackgroundFetchPlugin" source-language="en" target-language="zh-Hans">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Periodic background fetch</source>
         <target>周期性背景提取</target>
         
@@ -97,7 +97,7 @@
         <target>Bitbucket 用户名</target>
         
       </trans-unit>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Bitbucket Server</source>
         <target>Bitbucket 服务器</target>
         
@@ -296,7 +296,7 @@
   </file>
   <file datatype="plaintext" original="CreateLocalBranchesPlugin" source-language="en" target-language="zh-Hans">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Create local tracking branches</source>
         <target>创建本地跟踪分支</target>
         
@@ -458,7 +458,7 @@ Are you sure you want to continue?</source>
   </file>
   <file datatype="plaintext" original="DeleteUnusedBranchesPlugin" source-language="en" target-language="zh-Hans">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Delete obsolete branches</source>
         <target>删除废弃的分支</target>
         
@@ -581,7 +581,7 @@ Are you sure you want to continue?</source>
   </file>
   <file datatype="plaintext" original="FindLargeFilesPlugin" source-language="en" target-language="zh-Hans">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Find large files</source>
         <target>查找大文件</target>
         
@@ -1030,7 +1030,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GerritPlugin" source-language="en" target-language="zh-Hans">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gerrit Code Review</source>
         <target>Gerrit代码审查</target>
         
@@ -1242,7 +1242,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitFlowPlugin" source-language="en" target-language="zh-Hans">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitFlow</source>
         <target>GitFlow</target>
         
@@ -1251,7 +1251,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitHub3Plugin" source-language="en" target-language="zh-Hans">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitHub</source>
         <target>GitHub</target>
         
@@ -1279,7 +1279,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitImpactPlugin" source-language="en" target-language="zh-Hans">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Impact Graph</source>
         <target>影响图形</target>
         
@@ -1288,7 +1288,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitStatisticsPlugin" source-language="en" target-language="zh-Hans">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Statistics</source>
         <target>统计</target>
         
@@ -1312,7 +1312,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GourcePlugin" source-language="en" target-language="zh-Hans">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gource</source>
         <target>Gource</target>
         
@@ -1460,7 +1460,7 @@ Do you want to reset the configured path?</source>
   </file>
   <file datatype="plaintext" original="JiraCommitHintPlugin" source-language="en" target-language="zh-Hans">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Jira Commit Hint</source>
         <target>Jira Commit 提示</target>
         
@@ -1578,7 +1578,7 @@ Do you want to reset the configured path?</source>
   </file>
   <file datatype="plaintext" original="ProxySwitcherPlugin" source-language="en" target-language="zh-Hans">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Proxy Switcher</source>
         <target>代理切换</target>
         
@@ -1735,7 +1735,7 @@ branch names, tag names)</source>
   </file>
   <file datatype="plaintext" original="ReleaseNotesGeneratorPlugin" source-language="en" target-language="zh-Hans">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Release Notes Generator</source>
         <target>发行注记</target>
         

--- a/GitUI/Translation/Spanish.Plugins.xlf
+++ b/GitUI/Translation/Spanish.Plugins.xlf
@@ -10,7 +10,7 @@
   </file>
   <file datatype="plaintext" original="AutoCompileSubModulesPlugin" source-language="en" target-language="es">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Auto compile SubModules</source>
         <target>Autocompilar submódulos</target>
         
@@ -48,7 +48,7 @@
   </file>
   <file datatype="plaintext" original="BackgroundFetchPlugin" source-language="en" target-language="es">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Periodic background fetch</source>
         <target>Ejecuta fetch periódicamente en segundo plano</target>
         
@@ -97,7 +97,7 @@
         <target>Nombre de usuario de Bitbucket</target>
         
       </trans-unit>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Bitbucket Server</source>
         <target>Servidor Bitbucket</target>
         
@@ -296,7 +296,7 @@
   </file>
   <file datatype="plaintext" original="CreateLocalBranchesPlugin" source-language="en" target-language="es">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Create local tracking branches</source>
         <target>Crear ramas locales de tracking</target>
         
@@ -457,7 +457,7 @@ Las ramas serán eliminadas en el servidor remoto '{0}'. Esta acción no puede d
   </file>
   <file datatype="plaintext" original="DeleteUnusedBranchesPlugin" source-language="en" target-language="es">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Delete obsolete branches</source>
         <target>Eliminar ramas obsoletas</target>
         
@@ -580,7 +580,7 @@ Las ramas serán eliminadas en el servidor remoto '{0}'. Esta acción no puede d
   </file>
   <file datatype="plaintext" original="FindLargeFilesPlugin" source-language="en" target-language="es">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Find large files</source>
         <target>Encontrar archivos grandes</target>
         
@@ -1029,7 +1029,7 @@ Para habilitar Gerrit para un repositorio debe existir el archivo .gitreview, lo
   </file>
   <file datatype="plaintext" original="GerritPlugin" source-language="en" target-language="es">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gerrit Code Review</source>
         <target>Revisión de código Gerrit</target>
         
@@ -1241,7 +1241,7 @@ Para habilitar Gerrit para un repositorio debe existir el archivo .gitreview, lo
   </file>
   <file datatype="plaintext" original="GitFlowPlugin" source-language="en" target-language="es">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitFlow</source>
         <target>GitFlow</target>
         
@@ -1250,7 +1250,7 @@ Para habilitar Gerrit para un repositorio debe existir el archivo .gitreview, lo
   </file>
   <file datatype="plaintext" original="GitHub3Plugin" source-language="en" target-language="es">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitHub</source>
         <target>GitHub</target>
         
@@ -1279,7 +1279,7 @@ Para habilitar Gerrit para un repositorio debe existir el archivo .gitreview, lo
   </file>
   <file datatype="plaintext" original="GitImpactPlugin" source-language="en" target-language="es">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Impact Graph</source>
         <target>Gráfico de Impacto</target>
         
@@ -1288,7 +1288,7 @@ Para habilitar Gerrit para un repositorio debe existir el archivo .gitreview, lo
   </file>
   <file datatype="plaintext" original="GitStatisticsPlugin" source-language="en" target-language="es">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Statistics</source>
         <target>Estadísticas</target>
         
@@ -1312,7 +1312,7 @@ Para habilitar Gerrit para un repositorio debe existir el archivo .gitreview, lo
   </file>
   <file datatype="plaintext" original="GourcePlugin" source-language="en" target-language="es">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gource</source>
         <target>Gource</target>
         
@@ -1459,7 +1459,7 @@ Do you want to reset the configured path?</source>
   </file>
   <file datatype="plaintext" original="JiraCommitHintPlugin" source-language="en" target-language="es">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Jira Commit Hint</source>
         <target>Pista del commit de Jira</target>
         
@@ -1577,7 +1577,7 @@ Do you want to reset the configured path?</source>
   </file>
   <file datatype="plaintext" original="ProxySwitcherPlugin" source-language="en" target-language="es">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Proxy Switcher</source>
         <target>Cambiador de proxy</target>
         
@@ -1733,7 +1733,7 @@ nombres de ramas, ó nombres de tags)</target>
   </file>
   <file datatype="plaintext" original="ReleaseNotesGeneratorPlugin" source-language="en" target-language="es">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Release Notes Generator</source>
         <target>Generador de Notas de Versión.</target>
         

--- a/GitUI/Translation/en_pseudo.Plugins.xlf
+++ b/GitUI/Translation/en_pseudo.Plugins.xlf
@@ -10,7 +10,7 @@
   </file>
   <file datatype="plaintext" original="AutoCompileSubModulesPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Auto compile SubModules</source>
         <target>[Ȧŭŧǿ ƈǿḿƥīŀḗ ŞŭƀḾǿḓŭŀḗş ǈςıϰ ẛΐẛıϖϖ]</target>
         
@@ -48,7 +48,7 @@
   </file>
   <file datatype="plaintext" original="BackgroundFetchPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Periodic background fetch</source>
         <target>[Ƥḗřīǿḓīƈ ƀȧƈķɠřǿŭƞḓ ƒḗŧƈħ ϰϖςẛϵϵſǈ ϐẛ]</target>
         
@@ -97,7 +97,7 @@
         <target>[Ɓīŧƀŭƈķḗŧ Ŭşḗřƞȧḿḗ ϖϰΰẛǋϕϑϕǈ]</target>
         
       </trans-unit>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Bitbucket Server</source>
         <target>[Ɓīŧƀŭƈķḗŧ Şḗřṽḗř ſẛϕϖǅẛǅ衋ΰ ǅ]</target>
         
@@ -296,7 +296,7 @@
   </file>
   <file datatype="plaintext" original="CreateLocalBranchesPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Create local tracking branches</source>
         <target>[Ƈřḗȧŧḗ ŀǿƈȧŀ ŧřȧƈķīƞɠ ƀřȧƞƈħḗş ϱıϰϑϕΐ 靐靐ς]</target>
         
@@ -458,7 +458,7 @@ Are you sure you want to continue?</source>
   </file>
   <file datatype="plaintext" original="DeleteUnusedBranchesPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Delete obsolete branches</source>
         <target>[Ḓḗŀḗŧḗ ǿƀşǿŀḗŧḗ ƀřȧƞƈħḗş ǋ靐ſςςſ 鶱ϖǋ]</target>
         
@@ -581,7 +581,7 @@ Are you sure you want to continue?</source>
   </file>
   <file datatype="plaintext" original="FindLargeFilesPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Find large files</source>
         <target>[Ƒīƞḓ ŀȧřɠḗ ƒīŀḗş ςǈςς ıǅ衋ΐϐ]</target>
         
@@ -1030,7 +1030,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GerritPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gerrit Code Review</source>
         <target>[Ɠḗřřīŧ Ƈǿḓḗ Řḗṽīḗẇ ẛΐẛΐϐϱ ϑϱ衋]</target>
         
@@ -1242,7 +1242,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitFlowPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitFlow</source>
         <target>[ƓīŧƑŀǿẇ ςẛııΐϕϕ]</target>
         
@@ -1251,7 +1251,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitHub3Plugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>GitHub</source>
         <target>[ƓīŧĦŭƀ ςǲςϵΐϖ]</target>
         
@@ -1280,7 +1280,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitImpactPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Impact Graph</source>
         <target>[Īḿƥȧƈŧ Ɠřȧƥħ 靐ϐſϑǅı ǲϵϐ]</target>
         
@@ -1289,7 +1289,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GitStatisticsPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Statistics</source>
         <target>[Şŧȧŧīşŧīƈş ςǈϱϐǈ衋ſϱϖǅ]</target>
         
@@ -1313,7 +1313,7 @@ To enable Gerrit support for a repository, a .gitreview file must be created. Th
   </file>
   <file datatype="plaintext" original="GourcePlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Gource</source>
         <target>[Ɠǿŭřƈḗ ǅςẛǅǈϰ]</target>
         
@@ -1461,7 +1461,7 @@ Do you want to reset the configured path?</source>
   </file>
   <file datatype="plaintext" original="JiraCommitHintPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Jira Commit Hint</source>
         <target>[Ĵīřȧ Ƈǿḿḿīŧ Ħīƞŧ ǅǲıϐ ııẛΐǲς]</target>
         
@@ -1579,7 +1579,7 @@ Do you want to reset the configured path?</source>
   </file>
   <file datatype="plaintext" original="ProxySwitcherPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Proxy Switcher</source>
         <target>[Ƥřǿẋẏ Şẇīŧƈħḗř ǋϵǈϵẛ 靐ǅǈ衋ΰ靐]</target>
         
@@ -1736,7 +1736,7 @@ branch names, tag names)</source>
   </file>
   <file datatype="plaintext" original="ReleaseNotesGeneratorPlugin" source-language="en">
     <body>
-      <trans-unit id="Description.Text">
+      <trans-unit id="Name.Text">
         <source>Release Notes Generator</source>
         <target>[Řḗŀḗȧşḗ Ƞǿŧḗş Ɠḗƞḗřȧŧǿř ẛς鶱ςϐϑΐ ϑǅǅ]</target>
         

--- a/Plugins/AutoCompileSubmodules/AutoCompileSubModulesPlugin.cs
+++ b/Plugins/AutoCompileSubmodules/AutoCompileSubModulesPlugin.cs
@@ -19,7 +19,7 @@ namespace GitExtensions.Plugins.AutoCompileSubmodules
 
         public AutoCompileSubModulesPlugin() : base(true)
         {
-            SetNameAndDescription("Auto compile SubModules");
+            Name = "Auto compile SubModules";
             Translate();
             Icon = Resources.IconAutoCompileSubmodules;
         }

--- a/Plugins/AutoCompileSubmodules/AutoCompileSubModulesPlugin.cs
+++ b/Plugins/AutoCompileSubmodules/AutoCompileSubModulesPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Text;
@@ -19,6 +20,7 @@ namespace GitExtensions.Plugins.AutoCompileSubmodules
 
         public AutoCompileSubModulesPlugin() : base(true)
         {
+            Id = new Guid("D4D1ACB7-0B6B-4A3C-B0DB-A25056A277D9");
             Name = "Auto compile SubModules";
             Translate();
             Icon = Resources.IconAutoCompileSubmodules;

--- a/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
+++ b/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
@@ -18,6 +18,7 @@ namespace GitExtensions.Plugins.BackgroundFetch
     {
         public BackgroundFetchPlugin() : base(true)
         {
+            Id = new Guid("D19A7905-8AAD-4271-ACA9-817669B94A1D");
             Name = "Periodic background fetch";
             Translate();
             Icon = Resources.IconBackgroundFetch;

--- a/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
+++ b/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
@@ -18,7 +18,7 @@ namespace GitExtensions.Plugins.BackgroundFetch
     {
         public BackgroundFetchPlugin() : base(true)
         {
-            SetNameAndDescription("Periodic background fetch");
+            Name = "Periodic background fetch";
             Translate();
             Icon = Resources.IconBackgroundFetch;
         }

--- a/Plugins/Bitbucket/BitbucketPlugin.cs
+++ b/Plugins/Bitbucket/BitbucketPlugin.cs
@@ -18,7 +18,7 @@ namespace GitExtensions.Plugins.Bitbucket
 
         public BitbucketPlugin() : base(true)
         {
-            SetNameAndDescription("Bitbucket Server");
+            Name = "Bitbucket Server";
             Translate();
 
             Icon = Resources.IconPluginBitbucket;

--- a/Plugins/Bitbucket/BitbucketPlugin.cs
+++ b/Plugins/Bitbucket/BitbucketPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.Composition;
+﻿using System;
+using System.ComponentModel.Composition;
 using System.Windows.Forms;
 using GitExtensions.Plugins.Bitbucket.Properties;
 using GitUIPluginInterfaces;
@@ -18,6 +19,7 @@ namespace GitExtensions.Plugins.Bitbucket
 
         public BitbucketPlugin() : base(true)
         {
+            Id = new Guid("0DA2C988-37A1-461C-BAD4-AFE4930C3157");
             Name = "Bitbucket Server";
             Translate();
 

--- a/Plugins/CreateLocalBranches/CreateLocalBranchesPlugin.cs
+++ b/Plugins/CreateLocalBranches/CreateLocalBranchesPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.Composition;
+﻿using System;
+using System.ComponentModel.Composition;
 using GitExtensions.Plugins.CreateLocalBranches.Properties;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -10,6 +11,7 @@ namespace GitExtensions.Plugins.CreateLocalBranches
     {
         public CreateLocalBranchesPlugin() : base(false)
         {
+            Id = new Guid("BE7BEE10-21B5-489F-9664-957945C203DC");
             Name = "Create local tracking branches";
             Translate();
             Icon = Resources.IconCreateLocalBranches;

--- a/Plugins/CreateLocalBranches/CreateLocalBranchesPlugin.cs
+++ b/Plugins/CreateLocalBranches/CreateLocalBranchesPlugin.cs
@@ -10,7 +10,7 @@ namespace GitExtensions.Plugins.CreateLocalBranches
     {
         public CreateLocalBranchesPlugin() : base(false)
         {
-            SetNameAndDescription("Create local tracking branches");
+            Name = "Create local tracking branches";
             Translate();
             Icon = Resources.IconCreateLocalBranches;
         }

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesPlugin.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.Composition;
+﻿using System;
+using System.ComponentModel.Composition;
 using GitExtensions.Plugins.DeleteUnusedBranches.Properties;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -10,6 +11,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
     {
         public DeleteUnusedBranchesPlugin() : base(true)
         {
+            Id = new Guid("DC3CA904-B9A5-4FE8-BF63-5B8EE9C2DDAC");
             Name = "Delete obsolete branches";
             Translate();
             Icon = Resources.IconDeleteUnusedBranches;

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesPlugin.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesPlugin.cs
@@ -10,7 +10,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
     {
         public DeleteUnusedBranchesPlugin() : base(true)
         {
-            SetNameAndDescription("Delete obsolete branches");
+            Name = "Delete obsolete branches";
             Translate();
             Icon = Resources.IconDeleteUnusedBranches;
         }

--- a/Plugins/FindLargeFiles/FindLargeFilesPlugin.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesPlugin.cs
@@ -11,7 +11,7 @@ namespace GitExtensions.Plugins.FindLargeFiles
     {
         public FindLargeFilesPlugin() : base(true)
         {
-            SetNameAndDescription("Find large files");
+            Name = "Find large files";
             Translate();
             Icon = Resources.IconFindLargeFiles;
         }

--- a/Plugins/FindLargeFiles/FindLargeFilesPlugin.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using GitExtensions.Plugins.FindLargeFiles.Properties;
 using GitUIPluginInterfaces;
@@ -11,6 +12,7 @@ namespace GitExtensions.Plugins.FindLargeFiles
     {
         public FindLargeFilesPlugin() : base(true)
         {
+            Id = new Guid("5AE20AB1-D677-46C5-ABDB-7874FF5A9296");
             Name = "Find large files";
             Translate();
             Icon = Resources.IconFindLargeFiles;

--- a/Plugins/GitFlow/GitFlowPlugin.cs
+++ b/Plugins/GitFlow/GitFlowPlugin.cs
@@ -10,7 +10,7 @@ namespace GitExtensions.Plugins.GitFlow
     {
         public GitFlowPlugin() : base(false)
         {
-            SetNameAndDescription("GitFlow");
+            Name = "GitFlow";
             Translate();
             Icon = Resource.IconGitFlow;
         }

--- a/Plugins/GitFlow/GitFlowPlugin.cs
+++ b/Plugins/GitFlow/GitFlowPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.Composition;
+﻿using System;
+using System.ComponentModel.Composition;
 using GitExtensions.Plugins.GitFlow.Properties;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -10,6 +11,7 @@ namespace GitExtensions.Plugins.GitFlow
     {
         public GitFlowPlugin() : base(false)
         {
+            Id = new Guid("83E1F3F1-B502-4BFB-97D9-7EF108252401");
             Name = "GitFlow";
             Translate();
             Icon = Resource.IconGitFlow;

--- a/Plugins/GitHub3/GitHub3Plugin.cs
+++ b/Plugins/GitHub3/GitHub3Plugin.cs
@@ -90,7 +90,7 @@ namespace GitExtensions.Plugins.GitHub3
 
         public GitHub3Plugin() : base(true)
         {
-            SetNameAndDescription("GitHub");
+            Name = "GitHub";
             Translate();
 
             Instance ??= this;

--- a/Plugins/GitHub3/GitHub3Plugin.cs
+++ b/Plugins/GitHub3/GitHub3Plugin.cs
@@ -90,6 +90,7 @@ namespace GitExtensions.Plugins.GitHub3
 
         public GitHub3Plugin() : base(true)
         {
+            Id = new Guid("2EC3E1F0-EF37-413F-BEA5-B8FE1F9C505C");
             Name = "GitHub";
             Translate();
 

--- a/Plugins/GitUIPluginInterfaces/IGitPlugin.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitPlugin.cs
@@ -1,10 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 
 namespace GitUIPluginInterfaces
 {
     public interface IGitPlugin
     {
+        Guid Id { get; }
+
         string? Name { get; }
 
         string? Description { get; }

--- a/Plugins/Gource/GourcePlugin.cs
+++ b/Plugins/Gource/GourcePlugin.cs
@@ -35,7 +35,7 @@ namespace GitExtensions.Plugins.Gource
 
         public GourcePlugin() : base(true)
         {
-            SetNameAndDescription("Gource");
+            Name = "Gource";
             Translate();
             Icon = Resources.IconGource;
         }

--- a/Plugins/Gource/GourcePlugin.cs
+++ b/Plugins/Gource/GourcePlugin.cs
@@ -35,6 +35,7 @@ namespace GitExtensions.Plugins.Gource
 
         public GourcePlugin() : base(true)
         {
+            Id = new Guid("F0A6A769-6DCC-4452-9A43-343347015EEC");
             Name = "Gource";
             Translate();
             Icon = Resources.IconGource;

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -282,7 +282,7 @@ namespace GitExtensions.Plugins.JiraCommitHintPlugin
             }
             catch (Exception ex)
             {
-                return new[] { new JiraTaskDTO($"{Description} error", ex.ToString()) };
+                return new[] { new JiraTaskDTO($"{Name} error", ex.ToString()) };
             }
         }
 

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -47,7 +47,7 @@ namespace GitExtensions.Plugins.JiraCommitHintPlugin
 
         public JiraCommitHintPlugin() : base(true)
         {
-            SetNameAndDescription("Jira Commit Hint");
+            Name = "Jira Commit Hint";
             Translate();
             Icon = Resources.IconJira;
 

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -47,6 +47,7 @@ namespace GitExtensions.Plugins.JiraCommitHintPlugin
 
         public JiraCommitHintPlugin() : base(true)
         {
+            Id = new Guid("B0128E39-D312-47DA-B18A-43F5CA726D7D");
             Name = "Jira Commit Hint";
             Translate();
             Icon = Resources.IconJira;

--- a/Plugins/ProxySwitcher/ProxySwitcherPlugin.cs
+++ b/Plugins/ProxySwitcher/ProxySwitcherPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.Composition;
+﻿using System;
+using System.ComponentModel.Composition;
 using GitExtensions.Plugins.ProxySwitcher.Properties;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -15,6 +16,7 @@ namespace GitExtensions.Plugins.ProxySwitcher
 
         public ProxySwitcherPlugin() : base(true)
         {
+            Id = new Guid("C2A1C7A4-D519-4BD1-859B-6CE7DB9325FB");
             Name = "Proxy Switcher";
             Translate();
             Icon = Resources.IconProxySwitcher;

--- a/Plugins/ProxySwitcher/ProxySwitcherPlugin.cs
+++ b/Plugins/ProxySwitcher/ProxySwitcherPlugin.cs
@@ -15,7 +15,7 @@ namespace GitExtensions.Plugins.ProxySwitcher
 
         public ProxySwitcherPlugin() : base(true)
         {
-            SetNameAndDescription("Proxy Switcher");
+            Name = "Proxy Switcher";
             Translate();
             Icon = Resources.IconProxySwitcher;
         }

--- a/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorPlugin.cs
+++ b/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorPlugin.cs
@@ -11,7 +11,7 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
     {
         public ReleaseNotesGeneratorPlugin() : base(false)
         {
-            SetNameAndDescription("Release Notes Generator");
+            Name = "Release Notes Generator";
             Translate();
             Icon = Resources.IconReleaseNotesGenerator;
         }

--- a/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorPlugin.cs
+++ b/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.Composition;
+﻿using System;
+using System.ComponentModel.Composition;
 using System.Windows.Forms;
 using GitExtensions.Plugins.ReleaseNotesGenerator.Properties;
 using GitUIPluginInterfaces;
@@ -11,6 +12,7 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
     {
         public ReleaseNotesGeneratorPlugin() : base(false)
         {
+            Id = new Guid("49E7F2D6-AD79-489E-80A4-5CD212AE6DF3");
             Name = "Release Notes Generator";
             Translate();
             Icon = Resources.IconReleaseNotesGenerator;

--- a/Plugins/Statistics/GitImpact/GitImpactPlugin.cs
+++ b/Plugins/Statistics/GitImpact/GitImpactPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.Composition;
+﻿using System;
+using System.ComponentModel.Composition;
 using GitExtensions.Plugins.GitImpact.Properties;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -10,6 +11,7 @@ namespace GitExtensions.Plugins.GitImpact
     {
         public GitImpactPlugin() : base(false)
         {
+            Id = new Guid("F1ACFE42-6A5E-4C30-AC10-9A7C4BB8B480");
             Name = "Impact Graph";
             Translate();
             Icon = Resources.IconGitImpact;

--- a/Plugins/Statistics/GitImpact/GitImpactPlugin.cs
+++ b/Plugins/Statistics/GitImpact/GitImpactPlugin.cs
@@ -10,7 +10,7 @@ namespace GitExtensions.Plugins.GitImpact
     {
         public GitImpactPlugin() : base(false)
         {
-            SetNameAndDescription("Impact Graph");
+            Name = "Impact Graph";
             Translate();
             Icon = Resources.IconGitImpact;
         }

--- a/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
+++ b/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
@@ -19,7 +19,7 @@ namespace GitExtensions.Plugins.GitStatistics
 
         public GitStatisticsPlugin() : base(true)
         {
-            SetNameAndDescription("Statistics");
+            Name = "Statistics";
             Translate();
             Icon = Resources.IconGitStatistics;
         }

--- a/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
+++ b/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using GitExtensions.Plugins.GitStatistics.Properties;
 using GitUIPluginInterfaces;
@@ -19,6 +20,7 @@ namespace GitExtensions.Plugins.GitStatistics
 
         public GitStatisticsPlugin() : base(true)
         {
+            Id = new Guid("17D1507D-C00D-4A10-AB75-DECB2EA5FCBF");
             Name = "Statistics";
             Translate();
             Icon = Resources.IconGitStatistics;

--- a/ResourceManager/GitPluginBase.cs
+++ b/ResourceManager/GitPluginBase.cs
@@ -12,6 +12,8 @@ namespace ResourceManager
     [UsedImplicitly]
     public abstract class GitPluginBase : IGitPlugin, ITranslate
     {
+        public Guid Id { get; protected set; }
+
         public string? Description { get; protected set; }
         public string? Name { get; protected set; }
         public Image? Icon { get; protected set; }

--- a/ResourceManager/GitPluginBase.cs
+++ b/ResourceManager/GitPluginBase.cs
@@ -30,7 +30,6 @@ namespace ResourceManager
         protected void SetNameAndDescription(string name)
         {
             Name = name;
-            Description = name;
         }
 
         void IDisposable.Dispose()

--- a/ResourceManager/GitPluginBase.cs
+++ b/ResourceManager/GitPluginBase.cs
@@ -79,6 +79,8 @@ namespace ResourceManager
 
         protected void Translate()
         {
+            // Description for old plugin setting processing as key
+            Description = Name;
             Translator.Translate(this, AppSettings.CurrentTranslation);
         }
 

--- a/ResourceManager/GitPluginBase.cs
+++ b/ResourceManager/GitPluginBase.cs
@@ -90,7 +90,7 @@ namespace ResourceManager
         public virtual void TranslateItems(ITranslation translation)
         {
             string name = GetType().Name;
-            TranslationUtils.TranslateProperty(name, this, "Description", translation);
+            TranslationUtils.TranslateProperty(name, this, nameof(Name), translation);
             TranslationUtils.TranslateItemsFromFields(name, this, translation);
         }
     }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5797, https://github.com/gitextensions/gitextensions.extensibility/issues/14


## Proposed changes

- Don't use the plugin description field and switch to using the name field;
- Use Guid Id as plugin settings key.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/3169265/111083358-df2ce180-8515-11eb-977a-9efa51176c25.png)

### After

![image](https://user-images.githubusercontent.com/3169265/111083363-e5bb5900-8515-11eb-96b3-2a5a885164e1.png)

![image](https://user-images.githubusercontent.com/3169265/111083370-ece26700-8515-11eb-80f3-71a7731848d0.png)


## Test methodology <!-- How did you ensure quality? -->

- Manually
- Visually

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build f1944e19892542fa61f2efd29cb01ba1b9f114b4
- Git 2.30.2.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
