### PR TITLE
Some GitHub plugin fixes

### DIFF
--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.Designer.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.Designer.cs
@@ -36,7 +36,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             | System.Windows.Forms.AnchorStyles.Right)));
             this._titleTB.Location = new System.Drawing.Point(58, 19);
             this._titleTB.Name = "_titleTB";
-            this._titleTB.Size = new System.Drawing.Size(462, 23);
+            this._titleTB.Size = new System.Drawing.Size(462, 20);
             this._titleTB.TabIndex = 0;
             // 
             // label1
@@ -44,7 +44,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(6, 22);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(33, 15);
+            this.label1.Size = new System.Drawing.Size(30, 13);
             this.label1.TabIndex = 1;
             this.label1.Text = "Title:";
             // 
@@ -53,7 +53,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(6, 48);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(37, 15);
+            this.label2.Size = new System.Drawing.Size(34, 13);
             this.label2.TabIndex = 2;
             this.label2.Text = "Body:";
             // 
@@ -87,11 +87,13 @@ namespace GitUI.CommandsDialogs.RepoHosting
             // 
             // _pullReqTargetsCB
             // 
+            this._pullReqTargetsCB.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this._pullReqTargetsCB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this._pullReqTargetsCB.FormattingEnabled = true;
             this._pullReqTargetsCB.Location = new System.Drawing.Point(141, 12);
             this._pullReqTargetsCB.Name = "_pullReqTargetsCB";
-            this._pullReqTargetsCB.Size = new System.Drawing.Size(246, 23);
+            this._pullReqTargetsCB.Size = new System.Drawing.Size(391, 21);
             this._pullReqTargetsCB.TabIndex = 3;
             this._pullReqTargetsCB.SelectedIndexChanged += new System.EventHandler(this._pullReqTargetsCB_SelectedIndexChanged);
             // 
@@ -100,7 +102,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.label3.AutoSize = true;
             this.label3.Location = new System.Drawing.Point(9, 15);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(100, 15);
+            this.label3.Size = new System.Drawing.Size(89, 13);
             this.label3.TabIndex = 5;
             this.label3.Text = "Target repository:";
             // 
@@ -120,7 +122,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.label4.AutoSize = true;
             this.label4.Location = new System.Drawing.Point(9, 42);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(75, 15);
+            this.label4.Size = new System.Drawing.Size(68, 13);
             this.label4.TabIndex = 7;
             this.label4.Text = "Your branch:";
             // 
@@ -129,27 +131,31 @@ namespace GitUI.CommandsDialogs.RepoHosting
             this.label5.AutoSize = true;
             this.label5.Location = new System.Drawing.Point(9, 69);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(84, 15);
+            this.label5.Size = new System.Drawing.Size(77, 13);
             this.label5.TabIndex = 8;
             this.label5.Text = "Target branch:";
             // 
             // _yourBranchesCB
             // 
+            this._yourBranchesCB.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this._yourBranchesCB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this._yourBranchesCB.FormattingEnabled = true;
             this._yourBranchesCB.Location = new System.Drawing.Point(141, 39);
             this._yourBranchesCB.Name = "_yourBranchesCB";
-            this._yourBranchesCB.Size = new System.Drawing.Size(246, 23);
+            this._yourBranchesCB.Size = new System.Drawing.Size(391, 21);
             this._yourBranchesCB.TabIndex = 0;
             this._yourBranchesCB.SelectedIndexChanged += new System.EventHandler(this._yourBranchCB_SelectedIndexChanged);
             // 
             // _remoteBranchesCB
             // 
+            this._remoteBranchesCB.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this._remoteBranchesCB.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this._remoteBranchesCB.FormattingEnabled = true;
             this._remoteBranchesCB.Location = new System.Drawing.Point(141, 66);
             this._remoteBranchesCB.Name = "_remoteBranchesCB";
-            this._remoteBranchesCB.Size = new System.Drawing.Size(246, 23);
+            this._remoteBranchesCB.Size = new System.Drawing.Size(391, 21);
             this._remoteBranchesCB.TabIndex = 1;
             this._remoteBranchesCB.SelectedIndexChanged += new System.EventHandler(this._yourBranchCB_SelectedIndexChanged);
             // 

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -132,31 +132,37 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     {
                         await TaskScheduler.Default;
 
-                        IHostedRepository hostedRepository = remote.GetHostedRepository();
-                        var branches = hostedRepository.GetBranches();
-
-                        await this.SwitchToMainThreadAsync();
-
-                        comboBox.Items.Clear();
-
-                        var selectItem = 0;
-                        var defaultBranch = hostedRepository.GetDefaultBranch();
-                        for (var i = 0; i < branches.Count; i++)
+                        try
                         {
-                            if (branches[i].Name == defaultBranch)
+                            IHostedRepository hostedRepository = remote.GetHostedRepository();
+                            var branches = hostedRepository.GetBranches();
+
+                            await this.SwitchToMainThreadAsync();
+
+                            comboBox.Items.Clear();
+
+                            var selectItem = 0;
+                            var defaultBranch = hostedRepository.GetDefaultBranch();
+                            for (var i = 0; i < branches.Count; i++)
                             {
-                                selectItem = i;
+                                if (branches[i].Name == defaultBranch)
+                                {
+                                    selectItem = i;
+                                }
+
+                                comboBox.Items.Add(branches[i].Name);
                             }
 
-                            comboBox.Items.Add(branches[i].Name);
-                        }
+                            if (branches.Count > 0)
+                            {
+                                comboBox.SelectedIndex = selectItem;
+                            }
 
-                        if (branches.Count > 0)
+                            _createBtn.Enabled = true;
+                        }
+                        catch (Exception)
                         {
-                            comboBox.SelectedIndex = selectItem;
                         }
-
-                        _createBtn.Enabled = true;
                     })
                 .FileAndForget();
         }

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -112,11 +112,13 @@ namespace GitUI.CommandsDialogs.RepoHosting
             }
             catch (Exception)
             {
+                SelectNextHostedRepositoryIfFirstLoad();
                 return;
             }
 
             if (hostedRepo is null)
             {
+                SelectNextHostedRepositoryIfFirstLoad();
                 return;
             }
 
@@ -143,6 +145,14 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     }
                 })
                 .FileAndForget();
+
+            void SelectNextHostedRepositoryIfFirstLoad()
+            {
+                if (_isFirstLoad)
+                {
+                    SelectNextHostedRepository();
+                }
+            }
         }
 
         private void FileViewer_TopScrollReached(object sender, EventArgs e)
@@ -161,11 +171,14 @@ namespace GitUI.CommandsDialogs.RepoHosting
         {
             if (_isFirstLoad)
             {
-                _isFirstLoad = false;
                 if (infos is not null && infos.Count == 0 && _hostedRemotes is not null && _hostedRemotes.Count > 0)
                 {
                     SelectNextHostedRepository();
                     return;
+                }
+                else
+                {
+                    _isFirstLoad = false;
                 }
             }
 
@@ -217,7 +230,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             int i = _selectHostedRepoCB.SelectedIndex + 1;
             if (i >= _selectHostedRepoCB.Items.Count)
             {
-                i = 0;
+                return;
             }
 
             _selectHostedRepoCB.SelectedIndex = i;

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -10,6 +10,7 @@ using GitUIPluginInterfaces;
 using GitUIPluginInterfaces.RepositoryHosts;
 using Microsoft;
 using Microsoft.VisualStudio.Threading;
+using Microsoft.WindowsAPICodePack.Dialogs;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs.RepoHosting
@@ -26,6 +27,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         private readonly TranslationString _strUnableUnderstandPatch = new("Error: Unable to understand patch");
         private readonly TranslationString _strRemoteAlreadyExist = new("ERROR: Remote with name {0} already exists but it points to a different repository!\r\nDetails: Is {1} expected {2}");
         private readonly TranslationString _strCouldNotAddRemote = new("Could not add remote with name {0} and URL {1}");
+        private readonly TranslationString _strRemoteIgnore = new("Remote ignored");
         #endregion
 
         private GitProtocol _cloneGitProtocol;
@@ -82,8 +84,15 @@ namespace GitUI.CommandsDialogs.RepoHosting
                         {
                             hostedRemote.GetHostedRepository(); // We do this now because we want to do it in the async part.
                         }
-                        catch (Exception)
+                        catch (Exception ex)
                         {
+                            System.Windows.Forms.TaskDialog.ShowDialog(new TaskDialogPage
+                            {
+                                Icon = TaskDialogIcon.Error,
+                                Caption = _strRemoteIgnore.Text,
+                                Text = string.Format(TranslatedStrings.RemoteInError, ex.Message, hostedRemote.DisplayData),
+                                Buttons = { System.Windows.Forms.TaskDialogButton.OK },
+                            });
                         }
                     }
 
@@ -112,6 +121,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             }
             catch (Exception)
             {
+                // if fails to load this remote, select the next one
                 SelectNextHostedRepositoryIfFirstLoad();
                 return;
             }

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -107,6 +107,8 @@ namespace GitUI
         private readonly TranslationString _openInVisualStudioFailureText = new("Could not find this file in any open solution. Ensure you have a project containing this file open before trying again.");
         private readonly TranslationString _openInVisualStudioFailureCaption = new("Unable to open file");
 
+        private readonly TranslationString _remoteInError = new("{0}\n\nRemote: {1}");
+
         // public only because of FormTranslate
         public TranslatedStrings()
         {
@@ -219,6 +221,7 @@ namespace GitUI
 
         public static string OpenInVisualStudioFailureText => _instance.Value._openInVisualStudioFailureText.Text;
         public static string OpenInVisualStudioFailureCaption => _instance.Value._openInVisualStudioFailureCaption.Text;
+        public static string RemoteInError => _instance.Value._remoteInError.Text;
 
         #region Scripts
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1104,6 +1104,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Pull request</source>
         <target />
       </trans-unit>
+      <trans-unit id="_strRemoteFailToLoadBranches.Text">
+        <source>Fail to load target branches</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_strYouMustSpecifyATitle.Text">
         <source>You must specify a title.</source>
         <target />
@@ -9818,6 +9822,12 @@ Select this commit to populate the full message.</source>
         <source>Remote</source>
         <target />
       </trans-unit>
+      <trans-unit id="_remoteInError.Text">
+        <source>{0}
+
+Remote: {1}</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_remotesText.Text">
         <source>Remotes</source>
         <target />
@@ -10039,6 +10049,10 @@ Yes, I allow telemetry!</source>
       <trans-unit id="_strRemoteAlreadyExist.Text">
         <source>ERROR: Remote with name {0} already exists but it points to a different repository!
 Details: Is {1} expected {2}</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_strRemoteIgnore.Text">
+        <source>Remote ignored</source>
         <target />
       </trans-unit>
       <trans-unit id="_strUnableUnderstandPatch.Text">


### PR DESCRIPTION
## Proposed changes

-  ViewPullRequestsForm: 
    - better handle error on one remote (form is now still usable when a remote is on error)
    - fix selection of first remote found with at least a pull request
- CreatePullRequestForm: 
    - better handle error on one remote (form is now still usable when a remote is on error)
    - CreatePullRequestForm: increase width of dropdown 

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Unable to do one easily but red arrow in 'after' screenshot show width increase to display well long branch name

### After

![image](https://user-images.githubusercontent.com/460196/114780658-fca0d580-9d77-11eb-8340-787c075887a7.png)

- ViewPullRequestsForm:

![image](https://user-images.githubusercontent.com/460196/115632346-cc24e280-a307-11eb-8b3a-d12797eba8d6.png)

- CreatePullRequestForm: 

![image](https://user-images.githubusercontent.com/460196/115632436-ff677180-a307-11eb-9a39-df9b3b7d4377.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 47bb7083c58cafdb7d180c425a88389b116b6f44
- Git 2.28.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4341.0
- DPI 192dpi (200% scaling)

