### PR TITLE
Replace deprecated SmtpClient with Mailkit

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="AppInsights.WindowsDesktop" />
     <PackageReference Include="EnvDTE" />
     <PackageReference Include="ExCSS" />
+    <PackageReference Include="MailKit" />
     <PackageReference Include="Microsoft-WindowsAPICodePack-Core" />
     <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" />
     <PackageReference Include="System.IO.Abstractions" />

--- a/Packages.props
+++ b/Packages.props
@@ -28,6 +28,7 @@
     <PackageReference Update="System.Reactive.Linq" Version="4.4.1" />
     <PackageReference Update="System.Reactive.Interfaces" Version="4.4.1" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" /> <!-- Required? -->
+    <PackageReference Update="MailKit" Version="2.12.0"/>
 
     <!-- Setup infra -->
     <PackageReference Update="WiX" Version="3.11.2" />


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3856


## Proposed changes

- Smtpclient was deprecated https://docs.microsoft.com/en-us/dotnet/api/system.net.mail.smtpclient?view=net-5.0
- Microsoft suggests use Mailkit instead

## Test methodology <!-- How did you ensure quality? -->

- Use the format patch dialog and successfully send the patch to my email
- Test using non-English chars in Subject, Body and Patch.


## Test environment(s) <!-- Remove any that don't apply -->

- GIT: git version 2.29.1.windows.1
- Windows 10

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
