### PR TITLE
Diff/Commit: Do not show Open for deleted items

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1620,6 +1620,7 @@ namespace GitUI.CommandsDialogs
             var isAssumeUnchangedExist = Unstaged.SelectedItems.Any(s => s.Item.IsAssumeUnchanged);
             var isAssumeUnchangedAll = Unstaged.SelectedItems.All(s => s.Item.IsAssumeUnchanged);
             var isSkipWorktreeAll = Unstaged.SelectedItems.All(s => s.Item.IsSkipWorktree);
+            bool isAnyDeleted = Unstaged.SelectedItems.Any(i => i.Item.IsDeleted);
 
             openWithDifftoolToolStripMenuItem.Enabled = isTrackedSelected;
             viewFileHistoryToolStripItem.Enabled = isTrackedSelected;
@@ -1632,6 +1633,11 @@ namespace GitUI.CommandsDialogs
             bool isExactlyOneItemSelected = Unstaged.SelectedItems.Count() == 1;
             bool singleFileExists = isExactlyOneItemSelected && File.Exists(_fullPathResolver.Resolve(Unstaged?.SelectedGitItem?.Name));
             editFileToolStripMenuItem.Visible = singleFileExists;
+
+            openToolStripMenuItem.Enabled = !isAnyDeleted;
+            openWithToolStripMenuItem.Enabled = !isAnyDeleted;
+            deleteFileToolStripMenuItem.Enabled = !isAnyDeleted;
+            openContainingFolderToolStripMenuItem.Enabled = !isAnyDeleted;
         }
 
         private void StagedFileContext_Opening(object sender, System.ComponentModel.CancelEventArgs e)
@@ -1647,6 +1653,10 @@ namespace GitUI.CommandsDialogs
             bool isExactlyOneItemSelected = Staged.SelectedItems.Count() == 1;
             bool singleFileExists = isExactlyOneItemSelected && File.Exists(_fullPathResolver.Resolve(Staged?.SelectedGitItem?.Name));
             stagedEditFileToolStripMenuItem11.Visible = singleFileExists;
+            bool isAnyDeleted = Staged.SelectedItems.Any(i => i.Item.IsDeleted);
+            stagedOpenToolStripMenuItem7.Enabled = !isAnyDeleted;
+            stagedOpenWithToolStripMenuItem8.Enabled = !isAnyDeleted;
+            stagedOpenFolderToolStripMenuItem10.Enabled = !isAnyDeleted;
         }
 
         private void UnstagedSubmoduleContext_Opening(object sender, System.ComponentModel.CancelEventArgs e)

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -530,8 +530,11 @@ namespace GitUI.CommandsDialogs
             openWithDifftoolToolStripMenuItem.Enabled = _revisionDiffController.ShouldShowDifftoolMenus(selectionInfo);
             diffOpenWorkingDirectoryFileWithToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuEditWorkingDirectoryFile(selectionInfo);
             diffOpenRevisionFileToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuOpenRevision(selectionInfo);
+            diffOpenRevisionFileToolStripMenuItem.Enabled = _revisionDiffController.ShouldShowMenuShowInFileTree(selectionInfo);
             diffOpenRevisionFileWithToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuOpenRevision(selectionInfo);
+            diffOpenRevisionFileWithToolStripMenuItem.Enabled = _revisionDiffController.ShouldShowMenuShowInFileTree(selectionInfo);
             saveAsToolStripMenuItem1.Visible = _revisionDiffController.ShouldShowMenuSaveAs(selectionInfo);
+            saveAsToolStripMenuItem1.Enabled = _revisionDiffController.ShouldShowMenuShowInFileTree(selectionInfo);
             openContainingFolderToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuShowInFolder(selectionInfo);
             diffEditWorkingDirectoryFileToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuEditWorkingDirectoryFile(selectionInfo);
             diffDeleteFileToolStripMenuItem.Text = ResourceManager.TranslatedStrings.GetDeleteFile(selectionInfo.SelectedGitItemCount);


### PR DESCRIPTION
Fixes #9070

## Proposed changes

Avoid showing Open... menu items for deleted items.
Similar for a few other menu items, maybe not causing exceptions but having no effect (or as for Save, saving an emty file).

Note 1: "Show in folder" could be relevant for an index item if it is created in worktree, but let us skip this use case..

Note that Open in folder also exists for FormDiff, just nothing happens. I suggest we leave it at that (that form could maybe be retired).

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/117889599-23d5be80-b2b4-11eb-932d-4ec263152469.png)

### After

![image](https://user-images.githubusercontent.com/6248932/117889355-b590fc00-b2b3-11eb-9ed4-cd2e8213de5f.png)

![image](https://user-images.githubusercontent.com/6248932/117889412-c93c6280-b2b3-11eb-8460-ffc6e378604b.png)

![image](https://user-images.githubusercontent.com/6248932/117889553-0bfe3a80-b2b4-11eb-8080-6178148a51f0.png)

![image](https://user-images.githubusercontent.com/6248932/117889305-985c2d80-b2b3-11eb-9621-28829bf83cf4.png)

![image](https://user-images.githubusercontent.com/6248932/117889261-87abb780-b2b3-11eb-8a84-04d98826fd1f.png)

## Test methodology <!-- How did you ensure quality? -->

manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
