### PR TITLE
Keep persistent ssh settings in registry

### DIFF
--- a/GitCommands/Git/GitSshHelpers.cs
+++ b/GitCommands/Git/GitSshHelpers.cs
@@ -5,8 +5,6 @@ namespace GitCommands
 {
     public static class GitSshHelpers
     {
-        private static readonly ISshPathLocator _sshPathLocatorInstance = new SshPathLocator();
-
         public static bool UseSsh(string arguments)
         {
             var x = !Plink() && DoArgumentsRequireSsh();
@@ -39,10 +37,6 @@ namespace GitCommands
         }
 
         public static bool Plink()
-        {
-            var sshString = _sshPathLocatorInstance.Find(AppSettings.GitBinDir);
-
-            return sshString.EndsWith("plink.exe", StringComparison.CurrentCultureIgnoreCase);
-        }
+            => AppSettings.SshPath.EndsWith("plink.exe", StringComparison.CurrentCultureIgnoreCase);
     }
 }

--- a/GitCommands/SshPathLocator.cs
+++ b/GitCommands/SshPathLocator.cs
@@ -7,46 +7,21 @@ namespace GitCommands
 {
     public interface ISshPathLocator
     {
-        string Find(string gitBinDirectory);
         public string? GetSshFromGitDir(string gitBinDirectory);
     }
 
     public sealed class SshPathLocator : ISshPathLocator
     {
         private readonly IFileSystem _fileSystem;
-        private readonly IEnvironmentAbstraction _environment;
 
-        public SshPathLocator(IFileSystem fileSystem, IEnvironmentAbstraction environment)
+        public SshPathLocator(IFileSystem fileSystem)
         {
             _fileSystem = fileSystem;
-            _environment = environment;
         }
 
         public SshPathLocator()
-            : this(new FileSystem(), new EnvironmentAbstraction())
+            : this(new FileSystem())
         {
-        }
-
-        /// <summary>
-        /// Gets the git SSH command.
-        /// If the environment variable is not set, will try to find ssh.exe in git installation directory.
-        /// If not found, will return "".
-        /// </summary>
-        public string Find(string gitBinDirectory)
-        {
-            var ssh = _environment.GetEnvironmentVariable("GIT_SSH", EnvironmentVariableTarget.Process) ?? "";
-
-            if (!string.IsNullOrEmpty(ssh))
-            {
-                // OpenSSH uses empty path, compatibility with path set in 3.4
-                var path = GetSshFromGitDir(gitBinDirectory);
-                if (path == ssh)
-                {
-                    ssh = "";
-                }
-            }
-
-            return ssh;
         }
 
         /// <summary>
@@ -67,7 +42,7 @@ namespace GitCommands
                 // gitBinDirectory will normally end with a directory separator
                 // (at least this is what AppSettings.GitBinDir ensures),
                 // but then GetParent() returns the same directory, only without the trailing separator
-                var gitDirInfo = _fileSystem.Directory.GetParent(gitBinDirectory.RemoveTrailingPathSeparator());
+                IDirectoryInfo gitDirInfo = _fileSystem.Directory.GetParent(gitBinDirectory.RemoveTrailingPathSeparator());
                 if (gitDirInfo is null)
                 {
                     return null;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -136,7 +136,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         #endregion
 
         private const string _putty = "PuTTY";
-        private readonly ISshPathLocator _sshPathLocator = new SshPathLocator();
         private DiffMergeToolConfigurationManager? _diffMergeToolConfigurationManager;
 
         /// <summary>
@@ -450,7 +449,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                                         _puttyConfigured.Text);
             }
 
-            string ssh = _sshPathLocator.Find(AppSettings.GitBinDir);
+            string ssh = AppSettings.SshPath;
             if (!string.IsNullOrEmpty(ssh) && !File.Exists(ssh))
             {
                 RenderSettingUnset(SshConfig, SshConfig_Fix, string.Format(_sshClientNotFound.Text, ssh));

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
@@ -11,8 +11,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class SshSettingsPage : SettingsPageWithHeader
     {
-        private readonly ISshPathLocator _sshPathLocator = new SshPathLocator();
-
         public SshSettingsPage()
         {
             InitializeComponent();
@@ -34,7 +32,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             PageantPath.Text = AppSettings.Pageant;
             AutostartPageant.Checked = AppSettings.AutoStartPageant;
 
-            var sshPath = _sshPathLocator.Find(AppSettings.GitBinDir);
+            var sshPath = AppSettings.SshPath;
             if (string.IsNullOrEmpty(sshPath))
             {
                 OpenSSH.Checked = true;
@@ -74,7 +72,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 path = OtherSsh.Text;
             }
 
+            // Set persistent settings as well as the env var used by Git
             GitSshHelpers.SetSsh(path);
+            AppSettings.SshPath = path;
         }
 
         private void OpenSSH_CheckedChanged(object sender, EventArgs e)

--- a/GitUI/Infrastructure/Telemetry/AppEnvironmentTelemetryInitializer.cs
+++ b/GitUI/Infrastructure/Telemetry/AppEnvironmentTelemetryInitializer.cs
@@ -6,12 +6,10 @@ namespace GitUI.Infrastructure.Telemetry
 {
     internal class AppEnvironmentTelemetryInitializer : ITelemetryInitializer
     {
-        private readonly ISshPathLocator _sshPathLocator = new SshPathLocator();
-
         public void Initialize(ITelemetry telemetry)
         {
             string sshClient;
-            var sshPath = _sshPathLocator.Find(AppSettings.GitBinDir);
+            var sshPath = AppSettings.SshPath;
             if (string.IsNullOrEmpty(sshPath))
             {
                 sshClient = "OpenSSH";


### PR DESCRIPTION
Fixes #8162
Fixes #1663
Also see #7662 and a few others

See #9202 for a partial change for 3.5

## Proposed changes

Just read path from AppSettings.SshPath
Set GIT_SSH env var only set, not read.

Migrate explicit OpenSSH in settings to empty

Previously, the app first read registry for gitssh path and set environment variable GIT_SSH unless it was empty. This was maybe a feature for some, as you could share SSH settings.
However, when setting SSH in settings, GIT_SSH was always set which was inconsistent.
The behavior is changed to only set GIT_SSH, never set it.

## Test methodology <!-- How did you ensure quality? -->

Tests updated
As logic is simplified, tests are simplified too

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
