### PR TITLE
Straighten graph lanes over multiple rows

### DIFF
--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphRowTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphRowTests.cs
@@ -62,5 +62,40 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
             revisionGraphRow.GetLaneIndexForSegment(_segment1).Should().Be(expectedLane1);
             revisionGraphRow.GetLaneIndexForSegment(_segment2).Should().Be(expectedLane2);
         }
+
+        [TestCase(-1, 4, 1, 2, 3)]
+        [TestCase(0, 1, 2, 3, 4)]
+        [TestCase(0, 2, 1, 3, 4)]
+        [TestCase(0, 3, 1, 2, 4)]
+        [TestCase(0, 4, 1, 2, 3)]
+        [TestCase(1, 0, 1, 2, 3)]
+        [TestCase(1, 1, 0, 3, 4)]
+        [TestCase(1, 2, 0, 3, 4)]
+        [TestCase(1, 3, 0, 2, 4)]
+        [TestCase(1, 4, 0, 2, 3)]
+        [TestCase(2, 0, 1, 2, 3)]
+        [TestCase(2, 1, 0, 2, 3)]
+        [TestCase(2, 2, 0, 1, 4)]
+        [TestCase(2, 3, 0, 1, 4)]
+        [TestCase(2, 4, 0, 1, 3)]
+        [TestCase(3, 0, 1, 2, 3)]
+        [TestCase(3, 1, 0, 2, 3)]
+        [TestCase(3, 2, 0, 1, 3)]
+        [TestCase(3, 3, 0, 1, 2)]
+        [TestCase(4, 3, 0, 1, 2)]
+        public void MoveLanesRight_should_move_segments_twice(int fromLane1, int fromLane2, int expectedLane, int expectedLane1, int expectedLane2)
+        {
+            List<RevisionGraphSegment> segments = new() { _segment, _segment1, _segment2 };
+            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments);
+            revisionGraphRow.GetLaneCount().Should().Be(3);
+
+            revisionGraphRow.MoveLanesRight(fromLane1);
+            revisionGraphRow.MoveLanesRight(fromLane2);
+
+            revisionGraphRow.GetLaneCount().Should().Be(expectedLane2 + 1);
+            revisionGraphRow.GetLaneIndexForSegment(_segment).Should().Be(expectedLane);
+            revisionGraphRow.GetLaneIndexForSegment(_segment1).Should().Be(expectedLane1);
+            revisionGraphRow.GetLaneIndexForSegment(_segment2).Should().Be(expectedLane2);
+        }
     }
 }


### PR DESCRIPTION
Fixes #5782
Follow-up to / generalization of #9028

## Proposed changes

- Straighten lanes over multiple rows
- Fix-up missing handling of `RevisionGraphRow._revisionLane` and `RevisionGraph.GetCachedCount`

## Screenshots <!-- Remove this section if PR does not change UI -->

Before|After
-|-
![grafik](https://user-images.githubusercontent.com/36601201/113521918-eedf9900-959c-11eb-961b-3b02ab7f0a87.png)|![grafik](https://user-images.githubusercontent.com/36601201/113521868-8f818900-959c-11eb-9d23-0de2a54ff761.png)

Remark: The part of the red branch starting at `cff2c15` ending at the line with `03d75aa` could be straightened, too. Though this is not detected by the current implementation because this part consists of multiple segments. 

## Test methodology <!-- How did you ensure quality? -->

- manual with GE and Linux repos
- added NUnit test case

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 7835202d0aefbcfea65cad1ad884d6c410b978ec
- Git 2.27.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
