### PR TITLE
feat: add dot command to GitUICommands

### DIFF
--- a/GitUI/CommandsDialogs/FormCommandlineHelp.resx
+++ b/GitUI/CommandsDialogs/FormCommandlineHelp.resx
@@ -118,7 +118,8 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="_NO_TRANSLATE_commands.Text" xml:space="preserve">
-    <value>browse [path] [-filter=] [-commit=&lt;selectedSha&gt;[,&lt;firstSha&gt;]]
+    <value>[path]
+browse [path] [-filter=] [-commit=&lt;selectedSha&gt;[,&lt;firstSha&gt;]]
 about
 add [filename]
 addfiles [filename]

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1499,6 +1499,14 @@ namespace GitUI
                         return StartCloneDialog(null, args[1].Replace("github-mac://openRepo/", ""), true);
                     }
 
+                    // User supplied a path. Open the repository if its a valid path
+                    string dir = !string.IsNullOrWhiteSpace(command) && File.Exists(command) ? Path.GetDirectoryName(command) : command;
+                    if (args.Count == 2 && Directory.Exists(dir))
+                    {
+                        LaunchBrowse(dir);
+                        return true;
+                    }
+
                     break;
             }
 #pragma warning restore SA1025 // Code should not contain multiple whitespace in a row


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #


## Proposed changes

- dot command is widespread in most applications to open the current working directory. I have added a `private` function to handle the `.` command in this pull request. For Eg: If a user wants to open their current repository in GitExtensions, he should trigger the command `GitExtensions .`



## Screenshots <!-- Remove this section if PR does not change UI -->
![DotCommand](https://user-images.githubusercontent.com/26359740/116824274-f3e93580-aba6-11eb-8388-94f7d70bc90b.gif)

### Before
A user needs to enter different commands to open his current repository.
`GitExtensions browse .` is an example.
<!-- TODO -->

### After
By these changes, a user can open the repository in GitExtensions by just triggering the command `GitExtensions .`

### TODO
Need documentation for this command once this PR got sufficient approvals. 

## Test methodology <!-- How did you ensure quality? -->

- I have tested the changes by modifying the project launch setting property.
- Also, to ensure functionality, I have run the executables from a different git repository.
- Both negative and positive cases were tested.
- Since the added function is a private one, we don't need any unit tests.
- I captured the evidence from my local machine in this pull request.


## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
