### PR TITLE
Ignore `Image.FromHbitmap` failure

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1079,17 +1079,26 @@ namespace GitUI
             int GetWidth()
             {
                 var pathFormatter = new PathFormatter(FileStatusListView.CreateGraphics(), FileStatusListView.Font);
-                var controlWidth = FileStatusListView.ClientSize.Width;
+                int controlWidth = FileStatusListView.ClientSize.Width;
 
-                var contentWidth = FileStatusListView.Items()
-                    .Where(item => item.BoundsOrEmpty().IntersectsWith(FileStatusListView.ClientRectangle))
-                    .Select(item =>
-                    {
-                        (_, _, _, _, int textStart, int textWidth, _) = FormatListViewItem(item, pathFormatter, FileStatusListView.ClientSize.Width);
-                        return textStart + textWidth;
-                    })
-                    .DefaultIfEmpty(controlWidth)
-                    .Max();
+                int contentWidth = 0;
+                try
+                {
+                    contentWidth = FileStatusListView.Items()
+                        .Where(item => item.BoundsOrEmpty().IntersectsWith(FileStatusListView.ClientRectangle))
+                        .Select(item =>
+                        {
+                            (_, _, _, _, int textStart, int textWidth, _) = FormatListViewItem(item, pathFormatter, FileStatusListView.ClientSize.Width);
+                            return textStart + textWidth;
+                        })
+                        .DefaultIfEmpty(controlWidth)
+                        .Max();
+                }
+                catch (Exception)
+                {
+                    // See https://github.com/gitextensions/gitextensions/issues/9166#issuecomment-849567022
+                    // A rather obscure bug report, which may be causing random app crashes
+                }
 
                 return Math.Max(contentWidth, controlWidth);
             }


### PR DESCRIPTION
See https://github.com/gitextensions/gitextensions/issues/9166#issuecomment-849567022

```
Is fatal: False
System.Runtime.InteropServices.ExternalException (0x80004005): A generic error occurred in GDI+.
   at System.Drawing.Image.FromHbitmap(IntPtr hbitmap, IntPtr hpalette)
   at System.Drawing.Image.FromHbitmap(IntPtr hbitmap)
   at System.Windows.Forms.ImageList.GetBitmap(Int32 index)
   at System.Windows.Forms.ImageList.ImageCollection.get_Item(Int32 index)
   at GitUI.ListViewExtensions.Image(ListViewItem item)
   at GitUI.FileStatusList.FormatListViewItem(ListViewItem item, PathFormatter formatter, Int32 itemWidth)
   at GitUI.FileStatusList.<>c__DisplayClass127_0.<UpdateColumnWidth>b__2(ListViewItem item)
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Linq.Enumerable.<DefaultIfEmptyIterator>d__93`1.MoveNext()
   at System.Linq.Enumerable.Max(IEnumerable`1 source)
   at GitUI.FileStatusList.<UpdateColumnWidth>g__GetWidth|127_0()
   at GitUI.FileStatusList.UpdateColumnWidth()
   at GitUI.FileStatusList.UpdateFileStatusListView(Boolean updateCausedByFilter)
   at GitUI.FileStatusList.set_GitItemStatusesWithDescription(IReadOnlyList`1 value)
   at GitUI.FileStatusList.SetDiffs(IReadOnlyList`1 revisions, Func`2 getRevision)
   at GitUI.CommandsDialogs.RevisionDiffControl.SetDiffs(IReadOnlyList`1 revisions)
   at GitUI.CommandsDialogs.RevisionDiffControl.DisplayDiffTab(IReadOnlyList`1 revisions)
   at GitUI.CommandsDialogs.FormBrowse.FillDiff(IReadOnlyList`1 revisions)
   at GitUI.CommandsDialogs.FormBrowse.RefreshSelection()
   at GitUI.CommandsDialogs.FormBrowse.<.ctor>b__45_4(Object sender, EventArgs e)
   at GitUI.RevisionGridControl.<.ctor>b__123_0(Object _, EventArgs e)
   at System.Windows.Forms.Timer.OnTick(EventArgs e)
   at System.Windows.Forms.Timer.TimerNativeWindow.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```