### PR TITLE
Allow line patching for new worktree/index files

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -408,7 +408,7 @@ namespace GitUI.CommandsDialogs
                     Name = fileName,
                     IsSubmodule = GitModule.IsValidGitWorkingDir(_fullPathResolver.Resolve(fileName))
                 };
-                View.ViewGitItemRevisionAsync(file, revision.ObjectId);
+                View.ViewGitItemAsync(file, revision.ObjectId);
             }
             else if (tabControl1.SelectedTab == DiffTab)
             {

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -13,6 +13,7 @@ using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.Hotkey;
 using GitUI.Properties;
+using GitUI.UserControls;
 using GitUIPluginInterfaces;
 using JetBrains.Annotations;
 using ResourceManager;
@@ -371,7 +372,7 @@ See the changes in the commit form.");
                             IsSubmodule = gitItem.ObjectType == GitObjectType.Commit
                         };
 
-                        return FileText.ViewGitItemAsync(file);
+                        return FileText.ViewGitItemAsync(file, gitItem.ObjectId);
                     }
 
                     default:

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -73,7 +73,7 @@ namespace GitUI
             if (item.Item.IsNew || firstId is null || FileHelper.IsImage(item.Item.Name))
             {
                 // View blob guid from revision, or file for worktree
-                return fileViewer.ViewGitItemRevisionAsync(item.Item, item.SecondRevision.ObjectId, openWithDiffTool);
+                return fileViewer.ViewGitItemAsync(item, openWithDiffTool);
             }
 
             if (item.Item.IsRangeDiff)


### PR DESCRIPTION
Fixes #9280

## Proposed changes

Allow line patching for worktree/index files, both in Browse and Commit.
This was a case that was ignored when the separate code paths in Commit was removed and functionality only handled in FileViewer.

Note that it is not possible to unstage the last line in a new file (same as before). Ignored.

## Test methodology <!-- How did you ensure quality? -->

Manual (limited tests so far)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
