### PR TITLE
Stash pop/apply: Refresh grid if command was successful

### DIFF
--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -191,7 +191,10 @@ namespace GitUI
             bool Action()
             {
                 var arguments = GitCommandHelpers.StashSaveCmd(includeUntrackedFiles, keepIndex, message, selectedFiles);
-                return FormProcess.ShowDialog(owner, process: null, arguments, Module.WorkingDir, input: null, useDialogSettings: true);
+                FormProcess.ShowDialog(owner, process: null, arguments, Module.WorkingDir, input: null, useDialogSettings: true);
+
+                // git-stash may have changed commits also if aborted, the grid must be refreshed
+                return true;
             }
 
             return DoActionOnRepo(owner, Action);
@@ -201,8 +204,11 @@ namespace GitUI
         {
             bool Action()
             {
-                bool success = FormProcess.ShowDialog(owner, process: null, arguments: "stash pop", Module.WorkingDir, input: null, useDialogSettings: true);
-                return success && MergeConflictHandler.HandleMergeConflicts(this, owner, false, false);
+                FormProcess.ShowDialog(owner, process: null, arguments: "stash pop", Module.WorkingDir, input: null, useDialogSettings: true);
+                MergeConflictHandler.HandleMergeConflicts(this, owner, false, false);
+
+                // git-stash may have changed commits also if aborted, the grid must be refreshed
+                return true;
             }
 
             return DoActionOnRepo(owner, Action);
@@ -212,7 +218,10 @@ namespace GitUI
         {
             bool Action()
             {
-                return FormProcess.ShowDialog(owner, process: null, arguments: $"stash drop {stashName.Quote()}", Module.WorkingDir, input: null, useDialogSettings: true);
+                FormProcess.ShowDialog(owner, process: null, arguments: $"stash drop {stashName.Quote()}", Module.WorkingDir, input: null, useDialogSettings: true);
+
+                // git-stash may have changed commits also if aborted, the grid must be refreshed
+                return true;
             }
 
             return DoActionOnRepo(owner, Action);
@@ -222,8 +231,11 @@ namespace GitUI
         {
             bool Action()
             {
-                bool success = FormProcess.ShowDialog(owner, process: null, arguments: $"stash apply {stashName.Quote()}", Module.WorkingDir, input: null, useDialogSettings: true);
-                return success && MergeConflictHandler.HandleMergeConflicts(this, owner, false, false);
+                FormProcess.ShowDialog(owner, process: null, arguments: $"stash apply {stashName.Quote()}", Module.WorkingDir, input: null, useDialogSettings: true);
+                MergeConflictHandler.HandleMergeConflicts(this, owner, false, false);
+
+                // git-stash may have changed commits also if aborted, the grid must be refreshed
+                return true;
             }
 
             return DoActionOnRepo(owner, Action);


### PR DESCRIPTION
Fixes #9121


## Proposed changes

Refresh revision grid after Stash pop.
Also changed after stash-apply, but that makes no practical difference as the command is only invoked from FormStash (and not update the grid...)

Regression, to be cherry-picked for 3.5

## Test methodology <!-- How did you ensure quality? -->

See the issue. Stash, stash-pop and see that the grid refreshes.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
