### PR TITLE
Quote path for opening with `Explorer.exe`

### DIFF
--- a/GitUI/OsShellUtil.cs
+++ b/GitUI/OsShellUtil.cs
@@ -29,17 +29,18 @@ namespace GitUI
         /// <param name="filePath">Pathname of the file to open.</param>
         public static void OpenAs(string filePath)
         {
+            // filePath must not be quoted
             new Executable("rundll32.exe").Start("shell32.dll,OpenAs_RunDLL " + filePath, redirectOutput: true, outputEncoding: System.Text.Encoding.UTF8);
         }
 
         public static void SelectPathInFileExplorer(string filePath)
         {
-            OpenWithFileExplorer("/select, " + filePath);
+            OpenWithFileExplorer($"/select, {filePath.Quote()}", quote: false);
         }
 
-        public static void OpenWithFileExplorer(string arguments)
+        public static void OpenWithFileExplorer(string arguments, bool quote = true)
         {
-            new Executable("explorer.exe").Start(arguments);
+            new Executable("explorer.exe").Start(quote ? arguments.Quote() : arguments);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #8512
using @RussKie's variant plus adaptation of further function

## Proposed changes

Quote path given to `Explorer.exe` in
- `OsShellUtil.SelectPathInFileExplorer`
- `OsShellUtil.OpenWithFileExplorer`

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 69cdae72a1013b85f88f13c9fc617611547cc9d5
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).