### PR TITLE
Update Clone dialog's handling of clipboard text

### DIFF
--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -13,11 +13,6 @@ namespace GitCommands
         private static readonly IEnvironmentAbstraction EnvironmentAbstraction = new EnvironmentAbstraction();
         private static readonly IEnvironmentPathsProvider EnvironmentPathsProvider = new EnvironmentPathsProvider(EnvironmentAbstraction);
 
-        // URL regex obtained from https://www.regextester.com/53716 with some modifications
-        private static readonly Regex UrlRegex = new(
-            @"(?:(?:https?|ftp|file|ssh|git):\/\/|www\.)(?:[-A-Z0-9+&@#\/%=~_|$?!:,.])*(?:[A-Z0-9+&@#\/%=~_|$])",
-            RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
         public static readonly char PosixDirectorySeparatorChar = '/';
         public static readonly char NativeDirectorySeparatorChar = Path.DirectorySeparatorChar;
 
@@ -75,23 +70,6 @@ namespace GitCommands
             return !Regex.IsMatch(fileName, @"^(\w+):\/\/([\S]+)");
         }
 
-        /// <summary>
-        /// A slightly less naive way to check whether the given path is a URL by checking
-        /// whether it matches a regular expression defined in <see cref="UrlRegex"/>.
-        /// </summary>
-        /// <remarks>
-        /// Certain strings such as "http://" or "ssh:" are not considered valid URLs
-        /// as they don't have a host, port or path.
-        /// </remarks>
-        /// <param name="path">A path to check.</param>
-        /// <returns><see langword="true"/> if the given path starts with 'http', 'ssh' or 'git'; otherwise <see langword="false"/>.</returns>
-        [Pure]
-        public static bool IsUrl(string? path)
-        {
-            return !string.IsNullOrEmpty(path)
-                && UrlRegex.IsMatch(path);
-        }
-
         public static bool CanBeGitURL(string? url)
         {
             if (string.IsNullOrWhiteSpace(url))
@@ -99,7 +77,7 @@ namespace GitCommands
                 return false;
             }
 
-            return IsUrl(url)
+            return Uri.IsWellFormedUriString(url, UriKind.Absolute)
                    || url.EndsWith(".git", StringComparison.CurrentCultureIgnoreCase)
                    || GitModule.IsValidGitWorkingDir(url);
         }

--- a/GitCommands/UserRepositoryHistory/LocalRepositoryManager.cs
+++ b/GitCommands/UserRepositoryHistory/LocalRepositoryManager.cs
@@ -85,7 +85,7 @@ namespace GitCommands.UserRepositoryHistory
                 throw new ArgumentException(nameof(repositoryPath));
             }
 
-            if (PathUtil.IsUrl(repositoryPath))
+            if (Uri.IsWellFormedUriString(repositoryPath, UriKind.Absolute))
             {
                 // TODO: throw a specific exception
                 throw new NotSupportedException();

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -289,7 +289,7 @@ namespace GitUI.CommandsDialogs
         private bool PushChanges(IWin32Window? owner)
         {
             ErrorOccurred = false;
-            if (PushToUrl.Checked && !PathUtil.IsUrl(PushDestination.Text))
+            if (PushToUrl.Checked && !Uri.IsWellFormedUriString(PushDestination.Text, UriKind.Absolute))
             {
                 MessageBox.Show(owner, _selectDestinationDirectory.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCloneTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCloneTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CommonTestUtils;
+using FluentAssertions;
+using GitCommands.Git;
+using GitUI;
+using GitUI.CommandsDialogs;
+using NUnit.Framework;
+
+namespace GitExtensions.UITests.CommandsDialogs
+{
+    [Apartment(ApartmentState.STA)]
+    public class FormCloneTests
+    {
+        // Created once for the fixture
+        private ReferenceRepository _referenceRepository;
+
+        // Created once for each test
+        private GitUICommands _commands;
+
+        [SetUp]
+        public void SetUp()
+        {
+            if (_referenceRepository is null)
+            {
+                _referenceRepository = new ReferenceRepository();
+            }
+            else
+            {
+                _referenceRepository.Reset();
+            }
+
+            _commands = new GitUICommands(_referenceRepository.Module);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _referenceRepository.Dispose();
+        }
+
+        [TestCase(null, false, "")]
+        [TestCase("", false, "")]
+        [TestCase(" ", false, "")]
+        [TestCase("blah", false, "")]
+        [TestCase("git clone https://github.com/gitextensions/gitextensions && cd gitextensions", true, "https://github.com/gitextensions/gitextensions")]
+        [TestCase("git clone ssh://username@gerrit-server:/PROJECT", true, "ssh://username@gerrit-server:/PROJECT")]
+        [TestCase("git clone https://github.com/gitextensions/gitextensions && git clone https://github.com/gitextensions/git.hub", true, "https://github.com/gitextensions/gitextensions")]
+        public void Test_Url_extract_from_string(
+            string text, bool expected, string expectedUrl)
+        {
+            RunFormTest(
+                form =>
+                {
+                    var accessor = form.GetTestAccessor();
+
+                    accessor.TryExtractUrl(text, out var url).Should().Equals(expected);
+
+                    // No need to compare URL if the result was expected to be false
+                    if (expected)
+                    {
+                        url.Should().Equals(expectedUrl);
+                    }
+                });
+        }
+
+        private void RunFormTest(Action<FormClone> testDriver)
+        {
+            RunFormTest(
+                form =>
+                {
+                    testDriver(form);
+                    return Task.CompletedTask;
+                });
+        }
+
+        private void RunFormTest(Func<FormClone, Task> testDriverAsync)
+        {
+            UITest.RunForm(
+                () =>
+                {
+                    _commands.StartCloneDialog(owner: null, url: null);
+                },
+                testDriverAsync);
+        }
+    }
+}

--- a/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
@@ -101,22 +101,6 @@ namespace GitCommandsTests.Helpers
             Assert.AreEqual(PathUtil.IsLocalFile("ssh://domain\\user@serverip/cache/git/something/something.git"), false);
         }
 
-        [TestCase(null, false)]
-        [TestCase("", false)]
-        [TestCase("    ", false)]
-        [TestCase("http://", false)]
-        [TestCase("HTTPS://www", true)]
-        [TestCase("git://", false)]
-        [TestCase("file:", false)]
-        [TestCase("SSH:", false)]
-        [TestCase("SSH", false)]
-        [TestCase("rtsp://probably.not.a.git.url/default.mp4", false)]
-        [TestCase("https://myhost:12368/", true)]
-        public void IsUrl(string path, bool expected)
-        {
-            PathUtil.IsUrl(path).Should().Be(expected);
-        }
-
         [Test]
         public void GetFileNameTest()
         {
@@ -331,12 +315,17 @@ namespace GitCommandsTests.Helpers
         [TestCase("https://github.com/gitextensions/gitextensions", true)]
         [TestCase("https://github.com/gitextensions/gitextensions.git", true)]
         [TestCase("github.com/gitextensions/gitextensions.git", true)]
-        [TestCase("git clone https://github.com/gitextensions/gitextensions", true)]
         [TestCase("HTTPS://MYPRIVATEGITHUB.COM:8080/LOUDREPO.GIT", true)]
         [TestCase("git://myurl/myrepo.git", true)]
-        [TestCase("git clone https://github.com/gitextensions/gitextensions && cd gitextensions", true)]
         [TestCase("github.com/gitextensions", false)]
         [TestCase("github.com/gitextensions/gitextensions/pull/9018", false)]
+        [TestCase("http://", false)]
+        [TestCase("HTTPS://www", true)]
+        [TestCase("git://", true)]
+        [TestCase("file:", false)]
+        [TestCase("SSH:", true)]
+        [TestCase("SSH", false)]
+        [TestCase("https://myhost:12368/", true)]
         public void CanBeGitURL(string url, bool expected)
         {
             Assert.AreEqual(expected, PathUtil.CanBeGitURL(url));


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6260 


## Proposed changes

- Adds a new method in FormClone to extract a URL from a text string.
- Updates Clone form to use new method





## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Added new integration test in FormCloneTests.cs



## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.31.0.windows.1
- Windows 10.0.19043.985

<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
