### PR TITLE
Check Before script failure to abort action

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2300,8 +2300,13 @@ namespace GitUI.CommandsDialogs
 
         private void QuickFetch()
         {
-            ScriptManager.RunEventScripts(this, ScriptEvent.BeforeFetch);
-            bool success = FormProcess.ShowDialog(this, process: null, arguments: Module.FetchCmd(string.Empty, string.Empty, string.Empty), Module.WorkingDir, input: null, useDialogSettings: true);
+            bool success = ScriptManager.RunEventScripts(this, ScriptEvent.BeforeFetch);
+            if (!success)
+            {
+                return;
+            }
+
+            success = FormProcess.ShowDialog(this, process: null, arguments: Module.FetchCmd(string.Empty, string.Empty, string.Empty), Module.WorkingDir, input: null, useDialogSettings: true);
             if (!success)
             {
                 return;

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -372,7 +372,11 @@ namespace GitUI.CommandsDialogs
 
             Debug.Assert(originalId is not null, "originalId is not null");
 
-            ScriptManager.RunEventScripts(this, ScriptEvent.BeforeCheckout);
+            bool success = ScriptManager.RunEventScripts(this, ScriptEvent.BeforeCheckout);
+            if (!success)
+            {
+                return DialogResult.Cancel;
+            }
 
             if (UICommands.StartCommandLineProcessDialog(owner, new GitCheckoutBranchCmd(branchName, isRemote, localChanges, newBranchMode, newBranchName)))
             {

--- a/GitUI/CommandsDialogs/FormCheckoutRevision.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutRevision.cs
@@ -48,10 +48,14 @@ namespace GitUI.CommandsDialogs
 
                 Debug.Assert(checkedOutObjectId is not null, "checkedOutObjectId is not null");
 
-                ScriptManager.RunEventScripts(this, ScriptEvent.BeforeCheckout);
+                bool success = ScriptManager.RunEventScripts(this, ScriptEvent.BeforeCheckout);
+                if (!success)
+                {
+                    return;
+                }
 
                 string command = GitCommandHelpers.CheckoutCmd(selectedObjectId.ToString(), Force.Checked ? LocalChangesAction.Reset : 0);
-                bool success = FormProcess.ShowDialog(this, process: null, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
+                success = FormProcess.ShowDialog(this, process: null, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
                 if (success)
                 {
                     if (selectedObjectId != checkedOutObjectId)

--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -116,7 +116,11 @@ namespace GitUI.CommandsDialogs
         {
             var pushCmd = GitCommandHelpers.PushTagCmd(_currentRemote, tagName, false);
 
-            ScriptManager.RunEventScripts(this, ScriptEvent.BeforePush);
+            bool success = ScriptManager.RunEventScripts(this, ScriptEvent.BeforePush);
+            if (!success)
+            {
+                return;
+            }
 
             using var form = new FormRemoteProcess(UICommands, process: null, pushCmd)
             {

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -79,7 +79,11 @@ namespace GitUI.CommandsDialogs
 
                     var cmd = new GitDeleteRemoteBranchesCmd(remote, branches.Select(x => x.LocalName));
 
-                    ScriptManager.RunEventScripts(this, ScriptEvent.BeforePush);
+                    bool success = ScriptManager.RunEventScripts(this, ScriptEvent.BeforePush);
+                    if (!success)
+                    {
+                        return;
+                    }
 
                     using var form = new FormRemoteProcess(UICommands, process: null, cmd.Arguments)
                     {

--- a/GitUI/CommandsDialogs/FormDeleteTag.cs
+++ b/GitUI/CommandsDialogs/FormDeleteTag.cs
@@ -63,7 +63,11 @@ namespace GitUI.CommandsDialogs
         {
             var pushCmd = string.Format("push \"{0}\" :refs/tags/{1}", remotesComboboxControl1.SelectedRemote, tagName);
 
-            ScriptManager.RunEventScripts(this, ScriptEvent.BeforePush);
+            bool success = ScriptManager.RunEventScripts(this, ScriptEvent.BeforePush);
+            if (!success)
+            {
+                return;
+            }
 
             using var form = new FormRemoteProcess(UICommands, process: null, pushCmd);
             ////Remote = currentRemote,

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -88,7 +88,12 @@ namespace GitUI.CommandsDialogs
         {
             Module.EffectiveSettings.NoFastForwardMerge = noFastForward.Checked;
             AppSettings.DontCommitMerge = noCommit.Checked;
-            ScriptManager.RunEventScripts(this, ScriptEvent.BeforeMerge);
+
+            bool success = ScriptManager.RunEventScripts(this, ScriptEvent.BeforeMerge);
+            if (!success)
+            {
+                return;
+            }
 
             string? mergeMessagePath = null;
             if (addMergeMessage.Checked)
@@ -109,7 +114,7 @@ namespace GitUI.CommandsDialogs
                                                             allowUnrelatedHistories.Checked,
                                                             mergeMessagePath,
                                                             addLogMessages.Checked ? (int)nbMessages.Value : (int?)null);
-            bool success = FormProcess.ShowDialog(this, process: null, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
+            success = FormProcess.ShowDialog(this, process: null, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
 
             var wasConflict = MergeConflictHandler.HandleMergeConflicts(UICommands, this, !noCommit.Checked);
 

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -428,7 +428,10 @@ namespace GitUI.CommandsDialogs
                 return DialogResult.No;
             }
 
-            executeBeforeScripts();
+            if (!executeBeforeScripts())
+            {
+                return DialogResult.No;
+            }
 
             var stashed = CalculateStashedValue(owner);
 
@@ -596,15 +599,19 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            void executeBeforeScripts()
+            bool executeBeforeScripts()
             {
                 // Request to pull/merge in addition to the fetch
                 if (!Fetch.Checked)
                 {
-                    ScriptManager.RunEventScripts(this, ScriptEvent.BeforePull);
+                    bool success = ScriptManager.RunEventScripts(this, ScriptEvent.BeforePull);
+                    if (!success)
+                    {
+                        return false;
+                    }
                 }
 
-                ScriptManager.RunEventScripts(this, ScriptEvent.BeforeFetch);
+                return ScriptManager.RunEventScripts(this, ScriptEvent.BeforeFetch);
             }
 
             void executeAfterScripts()

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -461,7 +461,11 @@ namespace GitUI.CommandsDialogs
                 pushCmd = GitCommandHelpers.PushMultipleCmd(destination, pushActions);
             }
 
-            ScriptManager.RunEventScripts(this, ScriptEvent.BeforePush);
+            bool success = ScriptManager.RunEventScripts(this, ScriptEvent.BeforePush);
+            if (!success)
+            {
+                return false;
+            }
 
             // controls can be accessed only from UI thread
             _selectedBranch = _NO_TRANSLATE_Branch.Text;


### PR DESCRIPTION
Follow #9001 to apply script failure detection to others `Before` events as suggested : https://github.com/gitextensions/gitextensions/pull/9001#issuecomment-801801009

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
