### PR TITLE
Send GitHub authentication when fetching diff data

### DIFF
--- a/Plugins/GitHub3/GitHubPullRequest.cs
+++ b/Plugins/GitHub3/GitHubPullRequest.cs
@@ -28,12 +28,7 @@ namespace GitExtensions.Plugins.GitHub3
         {
             if (_diffData is null)
             {
-#pragma warning disable SYSLIB0014 // 'WebRequest.Create(string)' is obsolete
-                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(_pullRequest.DiffUrl);
-#pragma warning restore SYSLIB0014 // 'WebRequest.Create(string)' is obsolete
-                using WebResponse response = await request.GetResponseAsync();
-                using StreamReader reader = new(response.GetResponseStream(), Encoding.UTF8);
-                _diffData = await reader.ReadToEndAsync();
+                _diffData = await _pullRequest.GetDiffData(_pullRequest.DiffUrl);
             }
 
             return _diffData;


### PR DESCRIPTION
Fixes #9117 

## Proposed changes

This PR updates the GitHub3 plugin to use the new GetDiffData method defined in https://github.com/gitextensions/Git.hub/pull/18.

## Test methodology <!-- How did you ensure quality? -->

- WIP (I don't have access to a repository that requires a PAT on this GitHub account)

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.31.0.windows.1
- Windows 10.0.19042.868

<!-- Mention language, UI scaling, or anything else that might be relevant -->