### PR TITLE
Improve display of exceptions

### DIFF
--- a/GitUI/NBugReports/BugReportForm.Designer.cs
+++ b/GitUI/NBugReports/BugReportForm.Designer.cs
@@ -69,6 +69,7 @@
             this.btnCopy = new System.Windows.Forms.Button();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.IgnoreButton = new System.Windows.Forms.Button();
             this.mainTabs.SuspendLayout();
             this.generalTabPage.SuspendLayout();
             this.tpnlEnvInfo.SuspendLayout();
@@ -151,7 +152,7 @@
             this.clrTextBox.Size = new System.Drawing.Size(160, 20);
             this.clrTextBox.TabIndex = 9;
             // 
-            // clrLabel
+            // _NO_TRANSLATE_ClrLabel
             // 
             this._NO_TRANSLATE_ClrLabel.AutoSize = true;
             this._NO_TRANSLATE_ClrLabel.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -162,7 +163,7 @@
             this._NO_TRANSLATE_ClrLabel.Text = "CLR:";
             this._NO_TRANSLATE_ClrLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // gitLabel
+            // _NO_TRANSLATE_GitLabel
             // 
             this._NO_TRANSLATE_GitLabel.AutoSize = true;
             this._NO_TRANSLATE_GitLabel.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -482,7 +483,7 @@
             this.sendAndQuitButton.MinimumSize = new System.Drawing.Size(120, 25);
             this.sendAndQuitButton.Name = "sendAndQuitButton";
             this.sendAndQuitButton.Size = new System.Drawing.Size(120, 25);
-            this.sendAndQuitButton.TabIndex = 1;
+            this.sendAndQuitButton.TabIndex = 2;
             this.sendAndQuitButton.Text = "&Send and Quit";
             this.sendAndQuitButton.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.sendAndQuitButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
@@ -498,7 +499,7 @@
             this.quitButton.Name = "quitButton";
             this.quitButton.Padding = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.quitButton.Size = new System.Drawing.Size(34, 31);
-            this.quitButton.TabIndex = 2;
+            this.quitButton.TabIndex = 3;
             this.quitButton.TabStop = true;
             this.quitButton.Text = "&Quit";
             this.quitButton.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -530,12 +531,14 @@
             // 
             this.tableLayoutPanel1.AutoSize = true;
             this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tableLayoutPanel1.ColumnCount = 3;
+            this.tableLayoutPanel1.ColumnCount = 4;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel1.Controls.Add(this.quitButton, 2, 0);
-            this.tableLayoutPanel1.Controls.Add(this.sendAndQuitButton, 1, 0);
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.Controls.Add(this.quitButton, 3, 0);
+            this.tableLayoutPanel1.Controls.Add(this.sendAndQuitButton, 2, 0);
+            this.tableLayoutPanel1.Controls.Add(this.IgnoreButton, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.btnCopy, 0, 0);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(4, 434);
@@ -546,6 +549,17 @@
             this.tableLayoutPanel1.Size = new System.Drawing.Size(550, 31);
             this.tableLayoutPanel1.TabIndex = 1;
             // 
+            // IgnoreButton
+            // 
+            this.IgnoreButton.AutoSize = true;
+            this.IgnoreButton.Location = new System.Drawing.Point(302, 3);
+            this.IgnoreButton.Name = "IgnoreButton";
+            this.IgnoreButton.Size = new System.Drawing.Size(75, 25);
+            this.IgnoreButton.TabIndex = 1;
+            this.IgnoreButton.Text = "&Ignore";
+            this.IgnoreButton.UseVisualStyleBackColor = true;
+            this.IgnoreButton.Click += new System.EventHandler(this.IgnoreButton_Click);
+            // 
             // BugReportForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -554,12 +568,10 @@
             this.ClientSize = new System.Drawing.Size(558, 469);
             this.Controls.Add(this.mainTabs);
             this.Controls.Add(this.tableLayoutPanel1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "BugReportForm";
             this.Padding = new System.Windows.Forms.Padding(4);
-            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.TopMost = true;
             this.mainTabs.ResumeLayout(false);
@@ -626,5 +638,6 @@
         private System.Windows.Forms.TableLayoutPanel tlpnlGeneral;
         private System.Windows.Forms.Panel pnlHeading;
         private System.Windows.Forms.Panel pnlExceptionType;
+        private System.Windows.Forms.Button IgnoreButton;
     }
 }

--- a/GitUI/NBugReports/BugReportForm.cs
+++ b/GitUI/NBugReports/BugReportForm.cs
@@ -71,7 +71,7 @@ Send report anyway?");
             mainTabs.TabPages.Remove(mainTabs.TabPages["reportContentsTabPage"]);
         }
 
-        public DialogResult ShowDialog(IWin32Window? owner, Exception exception, string environmentInfo)
+        public DialogResult ShowDialog(IWin32Window? owner, Exception exception, string environmentInfo, bool canIgnore, bool showIgnore, bool focusDetails)
         {
             _lastException = new SerializableException(exception);
             _lastReport = new Report(_lastException);
@@ -93,6 +93,16 @@ Send report anyway?");
 
             // Fill in the 'Exception' tab
             exceptionDetails.Initialize(_lastException);
+
+            if (focusDetails)
+            {
+                mainTabs.SelectedTab = exceptionTabPage;
+            }
+
+            ControlBox = canIgnore;
+            showIgnore &= canIgnore;
+            IgnoreButton.Visible = showIgnore;
+            IgnoreButton.Visible = showIgnore;
 
             DialogResult = DialogResult.None;
 
@@ -161,6 +171,12 @@ Send report anyway?");
             Clipboard.SetDataObject(report, true, 5, 100);
 
             DialogResult = DialogResult.None;
+        }
+
+        private void IgnoreButton_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Ignore;
+            Close();
         }
 
         internal TestAccessor GetTestAccessor()

--- a/GitUI/NBugReports/BugReporter.cs
+++ b/GitUI/NBugReports/BugReporter.cs
@@ -124,8 +124,11 @@ namespace GitExtensions
         {
             var envInfo = UserEnvironmentInformation.GetInformation();
 
-            using var form = new GitUI.NBugReports.BugReportForm();
-            var result = form.ShowDialog(owner, exception, envInfo);
+            using BugReportForm form = new();
+            DialogResult result = form.ShowDialog(owner, exception, envInfo,
+                canIgnore: !isTerminating,
+                showIgnore: exception is ExternalOperationException,
+                focusDetails: exception is UserExternalOperationException);
             if (isTerminating || result == DialogResult.Abort)
             {
                 Environment.Exit(-1);

--- a/GitUI/NBugReports/BugReporter.cs
+++ b/GitUI/NBugReports/BugReporter.cs
@@ -16,110 +16,108 @@ namespace GitExtensions
         private static IntPtr OwnerFormHandle
             => OwnerForm?.Handle ?? IntPtr.Zero;
 
-        private static string FormatText(ExternalOperationException exception, bool canRaiseBug)
+        /// <summary>
+        /// Appends the exception data and gets the root error.
+        /// </summary>
+        /// <param name="text">A StringBuilder to which the exception data is appended.</param>
+        /// <param name="exception">An Exception to describe.</param>
+        /// <returns>The inner-most exception message.</returns>
+        internal static string Append(StringBuilder text, Exception exception)
         {
-            StringBuilder sb = new();
-
-            // Command: <command>
-            if (!string.IsNullOrWhiteSpace(exception.Command))
+            string rootError = exception.Message;
+            for (Exception innerException = exception.InnerException; innerException is not null; innerException = innerException.InnerException)
             {
-                sb.AppendLine($"{TranslatedStrings.Command}: {exception.Command}");
+                if (!string.IsNullOrEmpty(innerException.Message))
+                {
+                    rootError = innerException.Message;
+                }
             }
 
-            // Arguments: <args>
-            if (!string.IsNullOrWhiteSpace(exception.Arguments))
+            if (exception is UserExternalOperationException userExternalOperationException && !string.IsNullOrWhiteSpace(userExternalOperationException.Context))
             {
-                sb.AppendLine($"{TranslatedStrings.Arguments}: {exception.Arguments}");
+                // Context contains an error message as UserExternalOperationException is currently used. So append just "<context>"
+                text.AppendLine(userExternalOperationException.Context);
             }
 
-            // Working directory: <working dir>
-            sb.AppendLine($"{TranslatedStrings.WorkingDirectory}: {exception.WorkingDirectory}");
-
-            if (canRaiseBug)
+            if (exception is ExternalOperationException externalOperationException)
             {
-                // Directions to raise a bug
-                sb.AppendLine();
-                sb.AppendLine(TranslatedStrings.ReportBug);
+                // Command: <command>
+                AppendIfNotEmpty(externalOperationException.Command, TranslatedStrings.Command);
+
+                // Arguments: <args>
+                AppendIfNotEmpty(externalOperationException.Arguments, TranslatedStrings.Arguments);
+
+                // Directory: <dir>
+                AppendIfNotEmpty(externalOperationException.WorkingDirectory, TranslatedStrings.WorkingDirectory);
             }
 
-            return sb.ToString();
+            return rootError;
+
+            void AppendIfNotEmpty(string? value, string designation)
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    text.Append(designation).Append(": ").AppendLine(value);
+                }
+            }
         }
 
         public static void Report(Exception exception, bool isTerminating)
         {
-            if (exception is UserExternalOperationException userExternalException)
-            {
-                // Something happened that was likely caused by the user
-                ReportUserException(userExternalException, isTerminating);
-                return;
-            }
+            bool isUserExternalOperation = exception is UserExternalOperationException;
+            bool isExternalOperation = exception is ExternalOperationException;
 
-            if (exception is ExternalOperationException externalException)
-            {
-                // Something happened either in the app - can submit the bug to GitHub
-                ReportAppException(externalException, isTerminating);
-                return;
-            }
+            StringBuilder text = new();
+            string rootError = Append(text, exception);
 
-            // Report any other exceptions
-            ReportGenericException(exception, isTerminating);
-        }
-
-        private static void ReportAppException(ExternalOperationException exception, bool isTerminating)
-        {
-            // UserExternalOperationException wraps an actual exception, but be cautious just in case
-            string instructionText = exception.InnerException?.Message ?? TranslatedStrings.InstructionOperationFailed;
-
-            ShowException(FormatText(exception, canRaiseBug: true), instructionText, exception, isTerminating);
-        }
-
-        private static void ReportGenericException(Exception exception, bool isTerminating)
-        {
-            // This exception is arbitrary, see if there's additional information
-            string? moreInfo = exception.InnerException?.Message;
-            if (moreInfo is not null)
-            {
-                moreInfo += Environment.NewLine + Environment.NewLine;
-            }
-
-            ShowException($"{moreInfo}{TranslatedStrings.ReportBug}", exception.Message, exception, isTerminating);
-        }
-
-        private static void ReportUserException(UserExternalOperationException exception, bool isTerminating)
-            => ShowException(FormatText(exception, canRaiseBug: false), exception.Context, exception: null, isTerminating);
-
-        private static void ShowException(string text, string instructionText, Exception? exception, bool isTerminating)
-        {
-            using var dialog = new TaskDialog
+            using var taskDialog = new TaskDialog
             {
                 OwnerWindowHandle = OwnerFormHandle,
-                Text = text,
-                InstructionText = instructionText,
-                Caption = TranslatedStrings.Error,
                 Icon = TaskDialogStandardIcon.Error,
+                Caption = TranslatedStrings.Error,
+                InstructionText = rootError,
                 Cancelable = true,
             };
 
-            if (exception is not null)
+            // prefer to ignore failed external operations
+            if (isExternalOperation)
             {
-                var btnReport = new TaskDialogCommandLink("Report", TranslatedStrings.ButtonReportBug);
-                btnReport.Click += (s, e) =>
-                {
-                    dialog.Close();
-                    ShowNBug(OwnerForm, exception, isTerminating);
-                };
-
-                dialog.Controls.Add(btnReport);
+                AddIgnoreOrCloseButton();
             }
 
-            var btnIgnoreOrClose = new TaskDialogCommandLink("IgnoreOrClose", isTerminating ? TranslatedStrings.ButtonCloseApp : TranslatedStrings.ButtonIgnore);
-            btnIgnoreOrClose.Click += (s, e) =>
+            // no bug reports for user configured operations
+            if (!isUserExternalOperation)
             {
-                dialog.Close();
-            };
-            dialog.Controls.Add(btnIgnoreOrClose);
+                // directions and button to raise a bug
+                text.AppendLine().AppendLine(TranslatedStrings.ReportBug);
+            }
 
-            dialog.Show();
+            string buttonText = isUserExternalOperation ? TranslatedStrings.ButtonViewDetails : TranslatedStrings.ButtonReportBug;
+            TaskDialogCommandLink taskDialogCommandLink = new(buttonText, buttonText);
+            taskDialogCommandLink.Click += (s, e) =>
+                {
+                    taskDialog.Close();
+                    ShowNBug(OwnerForm, exception, isTerminating);
+                };
+            taskDialog.Controls.Add(taskDialogCommandLink);
+
+            // let the user decide whether to report the bug
+            if (!isExternalOperation)
+            {
+                AddIgnoreOrCloseButton();
+            }
+
+            taskDialog.Text = text.ToString().Trim();
+            taskDialog.Show();
+            return;
+
+            void AddIgnoreOrCloseButton()
+            {
+                string buttonText = isTerminating ? TranslatedStrings.ButtonCloseApp : TranslatedStrings.ButtonIgnore;
+                TaskDialogCommandLink taskDialogCommandLink = new(buttonText, buttonText);
+                taskDialogCommandLink.Click += (s, e) => taskDialog.Close();
+                taskDialog.Controls.Add(taskDialogCommandLink);
+            }
         }
 
         private static void ShowNBug(IWin32Window? owner, Exception exception, bool isTerminating)

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -20,9 +20,7 @@ namespace GitUI
         private readonly TranslationString _buttonIgnore = new("Ignore");
         private readonly TranslationString _buttonPush = new("&Push");
         private readonly TranslationString _buttonReportBug = new("Report bug!");
-
-        private readonly TranslationString _captionFailedExecute = new("Failed to execute");
-        private readonly TranslationString _instructionOperationFailed = new("Operation failed");
+        private readonly TranslationString _buttonViewDetails = new("View details");
 
         private readonly TranslationString _containedInCurrentCommitText = new("'{0}' is contained in the currently selected commit");
         private readonly TranslationString _containedInBranchesText = new("Contained in branches:");
@@ -138,9 +136,7 @@ namespace GitUI
         public static string ButtonIgnore => _instance.Value._buttonIgnore.Text;
         public static string ButtonPush => _instance.Value._buttonPush.Text;
         public static string ButtonReportBug => _instance.Value._buttonReportBug.Text;
-
-        public static string CaptionFailedExecute => _instance.Value._captionFailedExecute.Text;
-        public static string InstructionOperationFailed => _instance.Value._instructionOperationFailed.Text;
+        public static string ButtonViewDetails => _instance.Value._buttonViewDetails.Text;
 
         public static string ContainedInCurrentCommit => _instance.Value._containedInCurrentCommitText.Text;
         public static string ContainedInBranches => _instance.Value._containedInBranchesText.Text;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -372,6 +372,10 @@ Click this info icon for more details.</source>
   </file>
   <file datatype="plaintext" original="BugReportForm" source-language="en">
     <body>
+      <trans-unit id="IgnoreButton.Text">
+        <source>&amp;Ignore</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_noReproStepsSuppliedErrorMessage.Text">
         <source>Please provide as much as information as possible to help the developers solve this issue.</source>
         <target />

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9573,12 +9573,12 @@ Select this commit to populate the full message.</source>
         <source>Report bug!</source>
         <target />
       </trans-unit>
-      <trans-unit id="_cancelText.Text">
-        <source>Cancel</source>
+      <trans-unit id="_buttonViewDetails.Text">
+        <source>View details</source>
         <target />
       </trans-unit>
-      <trans-unit id="_captionFailedExecute.Text">
-        <source>Failed to execute</source>
+      <trans-unit id="_cancelText.Text">
+        <source>Cancel</source>
         <target />
       </trans-unit>
       <trans-unit id="_childrenText.Text">
@@ -9723,10 +9723,6 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_installGitInstructions.Text">
         <source>Install git...</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_instructionOperationFailed.Text">
-        <source>Operation failed</source>
         <target />
       </trans-unit>
       <trans-unit id="_invisibleCommitText.Text">

--- a/UnitTests/GitUI.Tests/NBugReports/BugReporterTests.cs
+++ b/UnitTests/GitUI.Tests/NBugReports/BugReporterTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections;
+using System.Text;
+using FluentAssertions;
+using GitExtensions;
+using GitExtUtils;
+using GitUI.NBugReports;
+using NUnit.Framework;
+
+namespace GitUITests.NBugReports
+{
+    [TestFixture]
+    public sealed class BugReporterTests
+    {
+        [Test, TestCaseSource(typeof(TestExceptions), "TestCases")]
+        public void Append(Exception exception, string expectedRootError, string expectedText)
+        {
+            StringBuilder text = new();
+            string rootError = BugReporter.Append(text, exception);
+            rootError.Should().Be(expectedRootError);
+            text.ToString().Should().Be(expectedText);
+        }
+    }
+
+    public class TestExceptions
+    {
+        private const string _messageOuter = "outer";
+        private const string _messageMiddle = "middle";
+        private const string _messageInner = "inner";
+        private const string _context = "context";
+        private const string _command = "command";
+        private const string _arguments = "arguments";
+        private const string _directory = "directory";
+
+        public static IEnumerable TestCases
+        {
+            get
+            {
+                yield return new TestCaseData(new Exception(_messageOuter),
+                    _messageOuter,
+                    "");
+                yield return new TestCaseData(new Exception(_messageOuter, new Exception(_messageMiddle)),
+                    _messageMiddle,
+                    "");
+                yield return new TestCaseData(new Exception(_messageOuter, new Exception(_messageMiddle, new Exception(_messageInner))),
+                    _messageInner,
+                    "");
+                yield return new TestCaseData(new UserExternalOperationException(_context,
+                    new ExternalOperationException(_command, _arguments, _directory, new Exception(_messageOuter, new Exception(_messageInner)))),
+                    _messageInner,
+                    $"{_context}{Environment.NewLine}"
+                    + $"Command: {_command}{Environment.NewLine}"
+                    + $"Arguments: {_arguments}{Environment.NewLine}"
+                    + $"Working directory: {_directory}{Environment.NewLine}");
+                yield return new TestCaseData(new UserExternalOperationException(null,
+                    new ExternalOperationException(null, null, null, new Exception(_messageInner))),
+                    _messageInner,
+                    "");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #8718, parts of #8802 as in #8988 for 3.6

## Proposed changes

- Display the error message of the inner-most exception
- Default to `Ignore` on `ExternalOperationException`
- Add `View details` on `UserExternalOperationException`, opens the `BugReportForm`, too
- Adapt `BugReportForm` to different exception types (disable close if `isTerminating`, add `Ignore` button for `U/EOE`)
- Make `BugReportForm` resizeable

## Screenshots

Exception|Before|After
-|-|-
`throw`<br/>`new Exception("Wrapping exception.",`<br/>`new Exception("Intermediate error.",`<br/>`new Exception("Cannot access locked file 'xyz'.")));`|![grafik](https://user-images.githubusercontent.com/36601201/111054126-39706880-846a-11eb-9243-eb157b903c06.png)|![grafik](https://user-images.githubusercontent.com/36601201/111054023-5ce6e380-8469-11eb-98bb-34b3c40236ee.png)
`throw`<br/>`new ExternalOperationException("<command>", "<arguments>", "<workdir>",`<br/>`new Exception("Wrapping exception.",`<br/>`new Exception("Intermediate error.",`<br/>`new Exception("Cannot access locked file 'xyz'.")));`|![grafik](https://user-images.githubusercontent.com/36601201/111054196-dfbc6e00-846a-11eb-9356-40c7cd17215f.png)|![grafik](https://user-images.githubusercontent.com/36601201/111054049-899afb00-8469-11eb-9691-791af9a1f63e.png)
`UserExternalOperationException`<br/>due to locked file|![grafik](https://user-images.githubusercontent.com/36601201/111053725-88b49a00-8466-11eb-91a4-4e4c8602221a.png)|"Cannot access file '...' because used by another process"<br/>![grafik](https://user-images.githubusercontent.com/36601201/111053746-b7327500-8466-11eb-8dac-4a93c0c1466e.png)
`UserExternalOperationException`<br/>due to invalid executable in user script|![grafik](https://user-images.githubusercontent.com/36601201/111053809-45a6f680-8467-11eb-8cef-4448abd9a312.png)|"Cannot find file"<br/>![grafik](https://user-images.githubusercontent.com/36601201/111053847-94ed2700-8467-11eb-84a6-ec85b357e50c.png)
`UserExternalOperationException`||![grafik](https://user-images.githubusercontent.com/36601201/112736950-f678bf80-8f56-11eb-9204-fbac50512509.png)
`isTerminating = true`||![grafik](https://user-images.githubusercontent.com/36601201/112737015-828ae700-8f57-11eb-80b3-08685c72da57.png)

## Test methodology <!-- How did you ensure quality? -->

- added unit tests
- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 3a31b3e6c11237e0f1304d0cae0bbba693171569
- Git 2.27.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).