### PR TITLE
Push from empty FormCommit

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1147,7 +1147,6 @@ namespace GitUI.CommandsDialogs
             this.CommitAndPush.Size = new System.Drawing.Size(171, 26);
             this.CommitAndPush.TabIndex = 9;
             this.CommitAndPush.TabStop = false;
-            this.CommitAndPush.Text = "Commit && &push";
             this.CommitAndPush.UseVisualStyleBackColor = true;
             this.CommitAndPush.Click += new System.EventHandler(this.CommitAndPush_Click);
             //

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -28,7 +28,6 @@ using GitUI.Hotkey;
 using GitUI.Properties;
 using GitUI.Script;
 using GitUI.SpellChecker;
-using GitUI.Theming;
 using GitUI.UserControls;
 using GitUIPluginInterfaces;
 using Microsoft;
@@ -51,6 +50,8 @@ namespace GitUI.CommandsDialogs
                                   Environment.NewLine + "Do you want to continue?");
 
         private readonly TranslationString _amendCommitCaption = new("Amend commit");
+
+        private readonly TranslationString _commitAndPush = new("Commit && &push");
 
         private readonly TranslationString _deleteFailed = new("Delete file failed");
 
@@ -212,6 +213,8 @@ namespace GitUI.CommandsDialogs
             _editedCommit = editedCommit;
 
             InitializeComponent();
+
+            CommitAndPush.Text = _commitAndPush.Text;
 
             splitRight.Panel2MinSize = DpiUtil.Scale(100);
 
@@ -1028,6 +1031,7 @@ namespace GitUI.CommandsDialogs
             LoadingStaged.Visible = false;
             Commit.Enabled = true;
             CommitAndPush.Enabled = true;
+            CommitAndPush.Text = doChangesExist ? _commitAndPush.Text : TranslatedStrings.ButtonPush;
             Amend.Enabled = true;
             Reset.Enabled = doChangesExist;
 
@@ -2703,6 +2707,12 @@ namespace GitUI.CommandsDialogs
 
         private void CommitAndPush_Click(object sender, EventArgs e)
         {
+            if (CommitAndPush.Text == TranslatedStrings.ButtonPush)
+            {
+                UICommands.StartPushDialog(this, pushOnShow: true);
+                return;
+            }
+
             CheckForStagedAndCommit(Amend.Checked, push: true);
         }
 

--- a/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -143,7 +143,6 @@
             this.Push.Name = "Push";
             this.Push.Size = new System.Drawing.Size(101, 25);
             this.Push.TabIndex = 4;
-            this.Push.Text = "&Push";
             this.Push.UseVisualStyleBackColor = true;
             this.Push.Click += new System.EventHandler(this.PushClick);
             // 

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -105,6 +105,8 @@ namespace GitUI.CommandsDialogs
         {
             InitializeComponent();
 
+            Push.Text = TranslatedStrings.ButtonPush;
+
             NewColumn.Width = DpiUtil.Scale(97);
             PushColumn.Width = DpiUtil.Scale(36);
             ForceColumn.Width = DpiUtil.Scale(101);

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -18,6 +18,7 @@ namespace GitUI
         private readonly TranslationString _buttonCloseApp = new("Close application");
         private readonly TranslationString _buttonCreateBranch = new("Create branch");
         private readonly TranslationString _buttonIgnore = new("Ignore");
+        private readonly TranslationString _buttonPush = new("&Push");
         private readonly TranslationString _buttonReportBug = new("Report bug!");
 
         private readonly TranslationString _captionFailedExecute = new("Failed to execute");
@@ -109,13 +110,13 @@ namespace GitUI
             Translator.Translate(this, AppSettings.CurrentTranslation);
         }
 
-        private static Lazy<TranslatedStrings> _instance = new Lazy<TranslatedStrings>();
+        private static Lazy<TranslatedStrings> _instance = new();
 
         public static void Reinitialize()
         {
             if (_instance.IsValueCreated)
             {
-                _instance = new Lazy<TranslatedStrings>();
+                _instance = new();
             }
         }
 
@@ -131,6 +132,7 @@ namespace GitUI
         public static string ButtonCloseApp => _instance.Value._buttonCloseApp.Text;
         public static string ButtonCreateBranch => _instance.Value._buttonCreateBranch.Text;
         public static string ButtonIgnore => _instance.Value._buttonIgnore.Text;
+        public static string ButtonPush => _instance.Value._buttonPush.Text;
         public static string ButtonReportBug => _instance.Value._buttonReportBug.Text;
 
         public static string CaptionFailedExecute => _instance.Value._captionFailedExecute.Text;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3213,10 +3213,6 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         <source>&amp;Commit</source>
         <target />
       </trans-unit>
-      <trans-unit id="CommitAndPush.Text">
-        <source>Commit &amp;&amp; &amp;push</source>
-        <target />
-      </trans-unit>
       <trans-unit id="Ok.Text">
         <source>Commit</source>
         <target />
@@ -3261,6 +3257,10 @@ Do you want to continue?</source>
         <source>Tell git to not check the status of this file for performance benefits.
 Use this feature when a file is big and never change.
 Git will never check if the file has changed that will improve status check performance.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_commitAndPush.Text">
+        <source>Commit &amp;&amp; &amp;push</source>
         <target />
       </trans-unit>
       <trans-unit id="_commitAuthorInfo.Text">
@@ -5423,10 +5423,6 @@ This will initialize and update all submodules recursive.</source>
       </trans-unit>
       <trans-unit id="Pull.Text">
         <source>Pull</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="Push.Text">
-        <source>&amp;Push</source>
         <target />
       </trans-unit>
       <trans-unit id="PushColumn.HeaderText">
@@ -9571,6 +9567,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_buttonIgnore.Text">
         <source>Ignore</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_buttonPush.Text">
+        <source>&amp;Push</source>
         <target />
       </trans-unit>
       <trans-unit id="_buttonReportBug.Text">

--- a/ResourceManager/TranslatedStrings.cs
+++ b/ResourceManager/TranslatedStrings.cs
@@ -27,8 +27,7 @@ Yes, I allow telemetry!");
 
         private readonly TranslationString _installGitInstructions = new("Install git...");
         private readonly TranslationString _findGitExecutable = new("Find git...");
-        private readonly TranslationString _gitExecutableNotFoundText =
-            new TranslationString("The Git executable could not be located on your system.");
+        private readonly TranslationString _gitExecutableNotFoundText = new("The Git executable could not be located on your system.");
         private readonly TranslationString _authorDateText = new("{0:Author date|Author dates}");
         private readonly TranslationString _committerText = new("Committer");
         private readonly TranslationString _commitDateText = new("{0:Commit date|Commit dates}");
@@ -46,7 +45,7 @@ Yes, I allow telemetry!");
         private readonly TranslationString _generalGitConfigExceptionMessage = new("Failed to read \"{0}\" due to the following error:{1}{1}{2}{1}{1}Due to the nature of this problem, the behavior of the application cannot be guaranteed and it must be closed.{1}{1}Please correct this issue and re-open Git Extensions.");
         private readonly TranslationString _generalGitConfigExceptionCaption = new("Repository Configuration Error");
 
-        private readonly TranslationString _disableMenuItem = new TranslationString("Disable this dropdown");
+        private readonly TranslationString _disableMenuItem = new("Disable this dropdown");
 
         // public only because of FormTranslate
         public TranslatedStrings()
@@ -54,13 +53,13 @@ Yes, I allow telemetry!");
             Translator.Translate(this, AppSettings.CurrentTranslation);
         }
 
-        private static Lazy<TranslatedStrings> _instance = new Lazy<TranslatedStrings>();
+        private static Lazy<TranslatedStrings> _instance = new();
 
         public static void Reinitialize()
         {
             if (_instance.IsValueCreated)
             {
-                _instance = new Lazy<TranslatedStrings>();
+                _instance = new();
             }
         }
 


### PR DESCRIPTION
Fixes #7179

## Proposed changes

- Turn `Commit & push` button of FormCommit into `&Push` if there are no changes at all
- Move translated string `&Push` from FormPush to `TranslatedStrings`
- Remove repeated type from `new` in `TranslatedStrings`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/111539199-e0584b80-876d-11eb-943e-3db2d5266711.png)
![grafik](https://user-images.githubusercontent.com/36601201/111539362-172e6180-876e-11eb-8797-0cf6544fe2b2.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/111539717-7be9bc00-876e-11eb-9a0f-6fe1f0ff0d1b.png)

![grafik](https://user-images.githubusercontent.com/36601201/111539992-d71bae80-876e-11eb-81e2-0cd448847ef3.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build b7931b63932f834365c4d8b8da505ae2c7a07bd7
- Git 2.27.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
