### PR TITLE
Color settings page events

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -27,6 +27,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             InitializeComponent();
             Text = "Colors";
             sbOpenThemeFolder.AutoSize = false;
+
+            _NO_TRANSLATE_cbSelectTheme.SelectedIndexChanged += ComboBoxTheme_SelectedIndexChanged;
+            chkUseSystemVisualStyle.CheckedChanged += ChkUseSystemVisualStyle_CheckedChanged;
+            chkColorblind.CheckedChanged += ChkColorblind_CheckedChanged;
+
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -75,6 +75,33 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             set => chkUseSystemVisualStyle.Checked = value;
         }
 
+        private bool SettingsAreModified
+        {
+            get
+            {
+                if (SelectedThemeId != ThemeModule.Settings.Theme.Id)
+                {
+                    return true;
+                }
+
+                if (SelectedThemeId == ThemeId.Default)
+                {
+                    // UseSystemVisualStyle and ThemeVariations settings are only applicable with non-default theme.
+                    // However, in order to preserve user preference, we do not reset these when
+                    // user chooses the default theme from the menu, we only disable the checkboxes.
+
+                    // This is why, when the default theme is selected, we should ignore any difference in
+                    // UseSystemVisualStyle or ThemeVariations checkboxes from the actual theme settings.
+                    // Their value is not applied and only kept to be applied when user chooses non-default theme
+                    // again.
+                    return false;
+                }
+
+                return UseSystemVisualStyle != ThemeModule.Settings.UseSystemVisualStyle ||
+                    !SelectedThemeVariations.SequenceEqual(AppSettings.ThemeVariations);
+            }
+        }
+
         protected override void OnRuntimeLoad()
         {
             base.OnRuntimeLoad();
@@ -170,12 +197,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             if (counter == 0)
             {
-                bool settingsChanged =
-                    UseSystemVisualStyle != ThemeModule.Settings.UseSystemVisualStyle ||
-                    SelectedThemeId != ThemeModule.Settings.Theme.Id ||
-                    !SelectedThemeVariations.SequenceEqual(AppSettings.ThemeVariations);
-
-                lblRestartNeeded.Visible = settingsChanged;
+                lblRestartNeeded.Visible = SettingsAreModified;
                 chkColorblind.Enabled =
                     chkUseSystemVisualStyle.Enabled = SelectedThemeId != ThemeId.Default;
             }


### PR DESCRIPTION
## Proposed changes

1. Event handlers in ColorSettingsPage.designer.cs were lost in fcdf2a8777e8755af3fcaa92c5a18b912bb7f729

Subscribing to event handers was moved to non- designer.cs file, because indeed, I have seen multiple times how important code is lost when massively updating .designer.cs file.

2. Fix false positive "Restart needed" message after user chooses default theme, restarts and opens color settings page.

## Test methodology

manual

## Test environment(s)

- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
