### PR TITLE
Do not reset a valid `AppSettings.GitBinDir`

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -65,15 +65,15 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 gitpath = possibleNewPath.Trim();
             }
 
-            foreach (string toolsPath in new[] { @"bin\", @"usr\bin\" })
+            foreach (string toolsPath in new[] { @"usr\bin\", @"bin\" })
             {
-                gitpath = gitpath.Replace(@"\cmd\git.exe", @"\" + toolsPath)
+                string linuxToolsPath = gitpath.Replace(@"\cmd\git.exe", @"\" + toolsPath)
                     .Replace(@"\cmd\git.cmd", @"\" + toolsPath)
                     .Replace(@"\bin\git.exe", @"\" + toolsPath);
 
-                if (ContainsSh(gitpath))
+                if (ContainsSh(linuxToolsPath))
                 {
-                    AppSettings.GitBinDir = gitpath;
+                    AppSettings.GitBinDir = linuxToolsPath;
                     return true;
                 }
 
@@ -90,7 +90,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
                 foreach (string path in GetGitLocations())
                 {
-                    gitpath = path + toolsPath;
+                    linuxToolsPath = path + toolsPath;
                     if (ContainsSh(gitpath))
                     {
                         AppSettings.GitBinDir = gitpath;

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -79,6 +79,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
                 if (CheckIfFileIsInPath("sh.exe") || CheckIfFileIsInPath("sh"))
                 {
+                    if (ContainsSh(AppSettings.GitBinDir))
+                    {
+                        return true;
+                    }
+
                     AppSettings.GitBinDir = string.Empty;
                     return true;
                 }

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -55,7 +55,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         {
             if (!EnvUtils.RunningOnWindows())
             {
-                AppSettings.GitBinDir = "";
+                AppSettings.GitBinDir = string.Empty;
                 return true;
             }
 
@@ -65,41 +65,38 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 gitpath = possibleNewPath.Trim();
             }
 
-            foreach (var toolsPath in new[] { @"bin\", @"usr\bin\" })
+            foreach (string toolsPath in new[] { @"bin\", @"usr\bin\" })
             {
                 gitpath = gitpath.Replace(@"\cmd\git.exe", @"\" + toolsPath)
                     .Replace(@"\cmd\git.cmd", @"\" + toolsPath)
                     .Replace(@"\bin\git.exe", @"\" + toolsPath);
 
-                if (Directory.Exists(gitpath))
+                if (ContainsSh(gitpath))
                 {
-                    if (File.Exists(gitpath + "sh.exe") || File.Exists(gitpath + "sh"))
+                    AppSettings.GitBinDir = gitpath;
+                    return true;
+                }
+
+                if (CheckIfFileIsInPath("sh.exe") || CheckIfFileIsInPath("sh"))
+                {
+                    AppSettings.GitBinDir = string.Empty;
+                    return true;
+                }
+
+                foreach (string path in GetGitLocations())
+                {
+                    gitpath = path + toolsPath;
+                    if (ContainsSh(gitpath))
                     {
                         AppSettings.GitBinDir = gitpath;
                         return true;
                     }
                 }
-
-                if (CheckIfFileIsInPath("sh.exe") || CheckIfFileIsInPath("sh"))
-                {
-                    AppSettings.GitBinDir = "";
-                    return true;
-                }
-
-                foreach (var path in GetGitLocations())
-                {
-                    if (Directory.Exists(path + toolsPath))
-                    {
-                        if (File.Exists(path + toolsPath + "sh.exe") || File.Exists(path + toolsPath + "sh"))
-                        {
-                            AppSettings.GitBinDir = path + toolsPath;
-                            return true;
-                        }
-                    }
-                }
             }
 
             return false;
+
+            static bool ContainsSh(string path) => Directory.Exists(path) && (File.Exists(path + "sh.exe") || File.Exists(path + "sh"));
         }
 
         private static IEnumerable<string> GetGitLocations()

--- a/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
@@ -30,7 +30,7 @@ namespace GitCommandsTests.Git
             var userAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             var settingPath = Path.Combine(userAppDataPath, "GitExtensions\\GitExtensions\\GitExtensions.settings");
             var settingContainer = new RepoDistSettings(null, GitExtSettingsCache.FromCache(settingPath), SettingLevel.Unknown);
-            _appPath = Path.Combine(settingContainer.GetString("gitbindir", ""), "git.exe");
+            _appPath = settingContainer.GetString("gitcommand", "git.exe");
 
             // Execute process in GitExtension working directory, so that git will return success exit-code
             // git always return non-zero exit code when run git reset outside of git repository


### PR DESCRIPTION
## Proposed changes

- Do not reset a valid `AppSettings.GitBinDir` if `sh` is found in - GE's extended private - `PATH`
- Really try "usr\bin" *and* "bin" subfolders - in changed sequence (as recommended by @vbjay)
- Fixup false friend "gitbindir" in setup of `ExecutableExtensionsTests.SetUp`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

This AppSetting was reset in the second run, and `Repair` did not work:
 
![grafik](https://user-images.githubusercontent.com/36601201/114321090-45a71e80-9b19-11eb-960f-f851e8b98637.png)
![grafik](https://user-images.githubusercontent.com/36601201/114320893-72a70180-9b18-11eb-94bf-00eca56d8b6b.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/114321233-fca39a00-9b19-11eb-97c3-6f3b4bf0d5b7.png)

## Test methodology <!-- How did you ensure quality? -->

- have git in the `PATH`, namely "C:\Program Files\Git\cmd"
- do not specify the path to the git executable
- set Linux tools path to "C:\Program Files\Git\bin"
- restart twice

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 639f83d6ffd9b756a61a7e433284e70221581047
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
