### PR TITLE
Remove false comment regarding ColorSettingsPage

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPageController.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPageController.cs
@@ -22,32 +22,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             _themePathProvider = themePathProvider;
         }
 
-        public bool SettingsAreModified
-        {
-            get
-            {
-                if (_page.SelectedThemeId != ThemeModule.Settings.Theme.Id)
-                {
-                    return true;
-                }
-
-                if (_page.SelectedThemeId == ThemeId.Default)
-                {
-                    // UseSystemVisualStyle and ThemeVariations settings are only applicable with non-default theme.
-                    // However, in order to preserve user preference, we do not reset these when
-                    // user chooses the default theme from the menu, we only disable the checkboxes.
-
-                    // This is why, when the default theme is selected, we should ignore any difference in
-                    // UseSystemVisualStyle or ThemeVariations checkboxes from the actual theme settings.
-                    // Their value is not applied and only kept to be applied when user chooses non-default theme
-                    // again.
-                    return false;
-                }
-
-                return _page.UseSystemVisualStyle != ThemeModule.Settings.UseSystemVisualStyle ||
-                    !_page.SelectedThemeVariations.SequenceEqual(AppSettings.ThemeVariations);
-            }
-        }
+        public bool SettingsAreModified =>
+            _page.SelectedThemeId != ThemeModule.Settings.Theme.Id ||
+            _page.UseSystemVisualStyle != ThemeModule.Settings.UseSystemVisualStyle ||
+            !_page.SelectedThemeVariations.SequenceEqual(AppSettings.ThemeVariations);
 
         public void ShowThemeSettings()
         {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPageController.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPageController.cs
@@ -23,9 +23,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         }
 
         public bool SettingsAreModified =>
-            _page.SelectedThemeId != ThemeModule.Settings.Theme.Id ||
-            _page.UseSystemVisualStyle != ThemeModule.Settings.UseSystemVisualStyle ||
-            !_page.SelectedThemeVariations.SequenceEqual(AppSettings.ThemeVariations);
+            _page.SelectedThemeId != ThemeModule.Settings.Theme.Id
+            || _page.UseSystemVisualStyle != ThemeModule.Settings.UseSystemVisualStyle
+            || !_page.SelectedThemeVariations.SequenceEqual(AppSettings.ThemeVariations);
 
         public void ShowThemeSettings()
         {

--- a/GitUI/Theming/ThemeModule.cs
+++ b/GitUI/Theming/ThemeModule.cs
@@ -11,6 +11,8 @@ namespace GitUI.Theming
 {
     public static class ThemeModule
     {
+        private static bool _suppressWin32Hooks;
+
         public static ThemeSettings Settings { get; private set; } = ThemeSettings.Default;
 
         private static ThemeRepository Repository { get; } = new();
@@ -74,7 +76,7 @@ namespace GitUI.Theming
                 return CreateFallbackSettings(invariantTheme);
             }
 
-            if (!AppSettings.UseSystemVisualStyle)
+            if (!AppSettings.UseSystemVisualStyle && !_suppressWin32Hooks)
             {
                 try
                 {
@@ -153,6 +155,12 @@ namespace GitUI.Theming
         {
             public static void ReloadThemeSettings(IThemeRepository repository) =>
                 Settings = LoadThemeSettings(repository);
+
+            public static bool SuppressWin32Hooks
+            {
+                get => _suppressWin32Hooks;
+                set => _suppressWin32Hooks = value;
+            }
         }
     }
 }

--- a/GitUI/Theming/ThemeModule.cs
+++ b/GitUI/Theming/ThemeModule.cs
@@ -11,7 +11,7 @@ namespace GitUI.Theming
 {
     public static class ThemeModule
     {
-        private static bool _suppressWin32Hooks;
+        private static bool _suppressWin32HooksForTests;
 
         public static ThemeSettings Settings { get; private set; } = ThemeSettings.Default;
 
@@ -76,7 +76,7 @@ namespace GitUI.Theming
                 return CreateFallbackSettings(invariantTheme);
             }
 
-            if (!AppSettings.UseSystemVisualStyle && !_suppressWin32Hooks)
+            if (!AppSettings.UseSystemVisualStyle && !_suppressWin32HooksForTests)
             {
                 try
                 {
@@ -158,8 +158,8 @@ namespace GitUI.Theming
 
             public static bool SuppressWin32Hooks
             {
-                get => _suppressWin32Hooks;
-                set => _suppressWin32Hooks = value;
+                get => _suppressWin32HooksForTests;
+                set => _suppressWin32HooksForTests = value;
             }
         }
     }


### PR DESCRIPTION
Some time ago the event handlers from ColorsSettingsPage.cs were lost by mistake.

Before knowing that, I misinterpreted what was going on, which lead me to writing [this](https://github.com/NikolayXHD/gitextensions/blob/b1f96fa753ec3d7960f71cd412f7fd80a42ac98a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettingsPage.cs#L89)

Here I revert that unnecessary complication, as well as the factually incorrect comment I wrote to explain it.

## Test

Tested manually and with unit tests

----
:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
