### PR TITLE
Get BLOB of first revision for deleted file

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -824,7 +824,7 @@ namespace GitUI.CommandsDialogs
             {
                 await TaskScheduler.Default;
 
-                var blob = Module.GetFileBlobHash(item.Item.Name, item.SecondRevision.ObjectId);
+                var blob = Module.GetFileBlobHash(item.Item.Name, item.Item.IsDeleted ? item.FirstRevision!.ObjectId : item.SecondRevision.ObjectId);
 
                 if (blob is null)
                 {


### PR DESCRIPTION
Fixes #9070

## Proposed changes

- If "Open *this* revision" is requested for a deleted file, retrieve the contents of the file anyway although it is from the *previous* revision

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 5b88365bdda5de67080752b639f53db126659bcc
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).