### PR TITLE
Workaround for splitter persistence in `FormBrowse`

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2497,6 +2497,13 @@ namespace GitUI.CommandsDialogs
 
             _splitterManager.RestoreSplitters();
             RefreshLayoutToggleButtonStates();
+
+            // Since #8849 and #8557 we have a geometry bug, which pushes the splitter up by 4px.
+            // Account for this shift. This is a workaround at best in the same way as for FormCommit.
+            if (!RevisionsSplitContainer.Panel2Collapsed)
+            {
+                RevisionsSplitContainer.SplitterDistance -= 4;
+            }
         }
 
         private void CommandsToolStripMenuItem_DropDownOpening(object sender, EventArgs e)

--- a/GitUI/SplitterManager.cs
+++ b/GitUI/SplitterManager.cs
@@ -29,7 +29,6 @@ namespace GitUI
 
         public void RestoreSplitters()
         {
-            // TODO: Disabled as splitters have become unstable. Refer to #8745 for more details.
             foreach (var splitter in _splitters)
             {
                 splitter.RestoreFromSettings(_settings);
@@ -38,7 +37,6 @@ namespace GitUI
 
         public void SaveSplitters()
         {
-            // TODO: Disabled as splitters have become unstable. Refer to #8745 for more details.
             foreach (var splitter in _splitters)
             {
                 splitter.SaveToSettings(_settings);


### PR DESCRIPTION
Workaround for #8745 for 3.5.1
addendum #9102

## Proposed changes

- add similar workaround for `FormBrowse`, too

## Screenshots <!-- Remove this section if PR does not change UI -->

affected layout:

![image](https://user-images.githubusercontent.com/36601201/116148371-1ed41500-a6e1-11eb-9350-9ac53e7d9bb1.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 6d07a7312a5b84b81f7ae1ff25e505c2fdd7b31c
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
