### PR TITLE
Set GIT_SSH only if path exists

### DIFF
--- a/GitCommands/Git/GitSshHelpers.cs
+++ b/GitCommands/Git/GitSshHelpers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 
 namespace GitCommands
 {
@@ -26,10 +27,15 @@ namespace GitCommands
         }
 
         /// <summary>Sets the git SSH command path.</summary>
-        public static void SetSsh(string? path)
+        public static void SetSsh(string path)
         {
             // Git will use the embedded OpenSSH ssh.exe if empty/unset
-            Environment.SetEnvironmentVariable("GIT_SSH", path ?? "", EnvironmentVariableTarget.Process);
+            if (!string.IsNullOrEmpty(path) && !File.Exists(path))
+            {
+                path = "";
+            }
+
+            Environment.SetEnvironmentVariable("GIT_SSH", path, EnvironmentVariableTarget.Process);
         }
 
         public static bool Plink()

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1546,6 +1546,7 @@ namespace GitCommands
 
             try
             {
+                // Set environment variable
                 GitSshHelpers.SetSsh(SshPath);
             }
             catch

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -27,8 +27,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private readonly TranslationString _gitVersionFound =
             new TranslationString("Git {0} is found on your computer.");
 
-        private readonly TranslationString _unknownSshClient =
-            new TranslationString("Unknown SSH client configured: {0}.");
+        private readonly TranslationString _sshClientNotFound = new("SSH client not found: {0}.");
+
+        private readonly TranslationString _otherSshClient = new("Other SSH client configured: {0}.");
 
         private readonly TranslationString _linuxToolsSshNotFound =
             new TranslationString("Linux tools (sh) not found. To solve this problem you can set the correct path in settings.");
@@ -196,6 +197,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 {
                     PageHost.GotoPage(SshSettingsPage.GetPageReference());
                 }
+            }
+            else
+            {
+                PageHost.GotoPage(SshSettingsPage.GetPageReference());
             }
         }
 
@@ -445,8 +450,14 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                                         _puttyConfigured.Text);
             }
 
-            var ssh = _sshPathLocator.Find(AppSettings.GitBinDir);
-            RenderSettingSet(SshConfig, SshConfig_Fix, string.IsNullOrEmpty(ssh) ? _opensshUsed.Text : string.Format(_unknownSshClient.Text, ssh));
+            string ssh = _sshPathLocator.Find(AppSettings.GitBinDir);
+            if (!string.IsNullOrEmpty(ssh) && !File.Exists(ssh))
+            {
+                RenderSettingUnset(SshConfig, SshConfig_Fix, string.Format(_sshClientNotFound.Text, ssh));
+                return false;
+            }
+
+            RenderSettingSet(SshConfig, SshConfig_Fix, string.IsNullOrEmpty(ssh) ? _opensshUsed.Text : string.Format(_otherSshClient.Text, ssh));
             return true;
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
@@ -59,20 +59,22 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.Pageant = PageantPath.Text;
             AppSettings.AutoStartPageant = AutostartPageant.Checked;
 
+            string path;
             if (OpenSSH.Checked)
             {
-                GitSshHelpers.SetSsh("");
+                path = "";
+            }
+            else if (Putty.Checked)
+            {
+                path = PlinkPath.Text;
+            }
+            else
+            {
+                // Other.Checked
+                path = OtherSsh.Text;
             }
 
-            if (Putty.Checked)
-            {
-                GitSshHelpers.SetSsh(PlinkPath.Text);
-            }
-
-            if (Other.Checked)
-            {
-                GitSshHelpers.SetSsh(OtherSsh.Text);
-            }
+            GitSshHelpers.SetSsh(path);
         }
 
         private void OpenSSH_CheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #9112

Presentation handled in #9149
A second part separated to #9188 

Also for 3.5, but translation changes to be null

## Proposed changes

If the SSH path does not exist, do not set GIT_SSH env var. 
Git will then attempt to use OpenSSH included with Git.

In 3.4 or earlier, the OpenSSH path was set in the registry, even if it was supposed to be empty (handled in #9149).
If the OpenSSH path is corrupted (as reported and discussed in #9112 when upgrading GE) it will just be ignored.
This will also recover from issues if the Git installation is changed.

The settings will check and report an illegal path too.

Note that viewing the SSH setting will change the presented, then saved path if the path does not exist. A follow up PR will address this.

## Test methodology <!-- How did you ensure quality? -->

Modify the gitssh key in the registry and start GE and make sure that OpenSSH can still be used.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
