### PR TITLE
Preparations for exceptions on git error (part 2)

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1116,19 +1116,11 @@ namespace GitCommands
             {
                 "--parents",
                 "--no-walk",
+                "--min-parents=2",
                 $"{startRev}..{endRev}"
             };
 
-            return _gitExecutable
-                .GetOutputLines(args)
-                .Any(IsTwoSha1Hashes);
-
-            static bool IsTwoSha1Hashes(string parents)
-            {
-                // TODO use Regex here to avoid allocations
-                string[] tab = parents.Split(Delimiters.Space);
-                return tab.Length > 2 && tab.All(parent => GitRevision.Sha1HashRegex.IsMatch(parent));
-            }
+            return _gitExecutable.GetOutputLines(args).Any();
         }
 
         public ConfigFile GetSubmoduleConfigFile()

--- a/GitExtUtils/GitCommandConfiguration.cs
+++ b/GitExtUtils/GitCommandConfiguration.cs
@@ -27,6 +27,7 @@ namespace GitExtUtils
             Default.Add(new GitConfigItem("diff.noprefix", "false"), "diff");
             Default.Add(new GitConfigItem("diff.mnemonicprefix", "false"), "diff");
             Default.Add(new GitConfigItem("diff.ignoreSubmodules", "none"), "diff", "status");
+            Default.Add(new GitConfigItem("core.safecrlf", "false"), "diff");
         }
 
         /// <summary>

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -283,7 +283,8 @@ namespace GitUI.BranchTreePanel
                     return;
                 }
 
-                Nodes newNodes = await loadNodesTask(token);
+                // Module is invalid in Dashboard
+                Nodes newNodes = Module.IsValidGitWorkingDir() ? await loadNodesTask(token) : new(tree: null);
 
                 await treeView.SwitchToMainThreadAsync(token);
 

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -624,9 +624,9 @@ namespace GitCommandsTests.Git.Commands
                 GitCommandHelpers.ApplyMailboxPatchCmd(signOff, ignoreWhitespace, patchFile).Arguments);
         }
 
-        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", false)]
-        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none diff --no-color extra -- ""new""", "new", "old", false, "extra", false)]
-        [TestCase(@"--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", true)]
+        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", false)]
+        [TestCase(@"-c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --no-color extra -- ""new""", "new", "old", false, "extra", false)]
+        [TestCase(@"--no-optional-locks -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --no-color -M -C --cached extra -- ""new"" ""old""", "new", "old", true, "extra", true)]
         public void GetCurrentChangesCmd(string expected, string fileName, string oldFileName, bool staged,
             string extraDiffArguments, bool noLocks)
         {


### PR DESCRIPTION
Some of the preparations for #9056 contributed by @gerhardol

## Proposed changes

- Suppress git warning for safecrlf
  occured if:
  * core.safecrlf is warn or true
  * core.autocrlf is true on Windows
  * a file stored in crlf is edited to lf
  * File is selected in Diff tab
- Let git filter for merge commits instead with own regex
- Avoid git error in Left Panel
  occurred when the ROT is initialized in the Dashboard without a working dir, of course

## Screenshots <!-- Remove this section if PR does not change UI -->

not affected

## Test methodology <!-- How did you ensure quality? -->

- NUnit tests
- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 0.0.0.0
- Build b430c3f01860c5cfaeeee18e72c2a1db456a449a
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.6
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).