### PR TITLE
FormCreateBranch: Fix branches list display on 2 lines

### DIFF
--- a/GitUI/UserControls/CommitSummaryUserControl.Designer.cs
+++ b/GitUI/UserControls/CommitSummaryUserControl.Designer.cs
@@ -161,7 +161,7 @@
             tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             tableLayoutPanel1.ColumnCount = 2;
             tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             tableLayoutPanel1.Controls.Add(this.labelDateCaption, 0, 3);
             tableLayoutPanel1.Controls.Add(this.labelAuthorCaption, 0, 2);
             tableLayoutPanel1.Controls.Add(this.labelAuthor, 1, 2);


### PR DESCRIPTION
when displaying the application with 150% scaling

Fixes #9115

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

WIth 150% scaling or by reducing the window form size to the minimum
![image](https://user-images.githubusercontent.com/460196/118042946-0288d700-b375-11eb-8125-373235846650.png)


### After

![image](https://user-images.githubusercontent.com/460196/118042870-ea18bc80-b374-11eb-8720-aae1fd56b30a.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual (set display scaling to 150%)


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 53b71f790833cff271aba3d0f4bd2cc91a2ff496 (Dirty)
- Git 2.28.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4341.0
- DPI 144dpi (150% scaling)

