### PR TITLE
Sanitize localized stack trace in exception tests

### DIFF
--- a/UnitTests/BugReporter.Tests/SerializableExceptionTests.cs
+++ b/UnitTests/BugReporter.Tests/SerializableExceptionTests.cs
@@ -12,6 +12,8 @@ using NUnit.Framework;
 namespace BugReporterTests
 {
     [TestFixture]
+    [SetCulture("en-US")]
+    [SetUICulture("en-US")]
     public sealed class SerializableExceptionTests
     {
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -72,15 +74,7 @@ namespace BugReporterTests
             StringBuilder m = new();
             foreach (string line in exceptionMessage.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
             {
-                Match match = Regex.Match(line, @".*(?<path>\sin\s.*)");
-                if (match.Success)
-                {
-                    m.AppendLine(line.Replace(match.Groups["path"].Value, string.Empty));
-                }
-                else
-                {
-                    m.AppendLine(line);
-                }
+                m.AppendLine(Regex.Replace(line, @"^(?<keep>.*)(?<codeLocationToBeRemoved>\sin\s.*)$", "${keep}"));
             }
 
             return m.ToString();


### PR DESCRIPTION
## Proposed changes

## Proposed changes

- Use fixed culture `en-US` in `SerializableExceptionTests`
- Simplify regex

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/36601201/116465868-15c47e80-a86e-11eb-9753-4d50eaf48bf5.png)

### After

![image](https://user-images.githubusercontent.com/36601201/116465970-3a205b00-a86e-11eb-81f0-674cb1ba3999.png)

## Test methodology <!-- How did you ensure quality? -->

- adapt NUnit test

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build a294965deda0a16bb72cf31556c9cbc1bad20362
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).