### PR TITLE
c# new var

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -136,6 +136,9 @@ csharp_style_unused_value_expression_statement_preference = discard_variable:sil
 # 'using' directive preferences
 csharp_using_directive_placement = outside_namespace:none
 
+# Use new(...)
+dotnet_diagnostic.IDE0090.severity = warning
+
 #### C# Formatting Rules ####
 
 # New line preferences

--- a/BugReporter/BugReportForm.cs
+++ b/BugReporter/BugReportForm.cs
@@ -218,7 +218,7 @@ Send report anyway?");
         #endregion
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/BugReporter/ErrorReportMarkDownBodyBuilder.cs
+++ b/BugReporter/ErrorReportMarkDownBodyBuilder.cs
@@ -18,7 +18,7 @@ namespace BugReporter
                 throw new ArgumentNullException(nameof(exception));
             }
 
-            var sb = new StringBuilder();
+            StringBuilder sb = new();
 
             sb.AppendLine(@"<!--
     :warning: Review existing issues to see whether someone else has already reported your issue.

--- a/BugReporter/ExceptionDetails.cs
+++ b/BugReporter/ExceptionDetails.cs
@@ -14,7 +14,7 @@ namespace BugReporter
 {
     internal partial class ExceptionDetails : UserControl
     {
-        private readonly Dictionary<TreeNode, SerializableException> _exceptionDetailsList = new Dictionary<TreeNode, SerializableException>();
+        private readonly Dictionary<TreeNode, SerializableException> _exceptionDetailsList = new();
 
         public ExceptionDetails()
         {
@@ -133,7 +133,7 @@ namespace BugReporter
 
         private void ExceptionDetailsListView_DoubleClick(object sender, EventArgs e)
         {
-            using var detailView = new ExceptionDetailView();
+            using ExceptionDetailView detailView = new();
             detailView.ShowDialog(exceptionDetailsListView.SelectedItems[0].Text, exceptionDetailsListView.SelectedItems[0].SubItems[1].Text);
         }
 
@@ -159,7 +159,7 @@ namespace BugReporter
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/BugReporter/Info/Report.cs
+++ b/BugReporter/Info/Report.cs
@@ -34,8 +34,8 @@ namespace BugReporter.Info
 
         public override string ToString()
         {
-            var serializer = new XmlSerializer(typeof(Report));
-            using var stream = new MemoryStream();
+            XmlSerializer serializer = new(typeof(Report));
+            using MemoryStream stream = new();
             stream.SetLength(0);
             serializer.Serialize(stream, this);
             stream.Position = 0;

--- a/BugReporter/Serialization/SerializableException.cs
+++ b/BugReporter/Serialization/SerializableException.cs
@@ -164,8 +164,8 @@ namespace BugReporter.Serialization
 
         public string ToXmlString()
         {
-            var serializer = new XmlSerializer(typeof(SerializableException));
-            using var stream = new MemoryStream();
+            XmlSerializer serializer = new(typeof(SerializableException));
+            using MemoryStream stream = new();
             stream.SetLength(0);
             serializer.Serialize(stream, this);
             stream.Position = 0;
@@ -175,7 +175,7 @@ namespace BugReporter.Serialization
 
         public static SerializableException FromXmlString(string xml)
         {
-            var serializer = new XmlSerializer(typeof(SerializableException));
+            XmlSerializer serializer = new(typeof(SerializableException));
             using StringReader reader = new(xml);
             SerializableException exception = (SerializableException)serializer.Deserialize(reader);
 
@@ -199,7 +199,7 @@ namespace BugReporter.Serialization
 
             if (extendedProperties.Any())
             {
-                var extendedInformation = new SerializableDictionary<string, object>();
+                SerializableDictionary<string, object> extendedInformation = new();
 
                 foreach (var property in extendedProperties.Where(property => property.GetValue(exception, null) is not null))
                 {

--- a/BugReporter/UserEnvironmentInformation.cs
+++ b/BugReporter/UserEnvironmentInformation.cs
@@ -54,7 +54,7 @@ namespace BugReporter
                 return $"- (minimum: {lastSupportedVersion}, recommended: {recommendedVersion})";
             }
 
-            var actualVersion = new GitVersion(gitVersion);
+            GitVersion actualVersion = new(gitVersion);
             if (actualVersion < lastSupportedVersion)
             {
                 return $"{gitVersion} (minimum: {lastSupportedVersion}, please update!)";

--- a/Externals/NetSpell.SpellChecker/Dictionary/WordDictionary.cs
+++ b/Externals/NetSpell.SpellChecker/Dictionary/WordDictionary.cs
@@ -224,7 +224,7 @@ namespace NetSpell.SpellChecker.Dictionary
             // Step 3 Remove suffix, Search BaseWords
 
             // save suffixed words for use when removing prefix
-            var suffixWords = new List<string>();
+            List<string> suffixWords = new();
 
             // Add word to suffix word list
             suffixWords.Add(word);
@@ -306,8 +306,8 @@ namespace NetSpell.SpellChecker.Dictionary
         /// </returns>
         public List<string> ExpandWord(Word word)
         {
-            var suffixWords = new List<string>();
-            var words = new List<string>();
+            List<string> suffixWords = new();
+            List<string> words = new();
 
             suffixWords.Add(word.Text);
             string prefixKeys = "";
@@ -374,7 +374,7 @@ namespace NetSpell.SpellChecker.Dictionary
             TryCharacters = "";
 
             // the following is used to split a line by white space
-            var spaceRegex = new Regex(@"[^\s]+", RegexOptions.Compiled);
+            Regex spaceRegex = new(@"[^\s]+", RegexOptions.Compiled);
 
             string currentSection = "";
             AffixRule currentRule = null;
@@ -460,7 +460,7 @@ namespace NetSpell.SpellChecker.Dictionary
                                     // part 1 = affix key
                                     if (currentRule.Name == partMatches[0].Value)
                                     {
-                                        var entry = new AffixEntry();
+                                        AffixEntry entry = new();
 
                                         // part 2 = strip char
                                         if (partMatches[1].Value != "0")
@@ -484,7 +484,7 @@ namespace NetSpell.SpellChecker.Dictionary
                                 partMatches = spaceRegex.Matches(tempLine);
                                 if (partMatches.Count >= 2)
                                 {
-                                    var rule = new PhoneticRule();
+                                    PhoneticRule rule = new();
                                     PhoneticUtility.EncodeRule(partMatches[0].Value, ref rule);
                                     rule.ReplaceString = partMatches[1].Value;
                                     PhoneticRules.Add(rule);
@@ -494,7 +494,7 @@ namespace NetSpell.SpellChecker.Dictionary
                             case "[Words]": // dictionary word list
                                 // splits word into its parts
                                 string[] parts = tempLine.Split('/');
-                                var tempWord = new Word();
+                                Word tempWord = new();
 
                                 // part 1 = base word
                                 tempWord.Text = parts[0];
@@ -546,7 +546,7 @@ namespace NetSpell.SpellChecker.Dictionary
         public string PhoneticCode(string word)
         {
             string tempWord = word.ToUpper();
-            var code = new StringBuilder();
+            StringBuilder code = new();
 
             while (tempWord.Length > 0)
             {

--- a/Externals/NetSpell.SpellChecker/Spelling.cs
+++ b/Externals/NetSpell.SpellChecker/Spelling.cs
@@ -271,7 +271,7 @@ namespace NetSpell.SpellChecker
 
         private void SuggestWord(string word, List<Word> tempSuggestion)
         {
-            var ws = new Word();
+            Word ws = new();
             ws.Text = word;
             ws.EditDistance = EditDistance(CurrentWord, word);
             tempSuggestion.Add(ws);
@@ -317,7 +317,7 @@ namespace NetSpell.SpellChecker
 
             for (int i = 0; i < CurrentWord.Length; i++)
             {
-                var tempWord = new StringBuilder(CurrentWord);
+                StringBuilder tempWord = new(CurrentWord);
                 for (int x = 0; x < tryme.Length; x++)
                 {
                     tempWord[i] = tryme[x];
@@ -339,7 +339,7 @@ namespace NetSpell.SpellChecker
             {
                 for (int i = 0; i < CurrentWord.Length; i++)
                 {
-                    var tempWord = new StringBuilder(CurrentWord);
+                    StringBuilder tempWord = new(CurrentWord);
                     tempWord.Remove(i, 1);
 
                     string word = tempWord.ToString();
@@ -362,7 +362,7 @@ namespace NetSpell.SpellChecker
             {
                 for (int x = 0; x < tryme.Length; x++)
                 {
-                    var tempWord = new StringBuilder(CurrentWord);
+                    StringBuilder tempWord = new(CurrentWord);
                     tempWord.Insert(i, tryme[x]);
 
                     string word = tempWord.ToString();
@@ -381,7 +381,7 @@ namespace NetSpell.SpellChecker
         {
             for (int i = 0; i < CurrentWord.Length - 1; i++)
             {
-                var tempWord = new StringBuilder(CurrentWord);
+                StringBuilder tempWord = new(CurrentWord);
 
                 char swap = tempWord[i];
                 tempWord[i] = tempWord[i + 1];
@@ -983,14 +983,14 @@ namespace NetSpell.SpellChecker
 
             Initialize();
 
-            var tempSuggestion = new List<Word>();
+            List<Word> tempSuggestion = new();
 
             if ((SuggestionMode == SuggestionEnum.PhoneticNearMiss
                 || SuggestionMode == SuggestionEnum.Phonetic)
                 && _dictionary.PhoneticRules.Count > 0)
             {
                 // generate phonetic code for possible root word
-                Dictionary<string, string> codes = new Dictionary<string, string>();
+                Dictionary<string, string> codes = new();
                 foreach (string tempWord in _dictionary.PossibleBaseWords)
                 {
                     string tempCode = _dictionary.PhoneticCode(tempWord);
@@ -1148,7 +1148,7 @@ namespace NetSpell.SpellChecker
         #region public properties
 
         private WordDictionary _dictionary;
-        private readonly HashSet<string> _autoCompleteWords = new HashSet<string>();
+        private readonly HashSet<string> _autoCompleteWords = new();
         private string _replacementWord = "";
         private StringBuilder _text = new();
         private int _wordIndex;

--- a/GitCommands/ArgumentBuilderExtensions.cs
+++ b/GitCommands/ArgumentBuilderExtensions.cs
@@ -301,7 +301,7 @@ namespace GitCommands
             }
 
             // Clone command as argument builder
-            var batches = new List<BatchArgumentItem>();
+            List<BatchArgumentItem> batches = new();
             var currentBatchItemCount = 0;
             var currentArgumentLength = baseArgument.Length;
             var lastBatchBuilder = arguments.Aggregate(builder, (currentBatchBuilder, argument) =>

--- a/GitCommands/AsyncLoader.cs
+++ b/GitCommands/AsyncLoader.cs
@@ -123,7 +123,7 @@ namespace GitCommands
 
         private bool OnLoadingError(Exception exception)
         {
-            var args = new AsyncErrorEventArgs(exception);
+            AsyncErrorEventArgs args = new(exception);
             LoadingError?.Invoke(this, args);
             return args.Handled;
         }

--- a/GitCommands/CommandStatus.cs
+++ b/GitCommands/CommandStatus.cs
@@ -8,7 +8,7 @@
             NeedsGridRefresh = needsGridRefresh;
         }
 
-        public static implicit operator CommandStatus(bool executed) => new CommandStatus(executed, false);
+        public static implicit operator CommandStatus(bool executed) => new(executed, false);
 
         public bool Executed { get; }
 

--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -205,7 +205,7 @@ namespace GitCommands
                 return false;
             }
 
-            var arguments = new GitArgumentBuilder("log")
+            GitArgumentBuilder arguments = new("log")
             {
                 "-1",
                 $"--pretty=\"format:{format}\"",
@@ -239,7 +239,7 @@ namespace GitCommands
                 endIndex--;
             }
 
-            var message = new StringBuilder();
+            StringBuilder message = new();
             bool notesStart = false;
 
             for (int i = startIndex; i <= endIndex; i++)

--- a/GitCommands/CommitMessageManager.cs
+++ b/GitCommands/CommitMessageManager.cs
@@ -173,7 +173,7 @@ namespace GitCommands
                 return string.Empty;
             }
 
-            var formattedCommitMessage = new StringBuilder();
+            StringBuilder formattedCommitMessage = new();
 
             var lineNumber = 1;
             foreach (var line in commitMessage.LazySplit('\n'))

--- a/GitCommands/CommitTemplateItem.cs
+++ b/GitCommands/CommitTemplateItem.cs
@@ -89,9 +89,9 @@ namespace GitCommands
                     int length = Convert.ToInt32(serializedString.Substring(0, p));
 
                     byte[] memoryData = Convert.FromBase64String(serializedString.Substring(p + 1));
-                    using var rs = new MemoryStream(memoryData, 0, length);
+                    using MemoryStream rs = new(memoryData, 0, length);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-                    var sf = new BinaryFormatter { Binder = new MoveNamespaceDeserializationBinder() };
+                    BinaryFormatter sf = new() { Binder = new MoveNamespaceDeserializationBinder() };
                     commitTemplateItem = (CommitTemplateItem[])sf.Deserialize(rs);
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
 

--- a/GitCommands/CommitTemplateManager.cs
+++ b/GitCommands/CommitTemplateManager.cs
@@ -58,7 +58,7 @@ namespace GitCommands
             }
         }
 
-        private static readonly List<RegisteredCommitTemplateItem> RegisteredTemplatesStorage = new List<RegisteredCommitTemplateItem>();
+        private static readonly List<RegisteredCommitTemplateItem> RegisteredTemplatesStorage = new();
         private readonly IFileSystem _fileSystem;
         private readonly Func<IGitModule> _getModule;
         private readonly IFullPathResolver _fullPathResolver;

--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -13,7 +13,7 @@ namespace GitCommands.Config
         private static Encoding GetEncoding() => GitModule.SystemEncoding;
         public static readonly char[] CommentChars = { ';', '#' };
 
-        private readonly List<IConfigSection> _configSections = new List<IConfigSection>();
+        private readonly List<IConfigSection> _configSections = new();
 
         public string FileName { get; }
         public bool Local { get; }
@@ -82,7 +82,7 @@ namespace GitCommands.Config
 
         public string GetAsString()
         {
-            var configFileContent = new StringBuilder();
+            StringBuilder configFileContent = new();
 
             foreach (var section in ConfigSections)
             {
@@ -226,7 +226,7 @@ namespace GitCommands.Config
 
         public IConfigSection? FindConfigSection(string name)
         {
-            var configSectionToFind = new ConfigSection(name, true);
+            ConfigSection configSectionToFind = new(name, true);
 
             return FindConfigSection(configSectionToFind);
         }

--- a/GitCommands/CustomDiffMergeToolCache.cs
+++ b/GitCommands/CustomDiffMergeToolCache.cs
@@ -88,7 +88,7 @@ namespace GitCommands
         /// <returns>list with tool names.</returns>
         private IEnumerable<string> ParseCustomDiffMergeTool(string output, string defaultTool)
         {
-            var tools = new List<string>();
+            List<string> tools = new();
 
             // Simple parsing of the textual output opposite to porcelain format
             // https://github.com/git/git/blob/main/git-mergetool--lib.sh#L298

--- a/GitCommands/DiffListSortService.cs
+++ b/GitCommands/DiffListSortService.cs
@@ -4,7 +4,7 @@ namespace GitCommands
 {
     public class DiffListSortService : IDiffListSortService
     {
-        private static readonly Lazy<DiffListSortService> _lazyDiffListSorting = new Lazy<DiffListSortService>(() => new DiffListSortService());
+        private static readonly Lazy<DiffListSortService> _lazyDiffListSorting = new(() => new DiffListSortService());
         public static DiffListSortService Instance => _lazyDiffListSorting.Value;
         private DiffListSortType _diffListSorting;
         public event EventHandler? DiffListSortingChanged;

--- a/GitCommands/DiffMergeTools/DiffMergeToolConfigurationManager.cs
+++ b/GitCommands/DiffMergeTools/DiffMergeToolConfigurationManager.cs
@@ -225,7 +225,7 @@ namespace GitCommands.DiffMergeTools
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitCommands/ExceptionUtils.cs
+++ b/GitCommands/ExceptionUtils.cs
@@ -33,7 +33,7 @@ namespace GitCommands
 
         public static string ToStringWithData(this Exception e)
         {
-            var sb = new StringBuilder();
+            StringBuilder sb = new();
             sb.AppendLine(e.ToString());
             sb.AppendLine();
             foreach (DictionaryEntry entry in e.Data)

--- a/GitCommands/ExternalLinks/ConfiguredLinkDefinitionsProvider.cs
+++ b/GitCommands/ExternalLinks/ConfiguredLinkDefinitionsProvider.cs
@@ -40,14 +40,14 @@ namespace GitCommands.ExternalLinks
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            var cachedSettings = new RepoDistSettings(null, settings.SettingsCache, SettingLevel.Unknown);
+            RepoDistSettings cachedSettings = new(null, settings.SettingsCache, SettingLevel.Unknown);
             IEnumerable<ExternalLinkDefinition>? effective = _externalLinksStorage.Load(cachedSettings);
 
             Validates.NotNull(effective);
 
             if (settings.LowerPriority is not null)
             {
-                var lowerPriorityLoader = new ConfiguredLinkDefinitionsProvider(_externalLinksStorage);
+                ConfiguredLinkDefinitionsProvider lowerPriorityLoader = new(_externalLinksStorage);
                 effective = effective.Union(lowerPriorityLoader.Get(settings.LowerPriority));
             }
 

--- a/GitCommands/ExternalLinks/ExternalLinkFormat.cs
+++ b/GitCommands/ExternalLinks/ExternalLinkFormat.cs
@@ -18,7 +18,7 @@ namespace GitCommands.ExternalLinks
 
         public ExternalLink Apply(Match? remoteMatch, Match? revisionMatch, GitRevision revision)
         {
-            var groups = new List<string>();
+            List<string> groups = new();
             AddGroupsFromMatches(remoteMatch);
             AddGroupsFromMatches(revisionMatch);
             var groupsArray = groups.ToArray<object>();

--- a/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
+++ b/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
@@ -46,7 +46,7 @@ namespace GitCommands.ExternalLinks
 
         private IEnumerable<Match?> ParseRemotes(ExternalLinkDefinition definition)
         {
-            var allMatches = new List<Match?>();
+            List<Match?> allMatches = new();
 
             if (string.IsNullOrWhiteSpace(definition.RemoteSearchPattern) || definition.RemoteSearchPatternRegex?.Value is null)
             {
@@ -54,7 +54,7 @@ namespace GitCommands.ExternalLinks
                 return allMatches;
             }
 
-            var remoteUrls = new List<string>();
+            List<string> remoteUrls = new();
 
             var remotes = _remotesManager.LoadRemotes(false);
             var matchingRemotes = GetMatchingRemotes(definition, remotes);
@@ -96,7 +96,7 @@ namespace GitCommands.ExternalLinks
 
         private static IEnumerable<ExternalLink> ParseRevision(GitRevision revision, ExternalLinkDefinition definition, Match? remoteMatch)
         {
-            var links = new List<IEnumerable<ExternalLink>>();
+            List<IEnumerable<ExternalLink>> links = new();
 
             if (definition.SearchInParts.Contains(ExternalLinkDefinition.RevisionPart.LocalBranches))
             {
@@ -129,7 +129,7 @@ namespace GitCommands.ExternalLinks
                 yield break;
             }
 
-            var allMatches = new List<Match>();
+            List<Match> allMatches = new();
 
             MatchCollection matches = definition.SearchPatternRegex.Value.Matches(part);
             for (var i = 0; i < matches.Count; i++)

--- a/GitCommands/ExternalLinks/ExternalLinksStorage.cs
+++ b/GitCommands/ExternalLinks/ExternalLinksStorage.cs
@@ -54,9 +54,9 @@ namespace GitCommands.ExternalLinks
                         definition.RemoveEmptyFormats();
                     }
 
-                    var sw = new StringWriter();
-                    var serializer = new XmlSerializer(typeof(List<ExternalLinkDefinition>));
-                    var ns = new XmlSerializerNamespaces();
+                    StringWriter sw = new();
+                    XmlSerializer serializer = new(typeof(List<ExternalLinkDefinition>));
+                    XmlSerializerNamespaces ns = new();
                     ns.Add(string.Empty, string.Empty);
                     serializer.Serialize(sw, definitions.OrderBy(x => x.Name).ToList(), ns);
                     xml = sw.ToString();
@@ -80,9 +80,9 @@ namespace GitCommands.ExternalLinks
 
             try
             {
-                var serializer = new XmlSerializer(typeof(List<ExternalLinkDefinition>));
-                using var stringReader = new StringReader(xmlString);
-                using var xmlReader = new XmlTextReader(stringReader);
+                XmlSerializer serializer = new(typeof(List<ExternalLinkDefinition>));
+                using StringReader stringReader = new(xmlString);
+                using XmlTextReader xmlReader = new(stringReader);
                 return serializer.Deserialize(xmlReader) as List<ExternalLinkDefinition>;
             }
             catch (Exception ex)

--- a/GitCommands/FileAssociatedIconProvider.cs
+++ b/GitCommands/FileAssociatedIconProvider.cs
@@ -23,7 +23,7 @@ namespace GitCommands
     public sealed class FileAssociatedIconProvider : IFileAssociatedIconProvider
     {
         private readonly IFileSystem _fileSystem;
-        private static readonly ConcurrentDictionary<string, Icon?> LoadedFileIcons = new ConcurrentDictionary<string, Icon?>(StringComparer.OrdinalIgnoreCase);
+        private static readonly ConcurrentDictionary<string, Icon?> LoadedFileIcons = new(StringComparer.OrdinalIgnoreCase);
 
         public FileAssociatedIconProvider(IFileSystem fileSystem)
         {

--- a/GitCommands/FileHelper.cs
+++ b/GitCommands/FileHelper.cs
@@ -65,7 +65,7 @@ namespace GitCommands
         private static bool? IsBinaryAccordingToGitAttributes(GitModule module, string fileName)
         {
             string[] diffValues = { "set", "astextplain", "ada", "bibtext", "cpp", "csharp", "fortran", "html", "java", "matlab", "objc", "pascal", "perl", "php", "python", "ruby", "tex" };
-            var cmd = new GitArgumentBuilder("check-attr")
+            GitArgumentBuilder cmd = new("check-attr")
             {
                 "-z",
                 "diff",
@@ -77,7 +77,7 @@ namespace GitCommands
             };
             string result = module.GitExecutable.GetOutput(cmd);
             var lines = result.Split(Delimiters.NullAndLineFeed);
-            var attributes = new Dictionary<string, string>();
+            Dictionary<string, string> attributes = new();
             for (int i = 0; i < lines.Length - 2; i += 3)
             {
                 attributes[lines[i + 1].Trim()] = lines[i + 2].Trim();

--- a/GitCommands/FileInfoExtensions.cs
+++ b/GitCommands/FileInfoExtensions.cs
@@ -18,7 +18,7 @@ namespace GitCommands
                 return;
             }
 
-            var fileInfo = new FileInfo(fileName);
+            FileInfo fileInfo = new(fileName);
             var oldAttributes = fileInfo.Attributes;
             fileInfo.Attributes = FileAttributes.Normal;
             writableAction(fileName);

--- a/GitCommands/Git/AheadBehindDataProvider.cs
+++ b/GitCommands/Git/AheadBehindDataProvider.cs
@@ -19,7 +19,7 @@ namespace GitCommands.Git
         // Parse info about remote branches, see below for explanation
         // This assumes that the Git output is not localised
         private readonly Regex _aheadBehindRegEx =
-            new Regex(
+            new(
                 @"^((?<gone_p>gone)|((ahead\s(?<ahead_p>\d+))?(,\s)?(behind\s(?<behind_p>\d+))?)|(?<unk_p>.*?))::
                    ((?<gone_u>gone)|((ahead\s(?<ahead_u>\d+))?(,\s)?(behind\s(?<behind_u>\d+))?)|(?<unk_u>.*?))::
                    (?<remote_p>.*?)::(?<remote_u>.*?)::(?<branch>.*)$",
@@ -54,7 +54,7 @@ namespace GitCommands.Git
                 return null;
             }
 
-            var aheadBehindGitCommand = new GitArgumentBuilder("for-each-ref")
+            GitArgumentBuilder aheadBehindGitCommand = new("for-each-ref")
             {
                 $"--color=never",
                 $"--format=\"{_refFormat}\"",
@@ -68,7 +68,7 @@ namespace GitCommands.Git
             }
 
             var matches = _aheadBehindRegEx.Matches(result);
-            var aheadBehindForBranchesData = new Dictionary<string, AheadBehindData>();
+            Dictionary<string, AheadBehindData> aheadBehindForBranchesData = new();
             foreach (Match match in matches)
             {
                 var branch = match.Groups["branch"].Value;
@@ -133,7 +133,7 @@ namespace GitCommands.Git
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -417,7 +417,7 @@ namespace GitCommands.Git.Commands
                 throw new ArgumentException($"For arguments \"{nameof(from)}\" and \"{nameof(onto)}\", either both must have values, or neither may.");
             }
 
-            var builder = new GitArgumentBuilder("rebase");
+            GitArgumentBuilder builder = new("rebase");
             if (ignoreDate)
             {
                 builder.Add("--ignore-date");
@@ -520,7 +520,7 @@ namespace GitCommands.Git.Commands
 
         public static ArgumentString GetAllChangedFilesCmd(bool excludeIgnoredFiles, UntrackedFilesMode untrackedFiles, IgnoreSubmodulesMode ignoreSubmodules = IgnoreSubmodulesMode.None, bool noLocks = false)
         {
-            var args = new GitArgumentBuilder("status", gitOptions:
+            GitArgumentBuilder args = new("status", gitOptions:
                 noLocks && GitVersion.Current.SupportNoOptionalLocks
                     ? (ArgumentString)"--no-optional-locks"
                     : default)

--- a/GitCommands/Git/DetachedHeadParser.cs
+++ b/GitCommands/Git/DetachedHeadParser.cs
@@ -24,7 +24,7 @@ namespace GitCommands.Git
                 return false;
             }
 
-            var sha1Match = new Regex(@"^\(.* (?<sha1>.*)\)$").Match(text);
+            Match sha1Match = new Regex(@"^\(.* (?<sha1>.*)\)$").Match(text);
             if (!sha1Match.Success)
             {
                 return false;

--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -55,7 +55,7 @@ namespace GitCommands
         private sealed class ProcessWrapper : IProcess
         {
             // TODO should this use TaskCreationOptions.RunContinuationsAsynchronously
-            private readonly TaskCompletionSource<int> _exitTaskCompletionSource = new TaskCompletionSource<int>();
+            private readonly TaskCompletionSource<int> _exitTaskCompletionSource = new();
 
             private readonly object _syncRoot = new();
             private readonly Process _process;

--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -18,7 +18,7 @@ namespace GitCommands
     public static class ExecutableExtensions
     {
         private static readonly Regex _ansiCodePattern = new(@"\u001B[\u0040-\u005F].*?[\u0040-\u007E]", RegexOptions.Compiled);
-        private static readonly Lazy<Encoding> _defaultOutputEncoding = new Lazy<Encoding>(() => GitModule.SystemEncoding, false);
+        private static readonly Lazy<Encoding> _defaultOutputEncoding = new(() => GitModule.SystemEncoding, false);
 
         /// <summary>
         /// Launches a process for the executable and returns its output.
@@ -70,7 +70,7 @@ namespace GitCommands
             CommandCache? cache = null,
             bool stripAnsiEscapeCodes = true)
         {
-            var sb = new StringBuilder();
+            StringBuilder sb = new();
             foreach (var batch in batchArguments)
             {
                 sb.Append(executable.GetOutput(batch.Argument, input, outputEncoding, cache, stripAnsiEscapeCodes));
@@ -116,8 +116,8 @@ namespace GitCommands
                 process.StandardInput.Close();
             }
 
-            var outputBuffer = new MemoryStream();
-            var errorBuffer = new MemoryStream();
+            MemoryStream outputBuffer = new();
+            MemoryStream errorBuffer = new();
             var outputTask = process.StandardOutput.BaseStream.CopyToAsync(outputBuffer);
             var errorTask = process.StandardError.BaseStream.CopyToAsync(errorBuffer);
             var exitTask = process.WaitForExitAsync();
@@ -356,16 +356,16 @@ namespace GitCommands
             }
 
             using var process = executable.Start(arguments, createWindow: false, redirectInput: writeInput is not null, redirectOutput: true, outputEncoding);
-            var outputBuffer = new MemoryStream();
-            var errorBuffer = new MemoryStream();
+            MemoryStream outputBuffer = new();
+            MemoryStream errorBuffer = new();
             var outputTask = process.StandardOutput.BaseStream.CopyToAsync(outputBuffer);
             var errorTask = process.StandardError.BaseStream.CopyToAsync(errorBuffer);
 
             if (writeInput is not null)
             {
 #if DEBUG
-                using MemoryStream mem = new MemoryStream();
-                using StreamWriter sw = new StreamWriter(mem);
+                using MemoryStream mem = new();
+                using StreamWriter sw = new(mem);
                 writeInput(sw);
 
                 System.Diagnostics.Debug.WriteLine($"git {arguments} {Encoding.UTF8.GetString(mem.ToArray(), 0, (int)mem.Length)}");

--- a/GitCommands/Git/GetAllChangedFilesOutputParser.cs
+++ b/GitCommands/Git/GetAllChangedFilesOutputParser.cs
@@ -48,7 +48,7 @@ namespace GitCommands.Git
         /// <returns>list with the git items.</returns>
         internal List<GitItemStatus> GetAllChangedFilesFromString_v1(string getAllChangedFilesCommandOutput, bool fromDiff, StagedStatus staged)
         {
-            var diffFiles = new List<GitItemStatus>();
+            List<GitItemStatus> diffFiles = new();
 
             if (string.IsNullOrEmpty(getAllChangedFilesCommandOutput))
             {
@@ -171,7 +171,7 @@ namespace GitCommands.Git
         /// <returns>list with the parsed GitItemStatus.</returns>
         private static IReadOnlyList<GitItemStatus> GetAllChangedFilesFromString_v2(string getAllChangedFilesCommandOutput)
         {
-            var diffFiles = new List<GitItemStatus>();
+            List<GitItemStatus> diffFiles = new();
 
             if (string.IsNullOrEmpty(getAllChangedFilesCommandOutput))
             {

--- a/GitCommands/Git/GitBlame.cs
+++ b/GitCommands/Git/GitBlame.cs
@@ -63,7 +63,7 @@ namespace GitCommands
 
         public override string ToString()
         {
-            var s = new StringBuilder();
+            StringBuilder s = new();
 
             s.Append("Author: ").AppendLine(Author);
             s.Append("Author date: ").AppendLine(AuthorTime.ToString(CultureInfo.CurrentCulture));

--- a/GitCommands/Git/GitBranchNameNormaliser.cs
+++ b/GitCommands/Git/GitBranchNameNormaliser.cs
@@ -159,7 +159,7 @@ namespace GitCommands.Git
         /// <returns>Normalised branch name.</returns>
         internal string Rule04(string branchName, GitBranchNameOptions options)
         {
-            var result = new StringBuilder(branchName.Length);
+            StringBuilder result = new(branchName.Length);
             foreach (char t in branchName)
             {
                 if (IsValidChar(t) || char.IsLetterOrDigit(t))

--- a/GitCommands/Git/GitConvert.cs
+++ b/GitCommands/Git/GitConvert.cs
@@ -16,7 +16,7 @@ namespace GitCommands
                 return buf;
             }
 
-            var bufStatistic = new BufStatistic(buf);
+            BufStatistic bufStatistic = new(buf);
 
             if (bufStatistic.cntLf == 0)
             {
@@ -38,7 +38,7 @@ namespace GitCommands
                 return buf;
             }
 
-            var bytes = new List<byte>((int)(buf.Length * 1.01));
+            List<byte> bytes = new((int)(buf.Length * 1.01));
 
             if (buf.Length >= 1)
             {

--- a/GitCommands/Git/GitGpgController.cs
+++ b/GitCommands/Git/GitGpgController.cs
@@ -103,7 +103,7 @@ namespace GitCommands.Gpg
             return await Task.Run(() =>
             {
                 CommitStatus cmtStatus;
-                var args = new GitArgumentBuilder("log")
+                GitArgumentBuilder args = new("log")
                 {
                     "--pretty=\"format:%G?\"",
                     "-1",
@@ -204,7 +204,7 @@ namespace GitCommands.Gpg
             }
 
             var module = GetModule();
-            var args = new GitArgumentBuilder("log")
+            GitArgumentBuilder args = new("log")
             {
                 "--pretty=\"format:%GG\"",
                 "-1",
@@ -237,7 +237,7 @@ namespace GitCommands.Gpg
             }
 
             var module = GetModule();
-            var args = new GitArgumentBuilder("verify-tag")
+            GitArgumentBuilder args = new("verify-tag")
             {
                 { raw, "--raw" },
                 tagName

--- a/GitCommands/Git/GitItemStatus.cs
+++ b/GitCommands/Git/GitItemStatus.cs
@@ -215,7 +215,7 @@ namespace GitCommands
 
         public override string ToString()
         {
-            var str = new StringBuilder();
+            StringBuilder str = new();
 
             if (!string.IsNullOrWhiteSpace(ErrorMessage))
             {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -103,14 +103,14 @@ namespace GitCommands
                 if (!string.IsNullOrEmpty(superprojectPath) && currentPath.ToPosixPath().StartsWith(superprojectPath.ToPosixPath()))
                 {
                     var submodulePath = currentPath.Substring(superprojectPath.Length).ToPosixPath();
-                    var configFile = new ConfigFile(Path.Combine(superprojectPath, ".gitmodules"), local: true);
+                    ConfigFile configFile = new(Path.Combine(superprojectPath, ".gitmodules"), local: true);
 
                     foreach (var configSection in configFile.ConfigSections)
                     {
                         if (configSection.GetValue("path") == submodulePath.ToPosixPath())
                         {
                             var submoduleName = configSection.SubSection;
-                            var superprojectModule = new GitModule(superprojectPath);
+                            GitModule superprojectModule = new(superprojectPath);
 
                             return (superprojectModule, submodulePath, submoduleName);
                         }
@@ -236,7 +236,7 @@ namespace GitCommands
             }
         }
 
-        public ConfigFileSettings LocalConfigFile => new ConfigFileSettings(null, EffectiveConfigFile.SettingsCache, SettingLevel.Local);
+        public ConfigFileSettings LocalConfigFile => new(null, EffectiveConfigFile.SettingsCache, SettingLevel.Local);
 
         IConfigFileSettings IGitModule.LocalConfigFile => LocalConfigFile;
 
@@ -300,7 +300,7 @@ namespace GitCommands
         /// <param name="relativePath">A path relative to the .git directory.</param>
         public string ResolveGitInternalPath(string relativePath)
         {
-            var args = new GitArgumentBuilder("rev-parse")
+            GitArgumentBuilder args = new("rev-parse")
             {
                 "--git-path",
                 relativePath.Quote()
@@ -339,7 +339,7 @@ namespace GitCommands
                 {
                     if (_gitCommonDirectory is null)
                     {
-                        var args = new GitArgumentBuilder("rev-parse") { "--git-common-dir" };
+                        GitArgumentBuilder args = new("rev-parse") { "--git-common-dir" };
                         var result = _gitExecutable.Execute(args);
 
                         var dir = result.StandardOutput.Trim().ToNativePath();
@@ -380,7 +380,7 @@ namespace GitCommands
 
         public bool IsSubmodule(string submodulePath)
         {
-            var args = new GitArgumentBuilder("submodule")
+            GitArgumentBuilder args = new("submodule")
             {
                 "status",
                 submodulePath
@@ -401,7 +401,7 @@ namespace GitCommands
         /// <inheritdoc />
         public IReadOnlyList<string> GetSubmodulesLocalPaths(bool recursive = true)
         {
-            var localPaths = new List<string>();
+            List<string> localPaths = new();
             try
             {
                 DoGetSubmodulesLocalPaths(this, "", localPaths, recursive);
@@ -469,7 +469,7 @@ namespace GitCommands
 
         public bool EditNotes(ObjectId commitId)
         {
-            var arguments = new GitArgumentBuilder("notes") { "edit", commitId };
+            GitArgumentBuilder arguments = new("notes") { "edit", commitId };
             var editor = GetEffectiveSetting("core.editor").ToLower();
             var createWindow = !editor.Contains("gitextensions") && !editor.Contains("notepad");
 
@@ -478,7 +478,7 @@ namespace GitCommands
 
         public bool InTheMiddleOfConflictedMerge()
         {
-            var args = new GitArgumentBuilder("ls-files")
+            GitArgumentBuilder args = new("ls-files")
             {
                 "-z",
                 "--unmerged"
@@ -489,7 +489,7 @@ namespace GitCommands
         public bool HandleConflictSelectSide(string fileName, string side)
         {
             Directory.SetCurrentDirectory(WorkingDir);
-            var args = new GitArgumentBuilder("checkout-index")
+            GitArgumentBuilder args = new("checkout-index")
             {
                 "-f",
                 $"--stage={GetSide(side)}",
@@ -516,7 +516,7 @@ namespace GitCommands
         {
             Directory.SetCurrentDirectory(WorkingDir);
 
-            var args = new GitArgumentBuilder("checkout-index")
+            GitArgumentBuilder args = new("checkout-index")
             {
                 $"--stage={GetSide(side)}",
                 "--temp",
@@ -629,7 +629,7 @@ namespace GitCommands
             {
                 if (unmerged is not null)
                 {
-                    var args = new GitArgumentBuilder("checkout-index")
+                    GitArgumentBuilder args = new("checkout-index")
                     {
                         "--temp",
                         $"--stage={part}",
@@ -684,8 +684,8 @@ namespace GitCommands
         {
             filename = filename.ToPosixPath();
 
-            var list = new List<ConflictData>();
-            var args = new GitArgumentBuilder("ls-files")
+            List<ConflictData> list = new();
+            GitArgumentBuilder args = new("ls-files")
             {
                 "-z",
                 "--unmerged",
@@ -754,7 +754,7 @@ namespace GitCommands
 
         private IGitItem? GetSubmoduleCommitHash(string? filename, string refName)
         {
-            var args = new GitArgumentBuilder("ls-tree")
+            GitArgumentBuilder args = new("ls-tree")
             {
                 refName,
                 { !string.IsNullOrWhiteSpace(filename), "--" },
@@ -772,7 +772,7 @@ namespace GitCommands
                 return 0;
             }
 
-            var args = new GitArgumentBuilder("rev-list")
+            GitArgumentBuilder args = new("rev-list")
             {
                 parent,
                 $"^{child}",
@@ -795,7 +795,7 @@ namespace GitCommands
                 return (0, 0);
             }
 
-            var args = new GitArgumentBuilder("rev-list")
+            GitArgumentBuilder args = new("rev-list")
             {
                 $"{firstId}...{secondId}",
                 "--count",
@@ -874,7 +874,7 @@ namespace GitCommands
         public void RunMergeTool(string? fileName = "", string? customTool = null)
         {
             var gui = GitVersion.Current.SupportGuiMergeTool ? "--gui" : string.Empty;
-            var args = new GitArgumentBuilder("mergetool")
+            GitArgumentBuilder args = new("mergetool")
             {
                 { string.IsNullOrWhiteSpace(customTool), gui, $"--tool={customTool}" },
                 { !string.IsNullOrWhiteSpace(fileName), "--" },
@@ -886,7 +886,7 @@ namespace GitCommands
 
         public string Init(bool bare, bool shared)
         {
-            var args = new GitArgumentBuilder("init")
+            GitArgumentBuilder args = new("init")
             {
                 { bare, "--bare" },
                 { shared, "--shared=all" }
@@ -918,7 +918,7 @@ namespace GitCommands
 
             var format = formatString + (shortFormat ? "%s" : "%B%nNotes:%n%-N");
 
-            var args = new GitArgumentBuilder("log")
+            GitArgumentBuilder args = new("log")
             {
                 "-n1",
                 $"--pretty=format:{format}",
@@ -930,7 +930,7 @@ namespace GitCommands
             // TODO improve parsing to reduce temporary string (see similar code in RevisionReader)
             string[] lines = revInfo.Split(Delimiters.LineFeed);
 
-            var revision = new GitRevision(ObjectId.Parse(lines[0]))
+            GitRevision revision = new(ObjectId.Parse(lines[0]))
             {
                 TreeGuid = ObjectId.Parse(lines[1]),
                 ParentIds = lines[2].LazySplit(' ', StringSplitOptions.RemoveEmptyEntries).Select(line => ObjectId.Parse(line)).ToList(),
@@ -975,7 +975,7 @@ namespace GitCommands
                     endIndex--;
                 }
 
-                var message = new StringBuilder();
+                StringBuilder message = new();
                 var inNoteSection = false;
 
                 for (var i = startIndex; i <= endIndex; i++)
@@ -999,7 +999,7 @@ namespace GitCommands
 
         public IReadOnlyList<ObjectId> GetParents(ObjectId commitId)
         {
-            var args = new GitArgumentBuilder("log")
+            GitArgumentBuilder args = new("log")
             {
                 "-n 1",
                 "--format=format:%P",
@@ -1027,7 +1027,7 @@ namespace GitCommands
 
         public void DeleteTag(string tagName)
         {
-            var args = new GitArgumentBuilder("tag")
+            GitArgumentBuilder args = new("tag")
             {
                 "-d",
                 tagName.QuoteNE()
@@ -1041,7 +1041,7 @@ namespace GitCommands
         /// </summary>
         public ObjectId? GetCurrentCheckout()
         {
-            var args = new GitArgumentBuilder("rev-parse") { "HEAD" };
+            GitArgumentBuilder args = new("rev-parse") { "HEAD" };
             var result = _gitExecutable.Execute(args);
 
             return result.ExitCode == 0 && ObjectId.TryParse(result.StandardOutput, offset: 0, out var objectId)
@@ -1057,7 +1057,7 @@ namespace GitCommands
                 return true;
             }
 
-            var args = new GitArgumentBuilder("rev-parse")
+            GitArgumentBuilder args = new("rev-parse")
             {
                 "--verify",
                 "--quiet",
@@ -1081,7 +1081,7 @@ namespace GitCommands
                 return (' ', null);
             }
 
-            var args = new GitArgumentBuilder("submodule")
+            GitArgumentBuilder args = new("submodule")
             {
                 "status",
                 "--cached",
@@ -1112,7 +1112,7 @@ namespace GitCommands
                 return false;
             }
 
-            var args = new GitArgumentBuilder($"rev-list")
+            GitArgumentBuilder args = new($"rev-list")
             {
                 "--parents",
                 "--no-walk",
@@ -1132,7 +1132,7 @@ namespace GitCommands
         }
 
         public ConfigFile GetSubmoduleConfigFile()
-            => new ConfigFile(WorkingDir + ".gitmodules", true);
+            => new(WorkingDir + ".gitmodules", true);
 
         public string? GetCurrentSubmoduleLocalPath()
         {
@@ -1187,7 +1187,7 @@ namespace GitCommands
                 yield return null;
             }
 
-            var args = new GitArgumentBuilder("submodule") { "status" };
+            GitArgumentBuilder args = new("submodule") { "status" };
             var lines = _gitExecutable.GetOutputLines(args);
 
             string? lastLine = null;
@@ -1267,7 +1267,7 @@ namespace GitCommands
 
         public string GetSubmoduleSummary(string submodule)
         {
-            var args = new GitArgumentBuilder("submodule")
+            GitArgumentBuilder args = new("submodule")
             {
                 "summary",
                 submodule
@@ -1390,7 +1390,7 @@ namespace GitCommands
 
         public static void StartPageantWithKey(string? sshKeyFile)
         {
-            var pageantExecutable = new Executable(AppSettings.Pageant);
+            Executable pageantExecutable = new(AppSettings.Pageant);
 
             // ensure pageant is loaded, so we can wait for loading a key in the next command
             // otherwise we'll stuck there waiting until pageant exits
@@ -1576,7 +1576,7 @@ namespace GitCommands
 
             foreach (var file in files)
             {
-                using var fs = new FileStream(file, FileMode.Open);
+                using FileStream fs = new(file, FileMode.Open);
                 fs.CopyTo(process.StandardInput.BaseStream);
             }
 
@@ -1653,7 +1653,7 @@ namespace GitCommands
                 return "";
             }
 
-            var output = new StringBuilder();
+            StringBuilder output = new();
             var nonDeletedFiles = files.Where(file => !file.IsDeleted).ToList();
             var deletedFiles = files.Where(file => file.IsDeleted).ToList();
 
@@ -1715,7 +1715,7 @@ namespace GitCommands
                 return "";
             }
 
-            var output = new StringBuilder();
+            StringBuilder output = new();
             var nonNewFiles = files.Where(file => !file.IsDeleted).ToList();
             var newFiles = files.Where(file => file.IsDeleted).ToList();
 
@@ -1763,8 +1763,8 @@ namespace GitCommands
         /// <returns><see langword="true" /> if changes should be rescanned; otherwise <see langword="false" />.</returns>.
         public bool BatchUnstageFiles(IEnumerable<GitItemStatus> selectedItems, Action<BatchProgressEventArgs>? action = null)
         {
-            var files = new List<GitItemStatus>();
-            var filesToRemove = new List<string>();
+            List<GitItemStatus> files = new();
+            List<string> filesToRemove = new();
             var shouldRescanChanges = false;
             foreach (var item in selectedItems)
             {
@@ -1806,7 +1806,7 @@ namespace GitCommands
 
         public async Task<bool> AddInteractiveAsync(GitItemStatus file)
         {
-            var args = new GitArgumentBuilder("add")
+            GitArgumentBuilder args = new("add")
             {
                 "-p",
                 file.Name.Quote()
@@ -1818,7 +1818,7 @@ namespace GitCommands
 
         public async Task<bool> ResetInteractiveAsync(GitItemStatus file)
         {
-            var args = new GitArgumentBuilder("checkout")
+            GitArgumentBuilder args = new("checkout")
             {
                 "-p",
                 file.Name.Quote()
@@ -1898,7 +1898,7 @@ namespace GitCommands
             string todoFile = RebaseTodoFilePath;
             string[]? todoCommits = File.Exists(todoFile) ? File.ReadAllText(todoFile).Trim().Split(Delimiters.LineFeedAndCarriageReturn, StringSplitOptions.RemoveEmptyEntries) : null;
 
-            var patchFiles = new List<PatchFile>();
+            List<PatchFile> patchFiles = new();
 
             if (todoCommits is not null)
             {
@@ -1943,7 +1943,7 @@ namespace GitCommands
 
         public IReadOnlyList<PatchFile> GetRebasePatchFiles()
         {
-            var patchFiles = new List<PatchFile>();
+            List<PatchFile> patchFiles = new();
 
             var nextFile = GetNextRebasePatch();
 
@@ -1963,8 +1963,8 @@ namespace GitCommands
                     continue;
                 }
 
-                var patchFile =
-                    new PatchFile
+                PatchFile patchFile =
+                    new()
                     {
                         Name = file,
                         FullName = fullFileName,
@@ -2077,7 +2077,7 @@ namespace GitCommands
 
         public string RemoveRemote(string remoteName)
         {
-            var args = new GitArgumentBuilder("remote")
+            GitArgumentBuilder args = new("remote")
             {
                 "rm",
                 remoteName.QuoteNE()
@@ -2087,7 +2087,7 @@ namespace GitCommands
 
         public string RenameRemote(string remoteName, string newName)
         {
-            var args = new GitArgumentBuilder("remote")
+            GitArgumentBuilder args = new("remote")
             {
                 "rename",
                 remoteName.QuoteNE(),
@@ -2098,7 +2098,7 @@ namespace GitCommands
 
         public string RenameBranch(string name, string newName)
         {
-            var args = new GitArgumentBuilder("branch")
+            GitArgumentBuilder args = new("branch")
             {
                 "-m",
                 name.QuoteNE(),
@@ -2139,7 +2139,7 @@ namespace GitCommands
 
             IReadOnlyList<Remote> ParseRemotes(IEnumerable<string> lines)
             {
-                var remotes = new List<Remote>();
+                List<Remote> remotes = new();
 
                 // See tests for explanation of the format
 
@@ -2246,7 +2246,7 @@ namespace GitCommands
             var args = GetStashesCmd(noLocks);
             var lines = _gitExecutable.GetOutput(args).Split(Delimiters.LineFeed);
 
-            var stashes = new List<GitStash>(lines.Length);
+            List<GitStash> stashes = new(lines.Length);
 
             foreach (var line in lines)
             {
@@ -2273,7 +2273,7 @@ namespace GitCommands
 
             string? diffOptions = _revisionDiffProvider.Get(firstRevision, secondRevision, fileName, oldFileName, isTracked);
 
-            var args = new GitArgumentBuilder("diff")
+            GitArgumentBuilder args = new("diff")
             {
                 "--no-color",
                 extraDiffArguments,
@@ -2316,7 +2316,7 @@ namespace GitCommands
             }
 
             // Supported since Git 2.19 (checks when adding the command)
-            var args = new GitArgumentBuilder("range-diff")
+            GitArgumentBuilder args = new("range-diff")
             {
                 "--no-color",
                 extraDiffArguments,
@@ -2458,7 +2458,7 @@ namespace GitCommands
             var resultCollection = GetDiffFilesWithUntracked(stashName + "^", stashName, StagedStatus.None, true).ToList();
 
             // shows untracked files
-            var args = new GitArgumentBuilder("log")
+            GitArgumentBuilder args = new("log")
             {
                 $"{stashName}^3",
                 "--pretty=format:\"%T\"",
@@ -2518,7 +2518,7 @@ namespace GitCommands
 
             if (!excludeAssumeUnchangedFiles || !excludeSkipWorktreeFiles)
             {
-                var args = new GitArgumentBuilder("ls-files") { "-v" };
+                GitArgumentBuilder args = new("ls-files") { "-v" };
                 string lsOutput = _gitExecutable.GetOutput(args);
 
                 if (!excludeAssumeUnchangedFiles)
@@ -2537,7 +2537,7 @@ namespace GitCommands
 
         private static IReadOnlyList<GitItemStatus> GetAssumeUnchangedFilesFromString(string lsString)
         {
-            var result = new List<GitItemStatus>();
+            List<GitItemStatus> result = new();
 
             foreach (string line in lsString.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries))
             {
@@ -2558,7 +2558,7 @@ namespace GitCommands
 
         private static IReadOnlyList<GitItemStatus> GetSkipWorktreeFilesFromString(string lsString)
         {
-            var result = new List<GitItemStatus>();
+            List<GitItemStatus> result = new();
 
             foreach (string line in lsString.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries))
             {
@@ -2616,7 +2616,7 @@ namespace GitCommands
 
         public IReadOnlyList<GitItemStatus> GetIndexFiles()
         {
-            var args = new GitArgumentBuilder("diff")
+            GitArgumentBuilder args = new("diff")
             {
                 "--no-color",
                 "-M",
@@ -2701,7 +2701,7 @@ namespace GitCommands
 
         private async Task<string?> GetFileContentsAsync(string? path)
         {
-            var args = new GitArgumentBuilder("show") { $"HEAD:{path.ToPosixPath().Quote()}" };
+            GitArgumentBuilder args = new("show") { $"HEAD:{path.ToPosixPath().Quote()}" };
             var result = await _gitExecutable.ExecuteAsync(args).ConfigureAwaitRunInline();
 
             return result.ExitCode == 0
@@ -2743,7 +2743,7 @@ namespace GitCommands
 
         public void UnstageFile(string file)
         {
-            var args = new GitArgumentBuilder("rm")
+            GitArgumentBuilder args = new("rm")
             {
                 "--cached",
                 file.ToPosixPath().QuoteNE()
@@ -2816,7 +2816,7 @@ namespace GitCommands
                 return head;
             }
 
-            var args = new GitArgumentBuilder("symbolic-ref")
+            GitArgumentBuilder args = new("symbolic-ref")
             {
                 "--quiet",
                 "HEAD"
@@ -2865,7 +2865,7 @@ namespace GitCommands
 
         public RemoteActionResult<IReadOnlyList<IGitRef>> GetRemoteServerRefs(string remote, bool tags, bool branches)
         {
-            var result = new RemoteActionResult<IReadOnlyList<IGitRef>>
+            RemoteActionResult<IReadOnlyList<IGitRef>> result = new()
             {
                 AuthenticationFail = false,
                 HostKeyFail = false,
@@ -2972,19 +2972,19 @@ namespace GitCommands
             //
             // Lines may also use \t as a column delimiter, such as output of "ls-remote --heads origin".
 
-            var regex = new Regex(@"^(?<objectid>[0-9a-f]{40})[ \t](?<refname>.+)$", RegexOptions.Multiline | RegexOptions.Compiled);
+            Regex regex = new(@"^(?<objectid>[0-9a-f]{40})[ \t](?<refname>.+)$", RegexOptions.Multiline | RegexOptions.Compiled);
 
             var matches = regex.Matches(refList);
 
-            var gitRefs = new List<IGitRef>();
-            var headByRemote = new Dictionary<string, GitRef>();
+            List<IGitRef> gitRefs = new();
+            Dictionary<string, GitRef> headByRemote = new();
 
             foreach (Match match in matches)
             {
                 var refName = match.Groups["refname"].Value;
                 var objectId = ObjectId.Parse(refList, match.Groups["objectid"]);
                 var remoteName = GitRefName.GetRemoteName(refName);
-                var head = new GitRef(this, objectId, refName, remoteName);
+                GitRef head = new(this, objectId, refName, remoteName);
 
                 if (GitRefName.IsRemoteHead(refName))
                 {
@@ -3026,7 +3026,7 @@ namespace GitCommands
                 return Array.Empty<string>();
             }
 
-            var args = new GitArgumentBuilder("branch")
+            GitArgumentBuilder args = new("branch")
             {
                 { getRemote && getLocal, "-a" },
                 { getRemote && !getLocal, "-r" },
@@ -3170,7 +3170,7 @@ namespace GitCommands
 
         public IEnumerable<INamedGitItem> GetTree(ObjectId? commitId, bool full)
         {
-            var args = new GitArgumentBuilder("ls-tree")
+            GitArgumentBuilder args = new("ls-tree")
             {
                 "-z",
                 { full, "-r" },
@@ -3184,7 +3184,7 @@ namespace GitCommands
 
         public GitBlame Blame(string? fileName, string from, Encoding encoding, string? lines = null)
         {
-            var args = new GitArgumentBuilder("blame")
+            GitArgumentBuilder args = new("blame")
             {
                 "--porcelain",
                 { AppSettings.DetectCopyInFileOnBlame, "-M" },
@@ -3274,10 +3274,10 @@ namespace GitCommands
             // We see the content of the chunks, where the first is a markdown header, the second
             // is a blank line, and third is an introductory paragraph about the project.
 
-            var commitByObjectId = new Dictionary<ObjectId, GitBlameCommit>();
-            var lines = new List<GitBlameLine>(capacity: 256);
+            Dictionary<ObjectId, GitBlameCommit> commitByObjectId = new();
+            List<GitBlameLine> lines = new(capacity: 256);
 
-            var headerRegex = new Regex(@"^(?<objectid>[0-9a-f]{40}) (?<origlinenum>\d+) (?<finallinenum>\d+)", RegexOptions.Compiled);
+            Regex headerRegex = new(@"^(?<objectid>[0-9a-f]{40}) (?<origlinenum>\d+) (?<finallinenum>\d+)", RegexOptions.Compiled);
 
             bool hasCommitHeader;
             ObjectId? objectId;
@@ -3441,7 +3441,7 @@ namespace GitCommands
 
         public string GetFileText(ObjectId id, Encoding encoding)
         {
-            var args = new GitArgumentBuilder("cat-file")
+            GitArgumentBuilder args = new("cat-file")
             {
                 "blob",
                 id.ToString().QuoteNE()
@@ -3462,7 +3462,7 @@ namespace GitCommands
             // TODO use regex for parsing
             if (objectId == ObjectId.IndexId)
             {
-                var args = new GitArgumentBuilder("ls-files")
+                GitArgumentBuilder args = new("ls-files")
                 {
                     "-s",
                     { !string.IsNullOrWhiteSpace(fileName), "--" },
@@ -3479,7 +3479,7 @@ namespace GitCommands
             }
             else
             {
-                var args = new GitArgumentBuilder("ls-tree")
+                GitArgumentBuilder args = new("ls-tree")
                 {
                     "-r",
                     objectId,
@@ -3502,13 +3502,13 @@ namespace GitCommands
 
             try
             {
-                var args = new GitArgumentBuilder("cat-file")
+                GitArgumentBuilder args = new("cat-file")
                 {
                     "blob",
                     blob
                 };
                 using var process = _gitCommandRunner.RunDetached(args, redirectOutput: true);
-                var stream = new MemoryStream();
+                MemoryStream stream = new();
                 process.StandardOutput.BaseStream.CopyTo(stream);
                 process.WaitForExit();
                 stream.Position = 0;
@@ -3523,7 +3523,7 @@ namespace GitCommands
 
         public IEnumerable<string?> GetPreviousCommitMessages(int count, string revision = "HEAD", string authorPattern = "")
         {
-            var args = new GitArgumentBuilder("log")
+            GitArgumentBuilder args = new("log")
             {
                 "-z",
                 $"-n {count}",
@@ -3560,7 +3560,7 @@ namespace GitCommands
         public string GetCustomDiffMergeTools(bool isDiff)
         {
             // Note that --gui has no effect here
-            var args = new GitArgumentBuilder(isDiff ? "difftool" : "mergetool") { "--tool-help" };
+            GitArgumentBuilder args = new(isDiff ? "difftool" : "mergetool") { "--tool-help" };
             return _gitExecutable.GetOutput(args);
         }
 
@@ -3622,7 +3622,7 @@ namespace GitCommands
                 return objectId;
             }
 
-            var args = new GitArgumentBuilder("rev-parse")
+            GitArgumentBuilder args = new("rev-parse")
             {
                 "--quiet",
                 "--verify",
@@ -3642,7 +3642,7 @@ namespace GitCommands
                 return a;
             }
 
-            var args = new GitArgumentBuilder("merge-base")
+            GitArgumentBuilder args = new("merge-base")
             {
                 a,
                 b
@@ -3748,7 +3748,7 @@ namespace GitCommands
             }
 
             branchName = branchName.Replace("\"", "\\\"");
-            var args = new GitArgumentBuilder("check-ref-format")
+            GitArgumentBuilder args = new("check-ref-format")
             {
                 "--branch",
                 branchName.QuoteNE()
@@ -3792,7 +3792,7 @@ namespace GitCommands
 
             // Get processes by "ps" command.
             var cmd = Path.Combine(AppSettings.GitBinDir, "ps");
-            var lines = new Executable(cmd).GetOutput("x").Split(Delimiters.LineFeed);
+            string[] lines = new Executable(cmd).GetOutput("x").Split(Delimiters.LineFeed);
 
             if (lines.Length <= 2)
             {
@@ -4022,7 +4022,7 @@ namespace GitCommands
 
         public IReadOnlyList<GitItemStatus> GetCombinedDiffFileList(string shaOfMergeCommit)
         {
-            var args = new GitArgumentBuilder($"diff-tree")
+            GitArgumentBuilder args = new($"diff-tree")
             {
                 "--name-only",
                 "-z",
@@ -4053,7 +4053,7 @@ namespace GitCommands
 
         public string? GetCombinedDiffContent(ObjectId revisionOfMergeCommit, string filePath, string extraArgs, Encoding encoding)
         {
-            var args = new GitArgumentBuilder("diff-tree")
+            GitArgumentBuilder args = new("diff-tree")
             {
                 { AppSettings.OmitUninterestingDiff, "--cc", "-c -p" },
                 "--no-commit-id",
@@ -4078,13 +4078,13 @@ namespace GitCommands
 
         public bool HasLfsSupport()
         {
-            var args = new GitArgumentBuilder("lfs") { "version" };
+            GitArgumentBuilder args = new("lfs") { "version" };
             return _gitExecutable.RunCommand(args);
         }
 
         public bool StopTrackingFile(string filename)
         {
-            var args = new GitArgumentBuilder("rm")
+            GitArgumentBuilder args = new("rm")
             {
                 "--cached",
                 filename.ToPosixPath().Quote()
@@ -4099,7 +4099,7 @@ namespace GitCommands
         /// <returns>Tag name if it exists, otherwise null</returns>
         public string? GetDescribe(ObjectId commitId)
         {
-            var args = new GitArgumentBuilder("describe")
+            GitArgumentBuilder args = new("describe")
             {
                 "--tags",
                 "--first-parent",
@@ -4120,11 +4120,11 @@ namespace GitCommands
 
         public (int totalCount, Dictionary<string, int> countByName) GetCommitsByContributor(DateTime? since = null, DateTime? until = null)
         {
-            var countByName = new Dictionary<string, int>();
+            Dictionary<string, int> countByName = new();
             var totalCommits = 0;
 
-            var regex = new Regex(@"^\s*(?<count>\d+)\s+(?<name>.*)$");
-            var args = new GitArgumentBuilder("shortlog")
+            Regex regex = new(@"^\s*(?<count>\d+)\s+(?<name>.*)$");
+            GitArgumentBuilder args = new("shortlog")
             {
                 "--all",
                 "-s",
@@ -4171,7 +4171,7 @@ namespace GitCommands
             }
         }
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitCommands/Git/GitPushAction.cs
+++ b/GitCommands/Git/GitPushAction.cs
@@ -70,7 +70,7 @@ namespace GitCommands
         /// <summary>Creates the 'push' command string. <example>"push --progress origin master:master"</example></summary>
         public override string ToString()
         {
-            var args = new GitArgumentBuilder("push")
+            GitArgumentBuilder args = new("push")
             {
                 { ReportProgress, "--progress" },
                 Remote.Quote(),

--- a/GitCommands/Git/GitRevisionSummaryBuilder.cs
+++ b/GitCommands/Git/GitRevisionSummaryBuilder.cs
@@ -26,7 +26,7 @@ namespace GitCommands
                 return null;
             }
 
-            var s = new StringBuilder(Math.Min(body.Length, CommitSummaryWorstCaseLength));
+            StringBuilder s = new(Math.Min(body.Length, CommitSummaryWorstCaseLength));
 
             int lineCount = 0;
             int lineStartPos = 0;

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -35,7 +35,7 @@ namespace GitCommands
             {
                 if (_current is null || _current.IsUnknown)
                 {
-                    var output = new Executable(AppSettings.GitCommand).GetOutput("--version");
+                    string output = new Executable(AppSettings.GitCommand).GetOutput("--version");
                     _current = new GitVersion(output);
                 }
 

--- a/GitCommands/Git/RevisionDiffProvider.cs
+++ b/GitCommands/Git/RevisionDiffProvider.cs
@@ -67,7 +67,7 @@ namespace GitCommands.Git
                     firstRevision + ", " + secondRevision);
             }
 
-            var extra = new ArgumentBuilder();
+            ArgumentBuilder extra = new();
             firstRevision = ArtificialToDiffOptions(firstRevision);
             secondRevision = ArtificialToDiffOptions(secondRevision);
 

--- a/GitCommands/Git/SystemEncodingReader.cs
+++ b/GitCommands/Git/SystemEncodingReader.cs
@@ -42,7 +42,7 @@ namespace GitCommands.Git
                 // git config --get with a malformed key (no section) returns:
                 // "error: key does not contain a section: <key>"
                 const string controlStr = "ą"; // "a caudata"
-                var arguments = new GitArgumentBuilder("config")
+                GitArgumentBuilder arguments = new("config")
                 {
                     "--get",
                     controlStr

--- a/GitCommands/Git/Tag/GitTagController.cs
+++ b/GitCommands/Git/Tag/GitTagController.cs
@@ -55,7 +55,7 @@ namespace GitCommands.Git.Tag
                 _fileSystem.File.WriteAllText(tagMessageFileName, args.TagMessage);
             }
 
-            var createTagCmd = new GitCreateTagCmd(args, tagMessageFileName);
+            GitCreateTagCmd createTagCmd = new(args, tagMessageFileName);
             try
             {
                 return _uiCommands.StartCommandLineProcessDialog(parentWindow, createTagCmd);

--- a/GitCommands/Logging/CommandLog.cs
+++ b/GitCommands/Logging/CommandLog.cs
@@ -131,7 +131,7 @@ namespace GitCommands.Logging
         {
             get
             {
-                var s = new StringBuilder();
+                StringBuilder s = new();
 
                 s.Append("File name:   ").AppendLine(FileName);
                 s.Append("Arguments:   ").AppendLine(Arguments);
@@ -152,7 +152,7 @@ namespace GitCommands.Logging
     {
         public static event Action? CommandsChanged;
 
-        private static ConcurrentQueue<CommandLogEntry> _queue = new ConcurrentQueue<CommandLogEntry>();
+        private static ConcurrentQueue<CommandLogEntry> _queue = new();
 
         public static IEnumerable<CommandLogEntry> Commands => _queue;
 
@@ -160,7 +160,7 @@ namespace GitCommands.Logging
         {
             const int MaxEntryCount = 500;
 
-            var entry = new CommandLogEntry(fileName, arguments, workDir, DateTime.Now, ThreadHelper.JoinableTaskContext.IsOnMainThread);
+            CommandLogEntry entry = new(fileName, arguments, workDir, DateTime.Now, ThreadHelper.JoinableTaskContext.IsOnMainThread);
 
             if (AppSettings.LogCaptureCallStacks)
             {

--- a/GitCommands/Patches/PatchManager.cs
+++ b/GitCommands/Patches/PatchManager.cs
@@ -69,7 +69,7 @@ namespace GitCommands.Patches
                 }
             }
 
-            var sb = new StringBuilder();
+            StringBuilder sb = new();
 
             foreach (string line in headerLines)
             {
@@ -98,7 +98,7 @@ namespace GitCommands.Patches
             }
 
             const string fileMode = "100644"; // given fake mode to satisfy patch format, git will override this
-            var header = new StringBuilder();
+            StringBuilder header = new();
 
             header.Append("diff --git a/").Append(newFileName).Append(" b/").Append(newFileName).Append('\n');
 
@@ -155,7 +155,7 @@ namespace GitCommands.Patches
             string diff = text.Substring(patchPos - 1);
 
             string[] chunks = diff.Split(new[] { "\n@@" }, StringSplitOptions.RemoveEmptyEntries);
-            var selectedChunks = new List<Chunk>();
+            List<Chunk> selectedChunks = new();
             int i = 0;
             int currentPos = patchPos - 1;
 
@@ -208,7 +208,7 @@ namespace GitCommands.Patches
 
         private static string? ToPatch(IEnumerable<Chunk> chunks, [InstantHandle] SubChunkToPatchFnc subChunkToPatch)
         {
-            var result = new StringBuilder();
+            StringBuilder result = new();
 
             foreach (Chunk chunk in chunks)
             {
@@ -443,7 +443,7 @@ namespace GitCommands.Patches
     internal sealed class Chunk
     {
         private int _startLine;
-        private readonly List<SubChunk> _subChunks = new List<SubChunk>();
+        private readonly List<SubChunk> _subChunks = new();
         private SubChunk? _currentSubChunk;
 
         private SubChunk CurrentSubChunk
@@ -522,7 +522,7 @@ namespace GitCommands.Patches
             bool inPreContext = true;
             int i = 1;
 
-            var result = new Chunk();
+            Chunk result = new();
             result.ParseHeader(lines[0]);
             currentPos += lines[0].Length + 1;
 
@@ -531,7 +531,7 @@ namespace GitCommands.Patches
                 string line = lines[i];
                 if (inPatch)
                 {
-                    var patchLine = new PatchLine(line);
+                    PatchLine patchLine = new(line);
 
                     // do not refactor, there are no break points condition in VS Express
                     if (currentPos <= selectionPosition + selectionLength && currentPos + line.Length >= selectionPosition)
@@ -579,7 +579,7 @@ namespace GitCommands.Patches
 
         public static Chunk FromNewFile(GitModule module, string fileText, int selectionPosition, int selectionLength, bool reset, byte[] filePreamble, Encoding fileContentEncoding)
         {
-            var result = new Chunk { _startLine = 0 };
+            Chunk result = new() { _startLine = 0 };
 
             int currentPos = 0;
             string gitEol = module.GetEffectiveSetting("core.eol");
@@ -599,7 +599,7 @@ namespace GitCommands.Patches
             {
                 string line = lines[i];
                 string preamble = i == 0 ? new string(fileContentEncoding.GetChars(filePreamble)) : string.Empty;
-                var patchLine = new PatchLine((reset ? "-" : "+") + preamble + line);
+                PatchLine patchLine = new((reset ? "-" : "+") + preamble + line);
 
                 // do not refactor, there are no breakpoints condition in VS Express
                 if (currentPos <= selectionPosition + selectionLength && currentPos + line.Length >= selectionPosition)
@@ -648,7 +648,7 @@ namespace GitCommands.Patches
             int addedCount = 0;
             int removedCount = 0;
 
-            var diff = new StringBuilder();
+            StringBuilder diff = new();
             foreach (SubChunk subChunk in _subChunks)
             {
                 if (diff.Length != 0)

--- a/GitCommands/Patches/PatchProcessor.cs
+++ b/GitCommands/Patches/PatchProcessor.cs
@@ -112,7 +112,7 @@ namespace GitCommands.Patches
             string? index = null;
             var changeType = PatchChangeType.ChangeFile;
             var fileType = PatchFileType.Text;
-            var patchText = new StringBuilder();
+            StringBuilder patchText = new();
 
             patchText.Append(header);
             if (lineIndex < lines.Length - 1)

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -14,7 +14,7 @@ namespace GitCommands
         private static readonly IEnvironmentPathsProvider EnvironmentPathsProvider = new EnvironmentPathsProvider(EnvironmentAbstraction);
 
         // URL regex obtained from https://www.regextester.com/53716 with some modifications
-        private static readonly Regex UrlRegex = new Regex(
+        private static readonly Regex UrlRegex = new(
             @"(?:(?:https?|ftp|file|ssh|git):\/\/|www\.)(?:[-A-Z0-9+&@#\/%=~_|$?!:,.])*(?:[A-Z0-9+&@#\/%=~_|$])",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 

--- a/GitCommands/Plink.cs
+++ b/GitCommands/Plink.cs
@@ -93,9 +93,9 @@ namespace GitCommands
             }
 
             // Turn ssh://user@host/path into user@host:path, which works better
-            var uri = new Uri(inputUrl, UriKind.Absolute);
+            Uri uri = new(inputUrl, UriKind.Absolute);
 
-            var fixedUrl = new StringBuilder();
+            StringBuilder fixedUrl = new();
 
             if (!uri.IsDefaultPort)
             {

--- a/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
+++ b/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
@@ -143,7 +143,7 @@ namespace GitCommands.Remotes
             var module = GetModule();
             bool IsSettingForBranch(string setting, string branchName)
             {
-                var head = new GitRef(module, null, setting);
+                GitRef head = new(module, null, setting);
                 return head.IsHead && head.Name.Equals(branchName, StringComparison.OrdinalIgnoreCase);
             }
 
@@ -219,7 +219,7 @@ namespace GitCommands.Remotes
         // TODO: candidate for Async implementations
         public IEnumerable<ConfigFileRemote> LoadRemotes(bool loadDisabled)
         {
-            var remotes = new List<ConfigFileRemote>();
+            List<ConfigFileRemote> remotes = new();
             var module = _getModule();
             if (module is null)
             {

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -123,7 +123,7 @@ namespace GitCommands
                 token.ThrowIfCancellationRequested();
 
                 // Pool string values likely to form a small set: encoding, authorname, authoremail, committername, committeremail
-                var stringPool = new StringPool();
+                StringPool stringPool = new();
 
                 var buffer = new byte[4096];
 
@@ -396,7 +396,7 @@ namespace GitCommands
             // Finally, decode the names, email, subject and body strings using the required text encoding
             var s = encoding.GetString(array, offset, lastOffset - offset);
 
-            var reader = new StringLineReader(s);
+            StringLineReader reader = new(s);
 
             var author = reader.ReadLine(stringPool);
             var authorEmail = reader.ReadLine(stringPool);
@@ -545,7 +545,7 @@ namespace GitCommands
         #endregion
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {
@@ -563,7 +563,7 @@ namespace GitCommands
             internal static (string? body, string? additionalData) ParseCommitBody(StringLineReader reader, string subject) =>
                 RevisionReader.ParseCommitBody(reader, subject);
 
-            internal static StringLineReader MakeReader(string s) => new StringLineReader(s);
+            internal static StringLineReader MakeReader(string s) => new(s);
 
             internal static string EndOfBody => RevisionReader.EndOfBody;
         }

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -693,7 +693,7 @@ namespace GitCommands
         }
 
         private static readonly Dictionary<string, string> _languageCodes =
-            new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
+            new(StringComparer.InvariantCultureIgnoreCase)
             {
                 { "Czech", "cs" },
                 { "Dutch", "nl" },
@@ -869,7 +869,7 @@ namespace GitCommands
             set => SetBool("revisiongraphdrawnonrelativestextgray", value);
         }
 
-        public static readonly Dictionary<string, Encoding> AvailableEncodings = new Dictionary<string, Encoding>();
+        public static readonly Dictionary<string, Encoding> AvailableEncodings = new();
 
         public enum PullAction
         {
@@ -2045,7 +2045,7 @@ namespace GitCommands
             }
             else
             {
-                var utf8 = new UTF8Encoding(false);
+                UTF8Encoding utf8 = new(false);
                 foreach (var encodingName in availableEncodings.LazySplit(';'))
                 {
 #pragma warning disable SYSLIB0001 // Type or member is obsolete
@@ -2084,7 +2084,7 @@ namespace GitCommands
             SetString("AvailableEncodings", availableEncodings);
         }
 
-        internal static TestAccessor GetTestAccessor() => new TestAccessor();
+        internal static TestAccessor GetTestAccessor() => new();
 
         internal struct TestAccessor
         {

--- a/GitCommands/Settings/ConfigFileSettingsCache.cs
+++ b/GitCommands/Settings/ConfigFileSettingsCache.cs
@@ -17,7 +17,7 @@ namespace GitCommands.Settings
 
         public static ConfigFileSettingsCache FromCache(string settingsFilePath, bool isLocal)
         {
-            var createSettingsCache = new Lazy<ConfigFileSettingsCache>(
+            Lazy<ConfigFileSettingsCache> createSettingsCache = new(
                 () => new ConfigFileSettingsCache(settingsFilePath, true, isLocal));
 
             return FromCache(settingsFilePath, createSettingsCache);

--- a/GitCommands/Settings/FileSettingsCache.cs
+++ b/GitCommands/Settings/FileSettingsCache.cs
@@ -250,7 +250,7 @@ namespace GitCommands.Settings
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitCommands/Settings/GitExtSettingsCache.cs
+++ b/GitCommands/Settings/GitExtSettingsCache.cs
@@ -6,7 +6,7 @@ namespace GitCommands.Settings
 {
     public class GitExtSettingsCache : FileSettingsCache
     {
-        private readonly XmlSerializableDictionary<string, string> _encodedNameMap = new XmlSerializableDictionary<string, string>();
+        private readonly XmlSerializableDictionary<string, string> _encodedNameMap = new();
 
         public GitExtSettingsCache(string settingsFilePath, bool autoSave = true)
             : base(settingsFilePath, autoSave)
@@ -15,7 +15,7 @@ namespace GitCommands.Settings
 
         public static GitExtSettingsCache FromCache(string settingsFilePath)
         {
-            var createSettingsCache = new Lazy<GitExtSettingsCache>(
+            Lazy<GitExtSettingsCache> createSettingsCache = new(
                 () => new GitExtSettingsCache(settingsFilePath, autoSave: true));
 
             return FromCache(settingsFilePath, createSettingsCache);
@@ -40,7 +40,7 @@ namespace GitCommands.Settings
 
         protected override void WriteSettings(string fileName)
         {
-            using var xtw = new XmlTextWriter(fileName, Encoding.UTF8) { Formatting = Formatting.Indented };
+            using XmlTextWriter xtw = new(fileName, Encoding.UTF8) { Formatting = Formatting.Indented };
             xtw.WriteStartDocument();
             xtw.WriteStartElement("dictionary");
             _encodedNameMap.WriteXml(xtw);
@@ -49,7 +49,7 @@ namespace GitCommands.Settings
 
         protected override void ReadSettings(string fileName)
         {
-            var readerSettings = new XmlReaderSettings
+            XmlReaderSettings readerSettings = new()
             {
                 IgnoreWhitespace = true,
                 CheckCharacters = false

--- a/GitCommands/Settings/SettingsCache.cs
+++ b/GitCommands/Settings/SettingsCache.cs
@@ -6,7 +6,7 @@ namespace GitCommands
 {
     public abstract class SettingsCache : IDisposable
     {
-        private readonly ConcurrentDictionary<string, object?> _byNameMap = new ConcurrentDictionary<string, object?>();
+        private readonly ConcurrentDictionary<string, object?> _byNameMap = new();
 
         public void Dispose()
         {

--- a/GitCommands/StreamExtensions.cs
+++ b/GitCommands/StreamExtensions.cs
@@ -107,7 +107,7 @@ namespace GitCommands
         public static byte[] ReadAllBytes(this Stream stream)
         {
             // NOTE no need to dispose MemoryStream
-            var memoryStream = new MemoryStream();
+            MemoryStream memoryStream = new();
             stream.CopyTo(memoryStream);
             return memoryStream.ToArray();
         }

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -226,7 +226,7 @@ namespace System
                 value = value.Substring(0, value.Length - 1);
             }
 
-            var sb = new StringBuilder(capacity: value.Length);
+            StringBuilder sb = new(capacity: value.Length);
 
             foreach (var line in value.LazySplit('\n'))
             {

--- a/GitCommands/StringPool.cs
+++ b/GitCommands/StringPool.cs
@@ -86,7 +86,7 @@ namespace GitCommands
             _capacity *= 2;
 
             var newBuckets = new object[_buckets.Length * 2];
-            var lists = new Stack<List<string>>();
+            Stack<List<string>> lists = new();
 
             for (var i = 0; i < _buckets.Length; i++)
             {

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -44,7 +44,7 @@ namespace GitCommands.Submodules
         private readonly CancellationTokenSequence _submodulesStatusSequence = new();
         private DateTime _previousSubmoduleUpdateTime;
         private SubmoduleInfoResult? _submoduleInfoResult;
-        private readonly Dictionary<string, SubmoduleInfo> _submoduleInfos = new Dictionary<string, SubmoduleInfo>();
+        private readonly Dictionary<string, SubmoduleInfo> _submoduleInfos = new();
 
         // Singleton accessor
         public static SubmoduleStatusProvider Default { get; } = new();
@@ -86,7 +86,7 @@ namespace GitCommands.Submodules
             await TaskScheduler.Default;
 
             // Start gathering new submodule structure asynchronously.
-            var currentModule = new GitModule(workingDirectory);
+            GitModule currentModule = new(workingDirectory);
             var result = GetSuperProjectRepositorySubmodulesStructure(currentModule, noBranchText);
 
             // Prepare info for status updates
@@ -160,7 +160,7 @@ namespace GitCommands.Submodules
                 cancelToken.ThrowIfCancellationRequested();
             }
 
-            var currentModule = new GitModule(workingDirectory);
+            GitModule currentModule = new(workingDirectory);
             await UpdateSubmodulesStatusAsync(currentModule, gitStatus, cancelToken);
 
             OnStatusUpdated(_submoduleInfoResult, structureUpdated: false, cancelToken);
@@ -184,7 +184,7 @@ namespace GitCommands.Submodules
         /// <param name="noBranchText">text with no branches.</param>
         private SubmoduleInfoResult GetSuperProjectRepositorySubmodulesStructure(GitModule currentModule, string noBranchText)
         {
-            var result = new SubmoduleInfoResult { Module = currentModule, CurrentSubmoduleStatus = null };
+            SubmoduleInfoResult result = new() { Module = currentModule, CurrentSubmoduleStatus = null };
 
             IGitModule topProject = currentModule.GetTopModule();
             bool isCurrentTopProject = currentModule.SuperprojectModule is null;
@@ -242,7 +242,7 @@ namespace GitCommands.Submodules
                     bold = true;
                 }
 
-                var smi = new SubmoduleInfo(text: name, path, bold);
+                SubmoduleInfo smi = new(text: name, path, bold);
                 result.AllSubmodules.Add(smi);
                 if (path == superWorkDir)
                 {
@@ -428,7 +428,7 @@ namespace GitCommands.Submodules
                 };
 
             // Recursively update submodules
-            var module = new GitModule(path);
+            GitModule module = new(path);
             if (submoduleStatus is not null && submoduleStatus.IsDirty)
             {
                 await GetSubmoduleDetailedStatusAsync(module, cancelToken);
@@ -467,7 +467,7 @@ namespace GitCommands.Submodules
             }
 
             _submoduleInfos[path].Detailed = null;
-            var module = new GitModule(path);
+            GitModule module = new(path);
             foreach (var name in module.GetSubmodulesLocalPaths(false))
             {
                 SetSubmoduleEmptyDetailedStatus(module, name);

--- a/GitCommands/UserRepositoryHistory/Legacy/RepositoryCategoryXmlSerialiser.cs
+++ b/GitCommands/UserRepositoryHistory/Legacy/RepositoryCategoryXmlSerialiser.cs
@@ -28,7 +28,7 @@ namespace GitCommands.UserRepositoryHistory.Legacy
 
             try
             {
-                var serializer = new XmlSerializer(typeof(List<RepositoryCategory>));
+                XmlSerializer serializer = new(typeof(List<RepositoryCategory>));
                 using TextReader reader = new StringReader(serialised);
                 if (serializer.Deserialize(reader) is List<RepositoryCategory> obj)
                 {

--- a/GitCommands/UserRepositoryHistory/RecentRepoInfo.cs
+++ b/GitCommands/UserRepositoryHistory/RecentRepoInfo.cs
@@ -66,9 +66,9 @@ namespace GitCommands.UserRepositoryHistory
 
         public void SplitRecentRepos(IList<Repository> recentRepositories, List<RecentRepoInfo> mostRecentRepoList, List<RecentRepoInfo> lessRecentRepoList)
         {
-            var orderedRepos = new SortedList<string, List<RecentRepoInfo>>();
-            var mostRecentRepos = new List<RecentRepoInfo>();
-            var lessRecentRepos = new List<RecentRepoInfo>();
+            SortedList<string, List<RecentRepoInfo>> orderedRepos = new();
+            List<RecentRepoInfo> mostRecentRepos = new();
+            List<RecentRepoInfo> lessRecentRepos = new();
 
             var middleDot = ShorteningStrategy == ShorteningRecentRepoPathStrategy.MiddleDots;
             var signDir = ShorteningStrategy == ShorteningRecentRepoPathStrategy.MostSignDir;
@@ -81,7 +81,7 @@ namespace GitCommands.UserRepositoryHistory
             {
                 bool mostRecent = (mostRecentRepos.Count < n && repository.Anchor == Repository.RepositoryAnchor.None) ||
                     repository.Anchor == Repository.RepositoryAnchor.MostRecent;
-                var ri = new RecentRepoInfo(repository, mostRecent);
+                RecentRepoInfo ri = new(repository, mostRecent);
                 if (ri.MostRecent)
                 {
                     mostRecentRepos.Add(ri);
@@ -188,7 +188,7 @@ namespace GitCommands.UserRepositoryHistory
                 orderedRepos.Add(repoInfo.Caption!, list);
             }
 
-            var tmpList = new List<RecentRepoInfo>();
+            List<RecentRepoInfo> tmpList = new();
             if (existsShortName)
             {
                 for (int i = list.Count - 1; i >= 0; i--)

--- a/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
+++ b/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
@@ -37,7 +37,7 @@ namespace GitCommands.UserRepositoryHistory
         /// <returns>Short name for repository.</returns>
         public string Get(string repositoryDir)
         {
-            var dirInfo = new DirectoryInfo(repositoryDir);
+            DirectoryInfo dirInfo = new(repositoryDir);
             if (!dirInfo.Exists)
             {
                 return dirInfo.Name;

--- a/GitCommands/UserRepositoryHistory/RepositoryHistoryManager.cs
+++ b/GitCommands/UserRepositoryHistory/RepositoryHistoryManager.cs
@@ -7,7 +7,7 @@
     {
         static RepositoryHistoryManager()
         {
-            var repositoryStorage = new RepositoryStorage();
+            RepositoryStorage repositoryStorage = new();
             Locals = new LocalRepositoryManager(repositoryStorage, new Legacy.RepositoryHistoryMigrator());
             Remotes = new RemoteRepositoryManager(repositoryStorage);
         }

--- a/GitCommands/UserRepositoryHistory/RepositoryXmlSerialiser.cs
+++ b/GitCommands/UserRepositoryHistory/RepositoryXmlSerialiser.cs
@@ -27,7 +27,7 @@ namespace GitCommands.UserRepositoryHistory
 
             try
             {
-                var serializer = new XmlSerializer(typeof(RepositoryHistorySurrogate));
+                XmlSerializer serializer = new(typeof(RepositoryHistorySurrogate));
                 using TextReader reader = new StringReader(serialised);
                 if (serializer.Deserialize(reader) is RepositoryHistorySurrogate obj)
                 {
@@ -57,10 +57,10 @@ namespace GitCommands.UserRepositoryHistory
 
             try
             {
-                var surrogate = new RepositoryHistorySurrogate(repositories);
-                using var sw = new StringWriter();
-                var serializer = new XmlSerializer(typeof(RepositoryHistorySurrogate));
-                var ns = new XmlSerializerNamespaces();
+                RepositoryHistorySurrogate surrogate = new(repositories);
+                using StringWriter sw = new();
+                XmlSerializer serializer = new(typeof(RepositoryHistorySurrogate));
+                XmlSerializerNamespaces ns = new();
                 ns.Add(string.Empty, string.Empty);
                 serializer.Serialize(sw, surrogate, ns);
                 return sw.ToString();

--- a/GitCommands/Utils/EncodingHelper.cs
+++ b/GitCommands/Utils/EncodingHelper.cs
@@ -18,7 +18,7 @@ namespace GitCommands
                 throw new ArgumentNullException(nameof(encoding));
             }
 
-            var sb = new StringBuilder();
+            StringBuilder sb = new();
 
             if (output is not null && output.Length > 0)
             {
@@ -61,7 +61,7 @@ namespace GitCommands
                 try
                 {
                     ms = new MemoryStream(output);
-                    using var reader = new StreamReader(ms, encoding);
+                    using StreamReader reader = new(ms, encoding);
                     ms = null;
                     reader.Peek();
                     encoding = reader.CurrentEncoding;
@@ -86,7 +86,7 @@ namespace GitCommands
                 try
                 {
                     ms = new MemoryStream(error);
-                    using var reader = new StreamReader(ms, encoding);
+                    using StreamReader reader = new(ms, encoding);
                     ms = null;
                     reader.Peek();
 

--- a/GitCommands/Utils/JsonSerializer.cs
+++ b/GitCommands/Utils/JsonSerializer.cs
@@ -8,7 +8,7 @@ namespace GitCommands.Utils
         public static string Serialize<T>(T? myObject) where T : class
         {
             var json = new System.Runtime.Serialization.Json.DataContractJsonSerializer(typeof(T));
-            var stream = new MemoryStream();
+            MemoryStream stream = new();
             json.WriteObject(stream, myObject);
             return Encoding.UTF8.GetString(stream.ToArray());
         }
@@ -16,7 +16,7 @@ namespace GitCommands.Utils
         public static T? Deserialize<T>(string myString) where T : class
         {
             var json = new System.Runtime.Serialization.Json.DataContractJsonSerializer(typeof(T));
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(myString));
+            MemoryStream stream = new(Encoding.UTF8.GetBytes(myString));
             return (T?)json.ReadObject(stream);
         }
     }

--- a/GitCommands/Utils/RFC2047Decoder.cs
+++ b/GitCommands/Utils/RFC2047Decoder.cs
@@ -8,9 +8,9 @@ namespace GitCommands
     {
         public static string Parse(string input)
         {
-            var sb = new StringBuilder();
-            var currentWord = new StringBuilder();
-            var currentSurroundingText = new StringBuilder();
+            StringBuilder sb = new();
+            StringBuilder currentWord = new();
+            StringBuilder currentSurroundingText = new();
             bool readingWord = false;
             bool hasSeenAtLeastOneWord = false;
             int wordQuestionMarkCount = 0;
@@ -75,7 +75,7 @@ namespace GitCommands
 
         private static string ParseEncodedWord(string input)
         {
-            var sb = new StringBuilder();
+            StringBuilder sb = new();
             if (!input.StartsWith("=?"))
             {
                 return input;

--- a/GitCommands/Utils/WeakRefCache.cs
+++ b/GitCommands/Utils/WeakRefCache.cs
@@ -8,7 +8,7 @@ namespace GitCommands.Utils
 {
     public class WeakRefCache : IDisposable
     {
-        private readonly Dictionary<string, WeakReference> _weakMap = new Dictionary<string, WeakReference>();
+        private readonly Dictionary<string, WeakReference> _weakMap = new();
         private readonly Timer _clearTimer = new(60 * 1000);
 
         public static readonly WeakRefCache Default = new();

--- a/GitCommands/XmlSerializableDictionary.cs
+++ b/GitCommands/XmlSerializableDictionary.cs
@@ -30,8 +30,8 @@ namespace GitCommands
 
         public void ReadXml(XmlReader reader)
         {
-            var keySerializer = new XmlSerializer(typeof(TKey));
-            var valueSerializer = new XmlSerializer(typeof(TValue));
+            XmlSerializer keySerializer = new(typeof(TKey));
+            XmlSerializer valueSerializer = new(typeof(TValue));
             var wasEmpty = reader.IsEmptyElement;
 
             reader.Read();
@@ -72,8 +72,8 @@ namespace GitCommands
 
         public void WriteXml(XmlWriter writer)
         {
-            var keySerializer = new XmlSerializer(typeof(TKey));
-            var valueSerializer = new XmlSerializer(typeof(TValue));
+            XmlSerializer keySerializer = new(typeof(TKey));
+            XmlSerializer valueSerializer = new(typeof(TValue));
 
             foreach (var (key, value) in this.OrderBy(pair => pair.Key))
             {

--- a/GitExtUtils/ArgumentBuilder.cs
+++ b/GitExtUtils/ArgumentBuilder.cs
@@ -96,7 +96,7 @@ namespace GitExtUtils
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitExtUtils/ArgumentString.cs
+++ b/GitExtUtils/ArgumentString.cs
@@ -14,8 +14,8 @@ namespace GitExtUtils
             Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
         }
 
-        public static implicit operator ArgumentString(string? args) => new ArgumentString(args ?? "");
-        public static implicit operator ArgumentString(ArgumentBuilder args) => new ArgumentString(args.ToString());
+        public static implicit operator ArgumentString(string? args) => new(args ?? "");
+        public static implicit operator ArgumentString(ArgumentBuilder args) => new(args.ToString());
         public static implicit operator string(ArgumentString args) => args.Arguments ?? "";
         public override string ToString() => Arguments ?? "";
     }

--- a/GitExtUtils/FileUtility.cs
+++ b/GitExtUtils/FileUtility.cs
@@ -12,7 +12,7 @@ namespace GitExtUtils
         /// <param name="contents">Text to write as file contents.</param>
         public static void SafeWriteAllText(string fileName, string contents, Encoding encoding)
         {
-            using var fs = new FileStream(fileName, FileMode.Open);
+            using FileStream fs = new(fileName, FileMode.Open);
             using (TextWriter tw = new StreamWriter(fs, encoding, bufferSize: 4096, leaveOpen: true))
             {
                 tw.Write(contents);

--- a/GitExtUtils/GitArgumentBuilder.cs
+++ b/GitExtUtils/GitArgumentBuilder.cs
@@ -111,7 +111,7 @@ namespace GitExtUtils
             var capacity = _configItems.Sum(i => i.Key.Length + i.Value.Length + 7) + _command.Length + 1 + arguments.Length;
             capacity += gitArgsLength + 1;
 
-            var str = new StringBuilder(capacity);
+            StringBuilder str = new(capacity);
 
             if (gitArgsLength > 0)
             {

--- a/GitExtUtils/GitCommandConfiguration.cs
+++ b/GitExtUtils/GitCommandConfiguration.cs
@@ -7,7 +7,7 @@ namespace GitExtUtils
     public sealed class GitCommandConfiguration
     {
         private readonly ConcurrentDictionary<string, GitConfigItem[]> _configByCommand
-            = new ConcurrentDictionary<string, GitConfigItem[]>(StringComparer.Ordinal);
+            = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets the default configuration for git commands used by Git Extensions.

--- a/GitExtUtils/GitUI/CancellationTokenSequence.cs
+++ b/GitExtUtils/GitUI/CancellationTokenSequence.cs
@@ -32,7 +32,7 @@ namespace GitUI
         /// <remarks>
         /// If this field is <c>null</c>, the object has been disposed.
         /// </remarks>
-        private CancellationTokenSource? _cancellationTokenSource = new CancellationTokenSource();
+        private CancellationTokenSource? _cancellationTokenSource = new();
 
         /// <summary>
         /// Issues the <see cref="CancellationToken"/> for use by the next asynchronous operation in the sequence,
@@ -50,7 +50,7 @@ namespace GitUI
         /// <exception cref="OperationCanceledException">This object is disposed.</exception>
         public CancellationToken Next()
         {
-            var next = new CancellationTokenSource();
+            CancellationTokenSource next = new();
 
             // Make sure to obtain the CancellationToken for the next source before exposing the source,
             // or another thread could dispose of source before we get a chance to access this property.

--- a/GitExtUtils/GitUI/ControlThreadingExtensions.cs
+++ b/GitExtUtils/GitUI/ControlThreadingExtensions.cs
@@ -14,7 +14,7 @@ namespace GitUI
 
         static ControlThreadingExtensions()
         {
-            using var cts = new CancellationTokenSource();
+            using CancellationTokenSource cts = new();
             cts.Cancel();
             _preCancelledToken = cts.Token;
 
@@ -144,7 +144,7 @@ namespace GitUI
                         return new StrongBox<CancellationToken>(_preCancelledToken);
                     }
 
-                    var cts = new CancellationTokenSource();
+                    CancellationTokenSource cts = new();
 
                     // Get a copy of the CancellationToken before the source can be disposed. After the source is cancelled
                     // and disposed, the CancellationToken will continue to behave properly, but

--- a/GitExtUtils/GitUI/ControlUtil.cs
+++ b/GitExtUtils/GitUI/ControlUtil.cs
@@ -17,7 +17,7 @@ namespace GitUI
         public static IEnumerable<Control> FindDescendants(this Control control,
             Func<Control, bool>? skip = null)
         {
-            var queue = new Queue<Control>();
+            Queue<Control> queue = new();
 
             foreach (Control child in control.Controls)
             {

--- a/GitExtUtils/GitUI/DpiUtil.cs
+++ b/GitExtUtils/GitUI/DpiUtil.cs
@@ -172,7 +172,7 @@ namespace GitExtUtils.GitUI
             }
 
             var size = Scale(new Size(image.Width, image.Height));
-            var bitmap = new Bitmap(size.Width, size.Height);
+            Bitmap bitmap = new(size.Width, size.Height);
 
             using var g = Graphics.FromImage(bitmap);
 

--- a/GitExtUtils/GitUI/ListViewExtensions.cs
+++ b/GitExtUtils/GitUI/ListViewExtensions.cs
@@ -67,7 +67,7 @@ namespace GitUI
             (Rectangle)_getItemRectOrEmptyMethod.Value.Invoke(item.ListView, new object[] { item.Index });
 
         private static readonly Lazy<MethodInfo> _getItemRectOrEmptyMethod =
-            new Lazy<MethodInfo>(() => typeof(ListView).GetMethod(
+            new(() => typeof(ListView).GetMethod(
                 "GetItemRectOrEmpty",
                 BindingFlags.Instance | BindingFlags.NonPublic));
     }

--- a/GitExtUtils/GitUI/Theming/AppColorDefaults.cs
+++ b/GitExtUtils/GitUI/Theming/AppColorDefaults.cs
@@ -8,7 +8,7 @@ namespace GitExtUtils.GitUI.Theming
         public static readonly Color FallbackColor = Color.Magenta;
 
         private static readonly Dictionary<AppColor, Color> Values =
-            new Dictionary<AppColor, Color>
+            new()
             {
                 { AppColor.OtherTag, Color.Gray },
                 { AppColor.AuthoredHighlight, Color.LightYellow },

--- a/GitExtUtils/GitUI/Theming/ColorHelper.cs
+++ b/GitExtUtils/GitUI/Theming/ColorHelper.cs
@@ -73,11 +73,11 @@ namespace GitExtUtils.GitUI.Theming
             KnownColor highlightColorName,
             float degreeOfGrayness = 1f)
         {
-            var grayTextHsl = new HslColor(ThemeSettings.InvariantTheme.GetNonEmptyColor(KnownColor.GrayText));
-            var textHsl = new HslColor(ThemeSettings.InvariantTheme.GetNonEmptyColor(textColorName));
-            var highlightTextHsl = new HslColor(ThemeSettings.InvariantTheme.GetNonEmptyColor(KnownColor.HighlightText));
-            var backgroundHsl = new HslColor(ThemeSettings.InvariantTheme.GetNonEmptyColor(backgroundColorName));
-            var highlightBackgroundHsl = new HslColor(ThemeSettings.InvariantTheme.GetNonEmptyColor(highlightColorName));
+            HslColor grayTextHsl = new(ThemeSettings.InvariantTheme.GetNonEmptyColor(KnownColor.GrayText));
+            HslColor textHsl = new(ThemeSettings.InvariantTheme.GetNonEmptyColor(textColorName));
+            HslColor highlightTextHsl = new(ThemeSettings.InvariantTheme.GetNonEmptyColor(KnownColor.HighlightText));
+            HslColor backgroundHsl = new(ThemeSettings.InvariantTheme.GetNonEmptyColor(backgroundColorName));
+            HslColor highlightBackgroundHsl = new(ThemeSettings.InvariantTheme.GetNonEmptyColor(highlightColorName));
 
             double grayTextL = textHsl.L + (degreeOfGrayness * (grayTextHsl.L - textHsl.L));
 
@@ -96,8 +96,8 @@ namespace GitExtUtils.GitUI.Theming
         /// </summary>
         public static Color GetGrayTextColor(KnownColor textColorName, float degreeOfGrayness = 1f)
         {
-            var grayTextHsl = new HslColor(ThemeSettings.InvariantTheme.GetNonEmptyColor(KnownColor.GrayText));
-            var textHsl = new HslColor(ThemeSettings.InvariantTheme.GetNonEmptyColor(textColorName));
+            HslColor grayTextHsl = new(ThemeSettings.InvariantTheme.GetNonEmptyColor(KnownColor.GrayText));
+            HslColor textHsl = new(ThemeSettings.InvariantTheme.GetNonEmptyColor(textColorName));
 
             double grayTextL = textHsl.L + (degreeOfGrayness * (grayTextHsl.L - textHsl.L));
             var highlightGrayTextHsl = grayTextHsl.WithLuminosity(grayTextL);
@@ -247,8 +247,8 @@ namespace GitExtUtils.GitUI.Theming
             Func<double, double>? s = null,
             Func<double, double>? l = null)
         {
-            var hsl = new HslColor(c);
-            var transformed = new HslColor(
+            HslColor hsl = new(c);
+            HslColor transformed = new(
                 h?.Invoke(hsl.H) ?? hsl.H,
                 s?.Invoke(hsl.S) ?? hsl.S,
                 l?.Invoke(hsl.L) ?? hsl.L);
@@ -288,7 +288,7 @@ namespace GitExtUtils.GitUI.Theming
 
         public static HslColor ToPerceptedHsl(this Color rgb)
         {
-            var hsl = new HslColor(rgb);
+            HslColor hsl = new(rgb);
             return hsl.WithLuminosity(PerceptedL(rgb, hsl.L));
         }
 
@@ -304,7 +304,7 @@ namespace GitExtUtils.GitUI.Theming
         {
             double excludeHTo = 15d; // orange
 
-            var hsl = new HslColor(color);
+            HslColor hsl = new(color);
             var deltaH = ((hsl.H * 360d) - excludeHTo + 180).Modulo(360) - 180;
 
             const double deltaFrom = -140d;

--- a/GitExtUtils/GitUI/Theming/ComparableExtensions.cs
+++ b/GitExtUtils/GitUI/Theming/ComparableExtensions.cs
@@ -22,7 +22,7 @@ namespace GitExtUtils.GitUI.Theming
             value.CompareTo(max) > 0 ? max : value;
 
         public static Size MultiplyBy(this Size original, Size multiplier) =>
-            new Size(
+            new(
                 original.Width * multiplier.Width,
                 original.Height * multiplier.Height);
 

--- a/GitExtUtils/GitUI/Theming/HslColor.cs
+++ b/GitExtUtils/GitUI/Theming/HslColor.cs
@@ -94,9 +94,9 @@ namespace GitExtUtils.GitUI.Theming
         /// </summary>
         public double L { get; }
 
-        public HslColor WithHue(double hue) => new HslColor(hue, S, L);
-        public HslColor WithSaturation(double saturation) => new HslColor(H, saturation, L);
-        public HslColor WithLuminosity(double luminosity) => new HslColor(H, S, luminosity);
+        public HslColor WithHue(double hue) => new(hue, S, L);
+        public HslColor WithSaturation(double saturation) => new(H, saturation, L);
+        public HslColor WithLuminosity(double luminosity) => new(H, S, luminosity);
 
         /// <summary>
         /// Converts this HSL color object to a <see cref="Color"/> object based on RGB values.

--- a/GitExtUtils/GitUI/Theming/LightnessCorrection.cs
+++ b/GitExtUtils/GitUI/Theming/LightnessCorrection.cs
@@ -31,7 +31,7 @@ namespace GitExtUtils.GitUI.Theming
         }
 
         private HslColor Transform(HslColor hsl) =>
-            new HslColor(hsl.H, TransformS(hsl), TransformL(hsl.L));
+            new(hsl.H, TransformS(hsl), TransformL(hsl.L));
 
         private void Transform(byte[] bgraValues, int location)
         {

--- a/GitExtUtils/GitUI/Theming/TabControlPaintContext.cs
+++ b/GitExtUtils/GitUI/Theming/TabControlPaintContext.cs
@@ -77,7 +77,7 @@ namespace GitExtUtils.GitUI.Theming
                 return;
             }
 
-            using var canvasBrush = new SolidBrush(_parentBackColor);
+            using SolidBrush canvasBrush = new(_parentBackColor);
             _graphics.FillRectangle(canvasBrush, _clipRectangle);
 
             RenderSelectedPageBackground();
@@ -141,7 +141,7 @@ namespace GitExtUtils.GitUI.Theming
         {
             var innerRect = _tabRects[index];
             int imgHeight = _imageSize.Height;
-            var imgRect = new Rectangle(
+            Rectangle imgRect = new(
                 new Point(innerRect.X + ImagePadding,
                     innerRect.Y + ((innerRect.Height - imgHeight) / 2)),
                 _imageSize);

--- a/GitExtUtils/GitUI/Theming/ThemeFix.cs
+++ b/GitExtUtils/GitUI/Theming/ThemeFix.cs
@@ -11,10 +11,10 @@ namespace GitExtUtils.GitUI.Theming
     public static class ThemeFix
     {
         private static readonly ConditionalWeakTable<IWin32Window, IWin32Window> AlreadyFixedControls =
-            new ConditionalWeakTable<IWin32Window, IWin32Window>();
+            new();
 
         private static readonly ConditionalWeakTable<IWin32Window, IWin32Window> AlreadyFixedContextMenuOwners =
-            new ConditionalWeakTable<IWin32Window, IWin32Window>();
+            new();
 
         public static ThemeSettings ThemeSettings { private get; set; } = ThemeSettings.Default;
 

--- a/GitExtUtils/GitUI/Win32ApiUtil.cs
+++ b/GitExtUtils/GitUI/Win32ApiUtil.cs
@@ -10,6 +10,6 @@ namespace GitUI
         /// Convert <see cref="Message.LParam"/> to <see cref="Point"/>.
         /// </summary>
         public static Point ToPoint(this IntPtr lparam) =>
-            new Point(unchecked((int)lparam.ToInt64()));
+            new(unchecked((int)lparam.ToInt64()));
     }
 }

--- a/GitExtUtils/Linq/LinqExtensions.cs
+++ b/GitExtUtils/Linq/LinqExtensions.cs
@@ -8,7 +8,7 @@ namespace System.Linq
     public static class LinqExtensions
     {
         [MustUseReturnValue]
-        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T>? comparer = null) => new HashSet<T>(source, comparer ?? EqualityComparer<T>.Default);
+        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T>? comparer = null) => new(source, comparer ?? EqualityComparer<T>.Default);
 
         [MustUseReturnValue]
         public static HashSet<TKey> ToHashSet<TSource, TKey>(
@@ -20,7 +20,7 @@ namespace System.Linq
                 throw new ArgumentNullException(nameof(keySelector));
             }
 
-            var result = new HashSet<TKey>();
+            HashSet<TKey> result = new();
 
             foreach (var element in source)
             {
@@ -161,7 +161,7 @@ namespace System.Linq
                 return Array.Empty<T>();
             }
 
-            var list = new List<T>();
+            List<T> list = new();
 
             do
             {

--- a/GitExtUtils/MruCache.cs
+++ b/GitExtUtils/MruCache.cs
@@ -14,7 +14,7 @@ namespace GitExtUtils
     public sealed class MruCache<TKey, TValue> where TValue : notnull
     {
         private readonly Dictionary<TKey, LinkedListNode<Entry>> _nodeByKey;
-        private readonly LinkedList<Entry> _entries = new LinkedList<Entry>();
+        private readonly LinkedList<Entry> _entries = new();
 
         /// <summary>
         /// Gets the maximum number of entries that this cache will hold.
@@ -49,7 +49,7 @@ namespace GitExtUtils
         /// <param name="value">The value to store against the provided key.</param>
         public void Add(TKey key, TValue value)
         {
-            var entry = new Entry(key, value);
+            Entry entry = new(key, value);
 
             if (_nodeByKey.TryGetValue(key, out var node))
             {

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -113,7 +113,7 @@ namespace GitExtensions
 
             if (string.IsNullOrEmpty(AppSettings.Translation))
             {
-                using var formChoose = new FormChooseTranslation();
+                using FormChooseTranslation formChoose = new();
                 formChoose.ShowDialog();
             }
 
@@ -142,10 +142,10 @@ namespace GitExtensions
 
                     if (AppSettings.CheckSettings)
                     {
-                        var uiCommands = new GitUICommands("");
-                        var commonLogic = new CommonLogic(uiCommands.Module);
-                        var checkSettingsLogic = new CheckSettingsLogic(commonLogic);
-                        var fakePageHost = new SettingsPageHostMock(checkSettingsLogic);
+                        GitUICommands uiCommands = new("");
+                        CommonLogic commonLogic = new(uiCommands.Module);
+                        CheckSettingsLogic checkSettingsLogic = new(commonLogic);
+                        SettingsPageHostMock fakePageHost = new(checkSettingsLogic);
                         using var checklistSettingsPage = SettingsPageBase.Create<ChecklistSettingsPage>(fakePageHost);
                         if (!checklistSettingsPage.CheckSettings())
                         {
@@ -167,7 +167,7 @@ namespace GitExtensions
                 MouseWheelRedirector.Active = true;
             }
 
-            var commands = new GitUICommands(GetWorkingDir(args));
+            GitUICommands commands = new(GetWorkingDir(args));
 
             if (args.Length <= 1)
             {
@@ -269,7 +269,7 @@ namespace GitExtensions
                                 if (DialogResult.OK.Equals(MessageBox.Show(string.Format("Files have been deleted.{0}{0}Would you like to attempt to restart Git Extensions?", Environment.NewLine), "Configuration Error", MessageBoxButtons.OKCancel, MessageBoxIcon.Question)))
                                 {
                                     var args = Environment.GetCommandLineArgs();
-                                    var p = new System.Diagnostics.Process { StartInfo = { FileName = args[0] } };
+                                    Process p = new() { StartInfo = { FileName = args[0] } };
                                     if (args.Length > 1)
                                     {
                                         args[0] = "";
@@ -312,20 +312,20 @@ namespace GitExtensions
         {
             int dialogResult = -1;
 
-            using var dialog1 = new Microsoft.WindowsAPICodePack.Dialogs.TaskDialog
+            using Microsoft.WindowsAPICodePack.Dialogs.TaskDialog dialog1 = new()
             {
                 InstructionText = ResourceManager.TranslatedStrings.GitExecutableNotFound,
                 Icon = TaskDialogStandardIcon.Error,
                 StandardButtons = TaskDialogStandardButtons.Cancel,
                 Cancelable = true,
             };
-            var btnFindGitExecutable = new TaskDialogCommandLink("FindGitExecutable", null, ResourceManager.TranslatedStrings.FindGitExecutable);
+            TaskDialogCommandLink btnFindGitExecutable = new("FindGitExecutable", null, ResourceManager.TranslatedStrings.FindGitExecutable);
             btnFindGitExecutable.Click += (s, e) =>
             {
                 dialogResult = 0;
                 dialog1.Close();
             };
-            var btnInstallGitInstructions = new TaskDialogCommandLink("InstallGitInstructions", null, ResourceManager.TranslatedStrings.InstallGitInstructions);
+            TaskDialogCommandLink btnInstallGitInstructions = new("InstallGitInstructions", null, ResourceManager.TranslatedStrings.InstallGitInstructions);
             btnInstallGitInstructions.Click += (s, e) =>
             {
                 dialogResult = 1;
@@ -339,7 +339,7 @@ namespace GitExtensions
             {
                 case 0:
                     {
-                        using var dialog = new System.Windows.Forms.OpenFileDialog
+                        using OpenFileDialog dialog = new()
                         {
                             Filter = @"git.exe|git.exe|git.cmd|git.cmd",
                         };

--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -18,7 +18,7 @@ namespace GitUI.AutoCompletion
 {
     public class CommitAutoCompleteProvider : IAutoCompleteProvider
     {
-        private static readonly Lazy<Dictionary<string, Regex>> _regexes = new Lazy<Dictionary<string, Regex>>(ParseRegexes);
+        private static readonly Lazy<Dictionary<string, Regex>> _regexes = new(ParseRegexes);
         private readonly Func<IGitModule> _getModule;
         private readonly GetAllChangedFilesOutputParser _getAllChangedFilesOutputParser;
 
@@ -32,7 +32,7 @@ namespace GitUI.AutoCompletion
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var autoCompleteWords = new HashSet<string>();
+            HashSet<string> autoCompleteWords = new();
 
             IGitModule module = GetModule();
             ArgumentString cmd = GitCommandHelpers.GetAllChangedFilesCmd(true, UntrackedFilesMode.Default, noLocks: true);
@@ -119,7 +119,7 @@ namespace GitUI.AutoCompletion
                 throw new NotImplementedException("Please add AutoCompleteRegexes.txt file into .csproj");
             }
 
-            using var sr = new StreamReader(s);
+            using StreamReader sr = new(s);
             return sr.ReadToEnd().Split(Delimiters.LineFeedAndCarriageReturn, StringSplitOptions.RemoveEmptyEntries);
         }
 
@@ -127,7 +127,7 @@ namespace GitUI.AutoCompletion
         {
             var autoCompleteRegexes = ReadOrInitializeAutoCompleteRegexes();
 
-            var regexes = new Dictionary<string, Regex>();
+            Dictionary<string, Regex> regexes = new();
 
             foreach (var line in autoCompleteRegexes)
             {
@@ -136,7 +136,7 @@ namespace GitUI.AutoCompletion
                 var regexStr = line.Substring(i + 1).Trim();
 
                 var extensions = extensionStr.LazySplit(',').Select(s => s.Trim()).Distinct();
-                var regex = new Regex(regexStr, RegexOptions.Compiled);
+                Regex regex = new(regexStr, RegexOptions.Compiled);
 
                 foreach (var extension in extensions)
                 {

--- a/GitUI/Avatars/AvatarDownloader.cs
+++ b/GitUI/Avatars/AvatarDownloader.cs
@@ -70,7 +70,7 @@ namespace GitUI.Avatars
 
             try
             {
-                using var webClient = new WebClient { Proxy = WebRequest.DefaultWebProxy };
+                using WebClient webClient = new() { Proxy = WebRequest.DefaultWebProxy };
                 webClient.Proxy.Credentials = CredentialCache.DefaultCredentials;
 
                 using var imageStream = await webClient.OpenReadTaskAsync(imageUrl);

--- a/GitUI/Avatars/AvatarService.cs
+++ b/GitUI/Avatars/AvatarService.cs
@@ -47,7 +47,7 @@ namespace GitUI.Avatars
         {
             // initialize download only if needed (some options, like local providers, don't need a downloader)
             // and use the downloader provided as parameter if possible.
-            var lazyDownloader = new Lazy<IAvatarDownloader>(() => downloader ?? new AvatarDownloader());
+            Lazy<IAvatarDownloader> lazyDownloader = new(() => downloader ?? new AvatarDownloader());
 
             // build collection of (non-null) providers
             var providers = new[]
@@ -116,8 +116,8 @@ namespace GitUI.Avatars
 
             MultiCacheCleaner cacheCleaner = new(persistentCacheProvider, memoryCachedProvider);
 
-            var mainProvider
-                = new SafetynetAvatarProvider(
+            SafetynetAvatarProvider mainProvider
+                = new(
                     new ChainedAvatarProvider(
                         memoryCachedProvider,
                         UserImageAvatarProvider));

--- a/GitUI/Avatars/CustomAvatarProvider.cs
+++ b/GitUI/Avatars/CustomAvatarProvider.cs
@@ -28,7 +28,7 @@ namespace GitUI.Avatars
         /// <inheritdoc/>
         public async Task<Image?> GetAvatarAsync(string email, string? name, int imageSize)
         {
-            var templateData = new UriTemplateData(email, name, imageSize);
+            UriTemplateData templateData = new(email, name, imageSize);
 
             foreach (var provider in _subProvider)
             {

--- a/GitUI/Avatars/GithubAvatarProvider.cs
+++ b/GitUI/Avatars/GithubAvatarProvider.cs
@@ -20,7 +20,7 @@ namespace GitUI.Avatars
          * RaMMicHaeL
          * SamuelLongchamps
          */
-        private static readonly Regex _gitHubEmailRegex = new Regex(@"^(\d+\+)?(?<username>[^@]+)@users\.noreply\.github\.com$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex _gitHubEmailRegex = new(@"^(\d+\+)?(?<username>[^@]+)@users\.noreply\.github\.com$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private readonly IAvatarDownloader _downloader;
         private readonly bool _onlySupplyNoReply;
@@ -85,7 +85,7 @@ namespace GitUI.Avatars
 
                 if (isBot)
                 {
-                    var client = new Git.hub.Client();
+                    Git.hub.Client client = new();
                     var userProfile = await client.GetUserAsync(username);
 
                     if (string.IsNullOrEmpty(userProfile?.AvatarUrl))
@@ -93,8 +93,8 @@ namespace GitUI.Avatars
                         return null;
                     }
 
-                    var builder = new UriBuilder(userProfile.AvatarUrl);
-                    var query = new StringBuilder(builder.Query.TrimStart('?'));
+                    UriBuilder builder = new(userProfile.AvatarUrl);
+                    StringBuilder query = new(builder.Query.TrimStart('?'));
                     query.Append(query.Length == 0 ? "?" : "&");
                     query.Append("s=").Append(imageSize);
                     builder.Query = query.ToString();

--- a/GitUI/Avatars/GravatarProvider.cs
+++ b/GitUI/Avatars/GravatarProvider.cs
@@ -38,7 +38,7 @@ namespace GitUI.Avatars
             var fallback = SerializeFallbackType(_fallback) ?? "404";
             var hash = ComputeHash(email);
 
-            var uri = new UriBuilder("https", "www.gravatar.com")
+            UriBuilder uri = new("https", "www.gravatar.com")
             {
                 Path = $"/avatar/{hash}",
                 Query = $"s={imageSize}&r={_rating}&d={fallback}"
@@ -63,7 +63,7 @@ namespace GitUI.Avatars
         private static string ComputeHash(string email)
         {
             // Hash specified at http://en.gravatar.com/site/implement/hash/
-            using var md5 = new MD5CryptoServiceProvider();
+            using MD5CryptoServiceProvider md5 = new();
 
             // Gravatar doesn't specify an encoding
             var emailBytes = Encoding.UTF8.GetBytes(email.Trim().ToLowerInvariant());

--- a/GitUI/Avatars/HexString.cs
+++ b/GitUI/Avatars/HexString.cs
@@ -14,7 +14,7 @@ namespace GitUI.Avatars
                 return string.Empty;
             }
 
-            var builder = new StringBuilder(capacity: data.Length * 2);
+            StringBuilder builder = new(capacity: data.Length * 2);
 
             foreach (var b in data)
             {

--- a/GitUI/Avatars/InitialsAvatarProvider.cs
+++ b/GitUI/Avatars/InitialsAvatarProvider.cs
@@ -104,7 +104,7 @@ namespace GitUI.Avatars
             lock (_avatarColors)
             {
                 var fontSizeEstimation = size / 4.0f;
-                var font = new Font(AppSettings.CommitFont.FontFamily, fontSizeEstimation);
+                Font font = new(AppSettings.CommitFont.FontFamily, fontSizeEstimation);
 
                 SizeF textSize = _graphics.MeasureString(text, font);
 
@@ -113,7 +113,7 @@ namespace GitUI.Avatars
                 font = new Font(AppSettings.CommitFont.FontFamily, fontSizeEstimation * size / sizeSquare);
                 textSize = _graphics.MeasureString(text, font);
 
-                var img = new Bitmap(size, size);
+                Bitmap img = new(size, size);
 
                 using var drawing = Graphics.FromImage(img);
                 drawing.Clear(backColor);

--- a/GitUI/Avatars/SafetynetAvatarProvider.cs
+++ b/GitUI/Avatars/SafetynetAvatarProvider.cs
@@ -20,7 +20,7 @@ namespace GitUI.Avatars
         private const int _defaultSize = 64;
 
         private readonly IAvatarProvider _avatarProvider;
-        private readonly Lazy<Image> _safetyNetFallback = new Lazy<Image>(GenerateSafetynetFallback);
+        private readonly Lazy<Image> _safetyNetFallback = new(GenerateSafetynetFallback);
 
         public SafetynetAvatarProvider(IAvatarProvider avatarProvider)
         {
@@ -59,7 +59,7 @@ namespace GitUI.Avatars
 
         private static Image GenerateSafetynetFallback()
         {
-            var bmp = new Bitmap(1, 1);
+            Bitmap bmp = new(1, 1);
             bmp.SetPixel(0, 0, Color.Red);
             return bmp;
         }

--- a/GitUI/Avatars/StaticImageAvatarProvider.cs
+++ b/GitUI/Avatars/StaticImageAvatarProvider.cs
@@ -7,7 +7,7 @@ namespace GitUI.Avatars
     public sealed class StaticImageAvatarProvider : IAvatarProvider
     {
         private readonly Image _image;
-        private readonly Dictionary<int, Image> _sizeCache = new Dictionary<int, Image>();
+        private readonly Dictionary<int, Image> _sizeCache = new();
 
         public StaticImageAvatarProvider(Image image)
         {
@@ -30,7 +30,7 @@ namespace GitUI.Avatars
                     return image;
                 }
 
-                var resizedImage = new Bitmap(_image, new Size(imageSize, imageSize));
+                Bitmap resizedImage = new(_image, new Size(imageSize, imageSize));
                 _sizeCache.Add(imageSize, resizedImage);
 
                 return resizedImage;

--- a/GitUI/Avatars/TemplateFormatter.cs
+++ b/GitUI/Avatars/TemplateFormatter.cs
@@ -20,7 +20,7 @@ namespace GitUI.Avatars
         /// </remarks>
         public static Func<TInput, string> Create<TInput>(string template, Func<string, Func<TInput, string?>> valueMapperProvider)
         {
-            var formatParts = new List<Action<StringBuilder, TInput>>();
+            List<Action<StringBuilder, TInput>> formatParts = new();
             var position = 0;
 
             while (true)
@@ -60,7 +60,7 @@ namespace GitUI.Avatars
         /// </summary>
         private static string FormatExecute<TInput>(TInput input, IEnumerable<Action<StringBuilder, TInput>> formatParts)
         {
-            var sb = new StringBuilder();
+            StringBuilder sb = new();
 
             foreach (var formatter in formatParts)
             {

--- a/GitUI/BranchTreePanel/ContextMenu/GitRefsSortByContextMenuItem.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/GitRefsSortByContextMenuItem.cs
@@ -21,7 +21,7 @@ namespace GitUI.BranchTreePanel.ContextMenu
 
             foreach (var option in EnumHelper.GetValues<GitRefsSortBy>().Select(e => (Text: e.GetDescription(), Value: e)))
             {
-                var item = new ToolStripMenuItem()
+                ToolStripMenuItem item = new()
                 {
                     Text = option.Text,
                     Image = null,
@@ -56,7 +56,7 @@ namespace GitUI.BranchTreePanel.ContextMenu
             }
         }
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal struct TestAccessor
         {

--- a/GitUI/BranchTreePanel/ContextMenu/GitRefsSortOrderContextMenuItem.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/GitRefsSortOrderContextMenuItem.cs
@@ -23,7 +23,7 @@ namespace GitUI.BranchTreePanel.ContextMenu
 
             foreach (var option in EnumHelper.GetValues<GitRefsSortOrder>().Select(e => (Text: e.GetDescription(), Value: e)))
             {
-                var item = new ToolStripMenuItem()
+                ToolStripMenuItem item = new()
                 {
                     Text = option.Text,
                     Image = null,
@@ -58,7 +58,7 @@ namespace GitUI.BranchTreePanel.ContextMenu
             }
         }
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal struct TestAccessor
         {

--- a/GitUI/BranchTreePanel/ContextMenu/MenuItemsGenerator.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/MenuItemsGenerator.cs
@@ -24,14 +24,14 @@ namespace GitUI.BranchTreePanel.ContextMenu
 
         private Dictionary<MenuItemKey, ToolStripItem> CreateItemsIndex()
         {
-            var itemsIndex = new Dictionary<MenuItemKey, ToolStripItem>();
+            Dictionary<MenuItemKey, ToolStripItem> itemsIndex = new();
             _items.Value.ForEach(r => itemsIndex.Add(r.Key, r.Item));
             return itemsIndex;
         }
 
         private List<ToolStripItemWithKey> CreateItems()
         {
-            var items = new List<ToolStripItemWithKey>();
+            List<ToolStripItemWithKey> items = new();
             Generate(items);
             return items;
         }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -18,7 +18,7 @@ namespace GitUI.BranchTreePanel
     {
         private GitRefsSortOrderContextMenuItem _sortOrderContextMenuItem;
         private GitRefsSortByContextMenuItem _sortByContextMenuItem;
-        private ToolStripSeparator _tsmiSortMenuSpacer = new ToolStripSeparator { Name = "tsmiSortMenuSpacer" };
+        private ToolStripSeparator _tsmiSortMenuSpacer = new() { Name = "tsmiSortMenuSpacer" };
         private ToolStripItem[] _menuBranchCopyContextMenuItems = Array.Empty<ToolStripItem>();
         private ToolStripItem[] _menuRemoteCopyContextMenuItems = Array.Empty<ToolStripItem>();
 
@@ -326,7 +326,7 @@ namespace GitUI.BranchTreePanel
 
         private ToolStripItem[] CreateCopyContextMenuItems()
         {
-            var copyContextMenuItem = new CopyContextMenuItem();
+            CopyContextMenuItem copyContextMenuItem = new();
 
             copyContextMenuItem.SetRevisionFunc(() => _scriptHost.GetSelectedRevisions());
 
@@ -366,7 +366,7 @@ namespace GitUI.BranchTreePanel
             where TMenuItem : ToolStripItem, new()
             where TNode : class, INode
         {
-            var result = new TMenuItem();
+            TMenuItem result = new();
             result.Image = icon;
             result.Text = text.Text;
             result.ToolTipText = toolTip.Text;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -381,11 +381,11 @@ namespace GitUI.BranchTreePanel
 
                 #endregion
 
-                var nodes = new Nodes(this);
+                Nodes nodes = new(this);
                 var aheadBehindData = _aheadBehindDataProvider?.GetData();
 
                 var currentBranch = Module.GetSelectedBranch();
-                var pathToNode = new Dictionary<string, BaseBranchNode>();
+                Dictionary<string, BaseBranchNode> pathToNode = new();
                 foreach (IGitRef branch in branches)
                 {
                     token.ThrowIfCancellationRequested();
@@ -393,7 +393,7 @@ namespace GitUI.BranchTreePanel
                     Validates.NotNull(branch.ObjectId);
 
                     bool isVisible = !IsFiltering.Value || _refsSource.Contains(branch.ObjectId);
-                    var localBranchNode = new LocalBranchNode(this, branch.ObjectId, branch.Name, branch.Name == currentBranch, isVisible);
+                    LocalBranchNode localBranchNode = new(this, branch.ObjectId, branch.Name, branch.Name == currentBranch, isVisible);
 
                     if (aheadBehindData is not null && aheadBehindData.ContainsKey(localBranchNode.FullPath))
                     {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Remotes.cs
@@ -74,13 +74,13 @@ namespace GitUI.BranchTreePanel
 
             private async Task<Nodes> FillBranchTreeAsync(IReadOnlyList<IGitRef> branches, CancellationToken token)
             {
-                var nodes = new Nodes(this);
-                var pathToNodes = new Dictionary<string, BaseBranchNode>();
+                Nodes nodes = new(this);
+                Dictionary<string, BaseBranchNode> pathToNodes = new();
 
-                var enabledRemoteRepoNodes = new List<RemoteRepoNode>();
+                List<RemoteRepoNode> enabledRemoteRepoNodes = new();
                 var remoteByName = (await Module.GetRemotesAsync().ConfigureAwaitRunInline()).ToDictionary(r => r.Name);
 
-                var remotesManager = new ConfigFileRemoteSettingsManager(() => Module);
+                ConfigFileRemoteSettingsManager remotesManager = new(() => Module);
 
                 // Create nodes for enabled remotes with branches
                 foreach (IGitRef branch in branches)
@@ -93,7 +93,7 @@ namespace GitUI.BranchTreePanel
                     var remoteName = branch.Name.SubstringUntil('/');
                     if (remoteByName.TryGetValue(remoteName, out Remote remote))
                     {
-                        var remoteBranchNode = new RemoteBranchNode(this, branch.ObjectId, branch.Name, isVisible);
+                        RemoteBranchNode remoteBranchNode = new(this, branch.ObjectId, branch.Name, isVisible);
 
                         var parent = remoteBranchNode.CreateRootNode(
                             pathToNodes,
@@ -112,7 +112,7 @@ namespace GitUI.BranchTreePanel
                 {
                     if (remoteByName.TryGetValue(remoteName, out var remote))
                     {
-                        var node = new RemoteRepoNode(this, remoteName, remotesManager, remote, true);
+                        RemoteRepoNode node = new(this, remoteName, remotesManager, remote, true);
                         enabledRemoteRepoNodes.Add(node);
                     }
                 }
@@ -126,14 +126,14 @@ namespace GitUI.BranchTreePanel
                 var disabledRemotes = remotesManager.GetDisabledRemotes();
                 if (disabledRemotes.Count > 0)
                 {
-                    var disabledRemoteRepoNodes = new List<RemoteRepoNode>();
+                    List<RemoteRepoNode> disabledRemoteRepoNodes = new();
                     foreach (var remote in disabledRemotes.OrderBy(remote => remote.Name))
                     {
-                        var node = new RemoteRepoNode(this, remote.Name, remotesManager, remote, false);
+                        RemoteRepoNode node = new(this, remote.Name, remotesManager, remote, false);
                         disabledRemoteRepoNodes.Add(node);
                     }
 
-                    var disabledFolderNode = new RemoteRepoFolderNode(this, TranslatedStrings.Inactive);
+                    RemoteRepoFolderNode disabledFolderNode = new(this, TranslatedStrings.Inactive);
                     disabledRemoteRepoNodes
                         .OrderBy(node => node.FullPath)
                         .ForEach(node => disabledFolderNode.Nodes.AddNode(node));

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -177,7 +177,7 @@ namespace GitUI.BranchTreePanel
                 }
                 else if (GitStatus is not null)
                 {
-                    var changeCount = new ArtificialCommitChangeCount();
+                    ArtificialCommitChangeCount changeCount = new();
                     changeCount.Update(GitStatus);
                     toolTip = changeCount.GetSummary();
                 }
@@ -376,12 +376,12 @@ namespace GitUI.BranchTreePanel
 
                 Validates.NotNull(threadModule);
 
-                var submoduleNodes = new List<SubmoduleNode>();
+                List<SubmoduleNode> submoduleNodes = new();
 
                 // We always want to display submodules rooted from the top project.
                 CreateSubmoduleNodes(result, threadModule, ref submoduleNodes);
 
-                var nodes = new Nodes(this);
+                Nodes nodes = new(this);
                 AddTopAndNodesToTree(ref nodes, submoduleNodes, threadModule, result);
                 return nodes;
             }
@@ -468,7 +468,7 @@ namespace GitUI.BranchTreePanel
                 var topModule = threadModule.GetTopModule();
 
                 // Build a mapping of top-module-relative path to node
-                var pathToNodes = new Dictionary<string, Node>();
+                Dictionary<string, Node> pathToNodes = new();
 
                 // Add existing SubmoduleNodes
                 foreach (var node in submoduleNodes)
@@ -491,8 +491,8 @@ namespace GitUI.BranchTreePanel
                 }
 
                 // Now build the tree
-                var rootNode = new DummyNode();
-                var nodesInTree = new HashSet<Node>();
+                DummyNode rootNode = new();
+                HashSet<Node> nodesInTree = new();
                 foreach (var node in submoduleNodes)
                 {
                     Node parentNode = rootNode;
@@ -516,7 +516,7 @@ namespace GitUI.BranchTreePanel
                 Validates.NotNull(result.TopProject);
 
                 // Add top-module node, and move children of root to it
-                var topModuleNode = new SubmoduleNode(
+                SubmoduleNode topModuleNode = new(
                     this,
                     result.TopProject,
                     result.TopProject.Bold,
@@ -574,13 +574,13 @@ namespace GitUI.BranchTreePanel
 
             public void StashSubmodule(IWin32Window owner, SubmoduleNode node)
             {
-                var uiCmds = new GitUICommands(new GitModule(node.Info.Path));
+                GitUICommands uiCmds = new(new GitModule(node.Info.Path));
                 uiCmds.StashSave(owner, AppSettings.IncludeUntrackedFilesInManualStash);
             }
 
             public void CommitSubmodule(IWin32Window owner, SubmoduleNode node)
             {
-                var submodulCommands = new GitUICommands(node.Info.Path.EnsureTrailingPathSeparator());
+                GitUICommands submodulCommands = new(node.Info.Path.EnsureTrailingPathSeparator());
                 submodulCommands.StartCommitDialog(owner);
             }
         }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -68,7 +68,7 @@ namespace GitUI.BranchTreePanel
 
             public bool Checkout()
             {
-                using var form = new FormCheckoutRevision(UICommands);
+                using FormCheckoutRevision form = new(UICommands);
                 form.SetRevision(FullPath);
                 return form.ShowDialog(TreeViewNode.TreeView) != DialogResult.Cancel;
             }
@@ -128,14 +128,14 @@ namespace GitUI.BranchTreePanel
 
             private Nodes FillTagTree(IReadOnlyList<IGitRef> tags, CancellationToken token)
             {
-                var nodes = new Nodes(this);
-                var pathToNodes = new Dictionary<string, BaseBranchNode>();
+                Nodes nodes = new(this);
+                Dictionary<string, BaseBranchNode> pathToNodes = new();
                 foreach (IGitRef tag in tags)
                 {
                     token.ThrowIfCancellationRequested();
 
                     bool isVisible = !IsFiltering.Value || (tag.ObjectId is not null && _refsSource.Contains(tag.ObjectId));
-                    var tagNode = new TagNode(this, tag.ObjectId, tag.Name, isVisible);
+                    TagNode tagNode = new(this, tag.ObjectId, tag.Name, isVisible);
                     var parent = tagNode.CreateRootNode(pathToNodes, (tree, parentPath) => new BasePathNode(tree, parentPath));
                     if (parent is not null)
                     {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -16,7 +16,7 @@ namespace GitUI.BranchTreePanel
     {
         private sealed class Nodes : IEnumerable<Node>
         {
-            private readonly List<Node> _nodesList = new List<Node>();
+            private readonly List<Node> _nodesList = new();
 
             public Tree? Tree { get; }
 
@@ -76,7 +76,7 @@ namespace GitUI.BranchTreePanel
             /// </summary>
             internal void FillTreeViewNode(TreeNode treeViewNode)
             {
-                var prevNodes = new HashSet<Node>();
+                HashSet<Node> prevNodes = new();
                 for (var i = 0; i < treeViewNode.Nodes.Count; i++)
                 {
                     prevNodes.Add(Node.GetNode(treeViewNode.Nodes[i]));
@@ -129,7 +129,7 @@ namespace GitUI.BranchTreePanel
             private bool _isCurrentlyFiltering;
 
             // A flag to indicate whether the data is being filtered (e.g. Show Current Branch Only).
-            private protected static AsyncLocal<bool> IsFiltering = new AsyncLocal<bool>();
+            private protected static AsyncLocal<bool> IsFiltering = new();
 
             protected Tree(TreeNode treeNode, IGitUICommandsSource uiCommands)
             {
@@ -407,7 +407,7 @@ namespace GitUI.BranchTreePanel
             }
 
             private static readonly Dictionary<Type, ContextMenuStrip> DefaultContextMenus
-                = new Dictionary<Type, ContextMenuStrip>();
+                = new();
 
             public static void RegisterContextMenu(Type type, ContextMenuStrip menu)
             {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -24,13 +24,13 @@ namespace GitUI.BranchTreePanel
     {
         private readonly CancellationTokenSequence _selectionCancellationTokenSequence = new();
         private readonly TranslationString _showBranchOnly =
-            new TranslationString("Filter the revision grid to show this branch only\nTo show all branches, right click the revision grid, select 'view' and then the 'show all branches'");
+            new("Filter the revision grid to show this branch only\nTo show all branches, right click the revision grid, select 'view' and then the 'show all branches'");
         private readonly TranslationString _searchTooltip = new("Search");
         private readonly TranslationString _showHideRefsTooltip = new("Show/hide branches/remotes/tags");
 
         private NativeTreeViewDoubleClickDecorator _doubleClickDecorator;
         private NativeTreeViewExplorerNavigationDecorator _explorerNavigationDecorator;
-        private readonly List<Tree> _rootNodes = new List<Tree>();
+        private readonly List<Tree> _rootNodes = new();
         private readonly SearchControl<string> _txtBranchCriterion;
         private BranchTree _branchesTree;
         private RemoteBranchTree _remotesTree;
@@ -143,7 +143,7 @@ namespace GitUI.BranchTreePanel
 
                 Image Pad(Image image)
                 {
-                    var padded = new Bitmap(image.Width, image.Height + rowPadding + rowPadding, PixelFormat.Format32bppArgb);
+                    Bitmap padded = new(image.Width, image.Height + rowPadding + rowPadding, PixelFormat.Format32bppArgb);
                     using var g = Graphics.FromImage(padded);
                     g.DrawImageUnscaled(image, 0, rowPadding);
                     return padded;
@@ -152,7 +152,7 @@ namespace GitUI.BranchTreePanel
 
             SearchControl<string> CreateSearchBox()
             {
-                var search = new SearchControl<string>(SearchForBranch, i => { })
+                SearchControl<string> search = new(SearchForBranch, i => { })
                 {
                     Anchor = AnchorStyles.Left | AnchorStyles.Right,
                     Name = "txtBranchCritierion",
@@ -182,7 +182,7 @@ namespace GitUI.BranchTreePanel
 
                 IEnumerable<string> CollectFilterCandidates()
                 {
-                    var list = new List<string>();
+                    List<string> list = new();
 
                     foreach (TreeNode rootNode in treeMain.Nodes)
                     {
@@ -329,7 +329,7 @@ namespace GitUI.BranchTreePanel
 
         private void CreateBranches()
         {
-            var rootNode = new TreeNode(TranslatedStrings.Branches)
+            TreeNode rootNode = new(TranslatedStrings.Branches)
             {
                 Name = TranslatedStrings.Branches,
                 ImageKey = nameof(Images.BranchLocalRoot),
@@ -340,7 +340,7 @@ namespace GitUI.BranchTreePanel
 
         private void CreateRemotes()
         {
-            var rootNode = new TreeNode(TranslatedStrings.Remotes)
+            TreeNode rootNode = new(TranslatedStrings.Remotes)
             {
                 Name = TranslatedStrings.Remotes,
                 ImageKey = nameof(Images.BranchRemoteRoot),
@@ -357,7 +357,7 @@ namespace GitUI.BranchTreePanel
 
         private void CreateTags()
         {
-            var rootNode = new TreeNode(TranslatedStrings.Tags)
+            TreeNode rootNode = new(TranslatedStrings.Tags)
             {
                 Name = TranslatedStrings.Tags,
                 ImageKey = nameof(Images.TagHorizontal),
@@ -368,7 +368,7 @@ namespace GitUI.BranchTreePanel
 
         private void CreateSubmodules()
         {
-            var rootNode = new TreeNode(TranslatedStrings.Submodules)
+            TreeNode rootNode = new(TranslatedStrings.Submodules)
             {
                 Name = TranslatedStrings.Submodules,
                 ImageKey = nameof(Images.FolderSubmodule),
@@ -464,8 +464,8 @@ namespace GitUI.BranchTreePanel
 
             List<TreeNode> SearchTree(string text, IEnumerable<TreeNode> nodes)
             {
-                var queue = new Queue<TreeNode>(nodes);
-                var ret = new List<TreeNode>();
+                Queue<TreeNode> queue = new(nodes);
+                List<TreeNode> ret = new();
 
                 while (queue.Count != 0)
                 {
@@ -557,7 +557,7 @@ namespace GitUI.BranchTreePanel
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/BrowseForPrivateKey.cs
+++ b/GitUI/BrowseForPrivateKey.cs
@@ -31,7 +31,7 @@ namespace GitUI
         /// </summary>
         public static string? Browse(IWin32Window parent)
         {
-            using var dialog = new OpenFileDialog
+            using OpenFileDialog dialog = new()
             {
                 Filter = " (*.ppk)|*.ppk",
                 InitialDirectory = ".",

--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -95,7 +95,7 @@ namespace GitUI.BuildServerIntegration
                 buildServerAdapter.GetFinishedBuildsSince(scheduler, nowFrozen)
                             .Finally(() => shouldLookForNewlyFinishedBuilds = false));
 
-            var cancellationToken = new CompositeDisposable
+            CompositeDisposable cancellationToken = new()
                     {
                         fullDayObservable.OnErrorResumeNext(fullObservable)
                                          .OnErrorResumeNext(Observable.Empty<BuildInfo>()
@@ -154,8 +154,8 @@ namespace GitUI.BuildServerIntegration
                         {
                             byte[] unprotectedData = ProtectedData.Unprotect(protectedData, null,
                                 DataProtectionScope.CurrentUser);
-                            using var memoryStream = new MemoryStream(unprotectedData);
-                            var credentialsConfig = new ConfigFile("", false);
+                            using MemoryStream memoryStream = new(unprotectedData);
+                            ConfigFile credentialsConfig = new("", false);
 
                             using (var textReader = new StreamReader(memoryStream, Encoding.UTF8))
                             {
@@ -196,7 +196,7 @@ namespace GitUI.BuildServerIntegration
 
                     if (buildServerCredentials is not null)
                     {
-                        var credentialsConfig = new ConfigFile("", true);
+                        ConfigFile credentialsConfig = new("", true);
 
                         var section = credentialsConfig.FindOrCreateConfigSection(CredentialsConfigName);
 
@@ -205,7 +205,7 @@ namespace GitUI.BuildServerIntegration
                         section.SetValue(PasswordKey, buildServerCredentials.Password);
 
                         using var stream = GetBuildServerOptionsIsolatedStorageStream(buildServerAdapter, FileAccess.Write, FileShare.None);
-                        using var memoryStream = new MemoryStream();
+                        using MemoryStream memoryStream = new();
                         using (var textWriter = new StreamWriter(memoryStream, Encoding.UTF8))
                         {
                             textWriter.Write(credentialsConfig.GetAsString());
@@ -243,7 +243,7 @@ namespace GitUI.BuildServerIntegration
         {
             await _revisionGrid.SwitchToMainThreadAsync();
 
-            using var form = new FormBuildServerCredentials(buildServerUniqueKey);
+            using FormBuildServerCredentials form = new(buildServerUniqueKey);
             form.BuildServerCredentials = buildServerCredentials;
 
             if (form.ShowDialog(_revisionGrid) == DialogResult.OK)

--- a/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
+++ b/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
@@ -76,7 +76,7 @@ namespace GitUI.CommandsDialogs.AboutBoxDialog
 
                 TabPage GetNewTabPage(TextBox textBox, string caption)
                 {
-                    var tabPage = new TabPage
+                    TabPage tabPage = new()
                     {
                         BorderStyle = BorderStyle.None,
                         Margin = new Padding(0),

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -162,7 +162,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 {
                     var padding24 = DpiUtil.Scale(24);
                     var padding3 = DpiUtil.Scale(3);
-                    var linkLabel = new LinkLabel
+                    LinkLabel linkLabel = new()
                     {
                         AutoSize = true,
                         AutoEllipsis = true,

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/FormDashboardCategoryTitle.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/FormDashboardCategoryTitle.cs
@@ -11,7 +11,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         private readonly TranslationString _categoryNameRequiredText = new("Category name is required");
         private readonly TranslationString _categoryNameExistsText = new("Category name already exists");
         private readonly TranslationString _renameCategoryText = new("Rename category");
-        private readonly List<string> _existingCategories = new List<string>();
+        private readonly List<string> _existingCategories = new();
 
         public FormDashboardCategoryTitle()
         {

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -474,7 +474,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private bool PromptCategoryName(List<string> categories, string? originalName, [NotNullWhen(returnValue: true)] out string? name)
         {
-            using var dialog = new FormDashboardCategoryTitle(categories, originalName);
+            using FormDashboardCategoryTitle dialog = new(categories, originalName);
             if (dialog.ShowDialog(this) == DialogResult.OK)
             {
                 name = dialog.Category;
@@ -556,12 +556,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 e.DrawBackground();
             }
 
-            var pointImage = new PointF(e.Bounds.Left + spacing4, e.Bounds.Top + (spacing2 * 4));
+            PointF pointImage = new(e.Bounds.Left + spacing4, e.Bounds.Top + (spacing2 * 4));
 
             // render anchor icon
             if (!string.IsNullOrWhiteSpace((e.Item.Tag as Repository)?.Category))
             {
-                var pointImage1 = new PointF(pointImage.X + imageList1.ImageSize.Width - 12, e.Bounds.Top + spacing2);
+                PointF pointImage1 = new(pointImage.X + imageList1.ImageSize.Width - 12, e.Bounds.Top + spacing2);
                 e.Graphics.DrawImage(Images.Star, pointImage1.X, pointImage1.Y, 16, 16);
             }
 
@@ -569,12 +569,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             e.Graphics.DrawImage(imageList1.Images[e.Item.ImageIndex], pointImage);
 
             // render path
-            var textPadding = new PointF(e.Bounds.Left + spacing4, e.Bounds.Top + spacing6);
-            var pointPath = new PointF(textPadding.X + textOffset, textPadding.Y);
+            PointF textPadding = new(e.Bounds.Left + spacing4, e.Bounds.Top + spacing6);
+            PointF pointPath = new(textPadding.X + textOffset, textPadding.Y);
             var pathBounds = DrawText(e.Graphics, e.Item.Text, AppSettings.Font, _foreColorBrush, textWidth, pointPath, spacing4 * 2);
 
             // render branch
-            var pointBranch = new PointF(pointPath.X, pointPath.Y + pathBounds.Height + spacing1);
+            PointF pointBranch = new(pointPath.X, pointPath.Y + pathBounds.Height + spacing1);
             var branchBounds = DrawText(e.Graphics, e.Item.SubItems[1].Text, _secondaryFont, _branchNameColorBrush, textWidth, pointBranch, spacing4 * 2);
 
             // render category
@@ -590,7 +590,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             {
                 var textBounds = TextRenderer.MeasureText(text, font);
                 var minWidth = Math.Min(textBounds.Width + spacing, maxTextWidth);
-                var bounds = new RectangleF(location, new SizeF(minWidth, textBounds.Height));
+                RectangleF bounds = new(location, new SizeF(minWidth, textBounds.Height));
                 var text1 = Math.Abs(maxTextWidth - minWidth) < float.Epsilon ? ShortenText(text, font, minWidth) : text;
                 g.DrawString(text1, font, brush, bounds, StringFormat.GenericTypographic);
 
@@ -647,7 +647,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private void mnuConfigure_Click(object sender, EventArgs e)
         {
-            using var frm = new FormRecentReposSettings();
+            using FormRecentReposSettings frm = new();
             var result = frm.ShowDialog(this);
             if (result == DialogResult.OK)
             {
@@ -684,7 +684,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 tsmiCategories.DropDownItems.Add(tsmiCategoryNone);
                 tsmiCategories.DropDownItems.AddRange(categories.Select(category =>
                 {
-                    var item = new ToolStripMenuItem(category) { Tag = category };
+                    ToolStripMenuItem item = new(category) { Tag = category };
                     item.Click += tsmiCategory_Click;
                     return item;
                 }).ToArray<ToolStripItem>());

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
@@ -55,10 +55,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         public (IReadOnlyList<RecentRepoInfo> recentRepositories, IReadOnlyList<RecentRepoInfo> favouriteRepositories) PreRenderRepositories(Graphics g)
         {
-            var mostRecentRepos = new List<RecentRepoInfo>();
-            var lessRecentRepos = new List<RecentRepoInfo>();
+            List<RecentRepoInfo> mostRecentRepos = new();
+            List<RecentRepoInfo> lessRecentRepos = new();
 
-            var splitter = new RecentRepoSplitter
+            RecentRepoSplitter splitter = new()
             {
                 Graphics = g,
                 MeasureFont = AppSettings.Font,

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
@@ -13,7 +13,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
     {
         // TODO: Improve me
         private readonly TranslationString _bisectStart =
-            new TranslationString("Mark selected revisions as start bisect range?");
+            new("Mark selected revisions as start bisect range?");
 
         private readonly RevisionGridControl _revisionGrid;
 

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
@@ -37,7 +37,7 @@ namespace GitUI.CommandsDialogs
 
         // we have to remember which items we registered with the menucommands because other
         // location (RevisionGrid) can register items too!
-        private readonly List<ToolStripMenuItem> _itemsRegisteredWithMenuCommand = new List<ToolStripMenuItem>();
+        private readonly List<ToolStripMenuItem> _itemsRegisteredWithMenuCommand = new();
 
         public FormBrowseMenus(ToolStrip menuStrip)
         {
@@ -100,7 +100,7 @@ namespace GitUI.CommandsDialogs
 
             static ToolStripItem CreateItem(ToolStrip senderToolStrip)
             {
-                var toolStripItem = new ToolStripMenuItem(senderToolStrip.Text)
+                ToolStripMenuItem toolStripItem = new(senderToolStrip.Text)
                 {
                     Checked = senderToolStrip.Visible,
                     CheckOnClick = true,
@@ -384,7 +384,7 @@ namespace GitUI.CommandsDialogs
         {
             toolStripMenuItemTarget.DropDownItems.Clear();
 
-            var toolStripItems = new List<ToolStripItem>();
+            List<ToolStripItem> toolStripItems = new();
             foreach (var menuCommand in menuCommands)
             {
                 var toolStripItem = MenuCommand.CreateToolStripItem(menuCommand);

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseUtil.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseUtil.cs
@@ -18,12 +18,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             if (File.Exists(path))
             {
-                var fileInfo = new FileInfo(path);
+                FileInfo fileInfo = new(path);
                 OsShellUtil.SelectPathInFileExplorer(fileInfo.FullName);
             }
             else if (Directory.Exists(path))
             {
-                var fileInfo = new FileInfo(path);
+                FileInfo fileInfo = new(path);
                 OsShellUtil.OpenWithFileExplorer(fileInfo.Directory.FullName);
             }
         }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
@@ -22,7 +22,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             LogItems.DisplayMember = nameof(CommandLogEntry.ColumnLine);
 
-            var font = new Font(FontFamily.GenericMonospace, 9);
+            Font font = new(FontFamily.GenericMonospace, 9);
             LogItems.Font = font;
             CommandCacheItems.Font = font;
             LogOutput.Font = font;
@@ -165,7 +165,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void mnuSaveToFile_Click(object sender, EventArgs e)
         {
-            using var fileDialog = new SaveFileDialog
+            using SaveFileDialog fileDialog = new()
             {
                 Title = Name,
                 DefaultExt = ".txt",

--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
@@ -45,7 +45,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private static IReadOnlyList<string> GetDirectories(GitModule? currentModule, IEnumerable<Repository> repositoryHistory)
         {
-            var directories = new List<string>();
+            List<string> directories = new();
 
             if (!string.IsNullOrWhiteSpace(AppSettings.DefaultCloneDestinationPath))
             {
@@ -54,7 +54,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             if (!string.IsNullOrWhiteSpace(currentModule?.WorkingDir))
             {
-                var di = new DirectoryInfo(currentModule.WorkingDir);
+                DirectoryInfo di = new(currentModule.WorkingDir);
                 if (di.Parent is not null)
                 {
                     directories.Add(di.Parent.FullName.EnsureTrailingPathSeparator());
@@ -82,7 +82,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         public static GitModule? OpenModule(IWin32Window owner, GitModule? currentModule)
         {
-            using var open = new FormOpenDirectory(currentModule);
+            using FormOpenDirectory open = new(currentModule);
             open.ShowDialog(owner);
             return open._chosenModule;
         }
@@ -123,7 +123,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             try
             {
-                var currentDirectory = new DirectoryInfo(_NO_TRANSLATE_Directory.Text);
+                DirectoryInfo currentDirectory = new(_NO_TRANSLATE_Directory.Text);
                 if (currentDirectory.Parent is null)
                 {
                     return;
@@ -145,7 +145,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             try
             {
-                var currentDirectory = new DirectoryInfo(_NO_TRANSLATE_Directory.Text);
+                DirectoryInfo currentDirectory = new(_NO_TRANSLATE_Directory.Text);
                 folderGoUpButton.Enabled = currentDirectory.Exists && currentDirectory.Parent is not null;
             }
             catch
@@ -161,7 +161,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 return null;
             }
 
-            var chosenModule = new GitModule(path.EnsureTrailingPathSeparator());
+            GitModule chosenModule = new(path.EnsureTrailingPathSeparator());
             if (!chosenModule.IsValidGitWorkingDir())
             {
                 return null;
@@ -172,7 +172,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
@@ -105,10 +105,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             MostRecentLB.Items.Clear();
             LessRecentLB.Items.Clear();
 
-            var mostRecentRepos = new List<RecentRepoInfo>();
-            var lessRecentRepos = new List<RecentRepoInfo>();
+            List<RecentRepoInfo> mostRecentRepos = new();
+            List<RecentRepoInfo> lessRecentRepos = new();
 
-            var splitter = new RecentRepoSplitter
+            RecentRepoSplitter splitter = new()
             {
                 MaxRecentRepositories = (int)_NO_TRANSLATE_maxRecentRepositories.Value,
                 ShorteningStrategy = GetShorteningStrategy(),
@@ -289,7 +289,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             var rowBounds = e.Bounds;
             int leftMargin = e.Item.GetBounds(ItemBoundsPortion.Label).Left;
-            var bounds = new Rectangle(leftMargin, rowBounds.Top, rowBounds.Width - leftMargin, rowBounds.Height);
+            Rectangle bounds = new(leftMargin, rowBounds.Top, rowBounds.Width - leftMargin, rowBounds.Height);
 
             e.Graphics.FillRectangle(SystemBrushes.Window, bounds);
             TextRenderer.DrawText(e.Graphics, e.Item.Text, listView.Font, bounds, SystemColors.ControlText,

--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -71,7 +71,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             try
             {
-                var github = new Client();
+                Client github = new();
                 Repository gitExtRepo = github.getRepository("gitextensions", "gitextensions");
 
                 var configData = gitExtRepo?.GetRef("heads/configdata");
@@ -189,7 +189,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
                 try
                 {
-                    using WebClient webClient = new WebClient();
+                    using WebClient webClient = new();
                     await webClient.DownloadFileTaskAsync(new Uri(UpdateUrl), Environment.GetEnvironmentVariable("TEMP") + "\\" + fileName);
                 }
                 catch (Exception ex)
@@ -268,7 +268,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         public static IEnumerable<ReleaseVersion> Parse(string versionsStr)
         {
-            var cfg = new ConfigFile("", true);
+            ConfigFile cfg = new("", true);
             cfg.LoadFromString(versionsStr);
             var sections = cfg.GetConfigSections("Version");
             sections = sections.Concat(cfg.GetConfigSections("RCVersion"));

--- a/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
@@ -28,7 +28,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 return new ToolStripSeparator();
             }
 
-            var toolStripMenuItem = new ToolStripMenuItem
+            ToolStripMenuItem toolStripMenuItem = new()
             {
                 Name = menuCommand.Name,
                 Text = menuCommand.Text,
@@ -53,7 +53,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             return toolStripMenuItem;
         }
 
-        private readonly List<ToolStripMenuItem> _registeredMenuItems = new List<ToolStripMenuItem>();
+        private readonly List<ToolStripMenuItem> _registeredMenuItems = new();
 
         /// <summary>
         /// if true all other properties have no meaning.

--- a/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
+++ b/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
@@ -24,7 +24,7 @@ namespace GitUI.CommandsDialogs
         private WebBrowserControl? _buildReportWebBrowser;
         private GitRevision? _selectedGitRevision;
         private string? _url;
-        private readonly LinkLabel _openReportLink = new LinkLabel { AutoSize = false, Text = TranslatedStrings.OpenReport, TextAlign = ContentAlignment.MiddleCenter, Dock = DockStyle.Fill };
+        private readonly LinkLabel _openReportLink = new() { AutoSize = false, Text = TranslatedStrings.OpenReport, TextAlign = ContentAlignment.MiddleCenter, Dock = DockStyle.Fill };
 
         public Control? Control { get; private set; } // for focusing
 

--- a/GitUI/CommandsDialogs/CommitDialog/FormCommitTemplateSettings.cs
+++ b/GitUI/CommandsDialogs/CommitDialog/FormCommitTemplateSettings.cs
@@ -8,7 +8,7 @@ namespace GitUI.CommandsDialogs.CommitDialog
     public partial class FormCommitTemplateSettings : GitExtensionsForm
     {
         private readonly TranslationString _emptyTemplate =
-            new TranslationString("empty");
+            new("empty");
 
         private CommitTemplateItem[]? _commitTemplates;
 

--- a/GitUI/CommandsDialogs/CommitDialog/WordWrapper.cs
+++ b/GitUI/CommandsDialogs/CommitDialog/WordWrapper.cs
@@ -8,7 +8,7 @@ namespace GitUI.CommandsDialogs.CommitDialog
     {
         private static IEnumerable<string> InternalWrapSingleLine(string line, int lineLimit)
         {
-            var wrapper = new WrapperState(lineLimit);
+            WrapperState wrapper = new(lineLimit);
             foreach (var word in line.Split())
             {
                 if (!wrapper.CanAddWord(word))
@@ -33,7 +33,7 @@ namespace GitUI.CommandsDialogs.CommitDialog
 
         private class WrapperState
         {
-            private readonly List<string> _wordList = new List<string>();
+            private readonly List<string> _wordList = new();
             private int _wordsLength;
             private readonly int _lineLimit;
 

--- a/GitUI/CommandsDialogs/DataGridViewCheckBoxHeaderCell.cs
+++ b/GitUI/CommandsDialogs/DataGridViewCheckBoxHeaderCell.cs
@@ -121,8 +121,8 @@ namespace GitUI.CommandsDialogs
             base.Paint(graphics, clipBounds, cellBounds, rowIndex, dataGridViewElementState, value, formattedValue, errorText, cellStyle, advancedBorderStyle, paintParts);
 
             var glyphSize = CheckBoxRenderer.GetGlyphSize(graphics, CheckBoxState.UncheckedNormal);
-            var relativeLocation = new Point((cellBounds.Width / 2) - (glyphSize.Width / 2), (cellBounds.Height / 2) - (glyphSize.Height / 2));
-            var absoluteLocation = new Point(cellBounds.Location.X + relativeLocation.X, cellBounds.Location.Y + relativeLocation.Y);
+            Point relativeLocation = new((cellBounds.Width / 2) - (glyphSize.Width / 2), (cellBounds.Height / 2) - (glyphSize.Height / 2));
+            Point absoluteLocation = new(cellBounds.Location.X + relativeLocation.X, cellBounds.Location.Y + relativeLocation.Y);
 
             _checkBoxArea = new Rectangle(relativeLocation, glyphSize);
             CheckBoxRenderer.DrawCheckBox(graphics, absoluteLocation, CheckBoxState);

--- a/GitUI/CommandsDialogs/FormAbout.cs
+++ b/GitUI/CommandsDialogs/FormAbout.cs
@@ -38,7 +38,7 @@ namespace GitUI.CommandsDialogs
             var contributorsList = GetContributorList();
             var thanksToContributorsText = string.Format(_thanksToContributors.Text, contributorsList.Count);
 
-            var random = new Random();
+            Random random = new();
 
             thanksTimer.Tick += delegate { ThankNextContributor(); };
             thanksTimer.Enabled = true;
@@ -51,7 +51,7 @@ namespace GitUI.CommandsDialogs
 
             void ShowContributorsForm()
             {
-                using var formContributors = new FormContributors();
+                using FormContributors formContributors = new();
                 formContributors.ShowDialog(owner: this);
             }
 

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -79,7 +79,7 @@ namespace GitUI.CommandsDialogs
                 Validates.NotNull(fileName);
                 FileInfoExtensions.MakeFileTemporaryWritable(fileName, x =>
                 {
-                    var gitIgnoreFileAddition = new StringBuilder();
+                    StringBuilder gitIgnoreFileAddition = new();
 
                     if (File.Exists(fileName) && !File.ReadAllText(fileName, GitModule.SystemEncoding).EndsWith(Environment.NewLine))
                     {

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -18,24 +18,24 @@ namespace GitUI.CommandsDialogs
         #region Translation
 
         private readonly TranslationString _conflictResolvedText =
-            new TranslationString("Conflicts resolved");
+            new("Conflicts resolved");
         private readonly TranslationString _conflictMergetoolText =
-            new TranslationString("Solve conflicts");
+            new("Solve conflicts");
 
         private readonly TranslationString _selectPatchFileFilter =
-            new TranslationString("Patch file (*.Patch)");
+            new("Patch file (*.Patch)");
         private readonly TranslationString _selectPatchFileCaption =
-            new TranslationString("Select patch file");
+            new("Select patch file");
 
         private readonly TranslationString _noFileSelectedText =
-            new TranslationString("Please select a patch to apply");
+            new("Please select a patch to apply");
 
         private readonly TranslationString _applyPatchMsgBox =
-            new TranslationString("Apply patch");
+            new("Apply patch");
 
         #endregion
 
-        private static readonly List<PatchFile> Skipped = new List<PatchFile>();
+        private static readonly List<PatchFile> Skipped = new();
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormApplyPatch()
@@ -149,7 +149,7 @@ namespace GitUI.CommandsDialogs
 
         private string SelectPatchFile(string initialDirectory)
         {
-            using var dialog = new OpenFileDialog
+            using OpenFileDialog dialog = new()
             {
                 Filter = _selectPatchFileFilter.Text + "|*.patch",
                 InitialDirectory = initialDirectory,
@@ -213,7 +213,7 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                using var sr = new StreamReader(path);
+                using StreamReader sr = new(path);
                 string line = sr.ReadLine();
 
                 return line is not null && (line.StartsWith("diff ") || line.StartsWith("Index: "));

--- a/GitUI/CommandsDialogs/FormArchive.cs
+++ b/GitUI/CommandsDialogs/FormArchive.cs
@@ -12,16 +12,16 @@ namespace GitUI.CommandsDialogs
     public partial class FormArchive : GitModuleForm
     {
         private readonly TranslationString _saveFileDialogFilterZip =
-            new TranslationString("Zip file (*.zip)");
+            new("Zip file (*.zip)");
 
         private readonly TranslationString _saveFileDialogFilterTar =
-            new TranslationString("Tar file (*.tar)");
+            new("Tar file (*.tar)");
 
         private readonly TranslationString _saveFileDialogCaption =
-            new TranslationString("Save archive as");
+            new("Save archive as");
 
         private readonly TranslationString _noRevisionSelected =
-            new TranslationString("You need to choose a target revision.");
+            new("You need to choose a target revision.");
 
         private GitRevision? _selectedRevision;
         public GitRevision? SelectedRevision
@@ -130,7 +130,7 @@ namespace GitUI.CommandsDialogs
                 filenameSuggestion += "_" + textBoxPaths.Lines[0].Trim().Replace(".", "_");
             }
 
-            using var saveFileDialog = new SaveFileDialog
+            using SaveFileDialog saveFileDialog = new()
             {
                 Filter = string.Format("{0}|*.{1}", fileFilterCaption, fileFilterEnding),
                 Title = _saveFileDialogCaption.Text,
@@ -177,7 +177,7 @@ namespace GitUI.CommandsDialogs
 
         private void btnChooseRevision_Click(object sender, EventArgs e)
         {
-            using var chooseForm = new FormChooseCommit(UICommands, SelectedRevision?.Guid);
+            using FormChooseCommit chooseForm = new(UICommands, SelectedRevision?.Guid);
             if (chooseForm.ShowDialog(this) == DialogResult.OK && chooseForm.SelectedRevision is not null)
             {
                 SelectedRevision = chooseForm.SelectedRevision;
@@ -195,7 +195,7 @@ namespace GitUI.CommandsDialogs
 
         private void btnDiffChooseRevision_Click(object sender, EventArgs e)
         {
-            using var chooseForm = new FormChooseCommit(UICommands, DiffSelectedRevision is not null ? DiffSelectedRevision.Guid : string.Empty);
+            using FormChooseCommit chooseForm = new(UICommands, DiffSelectedRevision is not null ? DiffSelectedRevision.Guid : string.Empty);
             if (chooseForm.ShowDialog(this) == DialogResult.OK && chooseForm.SelectedRevision is not null)
             {
                 DiffSelectedRevision = chooseForm.SelectedRevision;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -205,7 +205,7 @@ namespace GitUI.CommandsDialogs
             revisionDiff.Bind(RevisionGrid, fileTree, () => RequestRefresh());
             fileTree.Bind(() => RequestRefresh());
 
-            var repositoryDescriptionProvider = new RepositoryDescriptionProvider(new GitDirectoryResolver());
+            RepositoryDescriptionProvider repositoryDescriptionProvider = new(new GitDirectoryResolver());
             _appTitleGenerator = new AppTitleGenerator(repositoryDescriptionProvider);
             _windowsJumpListManager = new WindowsJumpListManager(repositoryDescriptionProvider);
 
@@ -430,7 +430,7 @@ namespace GitUI.CommandsDialogs
                                 TaskbarManager.Instance.SetOverlayIcon(overlay, "");
                             }
 
-                            var repoStateVisualiser = new RepoStateVisualiser();
+                            RepoStateVisualiser repoStateVisualiser = new();
                             var (image, _) = repoStateVisualiser.Invoke(status);
                             _windowsJumpListManager.UpdateCommitIcon(image);
                         }
@@ -485,7 +485,7 @@ namespace GitUI.CommandsDialogs
 
             Brush UpdateCommitButtonAndGetBrush(IReadOnlyList<GitItemStatus>? status, bool showCount)
             {
-                var repoStateVisualiser = new RepoStateVisualiser();
+                RepoStateVisualiser repoStateVisualiser = new();
                 var (image, brush) = repoStateVisualiser.Invoke(status);
 
                 if (showCount)
@@ -617,7 +617,7 @@ namespace GitUI.CommandsDialogs
                     continue;
                 }
 
-                var toolStripMenuItem = new ToolStripMenuItem(shell.Name);
+                ToolStripMenuItem toolStripMenuItem = new(shell.Name);
                 userShell.DropDownItems.Add(toolStripMenuItem);
                 toolStripMenuItem.Tag = shell;
                 toolStripMenuItem.Image = shell.Icon;
@@ -947,7 +947,7 @@ namespace GitUI.CommandsDialogs
                         continue;
                     }
 
-                    var item = new ToolStripMenuItem
+                    ToolStripMenuItem item = new()
                     {
                         Text = plugin.Name,
                         Image = plugin.Icon,
@@ -1026,7 +1026,7 @@ namespace GitUI.CommandsDialogs
                 if (AppSettings.CheckForUpdates && AppSettings.LastUpdateCheck.AddDays(7) < DateTime.Now)
                 {
                     AppSettings.LastUpdateCheck = DateTime.Now;
-                    var updateForm = new FormUpdates(AppSettings.AppVersion);
+                    FormUpdates updateForm = new(AppSettings.AppVersion);
                     updateForm.SearchForUpdatesAndShow(ownerWindow: this, alwaysShow: false);
                 }
 
@@ -1182,7 +1182,7 @@ namespace GitUI.CommandsDialogs
 
                 foreach (var script in scripts)
                 {
-                    var button = new ToolStripButton
+                    ToolStripButton button = new()
                     {
                         // store scriptname
                         Text = script.Name,
@@ -1266,9 +1266,9 @@ namespace GitUI.CommandsDialogs
             var recentRepositoryHistory = ThreadHelper.JoinableTaskFactory.Run(
                 () => RepositoryHistoryManager.Locals.AddAsMostRecentAsync(path));
 
-            var mostRecentRepos = new List<RecentRepoInfo>();
+            List<RecentRepoInfo> mostRecentRepos = new();
             using var graphics = CreateGraphics();
-            var splitter = new RecentRepoSplitter
+            RecentRepoSplitter splitter = new()
             {
                 MeasureFont = _NO_TRANSLATE_WorkingDir.Font,
                 Graphics = graphics
@@ -1297,7 +1297,7 @@ namespace GitUI.CommandsDialogs
         {
             _NO_TRANSLATE_WorkingDir.DropDownItems.Clear();
 
-            var tsmiCategorisedRepos = new ToolStripMenuItem(tsmiFavouriteRepositories.Text, tsmiFavouriteRepositories.Image);
+            ToolStripMenuItem tsmiCategorisedRepos = new(tsmiFavouriteRepositories.Text, tsmiFavouriteRepositories.Image);
             PopulateFavouriteRepositoriesMenu(tsmiCategorisedRepos);
             if (tsmiCategorisedRepos.DropDownItems.Count > 0)
             {
@@ -1308,11 +1308,11 @@ namespace GitUI.CommandsDialogs
 
             _NO_TRANSLATE_WorkingDir.DropDownItems.Add(new ToolStripSeparator());
 
-            var mnuOpenLocalRepository = new ToolStripMenuItem(openToolStripMenuItem.Text, openToolStripMenuItem.Image) { ShortcutKeys = openToolStripMenuItem.ShortcutKeys };
+            ToolStripMenuItem mnuOpenLocalRepository = new(openToolStripMenuItem.Text, openToolStripMenuItem.Image) { ShortcutKeys = openToolStripMenuItem.ShortcutKeys };
             mnuOpenLocalRepository.Click += OpenToolStripMenuItemClick;
             _NO_TRANSLATE_WorkingDir.DropDownItems.Add(mnuOpenLocalRepository);
 
-            var mnuRecentReposSettings = new ToolStripMenuItem(_configureWorkingDirMenu.Text);
+            ToolStripMenuItem mnuRecentReposSettings = new(_configureWorkingDirMenu.Text);
             mnuRecentReposSettings.Click += (hs, he) =>
             {
                 using (var frm = new FormRecentReposSettings())
@@ -1481,7 +1481,7 @@ namespace GitUI.CommandsDialogs
 
         private void AboutToolStripMenuItemClick(object sender, EventArgs e)
         {
-            using var frm = new FormAbout();
+            using FormAbout frm = new();
             frm.ShowDialog(this);
         }
 
@@ -1511,7 +1511,7 @@ namespace GitUI.CommandsDialogs
             {
                 Validates.NotNull(shell.ExecutablePath);
 
-                var executable = new Executable(shell.ExecutablePath, Module.WorkingDir);
+                Executable executable = new(shell.ExecutablePath, Module.WorkingDir);
                 executable.Start(createWindow: true);
             }
             catch (Exception exception)
@@ -1632,7 +1632,7 @@ namespace GitUI.CommandsDialogs
 
         private void DonateToolStripMenuItemClick(object sender, EventArgs e)
         {
-            using var frm = new FormDonate();
+            using FormDonate frm = new();
             frm.ShowDialog(this);
         }
 
@@ -1755,7 +1755,7 @@ namespace GitUI.CommandsDialogs
 
         private void ChangelogToolStripMenuItemClick(object sender, EventArgs e)
         {
-            using var frm = new FormChangeLog();
+            using FormChangeLog frm = new();
             frm.ShowDialog(this);
         }
 
@@ -1900,12 +1900,12 @@ namespace GitUI.CommandsDialogs
 
         private void PopulateFavouriteRepositoriesMenu(ToolStripDropDownItem container, in IList<Repository> repositoryHistory)
         {
-            var mostRecentRepos = new List<RecentRepoInfo>();
-            var lessRecentRepos = new List<RecentRepoInfo>();
+            List<RecentRepoInfo> mostRecentRepos = new();
+            List<RecentRepoInfo> lessRecentRepos = new();
 
             using (var graphics = CreateGraphics())
             {
-                var splitter = new RecentRepoSplitter
+                RecentRepoSplitter splitter = new()
                 {
                     MeasureFont = container.Font,
                     Graphics = graphics
@@ -1941,8 +1941,8 @@ namespace GitUI.CommandsDialogs
 
         private void PopulateRecentRepositoriesMenu(ToolStripDropDownItem container)
         {
-            var mostRecentRepos = new List<RecentRepoInfo>();
-            var lessRecentRepos = new List<RecentRepoInfo>();
+            List<RecentRepoInfo> mostRecentRepos = new();
+            List<RecentRepoInfo> lessRecentRepos = new();
 
             var repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.LoadRecentHistoryAsync());
             if (repositoryHistory.Count < 1)
@@ -1952,7 +1952,7 @@ namespace GitUI.CommandsDialogs
 
             using (var graphics = CreateGraphics())
             {
-                var splitter = new RecentRepoSplitter
+                RecentRepoSplitter splitter = new()
                 {
                     MeasureFont = container.Font,
                     Graphics = graphics
@@ -2060,7 +2060,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var fileNames = new StringBuilder();
+            StringBuilder fileNames = new();
             foreach (var item in diffFiles.SelectedItems)
             {
                 var path = PathUtil.Combine(module.WorkingDir, item.Item.Name);
@@ -2118,7 +2118,7 @@ namespace GitUI.CommandsDialogs
 
             void AddCheckoutBranchMenuItem()
             {
-                var checkoutBranchItem = new ToolStripMenuItem(checkoutBranchToolStripMenuItem.Text, Images.BranchCheckout)
+                ToolStripMenuItem checkoutBranchItem = new(checkoutBranchToolStripMenuItem.Text, Images.BranchCheckout)
                 {
                     ShortcutKeys = checkoutBranchToolStripMenuItem.ShortcutKeys,
                     ShortcutKeyDisplayString = checkoutBranchToolStripMenuItem.ShortcutKeyDisplayString
@@ -2743,7 +2743,7 @@ namespace GitUI.CommandsDialogs
 
         private ToolStripItem CreateSubmoduleMenuItem(SubmoduleInfo info, string textFormat = "{0}")
         {
-            var item = new ToolStripMenuItem(string.Format(textFormat, info.Text))
+            ToolStripMenuItem item = new(string.Format(textFormat, info.Text))
             {
                 Width = 200,
                 Tag = info.Path,
@@ -2867,13 +2867,13 @@ namespace GitUI.CommandsDialogs
 
             newItems.Add(new ToolStripSeparator());
 
-            var mi = new ToolStripMenuItem(updateAllSubmodulesToolStripMenuItem.Text, Images.SubmodulesUpdate);
+            ToolStripMenuItem mi = new(updateAllSubmodulesToolStripMenuItem.Text, Images.SubmodulesUpdate);
             mi.Click += UpdateAllSubmodulesToolStripMenuItemClick;
             newItems.Add(mi);
 
             if (result.CurrentSubmoduleName is not null)
             {
-                var item = new ToolStripMenuItem(_updateCurrentSubmodule.Text)
+                ToolStripMenuItem item = new(_updateCurrentSubmodule.Text)
                 {
                     Width = 200,
                     Tag = Module.WorkingDir,
@@ -2958,7 +2958,7 @@ namespace GitUI.CommandsDialogs
 
         private void checkForUpdatesToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var updateForm = new FormUpdates(AppSettings.AppVersion);
+            FormUpdates updateForm = new(AppSettings.AppVersion);
             updateForm.SearchForUpdatesAndShow(Owner, true);
         }
 
@@ -3028,7 +3028,7 @@ namespace GitUI.CommandsDialogs
                 }
 
                 // Create the terminal
-                var startInfo = new ConEmuStartInfo
+                ConEmuStartInfo startInfo = new()
                 {
                     StartupDirectory = Module.WorkingDir,
                     WhenConsoleProcessExits = WhenConsoleProcessExits.CloseConsoleEmulator
@@ -3081,7 +3081,7 @@ namespace GitUI.CommandsDialogs
 
         private void toolStripMenuItemReflog_Click(object sender, EventArgs e)
         {
-            using var formReflog = new FormReflog(UICommands);
+            using FormReflog formReflog = new(UICommands);
             formReflog.ShowDialog();
         }
 
@@ -3264,7 +3264,7 @@ namespace GitUI.CommandsDialogs
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/CommandsDialogs/FormBrowseController.cs
+++ b/GitUI/CommandsDialogs/FormBrowseController.cs
@@ -40,7 +40,7 @@ namespace GitUI.CommandsDialogs
                                           Action<object, GitModuleEventArgs> setGitModule)
         {
             string branchName = _repositoryCurrentBranchNameProvider.GetCurrentBranchName(repo.Path);
-            var item = new ToolStripMenuItem(caption)
+            ToolStripMenuItem item = new(caption)
             {
                 DisplayStyle = ToolStripItemDisplayStyle.ImageAndText,
                 ShortcutKeyDisplayString = branchName
@@ -87,7 +87,7 @@ namespace GitUI.CommandsDialogs
 
         private void ChangeWorkingDir(string path, Action<object, GitModuleEventArgs> setGitModule)
         {
-            var module = new GitModule(path);
+            GitModule module = new(path);
             if (module.IsValidGitWorkingDir())
             {
                 setGitModule(this, new GitModuleEventArgs(module));

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -22,21 +22,21 @@ namespace GitUI.CommandsDialogs
     {
         #region Translation
         private readonly TranslationString _customBranchNameIsEmpty =
-            new TranslationString("Custom branch name is empty.\nEnter valid branch name or select predefined value.");
+            new("Custom branch name is empty.\nEnter valid branch name or select predefined value.");
         private readonly TranslationString _customBranchNameIsNotValid =
-            new TranslationString("“{0}” is not valid branch name.\nEnter valid branch name or select predefined value.");
+            new("“{0}” is not valid branch name.\nEnter valid branch name or select predefined value.");
         private readonly TranslationString _createBranch =
-            new TranslationString("Create local branch with the name:");
+            new("Create local branch with the name:");
         private readonly TranslationString _applyStashedItemsAgainCaption =
-            new TranslationString("Auto stash");
+            new("Auto stash");
         private readonly TranslationString _applyStashedItemsAgain =
-            new TranslationString("Apply stashed items to working directory again?");
+            new("Apply stashed items to working directory again?");
 
         private readonly TranslationString _dontShowAgain =
-            new TranslationString("Don't show me this message again.");
+            new("Don't show me this message again.");
 
         private readonly TranslationString _resetNonFastForwardBranch =
-            new TranslationString("You are going to reset the “{0}” branch to a new location discarding ALL the commited changes since the {1} revision.\n\nAre you sure?");
+            new("You are going to reset the “{0}” branch to a new location discarding ALL the commited changes since the {1} revision.\n\nAre you sure?");
         private readonly TranslationString _resetCaption = new("Reset branch");
         #endregion
 
@@ -50,7 +50,7 @@ namespace GitUI.CommandsDialogs
         private string _localBranchName = "";
         private readonly IGitBranchNameNormaliser _branchNameNormaliser;
         private readonly GitBranchNameOptions _gitBranchNameOptions = new(AppSettings.AutoNormaliseSymbol);
-        private readonly Dictionary<Control, int> _controls = new Dictionary<Control, int>();
+        private readonly Dictionary<Control, int> _controls = new();
 
         private IReadOnlyList<IGitRef>? _localBranches;
         private IReadOnlyList<IGitRef>? _remoteBranches;
@@ -243,7 +243,7 @@ namespace GitUI.CommandsDialogs
 
             IReadOnlyList<string> GetContainsRevisionBranches()
             {
-                var result = new HashSet<string>();
+                HashSet<string> result = new();
                 if (_containRevisions.Count > 0)
                 {
                     var branches = Module.GetAllBranchesWhichContainGivenCommit(_containRevisions[0], LocalBranch.Checked,
@@ -385,7 +385,7 @@ namespace GitUI.CommandsDialogs
                     bool? messageBoxResult = AppSettings.AutoPopStashAfterCheckoutBranch;
                     if (messageBoxResult is null)
                     {
-                        using var dialog = new Microsoft.WindowsAPICodePack.Dialogs.TaskDialog
+                        using Microsoft.WindowsAPICodePack.Dialogs.TaskDialog dialog = new()
                         {
                             OwnerWindowHandle = Handle,
                             Text = _applyStashedItemsAgain.Text,

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -14,7 +14,7 @@ namespace GitUI.CommandsDialogs
     {
         #region Translation
         private readonly TranslationString _noneParentSelectedText =
-            new TranslationString("None parent is selected!");
+            new("None parent is selected!");
         #endregion
 
         private bool _isMerge;
@@ -97,7 +97,7 @@ namespace GitUI.CommandsDialogs
 
         private void Revert_Click(object sender, EventArgs e)
         {
-            var args = new ArgumentBuilder();
+            ArgumentBuilder args = new();
             var canExecute = true;
 
             if (_isMerge)

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -13,7 +13,7 @@ namespace GitUI.CommandsDialogs
     public partial class FormCleanupRepository : GitModuleForm
     {
         private readonly TranslationString _reallyCleanupQuestion =
-            new TranslationString("Are you sure you want to cleanup the repository?");
+            new("Are you sure you want to cleanup the repository?");
         private readonly TranslationString _reallyCleanupQuestionCaption = new("Cleanup");
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
@@ -109,7 +109,7 @@ namespace GitUI.CommandsDialogs
 
         private void AddPath_Click(object sender, EventArgs e)
         {
-            var dialog = new FolderBrowserDialog()
+            FolderBrowserDialog dialog = new()
             {
                 SelectedPath = Module.WorkingDir,
             };

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -277,7 +277,7 @@ namespace GitUI.CommandsDialogs
 
                 if (!string.IsNullOrEmpty(_puttySshKey))
                 {
-                    var clonedGitModule = new GitModule(dirTo);
+                    GitModule clonedGitModule = new(dirTo);
                     clonedGitModule.SetSetting(string.Format(SettingKeyString.RemotePuttySshKey, "origin"), _puttySshKey);
                     clonedGitModule.LocalConfigFile.Save();
                 }
@@ -285,7 +285,7 @@ namespace GitUI.CommandsDialogs
                 if (_openedFromProtocolHandler && AskIfNewRepositoryShouldBeOpened(dirTo))
                 {
                     Hide();
-                    var uiCommands = new GitUICommands(dirTo);
+                    GitUICommands uiCommands = new(dirTo);
                     uiCommands.StartBrowseDialog();
                 }
                 else if (ShowInTaskbar == false && _gitModuleChanged is not null &&

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -45,7 +45,7 @@ namespace GitUI.CommandsDialogs
         #region Translation
 
         private readonly TranslationString _amendCommit =
-            new TranslationString("You are about to rewrite history." + Environment.NewLine +
+            new("You are about to rewrite history." + Environment.NewLine +
                                   "Only use amend if the commit is not published yet!" + Environment.NewLine +
                                   Environment.NewLine + "Do you want to continue?");
 
@@ -56,15 +56,15 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _deleteFailed = new("Delete file failed");
 
         private readonly TranslationString _deleteSelectedFiles =
-            new TranslationString("Are you sure you want to delete the selected file(s)?");
+            new("Are you sure you want to delete the selected file(s)?");
 
         private readonly TranslationString _deleteSelectedFilesCaption = new("Delete");
 
         private readonly TranslationString _deleteUntrackedFiles =
-            new TranslationString("Are you sure you want to delete all untracked files?");
+            new("Are you sure you want to delete all untracked files?");
 
         private readonly TranslationString _deleteUntrackedFilesCaption =
-            new TranslationString("Delete untracked files.");
+            new("Delete untracked files.");
 
         private readonly TranslationString _enterCommitMessage = new("Please enter commit message");
         private readonly TranslationString _enterCommitMessageCaption = new("Commit message");
@@ -73,35 +73,35 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _enterCommitMessageHint = new("Enter commit message");
 
         private readonly TranslationString _mergeConflicts =
-            new TranslationString("There are unresolved merge conflicts, solve merge conflicts before committing.");
+            new("There are unresolved merge conflicts, solve merge conflicts before committing.");
 
         private readonly TranslationString _mergeConflictsCaption = new("Merge conflicts");
 
         private readonly TranslationString _noFilesStagedAndConfirmAnEmptyMergeCommit =
-            new TranslationString("There are no files staged for this commit.\nAre you sure you want to commit?");
+            new("There are no files staged for this commit.\nAre you sure you want to commit?");
         private readonly TranslationString _noFilesStagedCommitAllFilteredUnstagedOption =
-            new TranslationString("Stage and commit the unstaged files that match your filter");
+            new("Stage and commit the unstaged files that match your filter");
         private readonly TranslationString _noFilesStagedCommitAllUnstagedOption =
-            new TranslationString("Stage and commit all unstaged files");
+            new("Stage and commit all unstaged files");
         private readonly TranslationString _noFilesStagedMakeEmptyCommitOption =
-            new TranslationString("Make an empty commit");
+            new("Make an empty commit");
         private readonly TranslationString _noFilesStagedCommitCaption =
-            new TranslationString("Confirm commit");
+            new("Confirm commit");
         private readonly TranslationString _noFilesStagedCommitInstructions =
-            new TranslationString("There aren't any changes in the staging area.\nHow do you want to proceed?");
+            new("There aren't any changes in the staging area.\nHow do you want to proceed?");
 
         private readonly TranslationString _noStagedChanges = new("There are no staged changes");
         private readonly TranslationString _noUnstagedChanges = new("There are no unstaged changes");
 
         private readonly TranslationString _notOnBranch =
-            new TranslationString("This commit will be unreferenced when switching to another branch and can be lost." +
+            new("This commit will be unreferenced when switching to another branch and can be lost." +
                                   Environment.NewLine + Environment.NewLine + "Do you want to continue?");
 
         private readonly TranslationString _onlyStageChunkOfSingleFileError =
-            new TranslationString("You can only use this option when selecting a single file");
+            new("You can only use this option when selecting a single file");
 
         private readonly TranslationString _resetSelectedChangesText =
-            new TranslationString("Are you sure you want to reset all selected files?");
+            new("Are you sure you want to reset all selected files?");
 
         private readonly TranslationString _resetStageChunkOfFileCaption = new("Unstage chunk of file");
         private readonly TranslationString _stageDetails = new("Stage Details");
@@ -138,7 +138,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _commitCommitterToolTip = new("Click to change committer information.");
 
         private readonly TranslationString _modifyCommitMessageButtonToolTip
-            = new TranslationString("If you change the first line of the commit message, git will treat this commit as an ordinary commit," + Environment.NewLine
+            = new("If you change the first line of the commit message, git will treat this commit as an ordinary commit," + Environment.NewLine
                                     + "i.e. it may no longer be a fixup or an autosquash commit.");
 
         private readonly TranslationString _templateNotFoundCaption = new("Template Error");
@@ -165,9 +165,9 @@ namespace GitUI.CommandsDialogs
         private readonly bool _useFormCommitMessage = AppSettings.UseFormCommitMessage;
         private readonly CancellationTokenSequence _interactiveAddSequence = new();
         private readonly SplitterManager _splitterManager = new(new AppSettingsPath("CommitDialog"));
-        private readonly Subject<string> _selectionFilterSubject = new Subject<string>();
+        private readonly Subject<string> _selectionFilterSubject = new();
         private readonly IFullPathResolver _fullPathResolver;
-        private readonly List<string> _formattedLines = new List<string>();
+        private readonly List<string> _formattedLines = new();
 
         private CommitKind _commitKind;
         private FileStatusList? _currentFilesList;
@@ -402,7 +402,7 @@ namespace GitUI.CommandsDialogs
 
             void WorkaroundPaddingIncreaseBug()
             {
-                var padding = new Padding(1);
+                Padding padding = new(1);
 
                 splitLeft.Panel1.Padding = padding;
                 splitLeft.Panel2.Padding = padding;
@@ -1008,8 +1008,8 @@ namespace GitUI.CommandsDialogs
                 ? _currentSelection ?? Array.Empty<GitItemStatus>()
                 : Array.Empty<GitItemStatus>();
 
-            var unstagedFiles = new List<GitItemStatus>();
-            var stagedFiles = new List<GitItemStatus>();
+            List<GitItemStatus> unstagedFiles = new();
+            List<GitItemStatus> stagedFiles = new();
 
             foreach (var fileStatus in allChangedFiles)
             {
@@ -1213,7 +1213,7 @@ namespace GitUI.CommandsDialogs
                 bool ConfirmAndStageAllUnstaged()
                 {
                     bool mustStageAll = false;
-                    using var dialog = new Microsoft.WindowsAPICodePack.Dialogs.TaskDialog()
+                    using Microsoft.WindowsAPICodePack.Dialogs.TaskDialog dialog = new()
                     {
                         OwnerWindowHandle = Handle,
                         Cancelable = true,
@@ -1224,7 +1224,7 @@ namespace GitUI.CommandsDialogs
                     };
 
                     // Option 1: there are no staged files, but there are unstaged files. Most probably user forgot to stage them.
-                    var lnkStageAndCommit = new TaskDialogCommandLink("StageAndCommit", Unstaged.IsFilterActive ?
+                    TaskDialogCommandLink lnkStageAndCommit = new("StageAndCommit", Unstaged.IsFilterActive ?
                         _noFilesStagedCommitAllFilteredUnstagedOption.Text : _noFilesStagedCommitAllUnstagedOption.Text);
                     lnkStageAndCommit.Click += (s, e) =>
                     {
@@ -1234,7 +1234,7 @@ namespace GitUI.CommandsDialogs
                     dialog.Controls.Add(lnkStageAndCommit);
 
                     // Option 2: the user just wants to make an empty commmit
-                    var lnkEmptyCommit = new TaskDialogCommandLink("MakeEmptyCommit", _noFilesStagedMakeEmptyCommitOption.Text);
+                    TaskDialogCommandLink lnkEmptyCommit = new("MakeEmptyCommit", _noFilesStagedMakeEmptyCommitOption.Text);
                     lnkEmptyCommit.Click += (s, e) =>
                     {
                         dialog.Close(TaskDialogResult.Ok);
@@ -1295,7 +1295,7 @@ namespace GitUI.CommandsDialogs
                 {
                     int dialogResult = -1;
 
-                    using var dialog = new Microsoft.WindowsAPICodePack.Dialogs.TaskDialog
+                    using Microsoft.WindowsAPICodePack.Dialogs.TaskDialog dialog = new()
                     {
                         OwnerWindowHandle = Handle,
                         Text = _notOnBranch.Text,
@@ -1305,19 +1305,19 @@ namespace GitUI.CommandsDialogs
                         Icon = Microsoft.WindowsAPICodePack.Dialogs.TaskDialogStandardIcon.Error,
                         Cancelable = true,
                     };
-                    var btnCheckout = new TaskDialogCommandLink("Checkout", null, TranslatedStrings.ButtonCheckoutBranch);
+                    TaskDialogCommandLink btnCheckout = new("Checkout", null, TranslatedStrings.ButtonCheckoutBranch);
                     btnCheckout.Click += (s, e) =>
                     {
                         dialogResult = 0;
                         dialog.Close();
                     };
-                    var btnCreate = new TaskDialogCommandLink("Create", null, TranslatedStrings.ButtonCreateBranch);
+                    TaskDialogCommandLink btnCreate = new("Create", null, TranslatedStrings.ButtonCreateBranch);
                     btnCreate.Click += (s, e) =>
                     {
                         dialogResult = 1;
                         dialog.Close();
                     };
-                    var btnContinue = new TaskDialogCommandLink("Continue", null, TranslatedStrings.ButtonContinue);
+                    TaskDialogCommandLink btnContinue = new("Continue", null, TranslatedStrings.ButtonContinue);
                     btnContinue.Click += (s, e) =>
                     {
                         dialogResult = 2;
@@ -1794,7 +1794,7 @@ namespace GitUI.CommandsDialogs
                         {
                             Validates.NotNull(item.OldName);
 
-                            var clone = new GitItemStatus(item.OldName)
+                            GitItemStatus clone = new(item.OldName)
                             {
                                 IsDeleted = true,
                                 IsTracked = true,
@@ -1865,7 +1865,7 @@ namespace GitUI.CommandsDialogs
                 indexRev = new GitRevision(ObjectId.IndexId);
             }
 
-            var workTreeRev = new GitRevision(ObjectId.WorkTreeId) { ParentIds = new[] { ObjectId.IndexId } };
+            GitRevision workTreeRev = new(ObjectId.WorkTreeId) { ParentIds = new[] { ObjectId.IndexId } };
             return (headRev, indexRev, workTreeRev);
         }
 
@@ -1965,7 +1965,7 @@ namespace GitUI.CommandsDialogs
                     toolStripProgressBar1.Maximum = items.Count * 2;
                     toolStripProgressBar1.Value = 0;
 
-                    var files = new List<GitItemStatus>();
+                    List<GitItemStatus> files = new();
 
                     foreach (var item in items)
                     {
@@ -1997,14 +1997,14 @@ namespace GitUI.CommandsDialogs
                         InitializedStaged();
                         var unstagedFiles = Unstaged.GitItemStatuses.ToList();
                         _skipUpdate = true;
-                        var names = new HashSet<string?>();
+                        HashSet<string?> names = new();
                         foreach (var item in files)
                         {
                             names.Add(item.Name);
                             names.Add(item.OldName);
                         }
 
-                        var unstagedItems = new HashSet<GitItemStatus>();
+                        HashSet<GitItemStatus> unstagedItems = new();
 
                         foreach (var item in unstagedFiles)
                         {
@@ -2116,9 +2116,9 @@ namespace GitUI.CommandsDialogs
                 _currentFilesList.StoreNextIndexToSelect();
 
                 var deleteNewFiles = _currentFilesList.SelectedItems.Any(item => item.Item.IsNew) && (resetType == FormResetChanges.ActionEnum.ResetAndDelete);
-                var filesInUse = new List<string>();
-                var filesToReset = new List<string>();
-                var output = new StringBuilder();
+                List<string> filesInUse = new();
+                List<string> filesToReset = new();
+                StringBuilder output = new();
                 foreach (var item in _currentFilesList.SelectedItems)
                 {
                     if (item.Item.IsNew)
@@ -2429,14 +2429,14 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var sb = new StringBuilder();
+            StringBuilder sb = new();
             sb.AppendLine("Submodule" + (modules.Count == 1 ? " " : "s ") +
                 string.Join(", ", modules.Keys) + " updated");
             sb.AppendLine();
 
             foreach (var (path, name) in modules)
             {
-                var args = new GitArgumentBuilder("diff")
+                GitArgumentBuilder args = new("diff")
                 {
                     "--cached",
                     "-z",
@@ -2451,7 +2451,7 @@ namespace GitUI.CommandsDialogs
                 if (!string.IsNullOrEmpty(from) && !string.IsNullOrEmpty(to))
                 {
                     sb.AppendLine("Submodule " + path + ":");
-                    var module = new GitModule(_fullPathResolver.Resolve(name.EnsureTrailingPathSeparator()));
+                    GitModule module = new(_fullPathResolver.Resolve(name.EnsureTrailingPathSeparator()));
                     args = new GitArgumentBuilder("log")
                     {
                         "--pretty=format:\"    %m %h - %s\"",
@@ -2623,7 +2623,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var fileNames = new StringBuilder();
+            StringBuilder fileNames = new();
             foreach (var item in list.SelectedItems)
             {
                 var fileName = _fullPathResolver.Resolve(item.Item.Name);
@@ -3078,7 +3078,7 @@ namespace GitUI.CommandsDialogs
         private void commitSubmoduleChanges_Click(object sender, EventArgs e)
         {
             Validates.NotNull(_currentItem);
-            var submoduleCommands = new GitUICommands(_fullPathResolver.Resolve(_currentItem.Item.Name.EnsureTrailingPathSeparator()));
+            GitUICommands submoduleCommands = new(_fullPathResolver.Resolve(_currentItem.Item.Name.EnsureTrailingPathSeparator()));
             submoduleCommands.StartCommitDialog(this);
             Initialize();
         }
@@ -3141,7 +3141,7 @@ namespace GitUI.CommandsDialogs
 
             foreach (var item in unstagedFiles.Where(it => it.IsSubmodule))
             {
-                var commands = new GitUICommands(Module.GetSubmodule(item.Name));
+                GitUICommands commands = new(Module.GetSubmodule(item.Name));
                 commands.StashSave(this, AppSettings.IncludeUntrackedFilesInManualStash);
             }
 
@@ -3192,7 +3192,7 @@ namespace GitUI.CommandsDialogs
                         return;
                     }
 
-                    var toolStripItem = new ToolStripMenuItem(item.Name, item.Icon);
+                    ToolStripMenuItem toolStripItem = new(item.Name, item.Icon);
                     toolStripItem.Click += delegate
                     {
                         try
@@ -3217,7 +3217,7 @@ namespace GitUI.CommandsDialogs
 
                 void AddSettingsItem()
                 {
-                    var settingsItem = new ToolStripMenuItem(_commitMessageSettings.Text, Images.Settings);
+                    ToolStripMenuItem settingsItem = new(_commitMessageSettings.Text, Images.Settings);
                     settingsItem.Click += delegate
                     {
                         using (var frm = new FormCommitTemplateSettings())
@@ -3371,7 +3371,7 @@ namespace GitUI.CommandsDialogs
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -96,7 +96,7 @@ namespace GitUI.CommandsDialogs
                 return "";
             }
 
-            var createTagArgs = new GitCreateTagArgs(textBoxTagName.Text,
+            GitCreateTagArgs createTagArgs = new(textBoxTagName.Text,
                                                      objectId,
                                                      GetSelectedOperation(annotate.SelectedIndex),
                                                      tagMessage.Text,
@@ -122,7 +122,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            using var form = new FormRemoteProcess(UICommands, process: null, pushCmd)
+            using FormRemoteProcess form = new(UICommands, process: null, pushCmd)
             {
                 Remote = _currentRemote,
                 Text = string.Format(_pushToCaption.Text, _currentRemote),

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -15,12 +15,12 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _deleteBranchQuestion = new(
             "Are you sure you want to delete selected branches?" + Environment.NewLine + "Deleting a branch can cause commits to be deleted too!");
         private readonly TranslationString _deleteUnmergedBranchForcingSuggestion =
-            new TranslationString("You cannot delete unmerged branch until you set “force delete” mode.");
+            new("You cannot delete unmerged branch until you set “force delete” mode.");
         private readonly TranslationString _cannotDeleteCurrentBranchMessage =
-            new TranslationString("Cannot delete the branch “{0}” which you are currently on.");
+            new("Cannot delete the branch “{0}” which you are currently on.");
 
         private readonly IEnumerable<string> _defaultBranches;
-        private readonly HashSet<string> _mergedBranches = new HashSet<string>();
+        private readonly HashSet<string> _mergedBranches = new();
         private string? _currentBranch;
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
@@ -96,7 +96,7 @@ namespace GitUI.CommandsDialogs
                     return;
                 }
 
-                var cmd = new GitDeleteBranchCmd(selectedBranches, ForceDelete.Checked);
+                GitDeleteBranchCmd cmd = new(selectedBranches, ForceDelete.Checked);
                 UICommands.StartCommandLineProcessDialog(this, cmd);
             }
             catch (Exception ex)

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -17,9 +17,9 @@ namespace GitUI.CommandsDialogs
     {
         private readonly TranslationString _deleteRemoteBranchesCaption = new("Delete remote branches");
         private readonly TranslationString _confirmDeleteUnmergedRemoteBranchMessage =
-            new TranslationString("At least one remote branch is unmerged. Are you sure you want to delete it?" + Environment.NewLine + "Deleting a branch can cause commits to be deleted too!");
+            new("At least one remote branch is unmerged. Are you sure you want to delete it?" + Environment.NewLine + "Deleting a branch can cause commits to be deleted too!");
 
-        private readonly HashSet<string> _mergedBranches = new HashSet<string>();
+        private readonly HashSet<string> _mergedBranches = new();
         private readonly string _defaultRemoteBranch;
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
@@ -77,7 +77,7 @@ namespace GitUI.CommandsDialogs
                 {
                     EnsurePageant(remote);
 
-                    var cmd = new GitDeleteRemoteBranchesCmd(remote, branches.Select(x => x.LocalName));
+                    GitDeleteRemoteBranchesCmd cmd = new(remote, branches.Select(x => x.LocalName));
 
                     bool success = ScriptManager.RunEventScripts(this, ScriptEvent.BeforePush);
                     if (!success)
@@ -85,7 +85,7 @@ namespace GitUI.CommandsDialogs
                         return;
                     }
 
-                    using var form = new FormRemoteProcess(UICommands, process: null, cmd.Arguments)
+                    using FormRemoteProcess form = new(UICommands, process: null, cmd.Arguments)
                     {
                         Remote = remote
                     };

--- a/GitUI/CommandsDialogs/FormDeleteTag.cs
+++ b/GitUI/CommandsDialogs/FormDeleteTag.cs
@@ -69,7 +69,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            using var form = new FormRemoteProcess(UICommands, process: null, pushCmd);
+            using FormRemoteProcess form = new(UICommands, process: null, pushCmd);
             ////Remote = currentRemote,
             ////Text = string.Format(_deleteFromCaption.Text, currentRemote),
             form.ShowDialog();

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -325,7 +325,7 @@ namespace GitUI.CommandsDialogs
 
         private void PickAnotherBranch(GitRevision preSelectCommit, ref string? displayStr, ref GitRevision? revision)
         {
-            using var form = new FormCompareToBranch(UICommands, preSelectCommit.ObjectId);
+            using FormCompareToBranch form = new(UICommands, preSelectCommit.ObjectId);
             if (form.ShowDialog(this) == DialogResult.OK)
             {
                 displayStr = form.BranchName;
@@ -337,7 +337,7 @@ namespace GitUI.CommandsDialogs
 
         private void PickAnotherCommit(GitRevision preSelect, ref string? displayStr, ref GitRevision? revision)
         {
-            using var form = new FormChooseCommit(UICommands, preselectCommit: preSelect.Guid, showArtificial: true);
+            using FormChooseCommit form = new(UICommands, preselectCommit: preSelect.Guid, showArtificial: true);
             if (form.ShowDialog(this) == DialogResult.OK)
             {
                 revision = form.SelectedRevision;

--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -140,7 +140,7 @@ namespace GitUI.CommandsDialogs
                 }
                 else
                 {
-                    using var bytes = new MemoryStream();
+                    using MemoryStream bytes = new();
                     bytes.Write(fileViewer.FilePreamble, 0, fileViewer.FilePreamble.Length);
                     using (var writer = new StreamWriter(bytes, Module.FilesEncoding))
                     {
@@ -171,7 +171,7 @@ namespace GitUI.CommandsDialogs
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -252,7 +252,7 @@ namespace GitUI.CommandsDialogs
                     // note: This implementation is quite a quick hack (by someone who does not speak C# fluently).
                     //
 
-                    var args = new GitArgumentBuilder("log")
+                    GitArgumentBuilder args = new("log")
                     {
                         "--format=\"%n\"",
                         "--name-only",
@@ -262,10 +262,10 @@ namespace GitUI.CommandsDialogs
                         fileName.Quote()
                     };
 
-                    var listOfFileNames = new StringBuilder(fileName.Quote());
+                    StringBuilder listOfFileNames = new(fileName.Quote());
 
                     // keep a set of the file names already seen
-                    var setOfFileNames = new HashSet<string?> { fileName };
+                    HashSet<string?> setOfFileNames = new() { fileName };
 
                     var lines = Module.GitExecutable.GetOutputLines(args, outputEncoding: GitModule.LosslessEncoding);
 
@@ -401,7 +401,7 @@ namespace GitUI.CommandsDialogs
             {
                 Validates.NotNull(fileName);
                 View.Encoding = Diff.Encoding;
-                var file = new GitItemStatus(name: fileName)
+                GitItemStatus file = new(name: fileName)
                 {
                     IsTracked = true,
                     IsSubmodule = GitModule.IsValidGitWorkingDir(_fullPathResolver.Resolve(fileName))
@@ -411,13 +411,13 @@ namespace GitUI.CommandsDialogs
             else if (tabControl1.SelectedTab == DiffTab)
             {
                 Validates.NotNull(fileName);
-                var file = new GitItemStatus(name: fileName)
+                GitItemStatus file = new(name: fileName)
                 {
                     IsTracked = true,
                     IsSubmodule = GitModule.IsValidGitWorkingDir(_fullPathResolver.Resolve(fileName))
                 };
                 var revisions = FileChanges.GetSelectedRevisions();
-                var item = new FileStatusItem(firstRev: revisions.Skip(1).LastOrDefault(), secondRev: revisions.FirstOrDefault(), file);
+                FileStatusItem item = new(firstRev: revisions.Skip(1).LastOrDefault(), secondRev: revisions.FirstOrDefault(), file);
                 Diff.ViewChangesAsync(item, defaultText: "You need to select at least one revision to view diff.");
             }
             else if (tabControl1.SelectedTab == CommitInfoTabPage)
@@ -484,7 +484,7 @@ namespace GitUI.CommandsDialogs
                 }
 
                 fullName = fullName.ToNativePath();
-                using var fileDialog = new SaveFileDialog
+                using SaveFileDialog fileDialog = new()
                 {
                     InitialDirectory = Path.GetDirectoryName(fullName),
                     FileName = Path.GetFileName(fullName),

--- a/GitUI/CommandsDialogs/FormFileHistoryController.cs
+++ b/GitUI/CommandsDialogs/FormFileHistoryController.cs
@@ -35,11 +35,11 @@ namespace GitUI.CommandsDialogs
             if (EnvUtils.RunningOnWindows())
             {
                 // grab the 8.3 file path
-                var shortPath = new StringBuilder(4096);
+                StringBuilder shortPath = new(4096);
                 if (NativeMethods.GetShortPathNameW(path, shortPath, shortPath.Capacity) > 0)
                 {
                     // use 8.3 file path to get properly cased full file path
-                    var longPath = new StringBuilder(4096);
+                    StringBuilder longPath = new(4096);
                     if (NativeMethods.GetLongPathNameW(shortPath.ToString(), longPath, longPath.Capacity) > 0)
                     {
                         exactPath = longPath.ToString();

--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -15,27 +15,27 @@ namespace GitUI.CommandsDialogs
     {
         private readonly TranslationString _currentBranchText = new("Current branch:");
         private readonly TranslationString _noOutputPathEnteredText =
-            new TranslationString("You need to enter an output path.");
+            new("You need to enter an output path.");
         private readonly TranslationString _noEmailEnteredText =
-            new TranslationString("You need to enter an email address.");
+            new("You need to enter an email address.");
         private readonly TranslationString _noSubjectEnteredText =
-            new TranslationString("You need to enter a mail subject.");
+            new("You need to enter a mail subject.");
         private readonly TranslationString _wrongSmtpSettingsText =
-            new TranslationString("You need to enter a valid smtp in the settings dialog.");
+            new("You need to enter a valid smtp in the settings dialog.");
         private readonly TranslationString _revisionsNeededText =
-            new TranslationString("You need to select at least one revision");
+            new("You need to select at least one revision");
         private readonly TranslationString _revisionsNeededCaption =
-            new TranslationString("Patch error");
+            new("Patch error");
         private readonly TranslationString _sendMailResult =
-            new TranslationString("Send to:");
+            new("Send to:");
         private readonly TranslationString _sendMailResultFailed =
-            new TranslationString("Failed to send mail.");
+            new("Failed to send mail.");
         private readonly TranslationString _patchResultCaption =
-            new TranslationString("Patch result");
+            new("Patch result");
         private readonly TranslationString _noGitMailConfigured =
-            new TranslationString("There is no email address configured in the settings dialog.");
+            new("There is no email address configured in the settings dialog.");
         private readonly TranslationString _failCreatePatch =
-            new TranslationString("Unable to create patch file(s)");
+            new("Unable to create patch file(s)");
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormFormatPatch()
@@ -212,14 +212,14 @@ namespace GitUI.CommandsDialogs
 
                 string to = MailTo.Text;
 
-                using var mail = new MailMessage(from, to, MailSubject.Text, MailBody.Text);
+                using MailMessage mail = new(from, to, MailSubject.Text, MailBody.Text);
                 foreach (string file in Directory.GetFiles(dir, "*.patch"))
                 {
-                    var attachment = new Attachment(file);
+                    Attachment attachment = new(file);
                     mail.Attachments.Add(attachment);
                 }
 
-                var smtpClient = new SmtpClient(AppSettings.SmtpServer)
+                SmtpClient smtpClient = new(AppSettings.SmtpServer)
                 {
                     Port = AppSettings.SmtpPort,
                     EnableSsl = AppSettings.SmtpUseSsl

--- a/GitUI/CommandsDialogs/FormGitAttributes.cs
+++ b/GitUI/CommandsDialogs/FormGitAttributes.cs
@@ -10,19 +10,19 @@ namespace GitUI.CommandsDialogs
     public partial class FormGitAttributes : GitModuleForm
     {
         private readonly TranslationString _noWorkingDir =
-            new TranslationString(".gitattributes is only supported when there is a working directory.");
+            new(".gitattributes is only supported when there is a working directory.");
         private readonly TranslationString _noWorkingDirCaption =
-            new TranslationString("No working directory");
+            new("No working directory");
 
         private readonly TranslationString _cannotAccessGitattributes =
-            new TranslationString("Failed to save .gitattributes." + Environment.NewLine + "Check if file is accessible.");
+            new("Failed to save .gitattributes." + Environment.NewLine + "Check if file is accessible.");
         private readonly TranslationString _cannotAccessGitattributesCaption =
-            new TranslationString("Failed to save .gitattributes");
+            new("Failed to save .gitattributes");
 
         private readonly TranslationString _saveFileQuestion =
-            new TranslationString("Save changes to .gitattributes?");
+            new("Save changes to .gitattributes?");
         private readonly TranslationString _saveFileQuestionCaption =
-            new TranslationString("Save changes?");
+            new("Save changes?");
 
         public string GitAttributesFile = string.Empty;
         private readonly IFullPathResolver _fullPathResolver;

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -12,10 +12,10 @@ namespace GitUI.CommandsDialogs
     public sealed partial class FormGitIgnore : GitModuleForm
     {
         private readonly TranslationString _gitignoreOnlyInWorkingDirSupportedCaption =
-            new TranslationString("No working directory");
+            new("No working directory");
 
         private readonly TranslationString _saveFileQuestionCaption =
-            new TranslationString("Save changes?");
+            new("Save changes?");
 
         private readonly bool _localExclude;
         private string _originalGitIgnoreFileContent = string.Empty;

--- a/GitUI/CommandsDialogs/FormInit.cs
+++ b/GitUI/CommandsDialogs/FormInit.cs
@@ -11,16 +11,16 @@ namespace GitUI.CommandsDialogs
     public partial class FormInit : GitExtensionsDialog
     {
         private readonly TranslationString _chooseDirectory =
-            new TranslationString("Please choose a directory.");
+            new("Please choose a directory.");
 
         private readonly TranslationString _chooseDirectoryCaption =
-            new TranslationString("Choose directory");
+            new("Choose directory");
 
         private readonly TranslationString _chooseDirectoryNotFile =
-            new TranslationString("Cannot initialize a new repository on a file.\nPlease choose a directory.");
+            new("Cannot initialize a new repository on a file.\nPlease choose a directory.");
 
         private readonly TranslationString _initMsgBoxCaption =
-            new TranslationString("Create new repository");
+            new("Create new repository");
 
         private readonly EventHandler<GitModuleEventArgs>? _gitModuleChanged;
 
@@ -65,7 +65,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var module = new GitModule(directoryPath);
+            GitModule module = new(directoryPath);
 
             if (!System.IO.Directory.Exists(module.WorkingDir))
             {
@@ -90,7 +90,7 @@ namespace GitUI.CommandsDialogs
                 }
 
                 // this is going to throw if it's an invalid path (e.g. contains special chars)
-                var info = new DirectoryInfo(path);
+                DirectoryInfo info = new(path);
 
                 return Path.IsPathRooted(path.Trim());
             }
@@ -114,7 +114,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/CommandsDialogs/FormMailMap.cs
+++ b/GitUI/CommandsDialogs/FormMailMap.cs
@@ -10,19 +10,19 @@ namespace GitUI.CommandsDialogs
     public partial class FormMailMap : GitModuleForm
     {
         private readonly TranslationString _mailmapOnlyInWorkingDirSupported =
-            new TranslationString(".mailmap is only supported when there is a working directory.");
+            new(".mailmap is only supported when there is a working directory.");
         private readonly TranslationString _mailmapOnlyInWorkingDirSupportedCaption =
-            new TranslationString("No working directory");
+            new("No working directory");
 
         private readonly TranslationString _cannotAccessMailmap =
-            new TranslationString("Failed to save .mailmap." + Environment.NewLine + "Check if file is accessible.");
+            new("Failed to save .mailmap." + Environment.NewLine + "Check if file is accessible.");
         private readonly TranslationString _cannotAccessMailmapCaption =
-            new TranslationString("Failed to save .mailmap");
+            new("Failed to save .mailmap");
 
         private readonly TranslationString _saveFileQuestion =
-            new TranslationString("Save changes to .mailmap?");
+            new("Save changes to .mailmap?");
         private readonly TranslationString _saveFileQuestionCaption =
-            new TranslationString("Save changes?");
+            new("Save changes?");
 
         public string MailMapFile = string.Empty;
         private readonly IFullPathResolver _fullPathResolver;

--- a/GitUI/CommandsDialogs/FormMergeSubmodule.cs
+++ b/GitUI/CommandsDialogs/FormMergeSubmodule.cs
@@ -49,7 +49,7 @@ namespace GitUI.CommandsDialogs
 
         private void StageSubmodule()
         {
-            var args = new GitArgumentBuilder("add")
+            GitArgumentBuilder args = new("add")
             {
                 "--",
                 _filename.QuoteNE()
@@ -80,7 +80,7 @@ namespace GitUI.CommandsDialogs
         private void btCheckoutBranch_Click(object sender, EventArgs e)
         {
             var revisions = new[] { ObjectId.Parse(tbLocal.Text), ObjectId.Parse(tbRemote.Text) };
-            var submoduleCommands = new GitUICommands(Module.GetSubmoduleFullPath(_filename));
+            GitUICommands submoduleCommands = new(Module.GetSubmoduleFullPath(_filename));
             if (!submoduleCommands.StartCheckoutBranch(this, revisions))
             {
                 return;

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -27,43 +27,43 @@ namespace GitUI.CommandsDialogs
     {
         #region Translation
         private readonly TranslationString _areYouSureYouWantToRebaseMerge =
-            new TranslationString("The current commit is a merge." + Environment.NewLine +
+            new("The current commit is a merge." + Environment.NewLine +
                                   "Are you sure you want to rebase this merge?");
 
         private readonly TranslationString _areYouSureYouWantToRebaseMergeCaption =
-            new TranslationString("Rebase merge commit?");
+            new("Rebase merge commit?");
 
         private readonly TranslationString _allMergeConflictSolvedQuestion =
-            new TranslationString("Are all merge conflicts solved? Do you want to commit?");
+            new("Are all merge conflicts solved? Do you want to commit?");
 
         private readonly TranslationString _allMergeConflictSolvedQuestionCaption =
-            new TranslationString("Conflicts solved");
+            new("Conflicts solved");
 
         private readonly TranslationString _applyStashedItemsAgain =
-            new TranslationString("Apply stashed items to working directory again?");
+            new("Apply stashed items to working directory again?");
 
         private readonly TranslationString _applyStashedItemsAgainCaption =
-            new TranslationString("Auto stash");
+            new("Auto stash");
 
         private readonly TranslationString _fetchAllBranchesCanOnlyWithFetch =
-            new TranslationString("You can only fetch all remote branches (*) without merge or rebase." +
+            new("You can only fetch all remote branches (*) without merge or rebase." +
                                   Environment.NewLine + "If you want to fetch all remote branches, choose fetch." +
                                   Environment.NewLine +
                                   "If you want to fetch and merge a branch, choose a specific branch.");
 
         private readonly TranslationString _selectRemoteRepository =
-            new TranslationString("Please select a remote repository");
+            new("Please select a remote repository");
 
         private readonly TranslationString _selectSourceDirectory =
-            new TranslationString("Please select a source directory");
+            new("Please select a source directory");
 
         private readonly TranslationString _questionInitSubmodules =
-            new TranslationString("The pulled has submodules configured." + Environment.NewLine +
+            new("The pulled has submodules configured." + Environment.NewLine +
                                    "Do you want to initialize the submodules?" + Environment.NewLine +
                                    "This will initialize and update all submodules recursive.");
 
         private readonly TranslationString _questionInitSubmodulesCaption =
-            new TranslationString("Submodules");
+            new("Submodules");
 
         private readonly TranslationString _notOnBranch = new("You cannot \"pull\" when git head detached." +
                                   Environment.NewLine + Environment.NewLine + "Do you want to continue?");
@@ -87,7 +87,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _pruneBranchesCaption = new("Pull was rejected");
         private readonly TranslationString _pruneBranchesMainInstruction = new("Remote branch no longer exist");
         private readonly TranslationString _pruneBranchesBranch =
-            new TranslationString("Do you want to delete all stale remote-tracking branches?");
+            new("Do you want to delete all stale remote-tracking branches?");
 
         private readonly TranslationString _pruneFromCaption = new("Prune remote branches from {0}");
 
@@ -374,7 +374,7 @@ namespace GitUI.CommandsDialogs
             {
                 int dialogResult = -1;
 
-                using var dialog = new Microsoft.WindowsAPICodePack.Dialogs.TaskDialog
+                using Microsoft.WindowsAPICodePack.Dialogs.TaskDialog dialog = new()
                 {
                     OwnerWindowHandle = owner?.Handle ?? default,
                     Text = _notOnBranch.Text,
@@ -384,13 +384,13 @@ namespace GitUI.CommandsDialogs
                     Icon = TaskDialogStandardIcon.Error,
                     Cancelable = true,
                 };
-                var btnCheckout = new TaskDialogCommandLink("Checkout", null, TranslatedStrings.ButtonCheckoutBranch);
+                TaskDialogCommandLink btnCheckout = new("Checkout", null, TranslatedStrings.ButtonCheckoutBranch);
                 btnCheckout.Click += (s, e) =>
                 {
                     dialogResult = 0;
                     dialog.Close();
                 };
-                var btnContinue = new TaskDialogCommandLink("Continue", null, TranslatedStrings.ButtonContinue);
+                TaskDialogCommandLink btnContinue = new("Continue", null, TranslatedStrings.ButtonContinue);
                 btnContinue.Click += (s, e) =>
                 {
                     dialogResult = 1;
@@ -573,7 +573,7 @@ namespace GitUI.CommandsDialogs
                 bool? messageBoxResult = AppSettings.AutoPopStashAfterPull;
                 if (messageBoxResult is null)
                 {
-                    using var dialog = new Microsoft.WindowsAPICodePack.Dialogs.TaskDialog
+                    using Microsoft.WindowsAPICodePack.Dialogs.TaskDialog dialog = new()
                     {
                         OwnerWindowHandle = owner?.Handle ?? IntPtr.Zero,
                         Text = _applyStashedItemsAgain.Text,
@@ -701,11 +701,11 @@ namespace GitUI.CommandsDialogs
                 }
 
                 // auto pull only if current branch was rejected
-                var isRefRemoved = new Regex(@"Your configuration specifies to .* the ref '.*'[\r]?\nfrom the remote, but no such ref was fetched.");
+                Regex isRefRemoved = new(@"Your configuration specifies to .* the ref '.*'[\r]?\nfrom the remote, but no such ref was fetched.");
 
                 if (isRefRemoved.IsMatch(form.GetOutputString()))
                 {
-                    using var dialog = new Microsoft.WindowsAPICodePack.Dialogs.TaskDialog
+                    using Microsoft.WindowsAPICodePack.Dialogs.TaskDialog dialog = new()
                     {
                         OwnerWindowHandle = form.Handle,
                         Text = _pruneBranchesBranch.Text,
@@ -722,7 +722,7 @@ namespace GitUI.CommandsDialogs
                     {
                         string remote = _NO_TRANSLATE_Remotes.Text;
                         string pruneCmd = "remote prune " + remote;
-                        using var formPrune = new FormRemoteProcess(UICommands, process: null, pruneCmd)
+                        using FormRemoteProcess formPrune = new(UICommands, process: null, pruneCmd)
                         {
                             Remote = remote,
                             Text = string.Format(_pruneFromCaption.Text, remote)
@@ -752,7 +752,7 @@ namespace GitUI.CommandsDialogs
                 return true;
             }
 
-            var currentBranchRemote = new Lazy<string>(() => Module.GetSetting(string.Format(SettingKeyString.BranchRemote, localBranch.Text)));
+            Lazy<string> currentBranchRemote = new(() => Module.GetSetting(string.Format(SettingKeyString.BranchRemote, localBranch.Text)));
 
             if (_branch == localBranch.Text)
             {
@@ -775,7 +775,7 @@ namespace GitUI.CommandsDialogs
             {
                 int dialogResult = -1;
 
-                using var dialog = new Microsoft.WindowsAPICodePack.Dialogs.TaskDialog
+                using Microsoft.WindowsAPICodePack.Dialogs.TaskDialog dialog = new()
                 {
                     OwnerWindowHandle = Handle,
                     Text = string.Format(_noRemoteBranchMainInstruction.Text, remote),
@@ -789,7 +789,7 @@ namespace GitUI.CommandsDialogs
                     Cancelable = false
                 };
 
-                var btnPullFrom = new TaskDialogCommandLink("PullFrom", null, string.Format(_noRemoteBranchButton.Text, remote + "/" + curLocalBranch));
+                TaskDialogCommandLink btnPullFrom = new("PullFrom", null, string.Format(_noRemoteBranchButton.Text, remote + "/" + curLocalBranch));
                 btnPullFrom.Click += (s, e) =>
                 {
                     dialogResult = 0;
@@ -822,7 +822,7 @@ namespace GitUI.CommandsDialogs
 
                 int dialogResult = -1;
 
-                using var dialog = new Microsoft.WindowsAPICodePack.Dialogs.TaskDialog
+                using Microsoft.WindowsAPICodePack.Dialogs.TaskDialog dialog = new()
                 {
                     OwnerWindowHandle = Handle,
                     Text = string.Format(_noRemoteBranchForFetchMainInstruction.Text, remote),
@@ -834,7 +834,7 @@ namespace GitUI.CommandsDialogs
                     Cancelable = false
                 };
 
-                var btnPullFrom = new TaskDialogCommandLink("PullFrom", null, string.Format(_noRemoteBranchForFetchButton.Text, remote + "/" + curLocalBranch));
+                TaskDialogCommandLink btnPullFrom = new("PullFrom", null, string.Format(_noRemoteBranchForFetchButton.Text, remote + "/" + curLocalBranch));
                 btnPullFrom.Click += (s, e) =>
                 {
                     dialogResult = 0;
@@ -885,7 +885,7 @@ namespace GitUI.CommandsDialogs
             string remoteBranchName = Module.GetSetting(string.Format("branch.{0}.merge", _branch));
             if (!string.IsNullOrEmpty(remoteBranchName))
             {
-                var args = new GitArgumentBuilder("name-rev")
+                GitArgumentBuilder args = new("name-rev")
                 {
                     "--name-only",
                     remoteBranchName.QuoteNE()
@@ -905,7 +905,7 @@ namespace GitUI.CommandsDialogs
 
             if (File.Exists(AppSettings.Pageant))
             {
-                var files = new HashSet<string>(new PathEqualityComparer());
+                HashSet<string> files = new(new PathEqualityComparer());
                 foreach (var remote in GetSelectedRemotes())
                 {
                     var sshKeyFile = Module.GetPuttyKeyFileForRemote(remote);
@@ -1166,7 +1166,7 @@ namespace GitUI.CommandsDialogs
             AllTags.Checked = AllTags.Checked || PruneTags.Checked;
         }
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -50,7 +50,7 @@ namespace GitUI.CommandsDialogs
 
         #region Translation
         private readonly TranslationString _branchNewForRemote =
-            new TranslationString("The branch you are about to push seems to be a new branch for the remote." +
+            new("The branch you are about to push seems to be a new branch for the remote." +
                                   Environment.NewLine + "Are you sure you want to push this branch?");
 
         private readonly TranslationString _pushCaption = new("Push");
@@ -58,24 +58,24 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _pushToCaption = new("Push to {0}");
 
         private readonly TranslationString _selectDestinationDirectory =
-            new TranslationString("Please select a destination directory");
+            new("Please select a destination directory");
 
         private readonly TranslationString _errorPushToRemoteCaption = new("Push to remote");
         private readonly TranslationString _configureRemote = new($"Please configure a remote repository first.{Environment.NewLine}Would you like to do it now?");
 
         private readonly TranslationString _selectTag =
-            new TranslationString("You need to select a tag to push or select \"Push all tags\".");
+            new("You need to select a tag to push or select \"Push all tags\".");
 
         private readonly TranslationString _updateTrackingReference =
-            new TranslationString("The branch {0} does not have a tracking reference. Do you want to add a tracking reference to {1}?");
+            new("The branch {0} does not have a tracking reference. Do you want to add a tracking reference to {1}?");
 
         private readonly TranslationString _pullRepositoryMainMergeInstruction = new("Pull latest changes from remote repository");
         private readonly TranslationString _pullRepositoryMainForceInstruction = new("Push rejected");
         private readonly TranslationString _pullRepositoryMergeInstruction =
-            new TranslationString("The push was rejected because the tip of your current branch is behind its remote counterpart. " +
+            new("The push was rejected because the tip of your current branch is behind its remote counterpart. " +
                 "Merge the remote changes before pushing again.");
         private readonly TranslationString _pullRepositoryForceInstruction =
-            new TranslationString("The push was rejected because the tip of your current branch is behind its remote counterpart");
+            new("The push was rejected because the tip of your current branch is behind its remote counterpart");
         private readonly TranslationString _pullDefaultButton = new("Pull with the default pull action ({0})");
         private readonly TranslationString _pullRebaseButton = new("Pull with rebase");
         private readonly TranslationString _pullMergeButton = new("Pull with merge");
@@ -87,9 +87,9 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _pullRepositoryCaption = new("Push was rejected from \"{0}\"");
         private readonly TranslationString _dontShowAgain = new("Remember my decision.");
         private readonly TranslationString _useForceWithLeaseInstead =
-            new TranslationString("Force push may overwrite changes since your last fetch. Do you want to use the safer force with lease instead?");
+            new("Force push may overwrite changes since your last fetch. Do you want to use the safer force with lease instead?");
         private readonly TranslationString _forceWithLeaseTooltips =
-            new TranslationString("Force with lease is a safer way to force push. It ensures you only overwrite work that you have seen in your local repository");
+            new("Force with lease is a safer way to force push. It ensures you only overwrite work that you have seen in your local repository");
 
         #endregion
 
@@ -432,7 +432,7 @@ namespace GitUI.CommandsDialogs
             else
             {
                 // Push Multiple Branches Tab selected
-                var pushActions = new List<GitPushAction>();
+                List<GitPushAction> pushActions = new();
                 Validates.NotNull(_branchTable);
                 foreach (DataRow row in _branchTable.Rows)
                 {
@@ -475,7 +475,7 @@ namespace GitUI.CommandsDialogs
             _candidateForRebasingMergeCommit = PushToRemote.Checked && (_selectedBranch != AllRefs) && TabControlTagBranch.SelectedTab == BranchTab;
             _selectedRemoteBranchName = RemoteBranch.Text;
 
-            using var form = new FormRemoteProcess(UICommands, process: null, pushCmd)
+            using FormRemoteProcess form = new(UICommands, process: null, pushCmd)
             {
                 Remote = remote,
                 Text = string.Format(_pushToCaption.Text, destination),
@@ -549,7 +549,7 @@ namespace GitUI.CommandsDialogs
 
             // if push was rejected, offer force push and for current branch also pull/merge
             // Note that the Git output contains color codes etc too
-            var isRejected = new Regex($"! \\[rejected\\] .* ((?<currBranch>{Regex.Escape(_currentBranchName)})|.*) -> ");
+            Regex isRejected = new($"! \\[rejected\\] .* ((?<currBranch>{Regex.Escape(_currentBranchName)})|.*) -> ");
             Match match = isRejected.Match(form.GetOutputString());
             if (match.Success && !Module.IsBareRepository())
             {
@@ -644,7 +644,7 @@ namespace GitUI.CommandsDialogs
 
                 int dialogResult = -1;
 
-                using var dialog = new Microsoft.WindowsAPICodePack.Dialogs.TaskDialog
+                using Microsoft.WindowsAPICodePack.Dialogs.TaskDialog dialog = new()
                 {
                     OwnerWindowHandle = owner.Handle,
                     Text = allOptions ? _pullRepositoryMergeInstruction.Text : _pullRepositoryForceInstruction.Text,
@@ -657,25 +657,25 @@ namespace GitUI.CommandsDialogs
                     StartupLocation = Microsoft.WindowsAPICodePack.Dialogs.TaskDialogStartupLocation.CenterOwner,
                     Cancelable = true
                 };
-                var btnPullDefault = new TaskDialogCommandLink("PullDefault", null, pullDefaultButtonText);
+                TaskDialogCommandLink btnPullDefault = new("PullDefault", null, pullDefaultButtonText);
                 btnPullDefault.Click += (s, e) =>
                 {
                     dialogResult = 0;
                     dialog.Close();
                 };
-                var btnPullRebase = new TaskDialogCommandLink("PullRebase", null, _pullRebaseButton.Text);
+                TaskDialogCommandLink btnPullRebase = new("PullRebase", null, _pullRebaseButton.Text);
                 btnPullRebase.Click += (s, e) =>
                 {
                     dialogResult = 1;
                     dialog.Close();
                 };
-                var btnPullMerge = new TaskDialogCommandLink("PullMerge", null, _pullMergeButton.Text);
+                TaskDialogCommandLink btnPullMerge = new("PullMerge", null, _pullMergeButton.Text);
                 btnPullMerge.Click += (s, e) =>
                 {
                     dialogResult = 2;
                     dialog.Close();
                 };
-                var btnPushForce = new TaskDialogCommandLink("PushForce", null, _pushForceButton.Text);
+                TaskDialogCommandLink btnPushForce = new("PushForce", null, _pushForceButton.Text);
                 btnPushForce.Click += (s, e) =>
                 {
                     dialogResult = 3;
@@ -911,7 +911,7 @@ namespace GitUI.CommandsDialogs
                 // Solution: when pushing a branch that doesn't exist on the remote, ask what to do
                 Validates.NotNull(_currentBranchName);
                 Validates.NotNull(_selectedRemote.Name);
-                var currentBranch = new GitRef(Module, null, _currentBranchName, _selectedRemote.Name);
+                GitRef currentBranch = new(Module, null, _currentBranchName, _selectedRemote.Name);
                 _NO_TRANSLATE_Branch.Items.Add(currentBranch);
                 _NO_TRANSLATE_Branch.SelectedItem = currentBranch;
             }
@@ -1016,7 +1016,7 @@ namespace GitUI.CommandsDialogs
                 {
                     EnsurePageant(remote);
 
-                    var formProcess = new FormRemoteProcess(UICommands, process: null, $"ls-remote --heads \"{remote}\"")
+                    FormRemoteProcess formProcess = new(UICommands, process: null, $"ls-remote --heads \"{remote}\"")
                     {
                         Remote = remote
                     };
@@ -1317,7 +1317,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -14,7 +14,7 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormRebase : GitModuleForm
     {
-        private static readonly List<PatchFile> Skipped = new List<PatchFile>();
+        private static readonly List<PatchFile> Skipped = new();
         private readonly TranslationString _continueRebaseText = new("Continue rebase");
         private readonly TranslationString _solveConflictsText = new("Solve conflicts");
 
@@ -24,7 +24,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _noBranchSelectedText = new("Please select a branch");
 
         private readonly TranslationString _branchUpToDateText =
-            new TranslationString("Current branch a is up to date." + Environment.NewLine + "Nothing to rebase.");
+            new("Current branch a is up to date." + Environment.NewLine + "Nothing to rebase.");
         private readonly TranslationString _branchUpToDateCaption = new("Rebase");
 
         private readonly TranslationString _hoverShowImageLabelText = new("Hover to see scenario when fast forward is possible.");
@@ -331,7 +331,7 @@ namespace GitUI.CommandsDialogs
 
         private void btnChooseFromRevision_Click(object sender, EventArgs e)
         {
-            using var chooseForm = new FormChooseCommit(UICommands, txtFrom.Text);
+            using FormChooseCommit chooseForm = new(UICommands, txtFrom.Text);
             if (chooseForm.ShowDialog(this) == DialogResult.OK && chooseForm.SelectedRevision is not null)
             {
                 txtFrom.Text = chooseForm.SelectedRevision.ObjectId.ToShortString();
@@ -344,7 +344,7 @@ namespace GitUI.CommandsDialogs
             EnableButtons();
         }
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -58,7 +58,7 @@ namespace GitUI.CommandsDialogs
             lblDirtyWorkingDirectory.Visible = _isDirtyDir;
             resetCurrentBranchOnThisCommitToolStripMenuItem.Enabled = _isBranchCheckedOut;
 
-            var branches = new List<string> { "HEAD" };
+            List<string> branches = new() { "HEAD" };
             branches.AddRange(UICommands.Module.GetRefs(false, true).Select(r => r.Name).OrderBy(n => n));
             branches.AddRange(UICommands.Module.GetRemoteBranches().Select(r => r.Name).OrderBy(n => n));
             Branches.DataSource = branches;
@@ -72,7 +72,7 @@ namespace GitUI.CommandsDialogs
             {
                 var item = (string)Branches.SelectedItem;
                 await TaskScheduler.Default;
-                var arguments = new GitArgumentBuilder("reflog")
+                GitArgumentBuilder arguments = new("reflog")
                 {
                     "--no-abbrev",
                     item
@@ -102,7 +102,7 @@ namespace GitUI.CommandsDialogs
 
             UICommands.DoActionOnRepo(() =>
             {
-                using var form = new FormCreateBranch(UICommands, GetShaOfRefLine());
+                using FormCreateBranch form = new(UICommands, GetShaOfRefLine());
                 form.CheckoutAfterCreation = false;
                 form.UserAbleToChangeRevision = false;
                 form.CouldBeOrphan = false;

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -25,70 +25,70 @@ namespace GitUI.CommandsDialogs
 
         #region Translation
         private readonly TranslationString _remoteBranchDataError =
-            new TranslationString("Invalid ´{1}´ found for branch ´{0}´." + Environment.NewLine +
+            new("Invalid ´{1}´ found for branch ´{0}´." + Environment.NewLine +
                                   "Value has been reset to empty value.");
 
         private readonly TranslationString _questionAutoPullBehaviour =
-            new TranslationString("You have added a new remote repository." + Environment.NewLine +
+            new("You have added a new remote repository." + Environment.NewLine +
                                   "Do you want to automatically configure the default push and pull behavior for this remote?");
 
         private readonly TranslationString _questionAutoPullBehaviourCaption =
-            new TranslationString("New remote");
+            new("New remote");
 
         private readonly TranslationString _gitMessage =
-          new TranslationString("Message");
+          new("Message");
 
         private readonly TranslationString _questionDeleteRemote =
-            new TranslationString("Are you sure you want to delete this remote?");
+            new("Are you sure you want to delete this remote?");
 
         private readonly TranslationString _questionDeleteRemoteCaption =
-            new TranslationString("Delete");
+            new("Delete");
 
         private readonly TranslationString _sshKeyOpenFilter =
-            new TranslationString("Private key (*.ppk)");
+            new("Private key (*.ppk)");
 
         private readonly TranslationString _sshKeyOpenCaption =
-            new TranslationString("Select ssh key file");
+            new("Select ssh key file");
 
         private readonly TranslationString _errorNoKeyEntered =
-            new TranslationString("No SSH key file entered");
+            new("No SSH key file entered");
 
         private readonly TranslationString _labelUrlAsFetch =
-            new TranslationString("Fetch Url");
+            new("Fetch Url");
 
         private readonly TranslationString _labelUrlAsFetchPush =
-            new TranslationString("Url");
+            new("Url");
 
         private readonly TranslationString _gbMgtPanelHeaderNew =
-            new TranslationString("Create New Remote");
+            new("Create New Remote");
 
         private readonly TranslationString _gbMgtPanelHeaderEdit =
-            new TranslationString("Edit Remote Details");
+            new("Edit Remote Details");
 
         private readonly TranslationString _btnDeleteTooltip =
-            new TranslationString("Delete the selected remote");
+            new("Delete the selected remote");
 
         private readonly TranslationString _btnNewTooltip =
-            new TranslationString("Add a new remote");
+            new("Add a new remote");
 
         private readonly TranslationString _btnToggleStateTooltip_Activate =
-            new TranslationString("Activate the selected remote");
+            new("Activate the selected remote");
 
         private readonly TranslationString _btnToggleStateTooltip_Deactivate =
-            new TranslationString(@"Deactivate the selected remote.
+            new(@"Deactivate the selected remote.
 Inactive remote is completely invisible to git.");
 
         private readonly TranslationString _lvgEnabledHeader =
-            new TranslationString("Active");
+            new("Active");
 
         private readonly TranslationString _lvgDisabledHeader =
-            new TranslationString("Inactive");
+            new("Inactive");
 
         private readonly TranslationString _enabledRemoteAlreadyExists =
-            new TranslationString("An active remote named \"{0}\" already exists.");
+            new("An active remote named \"{0}\" already exists.");
 
         private readonly TranslationString _disabledRemoteAlreadyExists =
-            new TranslationString("An inactive remote named \"{0}\" already exists.");
+            new("An inactive remote named \"{0}\" already exists.");
         #endregion
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
@@ -322,7 +322,7 @@ Inactive remote is completely invisible to git.");
             // adjust width of the labels if required
             // this may be necessary if the translated labels require more space than English versions
             // the longest label is likely to be label3 (Private key file), so use it as a guide
-            var widestLabelMinSize = new Size(label3.Width, 0);
+            Size widestLabelMinSize = new(label3.Width, 0);
             label1.MinimumSize = label1.MaximumSize = widestLabelMinSize;        // Name
             label2.MinimumSize = label2.MaximumSize = widestLabelMinSize;        // Url
             labelPushUrl.MinimumSize = labelPushUrl.MaximumSize = widestLabelMinSize;  // Push URL
@@ -495,7 +495,7 @@ Inactive remote is completely invisible to git.");
 
         private void SshBrowseClick(object sender, EventArgs e)
         {
-            using var dialog = new OpenFileDialog
+            using OpenFileDialog dialog = new()
             {
                 Filter = _sshKeyOpenFilter.Text + @"|*.ppk",
                 InitialDirectory = ".",

--- a/GitUI/CommandsDialogs/FormResetChanges.cs
+++ b/GitUI/CommandsDialogs/FormResetChanges.cs
@@ -50,7 +50,7 @@ namespace GitUI.CommandsDialogs
         /// <param name="hasNewFiles">Where there are new (untracked) files selected.</param>
         public static ActionEnum ShowResetDialog(IWin32Window? owner, bool hasExistingFiles, bool hasNewFiles)
         {
-            using var form = new FormResetChanges(hasExistingFiles, hasNewFiles);
+            using FormResetChanges form = new(hasExistingFiles, hasNewFiles);
             form.ShowDialog(owner);
             return form.SelectedAction;
         }

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -81,19 +81,19 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _chooseRemoteFileFailedText = new("Choose remote file failed.");
 
         private readonly TranslationString _currentFormatFilter =
-            new TranslationString("Current format (*.{0})");
+            new("Current format (*.{0})");
         private readonly TranslationString _allFilesFilter =
-            new TranslationString("All files (*.*)");
+            new("All files (*.*)");
 
         private readonly TranslationString _abortCurrentOperation =
-            new TranslationString("You can abort the current operation by resetting changes." + Environment.NewLine +
+            new("You can abort the current operation by resetting changes." + Environment.NewLine +
                 "All changes since the last commit will be deleted." + Environment.NewLine +
                 Environment.NewLine + "Do you want to reset changes?");
 
         private readonly TranslationString _abortCurrentOperationCaption = new("Abort");
 
         private readonly TranslationString _areYouSureYouWantDeleteFiles =
-            new TranslationString("Are you sure you want to DELETE all changes?" + Environment.NewLine +
+            new("Are you sure you want to DELETE all changes?" + Environment.NewLine +
                 Environment.NewLine + "This action cannot be made undone.");
 
         private readonly TranslationString _areYouSureYouWantDeleteFilesCaption = new("WARNING!");
@@ -309,7 +309,7 @@ namespace GitUI.CommandsDialogs
             new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: false, ToolDelay);
         }
 
-        private readonly Dictionary<string, string> _mergeScripts = new Dictionary<string, string>
+        private readonly Dictionary<string, string> _mergeScripts = new()
         {
             { ".doc", "merge-doc.js" },
             { ".docx", "merge-doc.js" },
@@ -365,7 +365,7 @@ namespace GitUI.CommandsDialogs
             var filePath = _fullPathResolver.Resolve(fileName);
             DateTime lastWriteTimeBeforeMerge = File.Exists(filePath) ? File.GetLastWriteTime(filePath) : DateTime.Now;
 
-            var args = new ArgumentBuilder
+            ArgumentBuilder args = new()
             {
                 mergeScript.Quote(),
                 FixPath(filePath).Quote(),
@@ -479,7 +479,7 @@ namespace GitUI.CommandsDialogs
             var itemType = GetItemType(item.Filename);
             if (itemType == ItemType.Submodule)
             {
-                var form = new FormMergeSubmodule(UICommands, item.Filename);
+                FormMergeSubmodule form = new(UICommands, item.Filename);
                 if (form.ShowDialog() == DialogResult.OK)
                 {
                     StageFile(item.Filename);
@@ -902,7 +902,7 @@ namespace GitUI.CommandsDialogs
         private TaskDialog CreateSolveMergeConflictTaskDialog(IntPtr handle, string text, string instructionText, string caption, string applyToAllCheckBoxText,
             string keepLocalButtonText, string keepRemoteButtonText, string keepBaseButtonText)
         {
-            TaskDialog dialog = new TaskDialog
+            TaskDialog dialog = new()
             {
                 OwnerWindowHandle = handle,
                 Text = text,
@@ -917,7 +917,7 @@ namespace GitUI.CommandsDialogs
             };
 
             // Local
-            var btnKeepLocal = new TaskDialogCommandLink("KeepLocal", null, keepLocalButtonText);
+            TaskDialogCommandLink btnKeepLocal = new("KeepLocal", null, keepLocalButtonText);
             btnKeepLocal.Click += (s, e) =>
             {
                 _solveMergeConflictDialogResult = ConflictResolutionPreference.KeepLocal;
@@ -925,7 +925,7 @@ namespace GitUI.CommandsDialogs
             };
 
             // Remote
-            var btnKeepRemote = new TaskDialogCommandLink("KeepRemote", null, keepRemoteButtonText);
+            TaskDialogCommandLink btnKeepRemote = new("KeepRemote", null, keepRemoteButtonText);
             btnKeepRemote.Click += (s, e) =>
             {
                 _solveMergeConflictDialogResult = ConflictResolutionPreference.KeepRemote;
@@ -933,7 +933,7 @@ namespace GitUI.CommandsDialogs
             };
 
             // Base
-            var btnKeepBase = new TaskDialogCommandLink("KeepBase", null, keepBaseButtonText);
+            TaskDialogCommandLink btnKeepBase = new("KeepBase", null, keepBaseButtonText);
             btnKeepBase.Click += (s, e) =>
             {
                 _solveMergeConflictDialogResult = ConflictResolutionPreference.KeepBase;
@@ -1021,7 +1021,7 @@ namespace GitUI.CommandsDialogs
                             break;
                         case ConflictResolutionPreference.KeepBase:
                             // delete
-                            var args = new GitArgumentBuilder("rm")
+                            GitArgumentBuilder args = new("rm")
                             {
                                 "--",
                                 item.Filename.QuoteNE()
@@ -1079,7 +1079,7 @@ namespace GitUI.CommandsDialogs
                     {
                         case ConflictResolutionPreference.KeepLocal:
                             // delete
-                            var args = new GitArgumentBuilder("rm")
+                            GitArgumentBuilder args = new("rm")
                             {
                                 "--",
                                 item.Filename.QuoteNE()
@@ -1151,7 +1151,7 @@ namespace GitUI.CommandsDialogs
                             break;
                         case ConflictResolutionPreference.KeepRemote:
                             // remote
-                            var args = new GitArgumentBuilder("rm")
+                            GitArgumentBuilder args = new("rm")
                             {
                                 "--",
                                 item.Filename.QuoteNE()
@@ -1188,9 +1188,9 @@ namespace GitUI.CommandsDialogs
                     var items = GetConflicts();
                     _conflictItemsCount = items.Count;
 
-                    List<ConflictData> filesDeletedLocallyAndModifiedRemotely = new List<ConflictData>();
-                    List<ConflictData> filesModifiedLocallyAndDeletedRemotely = new List<ConflictData>();
-                    List<ConflictData> filesRemaining = new List<ConflictData>();
+                    List<ConflictData> filesDeletedLocallyAndModifiedRemotely = new();
+                    List<ConflictData> filesModifiedLocallyAndDeletedRemotely = new();
+                    List<ConflictData> filesRemaining = new();
 
                     // Insert(0, conflictData) is needed the task dialog shows the same order of files as selected in the grid
                     foreach (var conflictData in items)
@@ -1339,7 +1339,7 @@ namespace GitUI.CommandsDialogs
                 string fileName = PathUtil.GetFileName(conflictData.Filename);
                 var initialDirectory = _fullPathResolver.Resolve(Path.GetDirectoryName(conflictData.Filename));
 
-                using var fileDialog = new SaveFileDialog
+                using SaveFileDialog fileDialog = new()
                 {
                     FileName = fileName,
                     InitialDirectory = initialDirectory,
@@ -1453,7 +1453,7 @@ namespace GitUI.CommandsDialogs
 
         private void StageFile(string filename)
         {
-            var args = new GitArgumentBuilder("add")
+            GitArgumentBuilder args = new("add")
             {
                 "--",
                 filename.QuoteNE()

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -104,7 +104,7 @@ namespace GitUI.CommandsDialogs
         {
             DialogResult result = DialogResult.None;
 
-            using var form = new FormSettings(uiCommands, initialPage);
+            using FormSettings form = new(uiCommands, initialPage);
             AppSettings.UsingContainer(form._commonLogic.RepoDistSettingsSet.GlobalSettings, () =>
             {
                 result = form.ShowDialog(owner);
@@ -260,7 +260,7 @@ namespace GitUI.CommandsDialogs
             }
             catch (SaveSettingsException ex) when (ex.InnerException is not null)
             {
-                using var dialog = new TaskDialog
+                using TaskDialog dialog = new()
                 {
                     OwnerWindowHandle = Handle,
                     Text = ex.InnerException.Message,

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
@@ -22,7 +22,7 @@ namespace GitUI.CommandsDialogs
         public FormSparseWorkingCopy(GitUICommands commands)
             : base(commands)
         {
-            var sparse = new FormSparseWorkingCopyViewModel(commands);
+            FormSparseWorkingCopyViewModel sparse = new(commands);
             BindToViewModelGlobal(sparse);
             CreateView(sparse);
             InitializeComplete();
@@ -95,9 +95,9 @@ namespace GitUI.CommandsDialogs
             MinimumSize = new Size(800, 600);
 
             // Tooltips support for the form
-            var componentContainer = new Container();
+            Container componentContainer = new();
             _disposable1 = componentContainer;
-            var tooltip = new ToolTip(componentContainer) { AutomaticDelay = 100 };
+            ToolTip tooltip = new(componentContainer) { AutomaticDelay = 100 };
 
             Panel panelHeader = CreateViewHeader();
 
@@ -130,7 +130,7 @@ namespace GitUI.CommandsDialogs
 
         private static Panel CreateViewFooter(FormSparseWorkingCopyViewModel sparse, ToolTip tooltip, out Button btnSave, out Button btnCancel)
         {
-            var tableFooterButtons = new TableLayoutPanel { BackColor = SystemColors.ControlLightLight, Dock = DockStyle.Fill, AutoSize = true, AutoSizeMode = AutoSizeMode.GrowAndShrink, ColumnCount = 4, RowCount = 1, Margin = Padding.Empty, ColumnStyles = { new ColumnStyle(SizeType.Percent, 100) }, Padding = new Padding(10, 15, 10, 15), CellBorderStyle = TableLayoutPanelCellBorderStyle.None };
+            TableLayoutPanel tableFooterButtons = new() { BackColor = SystemColors.ControlLightLight, Dock = DockStyle.Fill, AutoSize = true, AutoSizeMode = AutoSizeMode.GrowAndShrink, ColumnCount = 4, RowCount = 1, Margin = Padding.Empty, ColumnStyles = { new ColumnStyle(SizeType.Percent, 100) }, Padding = new Padding(10, 15, 10, 15), CellBorderStyle = TableLayoutPanelCellBorderStyle.None };
 
             CheckBox check;
             tableFooterButtons.Controls.Add(check = new CheckBox { Text = Globalized.Strings.RefreshWorkingCopyUsingTheCurrentSettingsAndRules.Text, Checked = sparse.IsRefreshWorkingCopyOnSave, AutoSize = true, Dock = DockStyle.Fill, Margin = Padding.Empty });
@@ -148,7 +148,7 @@ namespace GitUI.CommandsDialogs
 
         private static Panel CreateViewHeader()
         {
-            var panelHeaderMain = new TableLayoutPanel { BackColor = SystemColors.ControlLightLight, Dock = DockStyle.Fill, AutoSize = true, Margin = Padding.Empty, Padding = Padding.Empty, RowCount = 2, ColumnCount = 1 };
+            TableLayoutPanel panelHeaderMain = new() { BackColor = SystemColors.ControlLightLight, Dock = DockStyle.Fill, AutoSize = true, Margin = Padding.Empty, Padding = Padding.Empty, RowCount = 2, ColumnCount = 1 };
 
             Label labelTitle;
             panelHeaderMain.Controls.Add(labelTitle = new Label { Text = Globalized.Strings.SparseWorkingCopy.Text, Dock = DockStyle.Bottom, AutoSize = true, Margin = new Padding(10, 10, 10, 0) });
@@ -162,7 +162,7 @@ namespace GitUI.CommandsDialogs
         private static Control CreateViewOnOff(FormSparseWorkingCopyViewModel sparse, ToolTip tooltip)
         {
             // When disabled: hint-like panel to enable
-            var panelWhenDisabled = new TableLayoutPanel { BackColor = SystemColors.Info, AutoSize = true, AutoSizeMode = AutoSizeMode.GrowAndShrink, Dock = DockStyle.Bottom, ColumnCount = 2, RowCount = 1, ColumnStyles = { new ColumnStyle(SizeType.Percent, 100) }, Margin = Padding.Empty, Padding = new Padding(10, 5, 10, 5) };
+            TableLayoutPanel panelWhenDisabled = new() { BackColor = SystemColors.Info, AutoSize = true, AutoSizeMode = AutoSizeMode.GrowAndShrink, Dock = DockStyle.Bottom, ColumnCount = 2, RowCount = 1, ColumnStyles = { new ColumnStyle(SizeType.Percent, 100) }, Margin = Padding.Empty, Padding = new Padding(10, 5, 10, 5) };
             panelWhenDisabled.Controls.Add(new Label { ForeColor = SystemColors.InfoText, Text = Globalized.Strings.SparseWorkingCopySupportHasNotBeenEnabledForThisRepository.Text, Dock = DockStyle.Fill, AutoSize = true, TextAlign = ContentAlignment.MiddleLeft, Margin = Padding.Empty });
             Button btnEnable;
             panelWhenDisabled.Controls.Add(btnEnable = new Button { Width = 75, Height = 23, Text = Globalized.Strings.Enable.Text, Anchor = AnchorStyles.Bottom | AnchorStyles.Right, Dock = DockStyle.Right, UseVisualStyleBackColor = true, Margin = Padding.Empty });
@@ -177,7 +177,7 @@ namespace GitUI.CommandsDialogs
             // When enabled: a less bold link to disable
             string labelBeforeLink = Globalized.Strings.SparseWorkingCopySupportIsEnabled.Text + ' ';
             string labelWithLink = labelBeforeLink + Globalized.Strings.DisableForThisRepository.Text;
-            var labelWhenEnabled = new LinkLabel { Text = labelWithLink, Dock = DockStyle.Bottom, AutoSize = true, Padding = new Padding(10, 10, 10, 5), FlatStyle = FlatStyle.System, UseCompatibleTextRendering = true };
+            LinkLabel labelWhenEnabled = new() { Text = labelWithLink, Dock = DockStyle.Bottom, AutoSize = true, Padding = new Padding(10, 10, 10, 5), FlatStyle = FlatStyle.System, UseCompatibleTextRendering = true };
             labelWhenEnabled.Links.Add(new LinkLabel.Link(labelBeforeLink.Length, labelWithLink.Length - labelBeforeLink.Length));
             labelWhenEnabled.LinkClicked += delegate { sparse.IsSparseCheckoutEnabled = false; };
             tooltip.SetToolTip(labelWhenEnabled, string.Format(Globalized.Strings.SetsTheGitPropertyToFalseForTheLocalRepository.Text, FormSparseWorkingCopyViewModel.SettingCoreSparseCheckout));
@@ -189,12 +189,12 @@ namespace GitUI.CommandsDialogs
         private static Panel CreateViewRules(FormSparseWorkingCopyViewModel sparse, ToolTip tooltip, IGitUICommandsSource commandsSource)
         {
             // Label
-            var label1 = new Label { AutoSize = true, Text = Globalized.Strings.SpecifyTheRulesForIncludingOrExcludingFilesAndDirectories.Text, Dock = DockStyle.Top, Padding = new Padding(10, 5, 10, 0) };
-            var label2 = new Label { AutoSize = true, Text = Globalized.Strings.SpecifyTheRulesForIncludingOrExcludingFilesAndDirectoriesLine2.Text, Dock = DockStyle.Top, Padding = new Padding(25, 3, 10, 3), ForeColor = SystemColors.GrayText };
+            Label label1 = new() { AutoSize = true, Text = Globalized.Strings.SpecifyTheRulesForIncludingOrExcludingFilesAndDirectories.Text, Dock = DockStyle.Top, Padding = new Padding(10, 5, 10, 0) };
+            Label label2 = new() { AutoSize = true, Text = Globalized.Strings.SpecifyTheRulesForIncludingOrExcludingFilesAndDirectoriesLine2.Text, Dock = DockStyle.Top, Padding = new Padding(25, 3, 10, 3), ForeColor = SystemColors.GrayText };
             sparse.PropertyChanged += delegate { label1.Visible = label2.Visible = sparse.IsSparseCheckoutEnabled; };
 
             // Text editor
-            var editor = new FileViewer { Dock = DockStyle.Fill, UICommandsSource = commandsSource, IsReadOnly = false };
+            FileViewer editor = new() { Dock = DockStyle.Fill, UICommandsSource = commandsSource, IsReadOnly = false };
             editor.TextLoaded += (sender, args) => sparse.SetRulesTextAsOnDisk(editor.GetText());
             try
             {
@@ -214,7 +214,7 @@ namespace GitUI.CommandsDialogs
             Control separator = CreateViewSeparator(DockStyle.Top);
             sparse.PropertyChanged += delegate { editor.Visible = separator.Visible = sparse.IsSparseCheckoutEnabled; };
 
-            var panel = new Panel { Margin = Padding.Empty, Padding = Padding.Empty, Controls = { editor, separator, label2, label1 }, AutoSize = true, Dock = DockStyle.Fill };
+            Panel panel = new() { Margin = Padding.Empty, Padding = Padding.Empty, Controls = { editor, separator, label2, label1 }, AutoSize = true, Dock = DockStyle.Fill };
 
             return panel;
         }

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
@@ -151,7 +151,7 @@ namespace GitUI.CommandsDialogs
         {
             // Re-apply tree to the index
             // TODO: check how it affects the uncommitted working copy changes
-            using var fromProcess = new FormRemoteProcess(_gitCommands, AppSettings.GitCommand, RefreshWorkingCopyCommandName);
+            using FormRemoteProcess fromProcess = new(_gitCommands, AppSettings.GitCommand, RefreshWorkingCopyCommandName);
             fromProcess.ShowDialog(Form.ActiveForm);
         }
 
@@ -225,7 +225,7 @@ namespace GitUI.CommandsDialogs
             }
 
             // Confirm
-            var args = new ComfirmAdjustingRulesOnDeactEventArgs(!rulelines.Any());
+            ComfirmAdjustingRulesOnDeactEventArgs args = new(!rulelines.Any());
             ComfirmAdjustingRulesOnDeactRequested(this, args);
             if (args.Cancel)
             {

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -185,12 +185,12 @@ namespace GitUI.CommandsDialogs
                 // Must be handled when displaying
                 var headId = Module.RevParse("HEAD");
                 Validates.NotNull(headId);
-                var headRev = new GitRevision(headId);
-                var indexRev = new GitRevision(ObjectId.IndexId)
+                GitRevision headRev = new(headId);
+                GitRevision indexRev = new(ObjectId.IndexId)
                 {
                     ParentIds = new[] { headId }
                 };
-                var workTreeRev = new GitRevision(ObjectId.WorkTreeId)
+                GitRevision workTreeRev = new(ObjectId.WorkTreeId)
                 {
                     ParentIds = new[] { ObjectId.IndexId }
                 };
@@ -205,7 +205,7 @@ namespace GitUI.CommandsDialogs
 
                 var selectedId = Module.RevParse(gitStash.Name);
                 Validates.NotNull(selectedId);
-                var secondRev = new GitRevision(selectedId);
+                GitRevision secondRev = new(selectedId);
                 if (firstId is not null)
                 {
                     secondRev.ParentIds = new[] { firstId };
@@ -270,7 +270,7 @@ namespace GitUI.CommandsDialogs
                 var stashName = GetStashName();
                 if (AppSettings.StashConfirmDropShow)
                 {
-                    using var dialog = new Microsoft.WindowsAPICodePack.Dialogs.TaskDialog
+                    using Microsoft.WindowsAPICodePack.Dialogs.TaskDialog dialog = new()
                     {
                         OwnerWindowHandle = Handle,
                         Text = _areYouSure.Text,

--- a/GitUI/CommandsDialogs/FormSubmodules.cs
+++ b/GitUI/CommandsDialogs/FormSubmodules.cs
@@ -20,7 +20,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _removeSelectedSubmodule = new("Are you sure you want remove the selected submodule?");
         private readonly TranslationString _removeSelectedSubmoduleCaption = new("Remove");
 
-        private readonly BindingList<IGitSubmoduleInfo?> _modules = new BindingList<IGitSubmoduleInfo?>();
+        private readonly BindingList<IGitSubmoduleInfo?> _modules = new();
         private GitSubmoduleInfo? _oldSubmoduleInfo;
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]

--- a/GitUI/CommandsDialogs/FormVerify.LostObject.cs
+++ b/GitUI/CommandsDialogs/FormVerify.LostObject.cs
@@ -102,7 +102,7 @@ namespace GitUI.CommandsDialogs
                 var rawType = matchedGroups[1].Value;
                 var objectType = GetObjectType(matchedGroups[3]);
                 var objectId = ObjectId.Parse(raw, matchedGroups[4]);
-                var result = new LostObject(objectType, rawType, objectId);
+                LostObject result = new(objectType, rawType, objectId);
 
                 if (objectType == LostObjectType.Commit)
                 {

--- a/GitUI/CommandsDialogs/FormVerify.SortableLostObjectsList.cs
+++ b/GitUI/CommandsDialogs/FormVerify.SortableLostObjectsList.cs
@@ -33,7 +33,7 @@ namespace GitUI.CommandsDialogs
 
             private static class LostObjectsComparer
             {
-                private static readonly Dictionary<string, Comparison<LostObject>> PropertyComparers = new Dictionary<string, Comparison<LostObject>>();
+                private static readonly Dictionary<string, Comparison<LostObject>> PropertyComparers = new();
 
                 static LostObjectsComparer()
                 {

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -22,14 +22,14 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _selectLostObjectsToRestoreMessage = new("Select objects to restore.");
         private readonly TranslationString _selectLostObjectsToRestoreCaption = new("Restore lost objects");
 
-        private readonly List<LostObject> _lostObjects = new List<LostObject>();
+        private readonly List<LostObject> _lostObjects = new();
         private readonly SortableLostObjectsList _filteredLostObjects = new();
         private readonly DataGridViewCheckBoxHeaderCell _selectedItemsHeader = new();
         private readonly IGitTagController _gitTagController;
 
         private LostObject? _previewedItem;
 
-        private static readonly Dictionary<string, string> LanguagesStartOfFile = new Dictionary<string, string>
+        private static readonly Dictionary<string, string> LanguagesStartOfFile = new()
         {
             { "{", "recovery.json" },
             { "#include", "recovery.cpp" },
@@ -119,7 +119,7 @@ namespace GitUI.CommandsDialogs
 
         private void mnuLostObjectsCreateTag_Click(object sender, EventArgs e)
         {
-            using var frm = new FormCreateTag(UICommands, GetCurrentGitRevision());
+            using FormCreateTag frm = new(UICommands, GetCurrentGitRevision());
             var dialogResult = frm.ShowDialog(this);
             if (dialogResult == DialogResult.OK)
             {
@@ -129,7 +129,7 @@ namespace GitUI.CommandsDialogs
 
         private void mnuLostObjectsCreateBranch_Click(object sender, EventArgs e)
         {
-            using var frm = new FormCreateBranch(UICommands, GetCurrentGitRevision());
+            using FormCreateBranch frm = new(UICommands, GetCurrentGitRevision());
             var dialogResult = frm.ShowDialog(this);
             if (dialogResult == DialogResult.OK)
             {
@@ -356,7 +356,7 @@ namespace GitUI.CommandsDialogs
 
             if (obj is not null)
             {
-                using var frm = new FormEdit(UICommands, obj);
+                using FormEdit frm = new(UICommands, obj);
                 frm.IsReadOnly = true;
                 frm.ShowDialog(this);
             }
@@ -382,7 +382,7 @@ namespace GitUI.CommandsDialogs
             {
                 currentTag++;
                 var tagName = lostObject.ObjectType == LostObjectType.Tag ? lostObject.TagName : currentTag.ToString();
-                var createTagArgs = new GitCreateTagArgs($"{RestoredObjectsTagPrefix}{tagName}", lostObject.ObjectId);
+                GitCreateTagArgs createTagArgs = new($"{RestoredObjectsTagPrefix}{tagName}", lostObject.ObjectId);
                 _gitTagController.CreateTag(createTagArgs, this);
             }
 
@@ -481,8 +481,8 @@ namespace GitUI.CommandsDialogs
 
             if (lostObject.ObjectType == LostObjectType.Blob)
             {
-                using var fileDialog =
-                    new SaveFileDialog
+                using SaveFileDialog fileDialog =
+                    new()
                     {
                         InitialDirectory = Module.WorkingDir,
                         FileName = "LOST_FOUND.txt",

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -61,7 +61,7 @@ namespace GitUI.CommandsDialogs
 
         private void BrowsePatch_Click(object sender, EventArgs e)
         {
-            var dialog = new OpenFileDialog
+            OpenFileDialog dialog = new()
             {
                 Filter = _patchFileFilterString.Text + "|*.patch",
                 InitialDirectory = @".",

--- a/GitUI/CommandsDialogs/GitIgnoreDialog/GitIgnoreModel.cs
+++ b/GitUI/CommandsDialogs/GitIgnoreDialog/GitIgnoreModel.cs
@@ -8,19 +8,19 @@ namespace GitUI.CommandsDialogs.GitIgnoreDialog
     public class GitIgnoreModel : Translate, IGitIgnoreDialogModel
     {
         private readonly TranslationString _editGitignoreTitle =
-            new TranslationString("Edit .gitignore");
+            new("Edit .gitignore");
 
         private readonly TranslationString _gitignoreOnlyInWorkingDirSupported =
-            new TranslationString(".gitignore is only supported when there is a working directory.");
+            new(".gitignore is only supported when there is a working directory.");
 
         private readonly TranslationString _cannotAccessGitignore =
-            new TranslationString("Failed to save .gitignore." + Environment.NewLine + "Check if file is accessible.");
+            new("Failed to save .gitignore." + Environment.NewLine + "Check if file is accessible.");
 
         private readonly TranslationString _cannotAccessGitignoreCaption =
-            new TranslationString("Failed to save .gitignore");
+            new("Failed to save .gitignore");
 
         private readonly TranslationString _saveFileQuestion =
-            new TranslationString("Save changes to .gitignore?");
+            new("Save changes to .gitignore?");
 
         private readonly IFullPathResolver _fullPathResolver;
 

--- a/GitUI/CommandsDialogs/GitIgnoreDialog/GitLocalExcludeModel.cs
+++ b/GitUI/CommandsDialogs/GitIgnoreDialog/GitLocalExcludeModel.cs
@@ -9,20 +9,20 @@ namespace GitUI.CommandsDialogs.GitIgnoreDialog
     public class GitLocalExcludeModel : Translate, IGitIgnoreDialogModel
     {
         private readonly TranslationString _editLocalExcludeTitle =
-            new TranslationString("Edit .git/info/exclude");
+            new("Edit .git/info/exclude");
 
         private readonly TranslationString _localExcludeOnlyInWorkingDirSupported =
-            new TranslationString(".git/info/exclude is only supported when there is a working directory.");
+            new(".git/info/exclude is only supported when there is a working directory.");
 
         private readonly TranslationString _cannotAccessLocalExclude =
-            new TranslationString("Failed to save .git/info/exclude." + Environment.NewLine +
+            new("Failed to save .git/info/exclude." + Environment.NewLine +
                                   "Check if file is accessible.");
 
         private readonly TranslationString _cannotAccessLocalExcludeCaption =
-            new TranslationString("Failed to save .git/info/exclude");
+            new("Failed to save .git/info/exclude");
 
         private readonly TranslationString _saveFileQuestion =
-            new TranslationString("Save changes to .git/info/exclude?");
+            new("Save changes to .git/info/exclude?");
 
         private readonly IGitModule _module;
 

--- a/GitUI/CommandsDialogs/InvalidRepositoryRemover.cs
+++ b/GitUI/CommandsDialogs/InvalidRepositoryRemover.cs
@@ -25,7 +25,7 @@ namespace GitUI.CommandsDialogs
                                                                    .Count(repo => !GitModule.IsValidGitWorkingDir(repo.Path));
             int dialogResult = -1;
 
-            using var dialog = new TaskDialog
+            using TaskDialog dialog = new()
             {
                 InstructionText = TranslatedStrings.DirectoryInvalidRepository,
                 Caption = TranslatedStrings.Open,
@@ -33,7 +33,7 @@ namespace GitUI.CommandsDialogs
                 StandardButtons = TaskDialogStandardButtons.Cancel,
                 Cancelable = true,
             };
-            var btnRemoveSelectedInvalidRepository = new TaskDialogCommandLink("RemoveSelectedInvalidRepository", null, TranslatedStrings.RemoveSelectedInvalidRepository);
+            TaskDialogCommandLink btnRemoveSelectedInvalidRepository = new("RemoveSelectedInvalidRepository", null, TranslatedStrings.RemoveSelectedInvalidRepository);
             btnRemoveSelectedInvalidRepository.Click += (s, e) =>
             {
                 dialogResult = 0;
@@ -42,7 +42,7 @@ namespace GitUI.CommandsDialogs
             dialog.Controls.Add(btnRemoveSelectedInvalidRepository);
             if (invalidPathCount > 1)
             {
-                var btnRemoveAllInvalidRepositories = new TaskDialogCommandLink("RemoveAllInvalidRepositories", null, string.Format(TranslatedStrings.RemoveAllInvalidRepositories, invalidPathCount));
+                TaskDialogCommandLink btnRemoveAllInvalidRepositories = new("RemoveAllInvalidRepositories", null, string.Format(TranslatedStrings.RemoveAllInvalidRepositories, invalidPathCount));
                 btnRemoveAllInvalidRepositories.Click += (s, e) =>
                 {
                     dialogResult = 1;

--- a/GitUI/CommandsDialogs/RememberFileContextMenuController.cs
+++ b/GitUI/CommandsDialogs/RememberFileContextMenuController.cs
@@ -29,8 +29,8 @@ namespace GitUI.CommandsDialogs
         [Pure]
         public FileStatusItem CreateFileStatusItem(string name, GitRevision rev)
         {
-            var gis = new GitItemStatus(name) { IsNew = true };
-            var fsi = new FileStatusItem(null, rev, gis);
+            GitItemStatus gis = new(name) { IsNew = true };
+            FileStatusItem fsi = new(null, rev, gis);
             return fsi;
         }
 

--- a/GitUI/CommandsDialogs/RepoHosting/DiscussionHtmlCreator.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/DiscussionHtmlCreator.cs
@@ -11,7 +11,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
     {
         public static string CreateFor(IPullRequestInformation currentPullRequestInfo, List<IDiscussionEntry>? entries = null)
         {
-            var html = new StringBuilder();
+            StringBuilder html = new();
             AddLine(html, "<html><body><style type='text/css'>");
             html.Append(CssData);
             AddLine(html, "</style>");

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -395,7 +395,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
             var cmd = GitCommandHelpers.CloneCmd(repoSrc, targetDir, depth: GetDepth());
 
-            var formRemoteProcess = new FormRemoteProcess(new GitUICommands(new GitModule(null)), AppSettings.GitCommand, cmd)
+            FormRemoteProcess formRemoteProcess = new(new GitUICommands(new GitModule(null)), AppSettings.GitCommand, cmd)
             {
                 Remote = repoSrc
             };
@@ -407,7 +407,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                 return;
             }
 
-            var module = new GitModule(targetDir);
+            GitModule module = new(targetDir);
 
             if (addUpstreamRemoteAsCB.Text.Trim().Length > 0 && !string.IsNullOrEmpty(repo.ParentReadOnlyUrl))
             {

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -357,7 +357,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             _diffCache = new Dictionary<string, string>();
 
             var fileParts = Regex.Split(diffData, @"(?:\n|^)diff --git ").Where(el => el is not null && el.Trim().Length > 10).ToList();
-            var giss = new List<GitItemStatus>();
+            List<GitItemStatus> giss = new();
 
             // baseSha is the sha of the merge to ("master") sha, the commit to be firstId
             GitRevision? firstRev = ObjectId.TryParse(baseSha, out ObjectId? firstId) ? new GitRevision(firstId) : null;
@@ -377,7 +377,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     return;
                 }
 
-                var gis = new GitItemStatus(name: match.Groups[2].Value.Trim())
+                GitItemStatus gis = new(name: match.Groups[2].Value.Trim())
                 {
                     IsChanged = true,
                     IsNew = false,

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -27,14 +27,14 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _saveFileFilterAllFiles = new("All files");
         private readonly TranslationString _deleteSelectedFilesCaption = new("Delete");
         private readonly TranslationString _deleteSelectedFiles =
-            new TranslationString("Are you sure you want to delete the selected file(s)?");
+            new("Are you sure you want to delete the selected file(s)?");
         private readonly TranslationString _deleteFailed = new("Delete file failed");
         private readonly TranslationString _multipleDescription = new("<multiple>");
         private readonly TranslationString _selectedRevision = new("Second: b/");
         private readonly TranslationString _firstRevision = new("First: a/");
 
         private readonly TranslationString _resetSelectedChangesText =
-            new TranslationString("Are you sure you want to reset all selected files to {0}?");
+            new("Are you sure you want to reset all selected files to {0}?");
 
         private RevisionGridControl? _revisionGrid;
         private RevisionFileTreeControl? _revisionFileTree;
@@ -335,7 +335,7 @@ namespace GitUI.CommandsDialogs
             bool isAnySubmodule = selectedItems.Any(item => item.Item.IsSubmodule);
             (bool allFilesExist, bool allDirectoriesExist, bool allFilesOrUntrackedDirectoriesExist) = FileOrUntrackedDirExists(selectedItems, _fullPathResolver);
 
-            var selectionInfo = new ContextMenuSelectionInfo(
+            ContextMenuSelectionInfo selectionInfo = new(
                 selectedRevision: selectedRev,
                 isDisplayOnlyDiff: isDisplayOnlyDiff,
                 isStatusOnly: isStatusOnly,
@@ -763,7 +763,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var item = new FileStatusItem(
+            FileStatusItem item = new(
                 firstRev: DiffFiles.SelectedItem.SecondRevision,
                 secondRev: DiffFiles.SelectedItem.FirstRevision,
                 item: DiffFiles.SelectedItem.Item);
@@ -981,8 +981,8 @@ namespace GitUI.CommandsDialogs
             }
 
             var fullName = _fullPathResolver.Resolve(item.Item.Name);
-            using var fileDialog =
-                new SaveFileDialog
+            using SaveFileDialog fileDialog =
+                new()
                 {
                     InitialDirectory = Path.GetDirectoryName(fullName),
                     FileName = Path.GetFileName(fullName),
@@ -1054,7 +1054,7 @@ namespace GitUI.CommandsDialogs
 
             foreach (var name in submodules)
             {
-                var submodulCommands = new GitUICommands(_fullPathResolver.Resolve(name.EnsureTrailingPathSeparator()));
+                GitUICommands submodulCommands = new(_fullPathResolver.Resolve(name.EnsureTrailingPathSeparator()));
                 submodulCommands.StartCommitDialog(this);
             }
 
@@ -1103,7 +1103,7 @@ namespace GitUI.CommandsDialogs
 
             foreach (var name in submodules)
             {
-                var uiCmds = new GitUICommands(Module.GetSubmodule(name));
+                GitUICommands uiCmds = new(Module.GetSubmodule(name));
                 uiCmds.StashSave(this, AppSettings.IncludeUntrackedFilesInManualStash);
             }
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -47,7 +47,7 @@ See the changes in the commit form.");
         private readonly TranslationString _success = new("Success");
 
         // store strings to not keep references to nodes
-        private readonly Stack<string> _lastSelectedNodes = new Stack<string>();
+        private readonly Stack<string> _lastSelectedNodes = new();
         private readonly IRevisionFileTreeController _revisionFileTreeController;
         private readonly IFullPathResolver _fullPathResolver;
         private readonly IFindFilePredicateProvider _findFilePredicateProvider;
@@ -361,7 +361,7 @@ See the changes in the commit form.");
                     case GitObjectType.Blob:
                     case GitObjectType.Commit:
                     {
-                        var file = new GitItemStatus(name: gitItem.FileName)
+                        GitItemStatus file = new(name: gitItem.FileName)
                         {
                             IsTracked = true,
                             TreeGuid = gitItem.ObjectId,
@@ -402,12 +402,12 @@ See the changes in the commit form.");
         {
             if (e.Item is TreeNode { Tag: GitItem gitItem })
             {
-                var fileList = new StringCollection();
+                StringCollection fileList = new();
                 var fileName = _fullPathResolver.Resolve(gitItem.FileName);
 
                 fileList.Add(fileName.ToNativePath());
 
-                var obj = new DataObject();
+                DataObject obj = new();
                 obj.SetFileDropList(fileList);
 
                 DoDragDrop(obj, DragDropEffects.Copy);
@@ -723,8 +723,8 @@ See the changes in the commit form.");
             if (tvGitTree.SelectedNode?.Tag is GitItem { ObjectType: GitObjectType.Blob } gitItem)
             {
                 var fullName = _fullPathResolver.Resolve(gitItem.FileName);
-                using var fileDialog =
-                    new SaveFileDialog
+                using SaveFileDialog fileDialog =
+                    new()
                     {
                         InitialDirectory = Path.GetDirectoryName(fullName),
                         FileName = Path.GetFileName(fullName),
@@ -764,7 +764,7 @@ See the changes in the commit form.");
                 return;
             }
 
-            var itemStatus = new GitItemStatus(name: selectedFile);
+            GitItemStatus itemStatus = new(name: selectedFile);
 
             var answer = MessageBox.Show(_assumeUnchangedMessage.Text, _assumeUnchangedCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeController.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeController.cs
@@ -151,7 +151,7 @@ namespace GitUI.CommandsDialogs
 
         public bool SelectFileOrFolder(NativeTreeView tree, string fileSubPath)
         {
-            var pathParts = new Queue<string>(fileSubPath.Split(Path.DirectorySeparatorChar));
+            Queue<string> pathParts = new(fileSubPath.Split(Path.DirectorySeparatorChar));
             var foundNode = FindSubNode(tree.Nodes, pathParts);
             if (foundNode is null)
             {

--- a/GitUI/CommandsDialogs/SettingsDialog/AutoLayoutSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/AutoLayoutSettingsPage.cs
@@ -118,7 +118,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
             if (caption is not null)
             {
-                var label = new Label
+                Label label = new()
                 {
                     Text = controlBinding.Caption(),
                     AutoSize = true,

--- a/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
@@ -15,10 +15,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog
     public sealed class CommonLogic : Translate
     {
         private static readonly TranslationString _cantReadRegistry =
-            new TranslationString("Git Extensions has insufficient permissions to check the registry.");
+            new("Git Extensions has insufficient permissions to check the registry.");
 
         private readonly TranslationString _selectFile =
-            new TranslationString("Select file");
+            new("Select file");
 
         public readonly RepoDistSettingsSet RepoDistSettingsSet;
         public readonly ConfigFileSettingsSet ConfigFileSettingsSet;
@@ -41,14 +41,14 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             var repoDistGlobalSettings = RepoDistSettings.CreateGlobal(false);
             var repoDistPulledSettings = RepoDistSettings.CreateDistributed(module, false);
             var repoDistLocalSettings = RepoDistSettings.CreateLocal(module, false);
-            var repoDistEffectiveSettings = new RepoDistSettings(
+            RepoDistSettings repoDistEffectiveSettings = new(
                 new RepoDistSettings(repoDistGlobalSettings, repoDistPulledSettings.SettingsCache, SettingLevel.Distributed),
                 repoDistLocalSettings.SettingsCache,
                 SettingLevel.Effective);
 
             var configFileGlobalSettings = ConfigFileSettings.CreateGlobal(false);
             var configFileLocalSettings = ConfigFileSettings.CreateLocal(module, false);
-            var configFileEffectiveSettings = new ConfigFileSettings(
+            ConfigFileSettings configFileEffectiveSettings = new(
                 configFileGlobalSettings, configFileLocalSettings.SettingsCache, SettingLevel.Effective);
 
             RepoDistSettingsSet = new RepoDistSettingsSet(
@@ -104,7 +104,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
         public string SelectFile(string initialDirectory, string filter, string prev)
         {
-            using var dialog = new System.Windows.Forms.OpenFileDialog
+            using System.Windows.Forms.OpenFileDialog dialog = new()
             {
                 Filter = filter,
                 InitialDirectory = initialDirectory,

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -196,7 +196,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     string fileName in
                         Directory.GetFiles(AppSettings.GetDictionaryDir(), "*.dic", SearchOption.TopDirectoryOnly))
                 {
-                    var file = new FileInfo(fileName);
+                    FileInfo file = new(fileName);
                     Dictionary.Items.Add(file.Name.Replace(".dic", ""));
                 }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
@@ -16,7 +16,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
     public partial class BuildServerIntegrationSettingsPage : RepoDistSettingsPage
     {
         private readonly TranslationString _noneItem =
-            new TranslationString("None");
+            new("None");
         private IConfigFileRemoteSettingsManager? _remotesManager;
         private JoinableTask<object>? _populateBuildServerTypeTask;
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -19,118 +19,118 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
     {
         #region Translations
         private readonly TranslationString _wrongGitVersion =
-            new TranslationString("Git found but version {0} is not supported. Upgrade to version {1} or later");
+            new("Git found but version {0} is not supported. Upgrade to version {1} or later");
 
         private readonly TranslationString _notRecommendedGitVersion =
-            new TranslationString("Git found but version {0} is older than recommended. Upgrade to version {1} or later");
+            new("Git found but version {0} is older than recommended. Upgrade to version {1} or later");
 
         private readonly TranslationString _gitVersionFound =
-            new TranslationString("Git {0} is found on your computer.");
+            new("Git {0} is found on your computer.");
 
         private readonly TranslationString _sshClientNotFound = new("SSH client not found: {0}.");
 
         private readonly TranslationString _otherSshClient = new("Other SSH client configured: {0}.");
 
         private readonly TranslationString _linuxToolsSshNotFound =
-            new TranslationString("Linux tools (sh) not found. To solve this problem you can set the correct path in settings.");
+            new("Linux tools (sh) not found. To solve this problem you can set the correct path in settings.");
 
         private readonly TranslationString _solveGitCommandFailedCaption =
-            new TranslationString("Locate git");
+            new("Locate git");
 
         private readonly TranslationString _gitCanBeRun =
-            new TranslationString("Git can be run using: {0}");
+            new("Git can be run using: {0}");
 
         private readonly TranslationString _gitCanBeRunCaption =
-            new TranslationString("Locate git");
+            new("Locate git");
 
         private readonly TranslationString _solveGitCommandFailed =
-            new TranslationString("The command to run git could not be determined automatically." + Environment.NewLine +
+            new("The command to run git could not be determined automatically." + Environment.NewLine +
                 "Please make sure git (Git for Windows or cygwin) is installed or set the correct command manually.");
 
         private readonly TranslationString _shellExtRegistered =
-            new TranslationString("Shell extensions registered properly.");
+            new("Shell extensions registered properly.");
 
         private readonly TranslationString _shellExtNoInstalled =
-            new TranslationString("Shell extensions are not installed. Run the installer to install the shell extensions.");
+            new("Shell extensions are not installed. Run the installer to install the shell extensions.");
 
         private readonly TranslationString _shellExtNeedsToBeRegistered =
-            new TranslationString("{0} needs to be registered in order to use the shell extensions.");
+            new("{0} needs to be registered in order to use the shell extensions.");
 
         private readonly TranslationString _registryKeyGitExtensionsMissing =
-            new TranslationString("Registry entry missing [Software\\GitExtensions\\InstallDir].");
+            new("Registry entry missing [Software\\GitExtensions\\InstallDir].");
 
         private readonly TranslationString _registryKeyGitExtensionsFaulty =
-            new TranslationString("Invalid installation directory stored in [Software\\GitExtensions\\InstallDir].");
+            new("Invalid installation directory stored in [Software\\GitExtensions\\InstallDir].");
 
         private readonly TranslationString _registryKeyGitExtensionsCorrect =
-            new TranslationString("Git Extensions is properly registered.");
+            new("Git Extensions is properly registered.");
 
         private readonly TranslationString _plinkputtyGenpageantNotFound =
-            new TranslationString("PuTTY is configured as SSH client but cannot find plink.exe, puttygen.exe or pageant.exe.");
+            new("PuTTY is configured as SSH client but cannot find plink.exe, puttygen.exe or pageant.exe.");
 
         private readonly TranslationString _puttyConfigured =
-            new TranslationString("SSH client PuTTY is configured properly.");
+            new("SSH client PuTTY is configured properly.");
 
         private readonly TranslationString _opensshUsed =
-            new TranslationString("Default SSH client, OpenSSH, will be used. (commandline window will appear on pull, push and clone operations)");
+            new("Default SSH client, OpenSSH, will be used. (commandline window will appear on pull, push and clone operations)");
 
         private readonly TranslationString _languageConfigured =
-            new TranslationString("The configured language is {0}.");
+            new("The configured language is {0}.");
 
         private readonly TranslationString _noLanguageConfigured =
-            new TranslationString("There is no language configured for Git Extensions.");
+            new("There is no language configured for Git Extensions.");
 
         private readonly TranslationString _noEmailSet =
-            new TranslationString("You need to configure a username and an email address.");
+            new("You need to configure a username and an email address.");
 
         private readonly TranslationString _emailSet =
-            new TranslationString("A username and an email address are configured.");
+            new("A username and an email address are configured.");
 
         private readonly TranslationString _mergeToolXConfiguredNeedsCmd =
-            new TranslationString("{0} is configured as mergetool, this is a custom mergetool and needs a custom cmd to be configured.");
+            new("{0} is configured as mergetool, this is a custom mergetool and needs a custom cmd to be configured.");
 
         private readonly TranslationString _customMergeToolXConfigured =
-            new TranslationString("There is a custom mergetool configured: {0}");
+            new("There is a custom mergetool configured: {0}");
 
         private readonly TranslationString _mergeToolXConfigured =
-            new TranslationString("There is a mergetool configured: {0}");
+            new("There is a mergetool configured: {0}");
 
         private readonly TranslationString _linuxToolsSshFound =
-            new TranslationString("Linux tools (sh) found on your computer.");
+            new("Linux tools (sh) found on your computer.");
 
         private readonly TranslationString _gitNotFound =
-            new TranslationString("Git not found. To solve this problem you can set the correct path in settings.");
+            new("Git not found. To solve this problem you can set the correct path in settings.");
 
         private readonly TranslationString _adviceDiffToolConfiguration =
-            new TranslationString("You should configure a diff tool to show file diff in external program.");
+            new("You should configure a diff tool to show file diff in external program.");
 
         private readonly TranslationString _diffToolXConfigured =
-            new TranslationString("There is a difftool configured: {0}");
+            new("There is a difftool configured: {0}");
 
         private readonly TranslationString _configureMergeTool =
-            new TranslationString("You need to configure merge tool in order to solve merge conflicts.");
+            new("You need to configure merge tool in order to solve merge conflicts.");
 
         private readonly TranslationString _cantRegisterShellExtension =
-            new TranslationString("Could not register the shell extension because '{0}' could not be found.");
+            new("Could not register the shell extension because '{0}' could not be found.");
 
         private readonly TranslationString _noDiffToolConfiguredCaption =
-            new TranslationString("Difftool");
+            new("Difftool");
 
         private readonly TranslationString _puttyFoundAuto =
-            new TranslationString("All paths needed for PuTTY could be automatically found and are set.");
+            new("All paths needed for PuTTY could be automatically found and are set.");
 
         private readonly TranslationString _linuxToolsShNotFound =
-            new TranslationString("The path to linux tools (sh) could not be found automatically." + Environment.NewLine +
+            new("The path to linux tools (sh) could not be found automatically." + Environment.NewLine +
                 "Please make sure there are linux tools installed (through Git for Windows or cygwin) or set the correct path manually.");
 
         private readonly TranslationString _linuxToolsShNotFoundCaption =
-            new TranslationString("Locate linux tools");
+            new("Locate linux tools");
 
         private readonly TranslationString _shCanBeRun =
-            new TranslationString("Command sh can be run using: {0}sh");
+            new("Command sh can be run using: {0}sh");
 
         private readonly TranslationString _shCanBeRunCaption =
-            new TranslationString("Locate linux tools");
+            new("Locate linux tools");
 
         private readonly TranslationString _gcmDetectedCaption = new("Obsolete git-credential-winstore.exe detected");
         #endregion
@@ -239,7 +239,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             {
                 try
                 {
-                    var pi = new ProcessStartInfo
+                    ProcessStartInfo pi = new()
                     {
                         FileName = "regsvr32",
                         Arguments = path.Quote(),

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.cs
@@ -13,13 +13,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private readonly ColorsSettingsPageController _controller;
 
         private static readonly TranslationString FormatBuiltinThemeName =
-            new TranslationString("{0}");
+            new("{0}");
 
         private static readonly TranslationString FormatUserDefinedThemeName =
-            new TranslationString("{0}, user-defined");
+            new("{0}, user-defined");
 
         private static readonly TranslationString DefaultThemeName =
-            new TranslationString("default");
+            new("default");
 
         public ColorsSettingsPage()
         {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
@@ -24,11 +24,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             base.OnLoad(e);
 
-            var translations = new List<string>(Translator.GetAllTranslations());
+            List<string> translations = new(Translator.GetAllTranslations());
             translations.Sort();
             translations.Insert(0, "English");
 
-            var imageList = new ImageList
+            ImageList imageList = new()
             {
                 ColorDepth = ColorDepth.Depth32Bit,
                 ImageSize = DpiUtil.Scale(new Size(150, 75)),

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -9,24 +9,24 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
     public partial class FormFixHome : GitExtensionsForm
     {
         private readonly TranslationString _gitGlobalConfigNotFound =
-            new TranslationString("The environment variable HOME does not point to a directory that contains the global git config file:" + Environment.NewLine +
+            new("The environment variable HOME does not point to a directory that contains the global git config file:" + Environment.NewLine +
                 "\" {0} \"" + Environment.NewLine + Environment.NewLine + "Do you want Git Extensions to help locate the correct folder?");
         private readonly TranslationString _gitGlobalConfigNotFoundCaption =
-            new TranslationString("Global config");
+            new("Global config");
 
         private readonly TranslationString _gitconfigFoundHome =
-            new TranslationString("Located .gitconfig in %HOME% ({0}). This setting has been chosen automatically.");
+            new("Located .gitconfig in %HOME% ({0}). This setting has been chosen automatically.");
         private readonly TranslationString _gitconfigFoundHomedrive =
-            new TranslationString("Located .gitconfig in %HOMEDRIVE%%HOMEPATH% ({0}). This setting has been chosen automatically.");
+            new("Located .gitconfig in %HOMEDRIVE%%HOMEPATH% ({0}). This setting has been chosen automatically.");
         private readonly TranslationString _gitconfigFoundUserprofile =
-            new TranslationString("Located .gitconfig in %USERPROFILE% ({0}). This setting has been chosen automatically.");
+            new("Located .gitconfig in %USERPROFILE% ({0}). This setting has been chosen automatically.");
         private readonly TranslationString _gitconfigFoundPersonalFolder =
-            new TranslationString("Located .gitconfig in personal folder ({0}). This setting has been chosen automatically.");
+            new("Located .gitconfig in personal folder ({0}). This setting has been chosen automatically.");
 
         private readonly TranslationString _noHomeDirectorySpecified =
-            new TranslationString("Please enter a HOME directory.");
+            new("Please enter a HOME directory.");
         private readonly TranslationString _homeNotAccessible =
-            new TranslationString("The environment variable HOME points to a directory that is not accessible:" + Environment.NewLine +
+            new("The environment variable HOME points to a directory that is not accessible:" + Environment.NewLine +
                                 "\"{0}\"");
 
         public FormFixHome()
@@ -101,7 +101,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             if (IsFixHome())
             {
-                using var frm = new FormFixHome();
+                using FormFixHome frm = new();
                 frm.ShowIfUserWant();
             }
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
@@ -141,7 +141,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     return string.Empty;
                 }
 
-                var dir = new DirectoryInfo(x.Path);
+                DirectoryInfo dir = new(x.Path);
                 if (dir.Parent is null)
                 {
                     return x.Path;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -181,7 +181,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 ? $"{toolName}|{diffMergeToolConfig.ExeFileName}"
                 : "*.exe;*.cmd;*.bat|*.exe;*.cmd;*.bat";
 
-            using var dialog = new OpenFileDialog
+            using OpenFileDialog dialog = new()
             {
                 Filter = filter,
                 InitialDirectory = initialDirectory,
@@ -319,7 +319,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void ConfigureEncoding_Click(object sender, EventArgs e)
         {
-            using var encodingDlg = new FormAvailableEncodings();
+            using FormAvailableEncodings encodingDlg = new();
             if (encodingDlg.ShowDialog() == DialogResult.OK)
             {
                 Global_FilesEncoding.Items.Clear();

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
@@ -46,7 +46,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             CheckSettingsLogic.SolveGitCommand(GitPath.Text.Trim());
 
-            using var browseDialog = new OpenFileDialog
+            using OpenFileDialog browseDialog = new()
             {
                 FileName = AppSettings.GitCommandValue,
                 Filter = "Git.cmd (git.cmd)|git.cmd|Git.exe (git.exe)|git.exe|Git (git)|git"

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
@@ -112,7 +112,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void Add_Click(object sender, EventArgs e)
         {
-            var definition = new ExternalLinkDefinition
+            ExternalLinkDefinition definition = new()
             {
                 Name = "<new>",
                 Enabled = true,

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -78,11 +78,11 @@ Current Branch:
             nameof(ScriptInfoProxy.Command),
             nameof(ScriptInfoProxy.Arguments),
         };
-        private static readonly ImageList EmbeddedIcons = new ImageList
+        private static readonly ImageList EmbeddedIcons = new()
         {
             ColorDepth = ColorDepth.Depth32Bit
         };
-        private readonly BindingList<ScriptInfoProxy> _scripts = new BindingList<ScriptInfoProxy>();
+        private readonly BindingList<ScriptInfoProxy> _scripts = new();
         private SimpleHelpDisplayDialog? _argumentsCheatSheet;
         private bool _handlingCheck;
 
@@ -138,7 +138,7 @@ Current Branch:
                 return;
             }
 
-            var rm = new System.Resources.ResourceManager("GitUI.Properties.Images", Assembly.GetExecutingAssembly());
+            System.Resources.ResourceManager rm = new("GitUI.Properties.Images", Assembly.GetExecutingAssembly());
 
             // dummy request; for some strange reason the ResourceSets are not loaded untill after the first object request... bug?
             rm.GetObject("dummy");

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/TextboxHotkey.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/TextboxHotkey.cs
@@ -7,7 +7,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
     public class TextboxHotkey : TextBox
     {
         private readonly TranslationString _hotkeyNotSet =
-            new TranslationString("None");
+            new("None");
 
         #region Key
         private Keys _keyData;

--- a/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/AzureDevopsExternalLinkDefinitionExtractor.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/AzureDevopsExternalLinkDefinitionExtractor.cs
@@ -19,7 +19,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
 
         public override IList<ExternalLinkDefinition> GetDefinitions(string remoteUrl)
         {
-            var externalLinkDefinitions = new List<ExternalLinkDefinition>();
+            List<ExternalLinkDefinition> externalLinkDefinitions = new();
             string? accountName = null;
             string? repoName = null;
 
@@ -32,7 +32,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
             repoName ??= "REPO_NAME";
 
             var azureDevopsUrl = $"https://dev.azure.com/{accountName}";
-            var definition = new ExternalLinkDefinition
+            ExternalLinkDefinition definition = new()
             {
                 Name = string.Format(CodeLink.Text, ServiceName),
                 Enabled = true,

--- a/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/CloudProviderExternalLinkDefinitionExtractorFactory.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/CloudProviderExternalLinkDefinitionExtractorFactory.cs
@@ -19,7 +19,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
         public IEnumerable<ICloudProviderExternalLinkDefinitionExtractor> GetAllExtractor()
         {
             var cloudProviderKinds = Enum.GetValues(typeof(CloudProviderKind)).OfType<CloudProviderKind>();
-            var cloudProviderExternalLinkDefinitionExtractorFactory = new CloudProviderExternalLinkDefinitionExtractorFactory();
+            CloudProviderExternalLinkDefinitionExtractorFactory cloudProviderExternalLinkDefinitionExtractorFactory = new();
             return cloudProviderKinds.Select(c => cloudProviderExternalLinkDefinitionExtractorFactory.Get(c))
                 .WhereNotNull();
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/GitHubExternalLinkDefinitionExtractor.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/GitHubExternalLinkDefinitionExtractor.cs
@@ -19,7 +19,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
 
         public override IList<ExternalLinkDefinition> GetDefinitions(string remoteUrl)
         {
-            var externalLinkDefinitions = new List<ExternalLinkDefinition>();
+            List<ExternalLinkDefinition> externalLinkDefinitions = new();
             string? organizationName = null;
             string? repoName = null;
 
@@ -32,7 +32,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
             repoName ??= "REPO_NAME";
 
             var gitHubUrl = $"https://github.com/{organizationName}/{repoName}";
-            var definition = new ExternalLinkDefinition
+            ExternalLinkDefinition definition = new()
             {
                 Name = string.Format(CodeLink.Text, ServiceName),
                 Enabled = true,

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
@@ -16,7 +16,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
     /// </summary>
     public abstract partial class SettingsPageBase : GitExtensionsControl, ISettingsPage
     {
-        private readonly List<ISettingControlBinding> _controlBindings = new List<ISettingControlBinding>();
+        private readonly List<ISettingControlBinding> _controlBindings = new();
         private ISettingsPageHost? _pageHost;
 
         protected SettingsPageBase()
@@ -52,7 +52,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
         public static T Create<[MeansImplicitUse] T>(ISettingsPageHost pageHost) where T : SettingsPageBase, new()
         {
-            var result = new T();
+            T result = new();
 
             result.AdjustForDpiScaling();
             result.EnableRemoveWordHotkey();
@@ -128,31 +128,31 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
         protected void AddSettingBinding(ISetting<bool> setting, CheckBox checkBox)
         {
-            var adapter = new BoolCheckBoxAdapter(setting, checkBox);
+            BoolCheckBoxAdapter adapter = new(setting, checkBox);
             AddControlBinding(adapter.CreateControlBinding());
         }
 
         protected void AddSettingBinding(ISetting<bool?> setting, CheckBox checkBox)
         {
-            var adapter = new BoolCheckBoxAdapter(setting, checkBox);
+            BoolCheckBoxAdapter adapter = new(setting, checkBox);
             AddControlBinding(adapter.CreateControlBinding());
         }
 
         protected void AddSettingBinding(ISetting<int> setting, TextBox control)
         {
-            var adapter = new IntTextBoxAdapter(setting, control);
+            IntTextBoxAdapter adapter = new(setting, control);
             AddControlBinding(adapter.CreateControlBinding());
         }
 
         protected void AddSettingBinding(ISetting<int?> setting, TextBox control)
         {
-            var adapter = new IntTextBoxAdapter(setting, control);
+            IntTextBoxAdapter adapter = new(setting, control);
             AddControlBinding(adapter.CreateControlBinding());
         }
 
         protected void AddSettingBinding(ISetting<string> setting, ComboBox comboBox)
         {
-            var adapter = new StringComboBoxAdapter(setting, comboBox);
+            StringComboBoxAdapter adapter = new(setting, comboBox);
             AddControlBinding(adapter.CreateControlBinding());
         }
 
@@ -172,9 +172,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         /// </summary>
         private static IReadOnlyList<string> GetChildrenText(Control control)
         {
-            var texts = new List<string>();
+            List<string> texts = new();
 
-            var queue = new Queue<Control>();
+            Queue<Control> queue = new();
             queue.Enqueue(control);
 
             while (queue.Count != 0)

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
@@ -17,8 +17,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         private bool _isSelectionChangeTriggeredByGoto;
         private List<TreeNode>? _nodesFoundByTextBox;
         private const string FindPrompt = "Type to find";
-        private readonly Dictionary<SettingsPageReference, TreeNode> _pages2NodeMap = new Dictionary<SettingsPageReference, TreeNode>();
-        private readonly List<ISettingsPage> _settingsPages = new List<ISettingsPage>();
+        private readonly Dictionary<SettingsPageReference, TreeNode> _pages2NodeMap = new();
+        private readonly List<ISettingsPage> _settingsPages = new();
 
         public event EventHandler<SettingsPageSelectedEventArgs>? SettingsPageSelected;
         public IEnumerable<ISettingsPage> SettingsPages => _settingsPages;

--- a/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
+++ b/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
@@ -16,7 +16,7 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
     public partial class FormAddSubmodule : GitModuleForm
     {
         private readonly TranslationString _remoteAndLocalPathRequired
-            = new TranslationString("A remote path and local path are required");
+            = new("A remote path and local path are required");
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormAddSubmodule()
@@ -102,7 +102,7 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
                 return Array.Empty<string>();
             }
 
-            var gitArguments = new GitArgumentBuilder("ls-remote") { "--heads", url.ToPosixPath().Quote() };
+            GitArgumentBuilder gitArguments = new("ls-remote") { "--heads", url.ToPosixPath().Quote() };
             var heads = gitExecutable.GetOutput(gitArguments);
             return heads.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries)
                         .Select(head =>

--- a/GitUI/CommandsDialogs/ToolStripPushButton.cs
+++ b/GitUI/CommandsDialogs/ToolStripPushButton.cs
@@ -13,10 +13,10 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _push = new("Push");
 
         private readonly TranslationString _aheadCommitsToPush =
-            new TranslationString("{0} new commit(s) will be pushed");
+            new("{0} new commit(s) will be pushed");
 
         private readonly TranslationString _behindCommitsTointegrateOrForcePush =
-            new TranslationString("{0} commit(s) should be integrated (or will be lost if force pushed)");
+            new("{0} commit(s) should be integrated (or will be lost if force pushed)");
 
         private IAheadBehindDataProvider? _aheadBehindDataProvider;
 
@@ -81,7 +81,7 @@ namespace GitUI.CommandsDialogs
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/CommandsDialogs/UserScriptContextMenuExtensions.cs
+++ b/GitUI/CommandsDialogs/UserScriptContextMenuExtensions.cs
@@ -12,7 +12,7 @@ namespace GitUI.CommandsDialogs
     {
         private const string ScriptNameSuffix = "_ownScript";
 
-        private static readonly Lazy<IEnumerable<HotkeyCommand>> Hotkeys = new Lazy<IEnumerable<HotkeyCommand>>(()
+        private static readonly Lazy<IEnumerable<HotkeyCommand>> Hotkeys = new(()
             => HotkeySettingsManager.LoadHotkeys(FormSettings.HotkeySettingsName));
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace GitUI.CommandsDialogs
 
             foreach (var script in scripts)
             {
-                var item = new ToolStripMenuItem
+                ToolStripMenuItem item = new()
                 {
                     Text = script.Name,
                     Name = $"{script.Name}{ScriptNameSuffix}",

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -105,7 +105,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         {
             // https://git-scm.com/docs/git-worktree
 
-            var args = new GitArgumentBuilder("worktree")
+            GitArgumentBuilder args = new("worktree")
             {
                 "add",
                 WorktreeDirectory.Quote(),
@@ -150,7 +150,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
                 try
                 {
-                    var directoryInfo = new DirectoryInfo(newWorktreeDirectory.Text);
+                    DirectoryInfo directoryInfo = new(newWorktreeDirectory.Text);
                     return !directoryInfo.Exists || (!directoryInfo.EnumerateFiles().Any() && !directoryInfo.EnumerateDirectories().Any());
                 }
                 catch

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -232,7 +232,7 @@ namespace GitUI.CommitInfo
 
         private IDictionary<string, int> GetSortedTags()
         {
-            var args = new GitArgumentBuilder("for-each-ref")
+            GitArgumentBuilder args = new("for-each-ref")
             {
                 "--sort=-taggerdate",
                 "--format=\"%(refname)\"",
@@ -247,7 +247,7 @@ namespace GitUI.CommitInfo
             }
 
             int i = 0;
-            var dict = new Dictionary<string, int>();
+            Dictionary<string, int> dict = new();
             foreach (var entry in tree.LazySplit('\n'))
             {
                 if (dict.ContainsKey(entry))
@@ -344,7 +344,7 @@ namespace GitUI.CommitInfo
 
                 ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
-                    var tasks = new List<Task>();
+                    List<Task> tasks = new();
 
                     tasks.Add(LoadLinksForRevisionAsync(initialRevision));
 
@@ -435,7 +435,7 @@ namespace GitUI.CommitInfo
                             return null;
                         }
 
-                        var result = new Dictionary<string, string>();
+                        Dictionary<string, string> result = new();
 
                         foreach (var gitRef in refs)
                         {
@@ -521,7 +521,7 @@ namespace GitUI.CommitInfo
                     {
                         var (precedingTag, commitCount) = _gitDescribeProvider.Get(commitId);
 
-                        var gitDescribeInfo = new StringBuilder();
+                        StringBuilder gitDescribeInfo = new();
                         if (!string.IsNullOrEmpty(precedingTag))
                         {
                             string tagString = ShowBranchesAsLinks ? _linkFactory.CreateTagLink(precedingTag) : WebUtility.HtmlEncode(precedingTag);
@@ -588,7 +588,7 @@ namespace GitUI.CommitInfo
                 IEnumerable<string> tagNames,
                 IDictionary<string, string> annotatedTagsMessages)
             {
-                var result = new StringBuilder();
+                StringBuilder result = new();
 
                 foreach (var tag in tagNames)
                 {
@@ -862,7 +862,7 @@ namespace GitUI.CommitInfo
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -28,8 +28,8 @@ namespace GitUI.CommitInfo
             InitializeComponent();
             InitializeComplete();
 
-            var labelFormatter = new TabbedHeaderLabelFormatter();
-            var headerRenderer = new TabbedHeaderRenderStyleProvider();
+            TabbedHeaderLabelFormatter labelFormatter = new();
+            TabbedHeaderRenderStyleProvider headerRenderer = new();
 
             _commitDataManager = new CommitDataManager(() => Module);
             _commitDataHeaderRenderer = new CommitDataHeaderRenderer(labelFormatter, _dateFormatter, headerRenderer, _linkFactory);

--- a/GitUI/CommitInfo/RefsFormatter.cs
+++ b/GitUI/CommitInfo/RefsFormatter.cs
@@ -60,7 +60,7 @@ namespace GitUI.CommitInfo
 
         private (IEnumerable<string> formattedBranches, bool truncated) FilterAndFormatBranches(IEnumerable<string> branches, bool showAsLinks, bool limit)
         {
-            var formattedBranches = new List<string>();
+            List<string> formattedBranches = new();
             bool truncated = false;
 
             const string remotesPrefix = "remotes/";

--- a/GitUI/CustomDiffMergeToolProvider.cs
+++ b/GitUI/CustomDiffMergeToolProvider.cs
@@ -61,7 +61,7 @@ namespace GitUI
                     menu.MenuItem.DropDown = new ContextMenuStrip(components);
                     foreach (var tool in tools)
                     {
-                        var item = new ToolStripMenuItem(tool) { Tag = tool };
+                        ToolStripMenuItem item = new(tool) { Tag = tool };
 
                         item.Click += menu.Click;
                         menu.MenuItem.DropDown.Items.Add(item);
@@ -83,7 +83,7 @@ namespace GitUI
                     {
                         // Allow disabling for difftools
                         menu.MenuItem.DropDown.Items.Add(new ToolStripSeparator());
-                        var disableItem = new ToolStripMenuItem
+                        ToolStripMenuItem disableItem = new()
                         {
                             Text = ResourceManager.TranslatedStrings.DisableMenuItem
                         };

--- a/GitUI/Design/PropertySorter.cs
+++ b/GitUI/Design/PropertySorter.cs
@@ -15,7 +15,7 @@ namespace GitUI.Design
         public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
         {
             PropertyDescriptorCollection pdc = TypeDescriptor.GetProperties(value, attributes);
-            var orderedProperties = new List<(string, int)>();
+            List<(string, int)> orderedProperties = new();
             foreach (PropertyDescriptor pd in pdc)
             {
                 Attribute attribute = pd.Attributes[typeof(PropertyOrderAttribute)];

--- a/GitUI/Editor/BlameAuthorMargin.cs
+++ b/GitUI/Editor/BlameAuthorMargin.cs
@@ -16,7 +16,7 @@ namespace GitUI.Editor
         private List<Image?>? _avatars;
         private readonly Color _backgroundColor;
         private List<GitBlameEntry>? _blameLines;
-        private readonly Dictionary<int, SolidBrush> _brushs = new Dictionary<int, SolidBrush>();
+        private readonly Dictionary<int, SolidBrush> _brushs = new();
         private bool _isVisible = true;
 
         public BlameAuthorMargin(TextArea textArea) : base(textArea)

--- a/GitUI/Editor/CommitMessageHighlightingStrategy.cs
+++ b/GitUI/Editor/CommitMessageHighlightingStrategy.cs
@@ -10,7 +10,7 @@ namespace GitUI.Editor
     {
         private static HighlightColor ColorSummary { get; } = new(SystemColors.WindowText, bold: true, italic: false);
 
-        private readonly List<TextMarker> _overlengthDescriptionMarkers = new List<TextMarker>();
+        private readonly List<TextMarker> _overlengthDescriptionMarkers = new();
 
         private readonly TextMarker _markerSummaryTooLong = new(0, 0, TextMarkerType.WaveLine, Color.Red) { ToolTip = "Summary line is too long." };
         private readonly TextMarker _markerSpacerNeeded = new(0, 0, TextMarkerType.WaveLine, Color.Red) { ToolTip = "There must be a blank line after the summary." };

--- a/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
+++ b/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
@@ -13,7 +13,7 @@ namespace GitUI.Editor.Diff
 
         public DiffLinesInfo Analyze(string diffContent)
         {
-            var ret = new DiffLinesInfo();
+            DiffLinesInfo ret = new();
             var isCombinedDiff = PatchProcessor.IsCombinedDiff(diffContent);
             var lineNumInDiff = 0;
             var leftLineNum = DiffLineInfo.NotApplicableLineNum;
@@ -31,7 +31,7 @@ namespace GitUI.Editor.Diff
                 lineNumInDiff++;
                 if (line.StartsWith("@"))
                 {
-                    var meta = new DiffLineInfo
+                    DiffLineInfo meta = new()
                     {
                         LineNumInDiff = lineNumInDiff,
                         LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
@@ -48,7 +48,7 @@ namespace GitUI.Editor.Diff
                 }
                 else if (isHeaderLineLocated && isCombinedDiff)
                 {
-                    var meta = new DiffLineInfo
+                    DiffLineInfo meta = new()
                     {
                         LineNumInDiff = lineNumInDiff,
                         LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
@@ -76,7 +76,7 @@ namespace GitUI.Editor.Diff
                 }
                 else if (isHeaderLineLocated && IsMinusLine(line))
                 {
-                    var meta = new DiffLineInfo
+                    DiffLineInfo meta = new()
                     {
                         LineNumInDiff = lineNumInDiff,
                         LeftLineNumber = leftLineNum,
@@ -89,7 +89,7 @@ namespace GitUI.Editor.Diff
                 }
                 else if (isHeaderLineLocated && IsPlusLine(line))
                 {
-                    var meta = new DiffLineInfo
+                    DiffLineInfo meta = new()
                     {
                         LineNumInDiff = lineNumInDiff,
                         LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
@@ -101,7 +101,7 @@ namespace GitUI.Editor.Diff
                 }
                 else if (line.StartsWith(GitModule.NoNewLineAtTheEnd))
                 {
-                    var meta = new DiffLineInfo
+                    DiffLineInfo meta = new()
                     {
                         LineNumInDiff = lineNumInDiff,
                         LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
@@ -112,7 +112,7 @@ namespace GitUI.Editor.Diff
                 }
                 else if (isHeaderLineLocated)
                 {
-                    var meta = new DiffLineInfo
+                    DiffLineInfo meta = new()
                     {
                         LineNumInDiff = lineNumInDiff,
                         LeftLineNumber = leftLineNum,

--- a/GitUI/Editor/Diff/DiffLinesInfo.cs
+++ b/GitUI/Editor/Diff/DiffLinesInfo.cs
@@ -5,7 +5,7 @@ namespace GitUI.Editor.Diff
 {
     public sealed class DiffLinesInfo
     {
-        private readonly Dictionary<int, DiffLineInfo> _diffLines = new Dictionary<int, DiffLineInfo>();
+        private readonly Dictionary<int, DiffLineInfo> _diffLines = new();
 
         public IReadOnlyDictionary<int, DiffLineInfo> DiffLines => _diffLines;
 

--- a/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
+++ b/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
@@ -65,7 +65,7 @@ namespace GitUI.Editor.Diff
             for (var y = 0; y < ((DrawingPosition.Height + textArea.TextView.VisibleLineDrawingRemainder) / fontHeight) + 1; ++y)
             {
                 var ypos = drawingPosition.Y + (fontHeight * y) - textArea.TextView.VisibleLineDrawingRemainder;
-                var backgroundRectangle = new Rectangle(drawingPosition.X, ypos, drawingPosition.Width, fontHeight);
+                Rectangle backgroundRectangle = new(drawingPosition.X, ypos, drawingPosition.Width, fontHeight);
                 if (!rect.IntersectsWith(backgroundRectangle))
                 {
                     continue;
@@ -129,7 +129,7 @@ namespace GitUI.Editor.Diff
 
         public void DisplayLineNumFor(string diff)
         {
-            var result = new DiffLineNumAnalyzer().Analyze(diff);
+            DiffLinesInfo result = new DiffLineNumAnalyzer().Analyze(diff);
             _diffLines = result.DiffLines;
             MaxLineNumber = result.MaxLineNumber;
         }

--- a/GitUI/Editor/Diff/LinePrefixHelper.cs
+++ b/GitUI/Editor/Diff/LinePrefixHelper.cs
@@ -20,7 +20,7 @@ namespace GitUI.Editor.Diff
 
         public List<ISegment> GetLinesStartingWith(IDocument document, ref int beginIndex, string[] prefixStrs, ref bool found)
         {
-            var result = new List<ISegment>();
+            List<ISegment> result = new();
 
             while (beginIndex < document.TotalNumberOfLines)
             {

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -329,14 +329,14 @@ namespace GitUI.Editor
 
         public ToolStripSeparator AddContextMenuSeparator()
         {
-            var separator = new ToolStripSeparator();
+            ToolStripSeparator separator = new();
             contextMenu.Items.Add(separator);
             return separator;
         }
 
         public ToolStripMenuItem AddContextMenuEntry(string text, EventHandler toolStripItem_Click)
         {
-            var toolStripItem = new ToolStripMenuItem(text);
+            ToolStripMenuItem toolStripItem = new(text);
             contextMenu.Items.Add(toolStripItem);
             toolStripItem.Click += toolStripItem_Click;
             return toolStripItem;
@@ -635,7 +635,7 @@ namespace GitUI.Editor
                 }
 
                 using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                using var reader = new StreamReader(stream, Module.FilesEncoding);
+                using StreamReader reader = new(stream, Module.FilesEncoding);
 #pragma warning disable VSTHRD103 // Call async methods when in an async method
                 var content = reader.ReadToEnd();
 #pragma warning restore VSTHRD103 // Call async methods when in an async method
@@ -855,7 +855,7 @@ namespace GitUI.Editor
 
                     if (File.Exists(resolvedPath))
                     {
-                        var file = new FileInfo(resolvedPath);
+                        FileInfo file = new(resolvedPath);
                         return file.Length;
                     }
                 }
@@ -895,7 +895,7 @@ namespace GitUI.Editor
         {
             if (IsIcon())
             {
-                using var icon = new Icon(stream);
+                using Icon icon = new(stream);
                 return icon.ToBitmap();
             }
 
@@ -908,7 +908,7 @@ namespace GitUI.Editor
 
             MemoryStream CopyStream()
             {
-                var copy = new MemoryStream();
+                MemoryStream copy = new();
                 stream.CopyTo(copy);
                 return copy;
             }
@@ -1027,7 +1027,7 @@ namespace GitUI.Editor
                                     ResetView(ViewMode.Text, null);
 
                                     var text = getFileText();
-                                    var summary = new StringBuilder()
+                                    StringBuilder summary = new StringBuilder()
                                         .AppendLine(string.Format(_cannotViewImage.Text, fileName))
                                         .AppendLine()
                                         .AppendLine($"{text.Length:N0} bytes:")
@@ -1432,7 +1432,7 @@ namespace GitUI.Editor
                 return;
             }
 
-            var args = new GitArgumentBuilder("apply")
+            GitArgumentBuilder args = new("apply")
             {
                 "--cached",
                 "--index",
@@ -1504,7 +1504,7 @@ namespace GitUI.Editor
                 return;
             }
 
-            var args = new GitArgumentBuilder("apply")
+            GitArgumentBuilder args = new("apply")
             {
                 "--whitespace=nowarn",
                 { currentItemStaged, "--reverse --index" }
@@ -1514,7 +1514,7 @@ namespace GitUI.Editor
             if (EnvUtils.RunningOnWindows())
             {
                 // remove file mode warnings
-                var regEx = new Regex("warning: .*has type .* expected .*", RegexOptions.Compiled);
+                Regex regEx = new("warning: .*has type .* expected .*", RegexOptions.Compiled);
                 output = output.RemoveLines(regEx.IsMatch);
             }
 
@@ -1560,7 +1560,7 @@ namespace GitUI.Editor
                 return;
             }
 
-            var args = new GitArgumentBuilder("apply")
+            GitArgumentBuilder args = new("apply")
             {
                 "--3way",
                 "--index",
@@ -1837,7 +1837,7 @@ namespace GitUI.Editor
 
         private void goToLineToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            using var formGoToLine = new FormGoToLine();
+            using FormGoToLine formGoToLine = new();
             formGoToLine.SetMaxLineNumber(internalFileViewer.MaxLineNumber);
             if (formGoToLine.ShowDialog(this) == DialogResult.OK)
             {
@@ -1902,7 +1902,7 @@ namespace GitUI.Editor
 
         #endregion
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -121,7 +121,7 @@ namespace GitUI.Editor
                 return Array.Empty<TextMarker>();
             }
 
-            var selectionMarkers = new List<TextMarker>();
+            List<TextMarker> selectionMarkers = new();
 
             string textContent = TextEditor.Document.TextContent;
             int indexMatch = -1;
@@ -132,7 +132,7 @@ namespace GitUI.Editor
                 {
                     Color highlightColor = AppColor.HighlightAllOccurences.GetThemeColor();
 
-                    var textMarker = new TextMarker(indexMatch,
+                    TextMarker textMarker = new(indexMatch,
                         word.Length, TextMarkerType.SolidBlock, highlightColor,
                         ColorHelper.GetForeColorForBackColor(highlightColor));
 
@@ -583,7 +583,7 @@ namespace GitUI.Editor
         {
             private readonly FileViewerInternal _viewer;
             private ViewPosition _currentViewPosition;
-            internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+            internal TestAccessor GetTestAccessor() => new(this);
 
             public CurrentViewPositionCache(FileViewerInternal viewer)
             {
@@ -598,7 +598,7 @@ namespace GitUI.Editor
                 }
 
                 // store the previous view position
-                var currentViewPosition = new ViewPosition
+                ViewPosition currentViewPosition = new()
                 {
                     ActiveLineNum = null,
                     FirstLine = _viewer.GetLineText(0),
@@ -725,7 +725,7 @@ namespace GitUI.Editor
             internal DiffLineInfo? ActiveLineNum;
         }
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/Editor/FindAndReplaceForm.cs
+++ b/GitUI/Editor/FindAndReplaceForm.cs
@@ -17,26 +17,26 @@ namespace GitUI
     public partial class FindAndReplaceForm : GitExtensionsForm
     {
         private readonly TranslationString _findAndReplaceString =
-            new TranslationString("Find & replace");
+            new("Find & replace");
         private readonly TranslationString _findString =
-            new TranslationString("Find");
+            new("Find");
         private readonly TranslationString _selectionOnlyString =
-            new TranslationString("selection only");
+            new("selection only");
         private readonly TranslationString _textNotFoundString =
-            new TranslationString("Text not found");
+            new("Text not found");
         private readonly TranslationString _noSearchString =
-            new TranslationString("No string specified to look for!");
+            new("No string specified to look for!");
         private readonly TranslationString _textNotFoundString2 =
-            new TranslationString("Search text not found.");
+            new("Search text not found.");
         private readonly TranslationString _notFoundString =
-            new TranslationString("Not found");
+            new("Not found");
         private readonly TranslationString _noOccurrencesFoundString =
-            new TranslationString("No occurrences found.");
+            new("No occurrences found.");
         private readonly TranslationString _replacedOccurrencesString =
-            new TranslationString("Replaced {0} occurrences.");
+            new("Replaced {0} occurrences.");
 
         private readonly Dictionary<TextEditorControl, HighlightGroup> _highlightGroups =
-            new Dictionary<TextEditorControl, HighlightGroup>();
+            new();
 
         private readonly TextEditorSearcher _search;
         private TextEditorControl? _editor;
@@ -271,7 +271,7 @@ namespace GitUI
                     offset = range.Offset + range.Length;
                     count++;
 
-                    var m = new TextMarker(range.Offset, range.Length,
+                    TextMarker m = new(range.Offset, range.Length,
                                            TextMarkerType.SolidBlock, Color.Yellow, Color.Black);
                     group.AddMarker(m);
                 }
@@ -418,7 +418,7 @@ namespace GitUI
             base.Dispose(disposing);
         }
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal readonly struct TestAccessor
         {
@@ -710,7 +710,7 @@ namespace GitUI
     {
         private readonly IDocument _document;
         private readonly TextEditorControl _editor;
-        private readonly List<TextMarker> _markers = new List<TextMarker>();
+        private readonly List<TextMarker> _markers = new();
 
         public HighlightGroup(TextEditorControl editor)
         {

--- a/GitUI/Editor/RebaseTodoHighlightingStrategy.cs
+++ b/GitUI/Editor/RebaseTodoHighlightingStrategy.cs
@@ -19,7 +19,7 @@ namespace GitUI.Editor
         d, drop = remove commit
         */
 
-        private static readonly Dictionary<char, (string longForm, HighlightColor color)> _commandByFirstChar = new Dictionary<char, (string longForm, HighlightColor color)>
+        private static readonly Dictionary<char, (string longForm, HighlightColor color)> _commandByFirstChar = new()
         {
             { 'p', ("pick", new HighlightColor(Color.Black, bold: true, italic: false)) },
             { 'r', ("reword", new HighlightColor(Color.Purple, bold: true, italic: false)) },

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -46,7 +46,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static IntPtr BeginUpdate(this RichTextBox rtb)
         {
-            var handleRef = new HandleRef(rtb, rtb.Handle);
+            HandleRef handleRef = new(rtb, rtb.Handle);
             return BeginUpdate(handleRef);
         }
 
@@ -71,7 +71,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static void EndUpdate(this RichTextBox rtb, IntPtr oldEventMask)
         {
-            var handleRef = new HandleRef(rtb, rtb.Handle);
+            HandleRef handleRef = new(rtb, rtb.Handle);
             EndUpdate(handleRef, oldEventMask);
         }
 
@@ -408,7 +408,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                     str = str.Remove(2, 1);
 
                     // Encode unicode characters
-                    var sb = new StringBuilder();
+                    StringBuilder sb = new();
                     foreach (var c in str)
                     {
                         if (c < 0x7f)
@@ -428,7 +428,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         private static PARAFORMAT GetParaFormat(HandleRef handleRef)
         {
-            var pf = new PARAFORMAT();
+            PARAFORMAT pf = new();
             pf.cbSize = Marshal.SizeOf(pf);
 
             // Get the alignment.
@@ -441,7 +441,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static PARAFORMAT GetParaFormat(this RichTextBox rtb)
         {
-            var handleRef = new HandleRef(rtb, rtb.Handle);
+            HandleRef handleRef = new(rtb, rtb.Handle);
             return GetParaFormat(handleRef);
         }
 
@@ -457,13 +457,13 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static void SetParaFormat(this RichTextBox rtb, PARAFORMAT value)
         {
-            var handleRef = new HandleRef(rtb, rtb.Handle);
+            HandleRef handleRef = new(rtb, rtb.Handle);
             SetParaFormat(handleRef, value);
         }
 
         private static PARAFORMAT GetDefaultParaFormat(HandleRef handleRef)
         {
-            var pf = new PARAFORMAT();
+            PARAFORMAT pf = new();
             pf.cbSize = Marshal.SizeOf(pf);
 
             // Get the alignment.
@@ -476,7 +476,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static PARAFORMAT GetDefaultParaFormat(this RichTextBox rtb)
         {
-            var handleRef = new HandleRef(rtb, rtb.Handle);
+            HandleRef handleRef = new(rtb, rtb.Handle);
             return GetDefaultParaFormat(handleRef);
         }
 
@@ -492,13 +492,13 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static void SetDefaultParaFormat(this RichTextBox rtb, PARAFORMAT value)
         {
-            var handleRef = new HandleRef(rtb, rtb.Handle);
+            HandleRef handleRef = new(rtb, rtb.Handle);
             SetDefaultParaFormat(handleRef, value);
         }
 
         private static CHARFORMAT GetCharFormat(HandleRef handleRef)
         {
-            var cf = new CHARFORMAT();
+            CHARFORMAT cf = new();
             cf.cbSize = Marshal.SizeOf(cf);
 
             // Get the alignment.
@@ -511,7 +511,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static CHARFORMAT GetCharFormat(this RichTextBox rtb)
         {
-            var handleRef = new HandleRef(rtb, rtb.Handle);
+            HandleRef handleRef = new(rtb, rtb.Handle);
             return GetCharFormat(handleRef);
         }
 
@@ -527,19 +527,19 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static void SetCharFormat(this RichTextBox rtb, CHARFORMAT value)
         {
-            var handleRef = new HandleRef(rtb, rtb.Handle);
+            HandleRef handleRef = new(rtb, rtb.Handle);
             SetCharFormat(handleRef, value);
         }
 
         public static void SetCharFormat(this RichTextBox rtb, CFM mask, CFE effects)
         {
-            var cf = new CHARFORMAT(mask, effects);
+            CHARFORMAT cf = new(mask, effects);
             rtb.SetCharFormat(cf);
         }
 
         private static CHARFORMAT GetDefaultCharFormat(HandleRef handleRef)
         {
-            var cf = new CHARFORMAT();
+            CHARFORMAT cf = new();
             cf.cbSize = Marshal.SizeOf(cf);
 
             // Get the alignment.
@@ -552,7 +552,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static CHARFORMAT GetDefaultCharFormat(this RichTextBox rtb)
         {
-            var handleRef = new HandleRef(rtb, rtb.Handle);
+            HandleRef handleRef = new(rtb, rtb.Handle);
             return GetDefaultCharFormat(handleRef);
         }
 
@@ -568,26 +568,26 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static void SetDefaultCharFormat(this RichTextBox rtb, CHARFORMAT value)
         {
-            var handleRef = new HandleRef(rtb, rtb.Handle);
+            HandleRef handleRef = new(rtb, rtb.Handle);
             SetDefaultCharFormat(handleRef, value);
         }
 
         public static void SetDefaultCharFormat(this RichTextBox rtb, CFM mask, CFE effects)
         {
-            var cf = new CHARFORMAT(mask, effects);
+            CHARFORMAT cf = new(mask, effects);
             rtb.SetDefaultCharFormat(cf);
         }
 
         private static Point GetScrollPoint(HandleRef handleRef)
         {
-            var scrollPoint = new Point();
+            Point scrollPoint = new();
             NativeMethods.SendMessage(handleRef, NativeMethods.EM_GETSCROLLPOS, IntPtr.Zero, ref scrollPoint);
             return scrollPoint;
         }
 
         public static Point GetScrollPoint(this RichTextBox rtb)
         {
-            var handleRef = new HandleRef(rtb, rtb.Handle);
+            HandleRef handleRef = new(rtb, rtb.Handle);
             return GetScrollPoint(handleRef);
         }
 
@@ -598,7 +598,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static void SetScrollPoint(this RichTextBox rtb, Point scrollPoint)
         {
-            var handleRef = new HandleRef(rtb, rtb.Handle);
+            HandleRef handleRef = new(rtb, rtb.Handle);
             SetScrollPoint(handleRef, scrollPoint);
         }
 
@@ -673,7 +673,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         public static string GetXHTMLText(this RichTextBox rtb, bool bParaFormat)
         {
-            var strHTML = new StringBuilder();
+            StringBuilder strHTML = new();
 
             rtb.HideSelection = true;
             IntPtr oldMask = rtb.BeginUpdate();
@@ -684,7 +684,7 @@ namespace GitUI.Editor.RichTextBoxExtension
             try
             {
                 // to store formatting
-                List<KeyValuePair<int, string>> colFormat = new List<KeyValuePair<int, string>>();
+                List<KeyValuePair<int, string>> colFormat = new();
                 string strT = ProcessTags(rtb, colFormat, bParaFormat);
 
                 // apply format by replacing and inserting HTML tags
@@ -720,7 +720,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
         private static string ProcessTags(RichTextBox rtb, List<KeyValuePair<int, string>> colFormat, bool bParaFormat)
         {
-            var sbT = new StringBuilder();
+            StringBuilder sbT = new();
 
             ctformatStates bold = ctformatStates.nctNone;
             ctformatStates bitalic = ctformatStates.nctNone;
@@ -812,7 +812,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                     // is italic? => close it
                     if (bitalic != ctformatStates.nctNone)
                     {
-                        var mfr = new KeyValuePair<int, string>(pos, "</i>");
+                        KeyValuePair<int, string> mfr = new(pos, "</i>");
                         colFormat.Add(mfr);
                         bitalic = ctformatStates.nctNone;
                     }
@@ -820,7 +820,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                     // is bold? => close it
                     if (bold != ctformatStates.nctNone)
                     {
-                        var mfr = new KeyValuePair<int, string>(pos, "</b>");
+                        KeyValuePair<int, string> mfr = new(pos, "</b>");
                         colFormat.Add(mfr);
                         bold = ctformatStates.nctNone;
                     }
@@ -828,7 +828,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                     // is underline? => close it
                     if (bunderline != ctformatStates.nctNone)
                     {
-                        var mfr = new KeyValuePair<int, string>(pos, "</u>");
+                        KeyValuePair<int, string> mfr = new(pos, "</u>");
                         colFormat.Add(mfr);
                         bunderline = ctformatStates.nctNone;
                     }
@@ -836,7 +836,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                     // is strikeout? => close it
                     if (bstrikeout != ctformatStates.nctNone)
                     {
-                        var mfr = new KeyValuePair<int, string>(pos, "</s>");
+                        KeyValuePair<int, string> mfr = new(pos, "</s>");
                         colFormat.Add(mfr);
                         bstrikeout = ctformatStates.nctNone;
                     }
@@ -844,7 +844,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                     // is super? => close it
                     if (super != ctformatStates.nctNone)
                     {
-                        var mfr = new KeyValuePair<int, string>(pos, "</sup>");
+                        KeyValuePair<int, string> mfr = new(pos, "</sup>");
                         colFormat.Add(mfr);
                         super = ctformatStates.nctNone;
                     }
@@ -852,7 +852,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                     // is sub? => close it
                     if (sub != ctformatStates.nctNone)
                     {
-                        var mfr = new KeyValuePair<int, string>(pos, "</sub>");
+                        KeyValuePair<int, string> mfr = new(pos, "</sub>");
                         colFormat.Add(mfr);
                         sub = ctformatStates.nctNone;
                     }
@@ -867,7 +867,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
                     if (bacenter == ctformatStates.nctNew)
                     {
-                        var mfr = new KeyValuePair<int, string>(pos, "<p align=\"center\">");
+                        KeyValuePair<int, string> mfr = new(pos, "<p align=\"center\">");
                         colFormat.Add(mfr);
                     }
                     else if (bacenter == ctformatStates.nctReset)
@@ -880,7 +880,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
                     if (baleft == ctformatStates.nctNew)
                     {
-                        var mfr = new KeyValuePair<int, string>(pos, "<p align=\"left\">");
+                        KeyValuePair<int, string> mfr = new(pos, "<p align=\"left\">");
                         colFormat.Add(mfr);
                     }
                     else if (baleft == ctformatStates.nctReset)
@@ -893,7 +893,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
                     if (baright == ctformatStates.nctNew)
                     {
-                        var mfr = new KeyValuePair<int, string>(pos, "<p align=\"right\">");
+                        KeyValuePair<int, string> mfr = new(pos, "<p align=\"right\">");
                         colFormat.Add(mfr);
                     }
                     else if (baright == ctformatStates.nctReset)
@@ -906,7 +906,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
                     if (bnumbering == ctformatStates.nctNew)
                     {
-                        var mfr = new KeyValuePair<int, string>(pos, "<li>");
+                        KeyValuePair<int, string> mfr = new(pos, "<li>");
                         colFormat.Add(mfr);
                     }
                     else if (bnumbering == ctformatStates.nctReset)
@@ -946,44 +946,44 @@ namespace GitUI.Editor.RichTextBoxExtension
             // close pending tags
             if (bold != ctformatStates.nctNone)
             {
-                var mfr = new KeyValuePair<int, string>(pos, "</b>");
+                KeyValuePair<int, string> mfr = new(pos, "</b>");
                 colFormat.Add(mfr);
             }
 
             if (bitalic != ctformatStates.nctNone)
             {
-                var mfr = new KeyValuePair<int, string>(pos, "</i>");
+                KeyValuePair<int, string> mfr = new(pos, "</i>");
                 colFormat.Add(mfr);
             }
 
             if (bstrikeout != ctformatStates.nctNone)
             {
-                var mfr = new KeyValuePair<int, string>(pos, "</s>");
+                KeyValuePair<int, string> mfr = new(pos, "</s>");
                 colFormat.Add(mfr);
             }
 
             if (bunderline != ctformatStates.nctNone)
             {
-                var mfr = new KeyValuePair<int, string>(pos, "</u>");
+                KeyValuePair<int, string> mfr = new(pos, "</u>");
                 colFormat.Add(mfr);
             }
 
             if (super != ctformatStates.nctNone)
             {
-                var mfr = new KeyValuePair<int, string>(pos, "</sup>");
+                KeyValuePair<int, string> mfr = new(pos, "</sup>");
                 colFormat.Add(mfr);
             }
 
             if (sub != ctformatStates.nctNone)
             {
-                var mfr = new KeyValuePair<int, string>(pos, "</sub>");
+                KeyValuePair<int, string> mfr = new(pos, "</sub>");
                 colFormat.Add(mfr);
             }
 
             if (fontSet)
             {
                 // close pending font format
-                var mfr = new KeyValuePair<int, string>(pos, "</font>");
+                KeyValuePair<int, string> mfr = new(pos, "</font>");
                 colFormat.Add(mfr);
             }
 
@@ -1029,12 +1029,12 @@ namespace GitUI.Editor.RichTextBoxExtension
         {
             if (state == ctformatStates.nctNew)
             {
-                var mfr = new KeyValuePair<int, string>(pos, "<" + tag + ">");
+                KeyValuePair<int, string> mfr = new(pos, "<" + tag + ">");
                 colFormat.Add(mfr);
             }
             else if (state == ctformatStates.nctReset)
             {
-                var mfr = new KeyValuePair<int, string>(pos, "</" + tag + ">");
+                KeyValuePair<int, string> mfr = new(pos, "</" + tag + ">");
                 colFormat.Add(mfr);
                 state = ctformatStates.nctNone;
             }
@@ -1061,7 +1061,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
             int nStart = rtb.SelectionStart;
             int nEnd = rtb.SelectionLength;
-            var text = new StringBuilder();
+            StringBuilder text = new();
 
             try
             {
@@ -1181,7 +1181,7 @@ namespace GitUI.Editor.RichTextBoxExtension
         /// </summary>
         private static string EscapeNonXMLChars(string input)
         {
-            var result = new StringBuilder();
+            StringBuilder result = new();
             foreach (char ch in input)
             {
                 if (XmlConvert.IsXmlChar(ch))
@@ -1233,15 +1233,15 @@ namespace GitUI.Editor.RichTextBoxExtension
             rtb.DetectUrls = false;
 
             rtb.Clear();
-            var cs = new RTFCurrentState();
+            RTFCurrentState cs = new();
 
-            var handleRef = new HandleRef(rtb, rtb.Handle);
+            HandleRef handleRef = new(rtb, rtb.Handle);
             cs.cf = GetDefaultCharFormat(handleRef); // to apply character formatting
             cs.pf = GetDefaultParaFormat(handleRef); // to apply paragraph formatting
 
             IntPtr oldMask = BeginUpdate(handleRef);
 
-            var settings = new XmlReaderSettings
+            XmlReaderSettings settings = new()
             {
                 ConformanceLevel = ConformanceLevel.Fragment,
                 CheckCharacters = false
@@ -1249,7 +1249,7 @@ namespace GitUI.Editor.RichTextBoxExtension
 
             try
             {
-                using var stringreader = new StringReader(EscapeNonXMLChars(xhtmlText));
+                using StringReader stringreader = new(EscapeNonXMLChars(xhtmlText));
                 XmlReader reader = XmlReader.Create(stringreader, settings);
                 while (reader.Read())
                 {
@@ -1262,7 +1262,7 @@ namespace GitUI.Editor.RichTextBoxExtension
             }
 
             // apply links style
-            var ncf = new CHARFORMAT(CFM.LINK, CFE.LINK);
+            CHARFORMAT ncf = new(CFM.LINK, CFE.LINK);
             ncf.cbSize = Marshal.SizeOf(ncf);
             foreach (var (start, length) in cs.links)
             {
@@ -1553,11 +1553,11 @@ namespace GitUI.Editor.RichTextBoxExtension
 
             rtb.HideSelection = true;
 
-            var settings = new XmlReaderSettings { ConformanceLevel = ConformanceLevel.Fragment };
+            XmlReaderSettings settings = new() { ConformanceLevel = ConformanceLevel.Fragment };
 
             try
             {
-                using var strReader = new StringReader(xhtmlText);
+                using StringReader strReader = new(xhtmlText);
                 XmlReader reader = XmlReader.Create(strReader, settings);
                 while (reader.Read())
                 {

--- a/GitUI/FilterBranchHelper.cs
+++ b/GitUI/FilterBranchHelper.cs
@@ -119,7 +119,7 @@ namespace GitUI
 
         private List<string> GetBranchHeads(bool local, bool remote)
         {
-            var list = new List<string>();
+            List<string> list = new();
             if (local && remote)
             {
                 var branches = Module.GetRefs(true, true);

--- a/GitUI/FormPuttyError.cs
+++ b/GitUI/FormPuttyError.cs
@@ -12,7 +12,7 @@ namespace GitUI
         /// <summary>Shows the "SSH error" dialog modally, and returns the path to the key, if one was loaded.</summary>
         public static bool AskForKey(IWin32Window parent, [NotNullWhen(returnValue: true)] out string? keyPath)
         {
-            using var form = new FormPuttyError();
+            using FormPuttyError form = new();
             var result = form.ShowDialog(parent);
             keyPath = form.KeyPath;
             return result == DialogResult.Retry;

--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -36,7 +36,7 @@ namespace GitUI
 
             FormClosing += GitExtensionsForm_FormClosing;
 
-            var cancelButton = new Button();
+            Button cancelButton = new();
             cancelButton.Click += CancelButtonClick;
             CancelButton = cancelButton;
 
@@ -140,7 +140,7 @@ namespace GitUI
             else
             {
                 // Calculate location for modal form with parent
-                Point calculatedLocation = new Point(
+                Point calculatedLocation = new(
                     Owner.Left + (Owner.Width / 2) - (Width / 2),
                     Owner.Top + (Owner.Height / 2) - (Height / 2));
                 Location = WindowPositionManager.FitWindowOnScreen(new Rectangle(calculatedLocation, Size), workingArea);
@@ -155,7 +155,7 @@ namespace GitUI
         }
 
         // This is a base class for many forms, which have own GetTestAccessor() methods. This has to be unique
-        internal GitExtensionsFormTestAccessor GetGitExtensionsFormTestAccessor() => new GitExtensionsFormTestAccessor(this);
+        internal GitExtensionsFormTestAccessor GetGitExtensionsFormTestAccessor() => new(this);
 
         internal readonly struct GitExtensionsFormTestAccessor
         {

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -147,7 +147,7 @@ namespace GitUI
         {
             return DoActionOnRepo(owner, action: () =>
             {
-                using var form = new FormDeleteBranch(this, branches);
+                using FormDeleteBranch form = new(this, branches);
                 form.ShowDialog(owner);
                 return true;
             }, changesRepo: false);
@@ -157,7 +157,7 @@ namespace GitUI
         {
             return DoActionOnRepo(owner, action: () =>
             {
-                using var form = new FormDeleteRemoteBranch(this, remoteBranch);
+                using FormDeleteRemoteBranch form = new(this, remoteBranch);
                 form.ShowDialog(owner);
                 return true;
             }, changesRepo: false);
@@ -167,7 +167,7 @@ namespace GitUI
         {
             return DoActionOnRepo(owner, action: () =>
             {
-                using var form = new FormCheckoutRevision(this);
+                using FormCheckoutRevision form = new(this);
                 form.SetRevision(revision);
                 return form.ShowDialog(owner) == DialogResult.OK;
             }, preEvent: PreCheckoutRevision, postEvent: PostCheckoutRevision);
@@ -335,7 +335,7 @@ namespace GitUI
         {
             return DoActionOnRepo(owner, action: () =>
             {
-                using var form = new FormCheckoutBranch(this, branch, remote, containRevisions);
+                using FormCheckoutBranch form = new(this, branch, remote, containRevisions);
                 return form.DoDefaultActionOrShow(owner) != DialogResult.Cancel;
             }, preEvent: PreCheckoutBranch, postEvent: PostCheckoutBranch);
         }
@@ -394,7 +394,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormLog(this);
+                using FormLog form = new(this);
                 return form.ShowDialog(owner) == DialogResult.OK;
             }
 
@@ -405,7 +405,7 @@ namespace GitUI
         {
             return DoActionOnRepo(owner, action: () =>
             {
-                using var form = new FormAddFiles(this, addFiles);
+                using FormAddFiles form = new(this, addFiles);
                 form.ShowDialog(owner);
                 return true;
             });
@@ -427,7 +427,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormCreateBranch(this, objectId, newBranchNamePrefix);
+                using FormCreateBranch form = new(this, objectId, newBranchNamePrefix);
                 return form.ShowDialog(owner) == DialogResult.OK;
             }
 
@@ -438,7 +438,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormClone(this, url, openedFromProtocolHandler, gitModuleChanged);
+                using FormClone form = new(this, url, openedFromProtocolHandler, gitModuleChanged);
                 form.ShowDialog(owner);
                 return true;
             }
@@ -453,7 +453,7 @@ namespace GitUI
 
         public bool StartCleanupRepositoryDialog(IWin32Window? owner = null, string? path = null)
         {
-            using var form = new FormCleanupRepository(this);
+            using FormCleanupRepository form = new(this);
             form.SetPathArgument(path);
             form.ShowDialog(owner);
 
@@ -464,7 +464,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormCommit(this, CommitKind.Squash, revision);
+                using FormCommit form = new(this, CommitKind.Squash, revision);
                 form.ShowDialog(owner);
                 return true;
             }
@@ -476,7 +476,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormCommit(this, CommitKind.Fixup, revision);
+                using FormCommit form = new(this, CommitKind.Fixup, revision);
                 form.ShowDialog(owner);
                 return true;
             }
@@ -513,7 +513,7 @@ namespace GitUI
                         });
                     }
 
-                    using var form = new FormCommit(this, commitMessage: commitMessage);
+                    using FormCommit form = new(this, commitMessage: commitMessage);
                     if (showOnlyWhenChanges)
                     {
                         form.ShowDialogWhenChanges(owner);
@@ -543,7 +543,7 @@ namespace GitUI
             {
                 dir ??= Module.IsValidGitWorkingDir() ? Module.WorkingDir : string.Empty;
 
-                using var frm = new FormInit(dir, gitModuleChanged);
+                using FormInit frm = new(dir, gitModuleChanged);
                 frm.ShowDialog(owner);
                 return true;
             }
@@ -574,7 +574,7 @@ namespace GitUI
 
             bool Action()
             {
-                using var formPull = new FormPull(this, remoteBranch, remote, pullAction);
+                using FormPull formPull = new(this, remoteBranch, remote, pullAction);
                 var dlgResult = pullOnShow
                     ? formPull.PullAndShowDialogWhenFailed(owner, remote, pullAction)
                     : formPull.ShowDialog(owner);
@@ -598,7 +598,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var viewPatch = new FormViewPatch(this);
+                using FormViewPatch viewPatch = new(this);
                 if (!string.IsNullOrEmpty(patchFile))
                 {
                     viewPatch.LoadPatch(patchFile);
@@ -616,7 +616,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var viewPatch = new FormCommitDiff(this, objectId);
+                using FormCommitDiff viewPatch = new(this, objectId);
                 viewPatch.ShowDialog(null);
                 return true;
             }
@@ -633,7 +633,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormSparseWorkingCopy(this);
+                using FormSparseWorkingCopy form = new(this);
                 form.ShowDialog(owner);
                 return true;
             }
@@ -655,7 +655,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormFormatPatch(this);
+                using FormFormatPatch form = new(this);
                 form.ShowDialog(owner);
                 return true;
             }
@@ -667,7 +667,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormStash(this) { ManageStashes = manageStashes };
+                using FormStash form = new(this) { ManageStashes = manageStashes };
                 form.ShowDialog(owner);
                 return true;
             }
@@ -695,7 +695,7 @@ namespace GitUI
             {
                 if (onlyWorkTree)
                 {
-                    var args = new GitArgumentBuilder("checkout")
+                    GitArgumentBuilder args = new("checkout")
                     {
                         "--",
                         "."
@@ -772,7 +772,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormRevertCommit(this, revision);
+                using FormRevertCommit form = new(this, revision);
                 return form.ShowDialog(owner) == DialogResult.OK;
             }
 
@@ -783,7 +783,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormResolveConflicts(this, offerCommit);
+                using FormResolveConflicts form = new(this, offerCommit);
                 form.ShowDialog(owner);
                 return true;
             }
@@ -795,7 +795,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormCherryPick(this, revision);
+                using FormCherryPick form = new(this, revision);
                 return form.ShowDialog(owner) == DialogResult.OK;
             }
 
@@ -820,7 +820,7 @@ namespace GitUI
                     // ReSharper disable once PossibleMultipleEnumeration
                     foreach (var r in revisions)
                     {
-                        var frm = new FormCherryPick(this, r);
+                        FormCherryPick frm = new(this, r);
                         if (prevForm is not null)
                         {
                             frm.CopyOptions(prevForm);
@@ -856,7 +856,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormMergeBranch(this, branch);
+                using FormMergeBranch form = new(this, branch);
                 form.ShowDialog(owner);
                 return true;
             }
@@ -868,7 +868,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormCreateTag(this, revision?.ObjectId);
+                using FormCreateTag form = new(this, revision?.ObjectId);
                 return form.ShowDialog(owner) == DialogResult.OK;
             }
 
@@ -879,7 +879,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormDeleteTag(this, tag);
+                using FormDeleteTag form = new(this, tag);
                 return form.ShowDialog(owner) == DialogResult.OK;
             }
 
@@ -890,7 +890,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormGitIgnore(this, localExcludes);
+                using FormGitIgnore form = new(this, localExcludes);
                 form.ShowDialog(owner);
                 return true;
             }
@@ -902,7 +902,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var frm = new FormAddToGitIgnore(this, localExclude, filePattern);
+                using FormAddToGitIgnore frm = new(this, localExclude, filePattern);
                 frm.ShowDialog(owner);
                 return true;
             }
@@ -942,7 +942,7 @@ namespace GitUI
         {
             return DoActionOnRepo(owner, action: () =>
                 {
-                    using var form = new FormArchive(this)
+                    using FormArchive form = new(this)
                     {
                         SelectedRevision = revision,
                     };
@@ -958,7 +958,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormMailMap(this);
+                using FormMailMap form = new(this);
                 form.ShowDialog(owner);
                 return true;
             }
@@ -970,7 +970,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormVerify(this);
+                using FormVerify form = new(this);
                 form.ShowDialog(owner);
                 return true;
             }
@@ -984,7 +984,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormRemotes(this)
+                using FormRemotes form = new(this)
                 {
                     PreselectRemoteOnLoad = preselectRemote,
                     PreselectLocalOnLoad = preselectLocal
@@ -1027,7 +1027,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormRebase(this, from, to, onto, interactive, startRebaseImmediately);
+                using FormRebase form = new(this, from, to, onto, interactive, startRebaseImmediately);
                 form.ShowDialog(owner);
                 return true;
             }
@@ -1039,7 +1039,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormRenameBranch(this, branch);
+                using FormRenameBranch form = new(this, branch);
                 return form.ShowDialog(owner) == DialogResult.OK;
             }
 
@@ -1050,7 +1050,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormSubmodules(this);
+                using FormSubmodules form = new(this);
                 form.ShowDialog(owner);
                 return true;
             }
@@ -1128,7 +1128,7 @@ namespace GitUI
         /// <param name="firstId">First selected commit id (as in a diff).</param>
         public bool StartBrowseDialog(IWin32Window? owner = null, string filter = "", ObjectId? selectedId = null, ObjectId? firstId = null)
         {
-            var form = new FormBrowse(this, filter, selectedId, firstId);
+            FormBrowse form = new(this, filter, selectedId, firstId);
 
             if (Application.MessageLoop)
             {
@@ -1168,7 +1168,7 @@ namespace GitUI
 
         public FormDiff ShowFormDiff(ObjectId baseCommitSha, ObjectId headCommitSha, string baseCommitDisplayStr, string headCommitDisplayStr)
         {
-            var diffForm = new FormDiff(this, baseCommitSha, headCommitSha, baseCommitDisplayStr, headCommitDisplayStr)
+            FormDiff diffForm = new(this, baseCommitSha, headCommitSha, baseCommitDisplayStr, headCommitDisplayStr)
             {
                 ShowInTaskbar = true
             };
@@ -1184,7 +1184,7 @@ namespace GitUI
 
             bool Action()
             {
-                using var form = new FormPush(this);
+                using FormPush form = new(this);
                 if (forceWithLease)
                 {
                     form.CheckForceWithLease();
@@ -1218,7 +1218,7 @@ namespace GitUI
         {
             return DoActionOnRepo(owner, action: () =>
                 {
-                    using var form = new FormApplyPatch(this);
+                    using FormApplyPatch form = new(this);
                     if (Directory.Exists(patchFile!))
                     {
                         form.SetPatchDir(patchFile!);
@@ -1238,7 +1238,7 @@ namespace GitUI
         {
             bool Action()
             {
-                using var form = new FormGitAttributes(this);
+                using FormGitAttributes form = new(this);
                 form.ShowDialog(owner);
                 return true;
             }
@@ -1250,7 +1250,7 @@ namespace GitUI
         {
             try
             {
-                var e = new GitUIEventArgs(ownerForm, this);
+                GitUIEventArgs e = new(ownerForm, this);
                 gitUIEventHandler?.Invoke(this, e);
                 return !e.Cancel;
             }
@@ -1266,7 +1266,7 @@ namespace GitUI
         {
             if (gitUIEventHandler is not null)
             {
-                var e = new GitUIPostActionEventArgs(ownerForm, this, actionDone);
+                GitUIPostActionEventArgs e = new(ownerForm, this, actionDone);
                 gitUIEventHandler(this, e);
             }
         }
@@ -1275,7 +1275,7 @@ namespace GitUI
         {
             if (!gitHoster.ConfigurationOk)
             {
-                var eventArgs = new GitUIEventArgs(null, this);
+                GitUIEventArgs eventArgs = new(null, this);
                 gitHoster.Execute(eventArgs);
             }
 
@@ -1298,7 +1298,7 @@ namespace GitUI
         {
             WrapRepoHostingCall(TranslatedStrings.ForkCloneRepo, gitHoster, gh =>
             {
-                using var frm = new ForkAndCloneForm(gitHoster, gitModuleChanged);
+                using ForkAndCloneForm frm = new(gitHoster, gitModuleChanged);
                 frm.ShowDialog(owner);
             });
         }
@@ -1308,7 +1308,7 @@ namespace GitUI
             WrapRepoHostingCall(TranslatedStrings.ViewPullRequest, gitHoster,
                                 gh =>
                                 {
-                                    var frm = new ViewPullRequestsForm(this, gitHoster) { ShowInTaskbar = true };
+                                    ViewPullRequestsForm frm = new(this, gitHoster) { ShowInTaskbar = true };
                                     frm.Show(owner);
                                 });
         }
@@ -1339,7 +1339,7 @@ namespace GitUI
                 gitHoster,
                 gh =>
                 {
-                    var form = new CreatePullRequestForm(this, gitHoster, chooseRemote, chooseBranch)
+                    CreatePullRequestForm form = new(this, gitHoster, chooseRemote, chooseBranch)
                     {
                         ShowInTaskbar = true
                     };
@@ -1544,7 +1544,7 @@ namespace GitUI
 
         private bool RunSearchFileCommand()
         {
-            var searchWindow = new SearchWindow<string>(FindFileMatches);
+            SearchWindow<string> searchWindow = new(FindFileMatches);
             Application.Run(searchWindow);
             if (searchWindow.SelectedItem is not null)
             {
@@ -1657,7 +1657,7 @@ namespace GitUI
 
         public bool StartFileEditorDialog(string? filename, bool showWarning = false)
         {
-            using var formEditor = new FormEditor(this, filename, showWarning);
+            using FormEditor formEditor = new(this, filename, showWarning);
             return formEditor.ShowDialog() != DialogResult.Cancel;
         }
 
@@ -1735,7 +1735,7 @@ namespace GitUI
 
             return DoActionOnRepo(owner: null, action: () =>
             {
-                using var frm = new FormBlame(this, blameFileName, null, initialLine);
+                using FormBlame frm = new(this, blameFileName, null, initialLine);
                 frm.ShowDialog(null);
                 return true;
             }, changesRepo: false);
@@ -1753,7 +1753,7 @@ namespace GitUI
 
         private static IReadOnlyDictionary<string, string?> InitializeArguments(IReadOnlyList<string> args)
         {
-            var arguments = new Dictionary<string, string?>();
+            Dictionary<string, string?> arguments = new();
 
             for (int i = 2; i < args.Count; i++)
             {
@@ -1884,7 +1884,7 @@ namespace GitUI
                     throw new InvalidOperationException("CommandText is required");
                 }
 
-                using var form = new FormRemoteProcess(_commands, process: null, CommandText);
+                using FormRemoteProcess form = new(_commands, process: null, CommandText);
                 if (Title is not null)
                 {
                     form.Text = Title;
@@ -1907,7 +1907,7 @@ namespace GitUI
             {
                 CommandOutput = form.GetOutputString();
 
-                var e = new GitRemoteCommandCompletedEventArgs(this, isError, false);
+                GitRemoteCommandCompletedEventArgs e = new(this, isError, false);
 
                 Completed?.Invoke(form, e);
 
@@ -1919,7 +1919,7 @@ namespace GitUI
 
         #endregion
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal struct TestAccessor
         {

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -73,7 +73,7 @@ namespace GitUI
                         fileViewer.GetExtraDiffArguments(isRangeDiff: true));
 
                 // Try set highlighting from first found filename
-                var match = new Regex(@"\n\s*(@@|##)\s+(?<file>[^#:\n]+)").Match(output ?? "");
+                Match match = new Regex(@"\n\s*(@@|##)\s+(?<file>[^#:\n]+)").Match(output ?? "");
                 var filename = match.Groups["file"].Success ? match.Groups["file"].Value : item.Item.Name;
 
                 return fileViewer.ViewRangeDiffAsync(filename, output ?? defaultText);
@@ -165,7 +165,7 @@ namespace GitUI
         {
             if (FindMaskPanel(control) is null)
             {
-                var panel = new LoadingControl
+                LoadingControl panel = new()
                 {
                     Dock = DockStyle.Fill,
                     IsAnimating = true,

--- a/GitUI/HelperDialogs/FormProcess.cs
+++ b/GitUI/HelperDialogs/FormProcess.cs
@@ -21,7 +21,7 @@ namespace GitUI.HelperDialogs
         public string? ProcessInput { get; }
         public readonly string WorkingDirectory;
         public HandleOnExit? HandleOnExitCallback { get; set; }
-        public readonly Dictionary<string, string> ProcessEnvVariables = new Dictionary<string, string>();
+        public readonly Dictionary<string, string> ProcessEnvVariables = new();
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -61,7 +61,7 @@ namespace GitUI.HelperDialogs
         {
             Debug.Assert(owner is not null, "Progress window must be owned by another window! This is a bug, please correct and send a pull request with a fix.");
 
-            using var formProcess = new FormProcess(commands: null, process, arguments, workingDirectory, input, useDialogSettings);
+            using FormProcess formProcess = new(commands: null, process, arguments, workingDirectory, input, useDialogSettings);
             formProcess.ShowDialog(owner);
             return !formProcess.ErrorOccurred();
         }
@@ -70,7 +70,7 @@ namespace GitUI.HelperDialogs
         {
             Debug.Assert(owner is not null, "Progress window must be owned by another window! This is a bug, please correct and send a pull request with a fix.");
 
-            using var formProcess = new FormProcess(commands: null, process, arguments, workingDirectory, input, useDialogSettings);
+            using FormProcess formProcess = new(commands: null, process, arguments, workingDirectory, input, useDialogSettings);
             formProcess.ShowDialog(owner);
             return formProcess.GetOutputString();
         }
@@ -139,7 +139,7 @@ namespace GitUI.HelperDialogs
             {
                 ConsoleOutput.KillProcess();
 
-                var module = new GitModule(WorkingDirectory);
+                GitModule module = new(WorkingDirectory);
                 module.UnlockIndex(includeSubmodules: true);
             }
             catch

--- a/GitUI/HelperDialogs/FormRemoteProcess.cs
+++ b/GitUI/HelperDialogs/FormRemoteProcess.cs
@@ -15,7 +15,7 @@ namespace GitUI.HelperDialogs
     {
         #region Translation
         private readonly TranslationString _fingerprintNotRegistredText =
-            new TranslationString(@"The fingerprint of this host is not registered by PuTTY.
+            new(@"The fingerprint of this host is not registered by PuTTY.
 This causes this process to hang, and that why it is automatically stopped.
 
 When the connection is opened detached from Git and Git Extensions, the host's fingerprint can be registered.
@@ -23,7 +23,7 @@ You could also manually add the host's fingerprint or run Test Connection from t
 
 Do you want to register the host's fingerprint and restart the process?");
         private readonly TranslationString _fingerprintNotRegistredTextCaption =
-            new TranslationString("Host Fingerprint not registered");
+            new("Host Fingerprint not registered");
         #endregion
 
         private bool _restart;
@@ -46,7 +46,7 @@ Do you want to register the host's fingerprint and restart the process?");
 
         public static bool ShowDialog(IWin32Window? owner, GitUICommands commands, ArgumentString arguments)
         {
-            using var formRemoteProcess = new FormRemoteProcess(commands, process: null, arguments);
+            using FormRemoteProcess formRemoteProcess = new(commands, process: null, arguments);
             formRemoteProcess.ShowDialog(owner);
             return !formRemoteProcess.ErrorOccurred();
         }

--- a/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -17,7 +17,7 @@ namespace GitUI.HelperDialogs
         private readonly TranslationString _localRefInvalid = new("The entered value '{0}' is not the name of an existing local branch.");
 
         public static FormResetAnotherBranch Create(GitUICommands gitUiCommands, GitRevision revision)
-            => new FormResetAnotherBranch(gitUiCommands, revision ?? throw new NotSupportedException(TranslatedStrings.NoRevision));
+            => new(gitUiCommands, revision ?? throw new NotSupportedException(TranslatedStrings.NoRevision));
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -24,7 +24,7 @@ namespace GitUI.HelperDialogs
         }
 
         public static FormResetCurrentBranch Create(GitUICommands commands, GitRevision revision, ResetType resetType = ResetType.Mixed)
-            => new FormResetCurrentBranch(commands, revision ?? throw new NotSupportedException(TranslatedStrings.NoRevision), resetType);
+            => new(commands, revision ?? throw new NotSupportedException(TranslatedStrings.NoRevision), resetType);
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/GitUI/HelperDialogs/FormSelectMultipleBranches.cs
+++ b/GitUI/HelperDialogs/FormSelectMultipleBranches.cs
@@ -46,7 +46,7 @@ namespace GitUI.HelperDialogs
 
         public IReadOnlyList<IGitRef> GetSelectedBranches()
         {
-            var branches = new List<IGitRef>();
+            List<IGitRef> branches = new();
 
             foreach (IGitRef head in Branches.CheckedItems)
             {

--- a/GitUI/HelperDialogs/FormStatus.cs
+++ b/GitUI/HelperDialogs/FormStatus.cs
@@ -118,7 +118,7 @@ namespace GitUI.HelperDialogs
 
         public static void ShowErrorDialog(IWin32Window owner, string text, params string[] output)
         {
-            using var form = new FormStatus(commands: null, new EditboxBasedConsoleOutputControl(), useDialogSettings: true);
+            using FormStatus form = new(commands: null, new EditboxBasedConsoleOutputControl(), useDialogSettings: true);
             form.Text = text;
             if (output?.Length > 0)
             {

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -23,7 +23,7 @@ namespace GitUI.Hotkey
 
         #endregion
 
-        private static readonly HashSet<Keys> _usedKeys = new HashSet<Keys>();
+        private static readonly HashSet<Keys> _usedKeys = new();
 
         /// <summary>
         /// Returns whether the hotkey is already assigned.
@@ -35,8 +35,8 @@ namespace GitUI.Hotkey
 
         public static HotkeyCommand[] LoadHotkeys(string name)
         {
-            var settings = new HotkeySettings();
-            var scriptKeys = new HotkeySettings();
+            HotkeySettings settings = new();
+            HotkeySettings scriptKeys = new();
             var allSettings = LoadSettings();
 
             UpdateUsedKeys(allSettings);
@@ -98,8 +98,8 @@ namespace GitUI.Hotkey
             {
                 UpdateUsedKeys(settings);
 
-                var str = new StringBuilder();
-                using var writer = new StringWriter(str);
+                StringBuilder str = new();
+                using StringWriter writer = new(str);
                 Serializer.Serialize(writer, settings);
                 AppSettings.SerializedHotkeys = str.ToString();
             }
@@ -116,7 +116,7 @@ namespace GitUI.Hotkey
                 return;
             }
 
-            var defaultCommands = new Dictionary<string, HotkeyCommand>();
+            Dictionary<string, HotkeyCommand> defaultCommands = new();
 
             FillDictionaryWithCommands();
             AssignHotkeysFromLoaded();
@@ -173,7 +173,7 @@ namespace GitUI.Hotkey
         {
             try
             {
-                using var reader = new StringReader(serializedHotkeys);
+                using StringReader reader = new(serializedHotkeys);
                 return (HotkeySettings[])Serializer.Deserialize(reader);
             }
             catch
@@ -208,7 +208,7 @@ namespace GitUI.Hotkey
 
         public static HotkeySettings[] CreateDefaultSettings()
         {
-            HotkeyCommand Hk(object en, Keys k) => new HotkeyCommand((int)en, en.ToString()) { KeyData = k };
+            HotkeyCommand Hk(object en, Keys k) => new((int)en, en.ToString()) { KeyData = k };
 
             const Keys OpenWithDifftoolHotkey = Keys.F3;
             const Keys OpenWithDifftoolFirstToLocalHotkey = Keys.Alt | Keys.F3;

--- a/GitUI/Hotkey/KeysExtensions.cs
+++ b/GitUI/Hotkey/KeysExtensions.cs
@@ -28,7 +28,7 @@ namespace GitUI.Hotkey
             // Retrieve the modifiers, mask away the rest
             Keys modifier = key & Keys.Modifiers;
 
-            var modifierList = new List<Keys>();
+            List<Keys> modifierList = new();
 
             void AddIfContains(Keys m)
             {

--- a/GitUI/Infrastructure/Telemetry/FormBrowseDiagnosticsReporter.cs
+++ b/GitUI/Infrastructure/Telemetry/FormBrowseDiagnosticsReporter.cs
@@ -15,7 +15,7 @@ namespace GitUI.Infrastructure.Telemetry
 
         public void Report()
         {
-            var properties = new Dictionary<string, string>
+            Dictionary<string, string> properties = new()
                 {
                     // layout
                     { "ShowLeftPanel".FormatKey(), _owner.MainSplitContainer.Panel1Collapsed.ToString() },

--- a/GitUI/Interops/POINT.cs
+++ b/GitUI/Interops/POINT.cs
@@ -13,8 +13,8 @@
                 Y = y;
             }
 
-            public static implicit operator System.Drawing.Point(POINT p) => new System.Drawing.Point(p.X, p.Y);
-            public static implicit operator POINT(System.Drawing.Point p) => new POINT(p.X, p.Y);
+            public static implicit operator System.Drawing.Point(POINT p) => new(p.X, p.Y);
+            public static implicit operator POINT(System.Drawing.Point p) => new(p.X, p.Y);
         }
     }
 }

--- a/GitUI/Interops/RECT.cs
+++ b/GitUI/Interops/RECT.cs
@@ -32,10 +32,10 @@ namespace System
                 => Rectangle.FromLTRB(r.left, r.top, r.right, r.bottom);
 
             public static implicit operator RECT(Rectangle r)
-                => new RECT(r);
+                => new(r);
 
             public Size Size
-                => new Size(right - left, bottom - top);
+                => new(right - left, bottom - top);
         }
 
         /// <summary>

--- a/GitUI/MessageBoxes.cs
+++ b/GitUI/MessageBoxes.cs
@@ -30,7 +30,7 @@ namespace GitUI
         private readonly TranslationString _pageantNotFound = new("Cannot load SSH key. PuTTY is not configured properly.");
 
         private readonly TranslationString _serverHostkeyNotCachedText =
-            new TranslationString("The server's host key is not cached in the registry.\n\nDo you want to trust this host key and then try again?");
+            new("The server's host key is not cached in the registry.\n\nDo you want to trust this host key and then try again?");
 
         private readonly TranslationString _updateSubmodules = new("Update submodules");
         private readonly TranslationString _theRepositorySubmodules = new("Update submodules on checkout?");
@@ -93,7 +93,7 @@ namespace GitUI
 
         public static bool ConfirmUpdateSubmodules(IWin32Window? owner)
         {
-            using var dialog = new Microsoft.WindowsAPICodePack.Dialogs.TaskDialog
+            using Microsoft.WindowsAPICodePack.Dialogs.TaskDialog dialog = new()
             {
                 OwnerWindowHandle = owner?.Handle ?? IntPtr.Zero,
                 Text = Instance._updateSubmodulesToo.Text,

--- a/GitUI/MouseWheelRedirector.cs
+++ b/GitUI/MouseWheelRedirector.cs
@@ -105,8 +105,8 @@ namespace GitUI
                     Y = y;
                 }
 
-                public static implicit operator Point(POINT p) => new Point(p.X, p.Y);
-                public static implicit operator POINT(Point p) => new POINT(p.X, p.Y);
+                public static implicit operator Point(POINT p) => new(p.X, p.Y);
+                public static implicit operator POINT(Point p) => new(p.X, p.Y);
             }
         }
     }

--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -82,7 +82,7 @@ namespace GitUI.NBugReports
             StringBuilder text = new();
             string rootError = Append(text, exception);
 
-            using var taskDialog = new Microsoft.WindowsAPICodePack.Dialogs.TaskDialog
+            using Microsoft.WindowsAPICodePack.Dialogs.TaskDialog taskDialog = new()
             {
                 OwnerWindowHandle = OwnerFormHandle,
                 Icon = TaskDialogStandardIcon.Error,

--- a/GitUI/Script/FormFilePrompt.cs
+++ b/GitUI/Script/FormFilePrompt.cs
@@ -33,7 +33,7 @@ namespace GitUI.Script
         private void btnBrowse_Click(object sender, EventArgs e)
         {
             const string separator = " ";
-            using var browseDialog = new OpenFileDialog
+            using OpenFileDialog browseDialog = new()
             {
                 Multiselect = true,
                 InitialDirectory = ".",

--- a/GitUI/Script/ScriptInfo.cs
+++ b/GitUI/Script/ScriptInfo.cs
@@ -47,7 +47,7 @@
 
             // Get all resources
             System.Resources.ResourceManager rm
-                = new System.Resources.ResourceManager("GitUI.Properties.Images",
+                = new("GitUI.Properties.Images",
                     System.Reflection.Assembly.GetExecutingAssembly());
 
             // return icon

--- a/GitUI/Script/ScriptManager.cs
+++ b/GitUI/Script/ScriptManager.cs
@@ -28,7 +28,7 @@ namespace GitUI.Script
 
             static void FixAmbiguousHotkeyCommandIdentifiers()
             {
-                var ids = new HashSet<int>();
+                HashSet<int> ids = new();
 
                 foreach (var script in _scripts!)
                 {
@@ -71,7 +71,7 @@ namespace GitUI.Script
         {
             try
             {
-                var sw = new StringWriter();
+                StringWriter sw = new();
                 _serializer.Serialize(sw, _scripts);
                 return sw.ToString();
             }
@@ -91,8 +91,8 @@ namespace GitUI.Script
 
             try
             {
-                using var stringReader = new StringReader(xml);
-                using var xmlReader = new XmlTextReader(stringReader);
+                using StringReader stringReader = new(xml);
+                using XmlTextReader xmlReader = new(stringReader);
                 return (BindingList<ScriptInfo>)_serializer.Deserialize(xmlReader);
             }
             catch (Exception ex)
@@ -101,7 +101,7 @@ namespace GitUI.Script
                 return DeserializeFromOldFormat(xml);
             }
 
-            BindingList<ScriptInfo> GetDefaultScripts() => new BindingList<ScriptInfo>
+            BindingList<ScriptInfo> GetDefaultScripts() => new()
             {
                 new ScriptInfo
                 {
@@ -170,7 +170,7 @@ namespace GitUI.Script
                 const string paramSeparator = "<_PARAM_SEPARATOR_>";
                 const string scriptSeparator = "<_SCRIPT_SEPARATOR_>";
 
-                var scripts = new BindingList<ScriptInfo>();
+                BindingList<ScriptInfo> scripts = new();
 
                 if (inputString.Contains(paramSeparator) || inputString.Contains(scriptSeparator))
                 {

--- a/GitUI/Script/ScriptOptionsParser.cs
+++ b/GitUI/Script/ScriptOptionsParser.cs
@@ -99,16 +99,16 @@ namespace GitUI.Script
             GitRevision? currentRevision = null;
 
             IReadOnlyList<GitRevision> allSelectedRevisions = Array.Empty<GitRevision>();
-            var selectedLocalBranches = new List<IGitRef>();
-            var selectedRemoteBranches = new List<IGitRef>();
-            var selectedRemotes = new List<string>();
-            var selectedBranches = new List<IGitRef>();
-            var selectedTags = new List<IGitRef>();
-            var currentLocalBranches = new List<IGitRef>();
-            var currentRemoteBranches = new List<IGitRef>();
+            List<IGitRef> selectedLocalBranches = new();
+            List<IGitRef> selectedRemoteBranches = new();
+            List<string> selectedRemotes = new();
+            List<IGitRef> selectedBranches = new();
+            List<IGitRef> selectedTags = new();
+            List<IGitRef> currentLocalBranches = new();
+            List<IGitRef> currentRemoteBranches = new();
             var currentRemote = "";
-            var currentBranches = new List<IGitRef>();
-            var currentTags = new List<IGitRef>();
+            List<IGitRef> currentBranches = new();
+            List<IGitRef> currentTags = new();
 
             foreach (string option in Options)
             {
@@ -168,7 +168,7 @@ namespace GitUI.Script
                 return string.Empty;
             }
 
-            using var f = new FormQuickGitRefSelector();
+            using FormQuickGitRefSelector f = new();
             f.Location = scriptHostControl?.GetQuickItemSelectorLocation() ?? new System.Drawing.Point();
             f.Init(FormQuickGitRefSelector.Action.Select, items);
             f.ShowDialog();
@@ -177,7 +177,7 @@ namespace GitUI.Script
 
         private static string AskToSpecify(IEnumerable<string> options, IScriptHostControl? scriptHostControl)
         {
-            using var f = new FormQuickStringSelector();
+            using FormQuickStringSelector f = new();
             f.Location = scriptHostControl?.GetQuickItemSelectorLocation() ?? new System.Drawing.Point();
             f.Init(options.ToList());
             f.ShowDialog();
@@ -469,7 +469,7 @@ namespace GitUI.Script
                     break;
 
                 case "UserFiles":
-                    using (FormFilePrompt prompt = new FormFilePrompt())
+                    using (FormFilePrompt prompt = new())
                     {
                         if (prompt.ShowDialog(owner) != DialogResult.OK)
                         {
@@ -546,7 +546,7 @@ namespace GitUI.Script
             return remoteBranchName;
         }
 
-        internal static TestAccessor GetTestAccessor() => new TestAccessor();
+        internal static TestAccessor GetTestAccessor() => new();
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -119,7 +119,7 @@ namespace GitUI.Script
                     {
                         if (string.Equals(plugin.Name, command, StringComparison.CurrentCultureIgnoreCase))
                         {
-                            var eventArgs = new GitUIEventArgs(owner, uiCommands);
+                            GitUIEventArgs eventArgs = new(owner, uiCommands);
                             return new CommandStatus(executed: true, needsGridRefresh: plugin.Execute(eventArgs));
                         }
                     }
@@ -138,7 +138,7 @@ namespace GitUI.Script
                 command = command.Replace(NavigateToPrefix, string.Empty);
                 if (!string.IsNullOrEmpty(command))
                 {
-                    var revisionRef = new Executable(command, module.WorkingDir).GetOutputLines(argument).FirstOrDefault();
+                    string revisionRef = new Executable(command, module.WorkingDir).GetOutputLines(argument).FirstOrDefault();
 
                     if (revisionRef is not null)
                     {

--- a/GitUI/Script/SplitButton.cs
+++ b/GitUI/Script/SplitButton.cs
@@ -316,7 +316,7 @@ namespace GitUI.Script
 
             int internalBorder = BorderSize;
             Rectangle focusRect =
-                new Rectangle(internalBorder - 1,
+                new(internalBorder - 1,
                               internalBorder - 1,
                               bounds.Width - _dropDownRectangle.Width - internalBorder,
                               bounds.Height - (internalBorder * 2) + 2);
@@ -403,7 +403,7 @@ namespace GitUI.Script
 
         private void PaintArrow(Graphics g, Rectangle dropDownRect)
         {
-            var middle = new Point(Convert.ToInt32(dropDownRect.Left + (dropDownRect.Width / 2)), Convert.ToInt32(dropDownRect.Top + (dropDownRect.Height / 2)));
+            Point middle = new(Convert.ToInt32(dropDownRect.Left + (dropDownRect.Width / 2)), Convert.ToInt32(dropDownRect.Top + (dropDownRect.Height / 2)));
 
             // if the width is odd - favor pushing it over one pixel right.
             middle.X += dropDownRect.Width % 2;

--- a/GitUI/Shells/BashShell.cs
+++ b/GitUI/Shells/BashShell.cs
@@ -34,7 +34,7 @@ namespace GitUI.Shells
         {
             try
             {
-                var directoryInfo = new DirectoryInfo(path);
+                DirectoryInfo directoryInfo = new(path);
                 if (directoryInfo.Exists)
                 {
                     string posixPath = "/" + directoryInfo.FullName.ToPosixPath().Remove(1, 1);

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -43,19 +43,19 @@ namespace GitUI.SpellChecker
         private static WordDictionary? _wordDictionary;
 
         private CancellationTokenSource _autoCompleteCancellationTokenSource = new();
-        private readonly List<IAutoCompleteProvider> _autoCompleteProviders = new List<IAutoCompleteProvider>();
+        private readonly List<IAutoCompleteProvider> _autoCompleteProviders = new();
         private AsyncLazy<IEnumerable<AutoCompleteWord>?>? _autoCompleteListTask;
         private bool _autoCompleteWasUserActivated;
         private bool _disableAutoCompleteTriggerOnTextUpdate = true; // only popup on key press
-        private readonly Dictionary<Keys, string> _keysToSendToAutoComplete = new Dictionary<Keys, string>
-                                                                     {
-                                                                             { Keys.Down, "{DOWN}" },
-                                                                             { Keys.Up, "{UP}" },
-                                                                             { Keys.PageUp, "{PGUP}" },
-                                                                             { Keys.PageDown, "{PGDN}" },
-                                                                             { Keys.End, "{END}" },
-                                                                             { Keys.Home, "{HOME}" }
-                                                                     };
+        private readonly Dictionary<Keys, string> _keysToSendToAutoComplete = new()
+        {
+            { Keys.Down, "{DOWN}" },
+            { Keys.Up, "{UP}" },
+            { Keys.PageUp, "{PGUP}" },
+            { Keys.PageDown, "{PGDN}" },
+            { Keys.End, "{END}" },
+            { Keys.Home, "{HOME}" }
+        };
 
         private readonly IWordAtCursorExtractor _wordAtCursorExtractor;
 
@@ -250,7 +250,7 @@ namespace GitUI.SpellChecker
 
         private ToolStripMenuItem AddContextMenuItem(string text, EventHandler eventHandler)
         {
-            var menuItem = new ToolStripMenuItem(text, null, eventHandler);
+            ToolStripMenuItem menuItem = new(text, null, eventHandler);
             SpellCheckContextMenu.Items.Add(menuItem);
             return menuItem;
         }
@@ -264,12 +264,12 @@ namespace GitUI.SpellChecker
         {
             try
             {
-                var dictionaryToolStripMenuItem = new ToolStripMenuItem(_dictionaryText.Text);
+                ToolStripMenuItem dictionaryToolStripMenuItem = new(_dictionaryText.Text);
                 SpellCheckContextMenu.Items.Add(dictionaryToolStripMenuItem);
 
-                var toolStripDropDown = new ContextMenuStrip();
+                ContextMenuStrip toolStripDropDown = new();
 
-                var noDicToolStripMenuItem = new ToolStripMenuItem("None");
+                ToolStripMenuItem noDicToolStripMenuItem = new("None");
                 noDicToolStripMenuItem.Click += DicToolStripMenuItemClick;
 
                 IDetachedSettings detachedSettings = Settings.Detached();
@@ -283,11 +283,11 @@ namespace GitUI.SpellChecker
 
                 foreach (var fileName in Directory.GetFiles(AppSettings.GetDictionaryDir(), "*.dic", SearchOption.TopDirectoryOnly))
                 {
-                    var file = new FileInfo(fileName);
+                    FileInfo file = new(fileName);
 
                     var dic = file.Name.Replace(".dic", "");
 
-                    var dicToolStripMenuItem = new ToolStripMenuItem(dic);
+                    ToolStripMenuItem dicToolStripMenuItem = new(dic);
                     dicToolStripMenuItem.Click += DicToolStripMenuItemClick;
 
                     if (detachedSettings.Dictionary == dic)
@@ -537,7 +537,7 @@ namespace GitUI.SpellChecker
 
             AddContextMenuSeparator();
 
-            var mi = new ToolStripMenuItem(_markIllFormedLinesText.Text)
+            ToolStripMenuItem mi = new(_markIllFormedLinesText.Text)
             {
                 Checked = AppSettings.MarkIllFormedLinesInCommitMsg
             };

--- a/GitUI/SpellChecker/SpellCheckEditControl.cs
+++ b/GitUI/SpellChecker/SpellCheckEditControl.cs
@@ -156,12 +156,12 @@ namespace GitUI.SpellChecker
 
         private void DrawWave(Point start, Point end)
         {
-            using var pen = new Pen(Color.Red, DpiUtil.ScaleX);
+            using Pen pen = new(Color.Red, DpiUtil.ScaleX);
             var waveWidth = DpiUtil.Scale(4);
             var waveHalfWidth = waveWidth >> 1;
             if ((end.X - start.X) > waveWidth)
             {
-                var pl = new List<Point>();
+                List<Point> pl = new();
                 for (var i = start.X; i <= (end.X - waveHalfWidth); i += waveWidth)
                 {
                     pl.Add(new Point(i, start.Y));
@@ -181,7 +181,7 @@ namespace GitUI.SpellChecker
         {
             var col = Color.FromArgb(120, 255, 255, 0);
             var lineHeight = LineHeight();
-            using var pen = new Pen(col, lineHeight);
+            using Pen pen = new(col, lineHeight);
             start.Offset(0, -lineHeight / 2);
             end.Offset(0, -lineHeight / 2);
             _bufferGraphics!.DrawLine(pen, start, end);

--- a/GitUI/SpellChecker/TextBoxHelper.cs
+++ b/GitUI/SpellChecker/TextBoxHelper.cs
@@ -25,13 +25,13 @@ namespace GitUI.SpellChecker
             var lineIndex = NativeMethods.SendMessageW(rtb.Handle, NativeMethods.EM_LINEINDEX, (IntPtr)lineNumber, IntPtr.Zero).ToInt32();
             var lineLength = NativeMethods.SendMessageW(rtb.Handle, NativeMethods.EM_LINELENGTH, (IntPtr)index, IntPtr.Zero).ToInt32();
 
-            var charRange = new NativeMethods.CHARRANGE
+            NativeMethods.CHARRANGE charRange = new()
             {
                 cpMin = lineIndex,
                 cpMax = lineIndex + lineLength
             };
 
-            var rect = new NativeMethods.RECT
+            NativeMethods.RECT rect = new()
             {
                 top = 0,
                 bottom = (int)AnInch,
@@ -39,7 +39,7 @@ namespace GitUI.SpellChecker
                 right = 10000000 ////(int)(rtb.Width * anInch + 20);
             };
 
-            var rectPage = new NativeMethods.RECT
+            NativeMethods.RECT rectPage = new()
             {
                 top = 0,
                 bottom = (int)AnInch,
@@ -50,7 +50,7 @@ namespace GitUI.SpellChecker
             var canvas = Graphics.FromHwnd(rtb.Handle);
             var canvasHdc = canvas.GetHdc();
 
-            var formatRange = new NativeMethods.FORMATRANGE
+            NativeMethods.FORMATRANGE formatRange = new()
             {
                 chrg = charRange,
                 hdc = canvasHdc,

--- a/GitUI/SplitterManager.cs
+++ b/GitUI/SplitterManager.cs
@@ -8,7 +8,7 @@ namespace GitUI
 {
     public sealed class SplitterManager
     {
-        private readonly List<SplitterData> _splitters = new List<SplitterData>();
+        private readonly List<SplitterData> _splitters = new();
         private readonly ISettingsSource _settings;
 
         public SplitterManager(ISettingsSource settings)

--- a/GitUI/Theming/Renderers/ButtonRenderer.cs
+++ b/GitUI/Theming/Renderers/ButtonRenderer.cs
@@ -163,7 +163,7 @@ namespace GitUI.Theming
                     };
                     using (ctx.HighQuality())
                     {
-                        using var checkPen = new Pen(foreColor, DpiUtil.Scale(1.5f));
+                        using Pen checkPen = new(foreColor, DpiUtil.Scale(1.5f));
                         ctx.Graphics.DrawLines(checkPen, points);
                     }
 

--- a/GitUI/Theming/Renderers/ComboBoxRenderer.cs
+++ b/GitUI/Theming/Renderers/ComboBoxRenderer.cs
@@ -203,7 +203,7 @@ namespace GitUI.Theming
 
             using (ctx.HighQuality())
             {
-                using var pen = new Pen(arrowColor, DpiUtil.Scale(2));
+                using Pen pen = new(arrowColor, DpiUtil.Scale(2));
                 ctx.Graphics.DrawLines(pen, arrowPoints);
             }
         }

--- a/GitUI/Theming/Renderers/ListViewRenderer.cs
+++ b/GitUI/Theming/Renderers/ListViewRenderer.cs
@@ -57,7 +57,7 @@ namespace GitUI.Theming
         private int RenderColumnDetail(Context ctx, Rectangle prect)
         {
             int width = Math.Max(1, prect.Width / 2);
-            using var brush = new SolidBrush(Color.FromArgb(32, SystemColors.HotTrack));
+            using SolidBrush brush = new(Color.FromArgb(32, SystemColors.HotTrack));
             ctx.Graphics.FillRectangle(
                 brush,
                 Rectangle.FromLTRB(
@@ -218,7 +218,7 @@ namespace GitUI.Theming
                     ctx.Graphics.FillEllipse(backBrush, prect.Inclusive());
                 }
 
-                using var forePen = new Pen(foreColor, DpiUtil.Scale(2));
+                using Pen forePen = new(foreColor, DpiUtil.Scale(2));
                 ctx.Graphics.DrawLines(forePen, arrowPoints);
             }
         }

--- a/GitUI/Theming/Renderers/ScrollBarRenderer.cs
+++ b/GitUI/Theming/Renderers/ScrollBarRenderer.cs
@@ -32,7 +32,7 @@ namespace GitUI.Theming
         {
             var foreColor = GetArrowButtonForeColor(stateId);
             var arrowPts = GetArrowPolygon(prect, stateId);
-            using var pen = new Pen(foreColor, DpiUtil.Scale(2));
+            using Pen pen = new(foreColor, DpiUtil.Scale(2));
             using (ctx.HighQuality())
             {
                 ctx.Graphics.DrawLines(pen, arrowPts);

--- a/GitUI/Theming/Renderers/SpinRenderer.cs
+++ b/GitUI/Theming/Renderers/SpinRenderer.cs
@@ -110,7 +110,7 @@ namespace GitUI.Theming
             ctx.Graphics.FillRectangle(backBrush, prect);
             using (ctx.HighQuality())
             {
-                using var pen = new Pen(foreColor, DpiUtil.Scale(2));
+                using Pen pen = new(foreColor, DpiUtil.Scale(2));
                 ctx.Graphics.DrawLines(pen, arrowPolygon);
             }
         }

--- a/GitUI/Theming/Renderers/ThemeRenderer.cs
+++ b/GitUI/Theming/Renderers/ThemeRenderer.cs
@@ -23,7 +23,7 @@ namespace GitUI.Theming
         /// </summary>
         public const int Handled = 0;
 
-        private readonly HashSet<IntPtr> _themeDataHandles = new HashSet<IntPtr>();
+        private readonly HashSet<IntPtr> _themeDataHandles = new();
 
         protected abstract string Clsid { get; }
 
@@ -83,7 +83,7 @@ namespace GitUI.Theming
         }
 
         protected Context CreateRenderContext(IntPtr hdc, NativeMethods.RECTCLS? clip) =>
-            new Context(hdc, clip);
+            new(hdc, clip);
 
         protected class Context : IDisposable
         {
@@ -117,7 +117,7 @@ namespace GitUI.Theming
             }
 
             public HighQualityScope HighQuality() =>
-                new HighQualityScope(Graphics);
+                new(Graphics);
 
             public void Dispose()
             {

--- a/GitUI/Theming/ThemeFileReader.cs
+++ b/GitUI/Theming/ThemeFileReader.cs
@@ -14,7 +14,7 @@ namespace GitUI.Theming
 
         public string ReadThemeFile(string themeFileName)
         {
-            var fileInfo = new FileInfo(themeFileName);
+            FileInfo fileInfo = new(themeFileName);
             if (fileInfo.Exists && fileInfo.Length > MaxFileSize)
             {
                 throw new ThemeException($"Theme file size exceeds {MaxFileSize:#,##0} bytes", themeFileName);

--- a/GitUI/Theming/ThemeLoader.cs
+++ b/GitUI/Theming/ThemeLoader.cs
@@ -32,7 +32,7 @@ namespace GitUI.Theming
 
         public Theme LoadTheme(string themeFileName, ThemeId themeId, in IReadOnlyList<string> allowedClasses)
         {
-            var themeColors = new ThemeColors();
+            ThemeColors themeColors = new();
             LoadThemeColors(themeFileName, cssImportChain: new[] { themeFileName }, allowedClasses, themeColors);
             return new Theme(themeColors.AppColors, themeColors.SysColors, themeId);
         }
@@ -182,13 +182,13 @@ namespace GitUI.Theming
         }
 
         private static ThemeException StyleRuleThemeException(StyleRule styleRule, string themePath)
-            => new ThemeException($"Invalid CSS rule '{styleRule.SelectorText}'", themePath);
+            => new($"Invalid CSS rule '{styleRule.SelectorText}'", themePath);
 
         private class ThemeColors
         {
-            public readonly Dictionary<AppColor, Color> AppColors = new Dictionary<AppColor, Color>();
-            public readonly Dictionary<KnownColor, Color> SysColors = new Dictionary<KnownColor, Color>();
-            public readonly Dictionary<string, int> SpecificityByColor = new Dictionary<string, int>();
+            public readonly Dictionary<AppColor, Color> AppColors = new();
+            public readonly Dictionary<KnownColor, Color> SysColors = new();
+            public readonly Dictionary<string, int> SpecificityByColor = new();
         }
     }
 }

--- a/GitUI/Theming/ThemeMigration.cs
+++ b/GitUI/Theming/ThemeMigration.cs
@@ -49,7 +49,7 @@ namespace GitUI.Theming
                 return;
             }
 
-            var migratedTheme = new Theme(
+            Theme migratedTheme = new(
                 Theme.AppColorNames.ToDictionary(name => name, AppSettings.GetColor),
                 new Dictionary<KnownColor, Color>(),
                 _migratedThemeId);

--- a/GitUI/Theming/ThemeModule.cs
+++ b/GitUI/Theming/ThemeModule.cs
@@ -151,7 +151,7 @@ namespace GitUI.Theming
         }
 
         private static ThemeSettings CreateFallbackSettings(Theme invariantTheme) =>
-            new ThemeSettings(Theme.Default, invariantTheme, ThemeVariations.None, useSystemVisualStyle: true);
+            new(Theme.Default, invariantTheme, ThemeVariations.None, useSystemVisualStyle: true);
 
         internal static class TestAccessor
         {

--- a/GitUI/Theming/ThemeRepository.cs
+++ b/GitUI/Theming/ThemeRepository.cs
@@ -79,7 +79,7 @@ namespace GitUI.Theming
                 return Enumerable.Empty<ThemeId>();
             }
 
-            var directory = new DirectoryInfo(_themePathProvider.UserThemesDirectory);
+            DirectoryInfo directory = new(_themePathProvider.UserThemesDirectory);
             return directory.Exists
                 ? directory
                     .EnumerateFiles("*" + _themePathProvider.ThemeExtension, SearchOption.TopDirectoryOnly)

--- a/GitUI/Theming/Win32ThemeHooks.cs
+++ b/GitUI/Theming/Win32ThemeHooks.cs
@@ -39,7 +39,7 @@ namespace GitUI.Theming
 
         internal static ThemeSettings ThemeSettings { private get; set; } = ThemeSettings.Default;
 
-        private static readonly HashSet<NativeListView> InitializingListViews = new HashSet<NativeListView>();
+        private static readonly HashSet<NativeListView> InitializingListViews = new();
         private static ScrollBarRenderer? _scrollBarRenderer;
         private static ListViewRenderer? _listViewRenderer;
         private static HeaderRenderer? _headerRenderer;
@@ -292,7 +292,7 @@ namespace GitUI.Theming
                 var renderer = _renderers.FirstOrDefault(_ => _.Supports(htheme));
                 if (renderer is not null && renderer.ForceUseRenderTextEx)
                 {
-                    NativeMethods.DTTOPTS poptions = new NativeMethods.DTTOPTS
+                    NativeMethods.DTTOPTS poptions = new()
                     {
                         dwSize = Marshal.SizeOf<NativeMethods.DTTOPTS>()
                     };

--- a/GitUI/UserControls/AvatarControl.cs
+++ b/GitUI/UserControls/AvatarControl.cs
@@ -27,7 +27,7 @@ namespace GitUI
 
             foreach (var avatarProvider in EnumHelper.GetValues<AvatarProvider>())
             {
-                var item = new ToolStripMenuItem
+                ToolStripMenuItem item = new()
                 {
                     CheckOnClick = true,
                     Tag = avatarProvider,
@@ -46,7 +46,7 @@ namespace GitUI
 
             foreach (var defaultImageType in EnumHelper.GetValues<AvatarFallbackType>())
             {
-                var item = new ToolStripMenuItem
+                ToolStripMenuItem item = new()
                 {
                     CheckOnClick = true,
                     Tag = defaultImageType,
@@ -121,7 +121,7 @@ namespace GitUI
             await this.SwitchToMainThreadAsync();
 
             // resize our control (I'm not using AutoSize for a reason)
-            var size = new Size(AppSettings.AuthorImageSizeInCommitInfo, AppSettings.AuthorImageSizeInCommitInfo);
+            Size size = new(AppSettings.AuthorImageSizeInCommitInfo, AppSettings.AuthorImageSizeInCommitInfo);
 
             DpiUtil.Scale(ref size);
 

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -263,7 +263,7 @@ namespace GitUI.Blame
             if (rect.Contains(MousePosition))
             {
                 Point p = BlameAuthor.PointToClient(MousePosition);
-                var me = new MouseEventArgs(0, 0, p.X, p.Y, 0);
+                MouseEventArgs me = new(0, 0, p.X, p.Y, 0);
                 BlameAuthor_MouseMove(this, me);
             }
         }
@@ -320,7 +320,7 @@ namespace GitUI.Blame
                 return ("", "", new List<GitBlameEntry>(0));
             }
 
-            var body = new StringBuilder(capacity: 4096);
+            StringBuilder body = new(capacity: 4096);
 
             GitBlameCommit? lastCommit = null;
 
@@ -343,10 +343,10 @@ namespace GitUI.Blame
                                                      .Max();
             var lineLengthEstimate = 25 + _blame.Lines.Max(l => l.Commit.Author?.Length ?? 0) + filePathLengthEstimate;
             var lineLength = Math.Max(80, lineLengthEstimate);
-            var lineBuilder = new StringBuilder(lineLength + 2);
-            var gutter = new StringBuilder(capacity: lineBuilder.Capacity * _blame.Lines.Count);
-            var emptyLine = new string(' ', lineLength);
-            var cacheAvatars = new Dictionary<string, Image?>();
+            StringBuilder lineBuilder = new(lineLength + 2);
+            StringBuilder gutter = new(capacity: lineBuilder.Capacity * _blame.Lines.Count);
+            string emptyLine = new(' ', lineLength);
+            Dictionary<string, Image?> cacheAvatars = new();
             var noAuthorImage = (Image)new Bitmap(Images.User80, avatarSize, avatarSize);
             for (var index = 0; index < _blame.Lines.Count; index++)
             {
@@ -451,7 +451,7 @@ namespace GitUI.Blame
         {
             var mostRecentDate = DateTime.Now.Ticks;
             var artificialOldBoundary = ArtificialOldBoundary;
-            var gitBlameDisplays = new List<GitBlameEntry>(blameLines.Count);
+            List<GitBlameEntry> gitBlameDisplays = new(blameLines.Count);
 
             var lessRecentDate = Math.Min(artificialOldBoundary.Ticks,
                                           blameLines.Select(l => l.Commit.AuthorTime)
@@ -464,7 +464,7 @@ namespace GitUI.Blame
             {
                 var relativeTicks = Math.Max(0, blame.Commit.AuthorTime.Ticks - lessRecentDate);
                 var ageBucketIndex = Math.Min((int)(relativeTicks / intervalSize), AgeBucketGradientColors.Count - 1);
-                var gitBlameDisplay = new GitBlameEntry
+                GitBlameEntry gitBlameDisplay = new()
                 {
                     AgeBucketIndex = ageBucketIndex,
                     AgeBucketColor = AgeBucketGradientColors[ageBucketIndex]
@@ -489,7 +489,7 @@ namespace GitUI.Blame
             }
             else
             {
-                using var frm = new FormCommitDiff(UICommands, _lastBlameLine.Commit.ObjectId);
+                using FormCommitDiff frm = new(UICommands, _lastBlameLine.Commit.ObjectId);
                 frm.ShowDialog(this);
             }
         }
@@ -611,7 +611,7 @@ namespace GitUI.Blame
                 return;
             }
 
-            using var frm = new FormCommitDiff(UICommands, revisionId);
+            using FormCommitDiff frm = new(UICommands, revisionId);
             frm.ShowDialog(this);
         }
 
@@ -624,7 +624,7 @@ namespace GitUI.Blame
                 return;
             }
 
-            using var frm = new FormCommitDiff(UICommands, commit.ObjectId);
+            using FormCommitDiff frm = new(UICommands, commit.ObjectId);
             frm.ShowDialog(this);
         }
 
@@ -640,7 +640,7 @@ namespace GitUI.Blame
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/UserControls/BranchComboBox.cs
+++ b/GitUI/UserControls/BranchComboBox.cs
@@ -80,7 +80,7 @@ namespace GitUI
         {
             Validates.NotNull(_branchesToSelect);
 
-            using var formSelectMultipleBranches = new FormSelectMultipleBranches(_branchesToSelect);
+            using FormSelectMultipleBranches formSelectMultipleBranches = new(_branchesToSelect);
             foreach (var branch in GetSelectedBranches())
             {
                 formSelectMultipleBranches.SelectBranch(branch.Name);

--- a/GitUI/UserControls/BranchSelector.cs
+++ b/GitUI/UserControls/BranchSelector.cs
@@ -76,7 +76,7 @@ namespace GitUI.UserControls
 
             string[] GetContainsRevisionBranches()
             {
-                var result = new HashSet<string>();
+                HashSet<string> result = new();
 
                 if (_containRevisions.Count > 0)
                 {

--- a/GitUI/UserControls/CommitPickerSmallControl.cs
+++ b/GitUI/UserControls/CommitPickerSmallControl.cs
@@ -75,7 +75,7 @@ namespace GitUI.UserControls
 
         private void buttonPickCommit_Click(object sender, EventArgs e)
         {
-            using var chooseForm = new FormChooseCommit(UICommands, SelectedObjectId?.ToString());
+            using FormChooseCommit chooseForm = new(UICommands, SelectedObjectId?.ToString());
             if (chooseForm.ShowDialog(this) == DialogResult.OK && chooseForm.SelectedRevision is not null)
             {
                 SetSelectedCommitHash(chooseForm.SelectedRevision.Guid);

--- a/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
+++ b/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
@@ -93,9 +93,9 @@ namespace GitUI.UserControls
             try
             {
                 var commandLine = new ArgumentBuilder { command.Quote(), arguments }.ToString();
-                var outputProcessor = new ConsoleCommandLineOutputProcessor(commandLine.Length, FireDataReceived);
+                ConsoleCommandLineOutputProcessor outputProcessor = new(commandLine.Length, FireDataReceived);
 
-                var startInfo = new ConEmuStartInfo
+                ConEmuStartInfo startInfo = new()
                 {
                     ConsoleProcessCommandLine = commandLine,
                     IsEchoingConsoleCommandLine = true,

--- a/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -108,7 +108,7 @@ namespace GitUI.UserControls
 
                 // process used to execute external commands
                 var outputEncoding = GitModule.SystemEncoding;
-                var startInfo = new ProcessStartInfo
+                ProcessStartInfo startInfo = new()
                 {
                     UseShellExecute = false,
                     ErrorDialog = false,
@@ -128,7 +128,7 @@ namespace GitUI.UserControls
                     startInfo.EnvironmentVariables.Add(name, value);
                 }
 
-                var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+                Process process = new() { StartInfo = startInfo, EnableRaisingEvents = true };
 
                 process.OutputDataReceived += (sender, args) => FireDataReceived(new TextEventArgs((args.Data ?? "") + '\n'));
                 process.ErrorDataReceived += (sender, args) => FireDataReceived(new TextEventArgs((args.Data ?? "") + '\n'));

--- a/GitUI/UserControls/ExListView.cs
+++ b/GitUI/UserControls/ExListView.cs
@@ -58,7 +58,7 @@ namespace GitUI.UserControls
 
         public ListViewGroupHitInfo? GetGroupHitInfo(Point location)
         {
-            var info = new LVHITTESTINFO
+            LVHITTESTINFO info = new()
             {
                 pt = location
             };
@@ -95,7 +95,7 @@ namespace GitUI.UserControls
         /// </remarks>
         public void SetGroups(IReadOnlyList<ListViewGroup> groups, StringComparer nameComparer)
         {
-            var groupNames = new HashSet<string>(groups.Select(g => g.Name), nameComparer);
+            HashSet<string> groupNames = new(groups.Select(g => g.Name), nameComparer);
 
             BeginGroupInsertion();
 
@@ -253,7 +253,7 @@ namespace GitUI.UserControls
                     return false;
                 }
 
-                var eventArgs = new ListViewGroupMouseEventArgs(button, hitInfo, 1, 0);
+                ListViewGroupMouseEventArgs eventArgs = new(button, hitInfo, 1, 0);
                 if (isDown)
                 {
                     GroupMouseDown?.Invoke(this, eventArgs);
@@ -275,7 +275,7 @@ namespace GitUI.UserControls
                 groupId = Groups.IndexOf(group) - _minGroupInsertionIndex;
             }
 
-            var lvgroup = new LVGROUPW();
+            LVGROUPW lvgroup = new();
             lvgroup.cbSize = (uint)sizeof(LVGROUPW);
             lvgroup.state = state;
             lvgroup.mask = LVGF.STATE;

--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -27,7 +27,7 @@ namespace GitUI
 
             GitModule module = GetModule();
 
-            var fileStatusDescs = new List<FileStatusWithDescription>();
+            List<FileStatusWithDescription> fileStatusDescs = new();
             if (revisions!.Count == 1)
             {
                 if (selectedRev.ParentIds is null || selectedRev.ParentIds.Count == 0)
@@ -159,10 +159,10 @@ namespace GitUI
             var allBaseToB = module.GetDiffFilesWithSubmodulesStatus(baseRevGuid, selectedRev.ObjectId, selectedRev.FirstParentId);
             var allBaseToA = module.GetDiffFilesWithSubmodulesStatus(baseRevGuid, firstRev.ObjectId, firstRev.FirstParentId);
 
-            var comparer = new GitItemStatusNameEqualityComparer();
+            GitItemStatusNameEqualityComparer comparer = new();
             var commonBaseToAandB = allBaseToB.Intersect(allBaseToA, comparer).Except(allAToB, comparer).ToList();
 
-            var revBase = new GitRevision(baseRevGuid);
+            GitRevision revBase = new(baseRevGuid);
             fileStatusDescs.Add(new FileStatusWithDescription(
                 firstRev: revBase,
                 secondRev: selectedRev,
@@ -180,14 +180,14 @@ namespace GitUI
                 statuses: commonBaseToAandB));
 
             // Add rangeDiff as a separate group (range is not the same as diff with artificial commits)
-            var statuses = new List<GitItemStatus> { new GitItemStatus(name: TranslatedStrings.DiffRange) { IsRangeDiff = true } };
+            List<GitItemStatus> statuses = new() { new GitItemStatus(name: TranslatedStrings.DiffRange) { IsRangeDiff = true } };
             var first = firstRev.ObjectId == firstRevHead ? firstRev : new GitRevision(firstRevHead);
             var selected = selectedRev.ObjectId == selectedRevHead ? selectedRev : new GitRevision(selectedRevHead);
             var (baseToFirstCount, baseToSecondCount) = module.GetCommitRangeDiffCount(first.ObjectId, selected.ObjectId);
             const int rangeDiffCommitLimit = 100;
             var desc = $"{TranslatedStrings.DiffRange} {baseToFirstCount ?? rangeDiffCommitLimit}↓ {baseToSecondCount ?? rangeDiffCommitLimit}↑";
 
-            var rangeDiff = new FileStatusWithDescription(
+            FileStatusWithDescription rangeDiff = new(
                 firstRev: first,
                 secondRev: selected,
                 summary: desc,

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -64,7 +64,7 @@ namespace GitUI
         [DefaultValue(false)]
         public bool DisableSubmoduleMenuItemBold { get; set; }
 
-        private readonly Dictionary<string, int> _stateImageIndexDict = new Dictionary<string, int>();
+        private readonly Dictionary<string, int> _stateImageIndexDict = new();
 
         public FileStatusList()
         {
@@ -115,7 +115,7 @@ namespace GitUI
             {
                 const int rowHeight = 18;
 
-                var list = new ImageList
+                ImageList list = new()
                 {
                     ColorDepth = ColorDepth.Depth32Bit,
                     ImageSize = DpiUtil.Scale(new Size(16, rowHeight)), // Scale ImageSize and images scale automatically
@@ -155,7 +155,7 @@ namespace GitUI
                 static Bitmap ScaleHeight(Bitmap input)
                 {
                     Debug.Assert(input.Height < rowHeight, "Can only increase row height");
-                    var scaled = new Bitmap(input.Width, rowHeight, input.PixelFormat);
+                    Bitmap scaled = new(input.Width, rowHeight, input.PixelFormat);
                     using var g = Graphics.FromImage(scaled);
                     g.DrawImageUnscaled(input, 0, (rowHeight - input.Height) / 2);
 
@@ -165,7 +165,7 @@ namespace GitUI
 
             ToolStripMenuItem CreateOpenSubmoduleMenuItem()
             {
-                var item = new ToolStripMenuItem
+                ToolStripMenuItem item = new()
                 {
                     Name = "openSubmoduleMenuItem",
                     Tag = "1",
@@ -178,7 +178,7 @@ namespace GitUI
 
             ToolStripMenuItem CreateOpenInVisualStudioMenuItem()
             {
-                var item = new ToolStripMenuItem
+                ToolStripMenuItem item = new()
                 {
                     Name = "openInVisualStudioMenuItem",
                     Text = TranslatedStrings.OpenInVisualStudio,
@@ -529,7 +529,7 @@ namespace GitUI
 
             ListViewItem? FindPrevItemInGroups()
             {
-                var searchInGroups = new List<ListViewGroup>();
+                List<ListViewGroup> searchInGroups = new();
                 var foundCurrentGroup = false;
                 for (var i = FileStatusListView.Groups.Count - 1; i >= 0; i--)
                 {
@@ -563,7 +563,7 @@ namespace GitUI
 
             ListViewItem? FindNextItemInGroups()
             {
-                var searchInGroups = new List<ListViewGroup>();
+                List<ListViewGroup> searchInGroups = new();
                 var foundCurrentGroup = false;
                 for (var i = 0; i < FileStatusListView.Groups.Count; i++)
                 {
@@ -901,7 +901,7 @@ namespace GitUI
 
             bool hasChanges = GitItemStatusesWithDescription.Any(x => x.Statuses.Count > 0);
 
-            var list = new List<ListViewItem>();
+            List<ListViewItem> list = new();
             foreach (var i in GitItemStatusesWithDescription)
             {
                 ListViewGroup? group = null;
@@ -936,7 +936,7 @@ namespace GitUI
                         continue;
                     }
 
-                    var listItem = new ListViewItem(string.Empty, group);
+                    ListViewItem listItem = new(string.Empty, group);
 
                     if (!item.IsStatusOnly || !string.IsNullOrWhiteSpace(item.ErrorMessage))
                     {
@@ -1099,7 +1099,7 @@ namespace GitUI
 
             int GetWidth()
             {
-                var pathFormatter = new PathFormatter(FileStatusListView.CreateGraphics(), FileStatusListView.Font);
+                PathFormatter pathFormatter = new(FileStatusListView.CreateGraphics(), FileStatusListView.Font);
                 var controlWidth = FileStatusListView.ClientSize.Width;
 
                 var contentWidth = FileStatusListView.Items()
@@ -1268,7 +1268,7 @@ namespace GitUI
                     Name = separatorKey,
                     Visible = mayBeMultipleRevs
                 });
-                var showAllDiferencesItem = new ToolStripMenuItem(TranslatedStrings.ShowDiffForAllParentsText)
+                ToolStripMenuItem showAllDiferencesItem = new(TranslatedStrings.ShowDiffForAllParentsText)
                 {
                     Checked = AppSettings.ShowDiffForAllParents,
                     ToolTipText = TranslatedStrings.ShowDiffForAllParentsTooltip,
@@ -1323,7 +1323,7 @@ namespace GitUI
         private void FileStatusListView_DrawSubItem(object sender, DrawListViewSubItemEventArgs e)
         {
             var item = e.Item;
-            var formatter = new PathFormatter(e.Graphics, FileStatusListView.Font);
+            PathFormatter formatter = new(e.Graphics, FileStatusListView.Font);
 
             var (image, prefix, text, suffix, prefixTextStartX, _, textMaxWidth) = FormatListViewItem(item, formatter, item.Bounds.Width);
 
@@ -1339,7 +1339,7 @@ namespace GitUI
 
             if (!string.IsNullOrEmpty(text))
             {
-                var textRect = new Rectangle(prefixTextStartX, item.Bounds.Top, textMaxWidth, item.Bounds.Height);
+                Rectangle textRect = new(prefixTextStartX, item.Bounds.Top, textMaxWidth, item.Bounds.Height);
 
                 Color grayTextColor = item.Selected
                     ? ColorHelper.GetHighlightGrayTextColor(
@@ -1457,7 +1457,7 @@ namespace GitUI
             {
                 if (SelectedItems.Any())
                 {
-                    var fileList = new StringCollection();
+                    StringCollection fileList = new();
 
                     foreach (FileStatusItem item in SelectedItems)
                     {
@@ -1469,7 +1469,7 @@ namespace GitUI
                         }
                     }
 
-                    var obj = new DataObject();
+                    DataObject obj = new();
                     obj.SetFileDropList(fileList);
 
                     // Proceed with the drag and drop, passing in the list item.
@@ -1484,7 +1484,7 @@ namespace GitUI
                 ListViewItem? hoveredItem;
                 try
                 {
-                    var point = new Point(e.X, e.Y);
+                    Point point = new(e.X, e.Y);
                     hoveredItem = listView.HitTest(point).Item;
                 }
                 catch (ArgumentOutOfRangeException)
@@ -1552,7 +1552,7 @@ namespace GitUI
         #region Filtering
 
         private string _toolTipText = "";
-        private readonly Subject<string> _filterSubject = new Subject<string>();
+        private readonly Subject<string> _filterSubject = new();
         private Regex? _filter;
         private bool _filterVisible = false;
 
@@ -1785,7 +1785,7 @@ namespace GitUI
         private readonly Color _invalidInputColor = Color.FromArgb(0xFF, 0xC8, 0xC8).AdaptBackColor();
         #endregion
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/UserControls/GotoUserManualControl.cs
+++ b/GitUI/UserControls/GotoUserManualControl.cs
@@ -7,7 +7,7 @@ namespace GitUI.UserControls
     public partial class GotoUserManualControl : GitExtensionsControl
     {
         private readonly TranslationString _gotoUserManualControlTooltip =
-            new TranslationString("Read more about this feature at {0}");
+            new("Read more about this feature at {0}");
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public GotoUserManualControl()

--- a/GitUI/UserControls/HelpImageDisplayUserControl.cs
+++ b/GitUI/UserControls/HelpImageDisplayUserControl.cs
@@ -198,8 +198,8 @@ namespace GitUI.Help
 
             // apply size to control
             var form = TopLevelControl as Form;
-            var s = new Size();
-            var ms = new Size();
+            Size s = new();
+            Size ms = new();
             if (form is not null)
             {
                 s = form.Size;

--- a/GitUI/UserControls/InteractiveGitActionControl.cs
+++ b/GitUI/UserControls/InteractiveGitActionControl.cs
@@ -258,7 +258,7 @@ namespace GitUI.UserControls
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/UserControls/MainThreadScheduler.cs
+++ b/GitUI/UserControls/MainThreadScheduler.cs
@@ -13,8 +13,8 @@ namespace GitUI.UserControls
 
         public override IDisposable Schedule<TState>(TState state, TimeSpan dueTime, Func<IScheduler, TState, IDisposable> action)
         {
-            var cancellationDisposable = new CancellationDisposable();
-            var disposable = new SingleAssignmentDisposable();
+            CancellationDisposable cancellationDisposable = new();
+            SingleAssignmentDisposable disposable = new();
             var normalizedTime = Scheduler.Normalize(dueTime);
             var token = cancellationDisposable.Token;
             ThreadHelper.JoinableTaskFactory.RunAsync(

--- a/GitUI/UserControls/NativeTreeViewDoubleClickDecorator.cs
+++ b/GitUI/UserControls/NativeTreeViewDoubleClickDecorator.cs
@@ -42,7 +42,7 @@ namespace GitUI.UserControls
 
             if (doubleClicked)
             {
-                var cancelEventArgs = new CancelEventArgs();
+                CancelEventArgs cancelEventArgs = new();
                 BeforeDoubleClickExpandCollapse?.Invoke(sender, cancelEventArgs);
                 e.Cancel = cancelEventArgs.Cancel;
             }

--- a/GitUI/UserControls/PathFormatter.cs
+++ b/GitUI/UserControls/PathFormatter.cs
@@ -141,7 +141,7 @@ namespace GitUI
 
                 if (truncatePathMethod == TruncatePathMethod.Compact && EnvUtils.RunningOnWindows())
                 {
-                    var result = new StringBuilder(length);
+                    StringBuilder result = new(length);
                     NativeMethods.PathCompactPathEx(result, path, length, 0);
                     return result.ToString();
                 }

--- a/GitUI/UserControls/RemotesComboboxControl.cs
+++ b/GitUI/UserControls/RemotesComboboxControl.cs
@@ -41,7 +41,7 @@ namespace GitUI.UserControls
                 return;
             }
 
-            var remotesManager = new ConfigFileRemoteSettingsManager(() => Module);
+            ConfigFileRemoteSettingsManager remotesManager = new(() => Module);
             comboBoxRemotes.DataSource = remotesManager.LoadRemotes(false).Select(x => x.Name).ToList();
         }
     }

--- a/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
@@ -78,7 +78,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                     .FileAndForget();
             }
 
-            var rect = new Rectangle(
+            Rectangle rect = new(
                 e.CellBounds.Left + padding,
                 e.CellBounds.Top + padding,
                 imageSize,

--- a/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
@@ -89,7 +89,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             {
                 size = DpiUtil.Scale(new Size(8, 8));
 
-                var location = new Point(
+                Point location = new(
                     e.CellBounds.Left + (size.Width / 2),
                     e.CellBounds.Top + ((e.CellBounds.Height - size.Height) / 2));
 

--- a/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
@@ -12,7 +12,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 {
     internal sealed class CommitIdColumnProvider : ColumnProvider
     {
-        private readonly Dictionary<Font, int[]> _widthByLengthByFont = new Dictionary<Font, int[]>(capacity: 4);
+        private readonly Dictionary<Font, int[]> _widthByLengthByFont = new(capacity: 4);
         private readonly RevisionGridControl _grid;
 
         public CommitIdColumnProvider(RevisionGridControl grid)

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -45,9 +45,9 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
         public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {
-            var indicator = new MultilineIndicator(e, revision);
+            MultilineIndicator indicator = new(e, revision);
             var messageBounds = indicator.RemainingCellBounds;
-            var superprojectRefs = new List<IGitRef>();
+            List<IGitRef> superprojectRefs = new();
             var offset = ColumnLeftMargin;
 
             if (_grid.TryGetSuperProjectInfo(out var spi))
@@ -346,7 +346,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             var imageVerticalPadding = DpiUtil.Scale(6);
             var textHorizontalPadding = DpiUtil.Scale(4);
             var imageSize = e.CellBounds.Height - imageVerticalPadding - imageVerticalPadding;
-            var imageRect = new Rectangle(
+            Rectangle imageRect = new(
                 messageBounds.Left + offset,
                 e.CellBounds.Top + imageVerticalPadding,
                 imageSize,

--- a/GitUI/UserControls/RevisionGrid/Columns/MultilineIndicator.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MultilineIndicator.cs
@@ -59,7 +59,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 return;
             }
 
-            var indicatorRect = new Rectangle(
+            Rectangle indicatorRect = new(
                 _e.CellBounds.Right - marginX - _indicatorRectWidth,
                 _e.CellBounds.Y + ((_e.CellBounds.Height - _indicatorRectHeight) / 2),
                 _indicatorRectWidth,

--- a/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
@@ -60,7 +60,7 @@ namespace GitUI.UserControls.RevisionGrid
                 displayText = PrependItemNumber(displayText);
             }
 
-            var item = new ToolStripMenuItem
+            ToolStripMenuItem item = new()
             {
                 Text = displayText.TrimEnd('\r', '\n'),
                 ShowShortcutKeys = true,
@@ -102,11 +102,11 @@ namespace GitUI.UserControls.RevisionGrid
 
             DropDownItems.Clear();
 
-            List<string> branchNames = new List<string>();
-            List<string> tagNames = new List<string>();
+            List<string> branchNames = new();
+            List<string> tagNames = new();
             foreach (var revision in revisions)
             {
-                var refLists = new GitRefListsForRevision(revision);
+                GitRefListsForRevision refLists = new(revision);
                 branchNames.AddRange(refLists.GetAllBranchNames());
                 tagNames.AddRange(refLists.GetAllTagNames());
             }
@@ -116,7 +116,7 @@ namespace GitUI.UserControls.RevisionGrid
             // Add items for branches
             if (branchNames.Any())
             {
-                var caption = new ToolStripMenuItem { Text = TranslatedStrings.Branches };
+                ToolStripMenuItem caption = new() { Text = TranslatedStrings.Branches };
                 MenuUtil.SetAsCaptionMenuItem(caption, Owner);
                 DropDownItems.Add(caption);
 
@@ -131,7 +131,7 @@ namespace GitUI.UserControls.RevisionGrid
             // Add items for tags
             if (tagNames.Any())
             {
-                var caption = new ToolStripMenuItem { Text = TranslatedStrings.Tags };
+                ToolStripMenuItem caption = new() { Text = TranslatedStrings.Tags };
                 MenuUtil.SetAsCaptionMenuItem(caption, Owner);
                 DropDownItems.Add(caption);
 

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -84,7 +84,7 @@ namespace GitUI.UserControls.RevisionGrid
                 _NO_TRANSLATE_Limit.Value = AppSettings.MaxRevisionGraphCommits;
             }
 
-            var filter = new ArgumentBuilder();
+            ArgumentBuilder filter = new();
 
             if (AuthorCheck.Checked && GitVersion.Current.IsRegExStringCmdPassable(Author.Text))
             {

--- a/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
@@ -31,7 +31,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 return NoInfoText.Text;
             }
 
-            var laneInfoText = new StringBuilder();
+            StringBuilder laneInfoText = new();
             if (!node.GitRevision.IsArtificial)
             {
                 if (isAtNode)
@@ -41,7 +41,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
                 laneInfoText.AppendLine(node.GitRevision.Guid);
 
-                var branch = new BranchFinder(node);
+                BranchFinder branch = new(node);
                 if (!string.IsNullOrWhiteSpace(branch.CommittedTo))
                 {
                     laneInfoText.AppendFormat("\n{0}: {1}", TranslatedStrings.Branch, branch.CommittedTo);

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -19,7 +19,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         private const int _straightenLanesLookAhead = 20;
 
         // Some unordered collections with raw data
-        private ConcurrentDictionary<ObjectId, RevisionGraphRevision> _nodeByObjectId = new ConcurrentDictionary<ObjectId, RevisionGraphRevision>();
+        private ConcurrentDictionary<ObjectId, RevisionGraphRevision> _nodeByObjectId = new();
         private ImmutableList<RevisionGraphRevision> _nodes = ImmutableList<RevisionGraphRevision>.Empty;
 
         /// <summary>
@@ -457,7 +457,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             }
         }
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
@@ -27,7 +27,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
         internal static Brush NonRelativeBrush { get; }
 
-        internal static readonly List<Brush> PresetGraphBrushes = new List<Brush>();
+        internal static readonly List<Brush> PresetGraphBrushes = new();
 
         static RevisionGraphLaneColor()
         {

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -62,7 +62,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
             int maxScore = Score;
 
-            var stack = new Stack<RevisionGraphRevision>();
+            Stack<RevisionGraphRevision> stack = new();
             stack.Push(this);
             while (stack.Count > 0)
             {
@@ -110,7 +110,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 return;
             }
 
-            var stack = new Stack<RevisionGraphRevision>();
+            Stack<RevisionGraphRevision> stack = new();
             stack.Push(this);
 
             while (stack.Count > 0)

--- a/GitUI/UserControls/RevisionGrid/LoadingControl.cs
+++ b/GitUI/UserControls/RevisionGrid/LoadingControl.cs
@@ -9,7 +9,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         public LoadingControl()
         {
-            var size = new Size(32, 32);
+            Size size = new(32, 32);
 
             _waitSpinner = new WaitSpinner
             {

--- a/GitUI/UserControls/RevisionGrid/NavigationHistory.cs
+++ b/GitUI/UserControls/RevisionGrid/NavigationHistory.cs
@@ -8,11 +8,11 @@ namespace GitUI.UserControls.RevisionGrid
     {
         // history of selected items (browse history)
         // head == currently selected item
-        private readonly Stack<ObjectId> _prevItems = new Stack<ObjectId>();
+        private readonly Stack<ObjectId> _prevItems = new();
 
         // backtracked items
         // head == item to show when navigating forward
-        private readonly Stack<ObjectId> _nextItems = new Stack<ObjectId>();
+        private readonly Stack<ObjectId> _nextItems = new();
 
         /// <summary>
         /// Sets <paramref name="curr"/> as current visible item and resets forward history.

--- a/GitUI/UserControls/RevisionGrid/ParentChildNavigationHistory.cs
+++ b/GitUI/UserControls/RevisionGrid/ParentChildNavigationHistory.cs
@@ -14,8 +14,8 @@ namespace GitUI.UserControls.RevisionGrid
 
         private readonly Action<ObjectId?> _setSelectedRevision;
         private NavigationDirection? _direction;
-        private readonly Stack<ObjectId> _childHistory = new Stack<ObjectId>();
-        private readonly Stack<ObjectId> _parentHistory = new Stack<ObjectId>();
+        private readonly Stack<ObjectId> _childHistory = new();
+        private readonly Stack<ObjectId> _parentHistory = new();
 
         public ParentChildNavigationHistory(Action<ObjectId?> setSelectedRevision)
         {

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -34,10 +34,10 @@ namespace GitUI.UserControls.RevisionGrid
 
         internal RevisionGraph _revisionGraph = new();
 
-        private readonly List<ColumnProvider> _columnProviders = new List<ColumnProvider>();
+        private readonly List<ColumnProvider> _columnProviders = new();
         private readonly CancellationTokenSequence _backgroundCancellationSequence;
         private readonly AsyncQueue<(Func<CancellationToken, Task> backgroundOperation, CancellationToken cancellationToken)> _backgroundQueue =
-            new AsyncQueue<(Func<CancellationToken, Task> backgroundOperation, CancellationToken cancellationToken)>();
+            new();
         private CancellationToken _backgroundCancellationToken;
         private JoinableTask? _backgroundProcessingTask;
         private int _backgroundScrollTo;
@@ -293,7 +293,7 @@ namespace GitUI.UserControls.RevisionGrid
                 var commitBodyForeColor = GetCommitBodyForeground(e.State, e.RowIndex);
 
                 e.Graphics.FillRectangle(backBrush, e.CellBounds);
-                var cellStyle = new CellStyle(backBrush, foreColor, commitBodyForeColor, _normalFont, _boldFont, _monospaceFont);
+                CellStyle cellStyle = new(backBrush, foreColor, commitBodyForeColor, _normalFont, _boldFont, _monospaceFont);
                 provider.OnCellPainting(e, revision, _rowHeight, cellStyle);
 
                 e.Handled = true;
@@ -466,7 +466,7 @@ namespace GitUI.UserControls.RevisionGrid
                     CancellationToken backgroundOperationCancellation;
                     try
                     {
-                        using var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+                        using CancellationTokenSource timeoutTokenSource = new(TimeSpan.FromMilliseconds(200));
                         using var linkedCancellation = timeoutTokenSource.Token.CombineWith(cancellationToken);
                         timeoutToken = timeoutTokenSource.Token;
                         (backgroundOperation, backgroundOperationCancellation) = await _backgroundQueue.DequeueAsync(linkedCancellation.Token);

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -261,7 +261,7 @@ namespace GitUI
 
             _buildServerWatcher = new BuildServerWatcher(this, _gridView, () => Module);
 
-            var gitRevisionSummaryBuilder = new GitRevisionSummaryBuilder();
+            GitRevisionSummaryBuilder gitRevisionSummaryBuilder = new();
             _revisionGraphColumnProvider = new RevisionGraphColumnProvider(this, _gridView._revisionGraph, gitRevisionSummaryBuilder);
             _gridView.AddColumn(_revisionGraphColumnProvider);
             _gridView.AddColumn(new MessageColumnProvider(this, gitRevisionSummaryBuilder));
@@ -404,7 +404,7 @@ namespace GitUI
                 return;
             }
 
-            using var dlg = new FormQuickGitRefSelector();
+            using FormQuickGitRefSelector dlg = new();
             dlg.Init(actionLabel, refs);
             dlg.Location = GetQuickItemSelectorLocation();
             if (dlg.ShowDialog(ParentForm) != DialogResult.OK || dlg.SelectedRef is null)
@@ -715,7 +715,7 @@ namespace GitUI
                 ? string.Empty
                 : revision.ObjectId.ToShortString() + ": ";
 
-            var gitRefListsForRevision = new GitRefListsForRevision(revision);
+            GitRefListsForRevision gitRefListsForRevision = new(revision);
 
             var descriptiveRef = gitRefListsForRevision.AllBranches
                 .Concat(gitRefListsForRevision.AllTags)
@@ -949,7 +949,7 @@ namespace GitUI
                     predicate = null;
                 }
 
-                var revisions = new Subject<GitRevision>();
+                Subject<GitRevision> revisions = new();
                 _revisionSubscription?.Dispose();
                 _revisionSubscription = revisions
                     .ObserveOn(ThreadPoolScheduler.Instance)
@@ -1061,7 +1061,7 @@ namespace GitUI
                     var userEmail = Module.GetEffectiveSetting(SettingKeyString.UserEmail);
 
                     // Add working directory as virtual commit
-                    var workTreeRev = new GitRevision(ObjectId.WorkTreeId)
+                    GitRevision workTreeRev = new(ObjectId.WorkTreeId)
                     {
                         Author = userName,
                         AuthorDate = DateTime.MaxValue,
@@ -1076,7 +1076,7 @@ namespace GitUI
                     _gridView.Add(workTreeRev);
 
                     // Add index as virtual commit
-                    var indexRev = new GitRevision(ObjectId.IndexId)
+                    GitRevision indexRev = new(ObjectId.IndexId)
                     {
                         Author = userName,
                         AuthorDate = DateTime.MaxValue,
@@ -1161,7 +1161,7 @@ namespace GitUI
                 return null;
             }
 
-            var spi = new SuperProjectInfo();
+            SuperProjectInfo spi = new();
             var (code, commit) = await gitModule.GetSuperprojectCurrentCheckoutAsync().ConfigureAwait(false);
             if (code == 'U')
             {
@@ -1288,7 +1288,7 @@ namespace GitUI
 
         private IEnumerable<ObjectId> TryGetParents(ObjectId objectId)
         {
-            var args = new GitArgumentBuilder("rev-list")
+            GitArgumentBuilder args = new("rev-list")
             {
                 { AppSettings.MaxRevisionGraphCommits > 0, $"--max-count={AppSettings.MaxRevisionGraphCommits}" },
                 objectId
@@ -1526,7 +1526,7 @@ namespace GitUI
 
             UICommands.DoActionOnRepo(() =>
             {
-                using var form = new FormCreateTag(UICommands, revision?.ObjectId);
+                using FormCreateTag form = new(UICommands, revision?.ObjectId);
                 return form.ShowDialog(ParentForm) == DialogResult.OK;
             });
         }
@@ -1565,7 +1565,7 @@ namespace GitUI
 
             UICommands.DoActionOnRepo(() =>
             {
-                using var form = new FormCreateBranch(UICommands, revision?.ObjectId);
+                using FormCreateBranch form = new(UICommands, revision?.ObjectId);
                 return form.ShowDialog(ParentForm) == DialogResult.OK;
             });
         }
@@ -1661,14 +1661,14 @@ namespace GitUI
             SetEnabled(stopBisectToolStripMenuItem, inTheMiddleOfBisect);
             SetEnabled(bisectSeparator, inTheMiddleOfBisect);
 
-            var deleteTagDropDown = new ContextMenuStrip();
-            var deleteBranchDropDown = new ContextMenuStrip();
-            var checkoutBranchDropDown = new ContextMenuStrip();
-            var mergeBranchDropDown = new ContextMenuStrip();
-            var renameDropDown = new ContextMenuStrip();
+            ContextMenuStrip deleteTagDropDown = new();
+            ContextMenuStrip deleteBranchDropDown = new();
+            ContextMenuStrip checkoutBranchDropDown = new();
+            ContextMenuStrip mergeBranchDropDown = new();
+            ContextMenuStrip renameDropDown = new();
 
             var revision = LatestSelectedRevision;
-            var gitRefListsForRevision = new GitRefListsForRevision(revision);
+            GitRefListsForRevision gitRefListsForRevision = new(revision);
             _rebaseOnTopOf = null;
 
             foreach (var head in gitRefListsForRevision.AllTags)
@@ -1710,7 +1710,7 @@ namespace GitUI
             // if there is no branch to merge, then let user to merge selected commit into current branch
             if (mergeBranchDropDown.Items.Count == 0 && !currentBranchPointsToRevision)
             {
-                var toolStripItem = new ToolStripMenuItem(revision.Guid);
+                ToolStripMenuItem toolStripItem = new(revision.Guid);
                 toolStripItem.Click += delegate { UICommands.StartMergeBranchDialog(ParentForm, revision.Guid); };
                 mergeBranchDropDown.Items.Add(toolStripItem);
                 _rebaseOnTopOf ??= toolStripItem.Tag as string;
@@ -1857,7 +1857,7 @@ namespace GitUI
 
             ToolStripMenuItem AddBranchMenuItem(ContextMenuStrip menu, IGitRef gitRef, EventHandler action)
             {
-                var menuItem = new ToolStripMenuItem(gitRef.Name)
+                ToolStripMenuItem menuItem = new(gitRef.Name)
                 {
                     Image = gitRef.IsRemote ? Images.BranchRemote : Images.BranchLocal
                 };
@@ -1887,7 +1887,7 @@ namespace GitUI
                 return;
             }
 
-            using var dialog = new Microsoft.WindowsAPICodePack.Dialogs.TaskDialog
+            using Microsoft.WindowsAPICodePack.Dialogs.TaskDialog dialog = new()
             {
                 OwnerWindowHandle = Handle,
                 Text = _areYouSureRebase.Text,
@@ -1926,7 +1926,7 @@ namespace GitUI
                 return;
             }
 
-            using var dialog = new Microsoft.WindowsAPICodePack.Dialogs.TaskDialog
+            using Microsoft.WindowsAPICodePack.Dialogs.TaskDialog dialog = new()
             {
                 OwnerWindowHandle = Handle,
                 Text = _areYouSureRebase.Text,
@@ -2383,7 +2383,7 @@ namespace GitUI
                 return;
             }
 
-            var args = new GitArgumentBuilder("merge-base")
+            GitArgumentBuilder args = new("merge-base")
             {
                 { revisions.Count > 2 || (revisions.Count == 2 && hasArtificial), "--octopus" },
                 { revisions.Count < 1, "HEAD" },
@@ -2475,7 +2475,7 @@ namespace GitUI
                 return;
             }
 
-            using var form = new FormCompareToBranch(UICommands, headCommit.ObjectId);
+            using FormCompareToBranch form = new(UICommands, headCommit.ObjectId);
             if (form.ShowDialog(ParentForm) == DialogResult.OK)
             {
                 Validates.NotNull(form.BranchName);
@@ -2777,7 +2777,7 @@ namespace GitUI
         }
 
         internal TestAccessor GetTestAccessor()
-            => new TestAccessor(this);
+            => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -410,7 +410,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         public void GotoCommitExecute()
         {
-            using var formGoToCommit = new FormGoToCommit(_revisionGrid.UICommands);
+            using FormGoToCommit formGoToCommit = new(_revisionGrid.UICommands);
             if (formGoToCommit.ShowDialog(_revisionGrid) != DialogResult.OK)
             {
                 return;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridRefRenderer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridRefRenderer.cs
@@ -31,7 +31,7 @@ namespace GitUI
             var backgroundHeight = textSize.Height + paddingTopBottom + paddingTopBottom - 1;
             var outerMarginTopBottom = (bounds.Height - backgroundHeight) / 2;
 
-            var rect = new Rectangle(
+            Rectangle rect = new(
                 bounds.X + offset,
                 bounds.Y + outerMarginTopBottom,
                 Math.Min(bounds.Width - offset, textSize.Width + arrowWidth + paddingLeftRight + paddingLeftRight - 1),
@@ -49,7 +49,7 @@ namespace GitUI
                 rect,
                 radius: 3, arrowType, dashedLine);
 
-            var textBounds = new Rectangle(
+            Rectangle textBounds = new(
                 rect.X + arrowWidth + paddingLeftRight,
                 rect.Y + paddingTopBottom - 1,
                 Math.Min(bounds.Width - offset - paddingLeftRight - paddingLeftRight, textSize.Width),
@@ -75,7 +75,7 @@ namespace GitUI
                 }
 
                 // frame
-                using var pen = new Pen(ColorHelper.Lerp(color, SystemColors.Window, 0.5F));
+                using Pen pen = new(ColorHelper.Lerp(color, SystemColors.Window, 0.5F));
                 if (dashedLine)
                 {
                     pen.DashPattern = _dashPattern;
@@ -155,12 +155,12 @@ namespace GitUI
 
             if (filled)
             {
-                using var brush = new SolidBrush(color);
+                using SolidBrush brush = new(color);
                 graphics.FillPolygon(brush, _arrowPoints);
             }
             else
             {
-                using var pen = new Pen(color);
+                using Pen pen = new(color);
                 graphics.DrawPolygon(pen, _arrowPoints);
             }
         }
@@ -172,7 +172,7 @@ namespace GitUI
             var right = left + rect.Width;
             var bottom = top + rect.Height;
 
-            var path = new GraphicsPath();
+            GraphicsPath path = new();
             path.AddArc(left, top, radius, radius, startAngle: 180, sweepAngle: 90);
             path.AddArc(right - radius, top, radius, radius, 270, 90);
             path.AddArc(right - radius, bottom - radius, radius, radius, 0, 90);

--- a/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
@@ -10,7 +10,7 @@ namespace GitUI
     internal sealed class RevisionGridToolTipProvider
     {
         private readonly ToolTip _toolTip = new();
-        private readonly Dictionary<Point, bool> _isTruncatedByCellPos = new Dictionary<Point, bool>();
+        private readonly Dictionary<Point, bool> _isTruncatedByCellPos = new();
         private readonly RevisionDataGridView _gridView;
         private int _previousRowIndex = -1;
         private int _previousColumnIndex = -1;

--- a/GitUI/UserControls/SortDiffListContextMenuItem.cs
+++ b/GitUI/UserControls/SortDiffListContextMenuItem.cs
@@ -81,7 +81,7 @@ namespace GitUI.UserControls
             _sortService.DiffListSorting = sortingType;
         }
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal struct TestAccessor
         {

--- a/GitUI/UserControls/TextBoxEx.cs
+++ b/GitUI/UserControls/TextBoxEx.cs
@@ -74,7 +74,7 @@ namespace GitUI.UserControls
                     var windowDC = NativeMethods.GetWindowDC(Handle);
                     {
                         using var graphics = Graphics.FromHdc(windowDC);
-                        using var pen = new Pen(penColor);
+                        using Pen pen = new(penColor);
 
                         ControlPaint.DrawBorder(graphics, ClientRectangle, penColor, ButtonBorderStyle.Solid);
                     }

--- a/GitUI/UserControls/TreeViewExtensions.cs
+++ b/GitUI/UserControls/TreeViewExtensions.cs
@@ -38,7 +38,7 @@ namespace GitUI.UserControls
         /// </summary>
         public static HashSet<string> GetExpandedNodesState(this TreeNode node)
         {
-            var result = new HashSet<string>();
+            HashSet<string> result = new();
             node.DoGetExpandedNodesState(result);
             return result;
         }

--- a/GitUI/UserEnvironmentInformation.cs
+++ b/GitUI/UserEnvironmentInformation.cs
@@ -54,7 +54,7 @@ namespace GitUI
                 return $"- (minimum: {lastSupportedVersion}, recommended: {recommendedVersion})";
             }
 
-            var actualVersion = new GitVersion(gitVersion);
+            GitVersion actualVersion = new(gitVersion);
             if (actualVersion < lastSupportedVersion)
             {
                 return $"{gitVersion} (minimum: {lastSupportedVersion}, please update!)";

--- a/GitUI/UserManual/SingleHtmlUserManual.cs
+++ b/GitUI/UserManual/SingleHtmlUserManual.cs
@@ -15,7 +15,7 @@ namespace GitUI.UserManual
                 if (_location is null)
                 {
                     var path = Path.Combine(AppSettings.GetInstallDir(), "help");
-                    var uri = new Uri(path);
+                    Uri uri = new(path);
                     _location = uri.AbsolutePath;
                 }
 

--- a/GitUI/WindowPositionManager.cs
+++ b/GitUI/WindowPositionManager.cs
@@ -170,7 +170,7 @@ namespace GitUI
                     }
                 }
 
-                var position = new WindowPosition(rectangle, DpiUtil.DpiX, formWindowState, name);
+                WindowPosition position = new(rectangle, DpiUtil.DpiX, formWindowState, name);
                 _windowPositionList.AddOrUpdate(position);
                 _windowPositionList.Save();
             }

--- a/GitUI/WindowsJumpListManager.cs
+++ b/GitUI/WindowsJumpListManager.cs
@@ -96,7 +96,7 @@ namespace GitUI
                 }
 
                 // sanitise
-                var sb = new StringBuilder(repositoryDescription);
+                StringBuilder sb = new(repositoryDescription);
                 foreach (char c in Path.GetInvalidFileNameChars())
                 {
                     sb.Replace(c, '_');
@@ -220,7 +220,7 @@ namespace GitUI
         /// <returns>An icon!!.</returns>
         private static Icon MakeIcon(Image img, int size, bool keepAspectRatio)
         {
-            var square = new Bitmap(size, size); // create new bitmap
+            Bitmap square = new(size, size); // create new bitmap
             Graphics g = Graphics.FromImage(square); // allow drawing to it
 
             int x, y, w, h; // dimensions for new image

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FileStatusListTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FileStatusListTests.cs
@@ -40,18 +40,18 @@ namespace GitExtensions.UITests.CommandsDialogs
         {
             var accessor = _fileStatusList.GetTestAccessor();
 
-            var itemNotInList = new GitItemStatus(name: "not in list");
-            var item0 = new GitItemStatus(name: "z.0");
-            var item1 = new GitItemStatus(name: "x.1");
-            var item2 = new GitItemStatus(name: "y.2");
-            var items = new List<GitItemStatus> { item0, item1, item2 };
+            GitItemStatus itemNotInList = new(name: "not in list");
+            GitItemStatus item0 = new(name: "z.0");
+            GitItemStatus item1 = new(name: "x.1");
+            GitItemStatus item2 = new(name: "y.2");
+            List<GitItemStatus> items = new() { item0, item1, item2 };
 
             // alphabetical order
             var itemAt0 = item1;
             var itemAt1 = item2;
             var itemAt2 = item0;
-            var firstRev = new GitRevision(ObjectId.Random());
-            var secondRev = new GitRevision(ObjectId.Random());
+            GitRevision firstRev = new(ObjectId.Random());
+            GitRevision secondRev = new(ObjectId.Random());
             _fileStatusList.SetDiffs(firstRev: firstRev, secondRev: secondRev, items: items);
 
             accessor.FileStatusListView.FocusedItem.Index.Should().Be(0);

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.ReorderNodes.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.ReorderNodes.cs
@@ -26,7 +26,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         private bool _originalShowAuthorAvatarColumn;
         private bool _showAvailableDiffTools;
 
-        private List<bool> _originalRepoObjectsTreeShow = new List<bool>();
+        private List<bool> _originalRepoObjectsTreeShow = new();
 
         private GitModuleTestHelper _repo1;
 

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -71,8 +71,8 @@ namespace GitExtensions.UITests.CommandsDialogs
             RunFormTest(
                 form =>
                 {
-                    var tsmiFavouriteRepositories = new ToolStripMenuItem();
-                    var repositoryHistory = new List<Repository>
+                    ToolStripMenuItem tsmiFavouriteRepositories = new();
+                    List<Repository> repositoryHistory = new()
                     {
                         new Repository(@"c:\") { Category = "D" },
                         new Repository(@"c:\") { Category = "A" },

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormEditorTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormEditorTests.cs
@@ -54,7 +54,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                 UITest.RunForm<FormEditor>(
                     () =>
                     {
-                        using var formEditor = new FormEditor(_commands, filePath, showWarning: false);
+                        using FormEditor formEditor = new(_commands, filePath, showWarning: false);
                         formEditor.ShowDialog();
                     },
                     form =>
@@ -104,7 +104,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                 UITest.RunForm<FormEditor>(
                     () =>
                     {
-                        using var formEditor = new FormEditor(_commands, filePath, showWarning: false);
+                        using FormEditor formEditor = new(_commands, filePath, showWarning: false);
                         formEditor.ShowDialog();
                     },
                     form =>

--- a/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
@@ -181,7 +181,7 @@ namespace GitUITests.GitUICommandsTests
         {
             var expectedTab = command.Contains("blame") ? "Blame" : "Diff";
 
-            var args = new System.Collections.Generic.List<string> { "ge.exe", command, "filename" };
+            System.Collections.Generic.List<string> args = new() { "ge.exe", command, "filename" };
             if (commit)
             {
                 args.Add(_referenceRepository.CommitHash);
@@ -210,7 +210,7 @@ namespace GitUITests.GitUICommandsTests
             };
             (bool commitValid, bool filter, bool filterValid) = invalidVariants[invalidVariant];
 
-            var args = new System.Collections.Generic.List<string> { "ge.exe", command, "filename" };
+            System.Collections.Generic.List<string> args = new() { "ge.exe", command, "filename" };
             args.Add(commitValid ? _referenceRepository.CommitHash : "no-commit");
             if (filter)
             {

--- a/IntegrationTests/UI.IntegrationTests/Script/ScriptRunnerTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/Script/ScriptRunnerTests.cs
@@ -130,7 +130,7 @@ namespace GitExtensions.UITests.Script
             _exampleScript.Command = "cmd";
             _exampleScript.Arguments = "/c echo {cHash}";
 
-            var revision = new GitRevision(ObjectId.IndexId);
+            GitRevision revision = new(ObjectId.IndexId);
             _module.GetRevision(shortFormat: true, loadRefs: true).Returns(x => revision);
 
             var result = ScriptRunner.RunScript(null, _module, _keyOfExampleScript, uiCommands: null, revisionGrid: null);

--- a/IntegrationTests/UI.IntegrationTests/UITest.cs
+++ b/IntegrationTests/UI.IntegrationTests/UITest.cs
@@ -12,7 +12,7 @@ namespace GitExtensions.UITests
     {
         public static async Task WaitForIdleAsync()
         {
-            var idleCompletionSource = new TaskCompletionSource<VoidResult>();
+            TaskCompletionSource<VoidResult> idleCompletionSource = new();
             Application.Idle += HandleApplicationIdle;
 
             // Queue an event to make sure we don't stall if the application was already idle
@@ -86,7 +86,7 @@ namespace GitExtensions.UITests
             RunForm<Form>(
                 showForm: () =>
                 {
-                    var form = new Form { Text = $"Test {typeof(T).Name}" };
+                    Form form = new() { Text = $"Test {typeof(T).Name}" };
                     control = createControl(form);
                     Assert.True(form.Controls.Contains(control));
                     Application.Run(form);

--- a/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.cs
@@ -40,7 +40,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
             _gitExecutable = new MockExecutable();
             typeof(GitModule).GetField("_gitExecutable", BindingFlags.Instance | BindingFlags.NonPublic)
                 .SetValue(_commands.Module, _gitExecutable);
-            var cmdRunner = new GitCommandRunner(_gitExecutable, () => GitModule.SystemEncoding);
+            GitCommandRunner cmdRunner = new(_gitExecutable, () => GitModule.SystemEncoding);
             typeof(GitModule).GetField("_gitCommandRunner", BindingFlags.Instance | BindingFlags.NonPublic)
                 .SetValue(_commands.Module, cmdRunner);
         }
@@ -71,7 +71,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
                 _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
                     "refs/remotes/origin/master\nrefs/heads/master\nrefs/heads/warning"); // does not contain "warning:"
 
-                var expected = new Dictionary<string, int>
+                Dictionary<string, int> expected = new()
                 {
                     ["refs/remotes/origin/master"] = 0,
                     ["refs/heads/master"] = 1,
@@ -93,7 +93,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
                 _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
                     "refs/remotes/origin/master\nrefs/heads/master\nrefs/remotes/origin/bugfix/YS-38651-test-twist-changes-r100-on-s375\nrefs/remotes/origin/bugfix/ys-38651-test-twist-changes-r100-on-s375"); // case sensitive duplicates
 
-                var expected = new Dictionary<string, int>
+                Dictionary<string, int> expected = new()
                 {
                     ["refs/remotes/origin/master"] = 0,
                     ["refs/heads/master"] = 1,
@@ -116,7 +116,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
                 _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
                     "refs/remotes/origin/master\nrefs/heads/master\nrefs/tags/v3.1\nrefs/tags/v3.1 \n refs/tags/v3.1"); // have leading and trailing spaces
 
-                var expected = new Dictionary<string, int>
+                Dictionary<string, int> expected = new()
                 {
                     ["refs/remotes/origin/master"] = 0,
                     ["refs/heads/master"] = 1,
@@ -140,7 +140,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
                 _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
                     "refs/remotes/origin/master\nrefs/remotes/foo/duplicate\nrefs/remotes/foo/bar\nrefs/remotes/foo/duplicate\nrefs/remotes/foo/last"); // exact duplicates
 
-                var expected = new Dictionary<string, int>
+                Dictionary<string, int> expected = new()
                 {
                     ["refs/remotes/origin/master"] = 0,
                     ["refs/remotes/foo/duplicate"] = 1,

--- a/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/CopyContextMenuItemTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/CopyContextMenuItemTests.cs
@@ -71,8 +71,8 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
         [Test]
         public void Should_show_info_if_commit_has_defined_branches()
         {
-            var revision = new GitRevision(ObjectId.Random());
-            var refs = new List<IGitRef>
+            GitRevision revision = new(ObjectId.Random());
+            List<IGitRef> refs = new()
             {
                 new GitRef(null, revision.ObjectId, "refs/heads/branch1"),
                 new GitRef(null, revision.ObjectId, "refs/heads/branch2")
@@ -97,8 +97,8 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
         [Test]
         public void Should_show_info_if_commit_has_defined_tags()
         {
-            var revision = new GitRevision(ObjectId.Random());
-            var refs = new List<IGitRef>
+            GitRevision revision = new(ObjectId.Random());
+            List<IGitRef> refs = new()
             {
                 new GitRef(null, revision.ObjectId, "refs/tags/tag1"),
                 new GitRef(null, revision.ObjectId, "refs/tags/tag2")
@@ -123,8 +123,8 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
         [Test]
         public void Should_show_info_if_commit_has_defined_branches_and_tags()
         {
-            var revision = new GitRevision(ObjectId.Random());
-            var refs = new List<IGitRef>
+            GitRevision revision = new(ObjectId.Random());
+            List<IGitRef> refs = new()
             {
                 new GitRef(null, revision.ObjectId, "refs/tags/tag1"),
                 new GitRef(null, revision.ObjectId, "refs/heads/branch1"),
@@ -155,13 +155,13 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
         [Test]
         public void Should_should_show_info_for_multiple_commits()
         {
-            var rev1 = new GitRevision(ObjectId.Random())
+            GitRevision rev1 = new(ObjectId.Random())
             {
                 Author = "Author1",
                 AuthorEmail = "author1@foo.bla",
                 AuthorDate = new DateTime(2018, 10, 23, 11, 34, 21),
             };
-            var rev2 = new GitRevision(ObjectId.Random())
+            GitRevision rev2 = new(ObjectId.Random())
             {
                 Author = "Author2",
                 AuthorEmail = "author2@foo.bla",
@@ -169,7 +169,7 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                 CommitterEmail = "committer2@foo.bar",
                 CommitDate = new DateTime(2018, 10, 23, 11, 34, 21),
             };
-            var rev3 = new GitRevision(ObjectId.Random())
+            GitRevision rev3 = new(ObjectId.Random())
             {
                 Author = "Author3",
                 AuthorEmail = "author3@foo.bla",

--- a/Plugins/AutoCompileSubmodules/AutoCompileSubModulesPlugin.cs
+++ b/Plugins/AutoCompileSubmodules/AutoCompileSubModulesPlugin.cs
@@ -14,9 +14,9 @@ namespace GitExtensions.Plugins.AutoCompileSubmodules
     public class AutoCompileSubModulesPlugin : GitPluginBase, IGitPluginForRepository
     {
         private readonly TranslationString _doYouWantBuild =
-            new TranslationString("Do you want to build {0}?\n\n{1}");
+            new("Do you want to build {0}?\n\n{1}");
         private readonly TranslationString _enterCorrectMsBuildPath =
-            new TranslationString("Please enter correct MSBuild path in the plugin settings dialog and try again.");
+            new("Please enter correct MSBuild path in the plugin settings dialog and try again.");
 
         public AutoCompileSubModulesPlugin() : base(true)
         {
@@ -68,7 +68,7 @@ namespace GitExtensions.Plugins.AutoCompileSubmodules
 
             var msbuildPath = _msBuildPath.ValueOrDefault(Settings);
 
-            var workingDir = new DirectoryInfo(args.GitModule.WorkingDir);
+            DirectoryInfo workingDir = new(args.GitModule.WorkingDir);
             var solutionFiles = workingDir.GetFiles("*.sln", SearchOption.AllDirectories);
 
             for (var n = solutionFiles.Length - 1; n > 0; n--)
@@ -122,7 +122,7 @@ namespace GitExtensions.Plugins.AutoCompileSubmodules
 
         private static string SolutionFilesToString(IReadOnlyList<FileInfo> solutionFiles)
         {
-            var solutionString = new StringBuilder();
+            StringBuilder solutionString = new();
 
             for (var n = solutionFiles.Count - 1; n > 0; n--)
             {

--- a/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
+++ b/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
@@ -33,7 +33,7 @@ namespace GitExtensions.Plugins.BackgroundFetch
             tb.Height = 500;
         });
         private readonly StringSetting _gitCommand = new("Arguments of git command to run", "fetch --all");
-        private readonly NumberSetting<int> _fetchInterval = new NumberSetting<int>("Fetch every (seconds) - set to 0 to disable", 0);
+        private readonly NumberSetting<int> _fetchInterval = new("Fetch every (seconds) - set to 0 to disable", 0);
         private readonly BoolSetting _autoRefresh = new("Refresh view after fetch", false);
         private readonly BoolSetting _fetchAllSubmodules = new("Fetch all submodules", false);
 

--- a/Plugins/Bitbucket/BitbucketPlugin.cs
+++ b/Plugins/Bitbucket/BitbucketPlugin.cs
@@ -39,7 +39,7 @@ namespace GitExtensions.Plugins.Bitbucket
                 return false;
             }
 
-            using var frm = new BitbucketPullRequestForm(settings, args.GitModule);
+            using BitbucketPullRequestForm frm = new(settings, args.GitModule);
             frm.ShowDialog(args.OwnerForm);
 
             return true;

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -27,7 +27,7 @@ namespace GitExtensions.Plugins.Bitbucket
         private readonly string _NO_TRANSLATE_LinkViewPull = "pull-requests";
 
         private readonly Settings? _settings;
-        private readonly BindingList<BitbucketUser> _reviewers = new BindingList<BitbucketUser>();
+        private readonly BindingList<BitbucketUser> _reviewers = new();
 
         public BitbucketPullRequestForm(Settings? settings, IGitModule? module)
         {
@@ -88,8 +88,8 @@ namespace GitExtensions.Plugins.Bitbucket
                 Validates.NotNull(_settings.ProjectKey);
                 Validates.NotNull(_settings.RepoSlug);
 
-                var list = new List<Repository>();
-                var getDefaultRepo = new GetRepoRequest(_settings.ProjectKey, _settings.RepoSlug, _settings);
+                List<Repository> list = new();
+                GetRepoRequest getDefaultRepo = new(_settings.ProjectKey, _settings.RepoSlug, _settings);
                 var defaultRepo = await getDefaultRepo.SendAsync().ConfigureAwait(false);
                 if (defaultRepo.Success)
                 {
@@ -123,8 +123,8 @@ namespace GitExtensions.Plugins.Bitbucket
                 Validates.NotNull(_settings.ProjectKey);
                 Validates.NotNull(_settings.RepoSlug);
 
-                var list = new List<PullRequest>();
-                var getPullRequests = new GetPullRequest(_settings.ProjectKey, _settings.RepoSlug, _settings);
+                List<PullRequest> list = new();
+                GetPullRequest getPullRequests = new(_settings.ProjectKey, _settings.RepoSlug, _settings);
                 var result = await getPullRequests.SendAsync().ConfigureAwait(false);
                 if (result.Success)
                 {
@@ -149,7 +149,7 @@ namespace GitExtensions.Plugins.Bitbucket
                     return;
                 }
 
-                var info = new PullRequestInfo
+                PullRequestInfo info = new()
                 {
                     Title = txtTitle.Text,
                     Description = txtDescription.Text,
@@ -160,7 +160,7 @@ namespace GitExtensions.Plugins.Bitbucket
                     Reviewers = _reviewers
                 };
                 Validates.NotNull(_settings);
-                var pullRequest = new CreatePullRequestRequest(_settings, info);
+                CreatePullRequestRequest pullRequest = new(_settings, info);
                 var response = await pullRequest.SendAsync();
                 await this.SwitchToMainThreadAsync();
                 if (response.Success)
@@ -176,7 +176,7 @@ namespace GitExtensions.Plugins.Bitbucket
             });
         }
 
-        private readonly Dictionary<Repository, IEnumerable<string>> _branches = new Dictionary<Repository, IEnumerable<string>>();
+        private readonly Dictionary<Repository, IEnumerable<string>> _branches = new();
         private async Task<IEnumerable<string>> GetBitbucketBranchesAsync(Repository selectedRepo)
         {
             lock (_branches)
@@ -189,8 +189,8 @@ namespace GitExtensions.Plugins.Bitbucket
 
             Validates.NotNull(_settings);
 
-            var list = new List<string>();
-            var getBranches = new GetBranchesRequest(selectedRepo, _settings);
+            List<string> list = new();
+            GetBranchesRequest getBranches = new(selectedRepo, _settings);
             var result = await getBranches.SendAsync().ConfigureAwait(false);
             if (result.Success)
             {
@@ -275,7 +275,7 @@ namespace GitExtensions.Plugins.Bitbucket
             }
 
             Validates.NotNull(_settings);
-            var getCommit = new GetHeadCommitRequest(repo, branch, _settings);
+            GetHeadCommitRequest getCommit = new(repo, branch, _settings);
             var result = await getCommit.SendAsync().ConfigureAwait(false);
             return result.Success ? result.Result : null;
         }
@@ -306,7 +306,7 @@ namespace GitExtensions.Plugins.Bitbucket
 
             Validates.NotNull(_settings);
 
-            var getCommitsInBetween = new GetInBetweenCommitsRequest(
+            GetInBetweenCommitsRequest getCommitsInBetween = new(
                 (Repository)ddlRepositorySource.SelectedValue,
                 (Repository)ddlRepositoryTarget.SelectedValue,
                 (Commit)ddlBranchSource.Tag,
@@ -320,7 +320,7 @@ namespace GitExtensions.Plugins.Bitbucket
 
                 await this.SwitchToMainThreadAsync();
 
-                var sb = new StringBuilder();
+                StringBuilder sb = new();
                 sb.AppendLine();
                 foreach (var commit in result.Result)
                 {
@@ -358,7 +358,7 @@ namespace GitExtensions.Plugins.Bitbucket
         {
             if (lbxPullRequests.SelectedItem is PullRequest curItem)
             {
-                var mergeInfo = new MergeRequestInfo
+                MergeRequestInfo mergeInfo = new()
                 {
                     Id = curItem.Id,
                     Version = curItem.Version,
@@ -369,7 +369,7 @@ namespace GitExtensions.Plugins.Bitbucket
                 Validates.NotNull(_settings);
 
                 // Merge
-                var mergeRequest = new MergePullRequest(_settings, mergeInfo);
+                MergePullRequest mergeRequest = new(_settings, mergeInfo);
                 var response = ThreadHelper.JoinableTaskFactory.Run(() => mergeRequest.SendAsync());
                 if (response.Success)
                 {
@@ -389,7 +389,7 @@ namespace GitExtensions.Plugins.Bitbucket
         {
             if (lbxPullRequests.SelectedItem is PullRequest curItem)
             {
-                var mergeInfo = new MergeRequestInfo
+                MergeRequestInfo mergeInfo = new()
                 {
                     Id = curItem.Id,
                     Version = curItem.Version,
@@ -400,7 +400,7 @@ namespace GitExtensions.Plugins.Bitbucket
                 Validates.NotNull(_settings);
 
                 // Approve
-                var approveRequest = new ApprovePullRequest(_settings, mergeInfo);
+                ApprovePullRequest approveRequest = new(_settings, mergeInfo);
                 var response = ThreadHelper.JoinableTaskFactory.Run(() => approveRequest.SendAsync());
                 if (response.Success)
                 {

--- a/Plugins/Bitbucket/BitbucketRequestBase.cs
+++ b/Plugins/Bitbucket/BitbucketRequestBase.cs
@@ -37,13 +37,13 @@ namespace GitExtensions.Plugins.Bitbucket
             Validates.NotNull(Settings.Username);
             Validates.NotNull(Settings.Password);
 
-            var client = new RestClient
+            RestClient client = new()
             {
                 BaseUrl = new System.Uri(Settings.BitbucketUrl),
                 Authenticator = new HttpBasicAuthenticator(Settings.Username, Settings.Password)
             };
 
-            var request = new RestRequest(ApiUrl, RequestMethod);
+            RestRequest request = new(ApiUrl, RequestMethod);
             if (RequestBody is not null)
             {
                 request.AddJsonBody(RequestBody);
@@ -90,17 +90,17 @@ namespace GitExtensions.Plugins.Bitbucket
             catch (JsonReaderException)
             {
                 MessageBox.Show(jsonString, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                var errorResponse = new BitbucketResponse<T> { Success = false };
+                BitbucketResponse<T> errorResponse = new() { Success = false };
                 return errorResponse;
             }
 
             if (json["errors"] is not null)
             {
-                var messages = new List<string>();
-                var errorResponse = new BitbucketResponse<T> { Success = false };
+                List<string> messages = new();
+                BitbucketResponse<T> errorResponse = new() { Success = false };
                 foreach (var error in json["errors"])
                 {
-                    var sb = new StringBuilder();
+                    StringBuilder sb = new();
                     sb.AppendLine(error["message"].ToString());
                     if (error["reviewerErrors"] is not null)
                     {

--- a/Plugins/Bitbucket/CreatePullRequestRequest.cs
+++ b/Plugins/Bitbucket/CreatePullRequestRequest.cs
@@ -58,7 +58,7 @@ namespace GitExtensions.Plugins.Bitbucket
             Validates.NotNull(_info.TargetBranch);
             Validates.NotNull(_info.Reviewers);
 
-            var resource = new JObject();
+            JObject resource = new();
             resource["title"] = _info.Title;
             resource["description"] = _info.Description;
 
@@ -70,10 +70,10 @@ namespace GitExtensions.Plugins.Bitbucket
                 _info.TargetRepo.ProjectKey,
                 _info.TargetRepo.RepoName, _info.TargetBranch);
 
-            var reviewers = new JArray();
+            JArray reviewers = new();
             foreach (var reviewer in _info.Reviewers)
             {
-                var r = new JObject();
+                JObject r = new();
                 r["user"] = new JObject();
                 r["user"]["name"] = reviewer.Slug;
 
@@ -87,7 +87,7 @@ namespace GitExtensions.Plugins.Bitbucket
 
         private static JObject CreatePullRequestRef(string projectKey, string repoName, string branchName)
         {
-            var reference = new JObject();
+            JObject reference = new();
             reference["id"] = branchName;
             reference["repository"] = new JObject();
             reference["repository"]["slug"] = repoName;

--- a/Plugins/Bitbucket/GetInBetweenCommitsRequest.cs
+++ b/Plugins/Bitbucket/GetInBetweenCommitsRequest.cs
@@ -32,7 +32,7 @@ namespace GitExtensions.Plugins.Bitbucket
 
         protected override List<Commit> ParseResponse(JObject json)
         {
-            var result = new List<Commit>();
+            List<Commit> result = new();
             foreach (JObject commit in json["values"])
             {
                 result.Add(Commit.Parse(commit));

--- a/Plugins/Bitbucket/GetPullRequest.cs
+++ b/Plugins/Bitbucket/GetPullRequest.cs
@@ -9,7 +9,7 @@ namespace GitExtensions.Plugins.Bitbucket
     {
         public static PullRequest Parse(JObject json)
         {
-            var request = new PullRequest
+            PullRequest request = new()
             {
                 Id = json["id"].ToString(),
                 Version = json["version"].ToString(),
@@ -109,7 +109,7 @@ namespace GitExtensions.Plugins.Bitbucket
 
         protected override List<PullRequest> ParseResponse(JObject json)
         {
-            var result = new List<PullRequest>();
+            List<PullRequest> result = new();
             foreach (JObject val in json["values"])
             {
                 result.Add(PullRequest.Parse(val));

--- a/Plugins/Bitbucket/GetRelatedRepoRequest.cs
+++ b/Plugins/Bitbucket/GetRelatedRepoRequest.cs
@@ -40,7 +40,7 @@ namespace GitExtensions.Plugins.Bitbucket
 
         protected override List<Repository> ParseResponse(JObject json)
         {
-            var result = new List<Repository>();
+            List<Repository> result = new();
             foreach (JObject val in json["values"])
             {
                 result.Add(Repository.Parse(val));

--- a/Plugins/Bitbucket/Settings.cs
+++ b/Plugins/Bitbucket/Settings.cs
@@ -15,7 +15,7 @@ namespace GitExtensions.Plugins.Bitbucket
 
         public static Settings? Parse(IGitModule gitModule, ISettingsSource settings, BitbucketPlugin plugin)
         {
-            var result = new Settings
+            Settings result = new()
             {
                 Username = plugin.BitbucketUsername.ValueOrDefault(settings),
                 Password = plugin.BitbucketPassword.ValueOrDefault(settings),

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -55,7 +55,7 @@ namespace AppVeyorIntegration
 
         private HttpClient? _httpClientAppVeyor;
 
-        private List<AppVeyorBuildInfo>? _allBuilds = new List<AppVeyorBuildInfo>();
+        private List<AppVeyorBuildInfo>? _allBuilds = new();
         private HashSet<ObjectId>? _fetchBuilds;
         private Func<ObjectId, bool>? _isCommitInRevisionGrid;
         private bool _shouldLoadTestResults;
@@ -133,7 +133,7 @@ namespace AppVeyorIntegration
 
             static HttpClient GetHttpClient(string baseUrl, string? accountToken)
             {
-                var httpClient = new HttpClient(new HttpClientHandler { UseDefaultCredentials = true })
+                HttpClient httpClient = new(new HttpClientHandler { UseDefaultCredentials = true })
                 {
                     Timeout = TimeSpan.FromMinutes(2),
                     BaseAddress = new Uri(baseUrl, UriKind.Absolute),
@@ -149,7 +149,7 @@ namespace AppVeyorIntegration
 
             List<AppVeyorBuildInfo> FilterBuilds(IEnumerable<AppVeyorBuildInfo> allBuilds)
             {
-                var filteredBuilds = new List<AppVeyorBuildInfo>();
+                List<AppVeyorBuildInfo> filteredBuilds = new();
                 foreach (var build in allBuilds.OrderByDescending(b => b.StartDate))
                 {
                     Validates.NotNull(build.CommitId);
@@ -203,7 +203,7 @@ namespace AppVeyorIntegration
             var baseWebUrl = $"{WebSiteUrl}/project/{projectId}/build/";
             var baseApiUrl = $"{ApiBaseUrl}{projectId}/";
 
-            var buildDetails = new List<AppVeyorBuildInfo>();
+            List<AppVeyorBuildInfo> buildDetails = new();
             foreach (var b in builds)
             {
                 try

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
@@ -86,7 +86,7 @@ namespace AzureDevOpsIntegration
 
             buildDefinitions = await HttpGetAsync<ListWrapper<BuildDefinition>>(BuildDefinitionsUrl);
 
-            var tfsBuildDefinitionNameFilter = new Regex(buildDefinitionNameFilter, RegexOptions.Compiled);
+            Regex tfsBuildDefinitionNameFilter = new(buildDefinitionNameFilter, RegexOptions.Compiled);
             return GetBuildDefinitionsIds(buildDefinitions.Value.Where(b => tfsBuildDefinitionNameFilter.IsMatch(b.Name)));
         }
 

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
@@ -172,9 +172,9 @@ Detail of the error:");
                         {
                             ProjectOnErrorKey = CacheKey;
 
-                            var btnOpenSettings = new TaskDialogButton("btnOpenSettings", "Open settings");
-                            var btnIgnore = new TaskDialogButton("btnIgnoreError", "Ignore");
-                            using var errorDialog = new TaskDialog
+                            TaskDialogButton btnOpenSettings = new("btnOpenSettings", "Open settings");
+                            TaskDialogButton btnIgnore = new("btnIgnoreError", "Ignore");
+                            using TaskDialog errorDialog = new()
                             {
                                 InstructionText = errorMessage,
                                 Icon = TaskDialogStandardIcon.Error,
@@ -288,7 +288,7 @@ Detail of the error:");
 
             Validates.NotNull(buildDetail.SourceVersion);
 
-            var buildInfo = new BuildInfo
+            BuildInfo buildInfo = new()
             {
                 Id = buildDetail.BuildNumber,
                 StartDate = buildDetail.StartTime ?? DateTime.MinValue,
@@ -322,7 +322,7 @@ Detail of the error:");
         }
 
         #region TestAccessor
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/ProjectUrlHelper.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/ProjectUrlHelper.cs
@@ -11,7 +11,7 @@ namespace AzureDevOpsIntegration.Settings
     /// </summary>
     public class ProjectUrlHelper
     {
-        private static readonly Dictionary<Regex, Func<Match, string>> RemoteToProjectUrlLookup = new Dictionary<Regex, Func<Match, string>>()
+        private static readonly Dictionary<Regex, Func<Match, string>> RemoteToProjectUrlLookup = new()
         {
             { // VS Team Services via HTTPS
                 new Regex(@"^(?<prot>(?:http|https))://(?<user>[^.@]+)(?:@[^.]*)?\.visualstudio\.com(?<port>:\d*)?(?:/DefaultCollection)?(?<project>(/[^/]+)?/[^/]+)/_(git|ssh)/(.+)$"),
@@ -39,7 +39,7 @@ namespace AzureDevOpsIntegration.Settings
             },
         };
 
-        private static readonly Dictionary<Regex, Func<Match, string>> ProjectToTokenManagementUrlLookup = new Dictionary<Regex, Func<Match, string>>()
+        private static readonly Dictionary<Regex, Func<Match, string>> ProjectToTokenManagementUrlLookup = new()
         {
             { // VS Team Services
                 new Regex(@"^(?<instanceurl>(?:http|https)://[^.@]+(?:@[^.]*)?\.visualstudio\.com(?::\d*)?)"),

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.cs
@@ -144,7 +144,7 @@ namespace AzureDevOpsIntegration.Settings
                     {
                         try
                         {
-                            using var apiClient = new ApiClient(projectUrl, _currentSettings.ApiToken);
+                            using ApiClient apiClient = new(projectUrl, _currentSettings.ApiToken);
                             buildDefinitionName = await apiClient.GetBuildDefinitionNameFromIdAsync(buildId) ?? "";
                         }
                         catch (Exception)

--- a/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
+++ b/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
@@ -58,7 +58,7 @@ namespace JenkinsIntegration
         private HttpClient? _httpClient;
 
         // last known build per project
-        private readonly Dictionary<string, long> _lastProjectBuildTime = new Dictionary<string, long>();
+        private readonly Dictionary<string, long> _lastProjectBuildTime = new();
         private Regex? _ignoreBuilds;
 
         public void Initialize(IBuildServerWatcher buildServerWatcher, ISettingsSource config, Action openSettings, Func<ObjectId, bool>? isCommitInRevisionGrid = null)
@@ -212,8 +212,8 @@ namespace JenkinsIntegration
         {
             try
             {
-                var allBuildInfos = new List<JoinableTask<ResponseInfo>>();
-                var latestBuildInfos = new List<JoinableTask<ResponseInfo>>();
+                List<JoinableTask<ResponseInfo>> allBuildInfos = new();
+                List<JoinableTask<ResponseInfo>> latestBuildInfos = new();
 
                 foreach (var projectUrl in _lastProjectBuildTime.Keys)
                 {
@@ -252,7 +252,7 @@ namespace JenkinsIntegration
                     return;
                 }
 
-                var builds = new Dictionary<ObjectId, BuildInfo.BuildStatus>();
+                Dictionary<ObjectId, BuildInfo.BuildStatus> builds = new();
                 foreach (var build in allBuildInfos)
                 {
                     if (build.Task.IsFaulted)
@@ -387,7 +387,7 @@ namespace JenkinsIntegration
             var webUrl = buildDescription["url"].ToObject<string>();
 
             var action = buildDescription["actions"];
-            var commitHashList = new List<ObjectId>();
+            List<ObjectId> commitHashList = new();
             string testResults = string.Empty;
             foreach (var element in action)
             {
@@ -442,7 +442,7 @@ namespace JenkinsIntegration
 
             var status = isRunning ? BuildInfo.BuildStatus.InProgress : ParseBuildStatus(statusValue);
             var statusText = status.ToString("G");
-            var buildInfo = new BuildInfo
+            BuildInfo buildInfo = new()
             {
                 Id = idValue,
                 StartDate = TimestampToDateTime(startDateTicks),
@@ -558,7 +558,7 @@ namespace JenkinsIntegration
         private async Task<string> GetResponseAsync(string relativePath, CancellationToken cancellationToken)
         {
             using var responseStream = await GetStreamAsync(relativePath, cancellationToken).ConfigureAwait(false);
-            using var reader = new StreamReader(responseStream);
+            using StreamReader reader = new(responseStream);
             return await reader.ReadToEndAsync();
         }
 

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCityBuildChooser.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCityBuildChooser.cs
@@ -58,7 +58,7 @@ namespace TeamCityIntegration.Settings
 
         private TreeNode ConvertProjectInTreeNode(Project project)
         {
-            var projectNode = new TreeNode(project.Name)
+            TreeNode projectNode = new(project.Name)
             {
                 Name = project.Name,
                 Tag = project,

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.cs
@@ -68,7 +68,7 @@ namespace TeamCityIntegration.Settings
         {
             try
             {
-                var teamCityBuildChooser = new TeamCityBuildChooser(TeamCityServerUrl.Text, TeamCityProjectName.Text, TeamCityBuildIdFilter.Text);
+                TeamCityBuildChooser teamCityBuildChooser = new(TeamCityServerUrl.Text, TeamCityProjectName.Text, TeamCityBuildIdFilter.Text);
                 var result = teamCityBuildChooser.ShowDialog(this);
 
                 if (result == DialogResult.OK)
@@ -98,7 +98,7 @@ namespace TeamCityIntegration.Settings
         {
             if (Clipboard.ContainsText() && Clipboard.GetText().Contains("buildTypeId="))
             {
-                var buildUri = new Uri(Clipboard.GetText());
+                Uri buildUri = new(Clipboard.GetText());
                 var teamCityServerUrl = buildUri.Scheme + "://" + buildUri.Authority;
                 TeamCityServerUrl.Text = teamCityServerUrl;
                 _teamCityAdapter.InitializeHttpClient(teamCityServerUrl);

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
@@ -63,7 +63,7 @@ namespace TeamCityIntegration
 
         private string? _httpClientHostSuffix;
 
-        private readonly List<JoinableTask<IEnumerable<string>>> _getBuildTypesTask = new List<JoinableTask<IEnumerable<string>>>();
+        private readonly List<JoinableTask<IEnumerable<string>>> _getBuildTypesTask = new();
 
         private CookieContainer? _teamCityNtlmAuthCookie;
 
@@ -81,7 +81,7 @@ namespace TeamCityIntegration
             }
 
             string url = serverUrl + "ntlmLogin.html";
-            var cookieContainer = new CookieContainer();
+            CookieContainer cookieContainer = new();
             var request = (HttpWebRequest)WebRequest.Create(url);
             request.CookieContainer = cookieContainer;
 
@@ -250,7 +250,7 @@ namespace TeamCityIntegration
 
         private void NotifyObserverOfBuilds(string[] buildIds, IObserver<BuildInfo> observer, CancellationToken cancellationToken)
         {
-            var tasks = new List<Task>(8);
+            List<Task> tasks = new(8);
             var buildsLeft = buildIds.Length;
 
             foreach (var buildId in buildIds.OrderByDescending(int.Parse))
@@ -338,7 +338,7 @@ namespace TeamCityIntegration
                 statusText = currentStageText;
             }
 
-            var buildInfo = new BuildInfo
+            BuildInfo buildInfo = new()
             {
                 Id = idValue,
                 StartDate = DecodeJsonDateTime(startDateText),
@@ -522,7 +522,7 @@ namespace TeamCityIntegration
 
         private Task<XDocument> GetFilteredBuildsXmlResponseAsync(string buildTypeId, CancellationToken cancellationToken, DateTime? sinceDate = null, bool? running = null)
         {
-            var values = new List<string> { "branch:(default:any)" };
+            List<string> values = new() { "branch:(default:any)" };
 
             if (sinceDate.HasValue)
             {

--- a/Plugins/CreateLocalBranches/CreateLocalBranchesForm.cs
+++ b/Plugins/CreateLocalBranches/CreateLocalBranchesForm.cs
@@ -20,7 +20,7 @@ namespace GitExtensions.Plugins.CreateLocalBranches
 
         private void button1_Click(object sender, EventArgs e)
         {
-            var args = new GitArgumentBuilder("branch") { "-a" };
+            GitArgumentBuilder args = new("branch") { "-a" };
             string[] references = _gitUiCommands.GitModule.GitExecutable.GetOutput(args)
                 .Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
 

--- a/Plugins/CreateLocalBranches/CreateLocalBranchesPlugin.cs
+++ b/Plugins/CreateLocalBranches/CreateLocalBranchesPlugin.cs
@@ -19,7 +19,7 @@ namespace GitExtensions.Plugins.CreateLocalBranches
 
         public override bool Execute(GitUIEventArgs args)
         {
-            using var frm = new CreateLocalBranchesForm(args);
+            using CreateLocalBranchesForm frm = new(args);
             frm.ShowDialog(args.OwnerForm);
 
             return true;

--- a/Plugins/DeleteUnusedBranches/DataGridViewCheckBoxHeaderCell.cs
+++ b/Plugins/DeleteUnusedBranches/DataGridViewCheckBoxHeaderCell.cs
@@ -42,7 +42,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
                 formattedValue, errorText, cellStyle,
                 advancedBorderStyle, paintParts);
 
-            var p = new Point();
+            Point p = new();
             Size s = CheckBoxRenderer.GetGlyphSize(graphics, CheckBoxState.UncheckedNormal);
             p.X = cellBounds.Location.X + (cellBounds.Width / 2) - (s.Width / 2);
             p.Y = cellBounds.Location.Y + (cellBounds.Height / 2) - (s.Height / 2);
@@ -65,7 +65,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
 
         protected override void OnMouseClick(DataGridViewCellMouseEventArgs e)
         {
-            var p = new Point(e.X + _cellLocation.X, e.Y + _cellLocation.Y);
+            Point p = new(e.X + _cellLocation.X, e.Y + _cellLocation.Y);
             if (p.X >= _checkBoxLocation.X &&
                 p.X <= _checkBoxLocation.X + _checkBoxSize.Width &&
                 p.Y >= _checkBoxLocation.Y &&

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -98,7 +98,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
             {
                 context.CancellationToken.ThrowIfCancellationRequested();
 
-                var args = new GitArgumentBuilder("log")
+                GitArgumentBuilder args = new("log")
                 {
                     "--pretty=%ci\n%an\n%s",
                     $"{branchName}^1..{branchName}"
@@ -128,7 +128,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
             var regex = string.IsNullOrEmpty(context.RegexFilter) ? null : new Regex(context.RegexFilter, options);
             bool regexMustMatch = !context.RegexDoesNotMatch;
 
-            var args = new GitArgumentBuilder("branch")
+            GitArgumentBuilder args = new("branch")
             {
                  "--list",
                  { context.IncludeRemotes, "-r" },
@@ -192,7 +192,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
                 {
                     // Delete branches one by one, because it is possible one fails
                     var remoteBranchNameOffset = remoteBranchPrefix.Length;
-                    var args = new GitArgumentBuilder("push")
+                    GitArgumentBuilder args = new("push")
                     {
                         remoteName,
                         $":{remoteBranch.Name.Substring(remoteBranchNameOffset)}"
@@ -202,7 +202,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
 
                 foreach (var localBranch in localBranches)
                 {
-                    var args = new GitArgumentBuilder("branch")
+                    GitArgumentBuilder args = new("branch")
                     {
                         "-d",
                         localBranch.Name
@@ -297,7 +297,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
 
             IsRefreshing = true;
             var curBranch = _gitUiCommands.GitModule.GetSelectedBranch();
-            var context = new RefreshContext(
+            RefreshContext context = new(
                 _gitCommands,
                 IncludeRemoteBranches.Checked,
                 includeUnmergedBranches.Checked,

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesPlugin.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesPlugin.cs
@@ -18,7 +18,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
         }
 
         private readonly StringSetting _mergedInBranch = new("Branch where all branches should be merged in", "HEAD");
-        private readonly NumberSetting<int> _daysOlderThan = new NumberSetting<int>("Delete obsolete branches older than (days)", 30);
+        private readonly NumberSetting<int> _daysOlderThan = new("Delete obsolete branches older than (days)", 30);
         private readonly BoolSetting _deleteRemoteBranchesFromFlag = new("Delete obsolete branches from remote", false);
         private readonly StringSetting _remoteName = new("Remote name obsoleted branches should be deleted from", "origin");
         private readonly BoolSetting _useRegexToFilterBranchesFlag = new("Use regex to filter branches to delete", false);
@@ -42,7 +42,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
 
         public override bool Execute(GitUIEventArgs args)
         {
-            var settings = new DeleteUnusedBranchesFormSettings(
+            DeleteUnusedBranchesFormSettings settings = new(
                 _daysOlderThan.ValueOrDefault(Settings),
                 _mergedInBranch.ValueOrDefault(Settings),
                 _deleteRemoteBranchesFromFlag.ValueOrDefault(Settings),
@@ -53,7 +53,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
                 _regexInvertedFlag.ValueOrDefault(Settings),
                 _includeUnmergedBranchesFlag.ValueOrDefault(Settings));
 
-            using var frm = new DeleteUnusedBranchesForm(settings, args.GitModule, args.GitUICommands, this);
+            using DeleteUnusedBranchesForm frm = new(settings, args.GitModule, args.GitUICommands, this);
             frm.ShowDialog(args.OwnerForm);
 
             return true;

--- a/Plugins/DeleteUnusedBranches/SortableBranchesList.cs
+++ b/Plugins/DeleteUnusedBranches/SortableBranchesList.cs
@@ -27,7 +27,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
 
         private static class BranchesComparer
         {
-            private static readonly Dictionary<string, Comparison<Branch>> PropertyComparers = new Dictionary<string, Comparison<Branch>>();
+            private static readonly Dictionary<string, Comparison<Branch>> PropertyComparers = new();
 
             static BranchesComparer()
             {

--- a/Plugins/FindLargeFiles/FindLargeFilesForm.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesForm.cs
@@ -23,7 +23,7 @@ namespace GitExtensions.Plugins.FindLargeFiles
         private readonly GitUIEventArgs _gitUiCommands;
         private readonly IGitModule _gitCommands;
         private string[] _revList = Array.Empty<string>();
-        private readonly Dictionary<string, GitObject> _list = new Dictionary<string, GitObject>();
+        private readonly Dictionary<string, GitObject> _list = new();
         private readonly SortableObjectsList _gitObjects = new();
 
         public FindLargeFilesForm(float threshold, GitUIEventArgs gitUiEventArgs)
@@ -55,14 +55,14 @@ namespace GitExtensions.Plugins.FindLargeFiles
             try
             {
                 var data = GetLargeFiles(_threshold);
-                Dictionary<string, DateTime> revData = new Dictionary<string, DateTime>();
+                Dictionary<string, DateTime> revData = new();
                 foreach (var d in data)
                 {
                     string commit = d.Commit.First();
                     DateTime date;
                     if (!revData.ContainsKey(commit))
                     {
-                        var args = new GitArgumentBuilder("show")
+                        GitArgumentBuilder args = new("show")
                         {
                             "-s",
                             commit,
@@ -109,7 +109,7 @@ namespace GitExtensions.Plugins.FindLargeFiles
                     var packFiles = Directory.GetFiles(objectsPackDirectory, "pack-*.idx");
                     foreach (var pack in packFiles)
                     {
-                        var args = new GitArgumentBuilder("verify-pack")
+                        GitArgumentBuilder args = new("verify-pack")
                         {
                             "-v",
                             pack
@@ -160,11 +160,11 @@ namespace GitExtensions.Plugins.FindLargeFiles
         {
             base.OnLoad(e);
 
-            var args = new GitArgumentBuilder("rev-list") { "HEAD" };
+            GitArgumentBuilder args = new("rev-list") { "HEAD" };
             _revList = _gitCommands.GitExecutable.GetOutput(args).Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
             pbRevisions.Maximum = (int)(_revList.Length * 1.1f);
             BranchesGrid.DataSource = _gitObjects;
-            var thread = new Thread(FindLargeFilesFunction);
+            Thread thread = new(FindLargeFilesFunction);
             thread.Start();
         }
 
@@ -179,7 +179,7 @@ namespace GitExtensions.Plugins.FindLargeFiles
                     pbRevisions.Value = i;
                 });
                 string rev = _revList[i];
-                var args = new GitArgumentBuilder("ls-tree")
+                GitArgumentBuilder args = new("ls-tree")
                 {
                     "-zrl",
                     rev
@@ -206,7 +206,7 @@ namespace GitExtensions.Plugins.FindLargeFiles
         {
             if (MessageBox.Show(this, _areYouSureToDelete.Text, _deleteCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
             {
-                var sb = new StringBuilder();
+                StringBuilder sb = new();
                 foreach (GitObject gitObject in _gitObjects.Where(gitObject => gitObject.Delete))
                 {
                     sb.AppendLine(string.Format("\"{0}\" filter-branch --index-filter \"git rm -r -f --cached --ignore-unmatch {1}\" --prune-empty -- --all",

--- a/Plugins/FindLargeFiles/FindLargeFilesPlugin.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesPlugin.cs
@@ -18,7 +18,7 @@ namespace GitExtensions.Plugins.FindLargeFiles
             Icon = Resources.IconFindLargeFiles;
         }
 
-        private readonly NumberSetting<float> _sizeLargeFile = new NumberSetting<float>("Find large files bigger than (Mb)", 1);
+        private readonly NumberSetting<float> _sizeLargeFile = new("Find large files bigger than (Mb)", 1);
 
         public override IEnumerable<ISetting> GetSettings()
         {
@@ -28,7 +28,7 @@ namespace GitExtensions.Plugins.FindLargeFiles
 
         public override bool Execute(GitUIEventArgs args)
         {
-            using var frm = new FindLargeFilesForm(_sizeLargeFile.ValueOrDefault(Settings), args);
+            using FindLargeFilesForm frm = new(_sizeLargeFile.ValueOrDefault(Settings), args);
             frm.ShowDialog(args.OwnerForm);
 
             return true;

--- a/Plugins/FindLargeFiles/SortableObjectsList.cs
+++ b/Plugins/FindLargeFiles/SortableObjectsList.cs
@@ -27,7 +27,7 @@ namespace GitExtensions.Plugins.FindLargeFiles
 
         private static class GitObjectsComparer
         {
-            private static readonly Dictionary<string, Comparison<GitObject>> PropertyComparers = new Dictionary<string, Comparison<GitObject>>();
+            private static readonly Dictionary<string, Comparison<GitObject>> PropertyComparers = new();
 
             static GitObjectsComparer()
             {

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -48,7 +48,7 @@ namespace GitExtensions.Plugins.GitFlow
         {
             get
             {
-                var args = new GitArgumentBuilder("config")
+                GitArgumentBuilder args = new("config")
                 {
                     "--get",
                     "gitflow.branch.master"
@@ -87,7 +87,7 @@ namespace GitExtensions.Plugins.GitFlow
                 btnPull.Enabled = btnPublish.Enabled = remotes.Any();
 
                 cbType.DataSource = BranchTypes;
-                var types = new List<string> { string.Empty };
+                List<string> types = new() { string.Empty };
                 types.AddRange(BranchTypes);
                 cbManageType.DataSource = types;
 
@@ -146,7 +146,7 @@ namespace GitExtensions.Plugins.GitFlow
 
         private IReadOnlyList<string> GetBranches(string typeBranch)
         {
-            var args = new GitArgumentBuilder("flow") { typeBranch };
+            GitArgumentBuilder args = new("flow") { typeBranch };
             var result = _gitUiCommands.GitModule.GitExecutable.Execute(args);
 
             if (result.ExitCode != 0 || result.StandardOutput is null)
@@ -196,7 +196,7 @@ namespace GitExtensions.Plugins.GitFlow
 
             List<string> GetLocalBranches()
             {
-                var args = new GitArgumentBuilder("branch");
+                GitArgumentBuilder args = new("branch");
                 return _gitUiCommands.GitModule
                     .GitExecutable.GetOutput(args)
                     .Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(e => e.Trim('*', ' ', '\n', '\r'))
@@ -209,7 +209,7 @@ namespace GitExtensions.Plugins.GitFlow
         #region Run GitFlow commands
         private void btnInit_Click(object sender, EventArgs e)
         {
-            var args = new GitArgumentBuilder("flow")
+            GitArgumentBuilder args = new("flow")
             {
                 "init",
                 "-d"
@@ -223,7 +223,7 @@ namespace GitExtensions.Plugins.GitFlow
         private void btnStartBranch_Click(object sender, EventArgs e)
         {
             var branchType = cbType.SelectedValue.ToString();
-            var args = new GitArgumentBuilder("flow")
+            GitArgumentBuilder args = new("flow")
             {
                 branchType,
                 "start",
@@ -268,7 +268,7 @@ namespace GitExtensions.Plugins.GitFlow
 
         private void btnPublish_Click(object sender, EventArgs e)
         {
-            var args = new GitArgumentBuilder("flow")
+            GitArgumentBuilder args = new("flow")
             {
                 cbManageType.SelectedValue.ToString(),
                 "publish",
@@ -279,7 +279,7 @@ namespace GitExtensions.Plugins.GitFlow
 
         private void btnPull_Click(object sender, EventArgs e)
         {
-            var args = new GitArgumentBuilder("flow")
+            GitArgumentBuilder args = new("flow")
             {
                 cbManageType.SelectedValue.ToString(),
                 "pull",
@@ -291,7 +291,7 @@ namespace GitExtensions.Plugins.GitFlow
 
         private void btnFinish_Click(object sender, EventArgs e)
         {
-            var args = new GitArgumentBuilder("flow")
+            GitArgumentBuilder args = new("flow")
             {
                 cbManageType.SelectedValue.ToString(),
                 "finish",
@@ -394,7 +394,7 @@ namespace GitExtensions.Plugins.GitFlow
 
         private void DisplayHead()
         {
-            var args = new GitArgumentBuilder("symbolic-ref") { "HEAD" };
+            GitArgumentBuilder args = new("symbolic-ref") { "HEAD" };
             var head = _gitUiCommands.GitModule.GitExecutable.GetOutput(args).Trim('*', ' ', '\n', '\r');
             lblHead.Text = head;
 

--- a/Plugins/GitFlow/GitFlowPlugin.cs
+++ b/Plugins/GitFlow/GitFlowPlugin.cs
@@ -19,7 +19,7 @@ namespace GitExtensions.Plugins.GitFlow
 
         public override bool Execute(GitUIEventArgs args)
         {
-            using var frm = new GitFlowForm(args);
+            using GitFlowForm frm = new(args);
             frm.ShowDialog(args.OwnerForm);
             return frm.IsRefreshNeeded;
         }

--- a/Plugins/GitHub3/GitHub3Plugin.cs
+++ b/Plugins/GitHub3/GitHub3Plugin.cs
@@ -75,7 +75,7 @@ namespace GitExtensions.Plugins.GitHub3
         private readonly TranslationString _tokenAlreadyExist = new("You already have an personal access token. To get a new one, delete your old one in Plugins > Plugin Settings first.");
         private readonly TranslationString _generateToken = new("Generate a GitHub personal access token");
         private readonly TranslationString _manageToken = new("Manage GitHub personal access token");
-        private readonly TranslationString _openLinkFailed = new TranslationString("Fail to open the link. Reason: ");
+        private readonly TranslationString _openLinkFailed = new("Fail to open the link. Reason: ");
 
         public static string GitHubAuthorizationRelativeUrl = "authorizations";
         public static string UpstreamConventionName = "upstream";
@@ -106,11 +106,11 @@ namespace GitExtensions.Plugins.GitHub3
         {
             yield return PersonalAccessToken;
 
-            var generateTokenLink = new LinkLabel { Text = _generateToken.Text };
+            LinkLabel generateTokenLink = new() { Text = _generateToken.Text };
             generateTokenLink.Click += GenerateTokenLink_Click;
             yield return new PseudoSetting(generateTokenLink);
 
-            var manageTokenLink = new LinkLabel { Text = _manageToken.Text };
+            LinkLabel manageTokenLink = new() { Text = _manageToken.Text };
             manageTokenLink.Click += ManageTokenLink_Click;
             yield return new PseudoSetting(manageTokenLink);
         }
@@ -238,7 +238,7 @@ namespace GitExtensions.Plugins.GitHub3
 
             IEnumerable<IHostedRemote> Remotes()
             {
-                var set = new HashSet<IHostedRemote>();
+                HashSet<IHostedRemote> set = new();
 
                 foreach (string remote in gitModule.GetRemoteNames())
                 {
@@ -251,7 +251,7 @@ namespace GitExtensions.Plugins.GitHub3
 
                     if (new GitHubRemoteParser().TryExtractGitHubDataFromRemoteUrl(url, out var owner, out var repository))
                     {
-                        var hostedRemote = new GitHubHostedRemote(remote, owner, repository, url);
+                        GitHubHostedRemote hostedRemote = new(remote, owner, repository, url);
 
                         if (set.Add(hostedRemote))
                         {
@@ -270,7 +270,7 @@ namespace GitExtensions.Plugins.GitHub3
                 return;
             }
 
-            var toolStripMenuItem = new ToolStripMenuItem(string.Format(_viewInWebSite.Text, Name), Icon);
+            ToolStripMenuItem toolStripMenuItem = new(string.Format(_viewInWebSite.Text, Name), Icon);
             contextMenu.Items.Add(toolStripMenuItem);
             toolStripMenuItem.Click += (s, e) => Process.Start(_hostedRemotesForModule.First().Data);
 

--- a/Plugins/GitHub3/GitHubPullRequest.cs
+++ b/Plugins/GitHub3/GitHubPullRequest.cs
@@ -33,7 +33,7 @@ namespace GitExtensions.Plugins.GitHub3
             {
                 var request = (HttpWebRequest)WebRequest.Create(_pullRequest.DiffUrl);
                 using var response = await request.GetResponseAsync();
-                using var reader = new StreamReader(response.GetResponseStream(), Encoding.UTF8);
+                using StreamReader reader = new(response.GetResponseStream(), Encoding.UTF8);
                 _diffData = await reader.ReadToEndAsync();
             }
 

--- a/Plugins/GitUIPluginInterfaces/GitCmdResult.cs
+++ b/Plugins/GitUIPluginInterfaces/GitCmdResult.cs
@@ -12,7 +12,7 @@ namespace GitUIPluginInterfaces
 
         public string GetString()
         {
-            var sb = new StringBuilder();
+            StringBuilder sb = new();
 
             if (!string.IsNullOrEmpty(StdOutput))
             {

--- a/Plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
+++ b/Plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
@@ -40,7 +40,7 @@ namespace GitUIPluginInterfaces
             if (lazyExportProvider is null)
             {
                 var capturedApplicationDataFolder = applicationDataFolder;
-                var newLazyExportProvider = new Lazy<ExportProvider>(() => CreateExportProvider(capturedApplicationDataFolder), LazyThreadSafetyMode.ExecutionAndPublication);
+                Lazy<ExportProvider> newLazyExportProvider = new(() => CreateExportProvider(capturedApplicationDataFolder), LazyThreadSafetyMode.ExecutionAndPublication);
                 lazyExportProvider = Interlocked.CompareExchange(ref _exportProvider, newLazyExportProvider, null) ?? newLazyExportProvider;
             }
 

--- a/Plugins/GitUIPluginInterfaces/ObjectId.cs
+++ b/Plugins/GitUIPluginInterfaces/ObjectId.cs
@@ -16,7 +16,7 @@ namespace GitUIPluginInterfaces
     /// </remarks>
     public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
     {
-        private static readonly ThreadLocal<byte[]> _buffer = new ThreadLocal<byte[]>(() => new byte[Sha1ByteCount], trackAllValues: false);
+        private static readonly ThreadLocal<byte[]> _buffer = new(() => new byte[Sha1ByteCount], trackAllValues: false);
         private static readonly Random _random = new();
 
         /// <summary>

--- a/Plugins/GitUIPluginInterfaces/Settings/PseudoSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/PseudoSetting.cs
@@ -23,7 +23,7 @@ namespace GitUIPluginInterfaces
 
             _textBoxCreator = () =>
             {
-                var textbox = new TextBox { ReadOnly = true, BorderStyle = BorderStyle.None, Text = text };
+                TextBox textbox = new() { ReadOnly = true, BorderStyle = BorderStyle.None, Text = text };
 
                 if (height.HasValue)
                 {

--- a/Plugins/Gource/GourcePlugin.cs
+++ b/Plugins/Gource/GourcePlugin.cs
@@ -113,7 +113,7 @@ namespace GitExtensions.Plugins.Gource
                 }
             }
 
-            using var gourceStart = new GourceStart(pathToGource, args, _gourceArguments.ValueOrDefault(Settings));
+            using GourceStart gourceStart = new(pathToGource, args, _gourceArguments.ValueOrDefault(Settings));
             gourceStart.ShowDialog(args.OwnerForm);
             Settings.SetValue(_gourceArguments.Name, gourceStart.GourceArguments, s => s);
             Settings.SetValue(_gourcePath.Name, gourceStart.PathToGource, s => s);
@@ -188,7 +188,7 @@ namespace GitExtensions.Plugins.Gource
             // classes throw exceptions upon error
             try
             {
-                var webClient = new WebClient { Proxy = WebRequest.DefaultWebProxy };
+                WebClient webClient = new() { Proxy = WebRequest.DefaultWebProxy };
                 webClient.Proxy.Credentials = CredentialCache.DefaultCredentials;
 
                 // Once the WebResponse object has been retrieved,
@@ -237,7 +237,7 @@ namespace GitExtensions.Plugins.Gource
         {
             try
             {
-                var webClient = new WebClient { Proxy = WebRequest.DefaultWebProxy };
+                WebClient webClient = new() { Proxy = WebRequest.DefaultWebProxy };
                 webClient.Proxy.Credentials = CredentialCache.DefaultCredentials;
                 webClient.Encoding = Encoding.UTF8;
 
@@ -245,7 +245,7 @@ namespace GitExtensions.Plugins.Gource
 
                 // find http://gource.googlecode.com/files/gource-0.26b.win32.zip
                 // find http://gource.googlecode.com/files/gource-0.34-rc2.win32.zip
-                var regEx = new Regex(@"(?:<a .*href="")(.*gource-.{3,15}win32\.zip)""");
+                Regex regEx = new(@"(?:<a .*href="")(.*gource-.{3,15}win32\.zip)""");
 
                 var matches = regEx.Matches(response);
 

--- a/Plugins/Gource/GourceStart.cs
+++ b/Plugins/Gource/GourceStart.cs
@@ -92,7 +92,7 @@ namespace GitExtensions.Plugins.Gource
                 File.Delete(file);
             }
 
-            var args = new GitArgumentBuilder("log") { "--pretty=format:\"%aE|%aN\"" };
+            GitArgumentBuilder args = new("log") { "--pretty=format:\"%aE|%aN\"" };
             var lines = GitUIArgs.GitModule.GitExecutable.GetOutput(args).Split('\n');
 
             var authors = lines.Select(
@@ -133,8 +133,8 @@ namespace GitExtensions.Plugins.Gource
 
         private void GourceBrowseClick(object sender, EventArgs e)
         {
-            using var fileDialog =
-                new OpenFileDialog
+            using OpenFileDialog fileDialog =
+                new()
                 {
                     Filter = "Gource (gource.exe)|gource.exe",
                     FileName = GourcePath.Text
@@ -146,7 +146,7 @@ namespace GitExtensions.Plugins.Gource
 
         private void WorkingDirBrowseClick(object sender, EventArgs e)
         {
-            using var folderDialog = new FolderBrowserDialog { SelectedPath = WorkingDir.Text };
+            using FolderBrowserDialog folderDialog = new() { SelectedPath = WorkingDir.Text };
             folderDialog.ShowDialog(this);
             WorkingDir.Text = folderDialog.SelectedPath;
         }

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -92,13 +92,13 @@ namespace GitExtensions.Plugins.JiraCommitHintPlugin
             _jqlQuerySettings.CustomControl = new TextBox();
             yield return _jqlQuerySettings;
 
-            var queryHelperLink = new LinkLabel { Text = QueryHelperLinkText.Text };
+            LinkLabel queryHelperLink = new() { Text = QueryHelperLinkText.Text };
             queryHelperLink.Click += QueryHelperLink_Click;
             yield return new PseudoSetting(queryHelperLink);
 
             yield return new PseudoSetting(_jiraFields, JiraFieldsLabel.Text, DpiUtil.Scale(55));
 
-            var txtTemplate = new TextBox
+            TextBox txtTemplate = new()
             {
                 Height = DpiUtil.Scale(75),
                 Multiline = true,

--- a/Plugins/ProxySwitcher/ProxySwitcherForm.cs
+++ b/Plugins/ProxySwitcher/ProxySwitcherForm.cs
@@ -60,7 +60,7 @@ namespace GitExtensions.Plugins.ProxySwitcher
 
         private void RefreshProxy()
         {
-            var args = new GitArgumentBuilder("config")
+            GitArgumentBuilder args = new("config")
             {
                 "--get",
                 "http.proxy"
@@ -83,7 +83,7 @@ namespace GitExtensions.Plugins.ProxySwitcher
 
         private string BuildHttpProxy()
         {
-            var sb = new StringBuilder();
+            StringBuilder sb = new();
             sb.Append("\"");
             var username = _plugin.Username.ValueOrDefault(_settings);
             if (!string.IsNullOrEmpty(username))
@@ -115,7 +115,7 @@ namespace GitExtensions.Plugins.ProxySwitcher
         {
             var httpProxy = BuildHttpProxy();
 
-            var args = new GitArgumentBuilder("config")
+            GitArgumentBuilder args = new("config")
             {
                 { ApplyGlobally_CheckBox.Checked, "--global" },
                 "http.proxy",

--- a/Plugins/ProxySwitcher/ProxySwitcherPlugin.cs
+++ b/Plugins/ProxySwitcher/ProxySwitcherPlugin.cs
@@ -32,7 +32,7 @@ namespace GitExtensions.Plugins.ProxySwitcher
 
         public override bool Execute(GitUIEventArgs args)
         {
-            using var form = new ProxySwitcherForm(this, Settings, args);
+            using ProxySwitcherForm form = new(this, Settings, args);
             form.ShowDialog(args.OwnerForm);
 
             return false;

--- a/Plugins/ReleaseNotesGenerator/GitLogLineParser.cs
+++ b/Plugins/ReleaseNotesGenerator/GitLogLineParser.cs
@@ -26,13 +26,13 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
                 return null;
             }
 
-            var logLine = new LogLine(m.Groups[1].Value, m.Groups[2].Value);
+            LogLine logLine = new(m.Groups[1].Value, m.Groups[2].Value);
             return logLine;
         }
 
         public IEnumerable<LogLine> Parse(IEnumerable<string>? lines)
         {
-            var resultList = new List<LogLine>();
+            List<LogLine> resultList = new();
             if (lines is null)
             {
                 return resultList;

--- a/Plugins/ReleaseNotesGenerator/HtmlFragment.cs
+++ b/Plugins/ReleaseNotesGenerator/HtmlFragment.cs
@@ -29,7 +29,7 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
         public static HtmlFragment FromClipboard()
         {
             string rawClipboardText = Clipboard.GetText(TextDataFormat.Html);
-            var h = new HtmlFragment(rawClipboardText);
+            HtmlFragment h = new(rawClipboardText);
             return h;
         }
 
@@ -175,7 +175,7 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
 
         internal static DataObject CreateHtmlFormatClipboardDataObject(string htmlFragment, string? title = "From Clipboard", Uri? sourceUri = null)
         {
-            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            System.Text.StringBuilder sb = new();
 
             // Builds the CF_HTML header. See format specification here:
             // http://msdn.microsoft.com/library/default.asp?url=/workshop/networking/clipboard/htmlclipboard.asp
@@ -223,7 +223,7 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
             // Finally copy to clipboard.
             // http://stackoverflow.com/questions/13332377/how-to-set-html-text-in-clipboard
             string data = sb.ToString();
-            var dataObject = new DataObject();
+            DataObject dataObject = new();
             dataObject.SetText(data, TextDataFormat.Html);
             dataObject.SetText(htmlFragment, TextDataFormat.Text);
 

--- a/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
+++ b/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorForm.cs
@@ -60,7 +60,7 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
                 return;
             }
 
-            var args = new GitArgumentBuilder("log")
+            GitArgumentBuilder args = new("log")
             {
                 string.Format(_NO_TRANSLATE_textBoxGitLogArguments.Text, textBoxRevFrom.Text, _NO_TRANSLATE_textBoxRevTo.Text)
             };
@@ -123,7 +123,7 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
             string colSeparatorFirstLine = separateColumnWithTabInsteadOfSpaces ? "\t" : " ";
             string colSeparatorRestLines = separateColumnWithTabInsteadOfSpaces ? "\t" : "        ";
 
-            var stringBuilder = new StringBuilder();
+            StringBuilder stringBuilder = new();
 
             foreach (var logLine in logLines)
             {
@@ -139,7 +139,7 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
 
         private static string CreateHtmlTable(IEnumerable<LogLine> logLines)
         {
-            var stringBuilder = new StringBuilder();
+            StringBuilder stringBuilder = new();
             stringBuilder.Append("<table>\r\n");
             foreach (var logLine in logLines)
             {

--- a/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorPlugin.cs
+++ b/Plugins/ReleaseNotesGenerator/ReleaseNotesGeneratorPlugin.cs
@@ -20,7 +20,7 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
 
         public override bool Execute(GitUIEventArgs args)
         {
-            using var form = new ReleaseNotesGeneratorForm(args);
+            using ReleaseNotesGeneratorForm form = new(args);
             if (form.ShowDialog(args.OwnerForm) == DialogResult.OK)
             {
                 return true;

--- a/Plugins/Statistics/GitImpact/GitImpactPlugin.cs
+++ b/Plugins/Statistics/GitImpact/GitImpactPlugin.cs
@@ -26,7 +26,7 @@ namespace GitExtensions.Plugins.GitImpact
                 return false;
             }
 
-            using var form = new FormImpact(args.GitModule);
+            using FormImpact form = new(args.GitModule);
             form.ShowDialog(args.OwnerForm);
 
             return false;

--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -251,13 +251,13 @@ namespace GitExtensions.Plugins.GitImpact
                     return;
                 }
 
-                using var font = new Font("Arial", LinesFontSize);
+                using Font font = new("Arial", LinesFontSize);
                 Brush brush = Brushes.White;
 
                 foreach (var (point, size) in _lineLabels[author])
                 {
                     SizeF sz = g.MeasureString(size.ToString(), font);
-                    var pt = new PointF(point.X - (sz.Width / 2), point.Y - (sz.Height / 2));
+                    PointF pt = new(point.X - (sz.Width / 2), point.Y - (sz.Height / 2));
                     g.DrawString(size.ToString(), font, brush, pt);
                 }
             }
@@ -267,13 +267,13 @@ namespace GitExtensions.Plugins.GitImpact
         {
             lock (_dataLock)
             {
-                using var font = new Font("Arial", WeekFontSize);
+                using Font font = new("Arial", WeekFontSize);
                 Brush brush = Brushes.Gray;
 
                 foreach (var (point, date) in _weekLabels)
                 {
                     SizeF sz = g.MeasureString(date.ToString("dd. MMM yy"), font);
-                    var pt = new PointF(point.X - (sz.Width / 2), point.Y + (sz.Height / 2));
+                    PointF pt = new(point.X - (sz.Width / 2), point.Y + (sz.Height / 2));
                     g.DrawString(date.ToString("dd. MMM yy"), font, brush, pt);
                 }
             }
@@ -290,7 +290,7 @@ namespace GitExtensions.Plugins.GitImpact
         {
             int h_max = 0;
             int x = 0;
-            var author_points_dict = new Dictionary<string, List<(Rectangle, int changeCount)>>();
+            Dictionary<string, List<(Rectangle, int changeCount)>> author_points_dict = new();
 
             lock (_dataLock)
             {
@@ -307,7 +307,7 @@ namespace GitExtensions.Plugins.GitImpact
                     {
                         // Calculate week-author-rectangle
                         int height = Math.Max(1, (int)Math.Round(Math.Pow(Math.Log(data.ChangedLines), 1.5) * 4));
-                        var rc = new Rectangle(x, y, BlockWidth, height);
+                        Rectangle rc = new(x, y, BlockWidth, height);
 
                         // Add rectangle to temporary list
                         if (!author_points_dict.ContainsKey(author))
@@ -346,7 +346,7 @@ namespace GitExtensions.Plugins.GitImpact
                 {
                     var (point, date) = _weekLabels[i];
 
-                    var adjustedPoint = new PointF(point.X, point.Y * (float)height_factor);
+                    PointF adjustedPoint = new(point.X, point.Y * (float)height_factor);
 
                     _weekLabels[i] = (adjustedPoint, date);
                 }
@@ -365,7 +365,7 @@ namespace GitExtensions.Plugins.GitImpact
                     {
                         var (unscaledRect, num) = points[i];
 
-                        var rect = new Rectangle(unscaledRect.Left, (int)(unscaledRect.Top * height_factor),
+                        Rectangle rect = new(unscaledRect.Left, (int)(unscaledRect.Top * height_factor),
                             unscaledRect.Width, Math.Max(1, (int)(unscaledRect.Height * height_factor)));
 
                         points[i] = (rect, num);
@@ -378,7 +378,7 @@ namespace GitExtensions.Plugins.GitImpact
 
                         if (rect.Height > LinesFontSize * 1.5)
                         {
-                            var adjustedPoint = new PointF(rect.Left + (BlockWidth / 2), rect.Top + (rect.Height / 2));
+                            PointF adjustedPoint = new(rect.Left + (BlockWidth / 2), rect.Top + (rect.Height / 2));
 
                             _lineLabels[author].Add((adjustedPoint, num));
                         }

--- a/Plugins/Statistics/GitImpact/ImpactLoader.cs
+++ b/Plugins/Statistics/GitImpact/ImpactLoader.cs
@@ -116,7 +116,7 @@ namespace GitExtensions.Plugins.GitImpact
             var authorName = RespectMailmap ? "%aN" : "%an";
             var command = $"log --pretty=tformat:\"--- %ad --- {authorName}\" --numstat --date=iso -C --all --no-merges";
 
-            var tasks = new List<JoinableTask>
+            List<JoinableTask> tasks = new()
             {
                 ThreadHelper.JoinableTaskFactory.RunAsync(
                     async () =>
@@ -229,8 +229,8 @@ namespace GitExtensions.Plugins.GitImpact
             foreach (var author in authors)
             {
                 // Determine first and last commit week of each author
-                var start = new DateTime();
-                var end = new DateTime();
+                DateTime start = new();
+                DateTime end = new();
                 var startFound = false;
 
                 foreach (var (weekDate, weekDataByAuthor) in impact)

--- a/Plugins/Statistics/GitStatistics/CodeFile.cs
+++ b/Plugins/Statistics/GitStatistics/CodeFile.cs
@@ -36,7 +36,7 @@ namespace GitExtensions.Plugins.GitStatistics
             IEnumerable<string> ReadLines()
             {
                 // NOTE not using File.ReadLines here as it doesn't appear to detect a BOM
-                using var reader = new StreamReader(file.FullName, detectEncodingFromByteOrderMarks: true);
+                using StreamReader reader = new(file.FullName, detectEncodingFromByteOrderMarks: true);
                 while (true)
                 {
                     var line = reader.ReadLine();

--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -110,7 +110,7 @@ namespace GitExtensions.Plugins.GitStatistics
 
                     TotalCommits.Text = string.Format(_commits.Text, totalCommits);
 
-                    var builder = new StringBuilder();
+                    StringBuilder builder = new();
 
                     var commitCountValues = new decimal[commitsPerUser.Count];
                     var commitCountLabels = new string[commitsPerUser.Count];
@@ -208,11 +208,11 @@ namespace GitExtensions.Plugins.GitStatistics
             var extensionValues = new decimal[_lineCounter.LinesOfCodePerExtension.Count];
             var extensionLabels = new string[_lineCounter.LinesOfCodePerExtension.Count];
 
-            var linesOfCodePerExtension = new List<KeyValuePair<string, int>>(_lineCounter.LinesOfCodePerExtension);
+            List<KeyValuePair<string, int>> linesOfCodePerExtension = new(_lineCounter.LinesOfCodePerExtension);
             linesOfCodePerExtension.Sort((first, next) => -first.Value.CompareTo(next.Value));
 
             var n = 0;
-            var linesOfCodePerLanguageText = new StringBuilder();
+            StringBuilder linesOfCodePerLanguageText = new();
             foreach (var (extension, loc) in linesOfCodePerExtension)
             {
                 var percent = (double)loc / _lineCounter.CodeLineCount;

--- a/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
+++ b/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
@@ -42,7 +42,7 @@ namespace GitExtensions.Plugins.GitStatistics
 
             var countSubmodule = !_ignoreSubmodules.ValueOrDefault(Settings);
 
-            var formStatistics = new FormGitStatistics(args.GitModule, _codeFiles.ValueOrDefault(Settings), countSubmodule)
+            FormGitStatistics formStatistics = new(args.GitModule, _codeFiles.ValueOrDefault(Settings), countSubmodule)
             {
                 DirectoriesToIgnore = _ignoreDirectories.ValueOrDefault(Settings).Replace("/", "\\")
             };

--- a/Plugins/Statistics/GitStatistics/PieChart/PieChart3D.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/PieChart3D.cs
@@ -462,7 +462,7 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
             }
 
             // split the backmost (at 270 degrees) pie slice
-            var pieSlices = new List<PieSlice>(PieSlices);
+            List<PieSlice> pieSlices = new(PieSlices);
             var splitSlices = PieSlices[0].Split(270F);
             pieSlices[0] = splitSlices[0];
             if (splitSlices[1].SweepAngle > 0F)
@@ -649,7 +649,7 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
             var largestDisplacementEllipseSize = LargestDisplacementEllipseSize;
             var maxDisplacementIndex = SliceRelativeDisplacements.Length - 1;
             var largestDisplacement = LargestDisplacement;
-            var listPieSlices = new List<PieSlice>();
+            List<PieSlice> listPieSlices = new();
             PieSlicesMapping.Clear();
             var colorIndex = 0;
             var backPieIndex = -1;
@@ -873,7 +873,7 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
         /// </param>
         protected void DrawSliceSides(Graphics graphics)
         {
-            var pieSlices = new List<PieSlice>(PieSlices);
+            List<PieSlice> pieSlices = new(PieSlices);
 
             // if the first slice spreads across 180 and 360 degrees boundaries it
             // will appear on both left and right edge so its periphery has to be

--- a/Plugins/Statistics/GitStatistics/PieChart/PieSlice.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/PieSlice.cs
@@ -542,7 +542,7 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
         /// </returns>
         internal RectangleF GetFittingRectangle()
         {
-            var boundingRectangle = new RectangleF(PointStart.X, PointStart.Y, 0, 0);
+            RectangleF boundingRectangle = new(PointStart.X, PointStart.Y, 0, 0);
             if ((StartAngle == 0F) || (StartAngle + SweepAngle >= 360))
             {
                 GraphicsUtil.IncludePointX(ref boundingRectangle, BoundingRectangle.Right);
@@ -984,7 +984,7 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
         /// </returns>
         private IEnumerable<PeripherySurfaceBounds> GetVisiblePeripherySurfaceBounds()
         {
-            var peripherySurfaceBounds = new List<PeripherySurfaceBounds>();
+            List<PeripherySurfaceBounds> peripherySurfaceBounds = new();
 
             // outer periphery side is visible only when startAngle or endAngle
             // is between 0 and 180 degrees
@@ -995,9 +995,9 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
                 if (StartAngle < 180)
                 {
                     var fi1 = StartAngle;
-                    var x1 = new PointF(PointStart.X, PointStart.Y);
+                    PointF x1 = new(PointStart.X, PointStart.Y);
                     var fi2 = EndAngle;
-                    var x2 = new PointF(PointEnd.X, PointEnd.Y);
+                    PointF x2 = new(PointEnd.X, PointEnd.Y);
                     if (StartAngle + SweepAngle > 180)
                     {
                         fi2 = 180;
@@ -1012,9 +1012,9 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
                 if (StartAngle + SweepAngle > 360)
                 {
                     const float fi1 = 0;
-                    var x1 = new PointF(BoundingRectangle.Right, Center.Y);
+                    PointF x1 = new(BoundingRectangle.Right, Center.Y);
                     var fi2 = EndAngle;
-                    var x2 = new PointF(PointEnd.X, PointEnd.Y);
+                    PointF x2 = new(PointEnd.X, PointEnd.Y);
                     if (fi2 > 180)
                     {
                         fi2 = 180;
@@ -1052,7 +1052,7 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
             float startAngle, float endAngle,
             PointF pointStart, PointF pointEnd)
         {
-            var path = new GraphicsPath();
+            GraphicsPath path = new();
             path.AddArc(BoundingRectangle, startAngle, endAngle - startAngle);
             path.AddLine(pointEnd.X, pointEnd.Y, pointEnd.X, pointEnd.Y + SliceHeight);
             path.AddArc(

--- a/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
+++ b/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
@@ -76,7 +76,7 @@ namespace ResourceManager.CommitDataRenders
 
             Validates.NotNull(_linkFactory);
 
-            var header = new StringBuilder();
+            StringBuilder header = new();
             header.AppendLine(_labelFormatter.FormatLabel(TranslatedStrings.Author, padding) + _linkFactory.CreateLink(commitData.Author, "mailto:" + authorEmail));
 
             if (!isArtificial)
@@ -131,7 +131,7 @@ namespace ResourceManager.CommitDataRenders
             bool datesEqual = commitData.AuthorDate.EqualsExact(commitData.CommitDate);
             var padding = _headerRendererStyleProvider.GetMaxWidth();
 
-            var header = new StringBuilder();
+            StringBuilder header = new();
             header.AppendLine(_labelFormatter.FormatLabel(TranslatedStrings.Author, padding) + commitData.Author);
             header.AppendLine(_labelFormatter.FormatLabel(datesEqual ? TranslatedStrings.Date : TranslatedStrings.AuthorDate, padding) + _dateFormatter.FormatDateAsRelativeLocal(commitData.AuthorDate));
             if (!authorIsCommitter)

--- a/ResourceManager/LinkFactory.cs
+++ b/ResourceManager/LinkFactory.cs
@@ -33,7 +33,7 @@ namespace ResourceManager
         private const string InternalScheme = "gitext";
         private const string ShowAll = "showall";
 
-        private readonly ConcurrentDictionary<string, string> _linksMap = new ConcurrentDictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string> _linksMap = new();
 
         public void Clear()
         {
@@ -132,7 +132,7 @@ namespace ResourceManager
                 return;
             }
 
-            using var process = new Process
+            using Process process = new()
             {
                 EnableRaisingEvents = false,
                 StartInfo = { FileName = uri.AbsoluteUri, UseShellExecute = true },

--- a/ResourceManager/LocalizationHelpers.cs
+++ b/ResourceManager/LocalizationHelpers.cs
@@ -30,7 +30,7 @@ namespace ResourceManager
         /// <see href="http://stackoverflow.com/questions/11/how-do-i-calculate-relative-time"/>
         public static string GetRelativeDateString(DateTime originDate, DateTime previousDate, bool displayWeeks = true)
         {
-            var ts = new TimeSpan(RoundDateTime(originDate).Ticks - RoundDateTime(previousDate).Ticks);
+            TimeSpan ts = new(RoundDateTime(originDate).Ticks - RoundDateTime(previousDate).Ticks);
             double delta = Math.Abs(ts.TotalSeconds);
 
             if (delta < 60)
@@ -79,7 +79,7 @@ namespace ResourceManager
 
         public static string GetSubmoduleText(GitModule superproject, string name, string hash, bool cache)
         {
-            var sb = new StringBuilder();
+            StringBuilder sb = new();
             sb.AppendLine("Submodule " + name);
             sb.AppendLine();
             GitModule module = superproject.GetSubmodule(name);
@@ -134,7 +134,7 @@ namespace ResourceManager
             }
 
             GitModule gitModule = moduleIsParent ? module.GetSubmodule(status.Name) : module;
-            var sb = new StringBuilder();
+            StringBuilder sb = new();
             sb.AppendLine("Submodule " + status.Name + " Change");
 
             // TEMP, will be moved in the follow up refactor

--- a/ResourceManager/Translator.cs
+++ b/ResourceManager/Translator.cs
@@ -50,7 +50,7 @@ namespace ResourceManager
 
         public static string[] GetAllTranslations()
         {
-            var translations = new List<string>();
+            List<string> translations = new();
             try
             {
                 string translationDir = GetTranslationDir();

--- a/ResourceManager/Xliff/TranslationSerializer.cs
+++ b/ResourceManager/Xliff/TranslationSerializer.cs
@@ -10,7 +10,7 @@ namespace ResourceManager.Xliff
         public static void Serialize(TranslationFile translation, string path)
         {
             using TextWriter tw = new StreamWriter(path, false);
-            var serializer = new XmlSerializer(typeof(TranslationFile));
+            XmlSerializer serializer = new(typeof(TranslationFile));
             serializer.Serialize(tw, translation);
         }
 
@@ -21,12 +21,12 @@ namespace ResourceManager.Xliff
                 return null;
             }
 
-            var serializer = new XmlSerializer(typeof(TranslationFile));
+            XmlSerializer serializer = new(typeof(TranslationFile));
             TextReader? stringReader = null;
             try
             {
                 stringReader = new StreamReader(path);
-                using var xmlReader = new XmlTextReader(stringReader);
+                using XmlTextReader xmlReader = new(stringReader);
                 stringReader = null;
                 return (TranslationFile)serializer.Deserialize(xmlReader);
             }

--- a/ResourceManager/Xliff/TranslationUtil.cs
+++ b/ResourceManager/Xliff/TranslationUtil.cs
@@ -242,7 +242,7 @@ namespace ResourceManager.Xliff
                    items.Count != 0;
         }
 
-        private static readonly HashSet<string> _translatableItemInComponentNames = new HashSet<string>(StringComparer.Ordinal)
+        private static readonly HashSet<string> _translatableItemInComponentNames = new(StringComparer.Ordinal)
         {
             "AccessibleDescription",
             "AccessibleName",
@@ -283,7 +283,7 @@ namespace ResourceManager.Xliff
 
         public static Dictionary<string, List<Type>> GetTranslatableTypes()
         {
-            var dictionary = new Dictionary<string, List<Type>>();
+            Dictionary<string, List<Type>> dictionary = new();
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
                 if (!assembly.IsTranslatable())

--- a/TranslationApp/TranslationHelpers.cs
+++ b/TranslationApp/TranslationHelpers.cs
@@ -20,7 +20,7 @@ namespace TranslationApp
                 var translatableTypes = TranslationUtil.GetTranslatableTypes();
                 foreach (var (key, types) in translatableTypes)
                 {
-                    var translation = new TranslationFile();
+                    TranslationFile translation = new();
                     try
                     {
                         foreach (Type type in types)
@@ -60,7 +60,7 @@ namespace TranslationApp
 
         public static IDictionary<string, List<TranslationItemWithCategory>> GetItemsDictionary(IDictionary<string, TranslationFile> translations)
         {
-            var items = new Dictionary<string, List<TranslationItemWithCategory>>();
+            Dictionary<string, List<TranslationItemWithCategory>> items = new();
             foreach (var (key, file) in translations)
             {
                 var list = from item in file.TranslationCategories
@@ -86,7 +86,7 @@ namespace TranslationApp
         public static IDictionary<string, List<TranslationItemWithCategory>> LoadTranslation(
             IDictionary<string, TranslationFile> translation, IDictionary<string, List<TranslationItemWithCategory>> neutralItems)
         {
-            var translateItems = new Dictionary<string, List<TranslationItemWithCategory>>();
+            Dictionary<string, List<TranslationItemWithCategory>> translateItems = new();
 
             var oldTranslationItems = GetItemsDictionary(translation);
 
@@ -94,7 +94,7 @@ namespace TranslationApp
             {
                 var oldItems = oldTranslationItems.Find(key);
                 var transItems = translateItems.Find(key);
-                var dict = new Dictionary<string, string>();
+                Dictionary<string, string> dict = new();
                 foreach (var item in items)
                 {
                     var curItems = oldItems.Where(
@@ -162,12 +162,12 @@ namespace TranslationApp
 
             foreach (var (key, translateItems) in items)
             {
-                var foreignTranslation = new TranslationFile(GitCommands.AppSettings.ProductVersion, "en", targetLanguageCode);
+                TranslationFile foreignTranslation = new(GitCommands.AppSettings.ProductVersion, "en", targetLanguageCode);
                 foreach (var translateItem in translateItems)
                 {
                     var item = translateItem.GetTranslationItem();
 
-                    var ti = new TranslationItem(item.Name, item.Property, item.Source, item.Value);
+                    TranslationItem ti = new(item.Name, item.Property, item.Source, item.Value);
                     ti.Value ??= string.Empty;
                     foreignTranslation.FindOrAddTranslationCategory(translateItem.Category)
                         .Body.AddTranslationItem(ti);

--- a/UnitTests/CommonTestUtils/AsyncTestHelper.cs
+++ b/UnitTests/CommonTestUtils/AsyncTestHelper.cs
@@ -22,7 +22,7 @@ namespace CommonTestUtils
 
         public static async Task JoinPendingOperationsAsync(TimeSpan timeout)
         {
-            using var cancellationTokenSource = new CancellationTokenSource(timeout);
+            using CancellationTokenSource cancellationTokenSource = new(timeout);
             await ThreadHelper.JoinPendingOperationsAsync(cancellationTokenSource.Token);
         }
     }

--- a/UnitTests/CommonTestUtils/ConfigureJoinableTaskFactoryAttribute.cs
+++ b/UnitTests/CommonTestUtils/ConfigureJoinableTaskFactoryAttribute.cs
@@ -65,7 +65,7 @@ namespace CommonTestUtils
                 try
                 {
                     // Wait for eventual pending operations triggered by the test.
-                    using var cts = new CancellationTokenSource(AsyncTestHelper.UnexpectedTimeout);
+                    using CancellationTokenSource cts = new(AsyncTestHelper.UnexpectedTimeout);
                     try
                     {
                         // Note that ThreadHelper.JoinableTaskContext.Factory must be used to bypass the default behavior of

--- a/UnitTests/CommonTestUtils/EmbeddedResourceLoader.cs
+++ b/UnitTests/CommonTestUtils/EmbeddedResourceLoader.cs
@@ -8,7 +8,7 @@ namespace CommonTestUtils
         public static string Load(Assembly asm, string fullResourceName)
         {
             using var stream = asm.GetManifestResourceStream(fullResourceName);
-            using var reader = new StreamReader(stream);
+            using StreamReader reader = new(stream);
             string result = reader.ReadToEnd();
             return result;
         }

--- a/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
+++ b/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
@@ -26,7 +26,7 @@ namespace CommonTestUtils
 
             Directory.CreateDirectory(path);
 
-            var module = new GitModule(path);
+            GitModule module = new(path);
             module.Init(bare: false, shared: false);
             Module = module;
 
@@ -150,7 +150,7 @@ namespace CommonTestUtils
             var paths = Module.GetSubmodulesLocalPaths(recursive: true);
             return paths.Select(path =>
             {
-                var module = new GitModule(Path.Combine(Module.WorkingDir, path).ToNativePath());
+                GitModule module = new(Path.Combine(Module.WorkingDir, path).ToNativePath());
                 SetDummyUserEmail(module);
                 return module;
             });

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -15,9 +15,9 @@ namespace CommonTestUtils
 {
     public sealed class MockExecutable : IExecutable
     {
-        private readonly ConcurrentDictionary<string, ConcurrentStack<(string output, int? exitCode)>> _outputStackByArguments = new ConcurrentDictionary<string, ConcurrentStack<(string output, int? exitCode)>>();
-        private readonly ConcurrentDictionary<string, int> _commandArgumentsSet = new ConcurrentDictionary<string, int>();
-        private readonly List<MockProcess> _processes = new List<MockProcess>();
+        private readonly ConcurrentDictionary<string, ConcurrentStack<(string output, int? exitCode)>> _outputStackByArguments = new();
+        private readonly ConcurrentDictionary<string, int> _commandArgumentsSet = new();
+        private readonly List<MockProcess> _processes = new();
         private int _nextCommandId;
 
         [MustUseReturnValue]
@@ -85,7 +85,7 @@ namespace CommonTestUtils
                     _outputStackByArguments.TryRemove(arguments, out _);
                 }
 
-                var process = new MockProcess(item.output, item.exitCode);
+                MockProcess process = new(item.output, item.exitCode);
 
                 _processes.Add(process);
                 return process;
@@ -93,7 +93,7 @@ namespace CommonTestUtils
 
             if (_commandArgumentsSet.TryRemove(arguments, out _))
             {
-                var process = new MockProcess();
+                MockProcess process = new();
                 _processes.Add(process);
                 return process;
             }
@@ -137,7 +137,7 @@ namespace CommonTestUtils
                 }
                 else
                 {
-                    var cts = new CancellationTokenSource();
+                    CancellationTokenSource cts = new();
                     var ct = cts.Token;
                     cts.Cancel();
                     return Task.FromCanceled<int>(ct);

--- a/UnitTests/CommonTestUtils/NoAssertContext.cs
+++ b/UnitTests/CommonTestUtils/NoAssertContext.cs
@@ -25,7 +25,7 @@ namespace System
         private static readonly object s_lock = new();
         private static bool s_hooked;
 
-        private static readonly ConcurrentDictionary<int, int> s_suppressedThreads = new ConcurrentDictionary<int, int>();
+        private static readonly ConcurrentDictionary<int, int> s_suppressedThreads = new();
 
         // "Default" is the listener that terminates the process when debug assertions fail.
         private static readonly TraceListener s_defaultListener = Trace.Listeners["Default"];

--- a/UnitTests/CommonTestUtils/ReferenceRepository.cs
+++ b/UnitTests/CommonTestUtils/ReferenceRepository.cs
@@ -25,22 +25,22 @@ namespace CommonTestUtils
 
         private string Commit(Repository repository, string commitMessage)
         {
-            var author = new LibGit2Sharp.Signature("GitUITests", "unittests@gitextensions.com", DateTimeOffset.Now);
+            LibGit2Sharp.Signature author = new("GitUITests", "unittests@gitextensions.com", DateTimeOffset.Now);
             var committer = author;
-            var options = new LibGit2Sharp.CommitOptions() { PrettifyMessage = false };
+            LibGit2Sharp.CommitOptions options = new() { PrettifyMessage = false };
             var commit = repository.Commit(commitMessage, author, committer, options);
             return commit.Id.Sha;
         }
 
         public void CreateBranch(string branchName, string commitHash, bool allowOverwrite = false)
         {
-            using var repository = new LibGit2Sharp.Repository(_moduleTestHelper.Module.WorkingDir);
+            using LibGit2Sharp.Repository repository = new(_moduleTestHelper.Module.WorkingDir);
             repository.Branches.Add(branchName, commitHash, allowOverwrite);
         }
 
         public void CreateCommit(string commitMessage, string content = null)
         {
-            using var repository = new LibGit2Sharp.Repository(_moduleTestHelper.Module.WorkingDir);
+            using LibGit2Sharp.Repository repository = new(_moduleTestHelper.Module.WorkingDir);
             _moduleTestHelper.CreateRepoFile("A.txt", content ?? commitMessage);
             repository.Index.Add("A.txt");
 
@@ -51,25 +51,25 @@ namespace CommonTestUtils
 
         public void CreateTag(string tagName, string commitHash, bool allowOverwrite = false)
         {
-            using var repository = new LibGit2Sharp.Repository(_moduleTestHelper.Module.WorkingDir);
+            using LibGit2Sharp.Repository repository = new(_moduleTestHelper.Module.WorkingDir);
             repository.Tags.Add(tagName, commitHash, allowOverwrite);
         }
 
         public void CheckoutRevision()
         {
-            using var repository = new LibGit2Sharp.Repository(Module.WorkingDir);
+            using LibGit2Sharp.Repository repository = new(Module.WorkingDir);
             Commands.Checkout(repository, CommitHash, new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
         }
 
         public void CheckoutMaster()
         {
-            using var repository = new LibGit2Sharp.Repository(Module.WorkingDir);
+            using LibGit2Sharp.Repository repository = new(Module.WorkingDir);
             Commands.Checkout(repository, "master", new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
         }
 
         public void CreateRemoteForMasterBranch()
         {
-            using var repository = new LibGit2Sharp.Repository(Module.WorkingDir);
+            using LibGit2Sharp.Repository repository = new(Module.WorkingDir);
             repository.Network.Remotes.Add("origin", "http://useless.url");
             Remote remote = repository.Network.Remotes["origin"];
 
@@ -82,17 +82,17 @@ namespace CommonTestUtils
 
         public void Fetch(string remoteName)
         {
-            using var repository = new LibGit2Sharp.Repository(Module.WorkingDir);
-            var options = new LibGit2Sharp.FetchOptions();
+            using LibGit2Sharp.Repository repository = new(Module.WorkingDir);
+            LibGit2Sharp.FetchOptions options = new();
             Commands.Fetch(repository, remoteName, Array.Empty<string>(), options, null);
         }
 
         public void Reset()
         {
             // Undo potential impact from earlier tests
-            using (var repository = new LibGit2Sharp.Repository(Module.WorkingDir))
+            using (LibGit2Sharp.Repository repository = new(Module.WorkingDir))
             {
-                var options = new LibGit2Sharp.CheckoutOptions();
+                LibGit2Sharp.CheckoutOptions options = new();
                 repository.Reset(LibGit2Sharp.ResetMode.Hard, (LibGit2Sharp.Commit)repository.Lookup(CommitHash, LibGit2Sharp.ObjectType.Commit), options);
                 repository.RemoveUntrackedFiles();
 

--- a/UnitTests/GitCommands.Tests/ArgumentBuilderExtensionsTests.cs
+++ b/UnitTests/GitCommands.Tests/ArgumentBuilderExtensionsTests.cs
@@ -221,7 +221,7 @@ namespace GitCommandsTests
 
                 foreach (T member in Enum.GetValues(typeof(T)))
                 {
-                    var args = new ArgumentBuilder();
+                    ArgumentBuilder args = new();
 
                     Assert.DoesNotThrow(() => method.Invoke(null, new object[] { args, member }));
                 }
@@ -248,7 +248,7 @@ namespace GitCommandsTests
         [TestCase(null)]
         public void Handle_null_objectid(ObjectId id)
         {
-            var args = new ArgumentBuilder
+            ArgumentBuilder args = new()
             {
                 id
             };
@@ -261,7 +261,7 @@ namespace GitCommandsTests
             foreach (int mode in Enum.GetValues(typeof(ForcePushOptions)))
             {
                 // unimplemented switches will result in InvalidEnumArgumentException
-                var args = new ArgumentBuilder
+                ArgumentBuilder args = new()
                 {
                     (ForcePushOptions)mode
                 };
@@ -274,7 +274,7 @@ namespace GitCommandsTests
             foreach (int mode in Enum.GetValues(typeof(GitBisectOption)))
             {
                 // unimplemented switches will result in InvalidEnumArgumentException
-                var args = new ArgumentBuilder
+                ArgumentBuilder args = new()
                 {
                     (GitBisectOption)mode
                 };
@@ -287,7 +287,7 @@ namespace GitCommandsTests
             foreach (int mode in Enum.GetValues(typeof(IgnoreSubmodulesMode)))
             {
                 // unimplemented switches will result in InvalidEnumArgumentException
-                var args = new ArgumentBuilder
+                ArgumentBuilder args = new()
                 {
                     (IgnoreSubmodulesMode)mode
                 };
@@ -300,7 +300,7 @@ namespace GitCommandsTests
             foreach (int mode in Enum.GetValues(typeof(CleanMode)))
             {
                 // unimplemented switches will result in InvalidEnumArgumentException
-                var args = new ArgumentBuilder
+                ArgumentBuilder args = new()
                 {
                     (CleanMode)mode
                 };
@@ -313,7 +313,7 @@ namespace GitCommandsTests
             foreach (int mode in Enum.GetValues(typeof(ResetMode)))
             {
                 // unimplemented switches will result in InvalidEnumArgumentException
-                var args = new ArgumentBuilder
+                ArgumentBuilder args = new()
                 {
                     (ResetMode)mode
                 };

--- a/UnitTests/GitCommands.Tests/AsyncLoaderTests.cs
+++ b/UnitTests/GitCommands.Tests/AsyncLoaderTests.cs
@@ -32,8 +32,8 @@ namespace GitCommandsTests
         {
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                var loadSignal = new SemaphoreSlim(0);
-                var completeSignal = new SemaphoreSlim(0);
+                SemaphoreSlim loadSignal = new(0);
+                SemaphoreSlim completeSignal = new(0);
 
                 var started = 0;
                 var completed = 0;
@@ -73,7 +73,7 @@ namespace GitCommandsTests
 
                 Assert.False(callerThread.IsThreadPoolThread);
 
-                using var loader = new AsyncLoader();
+                using AsyncLoader loader = new();
                 await loader.LoadAsync(
                     () => loadThread = Thread.CurrentThread,
                     () => continuationThread = Thread.CurrentThread);
@@ -89,8 +89,8 @@ namespace GitCommandsTests
         {
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                var loadSignal = new SemaphoreSlim(0);
-                var completeSignal = new SemaphoreSlim(0);
+                SemaphoreSlim loadSignal = new(0);
+                SemaphoreSlim completeSignal = new(0);
 
                 var started = 0;
                 var completed = 0;
@@ -155,8 +155,8 @@ namespace GitCommandsTests
         {
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                var loadSignal = new SemaphoreSlim(0);
-                var completeSignal = new SemaphoreSlim(0);
+                SemaphoreSlim loadSignal = new(0);
+                SemaphoreSlim completeSignal = new(0);
 
                 var started = 0;
                 var completed = 0;
@@ -208,7 +208,7 @@ namespace GitCommandsTests
         {
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                var observed = new List<Exception>();
+                List<Exception> observed = new();
 
                 _loader.LoadingError += (_, e) =>
                 {
@@ -216,7 +216,7 @@ namespace GitCommandsTests
                     e.Handled = true;
                 };
 
-                var ex = new Exception();
+                Exception ex = new();
 
                 await _loader.LoadAsync(
                     () => throw ex,
@@ -232,7 +232,7 @@ namespace GitCommandsTests
         {
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                var ex = new Exception();
+                Exception ex = new();
 
                 await _loader.LoadAsync(
                     () => throw ex,
@@ -243,7 +243,7 @@ namespace GitCommandsTests
         [Test]
         public void Error_raised_via_event_and_not_marked_as_handled_faults_task()
         {
-            var observed = new List<Exception>();
+            List<Exception> observed = new();
 
             _loader.LoadingError += (_, e) =>
             {
@@ -251,7 +251,7 @@ namespace GitCommandsTests
                 e.Handled = false;
             };
 
-            var ex = new Exception();
+            Exception ex = new();
 
             var loadTask = ThreadHelper.JoinableTaskFactory.RunAsync(() => _loader.LoadAsync(
                 () => throw ex,
@@ -267,7 +267,7 @@ namespace GitCommandsTests
         [Test]
         public async Task Using_load_or_cancel_after_dispose_throws()
         {
-            var loader = new AsyncLoader();
+            AsyncLoader loader = new();
 
             // Safe to dispose multiple times
             loader.Dispose();

--- a/UnitTests/GitCommands.Tests/CommitMessageManagerTests.cs
+++ b/UnitTests/GitCommands.Tests/CommitMessageManagerTests.cs
@@ -212,7 +212,7 @@ namespace GitCommandsTests
         [Test]
         public void WriteCommitMessageToFile_should_write_COMMITMESSAGE()
         {
-            var manager = new CommitMessageManager(_referenceRepository.Module.WorkingDir, _referenceRepository.Module.CommitEncoding, overriddenCommitMessage: null);
+            CommitMessageManager manager = new(_referenceRepository.Module.WorkingDir, _referenceRepository.Module.CommitEncoding, overriddenCommitMessage: null);
 
             File.Exists(manager.CommitMessagePath).Should().BeFalse();
 
@@ -226,7 +226,7 @@ namespace GitCommandsTests
         [Test]
         public void WriteCommitMessageToFile_should_write_MERGE_MSG()
         {
-            var manager = new CommitMessageManager(_referenceRepository.Module.WorkingDir, _referenceRepository.Module.CommitEncoding, overriddenCommitMessage: null);
+            CommitMessageManager manager = new(_referenceRepository.Module.WorkingDir, _referenceRepository.Module.CommitEncoding, overriddenCommitMessage: null);
 
             File.Exists(manager.MergeMessagePath).Should().BeFalse();
 

--- a/UnitTests/GitCommands.Tests/CommitTemplateManagerTests.cs
+++ b/UnitTests/GitCommands.Tests/CommitTemplateManagerTests.cs
@@ -111,8 +111,8 @@ namespace GitCommandsTests
             [Test]
             public void LoadGitCommitTemplate_real_filesystem()
             {
-                using var helper = new GitModuleTestHelper();
-                var manager = new CommitTemplateManager(() => helper.Module);
+                using GitModuleTestHelper helper = new();
+                CommitTemplateManager manager = new(() => helper.Module);
 
                 const string content = "line1\r\nline2\rline3\nline4";
 

--- a/UnitTests/GitCommands.Tests/Config/ConfigFileTest.cs
+++ b/UnitTests/GitCommands.Tests/Config/ConfigFileTest.cs
@@ -34,7 +34,7 @@ namespace GitCommandsTests.Config
 
         private static string GetDefaultConfigFileContent()
         {
-            var content = new StringBuilder();
+            StringBuilder content = new();
             content.AppendLine("[section1]");
             content.AppendLine("key1=value1");
             content.AppendLine("[section2.subsection]");
@@ -46,7 +46,7 @@ namespace GitCommandsTests.Config
 
         private string GetConfigValue(string cfgFile, string key)
         {
-            var args = new GitArgumentBuilder("config")
+            GitArgumentBuilder args = new("config")
             {
                 "-f",
                 cfgFile.Quote(),
@@ -79,7 +79,7 @@ namespace GitCommandsTests.Config
                 File.WriteAllText(GetConfigFileName(), GetDefaultConfigFileContent(), GitModule.SystemEncoding);
             }
 
-            var configFile = new ConfigFile(GetConfigFileName() + "\\", false);
+            ConfigFile configFile = new(GetConfigFileName() + "\\", false);
 
             Assert.IsNotNull(configFile);
         }
@@ -89,7 +89,7 @@ namespace GitCommandsTests.Config
         {
             try
             {
-                var file = new ConfigFile(null, true);
+                ConfigFile file = new(null, true);
                 file.GetValue("nonexistentSetting", string.Empty);
             }
             catch (Exception e)
@@ -101,7 +101,7 @@ namespace GitCommandsTests.Config
         [Test]
         public void TestSave()
         {
-            var configFile = new ConfigFile(GetConfigFileName(), true);
+            ConfigFile configFile = new(GetConfigFileName(), true);
             configFile.SetValue("branch.BranchName1.remote", "origin1");
             configFile.Save();
 
@@ -122,7 +122,7 @@ namespace GitCommandsTests.Config
         [Test]
         public void TestSetValueNonExisting()
         {
-            var configFile = new ConfigFile(GetConfigFileName(), true);
+            ConfigFile configFile = new(GetConfigFileName(), true);
             configFile.Save();
 
             configFile.SetValue("section1.key1", "section1key1");
@@ -139,7 +139,7 @@ namespace GitCommandsTests.Config
         [Test]
         public void TestSetValueExisting()
         {
-            var configFile = new ConfigFile(GetConfigFileName(), true);
+            ConfigFile configFile = new(GetConfigFileName(), true);
             configFile.SetValue("section.key", "section.key");
             configFile.Save();
 
@@ -153,7 +153,7 @@ namespace GitCommandsTests.Config
         [Test]
         public void TestSetValueSectionWithDotNonExisting()
         {
-            var configFile = new ConfigFile(GetConfigFileName(), true);
+            ConfigFile configFile = new(GetConfigFileName(), true);
             configFile.SetValue("submodule.test.test2.path1", "submodule.test.test2.path1");
             configFile.SetValue("submodule.test.test2.path2", "submodule.test.test2.path2");
             configFile.Save();
@@ -170,7 +170,7 @@ namespace GitCommandsTests.Config
         [Test]
         public void TestSetValueSectionWithDotExisting()
         {
-            var configFile = new ConfigFile(GetConfigFileName(), true);
+            ConfigFile configFile = new(GetConfigFileName(), true);
             configFile.SetValue("submodule.test.test1.path1", "invalid");
             configFile.SetValue("submodule.test.test2.path1", "submodule.test.test2.path1");
             configFile.SetValue("submodule.test.test2.path2", "submodule.test.test2.path2");
@@ -194,7 +194,7 @@ namespace GitCommandsTests.Config
                 File.WriteAllText(GetConfigFileName(), GetDefaultConfigFileContent(), GitModule.SystemEncoding);
             }
 
-            var configFile = new ConfigFile(GetConfigFileName(), true);
+            ConfigFile configFile = new(GetConfigFileName(), true);
             CheckValueIsEqual(configFile, "section1.key1", "value1");
             CheckValueIsEqual(configFile, "section2.subsection.key2", "value2");
             CheckValueIsEqual(configFile, "section3.subsection.key3", "value3");
@@ -203,7 +203,7 @@ namespace GitCommandsTests.Config
         [Test]
         public void TestWithNullSettings()
         {
-            var file = new ConfigFile(GetConfigFileName(), true);
+            ConfigFile file = new(GetConfigFileName(), true);
             Assert.Throws<ArgumentNullException>(() => file.GetValue(null, null));
         }
 
@@ -216,13 +216,13 @@ namespace GitCommandsTests.Config
                 File.WriteAllText(GetConfigFileName(), GetDefaultConfigFileContent(), GitModule.SystemEncoding);
 
                 // Make sure it is hidden
-                var configFile = new FileInfo(GetConfigFileName());
+                FileInfo configFile = new(GetConfigFileName());
                 configFile.Attributes = FileAttributes.Hidden;
             }
 
             // PERFORM TEST
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 CheckValueIsEqual(configFile, "section1.key1", "value1");
                 CheckValueIsEqual(configFile, "section2.subsection.key2", "value2");
                 CheckValueIsEqual(configFile, "section3.subsection.key3", "value3");
@@ -233,7 +233,7 @@ namespace GitCommandsTests.Config
 
             // CHECK WRITTEN VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 CheckValueIsEqual(configFile, "section1.key1", "new-value1");
             }
         }
@@ -243,7 +243,7 @@ namespace GitCommandsTests.Config
         {
             // TEST DATA
             {
-                var content = new StringBuilder();
+                StringBuilder content = new();
 
                 content.AppendLine("[merge]");
                 content.AppendLine("	tool = kdiff3");
@@ -266,20 +266,20 @@ namespace GitCommandsTests.Config
 
             // CHECK GET CONFIG VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 CheckValueIsEqual(configFile, "user.name", "Sergey Pustovit");
             }
 
             // CHECK SET CONFIG VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 configFile.SetValue("user.name", "new-value");
                 configFile.Save();
             }
 
             // CHECK WRITTEN VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 CheckValueIsEqual(configFile, "user.name", "new-value");
             }
         }
@@ -289,7 +289,7 @@ namespace GitCommandsTests.Config
         {
             // TEST DATA
             {
-                var content = new StringBuilder();
+                StringBuilder content = new();
 
                 content.AppendLine("[core]");
                 content.AppendLine("	repositoryformatversion = 0");
@@ -321,20 +321,20 @@ namespace GitCommandsTests.Config
 
             // CHECK GET CONFIG VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 CheckValueIsEqual(configFile, "core.repositoryformatversion", "0");
             }
 
             // CHECK SET CONFIG VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 configFile.SetValue("core.repositoryformatversion", "1");
                 configFile.Save();
             }
 
             // CHECK WRITTEN VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 CheckValueIsEqual(configFile, "core.repositoryformatversion", "1");
             }
         }
@@ -344,7 +344,7 @@ namespace GitCommandsTests.Config
         {
             // TEST DATA
             {
-                var content = new StringBuilder();
+                StringBuilder content = new();
 
                 content.AppendLine("[bugtraq]");
                 content.AppendLine("	url = http://192.168.0.1:8080/browse/%BUGID%");
@@ -360,33 +360,33 @@ namespace GitCommandsTests.Config
 
             // CHECK GET CONFIG VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 CheckValueIsEqual(configFile, "bugtraq.logregex", "\n([A-Z][A-Z0-9]+-/d+)");
             }
 
             // CHECK SET CONFIG VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 configFile.SetValue("bugtraq.logregex", "data\nnewline");
                 configFile.Save();
             }
 
             // CHECK WRITTEN VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 CheckValueIsEqual(configFile, "bugtraq.logregex", "data\nnewline");
             }
 
             // CHECK SET CONFIG VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 configFile.SetValue("bugtraq.logregex", "data\\newline");
                 configFile.Save();
             }
 
             // CHECK WRITTEN VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 CheckValueIsEqual(configFile, "bugtraq.logregex", "data\\newline");
             }
         }
@@ -396,7 +396,7 @@ namespace GitCommandsTests.Config
         {
             // TEST DATA
             {
-                var content = new StringBuilder();
+                StringBuilder content = new();
 
                 content.AppendLine("# issue tracker configuration");
                 content.AppendLine("[bugtraq]");
@@ -417,7 +417,7 @@ namespace GitCommandsTests.Config
 
             // CHECK GET CONFIG VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 CheckValueIsEqual(configFile, "bugtraq.url", "http://192.168.0.1:8080/browse/%BUGID%");
                 CheckValueIsEqual(configFile, "bugtraq.message", "This commit fixes %BUGID%");
                 CheckValueIsEqual(configFile, "bugtraq.number", "");
@@ -431,7 +431,7 @@ namespace GitCommandsTests.Config
         {
             // TEST DATA
             {
-                var content = new StringBuilder();
+                StringBuilder content = new();
 
                 content.AppendLine("# issue tracker configuration");
                 content.AppendLine("[bugtraq \"default\\\\5\"]");
@@ -443,7 +443,7 @@ namespace GitCommandsTests.Config
 
             // CHECK GET CONFIG VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 CheckValueIsEqual(configFile, "bugtraq.default\\5.url", "http://192.168.0.1:8080/browse/%BUGID%");
             }
         }
@@ -453,7 +453,7 @@ namespace GitCommandsTests.Config
         {
             // TEST DATA
             {
-                var content = new StringBuilder();
+                StringBuilder content = new();
 
                 content.AppendLine("[section \"sub section\"]");
                 content.AppendLine("	test = test");
@@ -464,20 +464,20 @@ namespace GitCommandsTests.Config
 
             // CHECK GET CONFIG VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 CheckValueIsEqual(configFile, "section.sub section.test", "test");
             }
 
             // CHECK SET CONFIG VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 configFile.SetValue("section.sub section.test", @"test2");
                 configFile.Save();
             }
 
             // CHECK WRITTEN VALUE
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
                 CheckValueIsEqual(configFile, "section.sub section.test", "test2");
             }
         }
@@ -499,7 +499,7 @@ namespace GitCommandsTests.Config
 
             // verify
             {
-                var configFile = new ConfigFile(GetConfigFileName(), true);
+                ConfigFile configFile = new(GetConfigFileName(), true);
 
                 string remote = "branch.BranchName1.remote";
                 CheckValueIsEqual(configFile, remote, "origin1");
@@ -538,7 +538,7 @@ namespace GitCommandsTests.Config
 [status]
       showUntrackedFiles = no
 ";
-            var cfg = new ConfigFile("", true);
+            ConfigFile cfg = new("", true);
             cfg.LoadFromString(configFileContent);
             string actual = cfg.GetValue("status.showUntrackedFiles", string.Empty);
             string expected = "no";
@@ -554,7 +554,7 @@ namespace GitCommandsTests.Config
       showUntrackedFiles = no
 [status]
 ";
-            var cfg = new ConfigFile("", true);
+            ConfigFile cfg = new("", true);
             cfg.LoadFromString(configFileContent);
             string actual = cfg.GetValue("status.showUntrackedFiles", string.Empty);
             string expected = "no";
@@ -571,7 +571,7 @@ namespace GitCommandsTests.Config
 [status]
       showUntrackedFiles = no
 ";
-            var cfg = new ConfigFile("", true);
+            ConfigFile cfg = new("", true);
             cfg.LoadFromString(configFileContent);
             string actual = cfg.GetValue("status.showUntrackedFiles", string.Empty);
             string expected = "no";
@@ -588,7 +588,7 @@ namespace GitCommandsTests.Config
 [status]
       showUntrackedFiles = no
 ";
-            var cfg = new ConfigFile("", true);
+            ConfigFile cfg = new("", true);
             cfg.LoadFromString(configFileContent);
             IEnumerable<string> actual = cfg.GetValues("status.showUntrackedFiles");
             IEnumerable<string> expected = new[] { "yes", "no" };
@@ -598,13 +598,13 @@ namespace GitCommandsTests.Config
         [Test]
         public void SquareBracketInValue()
         {
-            var content = new StringBuilder();
+            StringBuilder content = new();
 
             content.AppendLine("[branch \"reporting_bad_behaviour\"]");
             content.AppendLine("    remote = origin");
             content.AppendLine("	merge = refs/heads/[en]reporting_bad_behaviour");
 
-            var cfg = new ConfigFile("", true);
+            ConfigFile cfg = new("", true);
             cfg.LoadFromString(content.ToString());
             string actual = cfg.GetValue("branch.reporting_bad_behaviour.merge", string.Empty);
             string expected = "refs/heads/[en]reporting_bad_behaviour";
@@ -614,13 +614,13 @@ namespace GitCommandsTests.Config
         [Test]
         public void SquareBracketInSectionName()
         {
-            var content = new StringBuilder();
+            StringBuilder content = new();
 
             content.AppendLine("[branch \"[en]reporting_bad_behaviour\"]");
             content.AppendLine("    remote = origin");
             content.AppendLine("	merge = refs/heads/reporting_bad_behaviour");
 
-            var cfg = new ConfigFile("", true);
+            ConfigFile cfg = new("", true);
             cfg.LoadFromString(content.ToString());
             string actual = cfg.GetValue("branch.[en]reporting_bad_behaviour.merge", string.Empty);
             string expected = "refs/heads/reporting_bad_behaviour";
@@ -636,7 +636,7 @@ namespace GitCommandsTests.Config
             if (File.Exists(GetConfigFileName()))
             {
                 // Make sure it is hidden
-                var configFile = new FileInfo(GetConfigFileName());
+                FileInfo configFile = new(GetConfigFileName());
                 configFile.Attributes = FileAttributes.Normal;
 
                 File.Delete(GetConfigFileName());

--- a/UnitTests/GitCommands.Tests/DiffListSortServiceTests.cs
+++ b/UnitTests/GitCommands.Tests/DiffListSortServiceTests.cs
@@ -30,7 +30,7 @@ namespace GitCommandsTests
         public void Constructor_loads_persisted_setting(DiffListSortType persistedSetting)
         {
             AppSettings.DiffListSorting = persistedSetting;
-            var service = new DiffListSortService();
+            DiffListSortService service = new();
 
             Assert.AreEqual(persistedSetting, service.DiffListSorting);
         }
@@ -41,7 +41,7 @@ namespace GitCommandsTests
         [TestCase(DiffListSortType.FileStatus)]
         public void Changing_the_sort_modifies_persistence(DiffListSortType sortType)
         {
-            var service = new DiffListSortService();
+            DiffListSortService service = new();
 
             service.DiffListSorting = sortType;
 
@@ -51,7 +51,7 @@ namespace GitCommandsTests
         [Test]
         public void Change_notifications_occur_when_sort_is_changed()
         {
-            var service = new DiffListSortService();
+            DiffListSortService service = new();
             service.DiffListSorting = DiffListSortType.FilePath;
 
             var raisedCount = 0;

--- a/UnitTests/GitCommands.Tests/DiffMergeTools/DiffMergeToolConfigurationManagerTests.cs
+++ b/UnitTests/GitCommands.Tests/DiffMergeTools/DiffMergeToolConfigurationManagerTests.cs
@@ -178,7 +178,7 @@ namespace GitCommandsTests.DiffMergeTools
         [Test]
         public void LoadDiffMergeToolConfig_should_load_tool_config_if_tool_registered()
         {
-            var tool = new SemanticMerge();
+            SemanticMerge tool = new();
 
             var toolPath = @"c:\some\path\to the tool\MyTool.exe";
             _fileSettings.GetValue($"mergetool.{tool.Name}.path").Returns(toolPath);

--- a/UnitTests/GitCommands.Tests/ExternalLinks/ExternalLinkRevisionParserTests.cs
+++ b/UnitTests/GitCommands.Tests/ExternalLinks/ExternalLinkRevisionParserTests.cs
@@ -110,7 +110,7 @@ namespace GitCommandsTests.ExternalLinks
 
         private static BindingList<ConfigFileRemote> GetDefaultRemotes()
         {
-            var remotes = new BindingList<ConfigFileRemote>();
+            BindingList<ConfigFileRemote> remotes = new();
             remotes.Add(new ConfigFileRemote
             {
                 Name = "origin",
@@ -135,9 +135,9 @@ namespace GitCommandsTests.ExternalLinks
         [CanBeNull]
         private static IReadOnlyList<ExternalLinkDefinition> Parse(string xml)
         {
-            var serializer = new XmlSerializer(typeof(List<ExternalLinkDefinition>));
-            using var stringReader = new StringReader(xml);
-            using var xmlReader = new XmlTextReader(stringReader);
+            XmlSerializer serializer = new(typeof(List<ExternalLinkDefinition>));
+            using StringReader stringReader = new(xml);
+            using XmlTextReader xmlReader = new(stringReader);
             return serializer.Deserialize(xmlReader) as List<ExternalLinkDefinition>;
         }
 

--- a/UnitTests/GitCommands.Tests/ExternalLinks/ExternalLinksManagerIntegrationTests.cs
+++ b/UnitTests/GitCommands.Tests/ExternalLinks/ExternalLinksManagerIntegrationTests.cs
@@ -55,13 +55,13 @@ namespace GitCommandsTests.ExternalLinks
         {
             _externalLinksStorage.Load(_userRoaming).Count.Should().Be(1);
 
-            var manager = new ExternalLinksManager(_repoDistributed);
+            ExternalLinksManager manager = new(_repoDistributed);
 
             // 1 comes from the user roaming settings
             // 3 come from the distributed
             manager.GetEffectiveSettings().Count.Should().Be(4);
 
-            var definition = new ExternalLinkDefinition
+            ExternalLinkDefinition definition = new()
             {
                 Name = "test",
                 SearchPattern = "pattern"
@@ -84,14 +84,14 @@ namespace GitCommandsTests.ExternalLinks
         {
             _externalLinksStorage.Load(_userRoaming).Count.Should().Be(1);
 
-            var manager = new ExternalLinksManager(_repoLocal);
+            ExternalLinksManager manager = new(_repoLocal);
 
             // 1 comes from the user roaming settings
             // 3 come from the distributed
             // 1 comes from the local
             manager.GetEffectiveSettings().Count.Should().Be(5);
 
-            var definition = new ExternalLinkDefinition
+            ExternalLinkDefinition definition = new()
             {
                 Name = "test",
                 SearchPattern = "pattern"
@@ -116,14 +116,14 @@ namespace GitCommandsTests.ExternalLinks
             _externalLinksStorage.Load(_userRoaming).Count.Should().Be(1);
             _externalLinksStorage.Load(_repoDistributed).Count.Should().Be(3);
 
-            var manager = new ExternalLinksManager(_repoLocal);
+            ExternalLinksManager manager = new(_repoLocal);
 
             // 1 comes from the user roaming settings
             // 3 come from the distributed
             // 1 comes from the local
             manager.GetEffectiveSettings().Count.Should().Be(5);
 
-            var definition = new ExternalLinkDefinition
+            ExternalLinkDefinition definition = new()
             {
                 Name = "Stash",
                 SearchPattern = "pattern"
@@ -149,7 +149,7 @@ namespace GitCommandsTests.ExternalLinks
             _externalLinksStorage.Load(_userRoaming).Count.Should().Be(1);
             _externalLinksStorage.Load(_repoDistributed).Count.Should().Be(3);
 
-            var manager = new ExternalLinksManager(_repoLocal);
+            ExternalLinksManager manager = new(_repoLocal);
 
             var effective = manager.GetEffectiveSettings();
 

--- a/UnitTests/GitCommands.Tests/ExternalLinks/ExternalLinksStorageIntegrationTests.cs
+++ b/UnitTests/GitCommands.Tests/ExternalLinks/ExternalLinksStorageIntegrationTests.cs
@@ -26,10 +26,10 @@ namespace GitCommandsTests.ExternalLinks
         {
             var content = EmbeddedResourceLoader.Load(Assembly.GetExecutingAssembly(), $"{GetType().Namespace}.MockData.{fileName}.settings.xml");
 
-            using var testHelper = new GitModuleTestHelper();
+            using GitModuleTestHelper testHelper = new();
             var settingsFile = testHelper.CreateRepoFile(".git", "GitExtensions.settings", content);
-            using var settingsCache = new GitExtSettingsCache(settingsFile);
-            var settings = new RepoDistSettings(null, settingsCache, SettingLevel.Unknown);
+            using GitExtSettingsCache settingsCache = new(settingsFile);
+            RepoDistSettings settings = new(null, settingsCache, SettingLevel.Unknown);
 
             var definitions = _externalLinksStorage.Load(settings);
             definitions.Count.Should().Be(expected);

--- a/UnitTests/GitCommands.Tests/FullPathResolverTests.cs
+++ b/UnitTests/GitCommands.Tests/FullPathResolverTests.cs
@@ -60,7 +60,7 @@ namespace GitCommandsTests
         [TestCase(@"C:\dev\c#\repo\")]
         public void Resolve_combines_paths(string workingDir)
         {
-            var resolver = new FullPathResolver(() => workingDir);
+            FullPathResolver resolver = new(() => workingDir);
             resolver.Resolve("file.txt").Should().Be(Path.Combine(workingDir, "file.txt").Replace("/", "\\"));
         }
 
@@ -69,7 +69,7 @@ namespace GitCommandsTests
         [TestCase(" ")]
         public void Resolve_does_not_throw_on_invalid_workingDir(string workingDir)
         {
-            var resolver = new FullPathResolver(() => workingDir);
+            FullPathResolver resolver = new(() => workingDir);
             resolver.Resolve("file.txt").Should().Be(Path.Combine(Environment.CurrentDirectory, "file.txt").Replace("/", "\\"));
         }
     }

--- a/UnitTests/GitCommands.Tests/Git/AheadBehindDataProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/AheadBehindDataProviderTests.cs
@@ -255,7 +255,7 @@ namespace GitCommandsTests.Git
 
         private void SetResultOfGitCommand(string result)
         {
-            var writer = new StreamWriter(_standardOutputStream);
+            StreamWriter writer = new(_standardOutputStream);
             writer.Write(result);
             writer.Flush();
             _standardOutputStream.Position = 0;

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCheckoutBranchCmdTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCheckoutBranchCmdTest.cs
@@ -10,7 +10,7 @@ namespace GitCommandsTests.Git.Commands
         [Test]
         public void TestConstructor()
         {
-            var cmd = new GitCheckoutBranchCmd("branchName", true);
+            GitCheckoutBranchCmd cmd = new("branchName", true);
 
             Assert.IsNotNull(cmd);
             Assert.AreEqual(cmd.BranchName, "branchName");
@@ -20,7 +20,7 @@ namespace GitCommandsTests.Git.Commands
         [Test]
         public void TestConstructorRemoteIsFalse()
         {
-            var cmd = new GitCheckoutBranchCmd("branchName", false);
+            GitCheckoutBranchCmd cmd = new("branchName", false);
 
             Assert.IsNotNull(cmd);
             Assert.AreEqual(cmd.BranchName, "branchName");
@@ -30,7 +30,7 @@ namespace GitCommandsTests.Git.Commands
         [Test]
         public void TestAccessesRemoteIsFalse()
         {
-            var cmd = new GitCheckoutBranchCmd("branchName", true);
+            GitCheckoutBranchCmd cmd = new("branchName", true);
 
             Assert.IsFalse(cmd.AccessesRemote);
         }

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -71,7 +71,7 @@ namespace GitCommandsTests.Git.Commands
         public void TestFetchArguments()
         {
             // TODO produce a valid working directory
-            var module = new GitModule(Path.GetTempPath());
+            GitModule module = new(Path.GetTempPath());
             {
                 // Specifying a remote and a local branch creates a local branch
                 var fetchCmd = module.FetchCmd("origin", "some-branch", "local").Arguments;
@@ -135,7 +135,7 @@ namespace GitCommandsTests.Git.Commands
         [Test]
         public void TestUnsetStagedStatus()
         {
-            var item = new GitItemStatus("name");
+            GitItemStatus item = new("name");
             Assert.AreEqual(item.Staged, StagedStatus.Unset);
         }
 

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCreateTagCmdTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCreateTagCmdTests.cs
@@ -20,8 +20,8 @@ namespace GitCommandsTests.Git.Commands
         [TestCase("  ")]
         public void Validate_should_throw_if_tag_name_invalid(string tagName)
         {
-            var args = new GitCreateTagArgs(tagName, Revision);
-            var cmd = new GitCreateTagCmd(args, TagMessageFile);
+            GitCreateTagArgs args = new(tagName, Revision);
+            GitCreateTagCmd cmd = new(args, TagMessageFile);
 
             Assert.Throws<ArgumentException>(() => cmd.Validate());
         }
@@ -29,8 +29,8 @@ namespace GitCommandsTests.Git.Commands
         [Test]
         public void Validate_should_throw_if_tag_revision_invalid()
         {
-            var args = new GitCreateTagArgs(TagName, null);
-            var cmd = new GitCreateTagCmd(args, TagMessageFile);
+            GitCreateTagArgs args = new(TagName, null);
+            GitCreateTagCmd cmd = new(args, TagMessageFile);
 
             Assert.Throws<ArgumentException>(() => cmd.Validate());
         }
@@ -40,8 +40,8 @@ namespace GitCommandsTests.Git.Commands
         [TestCase("  ")]
         public void Validate_should_throw_for_SignWithSpecificKey_if_tag_keyId_invalid(string signKeyId)
         {
-            var args = new GitCreateTagArgs(TagName, Revision, TagOperation.SignWithSpecificKey, signKeyId: signKeyId);
-            var cmd = new GitCreateTagCmd(args, TagMessageFile);
+            GitCreateTagArgs args = new(TagName, Revision, TagOperation.SignWithSpecificKey, signKeyId: signKeyId);
+            GitCreateTagCmd cmd = new(args, TagMessageFile);
 
             Assert.Throws<ArgumentException>(() => cmd.Validate());
         }
@@ -49,8 +49,8 @@ namespace GitCommandsTests.Git.Commands
         [Test]
         public void ToLine_should_throw_if_operation_not_supported()
         {
-            var args = new GitCreateTagArgs(TagName, Revision, (TagOperation)10);
-            var cmd = new GitCreateTagCmd(args, TagMessageFile);
+            GitCreateTagArgs args = new(TagName, Revision, (TagOperation)10);
+            GitCreateTagCmd cmd = new(args, TagMessageFile);
 
             Assert.Throws<NotSupportedException>(() => _ = cmd.Arguments);
         }
@@ -59,8 +59,8 @@ namespace GitCommandsTests.Git.Commands
         [TestCase(false, "tag -s -F \"c:/.git/TAGMESSAGE\" \"bla\" -- 0123456789012345678901234567890123456789")]
         public void ToLine_should_render_force_flag(bool force, string expected)
         {
-            var args = new GitCreateTagArgs(TagName, Revision, TagOperation.SignWithDefaultKey, TagMessage, KeyId, force);
-            var cmd = new GitCreateTagCmd(args, TagMessageFile);
+            GitCreateTagArgs args = new(TagName, Revision, TagOperation.SignWithDefaultKey, TagMessage, KeyId, force);
+            GitCreateTagCmd cmd = new(args, TagMessageFile);
 
             var cmdLine = cmd.Arguments;
 
@@ -73,8 +73,8 @@ namespace GitCommandsTests.Git.Commands
         [TestCase(TagOperation.SignWithSpecificKey, "tag -f -u A9876F -F \"c:/.git/TAGMESSAGE\" \"bla\" -- 0123456789012345678901234567890123456789")]
         public void ToLine_should_render_different_operations(TagOperation operation, string expected)
         {
-            var args = new GitCreateTagArgs(TagName, Revision, operation, signKeyId: KeyId, force: true);
-            var cmd = new GitCreateTagCmd(args, TagMessageFile);
+            GitCreateTagArgs args = new(TagName, Revision, operation, signKeyId: KeyId, force: true);
+            GitCreateTagCmd cmd = new(args, TagMessageFile);
 
             var actualCmdLine = cmd.Arguments;
 

--- a/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
@@ -29,7 +29,7 @@ namespace GitCommandsTests.Git
             // We need to correct it to %APPDATA%\GitExtensions\GitExtensions for v3 at least
             var userAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             var settingPath = Path.Combine(userAppDataPath, "GitExtensions\\GitExtensions\\GitExtensions.settings");
-            var settingContainer = new RepoDistSettings(null, GitExtSettingsCache.FromCache(settingPath), SettingLevel.Unknown);
+            RepoDistSettings settingContainer = new(null, GitExtSettingsCache.FromCache(settingPath), SettingLevel.Unknown);
             _appPath = settingContainer.GetString("gitcommand", "git.exe");
 
             // Execute process in GitExtension working directory, so that git will return success exit-code
@@ -50,7 +50,7 @@ namespace GitCommandsTests.Git
         {
             const string arguments = "abc";
 
-            var cache = new CommandCache();
+            CommandCache cache = new();
 
             cache.Add(
                 arguments,
@@ -72,7 +72,7 @@ namespace GitCommandsTests.Git
             const string commandOutput = "Hello World!";
 
             // Empty cache
-            var cache = new CommandCache();
+            CommandCache cache = new();
 
             using (_executable.StageOutput(arguments, commandOutput))
             {
@@ -98,7 +98,7 @@ namespace GitCommandsTests.Git
             // 9: 'reset -- '
             // 1: ' ' added after second Add in ArgumentBuilder
             var appLength = _appPath.Length + 3;
-            var builder = new ArgumentBuilder() { "reset --" };
+            ArgumentBuilder builder = new() { "reset --" };
             var len = builder.ToString().Length;
             var args = builder.BuildBatchArguments(new string[]
             {
@@ -134,7 +134,7 @@ namespace GitCommandsTests.Git
 
         private string GenerateStringByLength(int length)
         {
-            var sb = new StringBuilder(length);
+            StringBuilder sb = new(length);
 
             for (int i = 0; i < length; i++)
             {

--- a/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/GetAllChangedFilesOutputParserTest.cs
@@ -24,8 +24,8 @@ namespace GitCommandsTests.Git.Commands
         public void TestGetStatusChangedFilesFromString(string testName, string statusString)
         {
             // TODO produce a valid working directory
-            var module = new GitModule(Path.GetTempPath());
-            var getAllChangedFilesOutputParser = new GetAllChangedFilesOutputParser(() => module);
+            GitModule module = new(Path.GetTempPath());
+            GetAllChangedFilesOutputParser getAllChangedFilesOutputParser = new(() => module);
 
             using (ApprovalResults.ForScenario(testName.Replace(' ', '_')))
             {

--- a/UnitTests/GitCommands.Tests/Git/GitBlameCommitTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitBlameCommitTests.cs
@@ -16,7 +16,7 @@ namespace GitCommandsTests.Git
             var authorTime = DateTime.Now;
             var commitHash = ObjectId.Random();
 
-            var str = new StringBuilder();
+            StringBuilder str = new();
 
             str.AppendLine("Author: Author");
             str.AppendLine("Author date: " + authorTime);
@@ -27,7 +27,7 @@ namespace GitCommandsTests.Git
             str.AppendLine();
             str.Append("FileName: fileName.txt");
 
-            var commit = new GitBlameCommit(
+            GitBlameCommit commit = new(
                 commitHash,
                 "Author",
                 "author@authormail.com",

--- a/UnitTests/GitCommands.Tests/Git/GitBranchNameOptionsTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitBranchNameOptionsTest.cs
@@ -14,7 +14,7 @@ namespace GitCommandsTests.Git
         [TestCase("", "")]
         public void ReplacementToken_can_be_null_or_empty(string token, string expected)
         {
-            var options = new GitBranchNameOptions(token);
+            GitBranchNameOptions options = new(token);
 
             options.ReplacementToken.Should().Be(expected);
         }

--- a/UnitTests/GitCommands.Tests/Git/GitDirectoryResolverTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitDirectoryResolverTests.cs
@@ -97,14 +97,14 @@ namespace GitCommandsTests.Git
         public void Resolve_non_bare_repository_real_filesystem()
         {
             _resolver = new GitDirectoryResolver();
-            using var helper = new GitModuleTestHelper();
+            using GitModuleTestHelper helper = new();
             _resolver.Resolve(helper.Module.WorkingDir).Should().Be(helper.Module.WorkingDirGitDir);
         }
 
         [Test]
         public void Resolve_submodule_real_filesystem()
         {
-            using var helper = new GitModuleTestHelper();
+            using GitModuleTestHelper helper = new();
             var submodulePath = Path.Combine(helper.Module.WorkingDir, "External", "Git.hub");
             helper.CreateFile(submodulePath, ".git", "\r \r\ngitdir: ../../.git/modules/Externals/Git.hub\r\ntext");
             _resolver = new GitDirectoryResolver();

--- a/UnitTests/GitCommands.Tests/Git/GitRefTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitRefTests.cs
@@ -76,7 +76,7 @@ namespace GitCommandsTests.Git
             localConfigFileSettings.GetValue($"branch.local_branch.merge").Returns(string.Empty);
             localConfigFileSettings.GetValue($"branch.local_branch.remote").Returns(string.Empty);
             localGitModule.LocalConfigFile.Returns(localConfigFileSettings);
-            var localBranchRef = new GitRef(localGitModule, ObjectId.Random(), "refs/heads/local_branch");
+            GitRef localBranchRef = new(localGitModule, ObjectId.Random(), "refs/heads/local_branch");
 
             GitRef remoteBranchRef = SetupLocalBranchWithATrackingReference("a_remote_branch", "origin");
 
@@ -88,7 +88,7 @@ namespace GitCommandsTests.Git
             var remoteGitModule = Substitute.For<IGitModule>();
             var remoteConfigFileSettings = Substitute.For<IConfigFileSettings>();
             remoteGitModule.LocalConfigFile.Returns(remoteConfigFileSettings);
-            var remoteBranchRef = new GitRef(remoteGitModule, ObjectId.Random(), $"refs/remotes/{remoteName}/{remoteBranchShortName}", remoteName);
+            GitRef remoteBranchRef = new(remoteGitModule, ObjectId.Random(), $"refs/remotes/{remoteName}/{remoteBranchShortName}", remoteName);
             return remoteBranchRef;
         }
 
@@ -99,7 +99,7 @@ namespace GitCommandsTests.Git
             localConfigFileSettings.GetValue($"branch.local_branch.merge").Returns($"refs/heads/{remoteShortName}");
             localConfigFileSettings.GetValue($"branch.local_branch.remote").Returns(remoteName);
             localGitModule.LocalConfigFile.Returns(localConfigFileSettings);
-            var localBranchRef = new GitRef(localGitModule, ObjectId.Random(), "refs/heads/local_branch");
+            GitRef localBranchRef = new(localGitModule, ObjectId.Random(), "refs/heads/local_branch");
             return localBranchRef;
         }
     }

--- a/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitRevisionTesterTests.cs
@@ -39,7 +39,7 @@ namespace GitCommandsTests.Git
         {
             var firstSelected = new[] { ObjectId.IndexId, ObjectId.Random() };
 
-            var selectedRevision = new GitRevision(ObjectId.WorkTreeId)
+            GitRevision selectedRevision = new(ObjectId.WorkTreeId)
             {
                 ParentIds = new[] { ObjectId.IndexId }
             };
@@ -59,7 +59,7 @@ namespace GitCommandsTests.Git
                 parent2
             };
 
-            var selectedRevision2 = new GitRevision(ObjectId.Random())
+            GitRevision selectedRevision2 = new(ObjectId.Random())
             {
                 ParentIds = new[] { parent1, parent2 }
             };
@@ -134,7 +134,7 @@ namespace GitCommandsTests.Git
         {
             var gitRef = Substitute.For<IGitRef>();
             gitRef.Name.Returns(x => "Name is MyName");
-            var revision = new GitRevision(ObjectId.Random()) { Refs = new[] { gitRef } };
+            GitRevision revision = new(ObjectId.Random()) { Refs = new[] { gitRef } };
 
             _tester.Matches(revision, criteria).Should().BeTrue();
         }
@@ -148,7 +148,7 @@ namespace GitCommandsTests.Git
             var gitRef = Substitute.For<IGitRef>();
             gitRef.Name.Returns(x => "Name is MyName");
 
-            var revision = new GitRevision(ObjectId.Parse("0011223344556677889900112233445566778899")) { Refs = new[] { gitRef } };
+            GitRevision revision = new(ObjectId.Parse("0011223344556677889900112233445566778899")) { Refs = new[] { gitRef } };
 
             _tester.Matches(revision, criteria).Should().Be(expected);
         }

--- a/UnitTests/GitCommands.Tests/Git/Gpg/GitGpgControllerTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/Gpg/GitGpgControllerTests.cs
@@ -42,8 +42,8 @@ namespace GitCommandsTests.Git.Gpg
         {
             var objectId = ObjectId.Random();
 
-            var revision = new GitRevision(objectId);
-            var args = new GitArgumentBuilder("log")
+            GitRevision revision = new(objectId);
+            GitArgumentBuilder args = new("log")
             {
                 "--pretty=\"format:%G?\"",
                 "-1",
@@ -77,7 +77,7 @@ namespace GitCommandsTests.Git.Gpg
 
             string gitRefCompleteName = "refs/tags/FirstTag^{}";
 
-            var revision = new GitRevision(objectId)
+            GitRevision revision = new(objectId)
             {
                 Refs = Enumerable.Range(0, numberOfTags)
                     .Select(_ => new GitRef(_module, objectId, gitRefCompleteName))
@@ -96,10 +96,10 @@ namespace GitCommandsTests.Git.Gpg
         {
             var objectId = ObjectId.Random();
 
-            var gitRef = new GitRef(_module, objectId, "refs/tags/FirstTag^{}");
+            GitRef gitRef = new(_module, objectId, "refs/tags/FirstTag^{}");
 
-            var revision = new GitRevision(objectId) { Refs = new[] { gitRef } };
-            var args = new GitArgumentBuilder("verify-tag")
+            GitRevision revision = new(objectId) { Refs = new[] { gitRef } };
+            GitArgumentBuilder args = new("verify-tag")
             {
                 "--raw",
                 gitRef.LocalName
@@ -116,8 +116,8 @@ namespace GitCommandsTests.Git.Gpg
         public void Validate_GetCommitVerificationMessage(string returnString)
         {
             var objectId = ObjectId.Random();
-            var revision = new GitRevision(objectId);
-            var args = new GitArgumentBuilder("log")
+            GitRevision revision = new(objectId);
+            GitArgumentBuilder args = new("log")
             {
                 "--pretty=\"format:%GG\"",
                 "-1",
@@ -149,7 +149,7 @@ namespace GitCommandsTests.Git.Gpg
         public void Validate_GetTagVerifyMessage(int usefulTagRefNumber, string expected)
         {
             var objectId = ObjectId.Random();
-            var revision = new GitRevision(objectId);
+            GitRevision revision = new(objectId);
 
             IDisposable validate = null;
 
@@ -158,7 +158,7 @@ namespace GitCommandsTests.Git.Gpg
                 case 0:
                     {
                         // Tag but not dereference
-                        var gitRef = new GitRef(_module, objectId, "refs/tags/TagName");
+                        GitRef gitRef = new(_module, objectId, "refs/tags/TagName");
                         revision.Refs = new[] { gitRef };
 
                         break;
@@ -167,10 +167,10 @@ namespace GitCommandsTests.Git.Gpg
                 case 1:
                     {
                         // One tag that's also IsDereference == true
-                        var gitRef = new GitRef(_module, objectId, "refs/tags/TagName^{}");
+                        GitRef gitRef = new(_module, objectId, "refs/tags/TagName^{}");
                         revision.Refs = new[] { gitRef };
 
-                        var args = new GitArgumentBuilder("verify-tag") { gitRef.LocalName };
+                        GitArgumentBuilder args = new("verify-tag") { gitRef.LocalName };
                         validate = _executable.StageOutput(args.ToString(), gitRef.LocalName);
 
                         break;
@@ -179,12 +179,12 @@ namespace GitCommandsTests.Git.Gpg
                 case 2:
                     {
                         // Two tag that's also IsDereference == true
-                        var gitRef1 = new GitRef(_module, objectId, "refs/tags/FirstTag^{}");
+                        GitRef gitRef1 = new(_module, objectId, "refs/tags/FirstTag^{}");
 
-                        var args = new GitArgumentBuilder("verify-tag") { gitRef1.LocalName };
+                        GitArgumentBuilder args = new("verify-tag") { gitRef1.LocalName };
                         _executable.StageOutput(args.ToString(), gitRef1.LocalName);
 
-                        var gitRef2 = new GitRef(_module, objectId, "refs/tags/SecondTag^{}");
+                        GitRef gitRef2 = new(_module, objectId, "refs/tags/SecondTag^{}");
                         revision.Refs = new[] { gitRef1, gitRef2 };
 
                         args = new GitArgumentBuilder("verify-tag") { gitRef2.LocalName };

--- a/UnitTests/GitCommands.Tests/Git/IndexLockManagerTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/IndexLockManagerTests.cs
@@ -132,7 +132,7 @@ namespace GitCommandsTests.Git
         [Test]
         public void Resolve_submodule_real_filesystem()
         {
-            using var helper = new GitModuleTestHelper();
+            using GitModuleTestHelper helper = new();
             helper.CreateFile(helper.Module.WorkingDir, ".gitmodules", @"[submodule ""Externals/NBug""]
     path = Externals/NBug
     url = https://github.com/gitextensions/NBug.git

--- a/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
@@ -268,7 +268,7 @@ namespace GitCommandsTests.Git
         public void TryParseAsciiHexBytes_returns_false_when_bounds_check_fails()
         {
             var bytes = new byte[ObjectId.Sha1CharCount];
-            var segment = new ArraySegment<byte>(bytes);
+            ArraySegment<byte> segment = new(bytes);
 
             Assert.False(ObjectId.TryParseAsciiHexBytes(segment, -1, out ObjectId objectId));
             Assert.Null(objectId);

--- a/UnitTests/GitCommands.Tests/Git/SubmoduleHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/SubmoduleHelpersTest.cs
@@ -22,7 +22,7 @@ namespace GitCommandsTests.Git
             Directory.CreateDirectory(Path.Combine(root, "Externals", "conemu-inside-b"));
             Directory.CreateDirectory(Path.Combine(root, "Assets", "Core", "Vehicle Physics core assets"));
 
-            var testModule = new GitModule(root);
+            GitModule testModule = new(root);
 
             // Submodule name without spaces in the name
 

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -381,14 +381,14 @@ namespace GitCommandsTests
         [Test]
         public void RevParse_should_return_null_if_revisionExpression_exceeds_260_symbols()
         {
-            var revisionExpression = new string('a', 261);
+            string revisionExpression = new('a', 261);
             _gitModule.RevParse(revisionExpression).Should().BeNull();
         }
 
         [Test]
         public void RevParse_should_return_ObjectId_if_revisionExpression_is_valid_hash()
         {
-            var revisionExpression = new string('1', ObjectId.Sha1CharCount);
+            string revisionExpression = new('1', ObjectId.Sha1CharCount);
             _gitModule.RevParse(revisionExpression).Should().Be(ObjectId.WorkTreeId);
         }
 
@@ -447,7 +447,7 @@ namespace GitCommandsTests
         public void GetDiffChangedFilesFromString(string testName, StagedStatus stagedStatus, string statusString)
         {
             // TODO produce a valid working directory
-            var module = new GitModule(Path.GetTempPath());
+            GitModule module = new(Path.GetTempPath());
             using (ApprovalResults.ForScenario(testName.Replace(' ', '_')))
             {
                 // git diff -M -C -z --name-status
@@ -602,7 +602,7 @@ namespace GitCommandsTests
         [Test]
         public void GetParents_calls_correct_command_and_parses_response()
         {
-            var args = new GitArgumentBuilder("log")
+            GitArgumentBuilder args = new("log")
             {
                 "-n 1",
                 "--format=format:%P",
@@ -725,7 +725,7 @@ namespace GitCommandsTests
         [Test]
         public void GetSubmodulesLocalPaths()
         {
-            var moduleTestHelpers = new List<CommonTestUtils.GitModuleTestHelper>();
+            List<CommonTestUtils.GitModuleTestHelper> moduleTestHelpers = new();
             try
             {
                 const int numModules = 4;
@@ -775,8 +775,8 @@ namespace GitCommandsTests
         public void GetSuperprojectCurrentCheckout()
         {
             // Create super and sub repo
-            using CommonTestUtils.GitModuleTestHelper moduleTestHelperSuper = new CommonTestUtils.GitModuleTestHelper("super repo"),
-                                                       moduleTestHelperSub = new CommonTestUtils.GitModuleTestHelper("sub repo");
+            using CommonTestUtils.GitModuleTestHelper moduleTestHelperSuper = new("super repo"),
+                                                       moduleTestHelperSub = new("sub repo");
 
             // Add and init the submodule
             moduleTestHelperSuper.AddSubmodule(moduleTestHelperSub, "sub repo");
@@ -821,7 +821,7 @@ namespace GitCommandsTests
         [TestCase(new object[] { "123", "567", "output.file", 2 })]
         public void Test_FormatPatch(string from, string to, string outputFile, int? start)
         {
-            var arguments = new StringBuilder();
+            StringBuilder arguments = new();
             arguments.Append("format-patch -M -C -B");
             if (start is not null)
             {
@@ -841,7 +841,7 @@ namespace GitCommandsTests
         [TestCase(new object[] { null, "567", "output.file", 2 })]
         public void Test_FormatPatchInRoot(string from, string to, string outputFile, int? start)
         {
-            var arguments = new StringBuilder();
+            StringBuilder arguments = new();
             arguments.Append("format-patch -M -C -B");
             if (start is not null)
             {
@@ -867,7 +867,7 @@ namespace GitCommandsTests
         public void ResetFiles_should_work_as_expected(string[] files, string args)
         {
             // Real GitModule is need to access AppSettings.GitCommand static property, avoid exception with dummy GitModule
-            using var moduleTestHelper = new GitModuleTestHelper();
+            using GitModuleTestHelper moduleTestHelper = new();
             var gitModule = GetGitModuleWithExecutable(_executable, module: moduleTestHelper.Module);
             string dummyCommandOutput = "The answer is 42. Just check that the Git arguments are as expected.";
             _executable.StageOutput(args, dummyCommandOutput);
@@ -879,7 +879,7 @@ namespace GitCommandsTests
         public void RemoveFiles_shouldWorkAsExpected(string[] files, string args)
         {
             // Real GitModule is need to access AppSettings.GitCommand static property, avoid exception with dummy GitModule
-            using var moduleTestHelper = new GitModuleTestHelper();
+            using GitModuleTestHelper moduleTestHelper = new();
             var gitModule = GetGitModuleWithExecutable(_executable, module: moduleTestHelper.Module);
             string dummyCommandOutput = "The answer is 42. Just check that the Git arguments are as expected.";
             _executable.StageOutput(args, dummyCommandOutput);
@@ -897,7 +897,7 @@ namespace GitCommandsTests
         public void BatchUnstageFiles_should_work_as_expected(GitItemStatus[] files, string[] args, bool expectedResult)
         {
             // Real GitModule is need to access AppSettings.GitCommand static property, avoid exception with dummy GitModule
-            using var moduleTestHelper = new GitModuleTestHelper();
+            using GitModuleTestHelper moduleTestHelper = new();
             var gitModule = GetGitModuleWithExecutable(_executable, module: moduleTestHelper.Module);
 
             foreach (var arg in args)
@@ -955,7 +955,7 @@ namespace GitCommandsTests
 
             typeof(GitModule).GetField("_gitExecutable", BindingFlags.Instance | BindingFlags.NonPublic)
                 .SetValue(module, executable);
-            var cmdRunner = new GitCommandRunner(executable, () => GitModule.SystemEncoding);
+            GitCommandRunner cmdRunner = new(executable, () => GitModule.SystemEncoding);
             typeof(GitModule).GetField("_gitCommandRunner", BindingFlags.Instance | BindingFlags.NonPublic)
                 .SetValue(module, cmdRunner);
 

--- a/UnitTests/GitCommands.Tests/GitRevisionInfoProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/GitRevisionInfoProviderTests.cs
@@ -76,7 +76,7 @@ namespace GitCommandsTests
         public void LoadChildren_should_return_shallow_tree_for_GitItem_with_updated_FileName()
         {
             var commitId = ObjectId.Random();
-            var item = new GitItem(0, GitObjectType.Tree, commitId, "folder");
+            GitItem item = new(0, GitObjectType.Tree, commitId, "folder");
 
             var items = new[] { Substitute.For<INamedGitItem>(), new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file2"), new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file3") };
             _module.GetTree(commitId, false).Returns(items);

--- a/UnitTests/GitCommands.Tests/Patches/PatchProcessorTest.cs
+++ b/UnitTests/GitCommands.Tests/Patches/PatchProcessorTest.cs
@@ -149,8 +149,8 @@ index cdf8bebba,55ff37bb9..000000000
             const string fileNameA = "thisisatesta.txt";
             const string fileNameB = "thisisatestb.txt";
 
-            var patchText = new StringBuilder();
-            var patchOutput = new StringBuilder();
+            StringBuilder patchText = new();
+            StringBuilder patchOutput = new();
 
             AppendHeaderLine(header);
             AppendHeaderLine(index);
@@ -171,7 +171,7 @@ index cdf8bebba,55ff37bb9..000000000
             AppendDiffLine("-ąśdkjaldskjlaksd");
             AppendDiffLine("+changed again€");
 
-            var patch = new Patch(header, index, PatchFileType.Text, fileNameA, fileNameB, false, PatchChangeType.ChangeFile, patchText.ToString());
+            Patch patch = new(header, index, PatchFileType.Text, fileNameA, fileNameB, false, PatchChangeType.ChangeFile, patchText.ToString());
 
             return new TestPatch(patch, patchOutput.ToString());
 

--- a/UnitTests/GitCommands.Tests/Patches/PatchTest.cs
+++ b/UnitTests/GitCommands.Tests/Patches/PatchTest.cs
@@ -9,7 +9,7 @@ namespace GitCommandsTests.Patches
         [Test]
         public void TestPatchConstructor()
         {
-            var patch = new Patch("header", "index", PatchFileType.Text, "A", "B", true, PatchChangeType.NewFile, "text");
+            Patch patch = new("header", "index", PatchFileType.Text, "A", "B", true, PatchChangeType.NewFile, "text");
 
             Assert.AreEqual("header", patch.Header);
             Assert.AreEqual("index", patch.Index);

--- a/UnitTests/GitCommands.Tests/Remote/AzureDevOpsRemoteParserTests.cs
+++ b/UnitTests/GitCommands.Tests/Remote/AzureDevOpsRemoteParserTests.cs
@@ -13,7 +13,7 @@ namespace GitCommandsTests.Remote
         [TestCase("owner@vs-ssh.visualstudio.com:v3/owner/project/repo")]
         public void Should_succeed_in_parsing_valid_url(string url)
         {
-            var azureDevOpsRemoteParser = new AzureDevOpsRemoteParser();
+            AzureDevOpsRemoteParser azureDevOpsRemoteParser = new();
             azureDevOpsRemoteParser.TryExtractAzureDevopsDataFromRemoteUrl(url, out var owner, out var project, out var repository).Should().BeTrue();
             owner.Should().Be("owner");
             project.Should().Be("project");
@@ -25,7 +25,7 @@ namespace GitCommandsTests.Remote
         [Test]
         public void Should_fail_in_parsing_invalid_url()
         {
-            var azureDevOpsRemoteParser = new AzureDevOpsRemoteParser();
+            AzureDevOpsRemoteParser azureDevOpsRemoteParser = new();
             var url = "https://owner@dev.bad.com/owner/project/_git/repo";
             azureDevOpsRemoteParser.TryExtractAzureDevopsDataFromRemoteUrl(url, out var owner, out var project, out var repository).Should().BeFalse();
             owner.Should().BeNull();

--- a/UnitTests/GitCommands.Tests/Remote/ConfigFileRemoteSettingsManagerTests.cs
+++ b/UnitTests/GitCommands.Tests/Remote/ConfigFileRemoteSettingsManagerTests.cs
@@ -73,7 +73,7 @@ namespace GitCommandsTests.Remote
             const string remoteName1 = "name1";
             const string remoteName2 = "name2";
             _module.GetRemoteNames().Returns(x => new[] { null, "", " ", "    ", remoteName1, "\t" });
-            var sections = new List<IConfigSection> { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{remoteName2}", true) };
+            List<IConfigSection> sections = new() { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{remoteName2}", true) };
             _configFile.GetConfigSections().Returns(x => sections);
 
             var remotes = _remotesManager.LoadRemotes(loadDisabled);
@@ -104,7 +104,7 @@ namespace GitCommandsTests.Remote
         [Test]
         public void RemoveRemote_success()
         {
-            var remote = new ConfigFileRemote { Name = "bla" };
+            ConfigFileRemote remote = new() { Name = "bla" };
 
             _remotesManager.RemoveRemote(remote);
 
@@ -162,7 +162,7 @@ namespace GitCommandsTests.Remote
             const string remoteName = "a";
             const string remoteUrl = "b";
             const string output = "yes!";
-            var gitRemote = new ConfigFileRemote { Name = "old", Url = remoteUrl };
+            ConfigFileRemote gitRemote = new() { Name = "old", Url = remoteUrl };
             _module.RenameRemote(Arg.Any<string>(), Arg.Any<string>()).Returns(x => output);
 
             var result = _remotesManager.SaveRemote(gitRemote, remoteName, remoteUrl, null, null);
@@ -178,7 +178,7 @@ namespace GitCommandsTests.Remote
             const string remoteName = "a";
             const string remoteUrl = "b";
             const string output = "yes!";
-            var gitRemote = new ConfigFileRemote { Name = "old", Url = "old" };
+            ConfigFileRemote gitRemote = new() { Name = "old", Url = "old" };
             _module.RenameRemote(Arg.Any<string>(), Arg.Any<string>()).Returns(x => output);
 
             var result = _remotesManager.SaveRemote(gitRemote, remoteName, remoteUrl, null, null);
@@ -194,7 +194,7 @@ namespace GitCommandsTests.Remote
         [TestCase("a", "b", "c")]
         public void SaveRemote_should_update_settings(string remoteUrl, string remotePushUrl, string remotePuttySshKey)
         {
-            var remote = new ConfigFileRemote { Name = "bla", Url = remoteUrl };
+            ConfigFileRemote remote = new() { Name = "bla", Url = remoteUrl };
 
             _remotesManager.SaveRemote(remote, remote.Name, remoteUrl, remotePushUrl, remotePuttySshKey);
 
@@ -239,7 +239,7 @@ namespace GitCommandsTests.Remote
         [TestCase("name2", true)]
         public void SetRemoteState_should_call_ToggleRemoteState(string remoteName, bool remoteDisabled)
         {
-            var sections = new List<IConfigSection> { new ConfigSection("-remote.name1", true), new ConfigSection("remote.name2", true) };
+            List<IConfigSection> sections = new() { new ConfigSection("-remote.name1", true), new ConfigSection("remote.name2", true) };
             _configFile.GetConfigSections().Returns(x => sections);
 
             _remotesManager.ToggleRemoteState(remoteName, remoteDisabled);
@@ -360,7 +360,7 @@ namespace GitCommandsTests.Remote
 
             _module.GetRemoteNames().Returns(x => new[] { enabledRemoteName, });
 
-            var sections = new List<IConfigSection> { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true) };
+            List<IConfigSection> sections = new() { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true) };
             _configFile.GetConfigSections().Returns(x => sections);
 
             var disabledRemotes = _remotesManager.GetDisabledRemotes();
@@ -380,7 +380,7 @@ namespace GitCommandsTests.Remote
 
             _module.GetRemoteNames().Returns(x => new[] { enabledRemoteName, });
 
-            var sections = new List<IConfigSection> { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true) };
+            List<IConfigSection> sections = new() { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true) };
             _configFile.GetConfigSections().Returns(x => sections);
 
             var enabledRemoteNames = _remotesManager.GetEnabledRemoteNames();
@@ -404,7 +404,7 @@ namespace GitCommandsTests.Remote
 
             _module.GetRefs().ReturnsForAnyArgs(refs);
 
-            var sections = new List<IConfigSection> { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true) };
+            List<IConfigSection> sections = new() { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true) };
             _configFile.GetConfigSections().Returns(x => sections);
 
             var enabledRemotesNoBranches = _remotesManager.GetEnabledRemoteNamesWithoutBranches();
@@ -420,7 +420,7 @@ namespace GitCommandsTests.Remote
 
             _module.GetRemoteNames().Returns(x => new[] { enabledRemoteName, });
 
-            var sections = new List<IConfigSection> { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true) };
+            List<IConfigSection> sections = new() { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true) };
             _configFile.GetConfigSections().Returns(x => sections);
 
             Assert.IsTrue(_remotesManager.EnabledRemoteExists(enabledRemoteName));
@@ -435,7 +435,7 @@ namespace GitCommandsTests.Remote
 
             _module.GetRemoteNames().Returns(x => new[] { enabledRemoteName, });
 
-            var sections = new List<IConfigSection> { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true) };
+            List<IConfigSection> sections = new() { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true) };
             _configFile.GetConfigSections().Returns(x => sections);
 
             Assert.IsTrue(_remotesManager.DisabledRemoteExists(disabledRemoteName));
@@ -447,8 +447,8 @@ namespace GitCommandsTests.Remote
             [Test]
             public void ToggleRemoteState_should_not_fail_if_activate_repeatedly()
             {
-                using var helper = new GitModuleTestHelper();
-                var manager = new ConfigFileRemoteSettingsManager(() => helper.Module);
+                using GitModuleTestHelper helper = new();
+                ConfigFileRemoteSettingsManager manager = new(() => helper.Module);
 
                 const string remoteName = "active";
                 helper.Module.AddRemote(remoteName, "http://localhost/remote/repo.git");
@@ -461,8 +461,8 @@ namespace GitCommandsTests.Remote
             [Test]
             public void ToggleRemoteState_should_not_fail_if_deactivate_repeatedly()
             {
-                using var helper = new GitModuleTestHelper();
-                var manager = new ConfigFileRemoteSettingsManager(() => helper.Module);
+                using GitModuleTestHelper helper = new();
+                ConfigFileRemoteSettingsManager manager = new(() => helper.Module);
 
                 const string remoteName = "active";
                 helper.Module.AddRemote(remoteName, "http://localhost/remote/repo.git");

--- a/UnitTests/GitCommands.Tests/Remote/GitHubRemoteParserTests.cs
+++ b/UnitTests/GitCommands.Tests/Remote/GitHubRemoteParserTests.cs
@@ -22,7 +22,7 @@ namespace GitCommandsTests.Remote
         [Test]
         public void Should_fail_in_parsing_invalid_url()
         {
-            var gitHubRemoteParser = new GitHubRemoteParser();
+            GitHubRemoteParser gitHubRemoteParser = new();
             var url = "https://owner@dev.bad.com/owner/project/_git/repo";
             gitHubRemoteParser.TryExtractGitHubDataFromRemoteUrl(url, out var owner, out var repository).Should().BeFalse();
             owner.Should().BeNull();

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
@@ -92,7 +92,7 @@ namespace GitCommandsTests
         [TestCase("s", "l2\n\nl4 \n", "f.ext ")]
         public void ParseCommitBody_should_work(string subject, string lines, string expectedAdditionalData)
         {
-            var encodedBody = new StringBuilder();
+            StringBuilder encodedBody = new();
             encodedBody.Append(subject);
             if (!string.IsNullOrEmpty(lines))
             {

--- a/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
@@ -48,7 +48,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             // Act
             var setting = Setting.Create<T>(settingsPath, settingName, settingDefault);
@@ -71,7 +71,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             T storedValue = default;
 
@@ -90,7 +90,7 @@ namespace GitCommandsTests.Settings
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
-            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+            RepoDistSettings container = new(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
 
             AppSettings.UsingContainer(container, () =>
             {
@@ -111,7 +111,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -143,7 +143,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -177,7 +177,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             T storedValue = default;
 
@@ -201,7 +201,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             T storedValue = default;
 
@@ -220,7 +220,7 @@ namespace GitCommandsTests.Settings
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
-            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+            RepoDistSettings container = new(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
 
             AppSettings.UsingContainer(container, () =>
             {
@@ -244,7 +244,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             // Act
             var setting = Setting.Create(settingsPath, settingName, settingDefault);
@@ -266,7 +266,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             string storedValue = null;
 
             // Act
@@ -284,7 +284,7 @@ namespace GitCommandsTests.Settings
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
-            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+            RepoDistSettings container = new(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
 
             AppSettings.UsingContainer(container, () =>
             {
@@ -304,7 +304,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -335,7 +335,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -371,7 +371,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             // Act
             var setting = Setting.Create<bool>(settingsPath, settingName);
@@ -395,7 +395,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             // Act
             var setting = Setting.Create<bool>(settingsPath, settingName);
@@ -420,7 +420,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -453,7 +453,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -485,7 +485,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             bool? storedValue = null;
 
@@ -507,7 +507,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             bool? storedValue = null;
 
@@ -526,7 +526,7 @@ namespace GitCommandsTests.Settings
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
-            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+            RepoDistSettings container = new(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
 
             AppSettings.UsingContainer(container, () =>
             {
@@ -549,7 +549,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             // Act
             var setting = Setting.Create<char>(settingsPath, settingName);
@@ -573,7 +573,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             // Act
             var setting = Setting.Create<char>(settingsPath, settingName);
@@ -598,7 +598,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -631,7 +631,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -663,7 +663,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             char? storedValue = null;
 
@@ -685,7 +685,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             char? storedValue = null;
 
@@ -704,7 +704,7 @@ namespace GitCommandsTests.Settings
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
-            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+            RepoDistSettings container = new(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
 
             AppSettings.UsingContainer(container, () =>
             {
@@ -727,7 +727,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             // Act
             var setting = Setting.Create<byte>(settingsPath, settingName);
@@ -752,7 +752,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             // Act
             var setting = Setting.Create<byte>(settingsPath, settingName);
@@ -778,7 +778,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -812,7 +812,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -844,7 +844,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             byte? storedValue = null;
 
@@ -866,7 +866,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             byte? storedValue = null;
 
@@ -885,7 +885,7 @@ namespace GitCommandsTests.Settings
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
-            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+            RepoDistSettings container = new(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
 
             AppSettings.UsingContainer(container, () =>
             {
@@ -908,7 +908,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             // Act
             var setting = Setting.Create<int>(settingsPath, settingName);
@@ -933,7 +933,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             // Act
             var setting = Setting.Create<int>(settingsPath, settingName);
@@ -959,7 +959,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -993,7 +993,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -1025,7 +1025,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             int? storedValue = null;
 
@@ -1047,7 +1047,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             int? storedValue = null;
 
@@ -1066,7 +1066,7 @@ namespace GitCommandsTests.Settings
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
-            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+            RepoDistSettings container = new(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
 
             AppSettings.UsingContainer(container, () =>
             {
@@ -1089,7 +1089,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             // Act
             var setting = Setting.Create<float>(settingsPath, settingName);
@@ -1114,7 +1114,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             // Act
             var setting = Setting.Create<float>(settingsPath, settingName);
@@ -1140,7 +1140,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -1174,7 +1174,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -1206,7 +1206,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             float? storedValue = null;
 
@@ -1228,7 +1228,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             float? storedValue = null;
 
@@ -1247,7 +1247,7 @@ namespace GitCommandsTests.Settings
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
-            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+            RepoDistSettings container = new(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
 
             AppSettings.UsingContainer(container, () =>
             {
@@ -1270,7 +1270,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             // Act
             var setting = Setting.Create<TestEnum>(settingsPath, settingName);
@@ -1294,7 +1294,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             // Act
             var setting = Setting.Create<TestEnum>(settingsPath, settingName);
@@ -1320,7 +1320,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             string storedValue = string.Empty;
 
@@ -1339,7 +1339,7 @@ namespace GitCommandsTests.Settings
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
-            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+            RepoDistSettings container = new(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
 
             AppSettings.UsingContainer(container, () =>
             {
@@ -1362,7 +1362,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -1395,7 +1395,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             var updated = false;
 
             // Act
@@ -1427,7 +1427,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             TestEnum? storedValue = null;
 
@@ -1449,7 +1449,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             TestEnum? storedValue = null;
 
@@ -1468,7 +1468,7 @@ namespace GitCommandsTests.Settings
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
-            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+            RepoDistSettings container = new(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
 
             AppSettings.UsingContainer(container, () =>
             {
@@ -1497,7 +1497,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
 
             // Act
             var setting = Setting.Create<TestStruct>(settingsPath, settingName);
@@ -1518,7 +1518,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             TestStruct? value = new TestStruct
             {
                 Bool = false,
@@ -1549,7 +1549,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             TestStruct? value = new TestStruct
             {
                 Bool = false,
@@ -1588,7 +1588,7 @@ namespace GitCommandsTests.Settings
             // Arrange
             var pathName = Guid.NewGuid().ToString();
             var settingName = Guid.NewGuid().ToString();
-            var settingsPath = new AppSettingsPath(pathName);
+            AppSettingsPath settingsPath = new(pathName);
             TestStruct? value = new TestStruct
             {
                 Bool = false,

--- a/UnitTests/GitCommands.Tests/StreamExtensionsTests.cs
+++ b/UnitTests/GitCommands.Tests/StreamExtensionsTests.cs
@@ -43,7 +43,7 @@ namespace GitCommandsTests
             new byte[0], new byte[] { 1 }, new byte[] { 2, 3 }, new byte[] { 4, 5, 6 }, new byte[] { 7, 8, 9, 10 })]
         public void ReadNullTerminatedLines(byte[] input, params byte[][] expectedChunks)
         {
-            var stream = new MemoryStream(input);
+            MemoryStream stream = new(input);
 
             // Run the test at multiple buffer sizes to test boundary conditions thoroughly
             for (var bufferSize = 1; bufferSize < input.Length + 2; bufferSize++)

--- a/UnitTests/GitCommands.Tests/StringPoolTests.cs
+++ b/UnitTests/GitCommands.Tests/StringPoolTests.cs
@@ -12,7 +12,7 @@ namespace GitCommandsTests
         [Test]
         public void Intern()
         {
-            var pool = new StringPool();
+            StringPool pool = new();
 
             const string source = "abcabcabcabcabc";
 
@@ -135,8 +135,8 @@ namespace GitCommandsTests
         [Test, Ignore("For hash analysis only, has no assertions")]
         public void AnalyzeHashFunctionDistribution()
         {
-            var seenHashes = new HashSet<int>();
-            var collisions = new List<int>();
+            HashSet<int> seenHashes = new();
+            List<int> collisions = new();
 
             const int hashCount = 200_000;
             const int sourceWidth = 40;

--- a/UnitTests/GitCommands.Tests/UserRepositoryHistory/Legacy/RepositoryCategoryXmlSerialiserTests.cs
+++ b/UnitTests/GitCommands.Tests/UserRepositoryHistory/Legacy/RepositoryCategoryXmlSerialiserTests.cs
@@ -69,7 +69,7 @@ namespace GitCommandsTests.UserRepositoryHistory.Legacy
         [Test]
         public void Verify_backwards_compatibility_of_object_graph()
         {
-            var surrogate = new List<RepositoryCategory>
+            List<RepositoryCategory> surrogate = new()
             {
                 new RepositoryCategory
                 {
@@ -95,9 +95,9 @@ namespace GitCommandsTests.UserRepositoryHistory.Legacy
             };
 
             string xml;
-            using var sw = new StringWriter();
-            var serializer = new XmlSerializer(typeof(List<RepositoryCategory>));
-            var ns = new XmlSerializerNamespaces();
+            using StringWriter sw = new();
+            XmlSerializer serializer = new(typeof(List<RepositoryCategory>));
+            XmlSerializerNamespaces ns = new();
             ns.Add(string.Empty, string.Empty);
             serializer.Serialize(sw, surrogate, ns);
             xml = sw.ToString();

--- a/UnitTests/GitCommands.Tests/UserRepositoryHistory/Legacy/RepositoryStorageTests.cs
+++ b/UnitTests/GitCommands.Tests/UserRepositoryHistory/Legacy/RepositoryStorageTests.cs
@@ -44,7 +44,7 @@ namespace GitCommandsTests.UserRepositoryHistory.Legacy
         public void LoadLegacy_should_return_collection()
         {
             AppSettings.SetString("repositories", "repos");
-            var history = new List<RepositoryCategory>
+            List<RepositoryCategory> history = new()
             {
                 new RepositoryCategory
                 {

--- a/UnitTests/GitCommands.Tests/UserRepositoryHistory/LocalRepositoryManagerTests.cs
+++ b/UnitTests/GitCommands.Tests/UserRepositoryHistory/LocalRepositoryManagerTests.cs
@@ -45,7 +45,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_add_new_path_as_top_entry()
         {
             const string repoToAdd = "path to add\\";
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("path1\\"),
                 new Repository("path3\\"),
@@ -64,7 +64,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_move_existing_path_as_top_entry()
         {
             const string repoToAdd = "path to add\\";
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("path1\\"),
                 new Repository("path3\\"),
@@ -84,7 +84,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_move_only_first_existing_path_as_top_entry()
         {
             const string repoToAdd = "path to add\\";
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("path1\\"),
                 new Repository("path3\\"),
@@ -106,7 +106,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_not_move_if_path_already_as_top_entry()
         {
             const string repoToAdd = "path to add\\";
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository(repoToAdd),
                 new Repository("path1\\"),
@@ -167,7 +167,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         {
             const int size = 3;
             AppSettings.RecentRepositoriesHistorySize = size;
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("path1") { Category = "my" },
                 new Repository("path2"),
@@ -189,7 +189,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task RemoveRecentAsync_should_remove_if_exists()
         {
             const string repoToDelete = "path to delete";
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("path1"),
                 new Repository(repoToDelete),
@@ -212,7 +212,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task RemoveFavouriteAsync_should_not_crash_if_not_exists()
         {
             const string repoToDelete = "path to delete";
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("path1"),
                 new Repository("path2"),
@@ -239,7 +239,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task RemoveFavouriteAsync_should_remove_if_exists()
         {
             const string repoToDelete = "path to delete";
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("path1"),
                 new Repository(repoToDelete),
@@ -266,7 +266,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task RemoveRecentAsync_should_not_crash_if_not_exists()
         {
             const string repoToDelete = "path to delete";
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("path1"),
                 new Repository("path2"),
@@ -295,7 +295,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         [Test]
         public async Task SaveFavouriteHistoryAsync_should_save()
         {
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("path1"),
                 new Repository("path2"),
@@ -321,7 +321,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         {
             const int size = 3;
             AppSettings.RecentRepositoriesHistorySize = size;
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("path1"),
                 new Repository("path2"),
@@ -338,7 +338,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         [Test]
         public async Task RemoveInvalidRepositoriesAsync_should_apply_predicate()
         {
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("Even"),
                 new Repository("Odd"),
@@ -358,7 +358,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         [Test]
         public async Task RemoveInvalidRepositoriesAsync_should_not_apply_predicate()
         {
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("Even"),
                 new Repository("Odd"),
@@ -379,7 +379,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         {
             const string repoToDelete = "different path";
 
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("path1"),
                 new Repository("path2"),
@@ -400,7 +400,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         {
             const string repoToDelete = "different path";
 
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("path1"),
                 new Repository("path2"),

--- a/UnitTests/GitCommands.Tests/UserRepositoryHistory/RemoteRepositoryManagerTests.cs
+++ b/UnitTests/GitCommands.Tests/UserRepositoryHistory/RemoteRepositoryManagerTests.cs
@@ -39,7 +39,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_add_new_path_as_top_entry()
         {
             const string repoToAdd = "https://path.to/add";
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("http://path1/"),
                 new Repository("http://path3/"),
@@ -58,7 +58,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_move_existing_path_as_top_entry()
         {
             const string repoToAdd = "https://path.to/add";
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("git://path1/"),
                 new Repository("git://path3/"),
@@ -78,7 +78,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_move_only_first_existing_path_as_top_entry()
         {
             const string repoToAdd = "https://path.to/add";
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("ssh://path1/"),
                 new Repository("ssh://path3/"),
@@ -100,7 +100,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_not_move_if_path_already_as_top_entry()
         {
             const string repoToAdd = "https://path.to/add";
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository(repoToAdd),
                 new Repository("http://path1/"),
@@ -121,7 +121,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task RemoveRecentAsync_should_remove_if_exists()
         {
             const string repoToDelete = "path to delete";
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("path1"),
                 new Repository(repoToDelete),
@@ -144,7 +144,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task RemoveRecentAsync_should_not_crash_if_not_exists()
         {
             const string repoToDelete = "path to delete";
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("path1"),
                 new Repository("path2"),
@@ -175,7 +175,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         {
             const int size = 3;
             AppSettings.RecentRepositoriesHistorySize = size;
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository("path1"),
                 new Repository("path2"),

--- a/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryStorageTests.cs
+++ b/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryStorageTests.cs
@@ -51,7 +51,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         public void Load_should_return_collection()
         {
             AppSettings.SetString("a", "repos");
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository(@"C:\Development\gitextensions\"),
                 new Repository(@"C:\Development\gitextensions\Externals\NBug\")

--- a/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryXmlSerialiserTests.cs
+++ b/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryXmlSerialiserTests.cs
@@ -109,7 +109,7 @@ namespace GitCommandsTests.UserRepositoryHistory
         [Test]
         public void Serialize_recent_repositories()
         {
-            var history = new List<Repository>
+            List<Repository> history = new()
             {
                 new Repository(@"C:\Development\gitextensions\"),
                 new Repository(@"C:\Development\gitextensions\Externals\NBug\")

--- a/UnitTests/GitExtUtils.Tests/ArgumentBuilderTests.cs
+++ b/UnitTests/GitExtUtils.Tests/ArgumentBuilderTests.cs
@@ -43,7 +43,7 @@ namespace GitExtUtilsTests
         [Test]
         public void IsEmpty()
         {
-            var builder = new ArgumentBuilder();
+            ArgumentBuilder builder = new();
             builder.IsEmpty.Should().BeTrue();
 
             builder.Add("test");
@@ -53,7 +53,7 @@ namespace GitExtUtilsTests
         [Test]
         public void Length()
         {
-            var builder = new ArgumentBuilder();
+            ArgumentBuilder builder = new();
             builder.GetTestAccessor().Arguments.Length.Should().Be(0);
 
             builder.Add("test");
@@ -74,7 +74,7 @@ namespace GitExtUtilsTests
         [TestCase(new[] { "test", null, "test" }, 9, "test test")]
         public void Add(string[] args, int expectedLength, string expected)
         {
-            var builder = new ArgumentBuilder();
+            ArgumentBuilder builder = new();
 
             foreach (string arg in args)
             {

--- a/UnitTests/GitExtUtils.Tests/ControlTagExtensionTests.cs
+++ b/UnitTests/GitExtUtils.Tests/ControlTagExtensionTests.cs
@@ -10,7 +10,7 @@ namespace GitExtUtilsTests
         [Test]
         public void Multiple_values_can_be_set()
         {
-            var control = new Control();
+            Control control = new();
 
             control.SetTag(1);
             control.SetTag(2f);
@@ -24,7 +24,7 @@ namespace GitExtUtilsTests
         [Test]
         public void When_tag_field_is_occupied_GetTag_returns_default()
         {
-            var control = new Control();
+            Control control = new();
             control.Tag = new object();
 
             Assert.That(control.HasTag<int>(), Is.False);
@@ -34,7 +34,7 @@ namespace GitExtUtilsTests
         [Test]
         public void When_tag_field_is_occupied_SetTag_replaces_existing_tag()
         {
-            var control = new Control();
+            Control control = new();
             control.Tag = new object();
 
             control.SetTag(1);
@@ -46,7 +46,7 @@ namespace GitExtUtilsTests
         [Test]
         public void When_another_type_is_stored_at_key_GetTag_return_default()
         {
-            var control = new Control();
+            Control control = new();
             control.SetTag("key", 1);
             control.SetTag("key", 2f);
 

--- a/UnitTests/GitExtUtils.Tests/GitArgumentBuilderTests.cs
+++ b/UnitTests/GitExtUtils.Tests/GitArgumentBuilderTests.cs
@@ -26,7 +26,7 @@ namespace GitExtUtilsTests
         [Test]
         public void Command_with_default_config_item()
         {
-            var args = new GitArgumentBuilder("log")
+            GitArgumentBuilder args = new("log")
             {
                 "-n 1"
             };
@@ -39,7 +39,7 @@ namespace GitExtUtilsTests
         [Test]
         public void Command_with_custom_config_item()
         {
-            var args = new GitArgumentBuilder("foo")
+            GitArgumentBuilder args = new("foo")
             {
                 new GitConfigItem("bar", "baz")
             };
@@ -52,7 +52,7 @@ namespace GitExtUtilsTests
         [Test]
         public void Command_with_custom_config_item_quoted()
         {
-            var args = new GitArgumentBuilder("foo")
+            GitArgumentBuilder args = new("foo")
             {
                 new GitConfigItem("bar", "baz bax")
             };
@@ -65,7 +65,7 @@ namespace GitExtUtilsTests
         [Test]
         public void Command_with_custom_config_item_already_quoted()
         {
-            var args = new GitArgumentBuilder("foo")
+            GitArgumentBuilder args = new("foo")
             {
                 new GitConfigItem("bar", "\"baz bax\"")
             };
@@ -78,7 +78,7 @@ namespace GitExtUtilsTests
         [Test]
         public void Command_with_custom_config_item_and_argument()
         {
-            var args = new GitArgumentBuilder("foo")
+            GitArgumentBuilder args = new("foo")
             {
                 new GitConfigItem("bar", "baz"),
                 "--arg"
@@ -92,7 +92,7 @@ namespace GitExtUtilsTests
         [Test]
         public void Command_with_custom_config_item_defined_after_argument()
         {
-            var args = new GitArgumentBuilder("foo")
+            GitArgumentBuilder args = new("foo")
             {
                 "--arg",
                 new GitConfigItem("bar", "baz") // order doesn't matter
@@ -106,7 +106,7 @@ namespace GitExtUtilsTests
         [Test]
         public void Command_with_default_and_custom_config_items()
         {
-            var args = new GitArgumentBuilder("log")
+            GitArgumentBuilder args = new("log")
             {
                 new GitConfigItem("bar", "baz"),
                 "-n 1"
@@ -120,7 +120,7 @@ namespace GitExtUtilsTests
         [Test]
         public void Command_with_default_and_custom_config_items_and_argument()
         {
-            var args = new GitArgumentBuilder("log")
+            GitArgumentBuilder args = new("log")
             {
                 new GitConfigItem("bar", "baz"),
                 "-n 1"
@@ -134,7 +134,7 @@ namespace GitExtUtilsTests
         [Test]
         public void Command_with_config_item_that_overrides_default()
         {
-            var args = new GitArgumentBuilder("log")
+            GitArgumentBuilder args = new("log")
             {
                 new GitConfigItem("log.showSignature", "true"),
                 "-n 1"
@@ -148,7 +148,7 @@ namespace GitExtUtilsTests
         [Test]
         public void Command_with_config_item_that_overrides_default_different_case()
         {
-            var args = new GitArgumentBuilder("log")
+            GitArgumentBuilder args = new("log")
             {
                 new GitConfigItem("LOG.showSIGNATURE", "true"),
                 "-n 1"

--- a/UnitTests/GitExtUtils.Tests/LazyStringSplitTests.cs
+++ b/UnitTests/GitExtUtils.Tests/LazyStringSplitTests.cs
@@ -37,7 +37,7 @@ namespace GitExtUtilsTests
             AssertEx.SequenceEqual(expected, actual);
 
             // Non boxing foreach
-            var list = new List<string>();
+            List<string> list = new();
 
             foreach (var s in new LazyStringSplit(input, delimiter, StringSplitOptions.None))
             {
@@ -78,7 +78,7 @@ namespace GitExtUtilsTests
             AssertEx.SequenceEqual(expected, actual);
 
             // Non boxing foreach
-            var list = new List<string>();
+            List<string> list = new();
 
             foreach (var s in new LazyStringSplit(input, delimiter, StringSplitOptions.RemoveEmptyEntries))
             {

--- a/UnitTests/GitExtUtils.Tests/MruCacheTests.cs
+++ b/UnitTests/GitExtUtils.Tests/MruCacheTests.cs
@@ -9,7 +9,7 @@ namespace GitExtUtilsTests
         [Test]
         public void Add_expires_last_used_entry_when_at_capacity()
         {
-            var cache = new MruCache<int, string>(capacity: 3);
+            MruCache<int, string> cache = new(capacity: 3);
 
             cache.Add(1, "one");
             cache.Add(2, "two");
@@ -30,7 +30,7 @@ namespace GitExtUtilsTests
         [Test]
         public void TryGetValue_renews_lifespan_of_entry()
         {
-            var cache = new MruCache<int, string>(capacity: 3);
+            MruCache<int, string> cache = new(capacity: 3);
 
             cache.Add(1, "one");
             cache.Add(2, "two");
@@ -51,7 +51,7 @@ namespace GitExtUtilsTests
         [Test]
         public void Clear_removes_all_entries()
         {
-            var cache = new MruCache<int, string>(capacity: 3);
+            MruCache<int, string> cache = new(capacity: 3);
 
             cache.Add(1, "one");
             cache.Add(2, "two");
@@ -67,7 +67,7 @@ namespace GitExtUtilsTests
         [Test]
         public void TryRemove_removes_existing_entries()
         {
-            var cache = new MruCache<int, string>(capacity: 3);
+            MruCache<int, string> cache = new(capacity: 3);
 
             cache.Add(1, "one");
             cache.Add(2, "two");
@@ -84,7 +84,7 @@ namespace GitExtUtilsTests
         [Test]
         public void TryRemove_returns_false_for_unknown_entry()
         {
-            var cache = new MruCache<int, string>(capacity: 3);
+            MruCache<int, string> cache = new(capacity: 3);
 
             cache.Add(1, "one");
 

--- a/UnitTests/GitExtUtils.Tests/TableLayoutPanelExtensionsTests.cs
+++ b/UnitTests/GitExtUtils.Tests/TableLayoutPanelExtensionsTests.cs
@@ -27,7 +27,7 @@ namespace GitExtUtilsTests
         [Test]
         public void AdjustWidthToSize_should_throw_if_index_outside_table_columns_count()
         {
-            var table = new TableLayoutPanel
+            TableLayoutPanel table = new()
             {
                 ColumnCount = 3
             };
@@ -40,7 +40,7 @@ namespace GitExtUtilsTests
         [Test]
         public void AdjustWidthToSize_should_throw_if_no_widths_given()
         {
-            var table = new TableLayoutPanel
+            TableLayoutPanel table = new()
             {
                 ColumnCount = 3
             };
@@ -50,7 +50,7 @@ namespace GitExtUtilsTests
         [Test]
         public void AdjustWidthToSize_should_throw_if_no_widths_given1()
         {
-            var table = new TableLayoutPanel
+            TableLayoutPanel table = new()
             {
                 ColumnCount = 3
             };
@@ -61,7 +61,7 @@ namespace GitExtUtilsTests
         [Test]
         public void AdjustWidthToSize_should_set_width_to_largest_value()
         {
-            var table = new TableLayoutPanel
+            TableLayoutPanel table = new()
             {
                 ColumnCount = 3
             };

--- a/UnitTests/GitExtUtils.Tests/Win32ApiTests.cs
+++ b/UnitTests/GitExtUtils.Tests/Win32ApiTests.cs
@@ -30,7 +30,7 @@ namespace GitExtUtilsTests
         }
 
         private static IntPtr ToLParam(short x, short y) =>
-            new IntPtr(
+            new(
                 x & 0x0000_FFFF |
                 (y & 0x0000_FFFF) << 16);
     }

--- a/UnitTests/GitUI.Tests/Avatars/AvatarPersistentCacheTests.cs
+++ b/UnitTests/GitUI.Tests/Avatars/AvatarPersistentCacheTests.cs
@@ -46,7 +46,7 @@ namespace GitUITests.Avatars
         [Test]
         public async Task GetAvatarAsync_should_create_if_folder_absent()
         {
-            var fileSystem = new MockFileSystem();
+            MockFileSystem fileSystem = new();
             _cache = new FileSystemAvatarCache(_inner, fileSystem);
             fileSystem.Directory.Exists(_folderPath).Should().BeFalse();
 
@@ -58,7 +58,7 @@ namespace GitUITests.Avatars
         [Test]
         public async Task GetAvatarAsync_should_create_image_from_stream()
         {
-            var fileSystem = new MockFileSystem();
+            MockFileSystem fileSystem = new();
             _cache = new FileSystemAvatarCache(_inner, fileSystem);
             fileSystem.Directory.Exists(_folderPath).Should().BeFalse();
 
@@ -106,7 +106,7 @@ namespace GitUITests.Avatars
         [Test]
         public async Task ClearCacheAsync_should_remove_all()
         {
-            var fileSystem = new MockFileSystem();
+            MockFileSystem fileSystem = new();
             _cache = new FileSystemAvatarCache(_inner, fileSystem);
 
             fileSystem.AddFile(Path.Combine(_folderPath, "a@a.com.16px.png"), new MockFileData(""));

--- a/UnitTests/GitUI.Tests/Avatars/AvatarTestBase.cs
+++ b/UnitTests/GitUI.Tests/Avatars/AvatarTestBase.cs
@@ -96,7 +96,7 @@ namespace GitUITests.Avatars
 
         protected Stream GetPngStream()
         {
-            var stream = new MemoryStream();
+            MemoryStream stream = new();
             _img1.Save(stream, ImageFormat.Png);
             stream.Position = 0;
             return stream;

--- a/UnitTests/GitUI.Tests/Avatars/CacheControlAvatarProviderTests.cs
+++ b/UnitTests/GitUI.Tests/Avatars/CacheControlAvatarProviderTests.cs
@@ -18,7 +18,7 @@ namespace GitUITests.Avatars
 
             var cacheClearedEventHandler = Substitute.For<EventHandler>();
 
-            var cacheCleaner = new MultiCacheCleaner(cacheCleaner1, cacheCleaner2, cacheCleaner3);
+            MultiCacheCleaner cacheCleaner = new(cacheCleaner1, cacheCleaner2, cacheCleaner3);
             cacheCleaner.CacheCleared += cacheClearedEventHandler;
 
             await cacheCleaner.ClearCacheAsync();

--- a/UnitTests/GitUI.Tests/Avatars/ChainedAvatarProviderTests.cs
+++ b/UnitTests/GitUI.Tests/Avatars/ChainedAvatarProviderTests.cs
@@ -42,7 +42,7 @@ namespace GitUITests.Avatars
         [Test]
         public async Task Construction_without_parameter_is_allowed_and_returns_null()
         {
-            var provider = new ChainedAvatarProvider();
+            ChainedAvatarProvider provider = new();
 
             var image = await provider.GetAvatarAsync(_email1, _name1, _size);
             Assert.Null(image);
@@ -92,7 +92,7 @@ namespace GitUITests.Avatars
             provider2.GetAvatarAsync(_email4, _name4, _size).Returns((Image)null);
             provider3.GetAvatarAsync(_email4, _name4, _size).Returns((Image)null);
 
-            var chainedProvider = new ChainedAvatarProvider(provider1, provider2, provider3);
+            ChainedAvatarProvider chainedProvider = new(provider1, provider2, provider3);
 
             var res1 = await chainedProvider.GetAvatarAsync(_email1, _name1, _size);
             var res2 = await chainedProvider.GetAvatarAsync(_email2, _name2, _size);

--- a/UnitTests/GitUI.Tests/Avatars/HotSwapProviderTests.cs
+++ b/UnitTests/GitUI.Tests/Avatars/HotSwapProviderTests.cs
@@ -23,7 +23,7 @@ namespace GitUITests.Avatars
         [Test]
         public async Task Returns_null_if_no_provider_is_set()
         {
-            var provider = new HotSwapAvatarProvider();
+            HotSwapAvatarProvider provider = new();
             var image = await provider.GetAvatarAsync(_email, _name, 16);
             Assert.Null(image);
         }
@@ -31,7 +31,7 @@ namespace GitUITests.Avatars
         [Test]
         public async Task Returns_the_same_image_as_the_wrapped_provider()
         {
-            var provider = new HotSwapAvatarProvider();
+            HotSwapAvatarProvider provider = new();
             var inner = Substitute.For<IAvatarProvider>();
             provider.Provider = inner;
 

--- a/UnitTests/GitUI.Tests/Avatars/StaticImageAvatarProviderTests.cs
+++ b/UnitTests/GitUI.Tests/Avatars/StaticImageAvatarProviderTests.cs
@@ -23,7 +23,7 @@ namespace GitUITests.Avatars
         [Test]
         public async Task Original_image_is_returned_if_size_matches()
         {
-            var provider = new StaticImageAvatarProvider(_img);
+            StaticImageAvatarProvider provider = new(_img);
 
             var result = await provider.GetAvatarAsync(_email, _name, _size);
 
@@ -33,7 +33,7 @@ namespace GitUITests.Avatars
         [Test]
         public async Task Resized_images_are_cached_and_same_instance_is_returned_on_second_call()
         {
-            var provider = new StaticImageAvatarProvider(_img);
+            StaticImageAvatarProvider provider = new(_img);
             var otherSize = 32;
 
             var result1 = await provider.GetAvatarAsync(_email, _name, otherSize);

--- a/UnitTests/GitUI.Tests/BranchTreePanel/GitRefMenuItemsTest.cs
+++ b/UnitTests/GitUI.Tests/BranchTreePanel/GitRefMenuItemsTest.cs
@@ -19,7 +19,7 @@ namespace GitUITests.BranchTreePanel
     {
         private const int expectedMenuItems = 7;
         private const int expectedTotal = expectedMenuItems + 1; // + end separator
-        private Queue<ToolStripMenuItem> _factoryQueue = new Queue<ToolStripMenuItem>();
+        private Queue<ToolStripMenuItem> _factoryQueue = new();
         private IMenuItemFactory _factory = null;
         private TestBranchNode _testNode = new();
 
@@ -88,7 +88,7 @@ namespace GitUITests.BranchTreePanel
         public void WithActiveBranch_HasFilteredItems()
         {
             // Arrange
-            var generator = new LocalBranchMenuItems<TestBranchNode>(_factory);
+            LocalBranchMenuItems<TestBranchNode> generator = new(_factory);
 
             // Act
             const int notFiltered = 2; // create branch, rename

--- a/UnitTests/GitUI.Tests/CancellationTokenSequenceTests.cs
+++ b/UnitTests/GitUI.Tests/CancellationTokenSequenceTests.cs
@@ -13,7 +13,7 @@ namespace GitUITests
         [Test]
         public void Next_cancels_previous_token()
         {
-            var sequence = new CancellationTokenSequence();
+            CancellationTokenSequence sequence = new();
 
             var token1 = sequence.Next();
 
@@ -28,7 +28,7 @@ namespace GitUITests
         [Test]
         public void Next_throws_if_disposed()
         {
-            var sequence = new CancellationTokenSequence();
+            CancellationTokenSequence sequence = new();
 
             sequence.Dispose();
 
@@ -38,7 +38,7 @@ namespace GitUITests
         [Test]
         public void Cancel_cancels_previous_token()
         {
-            var sequence = new CancellationTokenSequence();
+            CancellationTokenSequence sequence = new();
 
             var token = sequence.Next();
 
@@ -52,7 +52,7 @@ namespace GitUITests
         [Test]
         public void Cancel_is_idempotent()
         {
-            var sequence = new CancellationTokenSequence();
+            CancellationTokenSequence sequence = new();
 
             var token = sequence.Next();
 
@@ -67,7 +67,7 @@ namespace GitUITests
         [Test]
         public void Cancel_does_not_throw_if_no_token_yet_issued()
         {
-            var sequence = new CancellationTokenSequence();
+            CancellationTokenSequence sequence = new();
 
             sequence.CancelCurrent();
         }
@@ -75,7 +75,7 @@ namespace GitUITests
         [Test]
         public void Dispose_cancels_previous_token()
         {
-            var sequence = new CancellationTokenSequence();
+            CancellationTokenSequence sequence = new();
 
             var token = sequence.Next();
 
@@ -89,7 +89,7 @@ namespace GitUITests
         [Test]
         public void Dispose_is_idempotent()
         {
-            var sequence = new CancellationTokenSequence();
+            CancellationTokenSequence sequence = new();
 
             sequence.Next();
 
@@ -102,7 +102,7 @@ namespace GitUITests
         [Test]
         public void Dispose_does_not_throw_if_no_token_yet_issued()
         {
-            var sequence = new CancellationTokenSequence();
+            CancellationTokenSequence sequence = new();
 
             sequence.Dispose();
         }
@@ -115,12 +115,12 @@ namespace GitUITests
             var logicalProcessorCount = Environment.ProcessorCount;
             var threadCount = Math.Max(2, logicalProcessorCount);
 
-            using var sequence = new CancellationTokenSequence();
-            using var barrier = new Barrier(threadCount);
-            using var countdown = new CountdownEvent(loopCount * threadCount);
+            using CancellationTokenSequence sequence = new();
+            using Barrier barrier = new(threadCount);
+            using CountdownEvent countdown = new(loopCount * threadCount);
             var completedCount = 0;
 
-            var completionTokenSource = new CancellationTokenSource();
+            CancellationTokenSource completionTokenSource = new();
             var completionToken = completionTokenSource.Token;
             var winnerByIndex = new int[threadCount];
 

--- a/UnitTests/GitUI.Tests/CommandsDialogs/BrowseDialog/FormUpdateFixture.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/BrowseDialog/FormUpdateFixture.cs
@@ -12,7 +12,7 @@ namespace GitUITests.CommandsDialogs.BrowseDialog
     {
         private static string GetReleasesConfigFileText()
         {
-            var configFile = new ConfigFile("", true);
+            ConfigFile configFile = new("", true);
             configFile.SetValue("Version \"2.47\".ReleaseType", "Major");
             configFile.SetValue("Version \"2.48\".ReleaseType", "Major");
             configFile.SetValue("Version \"2.49\".ReleaseType", "ReleaseCandidate");
@@ -24,7 +24,7 @@ namespace GitUITests.CommandsDialogs.BrowseDialog
         [Test]
         public void CheckForReleaseCandidatesTest()
         {
-            var currentVersion = new Version(2, 47);
+            Version currentVersion = new(2, 47);
             var availableVersions = ReleaseVersion.Parse(GetReleasesConfigFileText());
 
             var updates = ReleaseVersion.GetNewerVersions(currentVersion, true, availableVersions);
@@ -40,7 +40,7 @@ namespace GitUITests.CommandsDialogs.BrowseDialog
         [Test]
         public void CheckForMajorReleasesTest()
         {
-            var currentVersion = new Version(2, 47);
+            Version currentVersion = new(2, 47);
             var availableVersions = ReleaseVersion.Parse(GetReleasesConfigFileText());
 
             var updates = ReleaseVersion.GetNewerVersions(currentVersion, false, availableVersions);
@@ -54,7 +54,7 @@ namespace GitUITests.CommandsDialogs.BrowseDialog
         [Test]
         public void CheckForNoMajorReleasesTest()
         {
-            var currentVersion = new Version(2, 48);
+            Version currentVersion = new(2, 48);
             var availableVersions = ReleaseVersion.Parse(GetReleasesConfigFileText());
 
             var updates = ReleaseVersion.GetNewerVersions(currentVersion, false, availableVersions);

--- a/UnitTests/GitUI.Tests/CommandsDialogs/FormAddSubmoduleTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/FormAddSubmoduleTests.cs
@@ -66,7 +66,7 @@ namespace GitUITests.CommandsDialogs
 
         private IDisposable MockupGitOutput(string output, string encodedUrl = DummyUrlEncoded)
         {
-            var gitArguments = new GitArgumentBuilder("ls-remote") { "--heads", encodedUrl };
+            GitArgumentBuilder gitArguments = new("ls-remote") { "--heads", encodedUrl };
             return _gitExecutable.StageOutput(gitArguments.ToString(), output);
         }
     }

--- a/UnitTests/GitUI.Tests/CommandsDialogs/FormBrowseControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/FormBrowseControllerTests.cs
@@ -30,11 +30,11 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void AddRecentRepositories_should_add_new_item()
         {
-            var containerMenu = new ToolStripMenuItem();
+            ToolStripMenuItem containerMenu = new();
 
             const string path = "";
             const string caption = "CAPTION";
-            var repository = new Repository(path);
+            Repository repository = new(path);
 
             _controller.AddRecentRepositories(containerMenu, repository, caption, (s, e) => { });
 
@@ -44,11 +44,11 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void AddRecentRepositories_should_set_properties_correctly()
         {
-            var containerMenu = new ToolStripMenuItem();
+            ToolStripMenuItem containerMenu = new();
 
             const string path = "";
             const string caption = "CAPTION";
-            var repository = new Repository(path);
+            Repository repository = new(path);
 
             _controller.AddRecentRepositories(containerMenu, repository, caption, (s, e) => { });
 
@@ -66,11 +66,11 @@ namespace GitUITests.CommandsDialogs
         {
             _repositoryCurrentBranchNameProvider.GetCurrentBranchName(Arg.Any<string>()).Returns(x => branch);
 
-            var containerMenu = new ToolStripMenuItem();
+            ToolStripMenuItem containerMenu = new();
 
             const string path = "somepath";
             const string caption = "CAPTION";
-            var repository = new Repository(path);
+            Repository repository = new(path);
 
             _controller.AddRecentRepositories(containerMenu, repository, caption, (s, e) => { });
 
@@ -81,11 +81,11 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void ChangeWorkingDir_should_promt_user_to_delete_invalid_repo()
         {
-            var containerMenu = new ToolStripMenuItem();
+            ToolStripMenuItem containerMenu = new();
 
             const string path = "";
             const string caption = "CAPTION";
-            var repository = new Repository(path);
+            Repository repository = new(path);
 
             _controller.AddRecentRepositories(containerMenu, repository, caption, (s, e) => { });
 

--- a/UnitTests/GitUI.Tests/CommandsDialogs/FormFileHistoryControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/FormFileHistoryControllerTests.cs
@@ -48,7 +48,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase("Folder2\\file1.txt", false, false)]
         public void TryGetExactPathName_should_check_if_path_matches_case(string relativePath, bool isResolved, bool doesMatch)
         {
-            using var repo = new GitModuleTestHelper();
+            using GitModuleTestHelper repo = new();
 
             // Create a file
             var notUsed = repo.CreateFile(Path.Combine(repo.TemporaryPath, "Folder1"), "file1.txt", "bla");

--- a/UnitTests/GitUI.Tests/CommandsDialogs/FormRemotesControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/FormRemotesControllerTests.cs
@@ -23,7 +23,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase("\t")]
         public void RemoteDelete_should_not_throw_or_mutate_list_of_remotes_if_oldRemoteUrl_null_or_empty(string oldRemoteUrl)
         {
-            var remotes = new List<Repository>
+            List<Repository> remotes = new()
             {
                 new Repository("a"),
                 new Repository("b")
@@ -37,7 +37,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void RemoteDelete_should_not_throw_or_mutate_list_of_remotes_if_oldRemoteUrl_not_in_list()
         {
-            var remotes = new List<Repository>
+            List<Repository> remotes = new()
             {
                 new Repository("a"),
                 new Repository("b")
@@ -51,7 +51,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void RemoteDelete_should_remove_remotes_matching_oldRemoteUrl()
         {
-            var remotes = new List<Repository>
+            List<Repository> remotes = new()
             {
                 new Repository("a"),
                 new Repository("b")
@@ -68,7 +68,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase("\t")]
         public void RemoteUpdate_should_not_throw_or_mutate_list_of_remotes_if_newRemoteUrl_null_or_empty(string newRemoteUrl)
         {
-            var remotes = new List<Repository>
+            List<Repository> remotes = new()
             {
                 new Repository("a"),
                 new Repository("b")
@@ -84,7 +84,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void RemoteDelete_should_replace_matching_oldRemoteUrl()
         {
-            var remotes = new List<Repository>
+            List<Repository> remotes = new()
             {
                 new Repository("a"),
                 new Repository("b")
@@ -99,7 +99,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void RemoteDelete_should_place_newRemoteUrl_as_first()
         {
-            var remotes = new List<Repository>
+            List<Repository> remotes = new()
             {
                 new Repository("a"),
                 new Repository("b"),

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RememberFileContextMenuControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RememberFileContextMenuControllerTests.cs
@@ -39,8 +39,8 @@ namespace GitUITests.CommandsDialogs
         [TestCase(true, true, true, false)]
         public void RememberFile_ShouldEnableFirstRemember_WorkTree(bool isSubmodule, bool isDeleted, bool isSecondRev, bool result)
         {
-            var rev = new GitRevision(ObjectId.Random());
-            var item = new FileStatusItem(
+            GitRevision rev = new(ObjectId.Random());
+            FileStatusItem item = new(
                 firstRev: rev,
                 secondRev: new GitRevision(ObjectId.WorkTreeId),
                 item: new GitItemStatus("file1")
@@ -61,8 +61,8 @@ namespace GitUITests.CommandsDialogs
         [TestCase(true, true, true, false)]
         public void RememberFile_ShouldEnableFirstRemember_Commit(bool isSubmodule, bool isDeleted, bool isSecondRev, bool result)
         {
-            var rev = new GitRevision(ObjectId.Random());
-            var item = new FileStatusItem(
+            GitRevision rev = new(ObjectId.Random());
+            FileStatusItem item = new(
                 firstRev: rev,
                 secondRev: rev,
                 item: new GitItemStatus(name: "file1")
@@ -83,8 +83,8 @@ namespace GitUITests.CommandsDialogs
         [TestCase(true, true, true, false)]
         public void RememberFile_ShouldEnableSecondRemember_WorkTree(bool isSubmodule, bool isDeleted, bool isSecondRev, bool result)
         {
-            var rev = new GitRevision(ObjectId.Random());
-            var item = new FileStatusItem(
+            GitRevision rev = new(ObjectId.Random());
+            FileStatusItem item = new(
                 firstRev: rev,
                 secondRev: new GitRevision(ObjectId.WorkTreeId),
                 item: new GitItemStatus("file1")
@@ -105,8 +105,8 @@ namespace GitUITests.CommandsDialogs
         [TestCase(true, true, true, false)]
         public void RememberFile_ShouldEnableSecondRemember_Commit(bool isSubmodule, bool isDeleted, bool isSecondRev, bool result)
         {
-            var rev = new GitRevision(ObjectId.Random());
-            var item = new FileStatusItem(
+            GitRevision rev = new(ObjectId.Random());
+            FileStatusItem item = new(
                 firstRev: rev,
                 secondRev: rev,
                 item: new GitItemStatus("file1")
@@ -120,12 +120,12 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void RememberFile_GetGitCommit_null()
         {
-            var rev = new GitRevision(ObjectId.Random());
-            var workTree = new GitRevision(ObjectId.WorkTreeId);
+            GitRevision rev = new(ObjectId.Random());
+            GitRevision workTree = new(ObjectId.WorkTreeId);
 
             _rememberFileContextMenuController.GetGitCommit(null, null, false).Should().BeNull();
 
-            var item = new FileStatusItem(
+            FileStatusItem item = new(
                 firstRev: null,
                 secondRev: rev,
                 item: new GitItemStatus("file"));
@@ -135,10 +135,10 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void RememberFile_GetGitCommit_FirstWorkTree()
         {
-            var rev = new GitRevision(ObjectId.Random());
-            var workTree = new GitRevision(ObjectId.WorkTreeId);
+            GitRevision rev = new(ObjectId.Random());
+            GitRevision workTree = new(ObjectId.WorkTreeId);
             var name = "WorkTreeFile";
-            var item = new FileStatusItem(
+            FileStatusItem item = new(
                 firstRev: workTree,
                 secondRev: rev,
                 item: new GitItemStatus(name));
@@ -148,10 +148,10 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void RememberFile_GetGitCommit_SecondWorkTree()
         {
-            var rev = new GitRevision(ObjectId.Random());
-            var workTree = new GitRevision(ObjectId.WorkTreeId);
+            GitRevision rev = new(ObjectId.Random());
+            GitRevision workTree = new(ObjectId.WorkTreeId);
             var name = "WorkTreeFile";
-            var item = new FileStatusItem(
+            FileStatusItem item = new(
                 firstRev: rev,
                 secondRev: workTree,
                 item: new GitItemStatus(name));
@@ -161,10 +161,10 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void RememberFile_GetGitCommit_Index_Tree()
         {
-            var rev = new GitRevision(ObjectId.Random());
-            var index = new GitRevision(ObjectId.IndexId);
+            GitRevision rev = new(ObjectId.Random());
+            GitRevision index = new(ObjectId.IndexId);
             const string name = "File";
-            var item = new FileStatusItem(
+            FileStatusItem item = new(
                 firstRev: rev,
                 secondRev: index,
                 item: new GitItemStatus(name) { TreeGuid = ObjectId.Random() });
@@ -174,10 +174,10 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void RememberFile_GetGitCommit_Index_GetBlob()
         {
-            var rev = new GitRevision(ObjectId.Random());
-            var index = new GitRevision(ObjectId.IndexId);
+            GitRevision rev = new(ObjectId.Random());
+            GitRevision index = new(ObjectId.IndexId);
             const string name = "File";
-            var item = new FileStatusItem(
+            FileStatusItem item = new(
                 firstRev: rev,
                 secondRev: index,
                 item: new GitItemStatus(name) { TreeGuid = null });
@@ -189,10 +189,10 @@ namespace GitUITests.CommandsDialogs
         public void RememberFile_GetGitCommit_Commit(bool isSecondRev)
         {
             var id = ObjectId.Random();
-            var rev = new GitRevision(id);
+            GitRevision rev = new(id);
             const string newName = "newName";
             const string oldName = "oldName";
-            var item = new FileStatusItem(
+            FileStatusItem item = new(
                 firstRev: rev,
                 secondRev: rev,
                 item: new GitItemStatus(name: newName)
@@ -208,9 +208,9 @@ namespace GitUITests.CommandsDialogs
         public void RememberFile_GetGitCommit_CommitNoOld(bool isSecondRev)
         {
             var id = ObjectId.Random();
-            var rev = new GitRevision(id);
+            GitRevision rev = new(id);
             const string newName = "newName";
-            var item = new FileStatusItem(
+            FileStatusItem item = new(
                 firstRev: rev,
                 secondRev: rev,
                 item: new GitItemStatus(name: newName));

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffContextMenuControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffContextMenuControllerTests.cs
@@ -19,7 +19,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void BrowseDiff_SuppressDiffToLocalWhenNoSelectedRevision()
         {
-            var selectionInfo = new ContextMenuDiffToolInfo();
+            ContextMenuDiffToolInfo selectionInfo = new();
             _revisionDiffContextMenuController.ShouldShowMenuFirstToSelected(selectionInfo).Should().BeFalse();
             _revisionDiffContextMenuController.ShouldShowMenuFirstToLocal(selectionInfo).Should().BeFalse();
             _revisionDiffContextMenuController.ShouldShowMenuSelectedToLocal(selectionInfo).Should().BeFalse();
@@ -28,8 +28,8 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void BrowseDiff_SuppressDiffToLocalWhenNoLocalExists()
         {
-            var rev = new GitRevision(ObjectId.Random());
-            var selectionInfo = new ContextMenuDiffToolInfo(selectedRevision: rev, localExists: false);
+            GitRevision rev = new(ObjectId.Random());
+            ContextMenuDiffToolInfo selectionInfo = new(selectedRevision: rev, localExists: false);
             _revisionDiffContextMenuController.ShouldShowMenuFirstToSelected(selectionInfo).Should().BeTrue();
             _revisionDiffContextMenuController.ShouldShowMenuFirstToLocal(selectionInfo).Should().BeFalse();
             _revisionDiffContextMenuController.ShouldShowMenuSelectedToLocal(selectionInfo).Should().BeFalse();
@@ -38,8 +38,8 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void BrowseDiff_ShowContextDiffToolForWorkTree()
         {
-            var rev = new GitRevision(ObjectId.WorkTreeId);
-            var selectionInfo = new ContextMenuDiffToolInfo(selectedRevision: rev);
+            GitRevision rev = new(ObjectId.WorkTreeId);
+            ContextMenuDiffToolInfo selectionInfo = new(selectedRevision: rev);
             _revisionDiffContextMenuController.ShouldShowMenuFirstToSelected(selectionInfo).Should().BeTrue();
             _revisionDiffContextMenuController.ShouldShowMenuFirstToLocal(selectionInfo).Should().BeTrue();
             _revisionDiffContextMenuController.ShouldShowMenuSelectedToLocal(selectionInfo).Should().BeFalse();
@@ -48,8 +48,8 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void BrowseDiff_ShowContextDiffToolForWorkTreeParent()
         {
-            var rev = new GitRevision(ObjectId.Random());
-            var selectionInfo = new ContextMenuDiffToolInfo(selectedRevision: rev, selectedItemParentRevs: new[] { ObjectId.WorkTreeId });
+            GitRevision rev = new(ObjectId.Random());
+            ContextMenuDiffToolInfo selectionInfo = new(selectedRevision: rev, selectedItemParentRevs: new[] { ObjectId.WorkTreeId });
             _revisionDiffContextMenuController.ShouldShowMenuFirstToSelected(selectionInfo).Should().BeTrue();
             _revisionDiffContextMenuController.ShouldShowMenuFirstToLocal(selectionInfo).Should().BeFalse();
             _revisionDiffContextMenuController.ShouldShowMenuSelectedToLocal(selectionInfo).Should().BeTrue();
@@ -61,8 +61,8 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false, false)]
         public void BrowseDiff_ShowContextDiffToolForDeletedAndNew(bool d, bool n)
         {
-            var rev = new GitRevision(ObjectId.Random());
-            var selectionInfo = new ContextMenuDiffToolInfo(selectedRevision: rev, allAreDeleted: d, allAreNew: n);
+            GitRevision rev = new(ObjectId.Random());
+            ContextMenuDiffToolInfo selectionInfo = new(selectedRevision: rev, allAreDeleted: d, allAreNew: n);
             _revisionDiffContextMenuController.ShouldShowMenuFirstToSelected(selectionInfo).Should().BeTrue();
             _revisionDiffContextMenuController.ShouldShowMenuFirstToLocal(selectionInfo).Should().BeTrue();
             _revisionDiffContextMenuController.ShouldShowMenuSelectedToLocal(selectionInfo).Should().Be(!d);

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
@@ -54,7 +54,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(1)]
         public void BrowseDiff_DifftoolMenu_Selected(int t)
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, selectedGitItemCount: t);
             _controller.ShouldShowDifftoolMenus(selectionInfo).Should().Be(t > 0);
         }
@@ -63,7 +63,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_DifftoolMenu_BareRepo(bool t)
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isBareRepository: t);
             _controller.ShouldShowDifftoolMenus(selectionInfo).Should().BeTrue();
         }
@@ -72,7 +72,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_DifftoolMenu_DisplayOnly(bool t)
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isDisplayOnlyDiff: t);
             _controller.ShouldShowDifftoolMenus(selectionInfo).Should().Be(!t);
         }
@@ -92,7 +92,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(1)]
         public void BrowseDiff_ResetMenu_Selected(int t)
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, selectedGitItemCount: t);
             _controller.ShouldShowResetFileMenus(selectionInfo).Should().Be(t > 0);
         }
@@ -101,7 +101,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_ResetMenu_Tracked(bool t)
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isAnyTracked: t);
             _controller.ShouldShowResetFileMenus(selectionInfo).Should().Be(t);
         }
@@ -110,7 +110,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_ResetMenu_BareRepo(bool t)
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isBareRepository: t);
             _controller.ShouldShowResetFileMenus(selectionInfo).Should().Be(!t);
         }
@@ -119,7 +119,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_ResetMenu_DisplayOnly(bool t)
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isDisplayOnlyDiff: t);
             _controller.ShouldShowResetFileMenus(selectionInfo).Should().Be(!t);
         }
@@ -150,7 +150,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void BrowseDiff_MainMenus_Default()
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(selectedRevision: rev);
             _controller.ShouldShowMenuSaveAs(selectionInfo).Should().BeTrue();
             _controller.ShouldShowMenuCherryPick(selectionInfo).Should().BeTrue();
@@ -171,7 +171,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(1)]
         public void BrowseDiff_MainMenus_SingleSelected(int t)
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(selectedRevision: rev, selectedGitItemCount: t);
             _controller.ShouldShowMenuSaveAs(selectionInfo).Should().Be(t != 0);
             _controller.ShouldShowMenuCherryPick(selectionInfo).Should().Be(t != 0);
@@ -192,7 +192,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_StageMenus_WorkTree(bool t)
         {
-            var rev = new GitRevision(ObjectId.WorkTreeId);
+            GitRevision rev = new(ObjectId.WorkTreeId);
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isAnyItemIndex: t);
             _controller.ShouldShowMenuUnstage(selectionInfo).Should().Be(t);
         }
@@ -201,7 +201,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_StageMenus_Index(bool t)
         {
-            var rev = new GitRevision(ObjectId.WorkTreeId);
+            GitRevision rev = new(ObjectId.WorkTreeId);
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isAnyItemWorkTree: t);
             _controller.ShouldShowMenuStage(selectionInfo).Should().Be(t);
         }
@@ -210,7 +210,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_EditOpen_IsAnySubmodule(bool t)
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(selectedRevision: rev, isAnySubmodule: t);
             _controller.ShouldShowMenuOpenRevision(selectionInfo).Should().Be(!t);
         }
@@ -220,7 +220,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(2)]
         public void BrowseDiff_OpenRevisionFile_Commit(int t)
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, selectedGitItemCount: t);
             _controller.ShouldShowMenuOpenRevision(selectionInfo).Should().Be(t == 1);
         }
@@ -228,7 +228,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void BrowseDiff_OpenRevisionFile_WorkTree()
         {
-            var rev = new GitRevision(ObjectId.WorkTreeId);
+            GitRevision rev = new(ObjectId.WorkTreeId);
             var selectionInfo = CreateContextMenuSelectionInfo(rev);
             _controller.ShouldShowMenuOpenRevision(selectionInfo).Should().BeFalse();
         }
@@ -236,7 +236,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void BrowseDiff_OpenRevisionFile_Index()
         {
-            var rev = new GitRevision(ObjectId.IndexId);
+            GitRevision rev = new(ObjectId.IndexId);
             var selectionInfo = CreateContextMenuSelectionInfo(rev);
             _controller.ShouldShowMenuOpenRevision(selectionInfo).Should().BeFalse();
         }
@@ -244,7 +244,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void BrowseDiff_OpenRevisionFile_DisplayOnly()
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isDisplayOnlyDiff: true);
             _controller.ShouldShowMenuOpenRevision(selectionInfo).Should().BeFalse();
         }
@@ -253,7 +253,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_SupportLinePatches(bool t)
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, supportPatches: t);
             _controller.ShouldShowMenuSaveAs(selectionInfo).Should().BeTrue();
             _controller.ShouldShowMenuCherryPick(selectionInfo).Should().Be(t);
@@ -264,7 +264,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_DisplayOnlyDiff(bool t)
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isDisplayOnlyDiff: t);
             _controller.ShouldShowMenuSaveAs(selectionInfo).Should().Be(!t);
             _controller.ShouldShowMenuCherryPick(selectionInfo).Should().Be(!t);
@@ -275,7 +275,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_StatusOnlyDiff(bool t)
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isStatusOnly: t);
             _controller.ShouldShowMenuCopyFileName(selectionInfo).Should().Be(!t);
             _controller.ShouldShowMenuShowInFolder(selectionInfo).Should().Be(!t);
@@ -286,7 +286,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_ShowInFileTree(bool t)
         {
-            var rev = new GitRevision(ObjectId.Random());
+            GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isDeleted: t);
             _controller.ShouldShowMenuCopyFileName(selectionInfo).Should().Be(true);
             _controller.ShouldShowMenuShowInFolder(selectionInfo).Should().Be(true);
@@ -297,7 +297,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_DeleteFile_WorkTree(bool t)
         {
-            var rev = new GitRevision(ObjectId.WorkTreeId);
+            GitRevision rev = new(ObjectId.WorkTreeId);
             var selectionInfo = CreateContextMenuSelectionInfo(rev, allFilesOrUntrackedDirectoriesExist: t);
             _controller.ShouldShowMenuDeleteFile(selectionInfo).Should().Be(t);
         }
@@ -306,7 +306,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false)]
         public void BrowseDiff_DeleteFile_Index(bool t)
         {
-            var rev = new GitRevision(ObjectId.IndexId);
+            GitRevision rev = new(ObjectId.IndexId);
             var selectionInfo = CreateContextMenuSelectionInfo(rev, allFilesOrUntrackedDirectoriesExist: t);
             _controller.ShouldShowMenuDeleteFile(selectionInfo).Should().Be(t);
         }
@@ -317,7 +317,7 @@ namespace GitUITests.CommandsDialogs
         [TestCase(false, false, false)]
         public void BrowseDiff_Submodules_WorkTree(bool isAnySubmodule, bool submodulesExist, bool expected)
         {
-            var rev = new GitRevision(ObjectId.WorkTreeId);
+            GitRevision rev = new(ObjectId.WorkTreeId);
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isAnySubmodule: isAnySubmodule, allDirectoriesExist: submodulesExist);
             _controller.ShouldShowSubmoduleMenus(selectionInfo).Should().Be(expected);
         }

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RevisionFileTreeControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RevisionFileTreeControllerTests.cs
@@ -42,7 +42,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void LoadItemsInTreeView_should_not_add_nodes_if_no_children()
         {
-            var item = new GitItem(0, GitObjectType.Tree, ObjectId.Random(), "folder");
+            GitItem item = new(0, GitObjectType.Tree, ObjectId.Random(), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(x => null);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -55,7 +55,7 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_add_all_none_GitItem_items_with_1st_level_nodes()
         {
             var items = new INamedGitItem[] { new MockGitItem("file1"), new MockGitItem("file2") };
-            var item = new MockGitItem("folder");
+            MockGitItem item = new("folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -76,7 +76,7 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_add_IsTree_as_folders()
         {
             var items = new[] { new GitItem(0, GitObjectType.Tree, ObjectId.Random(), "file1"), new GitItem(0, GitObjectType.Tree, ObjectId.Random(), "file2") };
-            var item = new GitItem(0, GitObjectType.Tree, ObjectId.Random(), "folder");
+            GitItem item = new(0, GitObjectType.Tree, ObjectId.Random(), "folder");
 
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
@@ -98,7 +98,7 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_add_IsCommit_as_submodule()
         {
             var items = new[] { new GitItem(0, GitObjectType.Commit, ObjectId.Random(), "file1"), new GitItem(0, GitObjectType.Commit, ObjectId.Random(), "file2") };
-            var item = new GitItem(0, GitObjectType.Tree, ObjectId.Random(), "folder");
+            GitItem item = new(0, GitObjectType.Tree, ObjectId.Random(), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -119,7 +119,7 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_add_IsBlob_as_file()
         {
             var items = new[] { new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file1"), new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file2") };
-            var item = new GitItem(0, GitObjectType.Tree, ObjectId.Random(), "folder");
+            GitItem item = new(0, GitObjectType.Tree, ObjectId.Random(), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -136,7 +136,7 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_not_load_icons_for_file_without_extension()
         {
             var items = new[] { new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file1."), new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file2") };
-            var item = new GitItem(0, GitObjectType.Tree, ObjectId.Random(), "folder");
+            GitItem item = new(0, GitObjectType.Tree, ObjectId.Random(), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -158,7 +158,7 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_not_add_icons_for_file_if_none_provided()
         {
             var items = new[] { new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file1.foo"), new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file2.txt") };
-            var item = new GitItem(0, GitObjectType.Tree, ObjectId.Random(), "folder");
+            GitItem item = new(0, GitObjectType.Tree, ObjectId.Random(), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);
@@ -180,9 +180,9 @@ namespace GitUITests.CommandsDialogs
         public void LoadItemsInTreeView_should_add_icon_for_file_extension_only_once()
         {
             var items = new[] { new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file1.txt"), new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file2.txt") };
-            var item = new GitItem(0, GitObjectType.Tree, ObjectId.Random(), "folder");
+            GitItem item = new(0, GitObjectType.Tree, ObjectId.Random(), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
-            using var bitmap = new Bitmap(1, 1);
+            using Bitmap bitmap = new(1, 1);
             using var icon = Icon.FromHandle(bitmap.GetHicon());
             _iconProvider.Get(Arg.Any<string>(), Arg.Is<string>(x => x.EndsWith(".txt"))).Returns(icon);
 
@@ -216,7 +216,7 @@ namespace GitUITests.CommandsDialogs
                 else
                 {
                     var node = nodes.Add(folder);
-                    var item = new GitItem(666, GitObjectType.Tree, ObjectId.WorkTreeId, folder);
+                    GitItem item = new(666, GitObjectType.Tree, ObjectId.WorkTreeId, folder);
                     node.Name = folder;
                     node.Tag = item;
                     nodes = node.Nodes;
@@ -224,14 +224,14 @@ namespace GitUITests.CommandsDialogs
             }
 
             var fileNode = nodes.Add(fileName);
-            var fileItem = new GitItem(666, GitObjectType.Blob, ObjectId.WorkTreeId, fileName);
+            GitItem fileItem = new(666, GitObjectType.Blob, ObjectId.WorkTreeId, fileName);
             fileNode.Tag = fileItem;
         }
 
         [Test]
         public void SelectFileOrFolder_should_select_a_folder()
         {
-            var nativeTreeView = new NativeTreeView();
+            NativeTreeView nativeTreeView = new();
             PopulateTreeView(nativeTreeView, @"folder1\file1");
             PopulateTreeView(nativeTreeView, @"folder2\file2");
             var isNodeFound = _controller.SelectFileOrFolder(nativeTreeView, "folder1");
@@ -243,7 +243,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void SelectFileOrFolder_should_select_a_file()
         {
-            var nativeTreeView = new NativeTreeView();
+            NativeTreeView nativeTreeView = new();
             PopulateTreeView(nativeTreeView, @"folder1\file1");
             PopulateTreeView(nativeTreeView, @"folder1\file2");
             var isNodeFound = _controller.SelectFileOrFolder(nativeTreeView, @"folder1\file1");
@@ -255,7 +255,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void SelectFileOrFolder_should_not_select_an_inexisting_folder()
         {
-            var nativeTreeView = new NativeTreeView();
+            NativeTreeView nativeTreeView = new();
             PopulateTreeView(nativeTreeView, @"folder1\file1");
             var isNodeFound = _controller.SelectFileOrFolder(nativeTreeView, "inexisting_folder");
 
@@ -266,7 +266,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void SelectFileOrFolder_should_select_a_file_in_complex_filetree()
         {
-            var nativeTreeView = new NativeTreeView();
+            NativeTreeView nativeTreeView = new();
             PopulateTreeView(nativeTreeView, @"folder1\subfolder1\subfolder2\file1");
             PopulateTreeView(nativeTreeView, @"folder1\subfolder1\subfolder2\file2");
             PopulateTreeView(nativeTreeView, @"folder1\subfolder3\file2");

--- a/UnitTests/GitUI.Tests/CommandsDialogs/SettingsDialog/Pages/ColorsPageSettingsPageControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/SettingsDialog/Pages/ColorsPageSettingsPageControllerTests.cs
@@ -22,13 +22,13 @@ namespace GitUITests.CommandsDialogs.SettingsDialog.Pages
         {
             ThemeModule.TestAccessor.SuppressWin32Hooks = true;
 
-            var page = new MockColorsSettingsPage();
+            MockColorsSettingsPage page = new();
             var themeRepository = Substitute.For<IThemeRepository>();
             var themePathProvider = Substitute.For<IThemePathProvider>();
             themeRepository
                 .GetTheme(Arg.Any<ThemeId>(), Arg.Any<IReadOnlyList<string>>())
                 .Returns(callInfo => new Theme(new Dictionary<AppColor, Color>(), new Dictionary<KnownColor, Color>(), callInfo.Arg<ThemeId>()));
-            var controller = new ColorsSettingsPageController(page, themeRepository, themePathProvider);
+            ColorsSettingsPageController controller = new(page, themeRepository, themePathProvider);
 
             _context = new ColorSettingsPageTestContext(page, controller, themeRepository);
         }

--- a/UnitTests/GitUI.Tests/ControlThreadingExtensionsTests.cs
+++ b/UnitTests/GitUI.Tests/ControlThreadingExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace GitUITests
         [Test]
         public void ControlSwitchToMainThreadOnMainThread()
         {
-            var form = new Form();
+            Form form = new();
 
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
@@ -27,7 +27,7 @@ namespace GitUITests
                 Assert.True(ThreadHelper.JoinableTaskContext.IsOnMainThread);
             });
 
-            var cancellationTokenSource = new CancellationTokenSource();
+            CancellationTokenSource cancellationTokenSource = new();
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 Assert.True(ThreadHelper.JoinableTaskContext.IsOnMainThread);
@@ -39,7 +39,7 @@ namespace GitUITests
         [Test]
         public void ControlSwitchToMainThreadOnMainThreadCompletesSynchronously()
         {
-            var form = new Form();
+            Form form = new();
 
             Assert.True(ThreadHelper.JoinableTaskContext.IsOnMainThread);
 
@@ -49,7 +49,7 @@ namespace GitUITests
 
             Assert.True(ThreadHelper.JoinableTaskContext.IsOnMainThread);
 
-            var cancellationTokenSource = new CancellationTokenSource();
+            CancellationTokenSource cancellationTokenSource = new();
             awaiter = form.SwitchToMainThreadAsync(cancellationTokenSource.Token).GetAwaiter();
             Assert.True(awaiter.IsCompleted);
             awaiter.GetResult();
@@ -60,7 +60,7 @@ namespace GitUITests
         [Test]
         public void ControlSwitchToMainThreadOnBackgroundThread()
         {
-            var form = new Form();
+            Form form = new();
 
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
@@ -70,7 +70,7 @@ namespace GitUITests
                 Assert.True(ThreadHelper.JoinableTaskContext.IsOnMainThread);
             });
 
-            var cancellationTokenSource = new CancellationTokenSource();
+            CancellationTokenSource cancellationTokenSource = new();
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 await TaskScheduler.Default;
@@ -83,7 +83,7 @@ namespace GitUITests
         [Test]
         public async Task ControlDisposedBeforeSwitchOnMainThread()
         {
-            var form = new Form();
+            Form form = new();
             form.Dispose();
 
             Assert.True(ThreadHelper.JoinableTaskContext.IsOnMainThread);
@@ -93,8 +93,8 @@ namespace GitUITests
         [Test]
         public async Task TokenCancelledBeforeSwitchOnMainThread()
         {
-            var form = new Form();
-            var cancellationTokenSource = new CancellationTokenSource();
+            Form form = new();
+            CancellationTokenSource cancellationTokenSource = new();
             cancellationTokenSource.Cancel();
 
             Assert.True(ThreadHelper.JoinableTaskContext.IsOnMainThread);
@@ -104,9 +104,9 @@ namespace GitUITests
         [Test]
         public async Task ControlDisposedAndTokenCancelledBeforeSwitchOnMainThread()
         {
-            var form = new Form();
+            Form form = new();
             form.Dispose();
-            var cancellationTokenSource = new CancellationTokenSource();
+            CancellationTokenSource cancellationTokenSource = new();
             cancellationTokenSource.Cancel();
 
             Assert.True(ThreadHelper.JoinableTaskContext.IsOnMainThread);
@@ -119,7 +119,7 @@ namespace GitUITests
         [Test]
         public async Task ControlDisposedAfterSwitchOnMainThread()
         {
-            var form = new Form();
+            Form form = new();
 
             var awaitable = form.SwitchToMainThreadAsync();
 
@@ -132,8 +132,8 @@ namespace GitUITests
         [Test]
         public async Task TokenCancelledAfterSwitchOnMainThread()
         {
-            var form = new Form();
-            var cancellationTokenSource = new CancellationTokenSource();
+            Form form = new();
+            CancellationTokenSource cancellationTokenSource = new();
 
             var awaitable = form.SwitchToMainThreadAsync(cancellationTokenSource.Token);
 
@@ -146,7 +146,7 @@ namespace GitUITests
         [Test]
         public async Task ControlDisposedBeforeSwitchOnBackgroundThread()
         {
-            var form = new Form();
+            Form form = new();
             form.Dispose();
 
             await TaskScheduler.Default;
@@ -158,11 +158,11 @@ namespace GitUITests
         [Test]
         public async Task TokenCancelledBeforeSwitchOnBackgroundThread()
         {
-            var form = new Form();
+            Form form = new();
 
             await TaskScheduler.Default;
 
-            var cancellationTokenSource = new CancellationTokenSource();
+            CancellationTokenSource cancellationTokenSource = new();
             cancellationTokenSource.Cancel();
 
             Assert.False(ThreadHelper.JoinableTaskContext.IsOnMainThread);
@@ -173,7 +173,7 @@ namespace GitUITests
         [Ignore("Hangs")]
         public async Task ControlDisposedAfterSwitchOnBackgroundThread()
         {
-            var form = new Form();
+            Form form = new();
 
             await TaskScheduler.Default;
 
@@ -194,11 +194,11 @@ namespace GitUITests
         [Test]
         public async Task TokenCancelledAfterSwitchOnBackgroundThread()
         {
-            var form = new Form();
+            Form form = new();
 
             await TaskScheduler.Default;
 
-            var cancellationTokenSource = new CancellationTokenSource();
+            CancellationTokenSource cancellationTokenSource = new();
 
             var awaitable = form.SwitchToMainThreadAsync(cancellationTokenSource.Token);
 

--- a/UnitTests/GitUI.Tests/ControlUtilTests.cs
+++ b/UnitTests/GitUI.Tests/ControlUtilTests.cs
@@ -11,7 +11,7 @@ namespace GitUITests
         [Test]
         public void FindDescendants()
         {
-            var root = new Control { Controls = { new Control(), new Control(), new Control() } };
+            Control root = new() { Controls = { new Control(), new Control(), new Control() } };
 
             Assert.AreEqual(3, root.FindDescendants().Count());
             Assert.AreEqual(3, root.FindDescendants().Distinct().Count());
@@ -20,7 +20,7 @@ namespace GitUITests
         [Test]
         public void FindDescendantsOfType()
         {
-            var root = new Control { Controls = { new Control(), new TextBox(), new Control() } };
+            Control root = new() { Controls = { new Control(), new TextBox(), new Control() } };
 
             Assert.AreEqual(1, root.FindDescendantsOfType<TextBox>().Count());
             Assert.AreEqual(1, root.FindDescendantsOfType<TextBox>().Distinct().Count());
@@ -29,7 +29,7 @@ namespace GitUITests
         [Test]
         public void FindDescendantsOfTypeWithPredicate()
         {
-            var root = new Control { Controls = { new Control(), new TextBox { Tag = "A" }, new TextBox { Tag = "B" } } };
+            Control root = new() { Controls = { new Control(), new TextBox { Tag = "A" }, new TextBox { Tag = "B" } } };
 
             Assert.NotNull(root.FindDescendantOfType<TextBox>(t => t.Tag as string == "A"));
             Assert.NotNull(root.FindDescendantOfType<TextBox>(t => t.Tag as string == "B"));

--- a/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
@@ -32,7 +32,7 @@ namespace GitUITests.Editor.Diff
         public void CanGetHeaders()
         {
             var result = _lineNumAnalyzer.Analyze(_sampleDiff);
-            var headerLines = new List<int> { 5, 17 };
+            List<int> headerLines = new() { 5, 17 };
             foreach (var header in headerLines)
             {
                 result.DiffLines[header].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);

--- a/UnitTests/GitUI.Tests/Editor/Diff/LinePrefixHelperFixture.cs
+++ b/UnitTests/GitUI.Tests/Editor/Diff/LinePrefixHelperFixture.cs
@@ -73,7 +73,7 @@ namespace GitUITests.Editor.Diff
 
             var doc = PreDocumentForDiffText(diffText);
 
-            var helper = new LinePrefixHelper(lineSegmentGetter);
+            LinePrefixHelper helper = new(lineSegmentGetter);
             helper.DoesLineStartWith(doc, 0, prefix).Should().BeTrue();
         }
 
@@ -85,7 +85,7 @@ namespace GitUITests.Editor.Diff
 
             var doc = PreDocumentForDiffText(diffText);
 
-            var helper = new LinePrefixHelper(lineSegmentGetter);
+            LinePrefixHelper helper = new(lineSegmentGetter);
             helper.DoesLineStartWith(doc, 0, "++").Should().BeFalse();
         }
 
@@ -109,7 +109,7 @@ namespace GitUITests.Editor.Diff
 
         private static List<ISegment> GetSegmentsForDiffText(string diffText)
         {
-            var lineSegments = new List<ISegment>();
+            List<ISegment> lineSegments = new();
             foreach (var diffLine in diffText.Split('\n'))
             {
                 var seg = Substitute.For<ISegment>();

--- a/UnitTests/GitUI.Tests/Editor/FileViewerInternal.CurrentViewPositionCacheTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/FileViewerInternal.CurrentViewPositionCacheTests.cs
@@ -34,7 +34,7 @@ namespace GitUITests.Editor
         {
             var test = _viewPositionCache.GetTestAccessor();
 
-            var existingViewPosition = new FileViewerInternal.ViewPosition
+            FileViewerInternal.ViewPosition existingViewPosition = new()
             {
                 FirstLine = "first line",
                 FirstVisibleLine = 24,
@@ -142,7 +142,7 @@ namespace GitUITests.Editor
             test.TextEditor.Text = Given.GitDiff;
             test.TextEditor.ActiveTextAreaControl.TextArea.TextView.DrawingPosition = new System.Drawing.Rectangle(0, 0, 100, 100);
 
-            var existingViewPosition = new FileViewerInternal.ViewPosition
+            FileViewerInternal.ViewPosition existingViewPosition = new()
             {
                 ActiveLineNum = new DiffLineInfo
                 {

--- a/UnitTests/GitUI.Tests/Editor/FileViewerTextTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/FileViewerTextTests.cs
@@ -46,8 +46,8 @@ namespace GitUITests.Editor
                         "2:\n" +
                         "3:Selected\n" +
                         "4:";
-            using var testHelper = new GitModuleTestHelper();
-            var uiCommands = new GitUICommands(testHelper.Module);
+            using GitModuleTestHelper testHelper = new();
+            GitUICommands uiCommands = new(testHelper.Module);
             _uiCommandsSource.UICommands.Returns(x => uiCommands);
             _fileViewer.UICommandsSource = _uiCommandsSource;
             _fileViewer.GetTestAccessor().FileViewerInternal.SetText(sampleText, null);
@@ -88,8 +88,8 @@ index 62a5c2f08..2bc482714 100644
 -            int scrollPos = ScrollPos;
 +            int scrollPos = VScrollPosition;";
 
-            using var testHelper = new GitModuleTestHelper();
-            var uiCommands = new GitUICommands(testHelper.Module);
+            using GitModuleTestHelper testHelper = new();
+            GitUICommands uiCommands = new(testHelper.Module);
             _uiCommandsSource.UICommands.Returns(x => uiCommands);
             _fileViewer.UICommandsSource = _uiCommandsSource;
 
@@ -121,8 +121,8 @@ index 62a5c2f08..2bc482714 100644
 -            int scrollPos = ScrollPos;
 +            int scrollPos = VScrollPosition;";
 
-            using var testHelper = new GitModuleTestHelper();
-            var uiCommands = new GitUICommands(testHelper.Module);
+            using GitModuleTestHelper testHelper = new();
+            GitUICommands uiCommands = new(testHelper.Module);
             _uiCommandsSource.UICommands.Returns(x => uiCommands);
             _fileViewer.UICommandsSource = _uiCommandsSource;
 
@@ -145,8 +145,8 @@ index 62a5c2f08..2bc482714 100644
 index b25b745..5194740 100644
 Binary files a/binaryfile.bin and b/binaryfile.bin differ";
 
-            using var testHelper = new GitModuleTestHelper();
-            var uiCommands = new GitUICommands(testHelper.Module);
+            using GitModuleTestHelper testHelper = new();
+            GitUICommands uiCommands = new(testHelper.Module);
             _uiCommandsSource.UICommands.Returns(x => uiCommands);
             _fileViewer.UICommandsSource = _uiCommandsSource;
 

--- a/UnitTests/GitUI.Tests/Editor/FindAndReplaceFormTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/FindAndReplaceFormTests.cs
@@ -152,7 +152,7 @@ namespace GitUITests.Editor
             AssertTextRange(new TextRange(0, 4), actualRange);
 
             // Move the caret outside of the originally selected region.
-            var newCaretPosition = new TextLocation(1, 1);
+            TextLocation newCaretPosition = new(1, 1);
             _textEditorControl.ActiveTextAreaControl.Caret.Position = newCaretPosition;
 
             actualRange = await _findAndReplaceForm.FindNextAsync(true, false, null);
@@ -236,7 +236,7 @@ namespace GitUITests.Editor
 
             if (scanRegion.Start != default || scanRegion.End != default)
             {
-                var selection = new DefaultSelection(_textEditorControl.Document, scanRegion.Start, scanRegion.End);
+                DefaultSelection selection = new(_textEditorControl.Document, scanRegion.Start, scanRegion.End);
                 _textEditorControl.ActiveTextAreaControl.SelectionManager.SetSelection(selection);
                 _textEditorControl.ActiveTextAreaControl.Caret.Position = scanRegion.End;
                 _testAccessor.Search.SetScanRegion(selection);

--- a/UnitTests/GitUI.Tests/Editor/RichTextBoxXhtmlSupportExtensionTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/RichTextBoxXhtmlSupportExtensionTests.cs
@@ -28,7 +28,7 @@ namespace GitUITests.Editor
 
         private void SetupLink(string prefix, string linkText, string uri, string suffix)
         {
-            var text = new StringBuilder();
+            StringBuilder text = new();
 
             if (prefix is not null)
             {

--- a/UnitTests/GitUI.Tests/GitExtensionsFormTests.cs
+++ b/UnitTests/GitUI.Tests/GitExtensionsFormTests.cs
@@ -25,7 +25,7 @@ namespace GitUITests
         [Test]
         public void RestorePosition_should_not_restore_position_if_not_required()
         {
-            using var form = new MockForm(false)
+            using MockForm form = new(false)
             {
                 Location = new Point(-100, -100),
                 Size = new Size(500, 500)
@@ -43,7 +43,7 @@ namespace GitUITests
         [Test]
         public void RestorePosition_should_not_restore_position_if_minimised()
         {
-            using var form = new MockForm(false)
+            using MockForm form = new(false)
             {
                 Location = new Point(-100, -100),
                 Size = new Size(500, 500),
@@ -63,7 +63,7 @@ namespace GitUITests
         [Test]
         public void RestorePosition_should_not_restore_position_if_not_persisted()
         {
-            using var form = new MockForm(true)
+            using MockForm form = new(true)
             {
                 Location = new Point(-100, -100),
                 Size = new Size(500, 500)
@@ -88,7 +88,7 @@ namespace GitUITests
         [TestCase(FormBorderStyle.None)]
         public void RestorePosition_should_not_scale_fixed_window_if_different_dpi(FormBorderStyle borderStyle)
         {
-            using var form = new MockForm(true)
+            using MockForm form = new(true)
             {
                 Location = new Point(-100, -100),
                 Size = new Size(300, 300),
@@ -124,7 +124,7 @@ namespace GitUITests
                 Assert.Inconclusive("The test must be run at 96dpi");
             }
 
-            using var form = new MockForm(true)
+            using MockForm form = new(true)
             {
                 Location = new Point(-100, -100),
                 Size = new Size(300, 300),
@@ -158,12 +158,12 @@ namespace GitUITests
                 Assert.Inconclusive("The test must be run at 96dpi");
             }
 
-            using var owner = new Form
+            using Form owner = new()
             {
                 Location = new Point(ownerFormTop, ownerFormLeft),
                 Size = new Size(800, 600)
             };
-            using var form = new MockForm(true)
+            using MockForm form = new(true)
             {
                 Owner = owner,
                 StartPosition = FormStartPosition.CenterParent

--- a/UnitTests/GitUI.Tests/GitUICommands/NormalizeFileNameTests.cs
+++ b/UnitTests/GitUI.Tests/GitUICommands/NormalizeFileNameTests.cs
@@ -21,8 +21,8 @@ namespace GitUITests.GitUICommandsTests
         [TestCase(@"C:/working/dir/path/file.ext", "C:/working/dir/path/file.ext")]
         public void NormalizeFileNameTest(string fileName, string expected)
         {
-            var module = new GitModule(@"c:\working\dir");
-            var commands = new GitUICommands(module);
+            GitModule module = new(@"c:\working\dir");
+            GitUICommands commands = new(module);
 
             commands.GetTestAccessor().NormalizeFileName(fileName).Should().Be(expected);
         }

--- a/UnitTests/GitUI.Tests/LinqExtensionsTests.cs
+++ b/UnitTests/GitUI.Tests/LinqExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace GitUITests
         [Test]
         public void AsReadOnlyList_copies_to_new_list_if_required()
         {
-            var set = new HashSet<int> { 1, 2, 3 };
+            HashSet<int> set = new() { 1, 2, 3 };
 
             Assert.AreEqual(new[] { 1, 2, 3 }, set.AsReadOnlyList());
         }

--- a/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
+++ b/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
@@ -109,7 +109,7 @@ namespace GitUITests.Script
         [Test]
         public void GetCurrentRevision_should_return_expected_if_current_revision_has_no_refs()
         {
-            var revision = new GitRevision(ObjectId.IndexId);
+            GitRevision revision = new(ObjectId.IndexId);
             _module.GetRevision(shortFormat: true, loadRefs: true).Returns(x => revision);
 
             var result = ScriptOptionsParser.GetTestAccessor()
@@ -153,7 +153,7 @@ namespace GitUITests.Script
         public void Parse_should_parse_c_arguments()
         {
             const string Subject = "line1";
-            var revision = new GitRevision(ObjectId.IndexId)
+            GitRevision revision = new(ObjectId.IndexId)
             {
                 Subject = Subject,
                 Body = $"{Subject}\n\nline3"
@@ -172,7 +172,7 @@ namespace GitUITests.Script
         public void Parse_should_parse_s_arguments()
         {
             const string Subject = "line1";
-            var revision = new GitRevision(ObjectId.IndexId)
+            GitRevision revision = new(ObjectId.IndexId)
             {
                 Subject = Subject,
                 Body = $"{Subject}\n\nline3"
@@ -219,7 +219,7 @@ namespace GitUITests.Script
         [Test]
         public void ParseScriptArguments_resolve_sRemotePathFromUrl_selectedRemotes_empty()
         {
-            var noSelectedRemotes = new List<string>();
+            List<string> noSelectedRemotes = new();
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{openUrl} https://gitlab.com{sRemotePathFromUrl}/tree/{sBranch}", option: "sRemotePathFromUrl",
@@ -235,7 +235,7 @@ namespace GitUITests.Script
         public void ParseScriptArguments_resolve_sRemotePathFromUrl_currentRemote_set()
         {
             var currentRemote = "myRemote";
-            var selectedRemotes = new List<string>() { currentRemote };
+            List<string> selectedRemotes = new() { currentRemote };
             _module.GetSetting(string.Format(SettingKeyString.RemoteUrl, currentRemote)).Returns("https://gitlab.com/gitlabhq/gitlabhq.git");
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
@@ -255,7 +255,7 @@ namespace GitUITests.Script
         {
             var option = "sRemoteBranch";
             var branch = remoteName + '/' + branchName;
-            var remoteBranches = new List<IGitRef>() { new GitRef(null, null, branch) };
+            List<IGitRef> remoteBranches = new() { new GitRef(null, null, branch) };
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
@@ -274,7 +274,7 @@ namespace GitUITests.Script
         {
             var option = "sRemoteBranchName";
             var branch = remoteName + '/' + branchName;
-            var remoteBranches = new List<IGitRef>() { new GitRef(null, null, branch) };
+            List<IGitRef> remoteBranches = new() { new GitRef(null, null, branch) };
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
@@ -293,7 +293,7 @@ namespace GitUITests.Script
         {
             var option = "cRemoteBranch";
             var branch = remoteName + '/' + branchName;
-            var remoteBranches = new List<IGitRef>() { new GitRef(null, null, branch) };
+            List<IGitRef> remoteBranches = new() { new GitRef(null, null, branch) };
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
@@ -312,7 +312,7 @@ namespace GitUITests.Script
         {
             var option = "cRemoteBranchName";
             var branch = remoteName + '/' + branchName;
-            var remoteBranches = new List<IGitRef>() { new GitRef(null, null, branch) };
+            List<IGitRef> remoteBranches = new() { new GitRef(null, null, branch) };
 
             var result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,

--- a/UnitTests/GitUI.Tests/Theming/CssUrlResolverTests.cs
+++ b/UnitTests/GitUI.Tests/Theming/CssUrlResolverTests.cs
@@ -16,7 +16,7 @@ namespace GitUITests.Theming
         [Test]
         public void Should_resolve_to_preinstalled_themes_directory_by_default()
         {
-            var resolver = new ThemeCssUrlResolver(CreateMockThemePathProvider());
+            ThemeCssUrlResolver resolver = new(CreateMockThemePathProvider());
             var resolvedPath = resolver.ResolveCssUrl("dark.css");
             resolvedPath.Should().Be(Path.Combine(PreinstalledThemesMockPath, "dark.css"));
         }
@@ -24,7 +24,7 @@ namespace GitUITests.Theming
         [Test]
         public void Should_resolve_to_user_defined_themes_directory_When_url_starts_with_macro()
         {
-            var resolver = new ThemeCssUrlResolver(CreateMockThemePathProvider());
+            ThemeCssUrlResolver resolver = new(CreateMockThemePathProvider());
             var resolvedPath = resolver.ResolveCssUrl("{UserAppData}/dark.css");
             resolvedPath.Should().Be(Path.Combine(UserDefinedThemesMockPath, "dark.css"));
         }

--- a/UnitTests/GitUI.Tests/Theming/ThemeFileReaderTests.cs
+++ b/UnitTests/GitUI.Tests/Theming/ThemeFileReaderTests.cs
@@ -13,7 +13,7 @@ namespace GitUITests.Theming
         {
             const string mockThemeContent = "test content";
 
-            var reader = new ThemeFileReader();
+            ThemeFileReader reader = new();
 
             var tempPath = Path.GetTempFileName();
             try
@@ -32,7 +32,7 @@ namespace GitUITests.Theming
         {
             string nonExistingFile = Path.Combine(TestContext.CurrentContext.TestDirectory, "non_existing_theme.css");
 
-            var reader = new ThemeFileReader();
+            ThemeFileReader reader = new();
             reader.Invoking(_ => _.ReadThemeFile(nonExistingFile))
                 .Should().Throw<ThemeException>()
                 .Which.InnerException.Should().BeOfType<FileNotFoundException>();

--- a/UnitTests/GitUI.Tests/Theming/ThemeLoaderTests.cs
+++ b/UnitTests/GitUI.Tests/Theming/ThemeLoaderTests.cs
@@ -48,7 +48,7 @@ namespace GitUITests.Theming
         {
             var mockFileReader = CreateMockFileReader(GetThemeContent(colorName, testColorValue));
             var mockCssUrlResolver = Substitute.For<IThemeCssUrlResolver>();
-            var loader = new ThemeLoader(mockCssUrlResolver, mockFileReader);
+            ThemeLoader loader = new(mockCssUrlResolver, mockFileReader);
 
             var theme = LoadTheme(loader);
 
@@ -62,7 +62,7 @@ namespace GitUITests.Theming
         {
             var mockFileReader = CreateMockFileReader(GetThemeContent(colorName, color));
             var mockCssUrlResolver = Substitute.For<IThemeCssUrlResolver>();
-            var loader = new ThemeLoader(mockCssUrlResolver, mockFileReader);
+            ThemeLoader loader = new(mockCssUrlResolver, mockFileReader);
 
             var theme = LoadTheme(loader);
 
@@ -77,7 +77,7 @@ namespace GitUITests.Theming
             var colorblindColor = Color.Blue;
             var mockFileReader = CreateMockFileReader(GetThemeContent(colorName, regularColor, colorblindColor));
             var mockCssUrlResolver = Substitute.For<IThemeCssUrlResolver>();
-            var loader = new ThemeLoader(mockCssUrlResolver, mockFileReader);
+            ThemeLoader loader = new(mockCssUrlResolver, mockFileReader);
 
             var regularTheme = LoadTheme(loader);
             regularTheme.GetColor(colorName).ToArgb().Should().Be(regularColor.ToArgb());
@@ -95,7 +95,7 @@ namespace GitUITests.Theming
             var colorblindColor = Color.Blue;
             var mockFileReader = CreateMockFileReader(GetThemeContent(colorName, regularColor, colorblindColor));
             var mockCssUrlResolver = Substitute.For<IThemeCssUrlResolver>();
-            var loader = new ThemeLoader(mockCssUrlResolver, mockFileReader);
+            ThemeLoader loader = new(mockCssUrlResolver, mockFileReader);
 
             var regularTheme = LoadTheme(loader);
             regularTheme.GetColor(colorName).ToArgb().Should().Be(regularColor.ToArgb());
@@ -115,7 +115,7 @@ namespace GitUITests.Theming
 
             var mockFileReader = CreateMockFileReader(commentedContent);
             var mockCssUrlResolver = Substitute.For<IThemeCssUrlResolver>();
-            var loader = new ThemeLoader(mockCssUrlResolver, mockFileReader);
+            ThemeLoader loader = new(mockCssUrlResolver, mockFileReader);
 
             var theme = LoadTheme(loader);
 
@@ -127,7 +127,7 @@ namespace GitUITests.Theming
         {
             var mockFileReader = CreateMockFileReader(GetThemeContent("InvalidColorName", Color.Red));
             var mockCssUrlResolver = Substitute.For<IThemeCssUrlResolver>();
-            var loader = new ThemeLoader(mockCssUrlResolver, mockFileReader);
+            ThemeLoader loader = new(mockCssUrlResolver, mockFileReader);
 
             loader.Invoking(l => LoadTheme(l))
                 .Should().Throw<ThemeException>()
@@ -139,7 +139,7 @@ namespace GitUITests.Theming
         {
             var mockFileReader = CreateMockFileReader(GetThemeContent(KnownColor.Control, Color.Red) + "}");
             var mockCssUrlResolver = Substitute.For<IThemeCssUrlResolver>();
-            var loader = new ThemeLoader(mockCssUrlResolver, mockFileReader);
+            ThemeLoader loader = new(mockCssUrlResolver, mockFileReader);
 
             loader.Invoking(l => LoadTheme(l))
                 .Should().Throw<ThemeException>()
@@ -152,7 +152,7 @@ namespace GitUITests.Theming
             [ValueSource(nameof(TestColorValues))] Color baseColor)
         {
             var pathProvider = CreateMockPathProvider();
-            var resolver = new ThemeCssUrlResolver(pathProvider);
+            ThemeCssUrlResolver resolver = new(pathProvider);
 
             string themePath = Path.Combine(pathProvider.AppThemesDirectory, "theme.css");
             string baseThemePath = Path.Combine(pathProvider.AppThemesDirectory, "base.css");
@@ -163,7 +163,7 @@ namespace GitUITests.Theming
                 [themePath] = "@import url(\"base.css\");",
             });
 
-            var loader = new ThemeLoader(resolver, mockFileReader);
+            ThemeLoader loader = new(resolver, mockFileReader);
 
             var theme = loader.LoadTheme(themePath, new ThemeId("theme", isBuiltin: true), allowedClasses: ThemeVariations.None);
             theme.GetColor(colorName).ToArgb().Should().Be(baseColor.ToArgb());
@@ -176,7 +176,7 @@ namespace GitUITests.Theming
             [ValueSource(nameof(AlternativeTestColorValues))] Color colorOverride)
         {
             var pathProvider = CreateMockPathProvider();
-            var resolver = new ThemeCssUrlResolver(pathProvider);
+            ThemeCssUrlResolver resolver = new(pathProvider);
 
             string themePath = Path.Combine(pathProvider.AppThemesDirectory, "theme.css");
             string baseThemePath = Path.Combine(pathProvider.AppThemesDirectory, "base.css");
@@ -189,7 +189,7 @@ namespace GitUITests.Theming
                     GetThemeContent(colorName, colorOverride)
             });
 
-            var loader = new ThemeLoader(resolver, mockFileReader);
+            ThemeLoader loader = new(resolver, mockFileReader);
 
             var theme = loader.LoadTheme(themePath, new ThemeId("theme", isBuiltin: true), allowedClasses: ThemeVariations.None);
             theme.GetColor(colorName).ToArgb().Should().Be(colorOverride.ToArgb());
@@ -200,7 +200,7 @@ namespace GitUITests.Theming
         public void Should_throw_When_cyclic_css_imports()
         {
             var pathProvider = CreateMockPathProvider();
-            var resolver = new ThemeCssUrlResolver(pathProvider);
+            ThemeCssUrlResolver resolver = new(pathProvider);
 
             string themePath = Path.Combine(pathProvider.AppThemesDirectory, "theme.css");
             string baseThemePath = Path.Combine(pathProvider.AppThemesDirectory, "base.css");
@@ -211,7 +211,7 @@ namespace GitUITests.Theming
                 [themePath] = "@import url(\"base.css\");"
             });
 
-            var loader = new ThemeLoader(resolver, mockFileReader);
+            ThemeLoader loader = new(resolver, mockFileReader);
 
             loader.Invoking(_ => _.LoadTheme(
                     themePath,

--- a/UnitTests/GitUI.Tests/ThreadHelperTests.cs
+++ b/UnitTests/GitUI.Tests/ThreadHelperTests.cs
@@ -30,8 +30,8 @@ namespace GitUITests
         [Ignore("Hangs")]
         public async Task FileAndForgetReportsThreadException()
         {
-            using var helper = new ThreadExceptionHelper();
-            var ex = new Exception();
+            using ThreadExceptionHelper helper = new();
+            Exception ex = new();
 
             ThrowExceptionAsync(ex).FileAndForget();
 
@@ -42,8 +42,8 @@ namespace GitUITests
         [Test]
         public async Task FileAndForgetIgnoresCancellationExceptions()
         {
-            using var helper = new ThreadExceptionHelper();
-            var form = new Form();
+            using ThreadExceptionHelper helper = new();
+            Form form = new();
             form.Dispose();
 
             YieldOntoControlMainThreadAsync(form).FileAndForget();
@@ -56,8 +56,8 @@ namespace GitUITests
         [Ignore("Hangs")]
         public async Task FileAndForgetFilterCanAllowExceptions()
         {
-            using var helper = new ThreadExceptionHelper();
-            var ex = new Exception();
+            using ThreadExceptionHelper helper = new();
+            Exception ex = new();
 
             ThrowExceptionAsync(ex).FileAndForget(fileOnlyIf: e => e == ex);
 
@@ -69,8 +69,8 @@ namespace GitUITests
         [Ignore("Hangs")]
         public async Task FileAndForgetFilterCanIgnoreExceptions()
         {
-            using var helper = new ThreadExceptionHelper();
-            var ex = new Exception();
+            using ThreadExceptionHelper helper = new();
+            Exception ex = new();
 
             ThrowExceptionAsync(ex).FileAndForget(fileOnlyIf: e => e != ex);
 
@@ -81,8 +81,8 @@ namespace GitUITests
         [Test]
         public async Task FileAndForgetFilterIgnoresCancellationExceptions()
         {
-            using var helper = new ThreadExceptionHelper();
-            var form = new Form();
+            using ThreadExceptionHelper helper = new();
+            Form form = new();
             form.Dispose();
 
             YieldOntoControlMainThreadAsync(form).FileAndForget(fileOnlyIf: ex => true);
@@ -124,14 +124,14 @@ namespace GitUITests
         [Test]
         public void CompletedResultThrowsIfNotCompleted()
         {
-            var tcs = new TaskCompletionSource<int>();
+            TaskCompletionSource<int> tcs = new();
             Assert.Throws<InvalidOperationException>(() => tcs.Task.CompletedResult());
         }
 
         [Test]
         public void CompletedResultReturnsResultIfCompleted()
         {
-            var tcs = new TaskCompletionSource<int>();
+            TaskCompletionSource<int> tcs = new();
             tcs.SetResult(1);
             Assert.AreEqual(1, tcs.Task.CompletedResult());
         }
@@ -139,7 +139,7 @@ namespace GitUITests
         [Test]
         public void CompletedResultThrowsIfCancelled()
         {
-            var tcs = new TaskCompletionSource<int>();
+            TaskCompletionSource<int> tcs = new();
             tcs.SetCanceled();
             var actual = Assert.Throws<AggregateException>(() => tcs.Task.CompletedResult());
             Assert.IsInstanceOf<TaskCanceledException>(actual.InnerException);
@@ -148,8 +148,8 @@ namespace GitUITests
         [Test]
         public void CompletedResultThrowsIfFaulted()
         {
-            var tcs = new TaskCompletionSource<int>();
-            var ex = new Exception();
+            TaskCompletionSource<int> tcs = new();
+            Exception ex = new();
             tcs.SetException(ex);
             var actual = Assert.Throws<AggregateException>(() => tcs.Task.CompletedResult());
             Assert.AreSame(ex, actual.InnerException);
@@ -159,14 +159,14 @@ namespace GitUITests
         [Test]
         public void CompletedOrDefaultReturnsDefaultIfNotCompleted()
         {
-            var tcs = new TaskCompletionSource<int>();
+            TaskCompletionSource<int> tcs = new();
             Assert.AreEqual(0, tcs.Task.CompletedOrDefault());
         }
 
         [Test]
         public void CompletedOrDefaultReturnsResultIfCompleted()
         {
-            var tcs = new TaskCompletionSource<int>();
+            TaskCompletionSource<int> tcs = new();
             tcs.SetResult(1);
             Assert.AreEqual(1, tcs.Task.CompletedOrDefault());
         }
@@ -174,7 +174,7 @@ namespace GitUITests
         [Test]
         public void CompletedOrDefaultThrowsIfCancelled()
         {
-            var tcs = new TaskCompletionSource<int>();
+            TaskCompletionSource<int> tcs = new();
             tcs.SetCanceled();
             var actual = Assert.Throws<AggregateException>(() => tcs.Task.CompletedOrDefault());
             Assert.IsInstanceOf<TaskCanceledException>(actual.InnerException);
@@ -183,8 +183,8 @@ namespace GitUITests
         [Test]
         public void CompletedOrDefaultThrowsIfFaulted()
         {
-            var tcs = new TaskCompletionSource<int>();
-            var ex = new Exception();
+            TaskCompletionSource<int> tcs = new();
+            Exception ex = new();
             tcs.SetException(ex);
             var actual = Assert.Throws<AggregateException>(() => tcs.Task.CompletedOrDefault());
             Assert.AreSame(ex, actual.InnerException);

--- a/UnitTests/GitUI.Tests/TranslationTest.cs
+++ b/UnitTests/GitUI.Tests/TranslationTest.cs
@@ -32,11 +32,11 @@ namespace GitUITests
 
             var translatableTypes = TranslationUtil.GetTranslatableTypes();
 
-            var problems = new List<(string typeName, Exception exception)>();
+            List<(string typeName, Exception exception)> problems = new();
 
             foreach (var types in translatableTypes.Values)
             {
-                var translation = new TranslationFile();
+                TranslationFile translation = new();
 
                 foreach (var type in types)
                 {

--- a/UnitTests/GitUI.Tests/UserControls/AuthorRevisionHighlightingTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/AuthorRevisionHighlightingTests.cs
@@ -18,7 +18,7 @@ namespace GitUITests.UserControls
         [Test]
         public void AuthorEmailToHighlight_should_be_null_when_no_revision_change_processed_yet()
         {
-            var sut = new AuthorRevisionHighlighting();
+            AuthorRevisionHighlighting sut = new();
 
             sut.AuthorEmailToHighlight.Should().BeNull();
         }
@@ -26,7 +26,7 @@ namespace GitUITests.UserControls
         [Test]
         public void When_multiple_revisions_selected_Then_ProcessSelectionChange_should_return_NoAction()
         {
-            var sut = new AuthorRevisionHighlighting();
+            AuthorRevisionHighlighting sut = new();
             var currentModule = NewModule();
 
             var action = sut.ProcessRevisionSelectionChange(currentModule,
@@ -42,7 +42,7 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_multiple_revisions_selected_Then_AuthorEmailToHighlight_should_not_change()
         {
-            var sut = new AuthorRevisionHighlighting();
+            AuthorRevisionHighlighting sut = new();
             var currentModule = NewModule();
             Assert.True(sut.ProcessRevisionSelectionChange(currentModule,
                                                new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) }));
@@ -60,7 +60,7 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_no_previously_selected_revision_When_single_revision_selected_Then_ProcessSelectionChange_should_return_RefreshUserInterface()
         {
-            var sut = new AuthorRevisionHighlighting();
+            AuthorRevisionHighlighting sut = new();
             var currentModule = NewModule();
 
             var action = sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
@@ -71,7 +71,7 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_no_previously_selected_revision_When_single_revision_selected_Then_AuthorEmailToHighlight_should_change()
         {
-            var sut = new AuthorRevisionHighlighting();
+            AuthorRevisionHighlighting sut = new();
             var currentModule = NewModule();
 
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
@@ -82,7 +82,7 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_single_revision_with_same_author_email_selected_Then_ProcessSelectionChange_should_return_NoAction()
         {
-            var sut = new AuthorRevisionHighlighting();
+            AuthorRevisionHighlighting sut = new();
             var currentModule = NewModule();
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
@@ -94,7 +94,7 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_single_revision_with_same_author_email_selected_Then_AuthorEmailToHighlight_should_not_change()
         {
-            var sut = new AuthorRevisionHighlighting();
+            AuthorRevisionHighlighting sut = new();
             var currentModule = NewModule();
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
@@ -106,7 +106,7 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_single_revision_with_different_author_email_selected_Then_ProcessSelectionChange_should_return_RefreshUserInterface()
         {
-            var sut = new AuthorRevisionHighlighting();
+            AuthorRevisionHighlighting sut = new();
             var currentModule = NewModule();
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
@@ -118,7 +118,7 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_single_revision_with_different_author_email_selected_Then_AuthorEmailToHighlight_should_change()
         {
-            var sut = new AuthorRevisionHighlighting();
+            AuthorRevisionHighlighting sut = new();
             var currentModule = NewModule();
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
 
@@ -130,7 +130,7 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_no_revision_selected_Then_ProcessSelectionChange_should_return_RefreshUserInterface()
         {
-            var sut = new AuthorRevisionHighlighting();
+            AuthorRevisionHighlighting sut = new();
             var currentModule = NewModule();
             currentModule.SetSetting(SettingKeyString.UserEmail, ExpectedAuthorEmail2);
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
@@ -143,7 +143,7 @@ namespace GitUITests.UserControls
         [Test]
         public void Given_previously_selected_revision_When_no_revision_selected_Then_AuthorEmailToHighlight_should_be_value_of_current_user_email_setting()
         {
-            var sut = new AuthorRevisionHighlighting();
+            AuthorRevisionHighlighting sut = new();
             var currentModule = NewModule();
             currentModule.SetSetting(SettingKeyString.UserEmail, ExpectedAuthorEmail2);
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(ExpectedAuthorEmail1) });
@@ -156,7 +156,7 @@ namespace GitUITests.UserControls
         [Test]
         public void IsHighlighted_should_return_false_if_revision_is_null()
         {
-            var sut = new AuthorRevisionHighlighting();
+            AuthorRevisionHighlighting sut = new();
 
             sut.IsHighlighted(null).Should().BeFalse();
         }
@@ -166,7 +166,7 @@ namespace GitUITests.UserControls
         [TestCase("\t")]
         public void IsHighlighted_should_return_false_if_revision_AuthorEmail_is_null_or_whitespace(string authorEmail)
         {
-            var sut = new AuthorRevisionHighlighting();
+            AuthorRevisionHighlighting sut = new();
 
             sut.IsHighlighted(new GitRevision(ObjectId.Random()) { AuthorEmail = authorEmail }).Should().BeFalse();
         }
@@ -180,7 +180,7 @@ namespace GitUITests.UserControls
         public void IsHighlighted_should_return_true_if_revision_AuthorEmail_matches_AuthorEmailToHighlight(string authorEmail, string highlightEmail, bool expected)
         {
             var currentModule = NewModule();
-            var sut = new AuthorRevisionHighlighting();
+            AuthorRevisionHighlighting sut = new();
             sut.ProcessRevisionSelectionChange(currentModule, new[] { NewRevisionWithAuthorEmail(highlightEmail) });
             sut.AuthorEmailToHighlight.Should().Be(highlightEmail);
 

--- a/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
@@ -24,7 +24,7 @@ namespace GitUITests.UserControls
         [SetUp]
         public void SetUp()
         {
-            var blameCommit1 = new GitBlameCommit(
+            GitBlameCommit blameCommit1 = new(
                 ObjectId.Random(),
                 "author1",
                 "author1@mail.fake",
@@ -37,7 +37,7 @@ namespace GitUITests.UserControls
                 "test summary commit1",
                 "fileName.txt");
 
-            var blameCommit2 = new GitBlameCommit(
+            GitBlameCommit blameCommit2 = new(
                 ObjectId.Random(),
                 "author2",
                 "author2@mail.fake",
@@ -77,7 +77,7 @@ namespace GitUITests.UserControls
         [TestCase(true, true, false, false, "3/22/2010 - author1")]
         public void BuildAuthorLine_When_FilePath_IsDifferent(bool showAuthorDate, bool showAuthor, bool showFilePath, bool displayAuthorFirst, string expectedResult)
         {
-            var line = new StringBuilder();
+            StringBuilder line = new();
 
             _blameControl.GetTestAccessor().BuildAuthorLine(_gitBlameLine, line, CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern,
                 "fileName_different.txt", showAuthor, showAuthorDate, showFilePath, displayAuthorFirst);
@@ -88,7 +88,7 @@ namespace GitUITests.UserControls
         [Test]
         public void BuildAuthorLine_When_FilePath_Is_Identic()
         {
-            var line = new StringBuilder();
+            StringBuilder line = new();
 
             _blameControl.GetTestAccessor().BuildAuthorLine(_gitBlameLine, line, CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern,
                 "fileName.txt", true, true, true, false);

--- a/UnitTests/GitUI.Tests/UserControls/CommitInfo/BranchComparerTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/CommitInfo/BranchComparerTests.cs
@@ -11,7 +11,7 @@ namespace GitUITests.UserControls.CommitInfo
         [Test]
         public void BranchComparer([Values(null, "current")] string currentBranch)
         {
-            var expectedBranches = new List<string>
+            List<string> expectedBranches = new()
             {
                 currentBranch,
 
@@ -58,7 +58,7 @@ namespace GitUITests.UserControls.CommitInfo
                 expectedBranches.RemoveAt(0);
             }
 
-            var branches = new List<string>(expectedBranches);
+            List<string> branches = new(expectedBranches);
 
             SortAndCheckListsForEquality();
 

--- a/UnitTests/GitUI.Tests/UserControls/ConsoleEmulatorOutputControlFixture.cs
+++ b/UnitTests/GitUI.Tests/UserControls/ConsoleEmulatorOutputControlFixture.cs
@@ -22,7 +22,7 @@ namespace GitUITests.UserControls
                 received += e.Text;
             }
 
-            var filter = new ConsoleCommandLineOutputProcessor(cmd.Length, FireDataReceived);
+            ConsoleCommandLineOutputProcessor filter = new(cmd.Length, FireDataReceived);
 
             string chunk1 = cmd.Substring(0, 10);
             string chunk2 = cmd.Substring(10, cmd.Length - 10) + Environment.NewLine + outputData;
@@ -44,7 +44,7 @@ namespace GitUITests.UserControls
                 received += e.Text;
             }
 
-            var filter = new ConsoleCommandLineOutputProcessor(cmd.Length, FireDataReceived);
+            ConsoleCommandLineOutputProcessor filter = new(cmd.Length, FireDataReceived);
 
             string chunk1 = cmd.Substring(0, 10);
             string chunk2 = cmd.Substring(10, cmd.Length - 10) + Environment.NewLine + outputData;
@@ -71,14 +71,14 @@ namespace GitUITests.UserControls
                 "Receiving: 100%\nReceived data\n"
             };
 
-            var received = new List<string>();
+            List<string> received = new();
 
             void FireDataReceived(TextEventArgs e)
             {
                 received.Add(e.Text);
             }
 
-            var filter = new ConsoleCommandLineOutputProcessor(cmd.Length, FireDataReceived);
+            ConsoleCommandLineOutputProcessor filter = new(cmd.Length, FireDataReceived);
 
             foreach (string chunk in outputData)
             {
@@ -116,14 +116,14 @@ namespace GitUITests.UserControls
                 "Receiving: 100%\nReceived\r\ndata\n"
             };
 
-            var received = new List<string>();
+            List<string> received = new();
 
             void FireDataReceived(TextEventArgs e)
             {
                 received.Add(e.Text);
             }
 
-            var filter = new ConsoleCommandLineOutputProcessor(cmd.Length, FireDataReceived);
+            ConsoleCommandLineOutputProcessor filter = new(cmd.Length, FireDataReceived);
 
             foreach (string chunk in outputData)
             {

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/GitRefListsForRevisionTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/GitRefListsForRevisionTests.cs
@@ -48,42 +48,42 @@ namespace GitUITests.UserControls.RevisionGrid
         [Test]
         public void AllBranches_must_return_all_revision_branches()
         {
-            var grl = new GitRefListsForRevision(_revision);
+            GitRefListsForRevision grl = new(_revision);
             grl.AllBranches.Count.Should().Be(2);
         }
 
         [Test]
         public void AllTags_must_return_all_revision_tags()
         {
-            var grl = new GitRefListsForRevision(_revision);
+            GitRefListsForRevision grl = new(_revision);
             grl.AllTags.Count.Should().Be(1);
         }
 
         [Test]
         public void GetAllBranchNames_must_return_branches_names()
         {
-            var grl = new GitRefListsForRevision(_revision);
+            GitRefListsForRevision grl = new(_revision);
             grl.GetAllBranchNames().Should().BeEquivalentTo("branch1", "branch1");
         }
 
         [Test]
         public void GetAllTagNames_must_return_branches_names()
         {
-            var grl = new GitRefListsForRevision(_revision);
+            GitRefListsForRevision grl = new(_revision);
             grl.GetAllTagNames().Should().BeEquivalentTo("tag1");
         }
 
         [Test]
         public void GetDeletableRefs_must_return_branches_names()
         {
-            var grl = new GitRefListsForRevision(_revision);
+            GitRefListsForRevision grl = new(_revision);
             grl.GetDeletableRefs("branch1").Should().BeEquivalentTo(_refs[2], _refs[0]);
         }
 
         [Test]
         public void GetRenameableLocalBranches_must_return_branches_names()
         {
-            var grl = new GitRefListsForRevision(_revision);
+            GitRefListsForRevision grl = new(_revision);
             grl.GetRenameableLocalBranches().Should().BeEquivalentTo(_refs[1]);
         }
     }

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
@@ -18,7 +18,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         /// for testing the LaneInfoProvider.References.MergeRegex
         /// "(?i)^merged? (pull request (.*) from )?(.*branch |tag )?'?([^ ']*[^ '.])'?( of [^ ]*[^ .])?( into (.*[^.]))?\\.?$"
         /// </summary>
-        private static readonly List<string> MergeSubjectsWithDecoding = new List<string>()
+        private static readonly List<string> MergeSubjectsWithDecoding = new()
         {
             "Merge Branch xxx", // case-insignificance
             "xxx", "master",
@@ -189,7 +189,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         [Test]
         public void GetLaneInfo_should_return_no_info_if_node_revision_null()
         {
-            var nodeWithoutRevision = new RevisionGraphRevision(ObjectId.WorkTreeId, 0);
+            RevisionGraphRevision nodeWithoutRevision = new(ObjectId.WorkTreeId, 0);
             _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (nodeWithoutRevision, isAtNode: false));
 
             _infoProvider.GetLaneInfo(0, 0).Should().Be(LaneInfoProvider.TestAccessor.NoInfoText.Text);
@@ -377,7 +377,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
             string into = MergeSubjectsWithDecoding[2];
             _mergeCommitNode.GitRevision.Subject = subject;
 
-            var gitRef = new GitRef(null, null, GitRefName.RefsHeadsPrefix + "local_branch");
+            GitRef gitRef = new(null, null, GitRefName.RefsHeadsPrefix + "local_branch");
             _mergeCommitNode.GitRevision.Refs = new GitRef[] { gitRef };
 
             GetLaneInfo_should_display(_realCommitNode, into);

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneNodeLocatorTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneNodeLocatorTests.cs
@@ -22,10 +22,10 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
 
         private RevisionGraphRevision SetupLaneRow(int row, int lane, int laneCount, int nodeLane = -1, RevisionGraphSegment firstSegment = null)
         {
-            var node = new RevisionGraphRevision(GitUIPluginInterfaces.ObjectId.WorkTreeId, 0);
+            RevisionGraphRevision node = new(GitUIPluginInterfaces.ObjectId.WorkTreeId, 0);
             var revisionGraphRow = Substitute.For<IRevisionGraphRow>();
 
-            var segments = new List<RevisionGraphSegment>();
+            List<RevisionGraphSegment> segments = new();
             if (firstSegment is not null)
             {
                 segments.Add(firstSegment);
@@ -128,9 +128,9 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         {
             const int row = 100;
             const int lane = 3;
-            var parentNode = new RevisionGraphRevision(GitUIPluginInterfaces.ObjectId.WorkTreeId, 0);
-            var childNode = new RevisionGraphRevision(GitUIPluginInterfaces.ObjectId.WorkTreeId, 0);
-            var segment = new RevisionGraphSegment(parentNode, childNode);
+            RevisionGraphRevision parentNode = new(GitUIPluginInterfaces.ObjectId.WorkTreeId, 0);
+            RevisionGraphRevision childNode = new(GitUIPluginInterfaces.ObjectId.WorkTreeId, 0);
+            RevisionGraphSegment segment = new(parentNode, childNode);
             var laneNode = SetupLaneRow(row, lane, laneCount: lane + 1, firstSegment: segment);
 
 #if !DEBUG

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphMultiThreadingTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphMultiThreadingTests.cs
@@ -45,13 +45,13 @@ namespace GitUITests.UserControls.RevisionGrid
             for (int i = 0; i < _numberOfRepeats; i++)
             {
                 // Simulate thread that loads revisions from git
-                var loadRevisionsTask = new Task(() => LoadRandomRevisions());
+                Task loadRevisionsTask = new(() => LoadRandomRevisions());
 
                 // Simulate thread that caches the rows in the background
-                var buildCacheTask = new Task(() => BuildCache());
+                Task buildCacheTask = new(() => BuildCache());
 
                 // Simulate thread that renders
-                var renderTask = new Task(() => Render());
+                Task renderTask = new(() => Render());
 
                 loadRevisionsTask.Start();
                 buildCacheTask.Start();
@@ -71,7 +71,7 @@ namespace GitUITests.UserControls.RevisionGrid
 
         private void LoadRandomRevisions()
         {
-            List<GitRevision> randomRevisions = new List<GitRevision>();
+            List<GitRevision> randomRevisions = new();
 
             for (int i = 0; i < _numberOfRevisionsAddedPerRun; i++)
             {

--- a/UnitTests/GitUI.Tests/UserControls/ToolStripPushButtonTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/ToolStripPushButtonTests.cs
@@ -94,7 +94,7 @@ namespace GitUITests.UserControls
         public void DisplayAheadBehindInformation_should_display_normal_state_when_in_ahead_state()
         {
             var branchName = "my-branch";
-            var data = new Dictionary<string, AheadBehindData>
+            Dictionary<string, AheadBehindData> data = new()
             {
                 { branchName, new AheadBehindData { AheadCount = "9", BehindCount = string.Empty, Branch = branchName } }
             };
@@ -112,7 +112,7 @@ namespace GitUITests.UserControls
         public void DisplayAheadBehindInformation_should_display_warning_state_when_in_behind_state()
         {
             var branchName = "my-branch";
-            var data = new Dictionary<string, AheadBehindData>
+            Dictionary<string, AheadBehindData> data = new()
             {
                 { branchName, new AheadBehindData { AheadCount = string.Empty, BehindCount = "2", Branch = branchName } }
             };
@@ -130,7 +130,7 @@ namespace GitUITests.UserControls
         public void DisplayAheadBehindInformation_should_display_warning_state_when_in_ahead_and_behind_state()
         {
             var branchName = "my-branch";
-            var data = new Dictionary<string, AheadBehindData>
+            Dictionary<string, AheadBehindData> data = new()
             {
                 { branchName, new AheadBehindData { AheadCount = "99", BehindCount = "3", Branch = branchName } }
             };

--- a/UnitTests/GitUI.Tests/UserControls/TreeViewExtensionsTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/TreeViewExtensionsTests.cs
@@ -64,7 +64,7 @@ namespace GitUITests.UserControls
         [Test]
         public void RestoreExpandedNodesState_should_restore_no_nodes()
         {
-            var expandedNodes = new HashSet<string>();
+            HashSet<string> expandedNodes = new();
             _root.RestoreExpandedNodesState(expandedNodes);
 
             var expandedNodesPost = _root.GetExpandedNodesState();
@@ -74,7 +74,7 @@ namespace GitUITests.UserControls
         [Test]
         public void RestoreExpandedNodesState_should_restore_one_node()
         {
-            var expandedNodes = new HashSet<string> { @"Root\B" };
+            HashSet<string> expandedNodes = new() { @"Root\B" };
             _root.RestoreExpandedNodesState(expandedNodes);
 
             var expandedNodesPost = _root.GetExpandedNodesState();
@@ -85,7 +85,7 @@ namespace GitUITests.UserControls
         [Test]
         public void RestoreExpandedNodesState_should_restore_all_nodes()
         {
-            var expandedNodes = new HashSet<string>
+            HashSet<string> expandedNodes = new()
             {
                 $"{_root.GetFullNamePath()}",
                 $"{_a.GetFullNamePath()}",

--- a/UnitTests/GitUI.Tests/UserManual/SingleHtmlUserManualFixture.cs
+++ b/UnitTests/GitUI.Tests/UserManual/SingleHtmlUserManualFixture.cs
@@ -12,7 +12,7 @@ namespace GitUITests.UserManual
         [TestCase("merge-conflicts")]
         public void GetUrl(string anchor)
         {
-            var sut = new SingleHtmlUserManual(anchor);
+            SingleHtmlUserManual sut = new(anchor);
 
             var expected = SingleHtmlUserManual.Location + "/index.html".Combine("#", anchor);
 

--- a/UnitTests/GitUI.Tests/UserManual/StandardHtmlUserManualFixture.cs
+++ b/UnitTests/GitUI.Tests/UserManual/StandardHtmlUserManualFixture.cs
@@ -16,7 +16,7 @@ namespace GitUITests.UserManual
             AppSettings.GetTestAccessor().ResetDocumentationBaseUrl();
             AppSettings.SetDocumentationBaseUrl("master");
 
-            var sut = new StandardHtmlUserManual(subFolder, anchor);
+            StandardHtmlUserManual sut = new(subFolder, anchor);
 
             sut.GetUrl().Should().Be(expected);
         }

--- a/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegration.Tests/AppVeyorAdapterTests.cs
+++ b/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegration.Tests/AppVeyorAdapterTests.cs
@@ -48,7 +48,7 @@ namespace AppVeyorIntegrationTests
         {
             var resultString = EmbeddedResourceLoader.Load(Assembly.GetExecutingAssembly(),
                 $"{GetType().Namespace}.MockData.{filename}");
-            var appVeyorAdapter = new AppVeyorAdapter();
+            AppVeyorAdapter appVeyorAdapter = new();
             appVeyorAdapter.Initialize(Substitute.For<IBuildServerWatcher>(), Substitute.For<ISettingsSource>(), () => { },
                 id => true);
 

--- a/UnitTests/Plugins/BuildServerIntegration/AzureDevOpsIntegration.Tests/AzureDevOpsAdapterTests.cs
+++ b/UnitTests/Plugins/BuildServerIntegration/AzureDevOpsIntegration.Tests/AzureDevOpsAdapterTests.cs
@@ -14,14 +14,14 @@ namespace AzureDevOpsIntegrationTests
         [SetUp]
         public void Initialize()
         {
-            var adapter = new AzureDevOpsAdapter();
+            AzureDevOpsAdapter adapter = new();
             _sut = adapter.GetTestAccessor();
         }
 
         [Test]
         public void Should_not_filter_running_builds_When_only_one_returned()
         {
-            var myBuild = new Build { SourceVersion = "ACommitHash" };
+            Build myBuild = new() { SourceVersion = "ACommitHash" };
             IList<Build> runningBuilds = new List<Build> { myBuild };
 
             var filteredRunningBuilds = _sut.FilterRunningBuilds(runningBuilds);
@@ -32,8 +32,8 @@ namespace AzureDevOpsIntegrationTests
         [Test]
         public void Should_not_filter_running_builds_When_builds_are_on_different_commits()
         {
-            var buildOnOneCommit = new Build { SourceVersion = "a_commit_Hash" };
-            var buildOnAnotherCommit = new Build { SourceVersion = "another_commit_Hash" };
+            Build buildOnOneCommit = new() { SourceVersion = "a_commit_Hash" };
+            Build buildOnAnotherCommit = new() { SourceVersion = "another_commit_Hash" };
             IList<Build> runningBuilds = new List<Build> { buildOnOneCommit, buildOnAnotherCommit };
 
             var filteredRunningBuilds = _sut.FilterRunningBuilds(runningBuilds);
@@ -44,9 +44,9 @@ namespace AzureDevOpsIntegrationTests
         [Test]
         public void Should_take_only_the_first_started_running_builds_When_multiple_builds_on_same_commit()
         {
-            var firstBuildStartedOnACommit = new Build { SourceVersion = "a_commit_Hash", StartTime = new DateTime(2010, 1, 1) };
-            var buildAlsoStartedOnSameCommitButAfter = new Build { SourceVersion = "a_commit_Hash", StartTime = new DateTime(2010, 1, 2) };
-            var buildAlsoStartedOnSameCommitButAfterAlso = new Build { SourceVersion = "a_commit_Hash", StartTime = new DateTime(2010, 1, 3) };
+            Build firstBuildStartedOnACommit = new() { SourceVersion = "a_commit_Hash", StartTime = new DateTime(2010, 1, 1) };
+            Build buildAlsoStartedOnSameCommitButAfter = new() { SourceVersion = "a_commit_Hash", StartTime = new DateTime(2010, 1, 2) };
+            Build buildAlsoStartedOnSameCommitButAfterAlso = new() { SourceVersion = "a_commit_Hash", StartTime = new DateTime(2010, 1, 3) };
             IList<Build> runningBuilds = new List<Build> { firstBuildStartedOnACommit, buildAlsoStartedOnSameCommitButAfter, buildAlsoStartedOnSameCommitButAfterAlso };
 
             var filteredRunningBuilds = _sut.FilterRunningBuilds(runningBuilds);
@@ -57,9 +57,9 @@ namespace AzureDevOpsIntegrationTests
         [Test]
         public void Should_take_whatever_build_When_multiple_not_yet_started_builds_on_same_commit()
         {
-            var firstBuildStartedOnACommit = new Build { SourceVersion = "a_commit_Hash" };
-            var buildAlsoStartedOnSameCommitButAfter = new Build { SourceVersion = "a_commit_Hash" };
-            var buildAlsoStartedOnSameCommitButAfterAlso = new Build { SourceVersion = "a_commit_Hash" };
+            Build firstBuildStartedOnACommit = new() { SourceVersion = "a_commit_Hash" };
+            Build buildAlsoStartedOnSameCommitButAfter = new() { SourceVersion = "a_commit_Hash" };
+            Build buildAlsoStartedOnSameCommitButAfterAlso = new() { SourceVersion = "a_commit_Hash" };
             IList<Build> runningBuilds = new List<Build> { firstBuildStartedOnACommit, buildAlsoStartedOnSameCommitButAfter, buildAlsoStartedOnSameCommitButAfterAlso };
 
             var filteredRunningBuilds = _sut.FilterRunningBuilds(runningBuilds);
@@ -70,9 +70,9 @@ namespace AzureDevOpsIntegrationTests
         [Test]
         public void Should_take_only_a_started_running_builds_When_multiple_builds_on_same_commit()
         {
-            var notStartedBuildOnACommit = new Build { SourceVersion = "a_commit_Hash" };
-            var startedBuild = new Build { SourceVersion = "a_commit_Hash", StartTime = new DateTime(2010, 1, 2) };
-            var anotherNotStartedBuildOnACommit = new Build { SourceVersion = "a_commit_Hash" };
+            Build notStartedBuildOnACommit = new() { SourceVersion = "a_commit_Hash" };
+            Build startedBuild = new() { SourceVersion = "a_commit_Hash", StartTime = new DateTime(2010, 1, 2) };
+            Build anotherNotStartedBuildOnACommit = new() { SourceVersion = "a_commit_Hash" };
             IList<Build> runningBuilds = new List<Build> { notStartedBuildOnACommit, startedBuild, anotherNotStartedBuildOnACommit };
 
             var filteredRunningBuilds = _sut.FilterRunningBuilds(runningBuilds);

--- a/UnitTests/Plugins/GitUIPluginInterfaces.Tests/FontParserTests.cs
+++ b/UnitTests/Plugins/GitUIPluginInterfaces.Tests/FontParserTests.cs
@@ -28,7 +28,7 @@ namespace GitUIPluginInterfacesTests
         [TestCase(FontStyle.Bold | FontStyle.Italic, "Arial;9;_IC_;1;1")]
         public void AsString_should_persist_font_with_styles(FontStyle fontStyle, string serialised)
         {
-            using var font = new Font("Arial", 9, fontStyle);
+            using Font font = new("Arial", 9, fontStyle);
             font.AsString().Should().Be(serialised);
         }
 

--- a/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataBodyRendererTests.cs
+++ b/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataBodyRendererTests.cs
@@ -49,7 +49,7 @@ namespace ResourceManagerTests.CommitDataRenders
                 return true;
             });
 
-            var data = new CommitData(ObjectId.Random(), ObjectId.Random(),
+            CommitData data = new(ObjectId.Random(), ObjectId.Random(),
                 Array.Empty<ObjectId>(),
                 "John Doe (Acme Inc) <John.Doe@test.com>", DateTime.UtcNow,
                 "John Doe <John.Doe@test.com>", DateTime.UtcNow,
@@ -63,7 +63,7 @@ namespace ResourceManagerTests.CommitDataRenders
         [Test]
         public void Render_should_render_body_without_links()
         {
-            var data = new CommitData(ObjectId.Random(), ObjectId.Random(),
+            CommitData data = new(ObjectId.Random(), ObjectId.Random(),
                 Array.Empty<ObjectId>(),
                 "John Doe (Acme Inc) <John.Doe@test.com>", DateTime.UtcNow,
                 "John Doe <John.Doe@test.com>", DateTime.UtcNow,

--- a/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererTests.cs
+++ b/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererTests.cs
@@ -61,7 +61,7 @@ namespace ResourceManagerTests.CommitDataRenders
         [Test]
         public void GetFont_should_get_font_from_style_provider()
         {
-            using var c = new Control();
+            using Control c = new();
             using var g = c.CreateGraphics();
             _renderer.GetFont(g);
 
@@ -89,7 +89,7 @@ namespace ResourceManagerTests.CommitDataRenders
             var committer = author;
             var authorDate = DateTime.Parse("2017-06-17T16:38:40+03");
             var commitDate = authorDate;
-            var data = new CommitData(
+            CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
                 ObjectId.Random(),
                 Array.Empty<ObjectId>(),
@@ -117,7 +117,7 @@ namespace ResourceManagerTests.CommitDataRenders
             var committer = "John Doe <John.Doe@test.com>";
             var authorDate = DateTime.Parse("2017-06-17T16:38:40+03");
             var commitDate = authorDate;
-            var data = new CommitData(
+            CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
                 ObjectId.Random(),
                 Array.Empty<ObjectId>(),
@@ -146,7 +146,7 @@ namespace ResourceManagerTests.CommitDataRenders
             var committer = author;
             var authorDate = DateTime.Parse("2017-06-17T16:38:40+03");
             var commitDate = DateTime.Parse("2017-10-23T06:17:11+05");
-            var data = new CommitData(
+            CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
                 ObjectId.Random(),
                 Array.Empty<ObjectId>(),
@@ -175,7 +175,7 @@ namespace ResourceManagerTests.CommitDataRenders
             var committer = author;
             var authorDate = DateTime.Parse("2017-06-17T16:38:40+03");
             var commitDate = authorDate;
-            var data = new CommitData(
+            CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
                 ObjectId.Random(),
                 Array.Empty<ObjectId>(),
@@ -207,7 +207,7 @@ namespace ResourceManagerTests.CommitDataRenders
             var committer = author;
             var authorDate = DateTime.Parse("2017-06-17T16:38:40+03");
             var commitDate = authorDate;
-            var data = new CommitData(
+            CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
                 ObjectId.Random(),
                 _parentHashes,
@@ -237,7 +237,7 @@ namespace ResourceManagerTests.CommitDataRenders
             var committer = author;
             var authorDate = DateTime.Parse("2017-06-17T16:38:40+03");
             var commitDate = authorDate;
-            var data = new CommitData(
+            CommitData data = new(
                 ObjectId.Parse(artificialGuid),
                 ObjectId.Random(),
                 _parentHashes,
@@ -271,7 +271,7 @@ namespace ResourceManagerTests.CommitDataRenders
             var committer = author;
             var authorDate = DateTime.Parse("2017-06-17T16:38:40+03");
             var commitDate = authorDate;
-            var data = new CommitData(
+            CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
                 ObjectId.Random(),
                 Array.Empty<ObjectId>(),
@@ -299,7 +299,7 @@ namespace ResourceManagerTests.CommitDataRenders
             var committer = "John Doe <John.Doe@test.com>";
             var authorDate = DateTime.Parse("2017-06-17T16:38:40+03");
             var commitDate = authorDate;
-            var data = new CommitData(
+            CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
                 ObjectId.Random(),
                 Array.Empty<ObjectId>(),
@@ -328,7 +328,7 @@ namespace ResourceManagerTests.CommitDataRenders
             var committer = author;
             var authorDate = DateTime.Parse("2017-06-17T16:38:40+03");
             var commitDate = DateTime.Parse("2017-10-23T06:17:11+05");
-            var data = new CommitData(
+            CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
                 ObjectId.Random(),
                 Array.Empty<ObjectId>(),

--- a/UnitTests/ResourceManager.Tests/LinkFactoryFixture.cs
+++ b/UnitTests/ResourceManager.Tests/LinkFactoryFixture.cs
@@ -13,7 +13,7 @@ namespace ResourceManagerTests
         [TestCase("no link")]
         public void ParseInvalidLink(string link)
         {
-            var linkFactory = new LinkFactory();
+            LinkFactory linkFactory = new();
             Assert.False(linkFactory.ParseLink(link, out var actualUri));
             Assert.That(actualUri, Is.Null);
         }
@@ -21,7 +21,7 @@ namespace ResourceManagerTests
         [Test]
         public void ParseGoToBranchLink()
         {
-            var linkFactory = new LinkFactory();
+            LinkFactory linkFactory = new();
             linkFactory.CreateBranchLink("master");
             string expected = "gitext://gotobranch/master";
             Assert.True(linkFactory.ParseLink("master#gitext://gotobranch/master", out var actualUri));
@@ -31,7 +31,7 @@ namespace ResourceManagerTests
         [Test]
         public void ParseGoToBranchLinkWithHash()
         {
-            var linkFactory = new LinkFactory();
+            LinkFactory linkFactory = new();
             linkFactory.CreateBranchLink("PR#23");
             string expected = "gitext://gotobranch/PR#23";
             Assert.True(linkFactory.ParseLink("PR#23#gitext://gotobranch/PR#23", out var actualUri));
@@ -40,7 +40,7 @@ namespace ResourceManagerTests
 
         private static void TestCreateLink(string caption, string uri)
         {
-            var linkFactory = new LinkFactory();
+            LinkFactory linkFactory = new();
             linkFactory.CreateLink(caption, uri);
             string expected = uri;
             Assert.True(linkFactory.ParseLink(caption + "#" + uri, out var actualUri));
@@ -62,7 +62,7 @@ namespace ResourceManagerTests
         [Test]
         public void ParseRawHttpLinkWithHash()
         {
-            var linkFactory = new LinkFactory();
+            LinkFactory linkFactory = new();
 
             string expected = "https://github.com/gitextensions/gitextensions/pull/3471#end";
             Assert.True(linkFactory.ParseLink("https://github.com/gitextensions/gitextensions/pull/3471#end", out var actualUri));
@@ -78,7 +78,7 @@ namespace ResourceManagerTests
         [Test]
         public void ParseInternalScheme_Null()
         {
-            var linkFactory = new LinkFactory();
+            LinkFactory linkFactory = new();
             Assert.False(linkFactory.ParseInternalScheme(null, out var actualCommandEventArgs));
             Assert.That(actualCommandEventArgs, Is.Null);
         }
@@ -89,8 +89,8 @@ namespace ResourceManagerTests
         [TestCase("http://x")]
         public void ParseInternalScheme_None(string link)
         {
-            var linkFactory = new LinkFactory();
-            var uri = new Uri(link);
+            LinkFactory linkFactory = new();
+            Uri uri = new(link);
             Assert.False(linkFactory.ParseInternalScheme(uri, out var actualCommandEventArgs));
             Assert.That(actualCommandEventArgs, Is.Null);
         }
@@ -105,8 +105,8 @@ namespace ResourceManagerTests
         [TestCase("gitext:not/an/internal/link", "", "not/an/internal/link")]
         public void ParseInternalScheme(string link, string expectedCommand, string expectedData)
         {
-            var linkFactory = new LinkFactory();
-            var uri = new Uri(link);
+            LinkFactory linkFactory = new();
+            Uri uri = new(link);
             Assert.True(linkFactory.ParseInternalScheme(uri, out var actualCommandEventArgs));
             Assert.That(actualCommandEventArgs.Command, Is.EqualTo(expectedCommand));
             Assert.That(actualCommandEventArgs.Data, Is.EqualTo(expectedData));
@@ -126,7 +126,7 @@ namespace ResourceManagerTests
             bool omitHandler,
             bool omitShowAll)
         {
-            var linkFactory = new LinkFactory();
+            LinkFactory linkFactory = new();
             CommandEventArgs actualCommandEventArgs = null;
             string actualShowAll = null;
             string actualException = "";


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-9#fit-and-finish-features

Part of #8788, #8728
Follow up to #8729, covering more cases

Done after getting requests to change existing code in some PRs

## Proposed changes

Use C#9 new() handling and remove var types.

Submitted in commits with the regex I used to replace the types.
Some hundreds of manual changes too.
To be squashed.

This could be mostly "replayed" but I prefer to merge this now...

```
^(\s*(using )?)var(?<eq> \w+\s+=\s+)new\s+(((?<ga>GitArgumentBuilder)(?<gaa>.*[^;]*;$))|((?<in>\w+<.*>)(?<ina>\(\);$))|((?<st>\w+(<[^>]+>)?)(?<sta>(\([^\.]*\));?\s*$)))
 $1${ga}${in}${st}${eq}new${gaa}${ina}${sta}
Some incorrect changes manually converted

^(\s*(using )?)var(?<eq>\s+\w+\s+=\s+)new\s+(?<st>\w+(<[^>]+>)?)(?<sta>\s*$)
$1${st}${eq}new()${sta}

^(\s*(using )?)var(?<eq> \w+\s+=\s+)new\s+(((?<ga>GitArgumentBuilder)(?<gaa>.*[^;]*;$))|((?<in>\w+<.*>)(?<ina>\(\);$))|((?<st>\w+(<[^>]+>)?)(?<sta>(\(.*\));?\s*$)))
$1${ga}${in}${st}${eq}new${gaa}${ina}${sta}
Slightly to aggressive, some reverted

Manual changes, search using
^(\s*(using )?)var\s+(?<eq>\w+\s+=\s+)new\s+
```

## Test methodology <!-- How did you ensure quality? -->

Manual - currently little runtime but this should only be a reformatting

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
