### PR TITLE
Handle errors accessing the amend state file

### DIFF
--- a/UnitTests/GitCommands.Tests/CommitMessageManagerTests.cs
+++ b/UnitTests/GitCommands.Tests/CommitMessageManagerTests.cs
@@ -134,7 +134,7 @@ namespace GitCommandsTests
         public void AmendState_should_be_false_if_file_contains(string amendText)
         {
             _file.Exists(_amendSaveStatePath).Returns(true);
-            _file.ReadAllText(_amendSaveStatePath).Returns(amendText);
+            _file.ReadAllText(_amendSaveStatePath, Encoding.Default).Returns(amendText);
 
             AppSettings.RememberAmendCommitState = true;
             _manager.AmendState.Should().BeFalse();
@@ -148,7 +148,7 @@ namespace GitCommandsTests
         public void AmendState_should_be_true_if_file_contains(string amendText)
         {
             _file.Exists(_amendSaveStatePath).Returns(true);
-            _file.ReadAllText(_amendSaveStatePath).Returns(amendText);
+            _file.ReadAllText(_amendSaveStatePath, Encoding.Default).Returns(amendText);
 
             AppSettings.RememberAmendCommitState = true;
             _manager.AmendState.Should().BeTrue();
@@ -158,7 +158,8 @@ namespace GitCommandsTests
         public void AmendState_true_should_write_true_to_file()
         {
             bool correctlyWritten = false;
-            _file.When(x => x.WriteAllText(_amendSaveStatePath, true.ToString())).Do(_ => correctlyWritten = true);
+            _file.When(x => x.WriteAllText(_amendSaveStatePath, true.ToString(), Encoding.Default)).Do(_ => correctlyWritten = true);
+            _directory.Exists(Path.GetDirectoryName(_amendSaveStatePath)).Returns(true);
 
             AppSettings.RememberAmendCommitState = true;
             _manager.AmendState = true;
@@ -170,6 +171,7 @@ namespace GitCommandsTests
         public void AmendState_true_should_delete_file_if_not_RememberAmendCommitState()
         {
             bool correctlyDeleted = false;
+            _file.Exists(_amendSaveStatePath).Returns(true);
             _file.When(x => x.Delete(_amendSaveStatePath)).Do(_ => correctlyDeleted = true);
 
             AppSettings.RememberAmendCommitState = false;
@@ -184,6 +186,7 @@ namespace GitCommandsTests
         {
             bool correctlyDeleted = false;
             _file.When(x => x.Delete(_amendSaveStatePath)).Do(_ => correctlyDeleted = true);
+            _file.Exists(_amendSaveStatePath).Returns(true);
 
             AppSettings.RememberAmendCommitState = rememberAmendCommitState;
             _manager.AmendState = false;


### PR DESCRIPTION
Fixes #9036


## Proposed changes

- Handle errors accessing the amend state file the same way as for the commit message file

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual
- slightly adapted existing NUnit tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 28d662737516d4f7d41611eb2a84ba18e240d58f
- Git 2.27.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).