### PR TITLE
Throw on non-zero exit code and on stderror output

### DIFF
--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -217,7 +217,7 @@ namespace GitCommands
 
             ExecutionResult exec = GetModule().GitExecutable.Execute(arguments,
                 outputEncoding: GitModule.LosslessEncoding,
-                cache: cache ? GitModule.GitCommandCache : null);
+                cache: cache ? GitModule.GitCommandCache : null, throwOnErrorOutput: false);
 
             if (!exec.ExitedSuccessfully)
             {

--- a/GitCommands/FileHelper.cs
+++ b/GitCommands/FileHelper.cs
@@ -75,7 +75,7 @@ namespace GitCommands
                 "--",
                 fileName.Quote()
             };
-            string result = module.GitExecutable.GetOutput(cmd);
+            string result = module.GitExecutable.GetOutput(cmd, throwOnErrorOutput: false);
             var lines = result.Split(Delimiters.NullAndLineFeed);
             Dictionary<string, string> attributes = new();
             for (int i = 0; i < lines.Length - 2; i += 3)

--- a/GitCommands/Git/AheadBehindDataProvider.cs
+++ b/GitCommands/Git/AheadBehindDataProvider.cs
@@ -60,7 +60,7 @@ namespace GitCommands.Git
                 "refs/heads/" + branchName
             };
 
-            ExecutionResult result = GetGitExecutable().Execute(aheadBehindGitCommand, outputEncoding: encoding);
+            ExecutionResult result = GetGitExecutable().Execute(aheadBehindGitCommand, outputEncoding: encoding, throwOnErrorOutput: false);
             if (!result.ExitedSuccessfully || string.IsNullOrEmpty(result.StandardOutput))
             {
                 return null;

--- a/GitCommands/Git/SubmoduleHelpers.cs
+++ b/GitCommands/Git/SubmoduleHelpers.cs
@@ -125,8 +125,11 @@ namespace GitCommands.Git
                 else
                 {
                     var submodule = module.GetSubmodule(fileName);
-                    addedCommits = submodule.GetCommitCount(commitId.ToString(), oldCommitId.ToString(), cache: true);
-                    removedCommits = submodule.GetCommitCount(oldCommitId.ToString(), commitId.ToString(), cache: true);
+                    if (submodule.IsValidGitWorkingDir())
+                    {
+                        addedCommits = submodule.GetCommitCount(commitId.ToString(), oldCommitId.ToString(), cache: true, throwOnErrorOutput: false);
+                        removedCommits = submodule.GetCommitCount(oldCommitId.ToString(), commitId.ToString(), cache: true, throwOnErrorOutput: false);
+                    }
                 }
             }
 

--- a/GitCommands/Git/SystemEncodingReader.cs
+++ b/GitCommands/Git/SystemEncodingReader.cs
@@ -48,7 +48,7 @@ namespace GitCommands.Git
                     controlStr
                 };
 
-                string? s = _module.GitExecutable.GetOutput(arguments, outputEncoding: Encoding.UTF8);
+                string? s = _module.GitExecutable.GetOutput(arguments, outputEncoding: Encoding.UTF8, throwOnErrorOutput: false);
                 if (s is not null && s.IndexOf(controlStr) != -1)
                 {
                     systemEncoding = new UTF8Encoding(false);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1517,7 +1517,7 @@ namespace GitUI.CommandsDialogs
                 Validates.NotNull(shell.ExecutablePath);
 
                 Executable executable = new(shell.ExecutablePath, Module.WorkingDir);
-                executable.Start(createWindow: true);
+                executable.Start(createWindow: true, throwOnErrorOutput: false); // throwOnErrorOutput would redirect the output
             }
             catch (Exception exception)
             {

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -558,7 +558,7 @@ namespace GitUI.CommandsDialogs
                     GitUIPluginInterfaces.ExecutionResult res;
                     try
                     {
-                        res = new Executable(_mergetoolPath, Module.WorkingDir).Execute(arguments);
+                        res = new Executable(_mergetoolPath, Module.WorkingDir).Execute(arguments, throwOnErrorOutput: false);
                     }
                     catch (Exception)
                     {

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1430,7 +1430,7 @@ namespace GitUI.Editor
                 { !stage, "--reverse" }
             };
 
-            string output = Module.GitExecutable.GetOutput(args, patch);
+            string output = Module.GitExecutable.GetOutput(args, patch, throwOnErrorOutput: false);
             ProcessApplyOutput(output, patch, patchUpdateDiff: true);
         }
 
@@ -1500,7 +1500,7 @@ namespace GitUI.Editor
                 { currentItemStaged, "--reverse --index" }
             };
 
-            string output = Module.GitExecutable.GetOutput(args, patch);
+            string output = Module.GitExecutable.GetOutput(args, patch, throwOnErrorOutput: false);
             if (EnvUtils.RunningOnWindows())
             {
                 // remove file mode warnings
@@ -1557,7 +1557,7 @@ namespace GitUI.Editor
                 "--whitespace=nowarn"
             };
 
-            string output = Module.GitExecutable.GetOutput(args, patch);
+            string output = Module.GitExecutable.GetOutput(args, patch, throwOnErrorOutput: false);
             ProcessApplyOutput(output, patch);
         }
 

--- a/GitUI/OsShellUtil.cs
+++ b/GitUI/OsShellUtil.cs
@@ -13,7 +13,7 @@ namespace GitUI
         {
             try
             {
-                new Executable(filePath).Start(useShellExecute: true);
+                new Executable(filePath).Start(useShellExecute: true, throwOnErrorOutput: false);
             }
             catch (Exception)
             {
@@ -48,7 +48,7 @@ namespace GitUI
         {
             if (!string.IsNullOrWhiteSpace(url))
             {
-                new Executable(url).Start(useShellExecute: true);
+                new Executable(url).Start(useShellExecute: true, throwOnErrorOutput: false);
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1277,11 +1277,7 @@ namespace GitUI
                 objectId
             };
 
-            // NOTE if the object ID does not exist we receive a message resembling (excluding quotes):
-            //
-            // "fatal: bad object b897cd39543bd933da30af872a633760e79472c9"
-
-            foreach (var line in Module.GitExecutable.GetOutputLines(args))
+            foreach (var line in Module.GitExecutable.GetOutputLines(args, throwOnErrorOutput: false))
             {
                 if (ObjectId.TryParse(line, out var parentId))
                 {

--- a/Plugins/GitUIPluginInterfaces/IExecutable.cs
+++ b/Plugins/GitUIPluginInterfaces/IExecutable.cs
@@ -23,6 +23,8 @@ namespace GitUIPluginInterfaces
         /// <param name="outputEncoding">The <see cref="Encoding"/> to use when interpreting standard output and standard
         /// error, or <c>null</c> if <paramref name="redirectOutput"/> is <c>false</c>.</param>
         /// <param name="useShellExecute">The value for the flag <c>ProcessStartInfo.UseShellExecute</c>.</param>
+        /// <param name="throwOnErrorOutput">A flag configuring whether to throw an exception if the exit code is not 0
+        /// or if the output to StandardError is not empty.</param>
         /// <returns>The started process.</returns>
         [MustUseReturnValue]
         IProcess Start(ArgumentString arguments = default,
@@ -30,6 +32,7 @@ namespace GitUIPluginInterfaces
                        bool redirectInput = false,
                        bool redirectOutput = false,
                        Encoding? outputEncoding = null,
-                       bool useShellExecute = false);
+                       bool useShellExecute = false,
+                       bool throwOnErrorOutput = true);
     }
 }

--- a/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
+++ b/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
@@ -136,7 +136,7 @@ namespace CommonTestUtils
             // Submodules require at least one commit
             subModuleHelper.Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Initial empty commit""");
 
-            Module.GitExecutable.GetOutput(GitCommandHelpers.AddSubmoduleCmd(subModuleHelper.Module.WorkingDir.ToPosixPath(), path, null, true));
+            Module.GitExecutable.GetOutput(GitCommandHelpers.AddSubmoduleCmd(subModuleHelper.Module.WorkingDir.ToPosixPath(), path, null, true), throwOnErrorOutput: false);
             Module.GitExecutable.GetOutput(@"commit -am ""Add submodule""");
         }
 
@@ -146,7 +146,7 @@ namespace CommonTestUtils
         /// <returns>All submodule Modules</returns>
         public IEnumerable<GitModule> GetSubmodulesRecursive()
         {
-            Module.GitExecutable.GetOutput(@"submodule update --init --recursive");
+            Module.GitExecutable.GetOutput(@"submodule update --init --recursive", throwOnErrorOutput: false);
             var paths = Module.GetSubmodulesLocalPaths(recursive: true);
             return paths.Select(path =>
             {

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -73,7 +73,7 @@ namespace CommonTestUtils
             }
         }
 
-        public IProcess Start(ArgumentString arguments, bool createWindow, bool redirectInput, bool redirectOutput, Encoding outputEncoding, bool useShellExecute = false)
+        public IProcess Start(ArgumentString arguments, bool createWindow, bool redirectInput, bool redirectOutput, Encoding outputEncoding, bool useShellExecute = false, bool throwOnErrorOutput = true)
         {
             System.Diagnostics.Debug.WriteLine($"mock-git {arguments}");
 

--- a/UnitTests/GitCommands.Tests/Config/ConfigFileTest.cs
+++ b/UnitTests/GitCommands.Tests/Config/ConfigFileTest.cs
@@ -55,7 +55,7 @@ namespace GitCommandsTests.Config
                 // Quote the key without unescaping internal quotes
                 $"\"{key}\""
             };
-            return Module.GitExecutable.GetOutput(args).TrimEnd('\n');
+            return Module.GitExecutable.GetOutput(args, throwOnErrorOutput: false).TrimEnd('\n');
         }
 
         private void CheckValueIsEqual(ConfigFile configFile, string key, string expectedValue)

--- a/UnitTests/GitCommands.Tests/Git/AheadBehindDataProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/AheadBehindDataProviderTests.cs
@@ -36,7 +36,7 @@ namespace GitCommandsTests.Git
             _process.StandardError.Returns(x => _errorStreamReader);
 
             _executable = Substitute.For<IExecutable>();
-            _executable.Start(Arg.Any<ArgumentString>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<Encoding>(), Arg.Any<bool>()).Returns(x => _process);
+            _executable.Start(Arg.Any<ArgumentString>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<Encoding>(), Arg.Any<bool>(), Arg.Any<bool>()).Returns(x => _process);
 
             _provider = new AheadBehindDataProvider(() => _executable);
         }

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -747,13 +747,13 @@ namespace GitCommandsTests
                     var child = moduleTestHelpers[i];
 
                     // Add child as submodule of parent
-                    parent.Module.GitExecutable.GetOutput(GitCommandHelpers.AddSubmoduleCmd(child.Module.WorkingDir.ToPosixPath(), $"repo{i}", null, true));
+                    parent.Module.GitExecutable.GetOutput(GitCommandHelpers.AddSubmoduleCmd(child.Module.WorkingDir.ToPosixPath(), $"repo{i}", null, true), throwOnErrorOutput: false);
                     parent.Module.GitExecutable.GetOutput(@"commit -am ""Add submodule""");
                 }
 
                 // Init all modules of root
                 var root = moduleTestHelpers[0];
-                root.Module.GitExecutable.GetOutput(@"submodule update --init --recursive");
+                root.Module.GitExecutable.GetOutput(@"submodule update --init --recursive", throwOnErrorOutput: false);
 
                 var paths = root.Module.GetSubmodulesLocalPaths(recursive: true);
                 Assert.AreEqual(new string[] { "repo1", "repo1/repo2", "repo1/repo2/repo3" }, paths, $"Modules: {string.Join(" ", paths)}");

--- a/UnitTests/GitCommands.Tests/Submodules/SubmoduleStatusProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/Submodules/SubmoduleStatusProviderTests.cs
@@ -183,7 +183,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
 
             // Revert the change
-            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -219,7 +219,7 @@ namespace GitCommandsTests.Submodules
 
             // Revert the change
             File.Delete(Path.Combine(_repo2Module.WorkingDir, "test.txt"));
-            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -302,7 +302,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
 
             // Revert the change
-            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -337,7 +337,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
 
             // Revert the change
-            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -401,7 +401,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Should().BeNull();
 
             // Revert the change
-            _repo1Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            _repo1Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -500,7 +500,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.IsDirty.Should().BeTrue();
 
             // Revert the change
-            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -561,7 +561,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Should().BeNull();
 
             // Revert the change
-            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -590,7 +590,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Should().BeNull();
 
             // Revert the change
-            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -678,7 +678,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.IsDirty.Should().BeTrue();
 
             // Revert the change
-            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -705,11 +705,11 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Should().BeNull();
 
             // Revert the change
-            _repo1Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            _repo1Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
             File.Delete(Path.Combine(_repo1Module.WorkingDir, "test.txt"));
-            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
             File.Delete(Path.Combine(_repo2Module.WorkingDir, "test.txt"));
-            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
             File.Delete(Path.Combine(_repo3Module.WorkingDir, "test.txt"));
             await CheckRevertedStatus(result);
         }
@@ -744,7 +744,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.IsDirty.Should().BeTrue();
 
             // Revert the change
-            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^");
+            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
             File.Delete(Path.Combine(_repo3Module.WorkingDir, "test.txt"));
             await CheckRevertedStatus(result);
         }


### PR DESCRIPTION
Fixes #6527
Fixes #8263
Fixes #8632
Closes #8906 as obsolete
Closes #8961 as obsolete

## Proposed changes

- Throw `ExternalOperationException` if a started process exits with a non-0 exit code or if the process printed output to `StandardError`
- Suppress this exception for commands whose errors are handled

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->

## Test methodology <!-- How did you ensure quality? -->

- manual
- existing NUnit tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 3bed1c81024391ba2f58c2b005f915d6fac21260
- Git 2.27.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4300.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).