### PR TITLE
fix: position setting window always in the window center screen

### DIFF
--- a/GitUI/CommandsDialogs/FormSettings.Designer.cs
+++ b/GitUI/CommandsDialogs/FormSettings.Designer.cs
@@ -219,7 +219,7 @@ namespace GitUI.CommandsDialogs
             this.MinimumSize = new System.Drawing.Size(966, 785);
             this.Name = "FormSettings";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Settings";
             this.Shown += new System.EventHandler(this.FormSettings_Shown);
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormSettings_FormClosing);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #
Settings window popup is not positioned correctly while GitExtension not in the center of the window or in maximized state. 
This issue is stated in issue: #9126 
## Proposed changes

- Always start the settings window pop-up from the center of the screen. 

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The settings window will start from the center of the GitExtension. So, if the GitExtension is in a corner ( especially on the left side of the window) a partial view of the settings pop-up will appear. The example could be found below: 
![GitExtSettingsWindowsPosIssue](https://user-images.githubusercontent.com/26359740/116923240-0d0be800-ac74-11eb-9f47-638328c3c2f9.gif)


### After
The settings window will start from the center of the window. It will ensure, the settings pop-up will be displayed correctly to the user regardless of the GitExtension position.

Evidence:


![GitExtSettingsWindowsPosIssueFixed](https://user-images.githubusercontent.com/26359740/116924657-cdde9680-ac75-11eb-9de8-b62c32c9e64a.gif)


## Test methodology <!-- How did you ensure quality? -->

- Positioned the GitExtension in different parts of the window and opened the settings dialogue. Verified the settings pop-up is correctly displayed.


## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
