### PR TITLE
Allow rollForward for .NET 5.0 SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "5.0.202"
+      "version": "5.0.202",
+      "rollForward": "feature"
     }
-  }
-  
+}


### PR DESCRIPTION
## Proposed changes

- Allow `rollForward` for .NET 5.0 SDK at `feature` level in order to use the latest one installed e.g. by the update to VS 16.10.0
refer to https://andrewlock.net/exploring-the-new-rollforward-and-allowprerelease-settings-in-global-json/

## Test methodology <!-- How did you ensure quality? -->

- `dotnet build`

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 88aec72ad50172033bc707e82c9f1641ea838e47
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.6
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
