### PR TITLE
Left Panel: Check `TreeViewNode.TreeView` for `null`

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Branches.cs
@@ -64,7 +64,7 @@ namespace GitUI.BranchTreePanel
             {
                 base.ApplyStyle();
 
-                TreeViewNode.ForeColor = Visible ? TreeViewNode.TreeView.ForeColor : Color.Silver.AdaptTextColor();
+                TreeViewNode.ForeColor = Visible && TreeViewNode.TreeView is not null ? TreeViewNode.TreeView.ForeColor : Color.Silver.AdaptTextColor();
                 TreeViewNode.ImageKey =
                     TreeViewNode.SelectedImageKey = Visible ? null : nameof(Images.EyeClosed);
             }
@@ -126,7 +126,7 @@ namespace GitUI.BranchTreePanel
 
             protected void SelectRevision()
             {
-                TreeViewNode.TreeView.BeginInvoke(new Action(() =>
+                TreeViewNode.TreeView?.BeginInvoke(new Action(() =>
                 {
                     UICommands.BrowseGoToRef(FullPath, showNoRevisionMsg: true, toggleSelection: ModifierKeys.HasFlag(Keys.Control));
                     TreeViewNode.TreeView?.Focus();
@@ -415,6 +415,12 @@ namespace GitUI.BranchTreePanel
                 if (firstTime)
                 {
                     TreeViewNode.Expand();
+                }
+
+                // Skip hidden node
+                if (TreeViewNode.TreeView is null)
+                {
+                    return;
                 }
 
                 if (TreeViewNode.TreeView.SelectedNode is not null)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -291,6 +291,13 @@ namespace GitUI.BranchTreePanel
                 Nodes.Clear();
                 Nodes.AddNodes(newNodes);
 
+                // Check again after switch to main thread
+                treeView = TreeViewNode.TreeView;
+                if (treeView is null || !IsAttached)
+                {
+                    return;
+                }
+
                 try
                 {
                     string? originalSelectedNodeFullNamePath = treeView.SelectedNode?.GetFullNamePath();
@@ -430,7 +437,7 @@ namespace GitUI.BranchTreePanel
 
             protected IWin32Window? ParentWindow()
             {
-                return TreeViewNode.TreeView.FindForm();
+                return TreeViewNode.TreeView?.FindForm();
             }
 
             protected virtual string DisplayText()


### PR DESCRIPTION
Fixes #9232

## Proposed changes

- Left Panel: Always check `TreeViewNode.TreeView` for `null`

## Screenshots <!-- Remove this section if PR does not change UI -->

not affected

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 0.0.0.0
- Build b988ca34e9a5c9f75f3890058963678fc0d73aec
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.6
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).