### PR TITLE
Handle `laneInfo` being `null`

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -71,11 +71,10 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
         public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {
-            if (AppSettings.ShowRevisionGridGraphColumn &&
-                e.State.HasFlag(DataGridViewElementStates.Visible) &&
-                e.RowIndex >= 0 &&
-                _revisionGraph.Count != 0 &&
-                _revisionGraph.Count > e.RowIndex)
+            if (AppSettings.ShowRevisionGridGraphColumn
+                && e.State.HasFlag(DataGridViewElementStates.Visible)
+                && e.RowIndex >= 0
+                && e.RowIndex < _revisionGraph.Count)
             {
                 try
                 {


### PR DESCRIPTION
## Proposed changes

- Handle `laneInfo` being `null` when determining the color of commits without neither parents nor children
- Consume exceptions from `RevisionGraphColumnProvider.OnCellPainting` since they do not bubble up to our handlers, and write them to the `Debug` output and - in debug build - also to `%TEMP%`
- Remove redundant condition in `RevisionGraphColumnProvider.OnCellPainting`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Graph rows drawn black completely due to throwing `Validates.NotNull(laneInfo)`

### After

![grafik](https://user-images.githubusercontent.com/36601201/121093812-e0f10300-c7ed-11eb-8a6d-4eeabb781a25.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build f89e7963407fb4b4cbc1229ff6db32332ed929c9
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.6
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
