### PR TITLE
Added 'Allow Empty' checkbox to commit form, and updated command logic

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2067,7 +2067,7 @@ namespace GitCommands
             }
         }
 
-        public ArgumentString CommitCmd(bool amend, bool signOff = false, string author = "", bool useExplicitCommitMessage = true, bool noVerify = false, bool gpgSign = false, string gpgKeyId = "")
+        public ArgumentString CommitCmd(bool amend, bool signOff = false, string author = "", bool useExplicitCommitMessage = true, bool noVerify = false, bool gpgSign = false, string gpgKeyId = "", bool allowEmpty = false)
         {
             return new GitArgumentBuilder("commit")
             {
@@ -2077,7 +2077,8 @@ namespace GitCommands
                 { !string.IsNullOrEmpty(author), $"--author=\"{author?.Trim().Trim('"')}\"" },
                 { gpgSign && string.IsNullOrWhiteSpace(gpgKeyId), "-S" },
                 { gpgSign && !string.IsNullOrWhiteSpace(gpgKeyId), $"-S{gpgKeyId}" },
-                { useExplicitCommitMessage, $"-F \"{Path.Combine(GetGitDirectory(), "COMMITMESSAGE")}\"" }
+                { useExplicitCommitMessage, $"-F \"{Path.Combine(GetGitDirectory(), "COMMITMESSAGE")}\"" },
+                { allowEmpty, "--allow-empty" }
             };
         }
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3364,16 +3364,25 @@ i.e. it may no longer be a fixup or an autosquash commit.</source>
 Are you sure you want to commit?</source>
         <target />
       </trans-unit>
-      <trans-unit id="_noFilesStagedAndNothingToCommit.Text">
-        <source>There are no files staged for this commit.</source>
+      <trans-unit id="_noFilesStagedCommitAllFilteredUnstagedOption.Text">
+        <source>Stage and commit the unstaged files that match your filter</source>
         <target />
       </trans-unit>
-      <trans-unit id="_noFilesStagedButSuggestToCommitAllFilteredUnstaged.Text">
-        <source>There are no files staged for this commit. Stage and commit the unstaged files that match your filter?</source>
+      <trans-unit id="_noFilesStagedCommitAllUnstagedOption.Text">
+        <source>Stage and commit all unstaged files</source>
         <target />
       </trans-unit>
-      <trans-unit id="_noFilesStagedButSuggestToCommitAllUnstaged.Text">
-        <source>There are no files staged for this commit. Stage and commit all unstaged files?</source>
+      <trans-unit id="_noFilesStagedCommitCaption.Text">
+        <source>Confirm commit</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_noFilesStagedCommitInstructions.Text">
+        <source>There aren't any changes in the staging area.
+How do you want to proceed?</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_noFilesStagedMakeEmptyCommitOption.Text">
+        <source>Make an empty commit</source>
         <target />
       </trans-unit>
       <trans-unit id="_noStagedChanges.Text">


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Implements #4631


## Proposed changes

-  Add new option to the commit dialog to allow commits with no changes.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![before-4631](https://user-images.githubusercontent.com/20910938/113140524-d54ef200-9228-11eb-9a41-d6573e9ab3fd.png)

### After

![after-4631](https://user-images.githubusercontent.com/20910938/113140700-0d563500-9229-11eb-98ac-00208f2b25e6.png)

## Test methodology <!-- How did you ensure quality? -->
Manual testing

## Test environment(s) <!-- Remove any that don't apply -->
- GIT 2.29
- Windows 10, 20H2

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
