### PR TITLE
Catch GDI exception

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1886,6 +1886,12 @@ namespace GitCommands
             return Properties.Settings.Default.IsPortable;
         }
 
+        public static bool WriteErrorLog
+        {
+            get => GetBool("WriteErrorLog", false);
+            set => SetBool("WriteErrorLog", value);
+        }
+
         private static IEnumerable<(string name, string value)> GetSettingsFromRegistry()
         {
             RegistryKey oldSettings = VersionIndependentRegKey.OpenSubKey("GitExtensions");

--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Windows.Forms;
 using BugReporter;
 using BugReporter.Serialization;
+using GitCommands;
 using GitExtUtils;
 
 namespace GitUI.NBugReports
@@ -68,8 +69,30 @@ namespace GitUI.NBugReports
             }
         }
 
+        public static void LogError(Exception exception, bool isTerminating = false)
+        {
+            string tempFolder = Path.GetTempPath();
+            string tempFileName = $"{AppSettings.ApplicationId}.{AppSettings.AppVersion}.{DateTime.Now.ToString("yyyyMMdd.HHmmssfff")}.log";
+            string tempFile = Path.Combine(tempFolder, tempFileName);
+
+            try
+            {
+                string content = $"Is fatal: {isTerminating}\r\n{exception}";
+                File.WriteAllText(tempFile, content);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to log error to {tempFile}\r\n{ex.Message}", "Error writing log", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
         public static void Report(Exception exception, bool isTerminating)
         {
+            if (AppSettings.WriteErrorLog)
+            {
+                LogError(exception, isTerminating);
+            }
+
             if (isTerminating)
             {
                 // TODO: this is not very efficient


### PR DESCRIPTION
#9245 and #9227 for dev branch

## Proposed changes

- Log exceptions to files in `%TEMP%` if enabled using `AppSettings.WriteErrorLog`
- Catch `System.Runtime.InteropServices.ExternalException` in `FileStatusList.UpdateColumnWidth` and log it to `%TEMP%`

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build e8aea1db1b9ffd3fdfe5b00d84ab8678838f322a
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.6
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
