### PR TITLE
Limit superproject refs in rev grid

### DIFF
--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -80,7 +80,7 @@ namespace GitCommands.Git.Commands
                 };
         }
 
-        public static ArgumentString GetRefsCmd(RefsFilter getRef, bool noLocks, GitRefsSortBy sortBy, GitRefsSortOrder sortOrder)
+        public static ArgumentString GetRefsCmd(RefsFilter getRef, bool noLocks, GitRefsSortBy sortBy, GitRefsSortOrder sortOrder, int count = 0)
         {
             bool hasTags = (getRef == RefsFilter.NoFilter) || (getRef & RefsFilter.Tags) != 0;
 
@@ -91,6 +91,7 @@ namespace GitCommands.Git.Commands
             {
                 SortCriteria(hasTags, sortBy, sortOrder),
                 GitRefsFormat(hasTags),
+                { count > 0, $"--count={count}" },
                 GitRefsPattern(getRef)
             };
 
@@ -334,38 +335,6 @@ namespace GitCommands.Git.Commands
                 { all, "--tags" },
                 { !all, $"tag {tag.Replace(" ", "")}" }
             };
-        }
-
-        public static ArgumentString GetSortedRefsCommand(bool noLocks = false)
-        {
-            if (AppSettings.ShowSuperprojectRemoteBranches)
-            {
-                return new GitArgumentBuilder("for-each-ref", gitOptions:
-                    noLocks && GitVersion.Current.SupportNoOptionalLocks
-                        ? (ArgumentString)"--no-optional-locks"
-                        : default)
-                {
-                    "--sort=-committerdate",
-                    "--format=\"%(objectname) %(refname)\"",
-                    "refs/"
-                };
-            }
-
-            if (AppSettings.ShowSuperprojectBranches || AppSettings.ShowSuperprojectTags)
-            {
-                return new GitArgumentBuilder("for-each-ref", gitOptions:
-                    noLocks && GitVersion.Current.SupportNoOptionalLocks
-                        ? (ArgumentString)"--no-optional-locks"
-                        : default)
-                {
-                    "--sort=-committerdate",
-                    "--format=\"%(objectname) %(refname)\"",
-                    { AppSettings.ShowSuperprojectBranches, "refs/heads/" },
-                    { AppSettings.ShowSuperprojectTags, " refs/tags/" }
-                };
-            }
-
-            return "";
         }
 
         public static ArgumentString StashSaveCmd(bool untracked, bool keepIndex, string message, IReadOnlyList<string>? selectedFiles)

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -58,7 +58,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 if (spi.Refs is not null && revision.ObjectId is not null &&
                     spi.Refs.TryGetValue(revision.ObjectId, out var refs))
                 {
-                    superprojectRefs.AddRange(refs.Where(RevisionGridControl.ShowRemoteRef));
+                    superprojectRefs.AddRange(refs);
                 }
             }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -801,26 +801,6 @@ namespace GitUI
             Translator.Translate(this, AppSettings.CurrentTranslation);
         }
 
-        internal static bool ShowRemoteRef(IGitRef r)
-        {
-            if (r.IsTag)
-            {
-                return AppSettings.ShowSuperprojectTags;
-            }
-
-            if (r.IsHead)
-            {
-                return AppSettings.ShowSuperprojectBranches;
-            }
-
-            if (r.IsRemote)
-            {
-                return AppSettings.ShowSuperprojectRemoteBranches;
-            }
-
-            return false;
-        }
-
         private void ShowLoading(bool sync = true)
         {
             _loadingControlSync.Visible = sync;
@@ -995,7 +975,7 @@ namespace GitUI
                 _superprojectCurrentCheckout = null;
                 ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
-                    var scc = await GetSuperprojectCheckoutAsync(ShowRemoteRef, capturedModule, noLocks: true);
+                    var scc = await GetSuperprojectCheckoutAsync(capturedModule, noLocks: true);
                     await this.SwitchToMainThreadAsync();
 
                     if (_superprojectCurrentCheckout != scc)
@@ -1156,7 +1136,7 @@ namespace GitUI
             }
         }
 
-        private static async Task<SuperProjectInfo?> GetSuperprojectCheckoutAsync(Func<IGitRef, bool> showRemoteRef, GitModule gitModule, bool noLocks = false)
+        private static async Task<SuperProjectInfo?> GetSuperprojectCheckoutAsync(GitModule gitModule, bool noLocks = false)
         {
             if (gitModule.SuperprojectModule is null)
             {
@@ -1179,7 +1159,7 @@ namespace GitUI
                 spi.CurrentBranch = commit;
             }
 
-            var refs = await gitModule.SuperprojectModule.GetSubmoduleItemsForEachRefAsync(gitModule.SubmodulePath, showRemoteRef, noLocks: noLocks);
+            var refs = await gitModule.SuperprojectModule.GetSubmoduleItemsForEachRefAsync(gitModule.SubmodulePath, noLocks: noLocks);
 
             if (refs is not null)
             {

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -634,13 +634,6 @@ namespace GitCommandsTests.Git.Commands
                 extraDiffArguments, noLocks).ToString());
         }
 
-        [TestCase(@"for-each-ref --sort=-committerdate --format=""%(objectname) %(refname)"" refs/heads/", false)]
-        [TestCase(@"--no-optional-locks for-each-ref --sort=-committerdate --format=""%(objectname) %(refname)"" refs/heads/", true)]
-        public void GetSortedRefsCommand(string expected, bool noLocks)
-        {
-            Assert.AreEqual(expected, GitCommandHelpers.GetSortedRefsCommand(noLocks).ToString());
-        }
-
         private static IEnumerable<TestCaseData> GetRefsCommandTestData
         {
             get
@@ -664,20 +657,22 @@ namespace GitCommandsTests.Git.Commands
                             sortConditionRef = $" --sort={prefix}*{sortBy}";
                         }
 
-                        yield return new TestCaseData(RefsFilter.Tags | RefsFilter.Heads | RefsFilter.Remotes, /* noLocks */ false, sortBy, sortOrder,
+                        yield return new TestCaseData(RefsFilter.Tags | RefsFilter.Heads | RefsFilter.Remotes, /* noLocks */ false, sortBy, sortOrder, 0,
                             /* expected */ $@"for-each-ref{sortConditionRef}{sortCondition}{format} refs/heads/ refs/remotes/ refs/tags/");
-                        yield return new TestCaseData(RefsFilter.Tags, /* noLocks */ false, sortBy, sortOrder,
+                        yield return new TestCaseData(RefsFilter.Tags, /* noLocks */ false, sortBy, sortOrder, 0,
                             /* expected */ $@"for-each-ref{sortConditionRef}{sortCondition}{format} refs/tags/");
-                        yield return new TestCaseData(RefsFilter.Heads, /* noLocks */ false, sortBy, sortOrder,
+                        yield return new TestCaseData(RefsFilter.Heads, /* noLocks */ false, sortBy, sortOrder, 0,
                             /* expected */ $@"for-each-ref{sortCondition}{formatNoTag} refs/heads/");
-                        yield return new TestCaseData(RefsFilter.Heads, /* noLocks */ true, sortBy, sortOrder,
+                        yield return new TestCaseData(RefsFilter.Heads, /* noLocks */ false, sortBy, sortOrder, 100,
+                            /* expected */ $@"for-each-ref{sortCondition}{formatNoTag} --count=100 refs/heads/");
+                        yield return new TestCaseData(RefsFilter.Heads, /* noLocks */ true, sortBy, sortOrder, 0,
                             /* expected */ $@"--no-optional-locks for-each-ref{sortCondition}{formatNoTag} refs/heads/");
-                        yield return new TestCaseData(RefsFilter.Remotes, /* noLocks */ false, sortBy, sortOrder,
+                        yield return new TestCaseData(RefsFilter.Remotes, /* noLocks */ false, sortBy, sortOrder, 0,
                             /* expected */ $@"for-each-ref{sortCondition}{formatNoTag} refs/remotes/");
 
-                        yield return new TestCaseData(RefsFilter.NoFilter, /* noLocks */ true, sortBy, sortOrder,
+                        yield return new TestCaseData(RefsFilter.NoFilter, /* noLocks */ true, sortBy, sortOrder, 0,
                             /* expected */ $@"--no-optional-locks for-each-ref{sortConditionRef}{sortCondition}{format}");
-                        yield return new TestCaseData(RefsFilter.Tags | RefsFilter.Heads | RefsFilter.Remotes | RefsFilter.NoFilter, /* noLocks */ true, sortBy, sortOrder,
+                        yield return new TestCaseData(RefsFilter.Tags | RefsFilter.Heads | RefsFilter.Remotes | RefsFilter.NoFilter, /* noLocks */ true, sortBy, sortOrder, 0,
                             /* expected */ $@"--no-optional-locks for-each-ref{sortConditionRef}{sortCondition}{format} refs/heads/ refs/remotes/ refs/tags/");
                     }
                 }
@@ -685,9 +680,9 @@ namespace GitCommandsTests.Git.Commands
         }
 
         [TestCaseSource(nameof(GetRefsCommandTestData))]
-        public void GetRefsCmd(RefsFilter getRefs, bool noLocks, GitRefsSortBy sortBy, GitRefsSortOrder sortOrder, string expected)
+        public void GetRefsCmd(RefsFilter getRefs, bool noLocks, GitRefsSortBy sortBy, GitRefsSortOrder sortOrder, int count, string expected)
         {
-            Assert.AreEqual(expected, GitCommandHelpers.GetRefsCmd(getRefs, noLocks, sortBy, sortOrder).ToString());
+            Assert.AreEqual(expected, GitCommandHelpers.GetRefsCmd(getRefs, noLocks, sortBy, sortOrder, count).ToString());
         }
     }
 }


### PR DESCRIPTION
Part of #9229

## Proposed changes

Limit the number of super project refs shown in a submodule.
The value is hardcoded to 100, could be a default in AppSettings so users could override if they want to see more even if this is not exposed in settings.
Maybe the number of references should be tweaked to an even lower value than 100.

![image](https://user-images.githubusercontent.com/6248932/120717317-a0c91200-c4c7-11eb-8c9f-784a07a9b13d.png)

![image](https://user-images.githubusercontent.com/6248932/120717965-c99dd700-c4c8-11eb-8ecc-d70e0f43bbbc.png)

The superproject branches can be interesting in a subrepo, but with a large number of refs (I have 1200 in my GE repo) the listing of superproject branches/remotes/tags require some time, so the update takes time. Quite some CPU load is used (in background) and the Git Command log is stalling the application if open.

This also cleans up the code, an unnecessary command to candle git-for-each-ref was removed. Note that the call was incorrect for tags, fixed in the "common" variant for 3.3 or so.

## Test methodology <!-- How did you ensure quality? -->

Tests are updated

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
