### PR TITLE
Ignore git clone prefix when checking clipboard for source URL

### DIFF
--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -14,6 +14,11 @@ namespace GitCommands
         private static readonly IEnvironmentAbstraction EnvironmentAbstraction = new EnvironmentAbstraction();
         private static readonly IEnvironmentPathsProvider EnvironmentPathsProvider = new EnvironmentPathsProvider(EnvironmentAbstraction);
 
+        // URL regex obtained from https://www.regextester.com/53716 with some modifications
+        private static readonly Regex UrlRegex = new Regex(
+            @"(?:(?:https?|ftp|file|ssh|git):\/\/|www\.)(?:[-A-Z0-9+&@#\/%=~_|$?!:,.])*(?:[A-Z0-9+&@#\/%=~_|$])",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         public static readonly char PosixDirectorySeparatorChar = '/';
         public static readonly char NativeDirectorySeparatorChar = Path.DirectorySeparatorChar;
 
@@ -72,20 +77,20 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// A naive way to check whether the given path is a URL by checking
-        /// whether it starts with either 'http', 'ssh' or 'git'.
+        /// A slightly less naive way to check whether the given path is a URL by checking
+        /// whether it matches a regular expression defined in <see cref="UrlRegex"/>.
         /// </summary>
+        /// <remarks>
+        /// Certain strings such as "http://" or "ssh:" are not considered valid URLs
+        /// as they don't have a host, port or path.
+        /// </remarks>
         /// <param name="path">A path to check.</param>
         /// <returns><see langword="true"/> if the given path starts with 'http', 'ssh' or 'git'; otherwise <see langword="false"/>.</returns>
         [Pure]
         public static bool IsUrl(string? path)
         {
             return !Strings.IsNullOrEmpty(path)
-                && (path.StartsWith("http:", StringComparison.CurrentCultureIgnoreCase)
-                 || path.StartsWith("https:", StringComparison.CurrentCultureIgnoreCase)
-                 || path.StartsWith("git:", StringComparison.CurrentCultureIgnoreCase)
-                 || path.StartsWith("ssh:", StringComparison.CurrentCultureIgnoreCase)
-                 || path.StartsWith("file:", StringComparison.CurrentCultureIgnoreCase));
+                && UrlRegex.IsMatch(path);
         }
 
         public static bool CanBeGitURL(string? url)

--- a/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
@@ -104,12 +104,14 @@ namespace GitCommandsTests.Helpers
         [TestCase(null, false)]
         [TestCase("", false)]
         [TestCase("    ", false)]
-        [TestCase("http://", true)]
+        [TestCase("http://", false)]
         [TestCase("HTTPS://www", true)]
-        [TestCase("git://", true)]
-        [TestCase("file:", true)]
-        [TestCase("SSH:", true)]
+        [TestCase("git://", false)]
+        [TestCase("file:", false)]
+        [TestCase("SSH:", false)]
         [TestCase("SSH", false)]
+        [TestCase("rtsp://probably.not.a.git.url/default.mp4", false)]
+        [TestCase("https://myhost:12368/", true)]
         public void IsUrl(string path, bool expected)
         {
             PathUtil.IsUrl(path).Should().Be(expected);
@@ -347,6 +349,12 @@ namespace GitCommandsTests.Helpers
         [TestCase("https://github.com/gitextensions/gitextensions", true)]
         [TestCase("https://github.com/gitextensions/gitextensions.git", true)]
         [TestCase("github.com/gitextensions/gitextensions.git", true)]
+        [TestCase("git clone https://github.com/gitextensions/gitextensions", true)]
+        [TestCase("HTTPS://MYPRIVATEGITHUB.COM:8080/LOUDREPO.GIT", true)]
+        [TestCase("git://myurl/myrepo.git", true)]
+        [TestCase("git clone https://github.com/gitextensions/gitextensions && cd gitextensions", true)]
+        [TestCase("github.com/gitextensions", false)]
+        [TestCase("github.com/gitextensions/gitextensions/pull/9018", false)]
         public void CanBeGitURL(string url, bool expected)
         {
             Assert.AreEqual(expected, PathUtil.CanBeGitURL(url));

--- a/contributors.txt
+++ b/contributors.txt
@@ -154,4 +154,5 @@ YYYY/MM/DD, github id, Full name, email
 2021/02/10, mabako, Marcus Bauer, mabako(at)gmail.com
 2021/03/11, AntonKedrov, Anton Kedrov, a-k(at)gmx.com
 2021/03/16, JuPrgn, Julien Peyregne, julienprgn(at)gmail.com
+2021/03/20, nyankoframe, Damit Senanayake, damit(at)outlook.com
 2021/03/31, darkcamper, Rubén Ruiz, darkcamper(at)gmail.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6260 


## Proposed changes
 
-  Detects whether clipboard contents contain a potential URL using regex; if so, clipboard contents are provided as-is allowing user to modify contents prior to clone operation.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Added new tests to PathUtilTest.IsUrl and PathUtilTest.CanBeGitURL

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.31.0.windows.1<!-- Add version 2.11 or above -->
- Windows 10.0.19042.868<!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
