### PR TITLE
Use static/cached GitVersion to resolve Git path

### DIFF
--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -43,6 +43,11 @@ namespace GitCommands
             }
         }
 
+        public static void ResetVersion()
+        {
+            _current = null;
+        }
+
         public readonly string Full;
         private readonly int _a;
         private readonly int _b;

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -336,6 +336,7 @@ namespace GitCommands
             }
             set
             {
+                GitVersion.ResetVersion();
                 if (IsPortable())
                 {
                     SetString("gitcommand", value);

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -177,6 +177,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             {
                 try
                 {
+                    // Use cached version if possible
+                    if (AppSettings.GitCommand == command && !(GitVersion.Current?.IsUnknown ?? true))
+                    {
+                        return true;
+                    }
+
                     string output = new Executable(command).GetOutput(arguments: "--version");
                     if (!string.IsNullOrEmpty(output))
                     {

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -178,7 +178,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 try
                 {
                     // Use cached version if possible
-                    if (AppSettings.GitCommand == command && !(GitVersion.Current?.IsUnknown ?? true))
+                    if (AppSettings.GitCommand == command && GitVersion.Current?.IsUnknown is false)
                     {
                         return true;
                     }


### PR DESCRIPTION
Part of #9229 

## Proposed changes

- Reset GitVersion cache when setting Git command path
Report new GitVersion after changes

- Use static/cached GitVersion to resolve Git path
This eliminates one `git --version` command during startup. At home this is about 35ms, at work 230ms (probably serialized, so delaying the startup considerably).

## Test methodology <!-- How did you ensure quality? -->

Tests exist
Manual
See Git Command Log for executed command, modify gitcommand path in registry to simulate issues

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
