### PR TITLE
Update Clone dialog's handling of clipboard text

### DIFF
--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -71,23 +71,6 @@ namespace GitCommands
             return !Regex.IsMatch(fileName, @"^(\w+):\/\/([\S]+)");
         }
 
-        /// <summary>
-        /// A naive way to check whether the given path is a URL by checking
-        /// whether it starts with either 'http', 'ssh' or 'git'.
-        /// </summary>
-        /// <param name="path">A path to check.</param>
-        /// <returns><see langword="true"/> if the given path starts with 'http', 'ssh' or 'git'; otherwise <see langword="false"/>.</returns>
-        [Pure]
-        public static bool IsUrl(string path)
-        {
-            return !string.IsNullOrEmpty(path)
-                && (path.StartsWith("http:", StringComparison.CurrentCultureIgnoreCase)
-                 || path.StartsWith("https:", StringComparison.CurrentCultureIgnoreCase)
-                 || path.StartsWith("git:", StringComparison.CurrentCultureIgnoreCase)
-                 || path.StartsWith("ssh:", StringComparison.CurrentCultureIgnoreCase)
-                 || path.StartsWith("file:", StringComparison.CurrentCultureIgnoreCase));
-        }
-
         public static bool CanBeGitURL(string url)
         {
             if (string.IsNullOrWhiteSpace(url))
@@ -95,7 +78,7 @@ namespace GitCommands
                 return false;
             }
 
-            return IsUrl(url)
+            return Uri.IsWellFormedUriString(url, UriKind.Absolute)
                    || url.EndsWith(".git", StringComparison.CurrentCultureIgnoreCase)
                    || GitModule.IsValidGitWorkingDir(url);
         }

--- a/GitCommands/UserRepositoryHistory/LocalRepositoryManager.cs
+++ b/GitCommands/UserRepositoryHistory/LocalRepositoryManager.cs
@@ -85,7 +85,7 @@ namespace GitCommands.UserRepositoryHistory
                 throw new ArgumentException(nameof(repositoryPath));
             }
 
-            if (PathUtil.IsUrl(repositoryPath))
+            if (Uri.IsWellFormedUriString(repositoryPath, UriKind.Absolute))
             {
                 // TODO: throw a specific exception
                 throw new NotSupportedException();

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -111,9 +111,9 @@ namespace GitUI.CommandsDialogs
                         string text = Clipboard.GetText(TextDataFormat.Text) ?? string.Empty;
 
                         // See if it's a valid URL.
-                        if (PathUtil.CanBeGitURL(text))
+                        if (TryExtractUrl(text, out var possibleURL))
                         {
-                            _NO_TRANSLATE_From.Text = text;
+                            _NO_TRANSLATE_From.Text = possibleURL;
                         }
                     }
                 }
@@ -466,6 +466,56 @@ namespace GitUI.CommandsDialogs
             }
 
             base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Check whether the given string contains one or more valid URLs and extracts
+        /// the first URL that exists, if any.
+        /// </summary>
+        /// <remarks>
+        /// Uri.IsWellFormedUriString is used instead of Uri.TryCreate as file URIs
+        /// of the form X:\\directory\\filename should not be treated as URLs.
+        /// The first URL extracted from <paramref name="contents"/> is assigned to
+        /// <paramref name="url"/>. If <paramref name="contents"/> contains more than one URL,
+        /// subsequent URLs are not extracted.
+        /// </remarks>
+        /// <param name="contents">A string to attempt to extract URLs from.</param>
+        /// <param name="url">A <see cref="string"/> that contains the URL, if any, extracted from <paramref name="contents"/>.</param>
+        /// <returns><see langword="true"/> if a URL was extracted; otherwise <see langword="false"/>.</returns>
+        private bool TryExtractUrl(string contents, out string url)
+        {
+            url = "";
+
+            if (string.IsNullOrEmpty(contents))
+            {
+                return false;
+            }
+
+            var parts = contents.Split(' ');
+            foreach (string s in parts)
+            {
+                if (Uri.IsWellFormedUriString(s, UriKind.Absolute))
+                {
+                    url = s;
+                    break;
+                }
+            }
+
+            return !string.IsNullOrEmpty(url);
+        }
+
+        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+
+        internal readonly struct TestAccessor
+        {
+            private readonly FormClone _form;
+
+            public TestAccessor(FormClone form)
+            {
+                _form = form;
+            }
+
+            public bool TryExtractUrl(string text, out string url) => _form.TryExtractUrl(text, out url);
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -283,7 +283,7 @@ namespace GitUI.CommandsDialogs
         private bool PushChanges(IWin32Window owner)
         {
             ErrorOccurred = false;
-            if (PushToUrl.Checked && !PathUtil.IsUrl(PushDestination.Text))
+            if (PushToUrl.Checked && !Uri.IsWellFormedUriString(PushDestination.Text, UriKind.Absolute))
             {
                 MessageBox.Show(owner, _selectDestinationDirectory.Text, Strings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCloneTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCloneTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CommonTestUtils;
+using FluentAssertions;
+using GitCommands.Git;
+using GitUI;
+using GitUI.CommandsDialogs;
+using NUnit.Framework;
+
+namespace GitExtensions.UITests.CommandsDialogs
+{
+    [Apartment(ApartmentState.STA)]
+    public class FormCloneTests
+    {
+        // Created once for the fixture
+        private ReferenceRepository _referenceRepository;
+
+        // Created once for each test
+        private GitUICommands _commands;
+
+        [SetUp]
+        public void SetUp()
+        {
+            if (_referenceRepository is null)
+            {
+                _referenceRepository = new ReferenceRepository();
+            }
+            else
+            {
+                _referenceRepository.Reset();
+            }
+
+            _commands = new GitUICommands(_referenceRepository.Module);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _referenceRepository.Dispose();
+        }
+
+        [TestCase(null, false, "")]
+        [TestCase("", false, "")]
+        [TestCase(" ", false, "")]
+        [TestCase("blah", false, "")]
+        [TestCase("git clone https://github.com/gitextensions/gitextensions && cd gitextensions", true, "https://github.com/gitextensions/gitextensions")]
+        [TestCase("git clone ssh://username@gerrit-server:/PROJECT", true, "ssh://username@gerrit-server:/PROJECT")]
+        [TestCase("git clone https://github.com/gitextensions/gitextensions && git clone https://github.com/gitextensions/git.hub", true, "https://github.com/gitextensions/gitextensions")]
+        public void Test_Url_extract_from_string(
+            string text, bool expected, string expectedUrl)
+        {
+            RunFormTest(
+                form =>
+                {
+                    var accessor = form.GetTestAccessor();
+
+                    accessor.TryExtractUrl(text, out var url).Should().Equals(expected);
+
+                    // No need to compare URL if the result was expected to be false
+                    if (expected)
+                    {
+                        url.Should().Equals(expectedUrl);
+                    }
+                });
+        }
+
+        private void RunFormTest(Action<FormClone> testDriver)
+        {
+            RunFormTest(
+                form =>
+                {
+                    testDriver(form);
+                    return Task.CompletedTask;
+                });
+        }
+
+        private void RunFormTest(Func<FormClone, Task> testDriverAsync)
+        {
+            UITest.RunForm(
+                () =>
+                {
+                    _commands.StartCloneDialog(owner: null, url: null);
+                },
+                testDriverAsync);
+        }
+    }
+}

--- a/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
@@ -101,20 +101,6 @@ namespace GitCommandsTests.Helpers
             Assert.AreEqual(PathUtil.IsLocalFile("ssh://domain\\user@serverip/cache/git/something/something.git"), false);
         }
 
-        [TestCase(null, false)]
-        [TestCase("", false)]
-        [TestCase("    ", false)]
-        [TestCase("http://", true)]
-        [TestCase("HTTPS://www", true)]
-        [TestCase("git://", true)]
-        [TestCase("file:", true)]
-        [TestCase("SSH:", true)]
-        [TestCase("SSH", false)]
-        public void IsUrl(string path, bool expected)
-        {
-            PathUtil.IsUrl(path).Should().Be(expected);
-        }
-
         [Test]
         public void GetFileNameTest()
         {
@@ -347,6 +333,17 @@ namespace GitCommandsTests.Helpers
         [TestCase("https://github.com/gitextensions/gitextensions", true)]
         [TestCase("https://github.com/gitextensions/gitextensions.git", true)]
         [TestCase("github.com/gitextensions/gitextensions.git", true)]
+        [TestCase("HTTPS://MYPRIVATEGITHUB.COM:8080/LOUDREPO.GIT", true)]
+        [TestCase("git://myurl/myrepo.git", true)]
+        [TestCase("github.com/gitextensions", false)]
+        [TestCase("github.com/gitextensions/gitextensions/pull/9018", false)]
+        [TestCase("http://", false)]
+        [TestCase("HTTPS://www", true)]
+        [TestCase("git://", true)]
+        [TestCase("file:", false)]
+        [TestCase("SSH:", true)]
+        [TestCase("SSH", false)]
+        [TestCase("https://myhost:12368/", true)]
         public void CanBeGitURL(string url, bool expected)
         {
             Assert.AreEqual(expected, PathUtil.CanBeGitURL(url));

--- a/contributors.txt
+++ b/contributors.txt
@@ -152,3 +152,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/01/24, bcolaco, Bruno Colaço, bcolaco[@)gmail.com
 2021/01/25, guybark, Guy Barker, guybark(at)microsoft.com
 2021/02/10, mabako, Marcus Bauer, mabako(at)gmail.com
+2021/03/20, nyankoframe, Damit Senanayake, damit(at)outlook.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6260 


## Proposed changes

- Adds a new method in FormClone to extract a URL from a text string.
- Updates Clone form to use new method

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Added new integration test in FormCloneTests.cs

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.31.0.windows.1
- Windows 10.0.19042.868

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
