### PR TITLE
RevGrid multiline indicators 3.5

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -100,11 +100,13 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
             if (!revision.IsArtificial && (revision.HasMultiLineMessage || revision.Refs.Count != 0))
             {
-                var bodySummary = _gitRevisionSummaryBuilder.BuildSummary(revision.Body);
-                var initialLength = (bodySummary?.Length ?? 50) + 10;
+                // The body is not stored for older commits (to save memory)
+                string bodySummary = _gitRevisionSummaryBuilder.BuildSummary(revision.Body)
+                    ?? revision.Subject + (revision.HasMultiLineMessage ? Strings.BodyNotLoaded : "");
+                int initialLength = bodySummary.Length + 10;
                 _toolTipBuilder.EnsureCapacity(initialLength);
 
-                _toolTipBuilder.Append(bodySummary ?? revision.Subject + Strings.BodyNotLoaded);
+                _toolTipBuilder.Append(bodySummary);
 
                 if (revision.Refs.Count != 0)
                 {

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -406,6 +406,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
             if (lines.Length == 1)
             {
+                indicator.Render();
                 return;
             }
 


### PR DESCRIPTION
Two issues from #9243 for 3.5
(unknown when the regressions occurred)

## Proposed changes

These issues relate to that the commit body is not stored for commits older than 6 months.
The subject and info if the commit has multiline info is always available.
If you select the commit in the grid, the full body is loaded (again).

- RevGrid tooltip: Only show "click to load" for multiline
This occurred if the commit had any related refs.

- Multiline indicator only shown if Body is available
Note that there is no tooltip if there are no refs or multiline. Without the multiline indicator it is hard to understand why.

## Screenshots <!-- Remove this section if PR does not change UI -->

before|after
--|--
![image](https://user-images.githubusercontent.com/6248932/120396362-b955f280-c336-11eb-8934-145a8818f689.png) | ![image](https://user-images.githubusercontent.com/6248932/120395383-2ec0c380-c335-11eb-888a-6de23d27eccf.png)

## Test methodology <!-- How did you ensure quality? -->

manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
