### PR TITLE
Ignore failure getting Process.Id for ShellExecute

### DIFF
--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -105,7 +105,15 @@ namespace GitCommands
                 try
                 {
                     _process.Start();
-                    _logOperation.SetProcessId(_process.Id);
+                    try
+                    {
+                        _logOperation.SetProcessId(_process.Id);
+                    }
+                    catch (InvalidOperationException ex) when (useShellExecute)
+                    {
+                        // _process.Start() has succeeded, ignore the failure getting the _process.Id
+                        _logOperation.LogProcessEnd(ex);
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Fixes #9169
(#9173 for main)

## Proposed changes

- Ignore failure getting `Process.Id` for `ShellExecute`

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 908f842356fd5d0323670f8ab95e179f0bf6eb77
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.5
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).