### PR TITLE
Avoid `FormatException` from `FormMergeSubmodule`

### DIFF
--- a/GitUI/CommandsDialogs/FormMergeSubmodule.cs
+++ b/GitUI/CommandsDialogs/FormMergeSubmodule.cs
@@ -40,6 +40,7 @@ namespace GitUI.CommandsDialogs
             tbLocal.Text = item.Local.ObjectId?.ToString() ?? _deleted.Text;
             tbRemote.Text = item.Remote.ObjectId?.ToString() ?? _deleted.Text;
             tbCurrent.Text = Module.GetSubmodule(_filename).GetCurrentCheckout()?.ToString() ?? "";
+            btCheckoutBranch.Enabled = item.Base.ObjectId is not null && item.Remote.ObjectId is not null;
         }
 
         private void btRefresh_Click(object sender, EventArgs e)


### PR DESCRIPTION
Fixes part of #7466

## Proposed changes

- Do not attempt to checkout not existing submodules in `FormMergeSubmodule` by disabling the `Checkout branch` button
  since the handler will attempt to parse the `ObjectId`s unconditionally:
```
        private void btCheckoutBranch_Click(object sender, EventArgs e)
        {
            var revisions = new[] { ObjectId.Parse(tbLocal.Text), ObjectId.Parse(tbRemote.Text) };
```

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 0.0.0.0
- Build acd96eaa7f68a7289339c21473baf1f9f9c28548
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.6
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).