### PR TITLE
Suppress "Theme not found" if setting is empty

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs
@@ -43,7 +43,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
             set
             {
-                var formattedThemeId = new FormattedThemeId(value);
+                FormattedThemeId formattedThemeId = new(value);
                 int index = _NO_TRANSLATE_cbSelectTheme.Items.IndexOf(formattedThemeId);
                 if (index < 0)
                 {
@@ -52,7 +52,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     // - user creates custom theme and selects it in this settings page
                     // - user saves app settings
                     // - user deletes the file with custom theme
-                    MessageBoxes.ShowError(this, "Theme not found: " + formattedThemeId);
+                    // - on first install; suppress MessageBox
+                    string theme = formattedThemeId.ToString();
+                    if (!string.IsNullOrWhiteSpace(theme))
+                    {
+                        MessageBoxes.ShowError(FindForm(), $"Theme not found: {theme}");
+                    }
+
                     index = 0;
                 }
 


### PR DESCRIPTION
## Proposed changes

- Suppress "Theme not found" if setting is empty (e.g. after first install)
- Use correct owner for MessageBox

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/114285732-bf77d300-9a59-11eb-831e-3951d2dd37c9.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/114285757-f0580800-9a59-11eb-9710-a7f683536ded.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 9f34af4e57d1eb9b2032dcd22e9d3780d34ff548
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).