### PR TITLE
Remove redundant creation of settings container

### DIFF
--- a/GitCommands/ExternalLinks/ExternalLinksStorage.cs
+++ b/GitCommands/ExternalLinks/ExternalLinksStorage.cs
@@ -32,8 +32,7 @@ namespace GitCommands.ExternalLinks
         /// </summary>
         public IReadOnlyList<ExternalLinkDefinition>? Load(RepoDistSettings settings)
         {
-            var cachedSettings = new RepoDistSettings(null, settings.SettingsCache, settings.SettingLevel);
-            var xml = cachedSettings.GetString(SettingName, null);
+            var xml = settings.GetString(SettingName, null);
             return LoadFromXmlString(xml);
         }
 
@@ -64,8 +63,7 @@ namespace GitCommands.ExternalLinks
                     xml = sw.ToString();
                 }
 
-                var cachedSettings = new RepoDistSettings(null, settings.SettingsCache, settings.SettingLevel);
-                cachedSettings.SetString(SettingName, xml);
+                settings.SetString(SettingName, xml);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Proposed changes

- Remove redundant creation of settings container


## Test methodology <!-- How did you ensure quality? -->

- Manually


![image](https://user-images.githubusercontent.com/3169265/112752621-94fb3400-8fdc-11eb-92c2-b02b018ba254.png)

![image](https://user-images.githubusercontent.com/3169265/112752647-ae03e500-8fdc-11eb-8151-cf5899450265.png)


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 6666fb64499e5305de7913662a3d657459f1cf6a
- Git 2.30.2.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
