### PR TITLE
Fix settings saving for "Detailed" section by selected setting source

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -11,7 +11,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using GitCommands.Settings;
-using GitCommands.Utils;
 using GitExtUtils;
 using GitExtUtils.GitUI.Theming;
 using GitUIPluginInterfaces;
@@ -1082,8 +1081,8 @@ namespace GitCommands
 
         public static string Dictionary
         {
-            get => SettingsContainer.Dictionary;
-            set => SettingsContainer.Dictionary = value;
+            get => SettingsContainer.Detached().Dictionary;
+            set => SettingsContainer.Detached().Dictionary = value;
         }
 
         public static bool ShowGitCommandLine

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -890,20 +890,20 @@ namespace GitCommands
 
         public static string SmtpServer
         {
-            get => GetString("SmtpServer", "smtp.gmail.com");
-            set => SetString("SmtpServer", value);
+            get => SettingsContainer.Detailed().SmtpServer;
+            set => SettingsContainer.Detailed().SmtpServer = value;
         }
 
         public static int SmtpPort
         {
-            get => GetInt("SmtpPort", 465);
-            set => SetInt("SmtpPort", value);
+            get => SettingsContainer.Detailed().SmtpPort;
+            set => SettingsContainer.Detailed().SmtpPort = value;
         }
 
         public static bool SmtpUseSsl
         {
-            get => GetBool("SmtpUseSsl", true);
-            set => SetBool("SmtpUseSsl", value);
+            get => SettingsContainer.Detailed().SmtpUseSsl;
+            set => SettingsContainer.Detailed().SmtpUseSsl = value;
         }
 
         public static bool AutoStash

--- a/GitCommands/Settings/BuildServerSettings.cs
+++ b/GitCommands/Settings/BuildServerSettings.cs
@@ -1,0 +1,63 @@
+﻿using GitUIPluginInterfaces;
+using GitUIPluginInterfaces.Settings;
+
+namespace GitCommands.Settings
+{
+    internal sealed class BuildServerSettings : IBuildServerSettings
+    {
+        private const string BuildServerGroupName = "BuildServer";
+
+        private const string? TypeDefault = null;
+        private const bool EnableIntegrationDefault = false;
+        private const bool ShowBuildResultPageDefault = true;
+
+        private readonly ISettingsSource _settingsSource;
+
+        public BuildServerSettings(ISettingsSource settingsSource)
+        {
+            _settingsSource = settingsSource;
+        }
+
+        public string? Type
+        {
+            get => _settingsSource.GetString($"{BuildServerGroupName}.{nameof(Type)}", TypeDefault);
+            set
+            {
+                if (Type == value)
+                {
+                    return;
+                }
+
+                _settingsSource.SetString($"{BuildServerGroupName}.{nameof(Type)}", value);
+            }
+        }
+
+        public bool EnableIntegration
+        {
+            get => _settingsSource.GetBool($"{BuildServerGroupName}.{nameof(EnableIntegration)}", EnableIntegrationDefault);
+            set
+            {
+                if (EnableIntegration == value)
+                {
+                    return;
+                }
+
+                _settingsSource.SetBool($"{BuildServerGroupName}.{nameof(EnableIntegration)}", value);
+            }
+        }
+
+        public bool ShowBuildResultPage
+        {
+            get => _settingsSource.GetBool($"{BuildServerGroupName}.{nameof(ShowBuildResultPage)}", ShowBuildResultPageDefault);
+            set
+            {
+                if (ShowBuildResultPage == value)
+                {
+                    return;
+                }
+
+                _settingsSource.SetBool($"{BuildServerGroupName}.{nameof(ShowBuildResultPage)}", value);
+            }
+        }
+    }
+}

--- a/GitCommands/Settings/DetachedServerSettings.cs
+++ b/GitCommands/Settings/DetachedServerSettings.cs
@@ -1,0 +1,46 @@
+﻿using GitUIPluginInterfaces;
+using GitUIPluginInterfaces.Settings;
+
+namespace GitCommands.Settings
+{
+    internal sealed class DetachedSettings : IDetachedSettings
+    {
+        private const string DictionaryDefault = "en-US";
+        private const bool NoFastForwardMergeDefault = false;
+
+        private readonly ISettingsSource _settingsSource;
+
+        public DetachedSettings(ISettingsSource settingsSource)
+        {
+            _settingsSource = settingsSource;
+        }
+
+        public string Dictionary
+        {
+            get => _settingsSource.GetString(nameof(Dictionary).ToLower(), DictionaryDefault);
+            set
+            {
+                if (Dictionary == value)
+                {
+                    return;
+                }
+
+                _settingsSource.SetString(nameof(Dictionary).ToLower(), value);
+            }
+        }
+
+        public bool NoFastForwardMerge
+        {
+            get => _settingsSource.GetBool(nameof(NoFastForwardMerge), NoFastForwardMergeDefault);
+            set
+            {
+                if (NoFastForwardMerge == value)
+                {
+                    return;
+                }
+
+                _settingsSource.SetBool(nameof(NoFastForwardMerge), value);
+            }
+        }
+    }
+}

--- a/GitCommands/Settings/DetailedSettings.cs
+++ b/GitCommands/Settings/DetailedSettings.cs
@@ -1,0 +1,108 @@
+﻿using GitUIPluginInterfaces;
+using GitUIPluginInterfaces.Settings;
+
+namespace GitCommands.Settings
+{
+    internal sealed class DetailedSettings : IDetailedSettings
+    {
+        private const string DetailedGroupName = "Detailed";
+
+        private const string SmtpServerDefault = "smtp.gmail.com";
+        private const int SmtpPortDefault = 465;
+        private const bool SmtpUseSslDefault = true;
+        private const bool GetRemoteBranchesDirectlyFromRemoteDefault = false;
+        private const bool AddMergeLogMessagesDefault = false;
+        private const int MergeLogMessagesCountDefault = 20;
+
+        private readonly ISettingsSource _settingsSource;
+
+        public DetailedSettings(ISettingsSource settingsSource)
+        {
+            _settingsSource = settingsSource;
+        }
+
+        public string SmtpServer
+        {
+            get => _settingsSource.GetString(nameof(SmtpServer), SmtpServerDefault);
+            set
+            {
+                if (SmtpServer == value)
+                {
+                    return;
+                }
+
+                _settingsSource.SetString(nameof(SmtpServer), value);
+            }
+        }
+
+        public int SmtpPort
+        {
+            get => _settingsSource.GetInt(nameof(SmtpPort), SmtpPortDefault);
+            set
+            {
+                if (SmtpPort == value)
+                {
+                    return;
+                }
+
+                _settingsSource.SetInt(nameof(SmtpPort), value);
+            }
+        }
+
+        public bool SmtpUseSsl
+        {
+            get => _settingsSource.GetBool(nameof(SmtpUseSsl), SmtpUseSslDefault);
+            set
+            {
+                if (SmtpUseSsl == value)
+                {
+                    return;
+                }
+
+                _settingsSource.SetBool(nameof(SmtpUseSsl), value);
+            }
+        }
+
+        public bool GetRemoteBranchesDirectlyFromRemote
+        {
+            get => _settingsSource.GetBool($"{DetailedGroupName}.{nameof(GetRemoteBranchesDirectlyFromRemote)}", GetRemoteBranchesDirectlyFromRemoteDefault);
+            set
+            {
+                if (GetRemoteBranchesDirectlyFromRemote == value)
+                {
+                    return;
+                }
+
+                _settingsSource.SetBool($"{DetailedGroupName}.{nameof(GetRemoteBranchesDirectlyFromRemote)}", value);
+            }
+        }
+
+        public bool AddMergeLogMessages
+        {
+            get => _settingsSource.GetBool($"{DetailedGroupName}.{nameof(AddMergeLogMessages)}", AddMergeLogMessagesDefault);
+            set
+            {
+                if (AddMergeLogMessages == value)
+                {
+                    return;
+                }
+
+                _settingsSource.SetBool($"{DetailedGroupName}.{nameof(AddMergeLogMessages)}", value);
+            }
+        }
+
+        public int MergeLogMessagesCount
+        {
+            get => _settingsSource.GetInt($"{DetailedGroupName}.{nameof(MergeLogMessagesCount)}", MergeLogMessagesCountDefault);
+            set
+            {
+                if (MergeLogMessagesCount == value)
+                {
+                    return;
+                }
+
+                _settingsSource.SetInt($"{DetailedGroupName}.{nameof(MergeLogMessagesCount)}", value);
+            }
+        }
+    }
+}

--- a/GitCommands/Settings/RepoDistSettings.cs
+++ b/GitCommands/Settings/RepoDistSettings.cs
@@ -14,7 +14,6 @@ namespace GitCommands.Settings
             : base(lowerPriority, settingsCache)
         {
             BuildServer = new BuildServer(this);
-            Detailed = new DetailedGroup(this);
             SettingLevel = settingLevel;
         }
 
@@ -100,7 +99,6 @@ namespace GitCommands.Settings
         }
 
         public readonly BuildServer BuildServer;
-        public readonly DetailedGroup Detailed;
 
         public bool NoFastForwardMerge
         {
@@ -130,20 +128,5 @@ namespace GitCommands.Settings
         }
 
         public SettingsPath TypeSettings => new SettingsPath(this, Type.Value!);
-    }
-
-    public class DetailedGroup : SettingsPath
-    {
-        public readonly ISetting<bool> GetRemoteBranchesDirectlyFromRemote;
-        public readonly ISetting<bool> AddMergeLogMessages;
-        public readonly ISetting<int> MergeLogMessagesCount;
-
-        public DetailedGroup(RepoDistSettings container)
-            : base(container, "Detailed")
-        {
-            GetRemoteBranchesDirectlyFromRemote = Setting.Create(this, nameof(GetRemoteBranchesDirectlyFromRemote), false);
-            AddMergeLogMessages = Setting.Create(this, nameof(AddMergeLogMessages), false);
-            MergeLogMessagesCount = Setting.Create(this, nameof(MergeLogMessagesCount), 20);
-        }
     }
 }

--- a/GitCommands/Settings/RepoDistSettings.cs
+++ b/GitCommands/Settings/RepoDistSettings.cs
@@ -13,7 +13,6 @@ namespace GitCommands.Settings
         public RepoDistSettings(RepoDistSettings? lowerPriority, GitExtSettingsCache settingsCache, SettingLevel settingLevel)
             : base(lowerPriority, settingsCache)
         {
-            BuildServer = new BuildServer(this);
             SettingLevel = settingLevel;
         }
 
@@ -98,8 +97,6 @@ namespace GitCommands.Settings
             }
         }
 
-        public readonly BuildServer BuildServer;
-
         public bool NoFastForwardMerge
         {
             get => GetBool("NoFastForwardMerge", false);
@@ -111,22 +108,5 @@ namespace GitCommands.Settings
             get => GetString("dictionary", "en-US");
             set => SetString("dictionary", value);
         }
-    }
-
-    public class BuildServer : SettingsPath
-    {
-        public readonly ISetting<string> Type;
-        public readonly ISetting<bool> EnableIntegration;
-        public readonly ISetting<bool> ShowBuildResultPage;
-
-        public BuildServer(RepoDistSettings container)
-            : base(container, "BuildServer")
-        {
-            Type = Setting.Create(this, nameof(Type), null);
-            EnableIntegration = Setting.Create(this, nameof(EnableIntegration), false);
-            ShowBuildResultPage = Setting.Create(this, nameof(ShowBuildResultPage), true);
-        }
-
-        public SettingsPath TypeSettings => new SettingsPath(this, Type.Value!);
     }
 }

--- a/GitCommands/Settings/RepoDistSettings.cs
+++ b/GitCommands/Settings/RepoDistSettings.cs
@@ -96,17 +96,5 @@ namespace GitCommands.Settings
                 LowerPriority!.SetValue(name, value, encode);
             }
         }
-
-        public bool NoFastForwardMerge
-        {
-            get => GetBool("NoFastForwardMerge", false);
-            set => SetBool("NoFastForwardMerge", value);
-        }
-
-        public string Dictionary
-        {
-            get => GetString("dictionary", "en-US");
-            set => SetString("dictionary", value);
-        }
     }
 }

--- a/GitCommands/Settings/SettingsSourceExtension.cs
+++ b/GitCommands/Settings/SettingsSourceExtension.cs
@@ -13,5 +13,8 @@ namespace GitCommands.Settings
 
         public static IBuildServerSettings BuildServer(this ISettingsSource settingsSource)
             => new BuildServerSettings(settingsSource);
+
+        public static IDetachedSettings Detached(this ISettingsSource settingsSource)
+            => new DetachedSettings(settingsSource);
     }
 }

--- a/GitCommands/Settings/SettingsSourceExtension.cs
+++ b/GitCommands/Settings/SettingsSourceExtension.cs
@@ -5,7 +5,13 @@ namespace GitCommands.Settings
 {
     public static class SettingsSourceExtension
     {
+        public static ISettingsSource ByPath(this ISettingsSource settingsSource, string pathName)
+            => new SettingsPath(settingsSource, pathName);
+
         public static IDetailedSettings Detailed(this ISettingsSource settingsSource)
             => new DetailedSettings(settingsSource);
+
+        public static IBuildServerSettings BuildServer(this ISettingsSource settingsSource)
+            => new BuildServerSettings(settingsSource);
     }
 }

--- a/GitCommands/Settings/SettingsSourceExtension.cs
+++ b/GitCommands/Settings/SettingsSourceExtension.cs
@@ -1,0 +1,11 @@
+﻿using GitUIPluginInterfaces;
+using GitUIPluginInterfaces.Settings;
+
+namespace GitCommands.Settings
+{
+    public static class SettingsSourceExtension
+    {
+        public static IDetailedSettings Detailed(this ISettingsSource settingsSource)
+            => new DetailedSettings(settingsSource);
+    }
+}

--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -14,6 +14,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.Remotes;
+using GitCommands.Settings;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;
 using GitUI.HelperDialogs;
 using GitUI.UserControls;
@@ -21,6 +22,7 @@ using GitUI.UserControls.RevisionGrid;
 using GitUI.UserControls.RevisionGrid.Columns;
 using GitUIPluginInterfaces;
 using GitUIPluginInterfaces.BuildServerIntegration;
+using GitUIPluginInterfaces.Settings;
 using Microsoft.VisualStudio.Threading;
 
 namespace GitUI.BuildServerIntegration
@@ -294,14 +296,15 @@ namespace GitUI.BuildServerIntegration
         {
             await TaskScheduler.Default;
 
-            var buildServerSettings = _module().EffectiveSettings.BuildServer;
+            IBuildServerSettings buildServerSettings = _module().GetEffectiveSettings()
+                .BuildServer();
 
-            if (!buildServerSettings.EnableIntegration.Value)
+            if (!buildServerSettings.EnableIntegration)
             {
                 return null;
             }
 
-            var buildServerType = buildServerSettings.Type.Value;
+            var buildServerType = buildServerSettings.Type;
             if (string.IsNullOrEmpty(buildServerType))
             {
                 return null;
@@ -323,7 +326,7 @@ namespace GitUI.BuildServerIntegration
 
                     var buildServerAdapter = export.Value;
 
-                    buildServerAdapter.Initialize(this, buildServerSettings.TypeSettings,
+                    buildServerAdapter.Initialize(this, _module().GetEffectiveSettings().ByPath(buildServerSettings.Type!),
                         () =>
                         {
                             // To run the `StartSettingsDialog()` in the UI Thread

--- a/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
+++ b/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
@@ -9,6 +9,7 @@ using System.Windows.Forms;
 using GitCommands.Settings;
 using GitUI.UserControls;
 using GitUIPluginInterfaces;
+using GitUIPluginInterfaces.Settings;
 using Microsoft;
 
 namespace GitUI.CommandsDialogs
@@ -220,8 +221,11 @@ namespace GitUI.CommandsDialogs
 
         private bool IsBuildResultPageEnabled()
         {
-            var settings = GetModule().GetEffectiveSettings() as RepoDistSettings;
-            return settings?.BuildServer.ShowBuildResultPage.Value ?? false;
+            IBuildServerSettings buildServerSettings = GetModule()
+                .GetEffectiveSettings()
+                .BuildServer();
+
+            return buildServerSettings.ShowBuildResultPage;
         }
 
         private IGitModule GetModule()

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -47,7 +47,10 @@ namespace GitUI.CommandsDialogs
             helpImageDisplayUserControl1.Visible = !AppSettings.DontShowHelpImages;
             _defaultBranch = defaultBranch;
 
-            noFastForward.Checked = Module.EffectiveSettings.NoFastForwardMerge;
+            IDetachedSettings detachedSettings = Module.GetEffectiveSettings()
+                .Detached();
+
+            noFastForward.Checked = detachedSettings.NoFastForwardMerge;
 
             IDetailedSettings detailedSettings = Module.GetEffectiveSettings()
                 .Detailed();
@@ -92,7 +95,10 @@ namespace GitUI.CommandsDialogs
 
         private void OkClick(object sender, EventArgs e)
         {
-            Module.EffectiveSettings.NoFastForwardMerge = noFastForward.Checked;
+            IDetachedSettings detachedSettings = Module.GetEffectiveSettings()
+                .Detached();
+
+            detachedSettings.NoFastForwardMerge = noFastForward.Checked;
             AppSettings.DontCommitMerge = noCommit.Checked;
 
             bool success = ScriptManager.RunEventScripts(this, ScriptEvent.BeforeMerge);

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -3,9 +3,11 @@ using System.Drawing;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git.Commands;
+using GitCommands.Settings;
 using GitExtUtils.GitUI.Theming;
 using GitUI.HelperDialogs;
 using GitUI.Script;
+using GitUIPluginInterfaces.Settings;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs
@@ -46,8 +48,12 @@ namespace GitUI.CommandsDialogs
             _defaultBranch = defaultBranch;
 
             noFastForward.Checked = Module.EffectiveSettings.NoFastForwardMerge;
-            addLogMessages.Checked = Module.EffectiveSettings.Detailed.AddMergeLogMessages.Value;
-            nbMessages.Value = Module.EffectiveSettings.Detailed.MergeLogMessagesCount.Value;
+
+            IDetailedSettings detailedSettings = Module.GetEffectiveSettings()
+                .Detailed();
+
+            addLogMessages.Checked = detailedSettings.AddMergeLogMessages;
+            nbMessages.Value = detailedSettings.MergeLogMessagesCount;
 
             advanced.Checked = AppSettings.AlwaysShowAdvOpt;
             advanced_CheckedChanged(this, EventArgs.Empty);
@@ -169,7 +175,11 @@ namespace GitUI.CommandsDialogs
         private void addMessages_CheckedChanged(object sender, EventArgs e)
         {
             nbMessages.Enabled = addLogMessages.Checked;
-            Module.EffectiveSettings.Detailed.AddMergeLogMessages.Value = addLogMessages.Checked;
+
+            IDetailedSettings detailedSettings = Module.GetEffectiveSettings()
+                .Detailed();
+
+            detailedSettings.AddMergeLogMessages = addLogMessages.Checked;
         }
 
         private void addMergeMessage_CheckedChanged(object sender, EventArgs e)
@@ -179,7 +189,10 @@ namespace GitUI.CommandsDialogs
 
         private void nbMessages_ValueChanged(object sender, EventArgs e)
         {
-            Module.EffectiveSettings.Detailed.MergeLogMessagesCount.Value = Convert.ToInt32(nbMessages.Value);
+            IDetailedSettings detailedSettings = Module.GetEffectiveSettings()
+                .Detailed();
+
+            detailedSettings.MergeLogMessagesCount = Convert.ToInt32(nbMessages.Value);
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -12,12 +12,14 @@ using GitCommands.Config;
 using GitCommands.Git;
 using GitCommands.Git.Commands;
 using GitCommands.Remotes;
+using GitCommands.Settings;
 using GitCommands.UserRepositoryHistory;
 using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
 using GitUI.Script;
 using GitUIPluginInterfaces;
+using GitUIPluginInterfaces.Settings;
 using Microsoft;
 using Microsoft.WindowsAPICodePack.Dialogs;
 using ResourceManager;
@@ -1008,7 +1010,10 @@ namespace GitUI.CommandsDialogs
             using (WaitCursorScope.Enter(Cursors.AppStarting))
             {
                 IReadOnlyList<IGitRef> remoteHeads;
-                if (Module.EffectiveSettings.Detailed.GetRemoteBranchesDirectlyFromRemote.Value)
+                IDetailedSettings detailedSettings = Module.GetEffectiveSettings()
+                    .Detailed();
+
+                if (detailedSettings.GetRemoteBranchesDirectlyFromRemote)
                 {
                     EnsurePageant(remote);
 

--- a/GitUI/CommandsDialogs/SettingsDialog/AutoLayoutSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/AutoLayoutSettingsPage.cs
@@ -3,19 +3,12 @@ using System.Drawing;
 using System.Windows.Forms;
 using GitExtUtils.GitUI;
 using GitUIPluginInterfaces;
-using Microsoft;
 
 namespace GitUI.CommandsDialogs.SettingsDialog
 {
     public abstract partial class AutoLayoutSettingsPage : RepoDistSettingsPage, ISettingsLayout
     {
         private ISettingsLayout? _settingsLayout;
-
-        protected override ISettingsSource GetCurrentSettings()
-        {
-            Validates.NotNull(CurrentSettings);
-            return CurrentSettings;
-        }
 
         protected virtual ISettingsLayout GetSettingsLayout()
         {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DetailedSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DetailedSettingsPage.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using GitCommands;
 using GitCommands.Settings;
-using Microsoft;
+using GitUIPluginInterfaces.Settings;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
@@ -14,37 +13,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             InitializeComplete();
         }
 
-        private DetailedGroup DetailedSettings
-        {
-            get
-            {
-                Validates.NotNull(CurrentSettings);
-                return CurrentSettings.Detailed;
-            }
-        }
-
         public static SettingsPageReference GetPageReference()
         {
             return new SettingsPageReferenceByType(typeof(DetailedSettingsPage));
-        }
-
-        protected override void Init(ISettingsPageHost pageHost)
-        {
-            base.Init(pageHost);
-            BindSettingsWithControls();
-        }
-
-        protected override void PageToSettings()
-        {
-            AppSettings.SmtpServer = SmtpServer.Text;
-            if (int.TryParse(SmtpServerPort.Text, out var port))
-            {
-                AppSettings.SmtpPort = port;
-            }
-
-            AppSettings.SmtpUseSsl = chkUseSSL.Checked;
-
-            base.PageToSettings();
         }
 
         protected override void OnRuntimeLoad()
@@ -57,18 +28,43 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         protected override void SettingsToPage()
         {
-            SmtpServer.Text = AppSettings.SmtpServer;
-            SmtpServerPort.Text = AppSettings.SmtpPort.ToString();
-            chkUseSSL.Checked = AppSettings.SmtpUseSsl;
+            IDetailedSettings detailedSettings = GetCurrentSettings()
+                .Detailed();
+
+            SmtpServer.Text = detailedSettings.SmtpServer;
+            SmtpServerPort.Text = detailedSettings.SmtpPort.ToString();
+            chkUseSSL.Checked = detailedSettings.SmtpUseSsl;
+
+            chkRemotesFromServer.Checked = detailedSettings.GetRemoteBranchesDirectlyFromRemote;
+            addLogMessages.Checked = detailedSettings.AddMergeLogMessages;
+            nbMessages.Text = detailedSettings.MergeLogMessagesCount.ToString();
 
             base.SettingsToPage();
         }
 
-        private void BindSettingsWithControls()
+        protected override void PageToSettings()
         {
-            AddSettingBinding(DetailedSettings.GetRemoteBranchesDirectlyFromRemote, chkRemotesFromServer);
-            AddSettingBinding(DetailedSettings.AddMergeLogMessages, addLogMessages);
-            AddSettingBinding(DetailedSettings.MergeLogMessagesCount, nbMessages);
+            IDetailedSettings detailedSettings = GetCurrentSettings()
+                .Detailed();
+
+            detailedSettings.SmtpServer = SmtpServer.Text;
+
+            if (int.TryParse(SmtpServerPort.Text, out var port))
+            {
+                detailedSettings.SmtpPort = port;
+            }
+
+            detailedSettings.SmtpUseSsl = chkUseSSL.Checked;
+
+            detailedSettings.GetRemoteBranchesDirectlyFromRemote = chkRemotesFromServer.Checked;
+            detailedSettings.AddMergeLogMessages = addLogMessages.Checked;
+
+            if (int.TryParse(nbMessages.Text, out var messagesCount))
+            {
+                detailedSettings.MergeLogMessagesCount = messagesCount;
+            }
+
+            base.PageToSettings();
         }
 
         private void chkUseSSL_CheckedChanged(object sender, EventArgs e)

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -11,6 +11,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Settings;
 using GitUI.AutoCompletion;
+using GitUIPluginInterfaces.Settings;
 using Microsoft;
 using Microsoft.VisualStudio.Threading;
 using NetSpell.SpellChecker;
@@ -270,7 +271,10 @@ namespace GitUI.SpellChecker
 
                 var noDicToolStripMenuItem = new ToolStripMenuItem("None");
                 noDicToolStripMenuItem.Click += DicToolStripMenuItemClick;
-                if (Settings.Dictionary == "None")
+
+                IDetachedSettings detachedSettings = Settings.Detached();
+
+                if (detachedSettings.Dictionary is "None")
                 {
                     noDicToolStripMenuItem.Checked = true;
                 }
@@ -286,7 +290,7 @@ namespace GitUI.SpellChecker
                     var dicToolStripMenuItem = new ToolStripMenuItem(dic);
                     dicToolStripMenuItem.Click += DicToolStripMenuItemClick;
 
-                    if (Settings.Dictionary == dic)
+                    if (detachedSettings.Dictionary == dic)
                     {
                         dicToolStripMenuItem.Checked = true;
                     }
@@ -356,7 +360,8 @@ namespace GitUI.SpellChecker
                 return;
             }
 
-            string dictionaryFile = string.Concat(Path.Combine(AppSettings.GetDictionaryDir(), Settings.Dictionary), ".dic");
+            IDetachedSettings detachedSettings = Settings.Detached();
+            string dictionaryFile = string.Concat(Path.Combine(AppSettings.GetDictionaryDir(), detachedSettings.Dictionary), ".dic");
 
             if (_wordDictionary is null || _wordDictionary.DictionaryFile != dictionaryFile)
             {
@@ -591,8 +596,10 @@ namespace GitUI.SpellChecker
             // it will set a dictionary only for this Module (repository) locally
 
             var settings = Module.LocalSettings ?? Settings;
+            IDetachedSettings detachedSettings = settings.Detached();
 
-            settings.Dictionary = ((ToolStripItem)sender).Text;
+            detachedSettings.Dictionary = ((ToolStripItem)sender).Text;
+
             LoadDictionary();
             CheckSpelling();
         }
@@ -637,7 +644,9 @@ namespace GitUI.SpellChecker
             {
                 OnTextChanged(e);
 
-                if (Settings.Dictionary == "None" || TextBox.Text.Length < 4)
+                IDetachedSettings detachedSettings = Settings.Detached();
+
+                if (detachedSettings.Dictionary is "None" || TextBox.Text.Length < 4)
                 {
                     return;
                 }

--- a/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
@@ -4,11 +4,13 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Settings;
 using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using GitUIPluginInterfaces;
 using GitUIPluginInterfaces.BuildServerIntegration;
+using GitUIPluginInterfaces.Settings;
 
 namespace GitUI.UserControls.RevisionGrid.Columns
 {
@@ -39,12 +41,14 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
         public override void Refresh(int rowHeight, in VisibleRowRange range)
         {
-            var settings = _module().EffectiveSettings.BuildServer;
-
             var showIcon = AppSettings.ShowBuildStatusIconColumn;
             var showText = AppSettings.ShowBuildStatusTextColumn;
-            var columnVisible = settings.EnableIntegration.Value &&
-                                (showIcon || showText);
+
+            IBuildServerSettings buildServerSettings = _module().GetEffectiveSettings()
+                .BuildServer();
+
+            var columnVisible = buildServerSettings.EnableIntegration
+                && (showIcon || showText);
 
             Column.Visible = columnVisible;
 

--- a/Plugins/GitUIPluginInterfaces/Settings/IBuildServerSettings.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/IBuildServerSettings.cs
@@ -1,0 +1,11 @@
+﻿namespace GitUIPluginInterfaces.Settings
+{
+    public interface IBuildServerSettings
+    {
+        string? Type { get; set; }
+
+        bool EnableIntegration { get; set; }
+
+        bool ShowBuildResultPage { get; set; }
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/Settings/IDetachedSettings.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/IDetachedSettings.cs
@@ -1,0 +1,9 @@
+﻿namespace GitUIPluginInterfaces.Settings
+{
+    public interface IDetachedSettings
+    {
+        string Dictionary { get; set; }
+
+        bool NoFastForwardMerge { get; set; }
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/Settings/IDetailedSettings.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/IDetailedSettings.cs
@@ -1,0 +1,17 @@
+﻿namespace GitUIPluginInterfaces.Settings
+{
+    public interface IDetailedSettings
+    {
+        string SmtpServer { get; set; }
+
+        int SmtpPort { get; set; }
+
+        bool SmtpUseSsl { get; set; }
+
+        bool GetRemoteBranchesDirectlyFromRemote { get; set; }
+
+        bool AddMergeLogMessages { get; set; }
+
+        int MergeLogMessagesCount { get; set; }
+    }
+}


### PR DESCRIPTION
## Proposed changes

- Fix settings saving for "Detailed" section by selected setting source.
- Provide a way to work with settings without being tied to a specific implementation and source.
- There is plan to change the CurrentSettings type to ISettingsSource.
- Small interface for each type of setting.

~For discussion without code formatting~.

## Test methodology <!-- How did you ensure quality? -->

- manually

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build f840a0ab83a461035f816951fe39c752a92abc4c
- Git 2.30.2.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
