### PR TITLE
Add `BugReporter.exe` to installer

### DIFF
--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -125,6 +125,9 @@
       <Component Id="GitExtensions.exe.config" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\GitExtensions.exe.config" />
       </Component>
+      <Component Id="BugReporter.exe" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\BugReporter.exe" />
+      </Component>
       <Component Id="System.IO.Abstractions.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\System.IO.Abstractions.dll" />
       </Component>
@@ -1489,6 +1492,7 @@
       <ComponentRef Id="gitextensions.ico" />
       <ComponentRef Id="gitex.cmd" />
       <ComponentRef Id="set_telemetry" />
+      <ComponentRef Id="BugReporter.exe" />
       <ComponentRef Id="GitExtensions.exe" />
       <ComponentRef Id="GitExtensions.exe.config" />
       <ComponentRef Id="GitCommands.dll" />


### PR DESCRIPTION
Related to #9166

## Proposed changes

- Add `BugReporter.exe` to installer

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build fec693532c9cc0e23e0e91c841b9a343c64f86c2
- Git 2.31.1.windows.1
- Microsoft Windows NT 6.2.9200.0
- .NET Framework 4.7.2633.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
