### PR TITLE
Let installer not activate disabled telemetry

### DIFF
--- a/Bin/set-telemetry.ps1
+++ b/Bin/set-telemetry.ps1
@@ -27,8 +27,10 @@ if (!$doc) {
 
 $node = $doc.SelectSingleNode("/dictionary/item/key/string[text()='TelemetryEnabled']")
 if ($node -ne $null) {
-    $node.ParentNode.ParentNode.value.string = "$telemetryEnabled";
-    $doc.Save($userAppDataPath)
+    if (-not $telemetryEnabled) {
+        $node.ParentNode.ParentNode.value.string = "$telemetryEnabled";
+        $doc.Save($userAppDataPath)
+    }
     exit 0
 }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8228

## Proposed changes

Workaround:
- Let the installer not activate disabled telemetry

Unchanged:
- Store setting from installer if setting has not existed or if turned off

Limitation:
- The script `set-telemetry.ps1` seems to be not executed at all if just changing the installation by running the installer again:

  ![grafik](https://user-images.githubusercontent.com/36601201/116012120-ea9d1d80-a628-11eb-97ac-205f7f21371e.png) 

## Screenshots <!-- Remove this section if PR does not change UI -->

Checked combobox is ignored if `GitExtensions.settings` already contains the `TelemetryEnabled` entry

![grafik](https://user-images.githubusercontent.com/36601201/116012156-20da9d00-a629-11eb-95a1-1eb8ac7b6594.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build a84a1b52d40568c84c06811885a0967e0c084b11
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.16299.0
- .NET Framework 4.7.2633.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
