### PR TITLE
Do not attempt to switch to a not created worktree

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3217,17 +3217,22 @@ namespace GitUI.CommandsDialogs
 
         private void manageWorktreeToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var formManageWorktree = new FormManageWorktree(UICommands);
+            using FormManageWorktree formManageWorktree = new(UICommands);
             formManageWorktree.ShowDialog(this);
         }
 
         private void createWorktreeToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var formCreateWorktree = new FormCreateWorktree(UICommands);
-            var dialogResult = formCreateWorktree.ShowDialog(this);
-            if (dialogResult == DialogResult.OK && formCreateWorktree.OpenWorktree)
+            using FormCreateWorktree formCreateWorktree = new(UICommands);
+            DialogResult dialogResult = formCreateWorktree.ShowDialog(this);
+            if (dialogResult != DialogResult.OK || !formCreateWorktree.OpenWorktree)
             {
-                var newModule = new GitModule(formCreateWorktree.WorktreeDirectory);
+                return;
+            }
+
+            GitModule newModule = new(formCreateWorktree.WorktreeDirectory);
+            if (newModule.IsValidGitWorkingDir())
+            {
                 SetGitModule(this, new GitModuleEventArgs(newModule));
             }
         }


### PR DESCRIPTION
Fixes the main part of #9165 2.

## Proposed changes

- Do not attempt to switch to a not created worktree
- Dispose worktree forms after usage

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual 

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build aed5edbf418d93b9e5f0497b62f226b0f5ae1b15
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).