### PR TITLE
Check BeforeCommit script failure to abort commit

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1320,7 +1320,12 @@ namespace GitUI.CommandsDialogs
                                                                        ensureCommitMessageSecondLineEmpty: AppSettings.EnsureCommitMessageSecondLineEmpty);
                     }
 
-                    ScriptManager.RunEventScripts(this, ScriptEvent.BeforeCommit);
+                    bool success = ScriptManager.RunEventScripts(this, ScriptEvent.BeforeCommit);
+
+                    if (!success)
+                    {
+                        return;
+                    }
 
                     var commitCmd = Module.CommitCmd(
                         amend,
@@ -1331,7 +1336,7 @@ namespace GitUI.CommandsDialogs
                         gpgSignCommitToolStripComboBox.SelectedIndex > 0,
                         toolStripGpgKeyTextBox.Text);
 
-                    bool success = FormProcess.ShowDialog(this, process: null, arguments: commitCmd, Module.WorkingDir, input: null, useDialogSettings: true);
+                    success = FormProcess.ShowDialog(this, process: null, arguments: commitCmd, Module.WorkingDir, input: null, useDialogSettings: true);
 
                     UICommands.RepoChangedNotifier.Notify();
 

--- a/GitUI/Script/ScriptManager.cs
+++ b/GitUI/Script/ScriptManager.cs
@@ -54,12 +54,18 @@ namespace GitUI.Script
             return null;
         }
 
-        public static void RunEventScripts(GitModuleForm form, ScriptEvent scriptEvent)
+        public static bool RunEventScripts(GitModuleForm form, ScriptEvent scriptEvent)
         {
             foreach (var script in GetScripts().Where(scriptInfo => scriptInfo.Enabled && scriptInfo.OnEvent == scriptEvent))
             {
-                ScriptRunner.RunScript(form, form.Module, script.Name, form.UICommands, revisionGrid: null);
+                var result = ScriptRunner.RunScript(form, form.Module, script.Name, form.UICommands, revisionGrid: null);
+                if (!result.Executed)
+                {
+                    return false;
+                }
             }
+
+            return true;
         }
 
         public static string? SerializeIntoXml()

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -151,7 +151,11 @@ namespace GitUI.Script
 
             if (!scriptInfo.RunInBackground)
             {
-                FormProcess.ShowDialog(owner, command, argument, module.WorkingDir, null, true);
+                bool success = FormProcess.ShowDialog(owner, command, argument, module.WorkingDir, null, true);
+                if (!success)
+                {
+                    return false;
+                }
             }
             else
             {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Should fix #2479

## Intro
I am not familiar with C # programming (first C# coding). And I don't have the environment to compile and test this modification but since it seems like a simple fix with few lines, I guess it can be easily checked.

## Proposed changes
My proposal is that when a `BeforeCommit `script is called and returns a failure, the commit action should be aborted.
This script failure detection should probably be applicable to other cases (`BeforePush`... ?).

I have a doubt on the fact that this function : https://github.com/gitextensions/gitextensions/blob/e721aadada0ed6c0df8435c36df7357d2c8e957c/GitUI/Script/ScriptRunner.cs#L48
returns `Executed : false` when a script failure happen (`exit 1`) or if this function just launch the script and the output information should be found somewhere else. 

## Test methodology <!-- How did you ensure quality? -->
I proposed test steps on https://github.com/gitextensions/gitextensions/issues/2479#issuecomment-800172413

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
