### PR TITLE
Gray / hide selections in `FormBrowse` if not focused

### DIFF
--- a/GitExtUtils/GitUI/Theming/OtherColors.cs
+++ b/GitExtUtils/GitUI/Theming/OtherColors.cs
@@ -4,10 +4,13 @@ namespace GitExtUtils.GitUI.Theming
 {
     public static class OtherColors
     {
-        public static readonly Color BackgroundColor = Color.FromArgb(251, 251, 251).AdaptBackColor();
-        public static readonly Color PanelBorderColor = Color.FromArgb(224, 224, 224).AdaptBackColor();
         public static readonly Color AmendButtonForcedColor = Color.FromArgb(230, 99, 99).AdaptBackColor();
+        public static readonly Color BackgroundColor = Color.FromArgb(251, 251, 251).AdaptBackColor();
+        public static readonly Color InactiveSelectionHighlightColor = Color.FromArgb(230, 230, 230).AdaptBackColor();
         public static readonly Color MergeConflictsColor = Color.FromArgb(230, 99, 99).AdaptBackColor();
+        public static readonly Color PanelBorderColor = Color.FromArgb(224, 224, 224).AdaptBackColor();
         public static readonly Color PanelMessageWarningColor = Color.FromArgb(230, 99, 99).AdaptBackColor();
+
+        public static readonly SolidBrush InactiveSelectionHighlightBrush = new(InactiveSelectionHighlightColor);
     }
 }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -73,7 +73,6 @@ namespace GitUI.BranchTreePanel
             RegisterContextActions();
 
             treeMain.ShowNodeToolTips = true;
-            treeMain.HideSelection = false;
 
             toolTip.SetToolTip(btnSearch, _searchTooltip.Text);
             tsbCollapseAll.ToolTipText = mnubtnCollapse.ToolTipText;

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1341,7 +1341,7 @@ namespace GitUI
 
             if (item.Selected)
             {
-                e.Graphics.FillRectangle(SystemBrushes.Highlight, e.Bounds);
+                e.Graphics.FillRectangle(Focused ? SystemBrushes.Highlight : OtherColors.InactiveSelectionHighlightBrush, e.Bounds);
             }
 
             if (image is not null)
@@ -1353,14 +1353,14 @@ namespace GitUI
             {
                 Rectangle textRect = new(prefixTextStartX, item.Bounds.Top, textMaxWidth, item.Bounds.Height);
 
-                Color grayTextColor = item.Selected
+                Color grayTextColor = item.Selected && Focused
                     ? ColorHelper.GetHighlightGrayTextColor(
                         backgroundColorName: KnownColor.Window,
                         textColorName: KnownColor.WindowText,
                         highlightColorName: KnownColor.Highlight)
                     : SystemColors.GrayText;
 
-                Color textColor = item.Selected
+                Color textColor = item.Selected && Focused
                     ? SystemColors.HighlightText
                     : SystemColors.WindowText;
 

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -359,11 +359,8 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
             var text = items.Count.ToString();
             var bounds = messageBounds.ReduceLeft(offset);
-            var color = e.State.HasFlag(DataGridViewElementStates.Selected)
-                ? SystemColors.HighlightText
-                : SystemColors.ControlText;
             var textWidth = Math.Max(
-                _grid.DrawColumnText(e, text, style.NormalFont, color, bounds),
+                _grid.DrawColumnText(e, text, style.NormalFont, style.ForeColor, bounds),
                 TextRenderer.MeasureText("88", style.NormalFont).Width);
             offset += textWidth + textHorizontalPadding;
         }

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -31,6 +31,7 @@ namespace GitUI.UserControls.RevisionGrid
     public sealed class RevisionDataGridView : DataGridView
     {
         private readonly SolidBrush _alternatingRowBackgroundBrush;
+        private readonly SolidBrush _authoredHighlightBrush;
 
         internal RevisionGraph _revisionGraph = new();
 
@@ -64,8 +65,8 @@ namespace GitUI.UserControls.RevisionGrid
             InitializeComponent();
             DoubleBuffered = true;
 
-            _alternatingRowBackgroundBrush =
-                new SolidBrush(KnownColor.Window.MakeBackgroundDarkerBy(0.025)); // 0.018
+            _alternatingRowBackgroundBrush = new SolidBrush(KnownColor.Window.MakeBackgroundDarkerBy(0.025)); // 0.018
+            _authoredHighlightBrush = new SolidBrush(AppColor.AuthoredHighlight.GetThemeColor());
 
             UpdateRowHeight();
 
@@ -261,7 +262,7 @@ namespace GitUI.UserControls.RevisionGrid
 
             if (AppSettings.HighlightAuthoredRevisions && revision is not null && !revision.IsArtificial && AuthorHighlighting?.IsHighlighted(revision) != false)
             {
-                return new SolidBrush(AppColor.AuthoredHighlight.GetThemeColor());
+                return _authoredHighlightBrush;
             }
 
             if (rowIndex % 2 == 0 && AppSettings.RevisionGraphDrawAlternateBackColor)

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -80,6 +80,8 @@ namespace GitUI.UserControls.RevisionGrid
             };
             Scroll += delegate { UpdateVisibleRowRange(); };
             Resize += delegate { UpdateVisibleRowRange(); };
+            GotFocus += (_, _) => InvalidateSelectedRows();
+            LostFocus += (_, _) => InvalidateSelectedRows();
             CellPainting += OnCellPainting;
             CellFormatting += (_, e) =>
             {
@@ -92,7 +94,6 @@ namespace GitUI.UserControls.RevisionGrid
                     }
                 }
             };
-            RowPrePaint += OnRowPrePaint;
 
             _revisionGraph.Updated += () =>
             {
@@ -117,18 +118,6 @@ namespace GitUI.UserControls.RevisionGrid
             Clear();
 
             return;
-
-            void OnRowPrePaint(object sender, DataGridViewRowPrePaintEventArgs e)
-            {
-                if (e.PaintParts.HasFlag(DataGridViewPaintParts.Background) &&
-                    e.RowBounds.Width > 0 &&
-                    e.RowBounds.Height > 0)
-                {
-                    // Draw row background
-                    var backBrush = GetBackground(e.State, e.RowIndex, null);
-                    e.Graphics.FillRectangle(backBrush, e.RowBounds);
-                }
-            }
 
             void InitializeComponent()
             {
@@ -156,6 +145,14 @@ namespace GitUI.UserControls.RevisionGrid
                 StandardTab = true;
                 ((ISupportInitialize)this).EndInit();
                 ResumeLayout(false);
+            }
+
+            void InvalidateSelectedRows()
+            {
+                for (int index = 0; index < SelectedRows.Count; ++index)
+                {
+                    InvalidateRow(SelectedRows[index].Index);
+                }
             }
         }
 
@@ -225,12 +222,12 @@ namespace GitUI.UserControls.RevisionGrid
         private Color GetForeground(DataGridViewElementStates state, int rowIndex)
         {
             bool isNonRelativeGray = AppSettings.RevisionGraphDrawNonRelativesTextGray && !RowIsRelative(rowIndex);
-            bool isSelected = state.HasFlag(DataGridViewElementStates.Selected);
-            return (isNonRelativeGray, isSelected) switch
+            bool isSelectedAndFocused = state.HasFlag(DataGridViewElementStates.Selected) && Focused;
+            return (isNonRelativeGray, isSelectedAndFocused) switch
             {
-                (isNonRelativeGray: false, isSelected: false) => SystemColors.ControlText,
-                (isNonRelativeGray: false, isSelected: true) => SystemColors.HighlightText,
-                (isNonRelativeGray: true, isSelected: false) => SystemColors.GrayText,
+                (isNonRelativeGray: false, isSelectedAndFocused: false) => SystemColors.ControlText,
+                (isNonRelativeGray: false, isSelectedAndFocused: true) => SystemColors.HighlightText,
+                (isNonRelativeGray: true, isSelectedAndFocused: false) => SystemColors.GrayText,
 
                 // (isGray: true, isSelected: true)
                 _ => getHighlightedGrayTextColor()
@@ -257,7 +254,7 @@ namespace GitUI.UserControls.RevisionGrid
         {
             if (state.HasFlag(DataGridViewElementStates.Selected))
             {
-                return SystemBrushes.Highlight;
+                return Focused ? SystemBrushes.Highlight : OtherColors.InactiveSelectionHighlightBrush;
             }
 
             if (AppSettings.HighlightAuthoredRevisions && revision is not null && !revision.IsArtificial && AuthorHighlighting?.IsHighlighted(revision) != false)
@@ -287,18 +284,19 @@ namespace GitUI.UserControls.RevisionGrid
                 return;
             }
 
+            Brush backBrush = GetBackground(e.State, e.RowIndex, revision);
+            e.Graphics.FillRectangle(backBrush, e.CellBounds);
+
             if (Columns[e.ColumnIndex].Tag is ColumnProvider provider)
             {
-                var backBrush = GetBackground(e.State, e.RowIndex, revision);
-                var foreColor = GetForeground(e.State, e.RowIndex);
-                var commitBodyForeColor = GetCommitBodyForeground(e.State, e.RowIndex);
-
-                e.Graphics.FillRectangle(backBrush, e.CellBounds);
+                Color foreColor = GetForeground(e.State, e.RowIndex);
+                Color commitBodyForeColor = GetCommitBodyForeground(e.State, e.RowIndex);
                 CellStyle cellStyle = new(backBrush, foreColor, commitBodyForeColor, _normalFont, _boldFont, _monospaceFont);
-                provider.OnCellPainting(e, revision, _rowHeight, cellStyle);
 
-                e.Handled = true;
+                provider.OnCellPainting(e, revision, _rowHeight, cellStyle);
             }
+
+            e.Handled = true;
         }
 
         public void Add(GitRevision revision, RevisionNodeFlags types = RevisionNodeFlags.None)


### PR DESCRIPTION
Fixes #9192 1. & 2.

## Proposed changes

- Gray selection if not focused for
  - `RevisionDataGridView`
  - `FileStatusList` (i.e. also for other Forms lile `FormCommit`)

  Inactive color value `OtherColors.InactiveSelectionHighlightColor` is chosen to be identical to `AppColor.DiffSection`, which is visible right beside.
- Remove redundant `RevisionDataGridView.OnRowPrePaint`
- Cache Brush for `AppColor.AuthoredHighlight` like for `_alternatingRowBackgroundBrush`
- Hide selection if not focused for `RepoObjectsTree`

## Screenshots <!-- Remove this section if PR does not change UI -->

Notice: The focus is in the `DiffView`.

### Before

![grafik](https://user-images.githubusercontent.com/36601201/121433664-9a7dde80-c97c-11eb-8681-2c42c030ee3d.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/121433923-e6c91e80-c97c-11eb-88ab-07a59b0ec0f2.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build e5d6cdd13bf1d2c15f43272183a8e16daa7144b4
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.6
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
