### PR TITLE
Set GIT_SSH only if path exists 3.5

### DIFF
--- a/GitCommands/Git/GitSshHelpers.cs
+++ b/GitCommands/Git/GitSshHelpers.cs
@@ -1,5 +1,5 @@
 using System;
-using GitExtensions;
+using System.IO;
 
 namespace GitCommands
 {
@@ -30,14 +30,25 @@ namespace GitCommands
         public static void SetSsh(string? path)
         {
             // Git will use the embedded OpenSSH ssh.exe if empty/unset
-            Environment.SetEnvironmentVariable("GIT_SSH", path ?? "", EnvironmentVariableTarget.Process);
+            if (!string.IsNullOrEmpty(path) && !File.Exists(path))
+            {
+                path = "";
+            }
+
+            if (!string.IsNullOrEmpty(path))
+            {
+                // OpenSSH uses empty path, compatibility with path set in 3.4
+                var openSsh = _sshPathLocatorInstance.GetSshFromGitDir(AppSettings.GitBinDir);
+                if (path == openSsh)
+                {
+                    path = "";
+                }
+            }
+
+            Environment.SetEnvironmentVariable("GIT_SSH", path, EnvironmentVariableTarget.Process);
         }
 
         public static bool Plink()
-        {
-            var sshString = _sshPathLocatorInstance.Find(AppSettings.GitBinDir);
-
-            return sshString.EndsWith("plink.exe", StringComparison.CurrentCultureIgnoreCase);
-        }
+            => AppSettings.SshPath.EndsWith("plink.exe", StringComparison.CurrentCultureIgnoreCase);
     }
 }

--- a/GitCommands/Git/GitSshHelpers.cs
+++ b/GitCommands/Git/GitSshHelpers.cs
@@ -26,19 +26,11 @@ namespace GitCommands
             }
         }
 
-        /// <summary>Un-sets the git SSH command path.</summary>
-        public static void UnsetSsh()
-        {
-            Environment.SetEnvironmentVariable("GIT_SSH", "", EnvironmentVariableTarget.Process);
-        }
-
         /// <summary>Sets the git SSH command path.</summary>
         public static void SetSsh(string? path)
         {
-            if (!Strings.IsNullOrEmpty(path))
-            {
-                Environment.SetEnvironmentVariable("GIT_SSH", path, EnvironmentVariableTarget.Process);
-            }
+            // Git will use the embedded OpenSSH ssh.exe if empty/unset
+            Environment.SetEnvironmentVariable("GIT_SSH", path ?? "", EnvironmentVariableTarget.Process);
         }
 
         public static bool Plink()

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -62,7 +62,6 @@ namespace GitCommands
         public static readonly string SettingsFileName = ApplicationId + ".settings";
         public static readonly string UserPluginsDirectoryName = "UserPlugins";
         private static string _applicationExecutablePath = Application.ExecutablePath;
-        private static readonly ISshPathLocator SshPathLocatorInstance = new SshPathLocator();
         private static string? _documentationBaseUrl;
 
         public static Lazy<string?> ApplicationDataPath { get; private set; }
@@ -301,10 +300,9 @@ namespace GitCommands
             set => WriteStringRegValue("CascadeShellMenuItems", value);
         }
 
-        [MaybeNull]
         public static string SshPath
         {
-            get => ReadStringRegValue("gitssh", null);
+            get => ReadStringRegValue("gitssh", "");
             set => WriteStringRegValue("gitssh", value);
         }
 
@@ -1529,7 +1527,6 @@ namespace GitCommands
             {
                 SettingsContainer.LockedAction(() =>
                 {
-                    SshPath = SshPathLocatorInstance.Find(GitBinDir);
                     SettingsContainer.Save();
                 });
 
@@ -1546,6 +1543,7 @@ namespace GitCommands
 
             try
             {
+                // Set environment variable
                 GitSshHelpers.SetSsh(SshPath);
             }
             catch

--- a/GitCommands/SshPathLocator.cs
+++ b/GitCommands/SshPathLocator.cs
@@ -31,6 +31,7 @@ namespace GitCommands
         /// Gets the git SSH command.
         /// If the environment variable is not set, will try to find ssh.exe in git installation directory.
         /// If not found, will return "".
+        /// Note: This method is unused in GE and removed in master, kept for plugins.
         /// </summary>
         public string Find(string gitBinDirectory)
         {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -26,8 +26,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private readonly TranslationString _gitVersionFound =
             new TranslationString("Git {0} is found on your computer.");
 
-        private readonly TranslationString _unknownSshClient =
-            new TranslationString("Unknown SSH client configured: {0}.");
+        private readonly TranslationString _unknownSshClient = new("Unknown SSH client configured: {0}.");
 
         private readonly TranslationString _linuxToolsSshNotFound =
             new TranslationString("Linux tools (sh) not found. To solve this problem you can set the correct path in settings.");
@@ -134,7 +133,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         #endregion
 
         private const string _putty = "PuTTY";
-        private readonly ISshPathLocator _sshPathLocator = new SshPathLocator();
         private DiffMergeToolConfigurationManager _diffMergeToolConfigurationManager;
 
         /// <summary>
@@ -194,6 +192,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 {
                     PageHost.GotoPage(SshSettingsPage.GetPageReference());
                 }
+            }
+            else
+            {
+                PageHost.GotoPage(SshSettingsPage.GetPageReference());
             }
         }
 
@@ -441,7 +443,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                                         _puttyConfigured.Text);
             }
 
-            var ssh = _sshPathLocator.Find(AppSettings.GitBinDir);
+            string ssh = AppSettings.SshPath;
+            if (!string.IsNullOrEmpty(ssh) && !File.Exists(ssh))
+            {
+                RenderSettingUnset(SshConfig, SshConfig_Fix, string.Format(_unknownSshClient.Text, ssh));
+                return false;
+            }
+
             RenderSettingSet(SshConfig, SshConfig_Fix, string.IsNullOrEmpty(ssh) ? _opensshUsed.Text : string.Format(_unknownSshClient.Text, ssh));
             return true;
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
@@ -11,8 +11,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class SshSettingsPage : SettingsPageWithHeader
     {
-        private readonly ISshPathLocator _sshPathLocator = new SshPathLocator();
-
         public SshSettingsPage()
         {
             InitializeComponent();
@@ -34,7 +32,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             PageantPath.Text = AppSettings.Pageant;
             AutostartPageant.Checked = AppSettings.AutoStartPageant;
 
-            var sshPath = _sshPathLocator.Find(AppSettings.GitBinDir);
+            var sshPath = AppSettings.SshPath;
             if (string.IsNullOrEmpty(sshPath))
             {
                 OpenSSH.Checked = true;
@@ -59,20 +57,24 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.Pageant = PageantPath.Text;
             AppSettings.AutoStartPageant = AutostartPageant.Checked;
 
+            string path;
             if (OpenSSH.Checked)
             {
-                GitSshHelpers.SetSsh("");
+                path = "";
+            }
+            else if (Putty.Checked)
+            {
+                path = PlinkPath.Text;
+            }
+            else
+            {
+                // Other.Checked
+                path = OtherSsh.Text;
             }
 
-            if (Putty.Checked)
-            {
-                GitSshHelpers.SetSsh(PlinkPath.Text);
-            }
-
-            if (Other.Checked)
-            {
-                GitSshHelpers.SetSsh(OtherSsh.Text);
-            }
+            // Set persistent settings as well as the env var used by Git
+            GitSshHelpers.SetSsh(path);
+            AppSettings.SshPath = path;
         }
 
         private void OpenSSH_CheckedChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
@@ -61,7 +61,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             if (OpenSSH.Checked)
             {
-                GitSshHelpers.UnsetSsh();
+                GitSshHelpers.SetSsh("");
             }
 
             if (Putty.Checked)

--- a/GitUI/Infrastructure/Telemetry/AppEnvironmentTelemetryInitializer.cs
+++ b/GitUI/Infrastructure/Telemetry/AppEnvironmentTelemetryInitializer.cs
@@ -6,12 +6,10 @@ namespace GitUI.Infrastructure.Telemetry
 {
     internal class AppEnvironmentTelemetryInitializer : ITelemetryInitializer
     {
-        private readonly ISshPathLocator _sshPathLocator = new SshPathLocator();
-
         public void Initialize(ITelemetry telemetry)
         {
             string sshClient;
-            var sshPath = _sshPathLocator.Find(AppSettings.GitBinDir);
+            var sshPath = AppSettings.SshPath;
             if (string.IsNullOrEmpty(sshPath))
             {
                 sshClient = "OpenSSH";

--- a/UnitTests/GitCommands.Tests/SshPathLocatorTest.cs
+++ b/UnitTests/GitCommands.Tests/SshPathLocatorTest.cs
@@ -72,11 +72,11 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public void Find_on_gitBinDir_having_ssh_exe_in_parent_directory_children_should_return_first_ssh_exe_found()
+        public void Find_on_gitBinDir_having_ssh_exe_in_parent_directory_children_should_return_empty()
         {
             var path = SetUpFileSystemWithSshExePathsAs("first", "second");
             var sshPathLocator = new SshPathLocator(_fileSystem, _environment);
-            sshPathLocator.Find(path).Should().Be("first");
+            sshPathLocator.Find(path).Should().Be("");
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace GitCommandsTests
             const string sshExe = @"C:\someotherdir\ssh.exe";
             var path = SetUpFileSystemWithSshExePathsAs(sshExe);
             var sshPathLocator = new SshPathLocator(_fileSystem, _environment);
-            sshPathLocator.Find(path + (withTrailingSeparator ? @"\" : "")).Should().Be(sshExe);
+            sshPathLocator.Find(path + (withTrailingSeparator ? @"\" : "")).Should().Be("");
         }
 
         private string SetUpFileSystemWithSshExePathsAs(params string[] sshExePaths)


### PR DESCRIPTION
#9182 and part of #9188 for 3.5
(#9188 could be applied but it introduces plugin interface changes)
#9182 Translation changes in #9182 was reverted too (stating "unknown" instead of "other")

## Proposed changes

Set GIT_SSH only if path exists

Just read path from AppSettings.SshPath
Set GIT_SSH env var only, not read.

Report if ssh path is not found in Settings

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
