### PR TITLE
Reduce allocations for RevisionGraph lane straightening

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -40,7 +40,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         /// <summary>
         /// Contains the gaps created by <cref>MoveLanesRight</cref>
         /// </summary>
-        private HashSet<int> _gaps = new();
+        private HashSet<int>? _gaps;
 
         /// <summary>
         /// The cached lanecount
@@ -185,7 +185,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
         public void MoveLanesRight(int fromLane)
         {
-            int nextGap = _gaps.Min(lane => lane > fromLane ? lane : null) ?? int.MaxValue;
+            int nextGap = _gaps?.Min(lane => lane > fromLane ? lane : null) ?? int.MaxValue;
 
             if (_revisionLane >= fromLane && _revisionLane < nextGap)
             {
@@ -201,6 +201,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 return;
             }
 
+            _gaps ??= new();
             _gaps.Add(fromLane);
             if (nextGap < int.MaxValue)
             {


### PR DESCRIPTION
Follow-up to #9050

## Proposed changes

- Allocate `HashSet<int> _gaps` only if lanes are straightened in a `RevisionGraph` row

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build d488e497cc6244483794abedb8e4779495ba861c (Dirty)
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).