### PR TITLE
Do not try to show deleted images in diffviewer

### DIFF
--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -53,7 +53,7 @@ namespace GitUI
 
             openWithDiffTool ??= OpenWithDiffTool;
 
-            if (item.Item.IsNew || firstId is null || FileHelper.IsImage(item.Item.Name))
+            if (item.Item.IsNew || firstId is null || (!item.Item.IsDeleted && FileHelper.IsImage(item.Item.Name)))
             {
                 // View blob guid from revision, or file for worktree
                 return fileViewer.ViewGitItemRevisionAsync(item.Item, item.SecondRevision.ObjectId, openWithDiffTool);


### PR DESCRIPTION
Fixes #9195

## Proposed changes

Do not try to view deleted images.
This applies both to difftab and commit.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

3.5
Separate view in worktree and index/commit

![image](https://user-images.githubusercontent.com/6248932/117881426-883f5080-b2a9-11eb-812e-3730ee00e316.png)

![image](https://user-images.githubusercontent.com/6248932/117881508-98efc680-b2a9-11eb-84ed-7b107e0e471f.png)

master has the popup, not really required

### After

Same for worktree and index

![image](https://user-images.githubusercontent.com/6248932/117881662-cccaec00-b2a9-11eb-869d-b3baaee436e6.png)

## Test methodology <!-- How did you ensure quality? -->

manual
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
