### PR TITLE
View changed submodule could hang GE

### DIFF
--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -115,9 +115,7 @@ namespace GitUI
 
                 if (file.IsSubmodule)
                 {
-                    // Patch already evaluated
-                    var status = ThreadHelper.JoinableTaskFactory.Run(
-                        () => file.GetSubmoduleStatusAsync() ?? Task.FromResult<GitSubmoduleStatus?>(null));
+                    var status = ThreadHelper.JoinableTaskFactory.Run(file.GetSubmoduleStatusAsync!);
                     return status is not null
                         ? LocalizationHelpers.ProcessSubmoduleStatus(fileViewer.Module, status)
                         : $"Failed to get status for submodule \"{file.Name}\"";

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -113,11 +113,11 @@ namespace GitUI
                         : diffOfConflict;
                 }
 
-                if (file.IsSubmodule
-                    && file.GetSubmoduleStatusAsync() is Task<GitSubmoduleStatus> task)
+                if (file.IsSubmodule)
                 {
                     // Patch already evaluated
-                    var status = ThreadHelper.JoinableTaskFactory.Run(() => task);
+                    var status = ThreadHelper.JoinableTaskFactory.Run(
+                        () => file.GetSubmoduleStatusAsync() ?? Task.FromResult<GitSubmoduleStatus?>(null));
                     return status is not null
                         ? LocalizationHelpers.ProcessSubmoduleStatus(fileViewer.Module, status)
                         : $"Failed to get status for submodule \"{file.Name}\"";


### PR DESCRIPTION
Temporary fix for #8914 (not closing #8914)

The proper fix is in #8923, but that PR introduces some test instabilities so the app code is patched instead.


## Proposed changes

Do not hang the application when submodule status is not evaluated when viewing.

## Test methodology <!-- How did you ensure quality? -->

Manual.
You may have to insert the error by installing Symantec or adding a delay to submodule status calculation.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
