### PR TITLE
FormCommitDiff cannot handle artificial commits

### DIFF
--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -135,7 +135,7 @@ namespace GitUI
 
             var patchFile = (PatchFile)Patches.SelectedRows[0].DataBoundItem;
 
-            if (patchFile.ObjectId is not null)
+            if (patchFile.ObjectId is not null && !patchFile.ObjectId.IsArtificial)
             {
                 UICommands.StartFormCommitDiff(patchFile.ObjectId);
                 return;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1505,7 +1505,7 @@ namespace GitUI
         public void ViewSelectedRevisions()
         {
             var selectedRevisions = GetSelectedRevisions();
-            if (selectedRevisions.Any(rev => rev is not null && !rev.IsArtificial))
+            if (selectedRevisions.Count > 0 && !selectedRevisions[0].IsArtificial)
             {
                 Form ProvideForm()
                 {


### PR DESCRIPTION
Fixes #9084

## Proposed changes

Avoid open FormCommitDiff for artificial commits
Other call sites (like in BlameControl) do not handle artificial commits, so these are the situations I saw.

## Test methodology <!-- How did you ensure quality? -->

Manual, see issue
Review

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
