### PR TITLE
Improve RevisionGridControlTests

### DIFF
--- a/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
@@ -92,7 +92,7 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                     Assert.True(revisionGridControl.IsShowFilteredBranchesChecked);
 
                     var ta = revisionGridControl.GetTestAccessor();
-                    ta.RefFilterOptions.Should().Be(RefFilterOptions.None);
+                    ta.RefFilterOptions.Should().Be(RefFilterOptions.Branches);
                 });
         }
 
@@ -325,6 +325,7 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                     {
                         Console.WriteLine($"{runTest.Method.Name} failed: {ex.Demystify()}");
                         Console.WriteLine(_referenceRepository.Module.GitExecutable.GetOutput("status"));
+                        throw;
                     }
                 });
         }
@@ -358,6 +359,7 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                     {
                         Console.WriteLine($"{runTest.Method.Name} failed: {ex.Demystify()}");
                         Console.WriteLine(_referenceRepository.Module.GitExecutable.GetOutput("status"));
+                        throw;
                     }
 
                     // let the focus events be handled

--- a/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
@@ -173,10 +173,11 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                 {
                     // If showGitStatusForArtificialCommits is false, we do not update ChangeCount and HasChanges returns false.
                     // Then ToggleBetweenArtificialAndHeadCommits does not check HasChanges and toggles through all three commits.
-                    var hasChangesWorkTree = revisionGridControl.GetChangeCount(ObjectId.WorkTreeId).HasChanges;
-                    var hasChangesIndex = revisionGridControl.GetChangeCount(ObjectId.IndexId).HasChanges;
-                    hasChangesWorkTree.Should().Be(showGitStatusForArtificialCommits);
-                    hasChangesIndex.Should().Be(showGitStatusForArtificialCommits);
+                    while (revisionGridControl.GetChangeCount(ObjectId.WorkTreeId).HasChanges != showGitStatusForArtificialCommits
+                        || revisionGridControl.GetChangeCount(ObjectId.IndexId).HasChanges != showGitStatusForArtificialCommits)
+                    {
+                        DoEvents();
+                    }
 
                     revisionGridControl.GoToRef(_initialCommit, showNoRevisionMsg: false);
                     revisionGridControl.LatestSelectedRevision.Guid.Should().Be(_initialCommit);
@@ -204,10 +205,11 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                 showGitStatusForArtificialCommits,
                 revisionGridControl =>
                 {
-                    var hasChangesWorkTree = revisionGridControl.GetChangeCount(ObjectId.WorkTreeId).HasChanges;
-                    var hasChangesIndex = revisionGridControl.GetChangeCount(ObjectId.IndexId).HasChanges;
-                    hasChangesWorkTree.Should().BeFalse();
-                    hasChangesIndex.Should().Be(showGitStatusForArtificialCommits);
+                    while (revisionGridControl.GetChangeCount(ObjectId.WorkTreeId).HasChanges != false
+                        || revisionGridControl.GetChangeCount(ObjectId.IndexId).HasChanges != showGitStatusForArtificialCommits)
+                    {
+                        DoEvents();
+                    }
 
                     revisionGridControl.GoToRef(_initialCommit, showNoRevisionMsg: false);
                     revisionGridControl.LatestSelectedRevision.Guid.Should().Be(_initialCommit);
@@ -240,10 +242,11 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                 showGitStatusForArtificialCommits,
                 revisionGridControl =>
                 {
-                    var hasChangesWorkTree = revisionGridControl.GetChangeCount(ObjectId.WorkTreeId).HasChanges;
-                    var hasChangesIndex = revisionGridControl.GetChangeCount(ObjectId.IndexId).HasChanges;
-                    hasChangesWorkTree.Should().Be(showGitStatusForArtificialCommits);
-                    hasChangesIndex.Should().BeFalse();
+                    while (revisionGridControl.GetChangeCount(ObjectId.WorkTreeId).HasChanges != showGitStatusForArtificialCommits
+                        || revisionGridControl.GetChangeCount(ObjectId.IndexId).HasChanges != false)
+                    {
+                        DoEvents();
+                    }
 
                     revisionGridControl.GoToRef(_initialCommit, showNoRevisionMsg: false);
                     revisionGridControl.LatestSelectedRevision.Guid.Should().Be(_initialCommit);
@@ -274,10 +277,11 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                 showGitStatusForArtificialCommits,
                 revisionGridControl =>
                 {
-                    var hasChangesWorkTree = revisionGridControl.GetChangeCount(ObjectId.WorkTreeId).HasChanges;
-                    var hasChangesIndex = revisionGridControl.GetChangeCount(ObjectId.IndexId).HasChanges;
-                    hasChangesWorkTree.Should().BeFalse();
-                    hasChangesIndex.Should().BeFalse();
+                    while (revisionGridControl.GetChangeCount(ObjectId.WorkTreeId).HasChanges != false
+                        || revisionGridControl.GetChangeCount(ObjectId.IndexId).HasChanges != false)
+                    {
+                        DoEvents();
+                    }
 
                     revisionGridControl.GoToRef(_initialCommit, showNoRevisionMsg: false);
                     revisionGridControl.LatestSelectedRevision.Guid.Should().Be(_initialCommit);


### PR DESCRIPTION
## Proposed changes

- Fixup RevisionGridControlTests:
  - Throw all errors instead of printing them
  - Fixup a wrong test assertion, which was ignored before
- Improve RevisionGridControlTests stability
  by waiting until change counts have been updated, before starting "toggle artificial" tests

## Test methodology <!-- How did you ensure quality? -->

- run the tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 5e6d755b7623f7d1d7f08645ddd679b3973d6e1d
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.6
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).