### PR TITLE
Avoid invalid line number in DiffHighlightService

### DIFF
--- a/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -164,8 +164,7 @@ namespace GitUI.Editor.Diff
                 endLine = document.GetLineSegment(line);
             }
 
-            line--;
-            line--;
+            line = Math.Max(0, line - 2);
             endLine = document.GetLineSegment(line);
 
             document.MarkerStrategy.AddMarker(new TextMarker(lineSegment.Offset,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8998

## Proposed changes

- make `DiffHighlightService.ProcessLineSegment` work for single-line text by limiting line number to 0

## Test methodology <!-- How did you ensure quality? -->

- manual with the steps in #8998 

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 883d1740edbb568ceb14f4be75be4dc094d5c887
- Git 2.27.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
