### PR TITLE
OpenSSH presented as OtherSSH in settings

### DIFF
--- a/GitCommands/Git/GitSshHelpers.cs
+++ b/GitCommands/Git/GitSshHelpers.cs
@@ -25,19 +25,11 @@ namespace GitCommands
             }
         }
 
-        /// <summary>Un-sets the git SSH command path.</summary>
-        public static void UnsetSsh()
-        {
-            Environment.SetEnvironmentVariable("GIT_SSH", "", EnvironmentVariableTarget.Process);
-        }
-
         /// <summary>Sets the git SSH command path.</summary>
         public static void SetSsh(string? path)
         {
-            if (!string.IsNullOrEmpty(path))
-            {
-                Environment.SetEnvironmentVariable("GIT_SSH", path, EnvironmentVariableTarget.Process);
-            }
+            // Git will use the embedded OpenSSH ssh.exe if empty/unset
+            Environment.SetEnvironmentVariable("GIT_SSH", path ?? "", EnvironmentVariableTarget.Process);
         }
 
         public static bool Plink()

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
@@ -61,7 +61,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             if (OpenSSH.Checked)
             {
-                GitSshHelpers.UnsetSsh();
+                GitSshHelpers.SetSsh("");
             }
 
             if (Putty.Checked)

--- a/UnitTests/GitCommands.Tests/SshPathLocatorTest.cs
+++ b/UnitTests/GitCommands.Tests/SshPathLocatorTest.cs
@@ -72,11 +72,11 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public void Find_on_gitBinDir_having_ssh_exe_in_parent_directory_children_should_return_first_ssh_exe_found()
+        public void Find_on_gitBinDir_having_ssh_exe_in_parent_directory_children_should_return_empty()
         {
             var path = SetUpFileSystemWithSshExePathsAs("first", "second");
             var sshPathLocator = new SshPathLocator(_fileSystem, _environment);
-            sshPathLocator.Find(path).Should().Be("first");
+            sshPathLocator.Find(path).Should().Be("");
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace GitCommandsTests
             const string sshExe = @"C:\someotherdir\ssh.exe";
             var path = SetUpFileSystemWithSshExePathsAs(sshExe);
             var sshPathLocator = new SshPathLocator(_fileSystem, _environment);
-            sshPathLocator.Find(path + (withTrailingSeparator ? @"\" : "")).Should().Be(sshExe);
+            sshPathLocator.Find(path + (withTrailingSeparator ? @"\" : "")).Should().Be("");
         }
 
         private string SetUpFileSystemWithSshExePathsAs(params string[] sshExePaths)


### PR DESCRIPTION
Part of #9112

## Proposed changes

Some SSH refactoring has changed the SSH setting to not always be stored as "" (stored in registry).
The OpenSSH setting is therefore always presented as other.

This is part of what described in #9112, but not the core problem.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

OpenSSH is not set, but the path is correct

![image](https://user-images.githubusercontent.com/6248932/117075300-dfd33e80-ad34-11eb-9b95-db6b995a94e6.png)

### After

![image](https://user-images.githubusercontent.com/6248932/117075584-5e2fe080-ad35-11eb-9a83-1585a9d07bf1.png)

## Test methodology <!-- How did you ensure quality? -->

manual

---

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
