### PR TITLE
fix-9085 Change DialogResult only after saving before closing

### DIFF
--- a/GitUI/CommandsDialogs/FormSettings.Designer.cs
+++ b/GitUI/CommandsDialogs/FormSettings.Designer.cs
@@ -222,6 +222,7 @@ namespace GitUI.CommandsDialogs
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Settings";
             this.Shown += new System.EventHandler(this.FormSettings_Shown);
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormSettings_FormClosing);
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.repositoryBindingSource)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.scriptInfoBindingSource)).EndInit();

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -30,6 +30,7 @@ namespace GitUI.CommandsDialogs
         private readonly CommonLogic _commonLogic;
         private readonly string _translatedTitle;
         private SettingsPageReference? _initialPage;
+        private bool _saved = false;
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -252,7 +253,7 @@ namespace GitUI.CommandsDialogs
                 // TODO: this method has a generic sounding name but only saves some specific settings
                 AppSettings.SaveSettings();
 
-                DialogResult = DialogResult.OK;
+                _saved = true;
 
                 return true;
             }
@@ -286,6 +287,14 @@ namespace GitUI.CommandsDialogs
                 }
 
                 settingsTreeView.GotoPage(_initialPage);
+            }
+        }
+
+        private void FormSettings_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            if (_saved)
+            {
+                DialogResult = DialogResult.OK;
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9085


## Proposed changes

- Change DialogResult only after saving before closing

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Settings dialog is closed

### After

Settings dialog is not closed


## Test methodology <!-- How did you ensure quality? -->

- manually

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build f840a0ab83a461035f816951fe39c752a92abc4c
- Git 2.30.2.windows.1
- Microsoft Windows NT 10.0.19041.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
