### PR TITLE
Delete temp files from settings tests

### DIFF
--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -56,7 +56,8 @@ namespace GitCommandsTests.Settings
 
             File.WriteAllText(filePath, SettingsFileContent);
 
-            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+            using GitExtSettingsCache cache = GitExtSettingsCache.Create(filePath);
+            RepoDistSettings container = new(null, cache, SettingLevel.Unknown);
             object storedValue = null;
 
             // Act
@@ -88,7 +89,8 @@ namespace GitCommandsTests.Settings
 
             File.WriteAllText(filePath, SettingsFileContent);
 
-            var container = new RepoDistSettings(null, GitExtSettingsCache.Create(filePath), SettingLevel.Unknown);
+            using GitExtSettingsCache cache = GitExtSettingsCache.Create(filePath);
+            RepoDistSettings container = new(null, cache, SettingLevel.Unknown);
             object storedValue = null;
 
             // Act

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -52,7 +53,9 @@ namespace GitCommandsTests.Settings
                     .GetProperty(nameof(ISetting<string>.Value));
             }
 
-            var filePath = Path.GetTempFileName();
+            using TempFileCollection tempFiles = new();
+            string filePath = tempFiles.AddExtension(".settings");
+            tempFiles.AddFile(filePath + ".backup", keepFile: false);
 
             File.WriteAllText(filePath, SettingsFileContent);
 
@@ -85,7 +88,9 @@ namespace GitCommandsTests.Settings
                     .GetProperty(nameof(ISetting<string>.Value));
             }
 
-            var filePath = Path.GetTempFileName();
+            using TempFileCollection tempFiles = new();
+            string filePath = tempFiles.AddExtension(".settings");
+            tempFiles.AddFile(filePath + ".backup", keepFile: false);
 
             File.WriteAllText(filePath, SettingsFileContent);
 

--- a/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.IO;
 using GitCommands;
@@ -13,6 +14,7 @@ namespace GitCommandsTests.Settings
     {
         private const string SettingsFileContent = @"<?xml version=""1.0"" encoding=""utf-8""?><dictionary />";
 
+        private static readonly TempFileCollection _tempFiles = new();
         private static string _settingFilePath;
         private static GitExtSettingsCache _gitExtSettingsCache;
         private static RepoDistSettings _settingContainer;
@@ -20,7 +22,8 @@ namespace GitCommandsTests.Settings
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            _settingFilePath = Path.GetTempFileName();
+            _settingFilePath = _tempFiles.AddExtension(".settings");
+            _tempFiles.AddFile(_settingFilePath + ".backup", keepFile: false);
 
             File.WriteAllText(_settingFilePath, SettingsFileContent);
 
@@ -32,6 +35,7 @@ namespace GitCommandsTests.Settings
         public void OneTimeTearDown()
         {
             _gitExtSettingsCache.Dispose();
+            ((IDisposable)_tempFiles).Dispose();
         }
 
         #region Setting
@@ -81,7 +85,8 @@ namespace GitCommandsTests.Settings
                 AppSettings.SaveSettings();
             });
 
-            var filePath = Path.GetTempFileName();
+            using TempFileCollection tempFiles = new();
+            string filePath = tempFiles.AddExtension(".settings");
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
@@ -210,7 +215,8 @@ namespace GitCommandsTests.Settings
                 AppSettings.SaveSettings();
             });
 
-            var filePath = Path.GetTempFileName();
+            using TempFileCollection tempFiles = new();
+            string filePath = tempFiles.AddExtension(".settings");
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
@@ -273,7 +279,8 @@ namespace GitCommandsTests.Settings
                 AppSettings.SaveSettings();
             });
 
-            var filePath = Path.GetTempFileName();
+            using TempFileCollection tempFiles = new();
+            string filePath = tempFiles.AddExtension(".settings");
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
@@ -514,7 +521,8 @@ namespace GitCommandsTests.Settings
                 AppSettings.SaveSettings();
             });
 
-            var filePath = Path.GetTempFileName();
+            using TempFileCollection tempFiles = new();
+            string filePath = tempFiles.AddExtension(".settings");
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
@@ -691,7 +699,8 @@ namespace GitCommandsTests.Settings
                 AppSettings.SaveSettings();
             });
 
-            var filePath = Path.GetTempFileName();
+            using TempFileCollection tempFiles = new();
+            string filePath = tempFiles.AddExtension(".settings");
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
@@ -871,7 +880,8 @@ namespace GitCommandsTests.Settings
                 AppSettings.SaveSettings();
             });
 
-            var filePath = Path.GetTempFileName();
+            using TempFileCollection tempFiles = new();
+            string filePath = tempFiles.AddExtension(".settings");
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
@@ -1051,7 +1061,8 @@ namespace GitCommandsTests.Settings
                 AppSettings.SaveSettings();
             });
 
-            var filePath = Path.GetTempFileName();
+            using TempFileCollection tempFiles = new();
+            string filePath = tempFiles.AddExtension(".settings");
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
@@ -1231,7 +1242,8 @@ namespace GitCommandsTests.Settings
                 AppSettings.SaveSettings();
             });
 
-            var filePath = Path.GetTempFileName();
+            using TempFileCollection tempFiles = new();
+            string filePath = tempFiles.AddExtension(".settings");
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
@@ -1322,7 +1334,8 @@ namespace GitCommandsTests.Settings
                 AppSettings.SaveSettings();
             });
 
-            var filePath = Path.GetTempFileName();
+            using TempFileCollection tempFiles = new();
+            string filePath = tempFiles.AddExtension(".settings");
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 
@@ -1450,7 +1463,8 @@ namespace GitCommandsTests.Settings
                 AppSettings.SaveSettings();
             });
 
-            var filePath = Path.GetTempFileName();
+            using TempFileCollection tempFiles = new();
+            string filePath = tempFiles.AddExtension(".settings");
 
             File.WriteAllText(filePath, File.ReadAllText(_settingFilePath));
 

--- a/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/SettingTests.cs
@@ -13,17 +13,25 @@ namespace GitCommandsTests.Settings
     {
         private const string SettingsFileContent = @"<?xml version=""1.0"" encoding=""utf-8""?><dictionary />";
 
-        private string _settingFilePath;
-        private RepoDistSettings _settingContainer;
+        private static string _settingFilePath;
+        private static GitExtSettingsCache _gitExtSettingsCache;
+        private static RepoDistSettings _settingContainer;
 
-        [SetUp]
-        public void SetUp()
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
         {
             _settingFilePath = Path.GetTempFileName();
 
             File.WriteAllText(_settingFilePath, SettingsFileContent);
 
-            _settingContainer = new RepoDistSettings(null, GitExtSettingsCache.Create(_settingFilePath), SettingLevel.Unknown);
+            _gitExtSettingsCache = GitExtSettingsCache.Create(_settingFilePath);
+            _settingContainer = new RepoDistSettings(null, _gitExtSettingsCache, SettingLevel.Unknown);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _gitExtSettingsCache.Dispose();
         }
 
         #region Setting


### PR DESCRIPTION
Fixes #9209

## Proposed changes

- Delete temp files from `AppSettingsTests` and `SettingTests`
- Dispose `GitExtSettingsCache` in all `AppSettingsTests` and in `OneTimeTearDown` of `SettingTests`
- Create `SettingTests._settingContainer` only once

## Test methodology <!-- How did you ensure quality? -->

- run NUnit tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 28814ce7ba5f63f1b557bbbd6f33616b5d016a45
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.6
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
