### PR TITLE
`CommitInfo`: Fix up threading issues

### DIFF
--- a/GitExtUtils/GitUI/ThreadHelper.cs
+++ b/GitExtUtils/GitUI/ThreadHelper.cs
@@ -117,6 +117,13 @@ namespace GitUI
             await _joinableTaskCollection.JoinTillEmptyAsync(cancellationToken);
         }
 
+        public static void JoinPendingOperations()
+        {
+            // Note that JoinableTaskContext.Factory must be used to bypass the default behavior of JoinableTaskFactory
+            // since the latter adds new tasks to the collection and would therefore never complete.
+            JoinableTaskContext.Factory.Run(_joinableTaskCollection.JoinTillEmptyAsync);
+        }
+
         public static T CompletedResult<T>(this Task<T> task)
         {
             if (!task.IsCompleted)

--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -11,19 +11,6 @@ namespace GitUI.CommitInfo
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary> 
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components is not null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         #region Component Designer generated code
 
         /// <summary> 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -144,6 +144,23 @@ namespace GitUI.CommitInfo
             rtbxCommitMessage.Height = 1;
         }
 
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _asyncLoadCancellation.CancelCurrent();
+                ThreadHelper.JoinPendingOperations(); // those run with FileAndForget
+
+                components?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
         private void RefreshSortedTags()
         {
             if (!Module.IsValidGitWorkingDir())

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -377,8 +377,11 @@ namespace GitUI.CommitInfo
                         tasks.Add(LoadDescribeInfoAsync(initialRevision.ObjectId));
                     }
 
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     await Task.WhenAll(tasks);
 
+                    await this.SwitchToMainThreadAsync(cancellationToken);
                     UpdateRevisionInfo();
                 }).FileAndForget();
 

--- a/UnitTests/CommonTestUtils/TestAppSettingsAttribute.cs
+++ b/UnitTests/CommonTestUtils/TestAppSettingsAttribute.cs
@@ -13,6 +13,7 @@ namespace CommonTestUtils
         public void BeforeTest(ITest test)
         {
             AppSettings.CheckForUpdates = false;
+            AppSettings.ShowAvailableDiffTools = false;
         }
 
         public void AfterTest(ITest test)


### PR DESCRIPTION
Fixes #9204

## Proposed changes

- Switch to UI thread before calling `CommitInfo.UpdateRevisionInfo`
  That's why it should go into 3.5.1, too.
- Join async operations before disposing `CommitInfo`
- Speed up tests by `AppSettings.ShowAvailableDiffTools = false`

## Screenshots

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual
- run unit & integration tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 0.0.0.0
- Build d25e6402326c9a1ddbbe8145b65b34e52843a9dc
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.6
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).