### PR TITLE
Replace PathUtil.Combine and GetExtension with Path.

### DIFF
--- a/GitCommands/FileAssociatedIconProvider.cs
+++ b/GitCommands/FileAssociatedIconProvider.cs
@@ -51,7 +51,7 @@ namespace GitCommands
         /// </remarks>
         public Icon? Get(string workingDirectory, string relativeFilePath)
         {
-            var extension = PathUtil.GetExtension(relativeFilePath);
+            var extension = Path.GetExtension(relativeFilePath);
             if (string.IsNullOrWhiteSpace(extension))
             {
                 return null;
@@ -68,7 +68,7 @@ namespace GitCommands
                     // extensions from the registry and using p/invokes and WinAPI, which have
                     // significantly higher maintenance overhead.
 
-                    var fullPath = PathUtil.Combine(workingDirectory, relativeFilePath);
+                    var fullPath = Path.Combine(workingDirectory, relativeFilePath);
                     if (!_fileSystem.File.Exists(fullPath))
                     {
                         tempFile = CreateTempFile(Path.GetFileName(fullPath));

--- a/GitCommands/FullPathResolver.cs
+++ b/GitCommands/FullPathResolver.cs
@@ -32,10 +32,6 @@ namespace GitCommands
         /// <summary>
         /// Resolves the provided path (folder or file) against the current working directory.
         /// </summary>
-        /// <remarks>
-        /// Behaves similar to the .NET Core 2.1 version that do not throw on paths with illegal
-        /// Windows characters (that could be OK in Git paths or for cross platform) but returns
-        /// null instead of an possible path.</remarks>
         /// <param name="path">Folder or file path to resolve.</param>
         /// <returns>
         /// <paramref name="path" /> if <paramref name="path" /> is rooted; otherwise resolved path from working directory of the current repository.
@@ -48,18 +44,9 @@ namespace GitCommands
                 return null;
             }
 
-            try
+            if (Path.IsPathRooted(path))
             {
-                if (Path.IsPathRooted(path))
-                {
-                    return path;
-                }
-            }
-            catch (ArgumentException)
-            {
-                // Illegal characters in path.
-                // This is used for Git paths that may not be possible in the host file system
-                return null;
+                return path;
             }
 
             var workingDir = _getWorkingDir();

--- a/GitCommands/Git/GitItemStatusFileExtensionComparer.cs
+++ b/GitCommands/Git/GitItemStatusFileExtensionComparer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace GitCommands.Git
 {
@@ -27,8 +28,8 @@ namespace GitCommands.Git
 
             var lhsPath = GetPrimarySortingPath(x);
             var rhsPath = GetPrimarySortingPath(y);
-            var lhsExt = PathUtil.GetExtension(lhsPath);
-            var rhsExt = PathUtil.GetExtension(rhsPath);
+            var lhsExt = Path.GetExtension(lhsPath);
+            var rhsExt = Path.GetExtension(rhsPath);
 
             var comparisonResult = StringComparer.InvariantCulture.Compare(lhsExt, rhsExt);
             if (comparisonResult == 0)

--- a/GitCommands/GitRevisionInfoProvider.cs
+++ b/GitCommands/GitRevisionInfoProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using GitCommands.Git;
 using GitUIPluginInterfaces;
 
@@ -58,7 +59,7 @@ namespace GitCommands
                 {
                     if (subItem is GitItem gitItem)
                     {
-                        gitItem.FileName = PathUtil.Combine(basePath, gitItem.FileName) ?? string.Empty;
+                        gitItem.FileName = Path.Combine(basePath, gitItem.FileName);
                     }
 
                     yield return subItem;

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -133,57 +133,6 @@ namespace GitCommands
             }
         }
 
-        /// <summary>
-        /// Wrapper for Path.Combine.
-        /// </summary>
-        /// <remark>
-        /// Similar to the .NET Core 2.1 variant, except that null is returned if Windows
-        /// invalid characters (that may be accepted in Git or other filesystems)
-        /// are in the paths instead of a possible path (the OS or file system will throw
-        /// if the paths are invalid).
-        /// </remark>
-        /// <param name="path1">initial part.</param>
-        /// <param name="path2">second part.</param>
-        /// <returns>path if it can be combined, null otherwise.</returns>
-        public static string? Combine(string path1, string path2)
-        {
-            try
-            {
-                return Path.Combine(path1, path2);
-            }
-            catch (ArgumentException)
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Wrapper for Path.GetExtension.
-        /// </summary>
-        /// <remark>
-        /// <see cref="Combine"/> for motivation.
-        /// </remark>
-        /// <param name="path">path to check.</param>
-        /// <returns>path if it can be combined, empty otherwise.</returns>
-        public static string GetExtension(string? path)
-        {
-            if (path is null)
-            {
-                return string.Empty;
-            }
-
-            try
-            {
-                return Path.GetExtension(path);
-            }
-            catch (ArgumentException)
-            {
-                // This could return part after a '.' using string commands,
-                // but wait for .NET Core with this edge case
-                return string.Empty;
-            }
-        }
-
         public static string Resolve(string path, string relativePath = "")
         {
             if (string.IsNullOrWhiteSpace(path))
@@ -269,13 +218,10 @@ namespace GitCommands
 
                 foreach (var path in EnvironmentPathsProvider.GetEnvironmentValidPaths())
                 {
-                    fullPath = Combine(path, fileName);
+                    fullPath = Path.Combine(path, fileName);
                     if (File.Exists(fullPath))
                     {
-                        // TODO remove suppression when targeting .NET 5
-#pragma warning disable CS8762 // Parameter must have a non-null value when exiting in some condition.
                         return true;
-#pragma warning restore CS8762 // Parameter must have a non-null value when exiting in some condition.
                     }
                 }
             }
@@ -298,13 +244,10 @@ namespace GitCommands
                     return true;
                 }
 
-                shellPath = Combine(AppSettings.GitBinDir, shell);
+                shellPath = Path.Combine(AppSettings.GitBinDir, shell);
                 if (File.Exists(shellPath))
                 {
-                    // TODO remove suppression when targeting .NET 5
-#pragma warning disable CS8762 // Parameter must have a non-null value when exiting in some condition.
                     return true;
-#pragma warning restore CS8762 // Parameter must have a non-null value when exiting in some condition.
                 }
 
                 if (TryFindFullPath(shell, out shellPath))
@@ -417,7 +360,7 @@ namespace GitCommands
                     return null;
                 }
 
-                var path = Combine(envVarFolder, location);
+                var path = Path.Combine(envVarFolder, location);
                 if (!Directory.Exists(path))
                 {
                     return null;
@@ -428,7 +371,7 @@ namespace GitCommands
 
             static string? FindFile(string location, string fileName1)
             {
-                string? fullName = Combine(location, fileName1);
+                string fullName = Path.Combine(location, fileName1);
                 if (File.Exists(fullName))
                 {
                     return fullName;

--- a/GitCommands/Settings/FileSettingsCache.cs
+++ b/GitCommands/Settings/FileSettingsCache.cs
@@ -35,17 +35,8 @@ namespace GitCommands.Settings
             _fileWatcher.Changed += _fileWatcher_Changed;
             _fileWatcher.Renamed += _fileWatcher_Renamed;
             _fileWatcher.Created += _fileWatcher_Created;
-            string? dir;
-            try
-            {
-                dir = Path.GetDirectoryName(SettingsFilePath);
-            }
-            catch (ArgumentException)
-            {
-                // Illegal characters in the filename
-                dir = null;
-            }
 
+            string? dir = Path.GetDirectoryName(SettingsFilePath);
             if (Directory.Exists(dir) && File.Exists(SettingsFilePath))
             {
                 _fileWatcher.Path = dir;

--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -42,7 +42,7 @@ namespace GitUI.AutoCompletion
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var regex = GetRegexForExtension(PathUtil.GetExtension(file.Name));
+                var regex = GetRegexForExtension(Path.GetExtension(file.Name) ?? "");
 
                 if (regex is not null)
                 {
@@ -97,7 +97,7 @@ namespace GitUI.AutoCompletion
 
             Validates.NotNull(appDataPath);
 
-            var path = PathUtil.Combine(appDataPath, "AutoCompleteRegexes.txt");
+            var path = Path.Combine(appDataPath, "AutoCompleteRegexes.txt");
 
             if (File.Exists(path))
             {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2063,7 +2063,7 @@ namespace GitUI.CommandsDialogs
             StringBuilder fileNames = new();
             foreach (var item in diffFiles.SelectedItems)
             {
-                var path = PathUtil.Combine(module.WorkingDir, item.Item.Name);
+                var path = Path.Combine(module.WorkingDir, item.Item.Name);
                 if (string.IsNullOrWhiteSpace(path))
                 {
                     continue;
@@ -2484,7 +2484,7 @@ namespace GitUI.CommandsDialogs
 
             foreach (var item in diffFiles.SelectedItems)
             {
-                string? filePath = PathUtil.Combine(module.WorkingDir, item.Item.Name.ToNativePath());
+                string filePath = Path.Combine(module.WorkingDir, item.Item.Name.ToNativePath());
 
                 if (!string.IsNullOrWhiteSpace(filePath))
                 {

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -328,17 +328,17 @@ namespace GitUI.CommandsDialogs
 
             try
             {
-                string extension = PathUtil.GetExtension(fileName).ToLower();
-                if (extension.Length <= 1)
+                string? extension = Path.GetExtension(fileName)?.ToLower();
+                if (extension?.Length <= 1)
                 {
                     return false;
                 }
 
-                string? dir = PathUtil.Combine(Path.GetDirectoryName(Application.ExecutablePath), "Diff-Scripts").EnsureTrailingPathSeparator();
+                string dir = Path.Combine(Path.GetDirectoryName(Application.ExecutablePath), "Diff-Scripts").EnsureTrailingPathSeparator();
                 if (Directory.Exists(dir))
                 {
                     if (_mergeScripts.TryGetValue(extension, out var mergeScript) &&
-                        File.Exists(PathUtil.Combine(dir!, mergeScript)))
+                        File.Exists(Path.Combine(dir!, mergeScript)))
                     {
                         if (MessageBox.Show(this, string.Format(_uskUseCustomMergeScript.Text, mergeScript),
                                             _uskUseCustomMergeScriptCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) ==

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -666,9 +666,7 @@ See the changes in the commit form.");
                 var fileName = _fullPathResolver.Resolve(gitItem.FileName);
                 if (File.Exists(fileName))
                 {
-                    // NOTE File.Exists is not annotated to imply that fileName is non-null when the returned value is true
-                    // in .NET Framework. This suppression will not be required when moving to .NET 5+.
-                    OsShellUtil.OpenAs(fileName!.ToNativePath());
+                    OsShellUtil.OpenAs(fileName.ToNativePath());
                 }
             }
         }
@@ -683,7 +681,7 @@ See the changes in the commit form.");
 
         private void diffWithRememberedFileToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (!(tvGitTree.SelectedNode?.Tag is GitItem gitItem) || _revision is null)
+            if (tvGitTree.SelectedNode?.Tag is not GitItem gitItem || _revision is null)
             {
                 return;
             }

--- a/GitUI/CommandsDialogs/RevisionFileTreeController.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeController.cs
@@ -121,7 +121,7 @@ namespace GitUI.CommandsDialogs
 
                     case GitObjectType.Blob:
                         {
-                            var extension = PathUtil.GetExtension(gitItem.FileName);
+                            var extension = Path.GetExtension(gitItem.FileName);
 
                             if (string.IsNullOrWhiteSpace(extension))
                             {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -575,8 +575,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 // Check if shell extensions are installed
                 string? installDir = AppSettings.GetInstallDir();
                 Validates.NotNull(installDir);
-                string? path32 = PathUtil.Combine(installDir, CommonLogic.GitExtensionsShellEx32Name);
-                string? path64 = PathUtil.Combine(installDir, CommonLogic.GitExtensionsShellEx64Name);
+                string path32 = Path.Combine(installDir, CommonLogic.GitExtensionsShellEx32Name);
+                string path64 = Path.Combine(installDir, CommonLogic.GitExtensionsShellEx64Name);
                 if (!File.Exists(path32) || (IntPtr.Size == 8 && !File.Exists(path64)))
                 {
                     RenderSettingSet(ShellExtensionsRegistered, ShellExtensionsRegistered_Fix, _shellExtNoInstalled.Text);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
@@ -36,7 +36,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             foreach (string translation in translations)
             {
-                var imagePath = PathUtil.Combine(Translator.GetTranslationDir(), translation + ".gif");
+                var imagePath = Path.Combine(Translator.GetTranslationDir(), translation + ".gif");
                 if (File.Exists(imagePath))
                 {
                     var image = Image.FromFile(imagePath);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -64,7 +64,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     try
                     {
                         if (!string.IsNullOrEmpty(candidate) &&
-                            File.Exists(PathUtil.Combine(candidate, ".gitconfig")))
+                            File.Exists(Path.Combine(candidate, ".gitconfig")))
                         {
                             return true;
                         }
@@ -136,7 +136,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             try
             {
                 string userHomeDir = Environment.GetEnvironmentVariable("HOME", EnvironmentVariableTarget.User);
-                if (!string.IsNullOrEmpty(userHomeDir) && File.Exists(PathUtil.Combine(userHomeDir, ".gitconfig")))
+                if (!string.IsNullOrEmpty(userHomeDir) && File.Exists(Path.Combine(userHomeDir, ".gitconfig")))
                 {
                     MessageBox.Show(this, string.Format(_gitconfigFoundHome.Text, userHomeDir), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     defaultHome.Checked = true;
@@ -154,7 +154,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             {
                 var path = Environment.GetEnvironmentVariable("HOMEDRIVE") +
                            Environment.GetEnvironmentVariable("HOMEPATH");
-                if (!string.IsNullOrEmpty(path) && File.Exists(PathUtil.Combine(path, ".gitconfig")))
+                if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
                 {
                     MessageBox.Show(this, string.Format(_gitconfigFoundHomedrive.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     defaultHome.Checked = true;
@@ -171,7 +171,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             try
             {
                 var path = Environment.GetEnvironmentVariable("USERPROFILE");
-                if (!string.IsNullOrEmpty(path) && File.Exists(PathUtil.Combine(path, ".gitconfig")))
+                if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
                 {
                     MessageBox.Show(this, string.Format(_gitconfigFoundUserprofile.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     userprofileHome.Checked = true;
@@ -188,7 +188,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             try
             {
                 var path = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-                if (!string.IsNullOrEmpty(path) && File.Exists(PathUtil.Combine(path, ".gitconfig")))
+                if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
                 {
                     MessageBox.Show(this, string.Format(_gitconfigFoundPersonalFolder.Text, Environment.GetFolderPath(Environment.SpecialFolder.Personal)),
                         "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPageController.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPageController.cs
@@ -18,27 +18,20 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 return null;
             }
 
-            try
+            // the path can be either a folder or a file
+            // if the path is a folder but lacks the trailing slash, Path.GetDirectoryName will return the parent directory
+            // so we want to ensure the supplied directory is slash-terminated
+            if (Directory.Exists(suppliedPath))
             {
-                // the path can be either a folder or a file
-                // if the path is a folder but lacks the trailing slash, Path.GetDirectoryName will return the parent directory
-                // so we want to ensure the supplied directory is slash-terminated
-                if (Directory.Exists(suppliedPath))
-                {
-                    suppliedPath = suppliedPath.EnsureTrailingPathSeparator();
-                }
-
-                // Path.GetDirectoryName returns directory information for path, or null if path denotes a root directory or is null.
-                // Returns Empty if path does not contain directory information.
-                string initialDirectory = Path.GetDirectoryName(suppliedPath) ?? suppliedPath;
-                if (!string.IsNullOrWhiteSpace(initialDirectory) && Directory.Exists(initialDirectory))
-                {
-                    return initialDirectory.EnsureTrailingPathSeparator();
-                }
+                suppliedPath = suppliedPath.EnsureTrailingPathSeparator();
             }
-            catch (ArgumentException)
+
+            // Path.GetDirectoryName returns directory information for path, or null if path denotes a root directory or is null.
+            // Returns Empty if path does not contain directory information.
+            string initialDirectory = Path.GetDirectoryName(suppliedPath) ?? suppliedPath;
+            if (!string.IsNullOrWhiteSpace(initialDirectory) && Directory.Exists(initialDirectory))
             {
-                // likely there was a problem with a path
+                return initialDirectory.EnsureTrailingPathSeparator();
             }
 
             return null;

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -521,7 +521,7 @@ namespace GitUI.Editor
             {
                 // File system access for other than Worktree,
                 // to handle that git-status does not detect details for untracked (git-diff --no-index will not give info)
-                var fullPath = PathUtil.Combine(Module.WorkingDir, file.Name);
+                var fullPath = Path.Combine(Module.WorkingDir, file.Name);
                 if (Directory.Exists(fullPath) && GitModule.IsValidGitWorkingDir(fullPath))
                 {
                     isSubmodule = true;

--- a/Plugins/Statistics/GitStatistics/LineCounter.cs
+++ b/Plugins/Statistics/GitStatistics/LineCounter.cs
@@ -54,18 +54,21 @@ namespace GitExtensions.Plugins.GitStatistics
             {
                 foreach (var file in filesToCheck)
                 {
-                    if (extensions.Contains(PathUtil.GetExtension(file)))
+                    FileInfo fileInfo = null;
+                    try
                     {
-                        FileInfo fileInfo;
-                        try
+                        if (extensions.Contains(Path.GetExtension(file)))
                         {
                             fileInfo = new FileInfo(file);
                         }
-                        catch
-                        {
-                            continue;
-                        }
+                    }
+                    catch
+                    {
+                        continue;
+                    }
 
+                    if (fileInfo is not null)
+                    {
                         yield return fileInfo;
                     }
                 }

--- a/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
@@ -190,28 +190,6 @@ namespace GitCommandsTests.Helpers
             PathUtil.NormalizePath(path).Should().Be(expected);
         }
 
-        // Path APIs don't throw an exception for invalid characters
-        // https://docs.microsoft.com/dotnet/core/compatibility/2.1#path-apis-dont-throw-an-exception-for-invalid-characters
-        [TestCase(@"C:\work\t.txt", "whatever", @"C:\work\t.txt\whatever")]
-        [TestCase(@"C:\wor""k\t.txt", "whatever", @"C:\wor""k\t.txt\whatever")]
-        [TestCase(@"\\WSL$\Ubuntu\home\jack\.\work\", "whatever", @"\\WSL$\Ubuntu\home\jack\.\work\whatever")]
-        public void Combine(string path1, string path2, string expected)
-        {
-            PathUtil.Combine(path1, path2).Should().Be(expected);
-        }
-
-        // Path APIs don't throw an exception for invalid characters
-        // https://docs.microsoft.com/dotnet/core/compatibility/2.1#path-apis-dont-throw-an-exception-for-invalid-characters
-        [TestCase(@"C:\work\t.txt", @".txt")]
-        [TestCase(@"C:\work\t.", @"")]
-        [TestCase(@"work/t.bmp", @".bmp")]
-        [TestCase(@"work""/t.bmp", @".bmp")]
-        [TestCase(@"\\WSL$\Ubuntu\home\jack\.\work", @"")]
-        public void GetExtension(string path, string expected)
-        {
-            PathUtil.GetExtension(path).Should().Be(expected);
-        }
-
         [TestCase(@"C:\WORK\GitExtensions\", @"C:\WORK\GitExtensions\")]
         [TestCase(@"\\my-pc\Work\GitExtensions\", @"\\my-pc\Work\GitExtensions\")]
         [TestCase(@"\\wsl$\Ubuntu\home\jack\work\", @"\\wsl$\Ubuntu\home\jack\work\")]


### PR DESCRIPTION
## Proposed changes

Prepare to replace PathUtil.Combine and PathUtil.GetExtension with the .NET5 Path variants directly. 
https://docs.microsoft.com/dotnet/core/compatibility/2.1#path-apis-dont-throw-an-exception-for-invalid-characters

.NET5 Path no longer throws ArgumentException on
"Illegal characters in path".
Replace PathUtil Combine and GetExtinsion with the Path
variant directly as well removing other catches of ArgumentException.

* Remove .NET5 todo

## Test methodology <!-- How did you ensure quality? -->

Tests were updated - when PathUtil versions are removed the tests will be removed though

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
