### PR TITLE
Fix stage/unstage implementations

### DIFF
--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -363,10 +363,24 @@ namespace GitCommands
 
             if (writeInput is not null)
             {
+#if DEBUG
+                using MemoryStream mem = new MemoryStream();
+                using StreamWriter sw = new StreamWriter(mem);
+                writeInput(sw);
+
+                System.Diagnostics.Debug.WriteLine($"git {arguments} {Encoding.UTF8.GetString(mem.ToArray(), 0, (int)mem.Length)}");
+#endif
+
                 // TODO do we want to make this async?
                 writeInput(process.StandardInput);
                 process.StandardInput.Close();
             }
+#if DEBUG
+            else
+            {
+                System.Diagnostics.Debug.WriteLine($"git {arguments}");
+            }
+#endif
 
             var exitTask = process.WaitForExitAsync();
 

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -954,7 +954,7 @@ namespace GitUI.CommandsDialogs
             this.toolStageAllItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStageAllItem.Name = "toolStageAllItem";
             this.toolStageAllItem.Size = new System.Drawing.Size(23, 23);
-            this.toolStageAllItem.Click += new System.EventHandler(this.StageAllToolStripMenuItemClick);
+            this.toolStageAllItem.Click += new System.EventHandler(this.toolStageAllItem_Click);
             //
             // toolStripSeparator10
             //
@@ -981,7 +981,7 @@ namespace GitUI.CommandsDialogs
             this.toolUnstageAllItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolUnstageAllItem.Name = "toolUnstageAllItem";
             this.toolUnstageAllItem.Size = new System.Drawing.Size(23, 23);
-            this.toolUnstageAllItem.Click += new System.EventHandler(this.UnstageAllToolStripMenuItemClick);
+            this.toolUnstageAllItem.Click += new System.EventHandler(this.toolUnstageAllItem_Click);
             //
             // toolStripSeparator11
             //

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -780,7 +780,7 @@ namespace GitUI.CommandsDialogs
                 return false;
             }
 
-            StageAllToolStripMenuItemClick(this, EventArgs.Empty);
+            StageAllAccordingToFilter();
             return true;
         }
 
@@ -1549,22 +1549,18 @@ namespace GitUI.CommandsDialogs
             Unstage();
         }
 
-        private void UnstageAllToolStripMenuItemClick(object sender, EventArgs e)
+        private void toolUnstageAllItem_Click(object sender, EventArgs e)
+        {
+            UnstageAllFiles();
+        }
+
+        private void UnstageAllFiles()
         {
             var lastSelection = _currentFilesList is not null
                 ? _currentSelection
                 : Array.Empty<GitItemStatus>();
 
             Validates.NotNull(lastSelection);
-
-            void StageAreaLoaded()
-            {
-                _currentFilesList = Unstaged;
-                RestoreSelectedFiles(Unstaged.GitItemStatuses, Staged.GitItemStatuses, lastSelection);
-                Unstaged.Focus();
-
-                OnStageAreaLoaded -= StageAreaLoaded;
-            }
 
             OnStageAreaLoaded += StageAreaLoaded;
 
@@ -1585,6 +1581,16 @@ namespace GitUI.CommandsDialogs
             }
 
             Initialize();
+            return;
+
+            void StageAreaLoaded()
+            {
+                _currentFilesList = Unstaged;
+                RestoreSelectedFiles(Unstaged.GitItemStatuses, Staged.GitItemStatuses, lastSelection);
+                Unstaged.Focus();
+
+                OnStageAreaLoaded -= StageAreaLoaded;
+            }
         }
 
         private void UnstagedSelectionChanged(object sender, EventArgs e)
@@ -1716,7 +1722,7 @@ namespace GitUI.CommandsDialogs
             var initialStagedCount = Staged.GitItemStatuses.Count;
             if (canUseUnstageAll && initialStagedCount > 10 && allFiles.Count == initialStagedCount)
             {
-                UnstageAllToolStripMenuItemClick(this, EventArgs.Empty);
+                UnstageAllFiles();
                 return;
             }
 
@@ -1891,7 +1897,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void StageAllToolStripMenuItemClick(object sender, EventArgs e)
+        private void toolStageAllItem_Click(object sender, EventArgs e)
         {
             StageAllAccordingToFilter();
         }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -273,8 +273,8 @@ namespace GitExtensions.UITests.CommandsDialogs
         public void Should_unstage_only_filtered_on_UnstageAll()
         {
             _referenceRepository.Reset();
-            _referenceRepository.CreateRepoFile("file1A.txt", "Test");
-            _referenceRepository.CreateRepoFile("file1B.txt", "Test");
+            _referenceRepository.CreateRepoFile("file1A-Привет.txt", "Test");   // escaped and not escaped in the same string
+            _referenceRepository.CreateRepoFile("file1B-두다.txt", "Test");      // escaped octal code points (Korean Hangul in this case)
             _referenceRepository.CreateRepoFile("file2.txt", "Test");
 
             RunFormTest(async form =>
@@ -296,7 +296,15 @@ namespace GitExtensions.UITests.CommandsDialogs
 
                 var testform = form.GetTestAccessor();
 
+                Assert.AreEqual(0, testform.StagedList.AllItemsCount);
+                Assert.AreEqual(3, testform.UnstagedList.AllItemsCount);
+
+                testform.StagedList.SetFilter("");
                 testform.StageAllToolItem.PerformClick();
+
+                Assert.AreEqual(3, testform.StagedList.AllItemsCount);
+                Assert.AreEqual(0, testform.UnstagedList.AllItemsCount);
+
                 testform.StagedList.ClearSelected();
                 testform.StagedList.SetFilter("file1");
 

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -75,6 +75,8 @@ namespace CommonTestUtils
 
         public IProcess Start(ArgumentString arguments, bool createWindow, bool redirectInput, bool redirectOutput, Encoding outputEncoding, bool useShellExecute = false)
         {
+            System.Diagnostics.Debug.WriteLine($"mock-git {arguments}");
+
             if (_outputStackByArguments.TryRemove(arguments, out var queue) && queue.TryPop(out var item))
             {
                 if (queue.Count == 0)


### PR DESCRIPTION
Resolves #9104

1. While staging files the 1st file would be placed on the same line as the command, which locally would lead to test failures with the following message:

    ````
    Ignoring path ﻿"\<first filename>"
    ````

    Rearrange file encoding routine to pass the newline before the filename.

2. Unstage using "git-reset" instead of "git-update-index"

    Unstage functionality used unconventional "git-update-index" command, which appears to have caused unexplained test instability locally:

    ````
    fatal: malformed index info ﻿0 0000000000000000000000000000000000000000	"<first filename>"?
    ````

    Replace the implementation with the more conventional "git-reset", and remove encoding routine introduced in #7288.

    "git-reset --stdin" is no available until git 2.31.1: https://github.com/git-for-windows/git/commit/ec339194c40485016cab92a0a11e59feb70704f5

<!-- Please read CONTRIBUTING.md before submitting a pull request -->
