### PR TITLE
Log errors

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1860,6 +1860,12 @@ namespace GitCommands
             set => SetInt("DiffViewer.AutomaticContinuousScrollDelay", value);
         }
 
+        public static bool WriteErrorLog
+        {
+            get => GetBool("WriteErrorLog", false);
+            set => SetBool("WriteErrorLog", value);
+        }
+
         public static bool IsPortable()
         {
             return Properties.Settings.Default.IsPortable;

--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -68,8 +68,30 @@ namespace GitUI.NBugReports
             }
         }
 
+        private static void LogError(Exception exception, bool isTerminating)
+        {
+            string tempFolder = Path.GetTempPath();
+            string tempFileName = $"{AppSettings.ApplicationId}.{AppSettings.AppVersion}.{DateTime.Now.ToString("yyyyMMdd.HHmmssfff")}.log";
+            string tempFile = Path.Combine(tempFolder, tempFileName);
+
+            try
+            {
+                string content = $"Is fatal: {isTerminating}\r\n{exception}";
+                File.WriteAllText(tempFile, content);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to error to {tempFile}\r\n{ex.Message}", "Error writing log", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
         public static void Report(Exception exception, bool isTerminating)
         {
+            if (AppSettings.WriteErrorLog)
+            {
+                LogError(exception, isTerminating);
+            }
+
             if (isTerminating)
             {
                 // TODO: this is not very efficient

--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -81,7 +81,7 @@ namespace GitUI.NBugReports
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to error to {tempFile}\r\n{ex.Message}", "Error writing log", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show($"Failed to log error to {tempFile}\r\n{ex.Message}", "Error writing log", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 


### PR DESCRIPTION
An attempt to capture an elusive error information for #9166.
Write an error log before showing the bug reporter dialog if `AppSettings.WriteErrorLog=true`.

Contributes to #9166
