### PR TITLE
Git commands should never have colors

### DIFF
--- a/GitCommands/Git/AheadBehindDataProvider.cs
+++ b/GitCommands/Git/AheadBehindDataProvider.cs
@@ -56,7 +56,6 @@ namespace GitCommands.Git
 
             GitArgumentBuilder aheadBehindGitCommand = new("for-each-ref")
             {
-                $"--color=never",
                 $"--format=\"{_refFormat}\"",
                 "refs/heads/" + branchName
             };

--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -69,9 +69,11 @@ namespace GitCommands.Git.Commands
                         ? (ArgumentString)"--no-optional-locks"
                         : default)
                 {
-                    { staged, "-M -C --cached" },
-                    extraDiffArguments,
+                    "--find-renames",
+                    "--find-copies",
                     { AppSettings.UseHistogramDiffAlgorithm, "--histogram" },
+                    extraDiffArguments,
+                    { staged, "--cached" },
                     "--",
                     fileName.ToPosixPath().Quote(),
                     { staged, oldFileName?.ToPosixPath().Quote() }

--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -69,7 +69,6 @@ namespace GitCommands.Git.Commands
                         ? (ArgumentString)"--no-optional-locks"
                         : default)
                 {
-                    "--no-color",
                     { staged, "-M -C --cached" },
                     extraDiffArguments,
                     { AppSettings.UseHistogramDiffAlgorithm, "--histogram" },

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1317,7 +1317,9 @@ namespace GitCommands
             return _gitExecutable.GetOutput(
                 new GitArgumentBuilder("format-patch")
                 {
-                    "-M -C -B",
+                    "--find-renames",
+                    "--find-copies",
+                    "--break-rewrites",
                     { start is not null, $"--start-number {start}" },
                     { !string.IsNullOrEmpty(from), $"{from.Quote()}..{to.Quote()}", $"--root {to.Quote()}" },
                     $"-o {output.ToPosixPath().Quote()}"
@@ -2267,9 +2269,10 @@ namespace GitCommands
 
             GitArgumentBuilder args = new("diff")
             {
-                extraDiffArguments,
+                "--find-renames",
+                "--find-copies",
                 { AppSettings.UseHistogramDiffAlgorithm, "--histogram" },
-                "-M -C",
+                extraDiffArguments,
                 diffOptions
             };
 
@@ -2309,9 +2312,10 @@ namespace GitCommands
             // Supported since Git 2.19 (checks when adding the command)
             GitArgumentBuilder args = new("range-diff")
             {
-                extraDiffArguments,
+                "--find-renames",
+                "--find-copies",
                 { AppSettings.UseHistogramDiffAlgorithm, "--histogram" },
-                "-M -C",
+                extraDiffArguments,
                 { firstBase is null || secondBase is null,  $"{firstId}...{secondId}", $"{firstBase}..{firstId} {secondBase}..{secondId}" }
             };
 
@@ -2354,7 +2358,8 @@ namespace GitCommands
             return _gitExecutable.Execute(
                 new GitArgumentBuilder("diff")
                 {
-                    "-M -C",
+                    "--find-renames",
+                    "--find-copies",
                     "--name-status",
                     { nullSeparated, "-z" },
                     _revisionDiffProvider.Get(firstRevision, secondRevision)
@@ -2606,11 +2611,11 @@ namespace GitCommands
         {
             GitArgumentBuilder args = new("diff")
             {
-                "-M",
-                "-C",
+                "--find-renames",
+                "--find-copies",
                 "-z",
-                "--cached",
-                "--name-status"
+                "--name-status",
+                "--cached"
             };
             ExecutionResult exec = _gitExecutable.Execute(args);
             if (exec.ExitedSuccessfully)
@@ -3547,8 +3552,9 @@ namespace GitCommands
             _gitCommandRunner.RunDetached(new GitArgumentBuilder("difftool")
             {
                 { string.IsNullOrWhiteSpace(customTool), "--gui", $"--tool={customTool}" },
+                "--find-renames",
+                "--find-copies",
                 "--no-prompt",
-                "-M -C",
                 extraDiffArguments,
                 _revisionDiffProvider.Get(firstRevision, secondRevision, filename, oldFileName, isTracked)
             });
@@ -3574,8 +3580,9 @@ namespace GitCommands
             _gitCommandRunner.RunDetached(new GitArgumentBuilder("difftool")
             {
                 { string.IsNullOrWhiteSpace(customTool), "--gui", $"--tool={customTool}" },
+                "--find-renames",
+                "--find-copies",
                 "--no-prompt",
-                "-M -C",
                 firstGitCommit.QuoteNE(),
                 secondGitCommit.QuoteNE()
             });

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2267,7 +2267,6 @@ namespace GitCommands
 
             GitArgumentBuilder args = new("diff")
             {
-                "--no-color",
                 extraDiffArguments,
                 { AppSettings.UseHistogramDiffAlgorithm, "--histogram" },
                 "-M -C",
@@ -2310,7 +2309,6 @@ namespace GitCommands
             // Supported since Git 2.19 (checks when adding the command)
             GitArgumentBuilder args = new("range-diff")
             {
-                "--no-color",
                 extraDiffArguments,
                 { AppSettings.UseHistogramDiffAlgorithm, "--histogram" },
                 "-M -C",
@@ -2356,7 +2354,6 @@ namespace GitCommands
             return _gitExecutable.Execute(
                 new GitArgumentBuilder("diff")
                 {
-                    "--no-color",
                     "-M -C",
                     "--name-status",
                     { nullSeparated, "-z" },
@@ -2609,7 +2606,6 @@ namespace GitCommands
         {
             GitArgumentBuilder args = new("diff")
             {
-                "--no-color",
                 "-M",
                 "-C",
                 "-z",

--- a/GitExtUtils/GitCommandConfiguration.cs
+++ b/GitExtUtils/GitCommandConfiguration.cs
@@ -23,6 +23,7 @@ namespace GitExtUtils
 
             Default.Add(new GitConfigItem("log.showSignature", "false"), "log", "show", "whatchanged");
 
+            Default.Add(new GitConfigItem("color.ui", "never"), "diff", "range-diff");
             Default.Add(new GitConfigItem("diff.submodule", "short"), "diff");
             Default.Add(new GitConfigItem("diff.noprefix", "false"), "diff");
             Default.Add(new GitConfigItem("diff.mnemonicprefix", "false"), "diff");

--- a/GitExtensions/AutoCompleteRegexes.txt
+++ b/GitExtensions/AutoCompleteRegexes.txt
@@ -8,7 +8,7 @@
 .asp, .aspx, .cs = (?:(?:(?:public|protected|private|internal)\s+(?:[\w.]+(?:\s*<[<>\w\s.,]+>)?\s+)*([\w.]+)(?:\s*<[<>\w\s.,]+>)?)|(?:namespace\s+([\w.]+))|(?:new\s+([\w]+))|(?:using\s+([\w.]+)))
 .h, .hpp, .hxx = ^\s*(?:class|struct)\s+([\w]+)|^\s+(?:\w+\s+)*([\w]+)\s*\(|^#define\s+(\w+)
 .html = \"#(\w+)\"
-.java = (?:public|protected|private|internal)\s+(?:[\w.]+\s+)*([\w.]+)|class\s+([\w]+)(?:(?:\s+)?(?:extends|implements)(?:\s+)?([\w]+)?)
+.java, .groovy = (?:public|protected|private|internal)\s+(?:[\w.]+\s+)*([\w.]+)|class\s+([\w]+)(?:(?:\s+)?(?:extends|implements)(?:\s+)?([\w]+)?)
 .js = (?:(?:prototype\.|this\.)(\w+)\s*=\s*)?function\s*(?:(\w*)\s*)\(
 .pas = (\w+)\s+=\s+(?:class|record|interface)|(?:procedure|function|property|constructor)\s+(\w+)
 .php = ^\s*class\s+(\w+)|^\s*(?:(?:public|private)?\s+function)\s+(\w+)|::(\w+)|->(\w+)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -544,11 +544,6 @@ namespace GitUI.Editor
 
             Image? GetImage()
             {
-                if (sha is null)
-                {
-                    return null;
-                }
-
                 try
                 {
                     using var stream = Module.GetFileStream(sha);

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -624,9 +624,9 @@ namespace GitCommandsTests.Git.Commands
                 GitCommandHelpers.ApplyMailboxPatchCmd(signOff, ignoreWhitespace, patchFile).Arguments);
         }
 
-        [TestCase(@"-c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", false)]
-        [TestCase(@"-c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff extra -- ""new""", "new", "old", false, "extra", false)]
-        [TestCase(@"--no-optional-locks -c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", true)]
+        [TestCase(@"-c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --find-renames --find-copies extra --cached -- ""new"" ""old""", "new", "old", true, "extra", false)]
+        [TestCase(@"-c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --find-renames --find-copies extra -- ""new""", "new", "old", false, "extra", false)]
+        [TestCase(@"--no-optional-locks -c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --find-renames --find-copies extra --cached -- ""new"" ""old""", "new", "old", true, "extra", true)]
         public void GetCurrentChangesCmd(string expected, string fileName, string oldFileName, bool staged,
             string extraDiffArguments, bool noLocks)
         {

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -624,9 +624,9 @@ namespace GitCommandsTests.Git.Commands
                 GitCommandHelpers.ApplyMailboxPatchCmd(signOff, ignoreWhitespace, patchFile).Arguments);
         }
 
-        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", false)]
-        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --no-color extra -- ""new""", "new", "old", false, "extra", false)]
-        [TestCase(@"--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", true)]
+        [TestCase(@"-c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", false)]
+        [TestCase(@"-c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff extra -- ""new""", "new", "old", false, "extra", false)]
+        [TestCase(@"--no-optional-locks -c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", true)]
         public void GetCurrentChangesCmd(string expected, string fileName, string oldFileName, bool staged,
             string extraDiffArguments, bool noLocks)
         {

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -450,7 +450,7 @@ namespace GitCommandsTests
             GitModule module = new(Path.GetTempPath());
             using (ApprovalResults.ForScenario(testName.Replace(' ', '_')))
             {
-                // git diff -M -C -z --name-status
+                // git diff --find-renames --find-copies -z --name-status
                 var statuses = module.GetTestAccessor().GetDiffChangedFilesFromString(statusString, stagedStatus);
                 Approvals.VerifyJson(JsonConvert.SerializeObject(statuses));
             }
@@ -822,7 +822,7 @@ namespace GitCommandsTests
         public void Test_FormatPatch(string from, string to, string outputFile, int? start)
         {
             StringBuilder arguments = new();
-            arguments.Append("format-patch -M -C -B");
+            arguments.Append("format-patch --find-renames --find-copies --break-rewrites");
             if (start is not null)
             {
                 arguments.AppendFormat(" --start-number {0}", start);
@@ -842,7 +842,7 @@ namespace GitCommandsTests
         public void Test_FormatPatchInRoot(string from, string to, string outputFile, int? start)
         {
             StringBuilder arguments = new();
-            arguments.Append("format-patch -M -C -B");
+            arguments.Append("format-patch --find-renames --find-copies --break-rewrites");
             if (start is not null)
             {
                 arguments.AppendFormat(" --start-number {0}", start);


### PR DESCRIPTION
A collection of some smaller issues

## Proposed changes

Align git-diff -M -C arguments

GetCurrentChangesCmd() only had the options for Index/staged files but not worktree.
This is not really an error but different from all other diff commands.

git-diff options for rename and copy of files were put in various order which made me confused.
There should be no significance in the ordering, this is a cleanup to avoid dong the investigation again
Order is set to beconsistent and more aligned with Git documentation.

Also, "-M -C" was at one occasion on separate lines, which made this harder to search for.
(The alternative is to change all options to be separated.)

--
Git commands should never have colors

Colors are excluded by default in pipe/file output
However, the user can override the settings
Most common command to override for users seem to be "diff",
why most diff commands have --no-colors arguments.
Also for range-diff
This was also set for for-each-ref, this is not needed

To ensure this is set for all commands use this as a configuration
for the Git commands instead

--
AutoCompletion for .groovy

In commit info, similar as for .cs etc

--
FileViewer: Remove unnecessary null check

Should have been removed at NRT changes

## Test methodology <!-- How did you ensure quality? -->

Tests updated

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
