### PR TITLE
AutoComplete: Avoid Git for non tracked files

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2725,10 +2725,20 @@ namespace GitCommands
                 : null;
         }
 
+        /// <summary>
+        /// Get the file contents for the HEAD commit
+        /// </summary>
+        /// <param name="file">The Git status item</param>
+        /// <returns>An awaitable task with the requested file contents.</returns>
         public async Task<string?> GetFileContentsAsync(GitItemStatus file)
         {
-            var contents = new StringBuilder();
+            if (!file.IsTracked || (file.Staged == StagedStatus.Index && file.IsNew))
+            {
+                // File is not in Git
+                return null;
+            }
 
+            StringBuilder contents = new();
             string? currentContents = await GetFileContentsAsync(file.Name).ConfigureAwaitRunInline();
             if (currentContents is not null)
             {

--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -149,19 +149,21 @@ namespace GitUI.AutoCompletion
 
         private static async Task<string?> GetChangedFileTextAsync(GitModule module, GitItemStatus file)
         {
-            var changes = await module.GetCurrentChangesAsync(file.Name, file.OldName, file.Staged == StagedStatus.Index, "-U1000000")
+            if (file.IsTracked)
+            {
+                var changes = await module.GetCurrentChangesAsync(file.Name, file.OldName, file.Staged == StagedStatus.Index, "-U1000000")
                 .ConfigureAwait(false);
 
-            if (changes is not null)
-            {
-                return changes.Text;
-            }
+                if (changes is not null)
+                {
+                    return changes.Text;
+                }
 
-            var content = await module.GetFileContentsAsync(file).ConfigureAwaitRunInline();
-
-            if (content is not null)
-            {
-                return content;
+                var content = await module.GetFileContentsAsync(file).ConfigureAwaitRunInline();
+                if (content is not null)
+                {
+                    return content;
+                }
             }
 
             // Try to read the contents of the file: if it cannot be read, skip the operation silently.


### PR DESCRIPTION
## Proposed changes

Requirement for #9056 

AutoComplete in FormCommit tries to list all files that are in worktree/index and parse them, to find names of functions etc to use in the autocompletion.
(Extensions and regexp in AutoCompleteRegexes.txt)
First git-diff is tried (OK, but empty), but git-show will raise a git error status. Better to not call Git here than to handle the error in #9056 

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/114272728-9a627080-9a17-11eb-9204-8bd127cd80b5.png)

### After

No Git calls

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
