### PR TITLE
Ignore failure getting `Process.Id` when opening URL

### DIFF
--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -111,7 +111,15 @@ namespace GitCommands
                 try
                 {
                     _process.Start();
-                    _logOperation.SetProcessId(_process.Id);
+                    try
+                    {
+                        _logOperation.SetProcessId(_process.Id);
+                    }
+                    catch (InvalidOperationException ex) when (useShellExecute)
+                    {
+                        // _process.Start() has succeeded, ignore the failure getting the _process.Id
+                        _logOperation.LogProcessEnd(ex);
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Fixes #9169

## Proposed changes

- Ignore failure getting `Process.Id` after successful `Process.Start` if `useShellExecute: true`

## Screenshots

### After

CommandLog:

![CommandLog](https://user-images.githubusercontent.com/36601201/117508588-23be8180-af89-11eb-93c5-006141c707e3.png)

## Test methodology <!-- How did you ensure quality? -->

- manual (see #9169)

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 8fbc9d3405af49bf27f1421b41874a1468018e69
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4341.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).