### PR TITLE
`FileViewer`: Remove decoration of default encoding

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -709,26 +709,9 @@ namespace GitUI.Editor
             ReloadHotkeys();
             Font = AppSettings.FixedWidthFont;
 
-            DetectDefaultEncoding();
-            return;
-
-            void DetectDefaultEncoding()
-            {
-                var encodings = AppSettings.AvailableEncodings.Values.Select(e => e.EncodingName).ToArray();
-                encodingToolStripComboBox.Items.AddRange(encodings);
-                encodingToolStripComboBox.ResizeDropDownWidth(50, 250);
-
-                var defaultEncodingName = Encoding.Default.EncodingName;
-
-                for (int i = 0; i < encodings.Length; i++)
-                {
-                    if (string.Equals(encodings[i], defaultEncodingName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        encodingToolStripComboBox.Items[i] = "Default (" + Encoding.Default.HeaderName + ")";
-                        break;
-                    }
-                }
-            }
+            var encodings = AppSettings.AvailableEncodings.Values.Select(e => e.EncodingName).ToArray();
+            encodingToolStripComboBox.Items.AddRange(encodings);
+            encodingToolStripComboBox.ResizeDropDownWidth(50, 250);
         }
 
         // Private methods
@@ -1824,10 +1807,6 @@ namespace GitUI.Editor
             if (string.IsNullOrEmpty(encodingToolStripComboBox.Text))
             {
                 encod = Module.FilesEncoding;
-            }
-            else if (encodingToolStripComboBox.Text.StartsWith("Default", StringComparison.CurrentCultureIgnoreCase))
-            {
-                encod = Encoding.Default;
             }
             else
             {


### PR DESCRIPTION
Fixes 1. of https://github.com/gitextensions/gitextensions/pull/8522#issuecomment-829594076 - unrelated to .NET 5.0

## Proposed changes

`FileViewer` toolbar: Remove the decoration of default `Encoding`
because of
- incomplete implementation: ComboBox empty due to not matching name
- inconsistent `Encoding` naming: `EncodingName` vs. `HeaderName`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/36601201/116829815-5db50f80-aba6-11eb-8eb5-7cc765daef3d.png)

### After

![image](https://user-images.githubusercontent.com/36601201/116829849-99e87000-aba6-11eb-861f-067fc8cece20.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 7213de011d4ae508fc819473c68f27a6c1f702e8
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).