### PR TITLE
Use exit status instead of IsGitErrorMessage()

### DIFF
--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -215,16 +215,18 @@ namespace GitCommands
             // This command can be cached if commitId is a git sha and Notes are ignored
             Debug.Assert(!cache || ObjectId.TryParse(commitId, out _), $"git-log cache should be used only for sha ({commitId})");
 
-            data = GetModule().GitExecutable.GetOutput(arguments,
+            ExecutionResult exec = GetModule().GitExecutable.Execute(arguments,
                 outputEncoding: GitModule.LosslessEncoding,
                 cache: cache ? GitModule.GitCommandCache : null);
 
-            if (GitModule.IsGitErrorMessage(data))
+            if (!exec.ExitedSuccessfully)
             {
+                data = null;
                 error = "Cannot find commit " + commitId;
                 return false;
             }
 
+            data = exec.StandardOutput;
             error = null;
             return true;
         }

--- a/ResourceManager/LocalizationHelpers.cs
+++ b/ResourceManager/LocalizationHelpers.cs
@@ -283,7 +283,16 @@ namespace ResourceManager
                     }
                 }
 
-                string diffs = gitModule.GetDiffFiles(status.OldCommit.ToString(), status.Commit.ToString(), nullSeparated: false);
+                // It is possible that a commit does not exist, should not raise an error to the user:
+                // * Create a commit in a submodule, do not push
+                // * Commit submodule changes
+                // * Open the repo in a worktree clone
+                // * Checkout the commit
+                // * Select the submodule in the diff tab
+                // This should not raise a popup to the user, but describe the error message
+                string diffs = gitModule.GetDiffFiles(status.OldCommit.ToString(), status.Commit.ToString(), nullSeparated: false)
+                    .AllOutput;
+
                 if (!string.IsNullOrEmpty(diffs))
                 {
                     sb.AppendLine("\nDifferences:");


### PR DESCRIPTION
Preparation for #9056 

## Proposed changes

ExecutableExtensions: CommandCache for Execute()
Previously caching was possible only for GetOutput()

Instead of parsing the combined standard/error output for 'fatal' or 'error:' in IsGitErrorMessage(), use the executable exit status.
The standard usage is to add a a fake GitStatusItem to show the failed command for the user in FileStatusList.
This handling is done _after_ standard output is parsed, as it is currently. 

Note that changes like GitConfigurationException makes it hard to reach these codepaths (you get constant popups, cannot do anything) so testing this is hard.

## Test methodology <!-- How did you ensure quality? -->

Manual, some commands are tested though

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
