### PR TITLE
Preparations for exceptions on git error

### DIFF
--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -120,7 +120,7 @@ namespace GitCommands
                     Dispose();
 
                     _logOperation.LogProcessEnd(ex);
-                    throw new ExternalOperationException(fileName, arguments, workDir, ex);
+                    throw new ExternalOperationException(fileName, arguments, workDir, innerException: ex);
                 }
             }
 

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2457,16 +2457,15 @@ namespace GitCommands
         {
             var resultCollection = GetDiffFilesWithUntracked(stashName + "^", stashName, StagedStatus.None, true).ToList();
 
-            // shows untracked files
+            // add - optionally stashed - untracked files
             GitArgumentBuilder args = new("log")
             {
                 $"{stashName}^3",
                 "--pretty=format:\"%T\"",
                 "--max-count=1"
             };
-            var untrackedTreeHash = _gitExecutable.GetOutput(args);
-
-            if (ObjectId.TryParse(untrackedTreeHash, out var treeId))
+            ExecutionResult executionResult = _gitExecutable.Execute(args);
+            if (executionResult.ExitedSuccessfully && ObjectId.TryParse(executionResult.StandardOutput, out ObjectId? treeId))
             {
                 var files = GetTreeFiles(treeId, full: true);
 

--- a/GitExtUtils/ExternalOperationException.cs
+++ b/GitExtUtils/ExternalOperationException.cs
@@ -15,13 +15,20 @@ namespace GitExtUtils
         /// <param name="command">The command that led to the exception.</param>
         /// <param name="arguments">The command arguments.</param>
         /// <param name="workingDirectory">The working directory.</param>
+        /// <param name="exitCode">The exit code of an executed process.</param>
         /// <param name="innerException">The exception that is the cause of the current exception.</param>
-        public ExternalOperationException(string? command, string? arguments, string workingDirectory, Exception? innerException)
+        public ExternalOperationException(
+            string? command = null,
+            string? arguments = null,
+            string? workingDirectory = null,
+            int? exitCode = null,
+            Exception? innerException = null)
             : base(innerException?.Message, innerException)
         {
             Command = command;
             Arguments = arguments;
             WorkingDirectory = workingDirectory;
+            ExitCode = exitCode;
         }
 
         /// <summary>
@@ -38,5 +45,10 @@ namespace GitExtUtils
         /// The working directory.
         /// </summary>
         public string WorkingDirectory { get; }
+
+        /// <summary>
+        /// The exit code of an executed process.
+        /// </summary>
+        public int? ExitCode { get; }
     }
 }

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -67,7 +67,8 @@ namespace GitExtensions
             {
                 DiagnosticsClient.Initialize(ThisAssembly.Git.IsDirty);
 
-                if (!Debugger.IsAttached)
+                // If you want to suppress the BugReportInvoker when debugging and exit quickly, uncomment the condition:
+                ////if (!Debugger.IsAttached)
                 {
                     AppDomain.CurrentDomain.UnhandledException += (s, e) => BugReportInvoker.Report((Exception)e.ExceptionObject, e.IsTerminating);
                     Application.ThreadException += (s, e) => BugReportInvoker.Report(e.Exception, isTerminating: false);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2090,9 +2090,8 @@ namespace GitUI.CommandsDialogs
             }
             catch (FileDeleteException ex)
             {
-                ThreadHelper.AssertOnUIThread();
                 throw new UserExternalOperationException(_indexLockCantDelete.Text,
-                    new ExternalOperationException(command: null, arguments: ex.FileName, Module.WorkingDir, ex));
+                    new ExternalOperationException(arguments: ex.FileName, workingDirectory: Module.WorkingDir, innerException: ex));
             }
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -177,7 +177,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             {
                 try
                 {
-                    string output = new Executable(command).GetOutput();
+                    string output = new Executable(command).GetOutput(arguments: "--version");
                     if (!string.IsNullOrEmpty(output))
                     {
                         if (command is not null)
@@ -236,7 +236,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
         public bool CanFindGitCmd()
         {
-            return !string.IsNullOrEmpty(Module?.GitExecutable.GetOutput(""));
+            return !string.IsNullOrEmpty(Module?.GitExecutable.GetOutput(arguments: "--version"));
         }
     }
 }

--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -45,6 +45,9 @@ namespace GitUI.NBugReports
 
             if (exception is ExternalOperationException externalOperationException)
             {
+                // Exit code: <n>
+                AppendIfNotEmpty($"{externalOperationException.ExitCode}{Environment.NewLine}", TranslatedStrings.ExitCode);
+
                 // Command: <command>
                 AppendIfNotEmpty(externalOperationException.Command, TranslatedStrings.Command);
 

--- a/GitUI/NBugReports/UserExternalOperationException.cs
+++ b/GitUI/NBugReports/UserExternalOperationException.cs
@@ -14,7 +14,7 @@ namespace GitUI.NBugReports
         /// <param name="context">The command that led to the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public UserExternalOperationException(string context, ExternalOperationException innerException)
-            : base(innerException.Command, innerException.Arguments, innerException.WorkingDirectory, innerException.InnerException)
+            : base(innerException.Command, innerException.Arguments, innerException.WorkingDirectory, innerException.ExitCode, innerException.InnerException)
         {
             Context = context;
         }

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -40,7 +40,6 @@ namespace GitUI.Script
             }
             catch (ExternalOperationException ex) when (ex is not UserExternalOperationException)
             {
-                ThreadHelper.AssertOnUIThread();
                 throw new UserExternalOperationException($"{TranslatedStrings.ScriptErrorFailedToExecute}: '{scriptKey}'", ex);
             }
         }
@@ -55,9 +54,8 @@ namespace GitUI.Script
             ScriptInfo? scriptInfo = ScriptManager.GetScript(scriptKey);
             if (scriptInfo is null)
             {
-                ThreadHelper.AssertOnUIThread();
                 throw new UserExternalOperationException($"{TranslatedStrings.ScriptErrorCantFind}: '{scriptKey}'",
-                    new ExternalOperationException(command: null, arguments: null, module.WorkingDir, innerException: null));
+                    new ExternalOperationException(workingDirectory: module.WorkingDir));
             }
 
             if (string.IsNullOrEmpty(scriptInfo.Command))
@@ -73,9 +71,8 @@ namespace GitUI.Script
                                                                         && ScriptOptionsParser.Contains(arguments, option));
                 if (optionDependingOnSelectedRevision is not null)
                 {
-                    ThreadHelper.AssertOnUIThread();
                     throw new UserExternalOperationException($"{TranslatedStrings.ScriptText}: '{scriptKey}'{Environment.NewLine}'{optionDependingOnSelectedRevision}' {TranslatedStrings.ScriptErrorOptionWithoutRevisionGridText}",
-                        new ExternalOperationException(scriptInfo.Command, arguments, module.WorkingDir, innerException: null));
+                        new ExternalOperationException(scriptInfo.Command, arguments, module.WorkingDir));
                 }
             }
 
@@ -90,9 +87,8 @@ namespace GitUI.Script
             (string? argument, bool abort) = ScriptOptionsParser.Parse(scriptInfo.Arguments, module, owner, revisionGrid);
             if (abort)
             {
-                ThreadHelper.AssertOnUIThread();
                 throw new UserExternalOperationException($"{TranslatedStrings.ScriptText}: '{scriptKey}'{Environment.NewLine}{TranslatedStrings.ScriptErrorOptionWithoutRevisionText}",
-                    new ExternalOperationException(scriptInfo.Command, arguments, module.WorkingDir, innerException: null));
+                    new ExternalOperationException(scriptInfo.Command, arguments, module.WorkingDir));
             }
 
             Validates.NotNull(argument);

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -101,6 +101,7 @@ namespace GitUI
 
         private readonly TranslationString _argumentsText = new("Arguments");
         private readonly TranslationString _commandText = new("Command");
+        private readonly TranslationString _exitCodeText = new("Exit code");
         private readonly TranslationString _workingDirectoryText = new("Working directory");
         private readonly TranslationString _reportBugText = new("If you think this was caused by Git Extensions, you can report a bug for the team to investigate.");
 
@@ -214,6 +215,7 @@ namespace GitUI
 
         public static string Arguments => _instance.Value._argumentsText.Text;
         public static string Command => _instance.Value._commandText.Text;
+        public static string ExitCode => _instance.Value._exitCodeText.Text;
         public static string WorkingDirectory => _instance.Value._workingDirectoryText.Text;
         public static string ReportBug => _instance.Value._reportBugText.Text;
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9698,6 +9698,10 @@ Select this commit to populate the full message.</source>
         <source>Not on a branch</source>
         <target />
       </trans-unit>
+      <trans-unit id="_exitCodeText.Text">
+        <source>Exit code</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_findGitExecutable.Text">
         <source>Find git...</source>
         <target />

--- a/UnitTests/GitUI.Tests/NBugReports/BugReportInvokerTests.cs
+++ b/UnitTests/GitUI.Tests/NBugReports/BugReportInvokerTests.cs
@@ -30,6 +30,7 @@ namespace GitUITests.NBugReports
         private const string _command = "command";
         private const string _arguments = "arguments";
         private const string _directory = "directory";
+        private const int _exitCode = 128;
 
         public static IEnumerable TestCases
         {
@@ -45,14 +46,15 @@ namespace GitUITests.NBugReports
                     _messageInner,
                     "");
                 yield return new TestCaseData(new UserExternalOperationException(_context,
-                    new ExternalOperationException(_command, _arguments, _directory, new Exception(_messageOuter, new Exception(_messageInner)))),
+                    new ExternalOperationException(_command, _arguments, _directory, _exitCode, new Exception(_messageOuter, new Exception(_messageInner)))),
                     _messageInner,
                     $"{_context}{Environment.NewLine}"
+                    + $"Exit code: {_exitCode}{Environment.NewLine}{Environment.NewLine}"
                     + $"Command: {_command}{Environment.NewLine}"
                     + $"Arguments: {_arguments}{Environment.NewLine}"
                     + $"Working directory: {_directory}{Environment.NewLine}");
-                yield return new TestCaseData(new UserExternalOperationException(null,
-                    new ExternalOperationException(null, null, null, new Exception(_messageInner))),
+                yield return new TestCaseData(new UserExternalOperationException(context: null,
+                    new ExternalOperationException(null, null, null, null, new Exception(_messageInner))),
                     _messageInner,
                     "");
             }


### PR DESCRIPTION
Preparations for #9056

## Proposed changes

- Handle more exceptions as "failed external operation" (same as #9094 for release/3.5)
- Do not crash on exception if debugger is attached
- Check `ExitedSuccessfully` in `GetStashDiffFiles`
- Avoid exit code 1 when checking for valid git executable
- `ExternalOperationException`: Add property `ExitCode`
- Remove unnecessary `ThreadHelper.AssertOnUIThread` before throwing `UserExternalOperationException`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/36601201/118411120-4a6c6e80-b693-11eb-97b0-a3cc62d2185e.png)

### After

![image](https://user-images.githubusercontent.com/36601201/118411129-58ba8a80-b693-11eb-946a-e692b4ec5830.png)

## Test methodology <!-- How did you ensure quality? -->

- extended existing NUnit tests
- manual tests with FormStash and `Include tracked` ticked

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 06582e3d0114e17540b03dbaa6f9388a0a0e07a2
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.6
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).