### PR TITLE
FormBisect: Autosize form to prevent content to be clipped

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormBisect.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBisect.Designer.cs
@@ -54,8 +54,8 @@
             this.Good.Location = new System.Drawing.Point(12, 70);
             this.Good.Name = "Good";
             this.Good.Size = new System.Drawing.Size(224, 25);
-            this.Good.TabIndex = 1;
-            this.Good.Text = "Mark current revision good";
+            this.Good.TabIndex = 2;
+            this.Good.Text = "Mark current revision &good";
             this.Good.UseVisualStyleBackColor = true;
             this.Good.Click += new System.EventHandler(this.Good_Click);
             // 
@@ -66,8 +66,8 @@
             this.Bad.Location = new System.Drawing.Point(12, 41);
             this.Bad.Name = "Bad";
             this.Bad.Size = new System.Drawing.Size(224, 25);
-            this.Bad.TabIndex = 2;
-            this.Bad.Text = "Mark current revision bad";
+            this.Bad.TabIndex = 1;
+            this.Bad.Text = "Mark current revision &bad";
             this.Bad.UseVisualStyleBackColor = true;
             this.Bad.Click += new System.EventHandler(this.Bad_Click);
             // 
@@ -79,7 +79,7 @@
             this.Stop.Margin = new System.Windows.Forms.Padding(3, 3, 3, 12);
             this.Stop.Name = "Stop";
             this.Stop.Size = new System.Drawing.Size(224, 25);
-            this.Stop.TabIndex = 3;
+            this.Stop.TabIndex = 4;
             this.Stop.Text = "Stop bisect";
             this.Stop.UseVisualStyleBackColor = true;
             this.Stop.Click += new System.EventHandler(this.Stop_Click);
@@ -91,8 +91,8 @@
             this.btnSkip.Location = new System.Drawing.Point(12, 101);
             this.btnSkip.Name = "btnSkip";
             this.btnSkip.Size = new System.Drawing.Size(224, 25);
-            this.btnSkip.TabIndex = 4;
-            this.btnSkip.Text = "Skip current revision";
+            this.btnSkip.TabIndex = 3;
+            this.btnSkip.Text = "&Skip current revision";
             this.btnSkip.UseVisualStyleBackColor = true;
             this.btnSkip.Click += new System.EventHandler(this.btnSkip_Click);
             // 

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBisect.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBisect.Designer.cs
@@ -39,10 +39,9 @@
             // 
             this.Start.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.Start.Location = new System.Drawing.Point(15, 15);
-            this.Start.Margin = new System.Windows.Forms.Padding(4);
+            this.Start.Location = new System.Drawing.Point(12, 12);
             this.Start.Name = "Start";
-            this.Start.Size = new System.Drawing.Size(280, 31);
+            this.Start.Size = new System.Drawing.Size(224, 25);
             this.Start.TabIndex = 0;
             this.Start.Text = "Start bisect";
             this.Start.UseVisualStyleBackColor = true;
@@ -52,10 +51,9 @@
             // 
             this.Good.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.Good.Location = new System.Drawing.Point(15, 88);
-            this.Good.Margin = new System.Windows.Forms.Padding(4);
+            this.Good.Location = new System.Drawing.Point(12, 70);
             this.Good.Name = "Good";
-            this.Good.Size = new System.Drawing.Size(280, 31);
+            this.Good.Size = new System.Drawing.Size(224, 25);
             this.Good.TabIndex = 1;
             this.Good.Text = "Mark current revision good";
             this.Good.UseVisualStyleBackColor = true;
@@ -65,10 +63,9 @@
             // 
             this.Bad.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.Bad.Location = new System.Drawing.Point(15, 51);
-            this.Bad.Margin = new System.Windows.Forms.Padding(4);
+            this.Bad.Location = new System.Drawing.Point(12, 41);
             this.Bad.Name = "Bad";
-            this.Bad.Size = new System.Drawing.Size(280, 31);
+            this.Bad.Size = new System.Drawing.Size(224, 25);
             this.Bad.TabIndex = 2;
             this.Bad.Text = "Mark current revision bad";
             this.Bad.UseVisualStyleBackColor = true;
@@ -78,10 +75,10 @@
             // 
             this.Stop.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.Stop.Location = new System.Drawing.Point(15, 165);
-            this.Stop.Margin = new System.Windows.Forms.Padding(4);
+            this.Stop.Location = new System.Drawing.Point(12, 132);
+            this.Stop.Margin = new System.Windows.Forms.Padding(3, 3, 3, 12);
             this.Stop.Name = "Stop";
-            this.Stop.Size = new System.Drawing.Size(280, 31);
+            this.Stop.Size = new System.Drawing.Size(224, 25);
             this.Stop.TabIndex = 3;
             this.Stop.Text = "Stop bisect";
             this.Stop.UseVisualStyleBackColor = true;
@@ -91,10 +88,9 @@
             // 
             this.btnSkip.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnSkip.Location = new System.Drawing.Point(15, 126);
-            this.btnSkip.Margin = new System.Windows.Forms.Padding(4);
+            this.btnSkip.Location = new System.Drawing.Point(12, 101);
             this.btnSkip.Name = "btnSkip";
-            this.btnSkip.Size = new System.Drawing.Size(280, 31);
+            this.btnSkip.Size = new System.Drawing.Size(224, 25);
             this.btnSkip.TabIndex = 4;
             this.btnSkip.Text = "Skip current revision";
             this.btnSkip.UseVisualStyleBackColor = true;
@@ -102,19 +98,19 @@
             // 
             // FormBisect
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(310, 208);
+            this.AutoSize = true;
+            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.ClientSize = new System.Drawing.Size(248, 171);
             this.Controls.Add(this.btnSkip);
             this.Controls.Add(this.Stop);
             this.Controls.Add(this.Bad);
             this.Controls.Add(this.Good);
             this.Controls.Add(this.Start);
-            this.Margin = new System.Windows.Forms.Padding(4);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(500, 253);
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(253, 253);
             this.Name = "FormBisect";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Bisect";

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2080,11 +2080,11 @@ compare with first:</source>
         <target />
       </trans-unit>
       <trans-unit id="Bad.Text">
-        <source>Mark current revision bad</source>
+        <source>Mark current revision &amp;bad</source>
         <target />
       </trans-unit>
       <trans-unit id="Good.Text">
-        <source>Mark current revision good</source>
+        <source>Mark current revision &amp;good</source>
         <target />
       </trans-unit>
       <trans-unit id="Start.Text">
@@ -2100,7 +2100,7 @@ compare with first:</source>
         <target />
       </trans-unit>
       <trans-unit id="btnSkip.Text">
-        <source>Skip current revision</source>
+        <source>&amp;Skip current revision</source>
         <target />
       </trans-unit>
     </body>


### PR DESCRIPTION
## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/111540798-e3543b80-876f-11eb-9b5d-c058a3d1ec3a.png)

### After

![image](https://user-images.githubusercontent.com/460196/111540890-0121a080-8770-11eb-91ea-1394ed5e7b7f.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 549f02363b5470696a27a1f002241f5ae4f5c719
- Git 2.28.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.17134.0
- .NET Framework 4.8.4311.0
- DPI 192dpi (200% scaling)

