### PR TITLE
Display appropriate message when deleting branch checked out at another worktree

### DIFF
--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -540,5 +540,10 @@ namespace GitCommands.Git.Commands
                 branch
             };
         }
+
+        public static ArgumentString ListWorkTreeCmd()
+        {
+            return new GitArgumentBuilder("worktree") { "list", "--porcelain" };
+        }
     }
 }

--- a/GitCommands/Git/WorkTrees/GitWorkTree.cs
+++ b/GitCommands/Git/WorkTrees/GitWorkTree.cs
@@ -1,0 +1,12 @@
+namespace GitCommands.Git.WorkTrees
+{
+    public class GitWorkTree
+    {
+        public string? Path { get; set; }
+        public HeadType Type { get; set; }
+        public string? Sha1 { get; set; }
+        public string? CompleteBranchName { get; set; }
+        public string? BranchName { get; set; }
+        public bool IsDeleted { get; set; }
+    }
+}

--- a/GitCommands/Git/WorkTrees/HeadType.cs
+++ b/GitCommands/Git/WorkTrees/HeadType.cs
@@ -1,0 +1,9 @@
+namespace GitCommands.Git.WorkTrees
+{
+    public enum HeadType
+    {
+        Bare,
+        Branch,
+        Detached
+    }
+}

--- a/GitCommands/Git/WorkTrees/ListWorkTreeOutputParser.cs
+++ b/GitCommands/Git/WorkTrees/ListWorkTreeOutputParser.cs
@@ -63,7 +63,7 @@ namespace GitCommands.Git.WorkTrees
                         Validates.NotNull(currentWorktree);
                         currentWorktree.Type = HeadType.Branch;
                         currentWorktree.CompleteBranchName = strings[1];
-                        currentWorktree.BranchName = strings[1].Replace("refs/heads/", string.Empty);
+                        currentWorktree.BranchName = strings[1].Replace(GitRefName.RefsHeadsPrefix, string.Empty);
                         break;
                     case "detached":
                         Validates.NotNull(currentWorktree);

--- a/GitCommands/Git/WorkTrees/ListWorkTreeOutputParser.cs
+++ b/GitCommands/Git/WorkTrees/ListWorkTreeOutputParser.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.IO;
+using GitCommands.Git.Commands;
+using GitExtUtils;
+using Microsoft;
+
+namespace GitCommands.Git.WorkTrees
+{
+    /// <summary>
+    /// Provides a parser for output of <see cref="GitCommandHelpers.ListWorkTreeCmd"/> command.
+    /// </summary>
+    public class ListWorkTreeOutputParser
+    {
+        /// <summary>
+        /// Parse the output from <see cref="GitCommandHelpers.ListWorkTreeCmd"/> command
+        /// </summary>
+        /// <param name="listWorkTreeCommandOutput">An output of <see cref="GitCommandHelpers.ListWorkTreeCmd"/> command.</param>
+        /// <returns>list with the parsed GitWorkTree.</returns>
+        /// <seealso href="https://git-scm.com/docs/git-worktree"/>
+        public static List<GitWorkTree> Parse(string listWorkTreeCommandOutput)
+        {
+            // Here are the 3 types of lines return by the `worktree list --porcelain` that should be handled:
+            //
+            // 1:
+            // worktree /path/to/bare-source
+            // bare
+            //
+            // 2:
+            // worktree /path/to/linked-worktree
+            // HEAD abcd1234abcd1234abcd1234abcd1234abcd1234
+            // branch refs/heads/master
+            //
+            // 3:
+            // worktree /path/to/other-linked-worktree
+            // HEAD 1234abc1234abc1234abc1234abc1234abc1234a
+            // detached.
+            List<GitWorkTree> result = new();
+            GitWorkTree? currentWorktree = null;
+            foreach (string line in listWorkTreeCommandOutput.LazySplit('\n'))
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                string[] strings = line.Split(' ');
+                switch (strings[0])
+                {
+                    case "worktree":
+                        currentWorktree = new GitWorkTree { Path = line.Substring(9) };
+                        currentWorktree.IsDeleted = !Directory.Exists(currentWorktree.Path);
+                        result.Add(currentWorktree);
+                        break;
+                    case "HEAD":
+                        Validates.NotNull(currentWorktree);
+                        currentWorktree.Sha1 = strings[1];
+                        break;
+                    case "bare":
+                        Validates.NotNull(currentWorktree);
+                        currentWorktree.Type = HeadType.Bare;
+                        break;
+                    case "branch":
+                        Validates.NotNull(currentWorktree);
+                        currentWorktree.Type = HeadType.Branch;
+                        currentWorktree.CompleteBranchName = strings[1];
+                        currentWorktree.BranchName = strings[1].Replace("refs/heads/", string.Empty);
+                        break;
+                    case "detached":
+                        Validates.NotNull(currentWorktree);
+                        currentWorktree.Type = HeadType.Detached;
+                        break;
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -48,7 +48,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
             Path.DataPropertyName = nameof(GitWorkTree.Path);
             Type.DataPropertyName = nameof(GitWorkTree.Type);
-            Branch.DataPropertyName = nameof(GitWorkTree.CompleteBranchName);
+            Branch.DataPropertyName = nameof(GitWorkTree.BranchName);
             Sha1.DataPropertyName = nameof(GitWorkTree.Sha1);
             IsDeleted.DataPropertyName = nameof(GitWorkTree.IsDeleted);
         }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -4034,8 +4034,16 @@ You can unset the template:
         <source>Force delete</source>
         <target />
       </trans-unit>
+      <trans-unit id="_branchPathMessage.Text">
+        <source> - "{0}" checked out at "{1}"</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_cannotDeleteCurrentBranchMessage.Text">
-        <source>Cannot delete the branch “{0}” which you are currently on.</source>
+        <source>Cannot delete the branch "{0}" which you are currently on.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_cannotDeleteWorktreeBranchMessage.Text">
+        <source>Cannot delete branch(es):</source>
         <target />
       </trans-unit>
       <trans-unit id="_deleteBranchCaption.Text">
@@ -4048,7 +4056,7 @@ Deleting a branch can cause commits to be deleted too!</source>
         <target />
       </trans-unit>
       <trans-unit id="_deleteUnmergedBranchForcingSuggestion.Text">
-        <source>You cannot delete unmerged branch until you set “force delete” mode.</source>
+        <source>You cannot delete unmerged branch until you set "force delete" mode.</source>
         <target />
       </trans-unit>
       <trans-unit id="labelDeleteBranchWarning.Text">

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -684,5 +684,11 @@ namespace GitCommandsTests.Git.Commands
         {
             Assert.AreEqual(expected, GitCommandHelpers.GetRefsCmd(getRefs, noLocks, sortBy, sortOrder, count).ToString());
         }
+
+        [Test]
+        public void ListWorkTreeCmd()
+        {
+            Assert.AreEqual("worktree list --porcelain", GitCommandHelpers.ListWorkTreeCmd().Arguments);
+        }
     }
 }

--- a/UnitTests/GitCommands.Tests/Git/WorkTree/ListWorkTreeOutputParserTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/WorkTree/ListWorkTreeOutputParserTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Reflection;
+using CommonTestUtils;
+using FluentAssertions;
+using GitCommands.Git.WorkTrees;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Git.WorkTree
+{
+    [TestFixture]
+    public class ListWorkTreeOutputParserTests
+    {
+        [TestCase("")]
+        [TestCase("  ")]
+        [TestCase("Lorem ipsum dolor sit amet, solet soleat option mel no.")]
+        public void Parse_should_return_empty_list(string output)
+        {
+            List<GitWorkTree> worktrees = ListWorkTreeOutputParser.Parse(output);
+            Assert.AreEqual(0, worktrees.Count);
+        }
+
+        [Test]
+        public void Parse_should_return_three_valid_items()
+        {
+            string resourceName = $"{GetType().Namespace}.MockData.List_worktree_output.txt";
+            string output = EmbeddedResourceLoader.Load(Assembly.GetExecutingAssembly(), resourceName);
+            List<GitWorkTree> worktrees = ListWorkTreeOutputParser.Parse(output);
+
+            Assert.AreEqual(3, worktrees.Count);
+
+            Assert.AreEqual("/path/to/bare-source", worktrees[0].Path);
+            Assert.AreEqual(HeadType.Bare, worktrees[0].Type);
+            Assert.AreEqual(null, worktrees[0].CompleteBranchName);
+            Assert.AreEqual(null, worktrees[0].BranchName);
+            Assert.AreEqual(null, worktrees[0].Sha1);
+
+            Assert.AreEqual("/path/to/linked-worktree", worktrees[1].Path);
+            Assert.AreEqual(HeadType.Branch, worktrees[1].Type);
+            Assert.AreEqual("refs/heads/master", worktrees[1].CompleteBranchName);
+            Assert.AreEqual("master", worktrees[1].BranchName);
+            Assert.AreEqual("abcd1234abcd1234abcd1234abcd1234abcd1234", worktrees[1].Sha1);
+
+            Assert.AreEqual("/path/to/other-linked-worktree", worktrees[2].Path);
+            Assert.AreEqual(HeadType.Detached, worktrees[2].Type);
+            Assert.AreEqual(null, worktrees[2].CompleteBranchName);
+            Assert.AreEqual(null, worktrees[2].BranchName);
+            Assert.AreEqual("1234abc1234abc1234abc1234abc1234abc1234a", worktrees[2].Sha1);
+        }
+    }
+}

--- a/UnitTests/GitCommands.Tests/Git/WorkTree/MockData/List_worktree_output.txt
+++ b/UnitTests/GitCommands.Tests/Git/WorkTree/MockData/List_worktree_output.txt
@@ -1,0 +1,10 @@
+worktree /path/to/bare-source
+bare
+
+worktree /path/to/linked-worktree
+HEAD abcd1234abcd1234abcd1234abcd1234abcd1234
+branch refs/heads/master
+
+worktree /path/to/other-linked-worktree
+HEAD 1234abc1234abc1234abc1234abc1234abc1234a
+detached

--- a/UnitTests/GitCommands.Tests/GitCommands.Tests.csproj
+++ b/UnitTests/GitCommands.Tests/GitCommands.Tests.csproj
@@ -21,6 +21,7 @@
     <EmbeddedResource Include="Helpers\MockData\WindowsLines.bin" />
     <EmbeddedResource Include="MockData\Too_long_lines.txt" />
     <EmbeddedResource Include="MockData\Too_many_lines.txt" />
+    <EmbeddedResource Include="Git\WorkTree\MockData\List_worktree_output.txt" />
     <None Include="Patches\testdata\big.patch">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

Fixes #7669

- Now the message box says that branch cannot be deleted because it is not merged but in reality the branch is merged but checked out at another worktree. This PR adds additional checks for this situation and displays appropriate message.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

 - Attempt to delete

![delete_mergd](https://user-images.githubusercontent.com/4993430/120528103-be24b000-c3e3-11eb-9e5a-c1bb8e6c7509.png)

- `Force delete` checked

![delete_mergd_force](https://user-images.githubusercontent.com/4993430/120528274-f0361200-c3e3-11eb-9df3-eca4e93bff3f.png)

### After

- Attempt to delete several branches

![delete_mergd_new](https://user-images.githubusercontent.com/4993430/120528368-0c39b380-c3e4-11eb-89f3-9bec8c799f28.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.31.1 <!-- Add version 2.11 or above -->
- Windows 7 SP1 <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
