### PR TITLE
Restore "Commit & push" button if amending

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1031,9 +1031,9 @@ namespace GitUI.CommandsDialogs
             LoadingStaged.Visible = false;
             Commit.Enabled = true;
             CommitAndPush.Enabled = true;
-            CommitAndPush.Text = doChangesExist ? _commitAndPush.Text : TranslatedStrings.ButtonPush;
             Amend.Enabled = true;
             Reset.Enabled = doChangesExist;
+            SetCommitAndPushText();
 
             EnableStageButtons(true);
             workingToolStripMenuItem.Enabled = true;
@@ -3241,6 +3241,8 @@ namespace GitUI.CommandsDialogs
 
                 CommitAndPush.SetForeColorForBackColor();
             }
+
+            SetCommitAndPushText();
         }
 
         private void StageInSuperproject_CheckedChanged(object sender, EventArgs e)
@@ -3305,6 +3307,11 @@ namespace GitUI.CommandsDialogs
             {
                 MessageBox.Show(string.Format(_stopTrackingFail.Text, filename), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
+        }
+
+        private void SetCommitAndPushText()
+        {
+            CommitAndPush.Text = Reset.Enabled || Amend.Checked ? _commitAndPush.Text : TranslatedStrings.ButtonPush;
         }
 
         internal TestAccessor GetTestAccessor()


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/pull/9017#issuecomment-806239038

## Proposed changes

- Restore "Commit & push" button if amending without file changes

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/112529236-57f92c80-8da5-11eb-8c4b-4d8bcf3e1282.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/112529167-444dc600-8da5-11eb-9c80-6954b5493ec3.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 5fff126b0629a85e51b02ac513b3a2d59728f644
- Git 2.27.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).