### PR TITLE
Update UI only after save settings

### DIFF
--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -252,6 +252,8 @@ namespace GitUI.CommandsDialogs
                 // TODO: this method has a generic sounding name but only saves some specific settings
                 AppSettings.SaveSettings();
 
+                DialogResult = DialogResult.OK;
+
                 return true;
             }
             catch (SaveSettingsException ex) when (ex.InnerException is not null)

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -902,9 +902,8 @@ namespace GitUI
         {
             bool Action()
             {
-                FormSettings.ShowSettingsDialog(this, owner, initialPage);
-
-                return true;
+                return FormSettings.ShowSettingsDialog(this, owner, initialPage)
+                    is DialogResult.OK;
             }
 
             return DoActionOnRepo(owner, Action, requiresValidWorkingDir: false, postEvent: PostSettings);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Update UI only after save settings.

### Before

UI is reloaded after closing settings.

### After

UI is reloaded after saving settings dialog.


## Test methodology <!-- How did you ensure quality? -->

- Manually
- Visually


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 6aed59b6e436ee584bd9a61a4b4655f5f18530dc (Dirty)
- Git 2.30.2.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
