### PR TITLE
Straighten graph lanes

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -15,7 +15,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 {
     internal sealed class RevisionGraphColumnProvider : ColumnProvider
     {
-        private const int MaxLanes = 40;
+        private const int MaxLanes = RevisionGraph.MaxLanes;
 
         private static readonly int LaneLineWidth = DpiUtil.Scale(2);
         private static readonly int LaneWidth = DpiUtil.Scale(16);

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -73,7 +73,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         }
 
         /// <summary>
-        /// Builds the revision graph cache. There are two caches that are build in this method.
+        /// Builds the revision graph cache. There are two caches that are built in this method.
         /// <para>Cache 1: an ordered list of the revisions. This is very cheap to build. (_orderedNodesCache).</para>
         /// <para>Cache 2: an ordered list of all prepared graph rows. This is expensive to build. (_orderedRowCache).</para>
         /// </summary>
@@ -81,7 +81,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         /// The row that needs to be displayed. This ensures the ordered revisions are available up to this index.
         /// </param>
         /// <param name="lastToCacheRowIndex">
-        /// The graph can be build per x rows. This defines the last row index that the graph will build cache to.
+        /// The graph can be built per x rows. This defines the last row index that the graph will build cache to.
         /// </param>
         public void CacheTo(int currentRowIndex, int lastToCacheRowIndex)
         {
@@ -249,21 +249,21 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         private void BuildOrderedRowCache(IList<RevisionGraphRevision> orderedNodesCache, int currentRowIndex, int lastToCacheRowIndex)
         {
             // Ensure we keep using the same instance of the rowcache from here on
-            var localOrderedRowCache = _orderedRowCache;
+            IList<RevisionGraphRow>? localOrderedRowCache = _orderedRowCache;
 
             if (localOrderedRowCache is null || CheckRowCacheIsDirty(localOrderedRowCache, orderedNodesCache))
             {
                 localOrderedRowCache = new List<RevisionGraphRow>(currentRowIndex);
             }
 
-            int nextIndex = localOrderedRowCache.Count;
-            if (nextIndex > lastToCacheRowIndex)
+            lastToCacheRowIndex = Math.Min(lastToCacheRowIndex, orderedNodesCache.Count - 1);
+            int startIndex = localOrderedRowCache.Count;
+            if (startIndex > lastToCacheRowIndex)
             {
                 return;
             }
 
-            int cacheCount = orderedNodesCache.Count;
-            while (nextIndex <= lastToCacheRowIndex && cacheCount > nextIndex)
+            for (int nextIndex = startIndex; nextIndex <= lastToCacheRowIndex; ++nextIndex)
             {
                 bool startSegmentsAdded = false;
 
@@ -308,7 +308,6 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 }
 
                 localOrderedRowCache.Add(new RevisionGraphRow(revision, segments));
-                nextIndex++;
             }
 
             // Overwrite the global instance at the end, to prevent flickering

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -15,6 +15,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
     // The RevisionGraph contains all the basic structures needed to render the graph.
     public class RevisionGraph : IRevisionGraphRowProvider
     {
+        public const int MaxLanes = 40;
         private const int _straightenLanesLookAhead = 1;
 
         // Some unordered collections with raw data
@@ -342,9 +343,15 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 startIndex = Math.Max(1, startIndex);
                 for (int currentIndex = startIndex; currentIndex < lastIndex;)
                 {
+                    IRevisionGraphRow currentRow = localOrderedRowCache[currentIndex];
+                    if (currentRow.Segments.Count >= MaxLanes)
+                    {
+                        ++currentIndex;
+                        continue;
+                    }
+
                     bool moved = false;
                     IRevisionGraphRow previousRow = localOrderedRowCache[currentIndex - 1];
-                    IRevisionGraphRow currentRow = localOrderedRowCache[currentIndex];
                     IRevisionGraphRow nextRow = localOrderedRowCache[currentIndex + 1];
                     foreach (RevisionGraphSegment revisionGraphSegment in currentRow.Segments)
                     {

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -10,6 +10,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
     //     *  <- child revision
     //     |
     //     *  <- parent revision
+    [DebuggerDisplay("{Objectid}")]
     public class RevisionGraphRevision
     {
         private ImmutableStack<RevisionGraphRevision> _parents = ImmutableStack<RevisionGraphRevision>.Empty;

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft;
 
 namespace GitUI.UserControls.RevisionGrid.Graph
 {
@@ -11,6 +13,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         int GetLaneCount();
         IEnumerable<RevisionGraphSegment> GetSegmentsForIndex(int index);
         int GetLaneIndexForSegment(RevisionGraphSegment revisionGraphRevision);
+        void MoveLanesRight(int fromLane);
     }
 
     // The RevisionGraphRow contains an ordered list of Segments that crosses the row or connects to the revision in the row.
@@ -29,7 +32,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         public IReadOnlyList<RevisionGraphSegment> Segments { get; }
 
         // This dictonary contains a cached list of all segments and the lane index the segment is in for this row.
-        private IReadOnlyDictionary<RevisionGraphSegment, int>? _segmentLanes;
+        private IDictionary<RevisionGraphSegment, int>? _segmentLanes;
 
         // The cached lanecount
         private int _laneCount;
@@ -166,6 +169,24 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             }
 
             return -1;
+        }
+
+        public void MoveLanesRight(int fromLane)
+        {
+            Validates.NotNull(_segmentLanes);
+            RevisionGraphSegment[] segmentsToBeMoved = _segmentLanes.Where(keyValue => keyValue.Value >= fromLane)
+                                                                    .Select(keyValue => keyValue.Key)
+                                                                    .ToArray();
+            if (!segmentsToBeMoved.Any())
+            {
+                return;
+            }
+
+            ++_laneCount;
+            foreach (RevisionGraphSegment segment in segmentsToBeMoved)
+            {
+                ++_segmentLanes[segment];
+            }
         }
     }
 }

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -52,13 +52,13 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             // We do not want SegementLanes to be build multiple times. Lock it.
             lock (Revision)
             {
-                // Another thread could be waiting for the lock, while the segmentlanes where being build. Check again if segmentslanes is null.
+                // Another thread could be waiting for the lock, while the segmentlanes were being built. Check again if segmentslanes is null.
                 if (_segmentLanes is not null)
                 {
                     return;
                 }
 
-                Dictionary<RevisionGraphSegment, int> newSegmentLanes = new Dictionary<RevisionGraphSegment, int>();
+                Dictionary<RevisionGraphSegment, int> newSegmentLanes = new();
 
                 int currentRevisionLane = -1;
                 int laneIndex = 0;

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.UserControls.RevisionGrid.Graph
+﻿using System.Diagnostics;
+
+namespace GitUI.UserControls.RevisionGrid.Graph
 {
     // This class represents the connection between 2 revisions.
     //     *    <- Child
@@ -15,6 +17,7 @@
     //     *  |
     //     | /
     //     *    <- Parent
+    [DebuggerDisplay("Child: {Child} - Parent: {Parent}")]
     public class RevisionGraphSegment
     {
         public RevisionGraphSegment(RevisionGraphRevision parent, RevisionGraphRevision child)

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphRowTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphRowTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using GitUI.UserControls.RevisionGrid.Graph;
+using GitUIPluginInterfaces;
+using NUnit.Framework;
+
+namespace GitUITests.UserControls.RevisionGrid.Graph
+{
+    [TestFixture]
+    public class RevisionGraphRowTests
+    {
+        private RevisionGraphSegment _segment = new(parent: new(ObjectId.IndexId, guessScore: 0), child: new(ObjectId.WorkTreeId, guessScore: 0));
+        private RevisionGraphSegment _segment1 = new(parent: new(ObjectId.Random(), guessScore: 0), child: new(ObjectId.Random(), guessScore: 0));
+        private RevisionGraphSegment _segment2 = new(parent: new(ObjectId.Random(), guessScore: 0), child: new(ObjectId.Random(), guessScore: 0));
+
+        [Test]
+        public void MoveLanesRight_should_do_nothing_if_empty([Values(-1, 0, 1)] int fromLane)
+        {
+            List<RevisionGraphSegment> segments = new();
+            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments);
+            revisionGraphRow.GetLaneCount().Should().Be(1);
+
+            revisionGraphRow.MoveLanesRight(fromLane);
+
+            revisionGraphRow.GetLaneCount().Should().Be(1);
+            revisionGraphRow.Segments.Should().BeEmpty();
+        }
+
+        [TestCase(-1, 1)]
+        [TestCase(0, 1)]
+        [TestCase(1, 0)]
+        [TestCase(2, 0)]
+        public void MoveLanesRight_should_move_single_segment(int fromLane, int expectedLane)
+        {
+            List<RevisionGraphSegment> segments = new() { _segment };
+            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments);
+            revisionGraphRow.GetLaneCount().Should().Be(segments.Count);
+
+            revisionGraphRow.MoveLanesRight(fromLane);
+
+            revisionGraphRow.GetLaneCount().Should().Be(fromLane >= segments.Count ? segments.Count : segments.Count + 1);
+            revisionGraphRow.GetLaneIndexForSegment(_segment).Should().Be(expectedLane);
+        }
+
+        [TestCase(-1, 1, 2, 3)]
+        [TestCase(0, 1, 2, 3)]
+        [TestCase(1, 0, 2, 3)]
+        [TestCase(2, 0, 1, 3)]
+        [TestCase(3, 0, 1, 2)]
+        [TestCase(4, 0, 1, 2)]
+        public void MoveLanesRight_should_move_segments(int fromLane, int expectedLane, int expectedLane1, int expectedLane2)
+        {
+            List<RevisionGraphSegment> segments = new() { _segment, _segment1, _segment2 };
+            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments);
+            revisionGraphRow.GetLaneCount().Should().Be(3);
+
+            revisionGraphRow.MoveLanesRight(fromLane);
+
+            revisionGraphRow.GetLaneCount().Should().Be(fromLane >= segments.Count ? segments.Count : segments.Count + 1);
+            revisionGraphRow.GetLaneIndexForSegment(_segment).Should().Be(expectedLane);
+            revisionGraphRow.GetLaneIndexForSegment(_segment1).Should().Be(expectedLane1);
+            revisionGraphRow.GetLaneIndexForSegment(_segment2).Should().Be(expectedLane2);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5782

## Proposed changes

- Move lanes to the right if a branch would go to one lane left for one row
- Use array instead of `List<RevisionGraphRevision>` in `RevisionGraph`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/111918509-aea0f680-8a85-11eb-978e-8e006ba450c2.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/111918519-bbbde580-8a85-11eb-848f-deaaf084d0b4.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build b737b5330fc78f10310d5d4aec83f94db23a1e52
- Git 2.27.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).