### PR TITLE
FileSettingsCache: No exception if Git config is inaccessible

### DIFF
--- a/GitCommands/Settings/FileSettingsCache.cs
+++ b/GitCommands/Settings/FileSettingsCache.cs
@@ -46,7 +46,7 @@ namespace GitCommands.Settings
                 dir = null;
             }
 
-            if (Directory.Exists(dir))
+            if (Directory.Exists(dir) && File.Exists(SettingsFilePath))
             {
                 _fileWatcher.Path = dir;
                 _fileWatcher.Filter = Path.GetFileName(SettingsFilePath);


### PR DESCRIPTION
Part of #8890

## Proposed changes

If the .gitconfig file is not accessible at startup you should get a prompt asking to change.
This was not happening in #8890 though, the GE config had to be edited manually.
This PR eliminates some additional exceptions at many operations due to that the FileSettingsCache cannot enable the FileSystemWatcher.
Most normal operation after this.

Note that it is still not possible to store settings, even if .gitconfig is not changed at all.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/111389574-7ed2a700-86b1-11eb-9483-a88c33a0d55a.png)

### After

Normal operation - mostly

## Test methodology 

Manual
Repro (part of the original issue) in the issue

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
