### PR TITLE
rev-parse should use --quiet --verify

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2822,10 +2822,14 @@ namespace GitCommands
                 return head;
             }
 
-            var args = new GitArgumentBuilder("symbolic-ref") { "HEAD" };
+            var args = new GitArgumentBuilder("symbolic-ref")
+            {
+                "--quiet",
+                "HEAD"
+            };
             var result = _gitExecutable.Execute(args);
 
-            return result.ExitCode == 0
+            return result.ExitedSuccessfully
                 ? result.StandardOutput
                 : setDefaultIfEmpty ? DetachedHeadParser.DetachedBranch : string.Empty;
         }
@@ -3622,10 +3626,15 @@ namespace GitCommands
                 return objectId;
             }
 
-            var args = new GitArgumentBuilder("rev-parse") { $"\"{revisionExpression}~0\"" };
+            var args = new GitArgumentBuilder("rev-parse")
+            {
+                "--quiet",
+                "--verify",
+                $"\"{revisionExpression}~0\""
+            };
             var result = _gitExecutable.Execute(args);
 
-            return result.ExitCode == 0 && ObjectId.TryParse(result.StandardOutput, offset: 0, out objectId)
+            return result.ExitedSuccessfully && ObjectId.TryParse(result.StandardOutput, offset: 0, out objectId)
                 ? objectId
                 : null;
         }

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -142,42 +142,42 @@ namespace GitCommandsTests
             // TODO test case where this is false
             Assert.IsTrue(GitVersion.Current.FetchCanAskForProgress);
 
-            using (_executable.StageOutput("rev-parse \"refs/heads/remotebranch~0\"", null))
+            using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
                     "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch").Arguments);
             }
 
-            using (_executable.StageOutput("rev-parse \"refs/heads/remotebranch~0\"", null))
+            using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
                     "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --tags",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", true).Arguments);
             }
 
-            using (_executable.StageOutput("rev-parse \"refs/heads/remotebranch~0\"", null))
+            using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
                     "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", null).Arguments);
             }
 
-            using (_executable.StageOutput("rev-parse \"refs/heads/remotebranch~0\"", null))
+            using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
                     "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --unshallow",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", isUnshallow: true).Arguments);
             }
 
-            using (_executable.StageOutput("rev-parse \"refs/heads/remotebranch~0\"", null))
+            using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
                     "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", pruneRemoteBranches: true).Arguments);
             }
 
-            using (_executable.StageOutput("rev-parse \"refs/heads/remotebranch~0\"", null))
+            using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
                     "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --prune-tags",
@@ -214,49 +214,49 @@ namespace GitCommandsTests
         [Test]
         public void PushCmd()
         {
-            using (_executable.StageOutput("rev-parse \"refs/heads/from-branch~0\"", null))
+            using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/from-branch~0\"", null))
             {
                 Assert.AreEqual(
                     "push --progress \"remote\" from-branch",
                     _gitModule.PushCmd("remote", "from-branch", null, ForcePushOptions.DoNotForce, track: false, recursiveSubmodules: 0).Arguments);
             }
 
-            using (_executable.StageOutput("rev-parse \"refs/heads/from-branch~0\"", null))
+            using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/from-branch~0\"", null))
             {
                 Assert.AreEqual(
                     "push --progress \"remote\" from-branch:refs/heads/to-branch",
                     _gitModule.PushCmd("remote", "from-branch", "to-branch", ForcePushOptions.DoNotForce, track: false, recursiveSubmodules: 0).Arguments);
             }
 
-            using (_executable.StageOutput("rev-parse \"refs/heads/from-branch~0\"", null))
+            using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/from-branch~0\"", null))
             {
                 Assert.AreEqual(
                     "push -f --progress \"remote\" from-branch:refs/heads/to-branch",
                     _gitModule.PushCmd("remote", "from-branch", "to-branch", ForcePushOptions.Force, track: false, recursiveSubmodules: 0).Arguments);
             }
 
-            using (_executable.StageOutput("rev-parse \"refs/heads/from-branch~0\"", null))
+            using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/from-branch~0\"", null))
             {
                 Assert.AreEqual(
                     "push --force-with-lease --progress \"remote\" from-branch:refs/heads/to-branch",
                     _gitModule.PushCmd("remote", "from-branch", "to-branch", ForcePushOptions.ForceWithLease, track: false, recursiveSubmodules: 0).Arguments);
             }
 
-            using (_executable.StageOutput("rev-parse \"refs/heads/from-branch~0\"", null))
+            using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/from-branch~0\"", null))
             {
                 Assert.AreEqual(
                     "push -u --progress \"remote\" from-branch:refs/heads/to-branch",
                     _gitModule.PushCmd("remote", "from-branch", "to-branch", ForcePushOptions.DoNotForce, track: true, recursiveSubmodules: 0).Arguments);
             }
 
-            using (_executable.StageOutput("rev-parse \"refs/heads/from-branch~0\"", null))
+            using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/from-branch~0\"", null))
             {
                 Assert.AreEqual(
                     "push --recurse-submodules=check --progress \"remote\" from-branch:refs/heads/to-branch",
                     _gitModule.PushCmd("remote", "from-branch", "to-branch", ForcePushOptions.DoNotForce, track: false, recursiveSubmodules: 1).Arguments);
             }
 
-            using (_executable.StageOutput("rev-parse \"refs/heads/from-branch~0\"", null))
+            using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/from-branch~0\"", null))
             {
                 Assert.AreEqual(
                     "push --recurse-submodules=on-demand --progress \"remote\" from-branch:refs/heads/to-branch",
@@ -414,7 +414,7 @@ namespace GitCommandsTests
         public void RevParse_should_query_git_and_return_ObjectId_if_get_valid_hash()
         {
             var revisionExpression = "11111";
-            using (_executable.StageOutput($"rev-parse \"{revisionExpression}~0\"", new string('1', ObjectId.Sha1CharCount), 0))
+            using (_executable.StageOutput($"rev-parse --quiet --verify \"{revisionExpression}~0\"", new string('1', ObjectId.Sha1CharCount), 0))
             {
                 _gitModule.RevParse(revisionExpression).Should().Be(ObjectId.WorkTreeId);
             }
@@ -424,7 +424,7 @@ namespace GitCommandsTests
         public void RevParse_should_query_git_and_return_null_if_invalid_response()
         {
             var revisionExpression = "11111";
-            using (_executable.StageOutput($"rev-parse \"{revisionExpression}~0\"", "foo bar", 0))
+            using (_executable.StageOutput($"rev-parse --quiet --verify \"{revisionExpression}~0\"", "foo bar", 0))
             {
                 _gitModule.RevParse(revisionExpression).Should().BeNull();
             }


### PR DESCRIPTION
## Proposed changes

Really just a refactoring, to make it simpler to see in Git Command Log that gir-rev-parse and git-symbolic-ref may exit with error.
The command output has less IO too (to offset the extra parsing of options...)
The commands with actual errors stick out more.
If I see a command with --quiet, I can expect error exit to be handled.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/114272233-a3524280-9a15-11eb-995f-e43ea3f4ddbb.png)

### After

![image](https://user-images.githubusercontent.com/6248932/114272269-d1378700-9a15-11eb-8e13-aa02a1165132.png)

## Test methodology <!-- How did you ensure quality? -->

Updated test, manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
