### PR TITLE
LogCaptureCallStacks in AppSettings

### DIFF
--- a/GitCommands/Logging/CommandLog.cs
+++ b/GitCommands/Logging/CommandLog.cs
@@ -154,8 +154,6 @@ namespace GitCommands.Logging
 
         private static ConcurrentQueue<CommandLogEntry> _queue = new ConcurrentQueue<CommandLogEntry>();
 
-        public static bool CaptureCallStacks { get; set; }
-
         public static IEnumerable<CommandLogEntry> Commands => _queue;
 
         public static ProcessOperation LogProcessStart(string fileName, string arguments = "", string workDir = "")
@@ -164,7 +162,7 @@ namespace GitCommands.Logging
 
             var entry = new CommandLogEntry(fileName, arguments, workDir, DateTime.Now, ThreadHelper.JoinableTaskContext.IsOnMainThread);
 
-            if (CaptureCallStacks)
+            if (AppSettings.LogCaptureCallStacks)
             {
                 entry.CallStack = new StackTrace();
             }

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1863,6 +1863,12 @@ namespace GitCommands
             set => SetInt("DiffViewer.AutomaticContinuousScrollDelay", value);
         }
 
+        public static bool LogCaptureCallStacks
+        {
+            get => GetBool("Log.CaptureCallStacks", false);
+            set => SetBool("Log.CaptureCallStacks", value);
+        }
+
         public static bool IsPortable()
         {
             return Properties.Settings.Default.IsPortable;

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
@@ -28,8 +28,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             LogOutput.Font = font;
             commandCacheOutput.Font = font;
 
-            chkCaptureCallStacks.Checked = CommandLog.CaptureCallStacks;
-            chkCaptureCallStacks.CheckedChanged += delegate { CommandLog.CaptureCallStacks = chkCaptureCallStacks.Checked; };
+            chkCaptureCallStacks.Checked = AppSettings.LogCaptureCallStacks;
+            chkCaptureCallStacks.CheckedChanged += delegate { AppSettings.LogCaptureCallStacks = chkCaptureCallStacks.Checked; };
 
             chkWordWrap.CheckedChanged += delegate
             {


### PR DESCRIPTION
## Proposed changes

Related to Git issues, like debugging for #9056 it is very helpful to have call stacks always available in the Command Log. This is especially important for commands during the startup phase, before the capture can be enabled.
It can be hard to recreate the situation a reporter experiences.

I often have this enabled in my private builds, but with #9056 I expect at least developers to require this.
(#9056 is a good change to avoid just swallowing Git errors.)

## Screenshots <!-- Remove this section if PR does not change UI -->

No UI change, just showing what is made persistent

![image](https://user-images.githubusercontent.com/6248932/118174930-b8186080-b42f-11eb-9313-20e56d87ccc1.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
