### PR TITLE
Add mnemonics to frequently used dialogs

### DIFF
--- a/GitUI/CommandsDialogs/FormCheckoutRevision.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutRevision.Designer.cs
@@ -79,7 +79,7 @@
             this.OkCheckout.Name = "OkCheckout";
             this.OkCheckout.Size = new System.Drawing.Size(122, 25);
             this.OkCheckout.TabIndex = 1;
-            this.OkCheckout.Text = "Checkout";
+            this.OkCheckout.Text = "&Checkout";
             this.OkCheckout.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.OkCheckout.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
             this.OkCheckout.UseVisualStyleBackColor = true;
@@ -93,7 +93,7 @@
             this.Force.Name = "Force";
             this.Force.Size = new System.Drawing.Size(166, 19);
             this.Force.TabIndex = 5;
-            this.Force.Text = "Force (reset local changes)";
+            this.Force.Text = "&Force (reset local changes)";
             this.Force.UseVisualStyleBackColor = true;
             // 
             // flowLayoutPanel1
@@ -114,7 +114,7 @@
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(124, 15);
             this.label2.TabIndex = 2;
-            this.label2.Text = "Checkout this revision";
+            this.label2.Text = "Checkout this &revision";
             // 
             // commitPickerSmallControl1
             // 

--- a/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -64,7 +64,7 @@ namespace GitUI.CommandsDialogs
             this.tableLayoutPanel3.SetRowSpan(this.Pick, 2);
             this.Pick.Size = new System.Drawing.Size(136, 31);
             this.Pick.TabIndex = 10;
-            this.Pick.Text = "Cherry pick";
+            this.Pick.Text = "&Cherry pick";
             this.Pick.UseVisualStyleBackColor = true;
             this.Pick.Click += new System.EventHandler(this.Revert_Click);
             // 
@@ -76,7 +76,7 @@ namespace GitUI.CommandsDialogs
             this.btnChooseRevision.Margin = new System.Windows.Forms.Padding(4);
             this.btnChooseRevision.Name = "btnChooseRevision";
             this.btnChooseRevision.Size = new System.Drawing.Size(31, 30);
-            this.btnChooseRevision.TabIndex = 33;
+            this.btnChooseRevision.TabIndex = 34;
             this.btnChooseRevision.UseVisualStyleBackColor = true;
             this.btnChooseRevision.Click += new System.EventHandler(this.btnChooseRevision_Click);
             // 
@@ -88,8 +88,8 @@ namespace GitUI.CommandsDialogs
             this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(132, 46);
-            this.label2.TabIndex = 34;
-            this.label2.Text = "Choose another\r\nrevision:";
+            this.label2.TabIndex = 33;
+            this.label2.Text = "C&hoose another\r\nrevision:";
             // 
             // ParentsLabel
             // 
@@ -98,8 +98,8 @@ namespace GitUI.CommandsDialogs
             this.ParentsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.ParentsLabel.Name = "ParentsLabel";
             this.ParentsLabel.Size = new System.Drawing.Size(298, 23);
-            this.ParentsLabel.TabIndex = 13;
-            this.ParentsLabel.Text = "This commit is a merge, select parent:";
+            this.ParentsLabel.TabIndex = 12;
+            this.ParentsLabel.Text = "This commit is a merge, select &parent:";
             // 
             // ParentsList
             // 
@@ -119,7 +119,7 @@ namespace GitUI.CommandsDialogs
             this.ParentsList.MultiSelect = false;
             this.ParentsList.Name = "ParentsList";
             this.ParentsList.Size = new System.Drawing.Size(726, 109);
-            this.ParentsList.TabIndex = 12;
+            this.ParentsList.TabIndex = 13;
             this.ParentsList.UseCompatibleStateImageBehavior = false;
             this.ParentsList.View = System.Windows.Forms.View.Details;
             // 
@@ -152,7 +152,7 @@ namespace GitUI.CommandsDialogs
             this.checkAddReference.Name = "checkAddReference";
             this.checkAddReference.Size = new System.Drawing.Size(357, 27);
             this.checkAddReference.TabIndex = 14;
-            this.checkAddReference.Text = "Add commit reference to commit message";
+            this.checkAddReference.Text = "A&dd commit reference to commit message";
             this.checkAddReference.UseVisualStyleBackColor = true;
             // 
             // AutoCommit
@@ -164,7 +164,7 @@ namespace GitUI.CommandsDialogs
             this.AutoCommit.Name = "AutoCommit";
             this.AutoCommit.Size = new System.Drawing.Size(265, 27);
             this.AutoCommit.TabIndex = 11;
-            this.AutoCommit.Text = "Automatically create a commit";
+            this.AutoCommit.Text = "&Automatically create a commit";
             this.AutoCommit.UseVisualStyleBackColor = true;
             // 
             // BranchInfo

--- a/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -93,7 +93,7 @@
             this.ckForceWithLease.Name = "ckForceWithLease";
             this.ckForceWithLease.Size = new System.Drawing.Size(109, 17);
             this.ckForceWithLease.TabIndex = 0;
-            this.ckForceWithLease.Text = "Force With &Lease";
+            this.ckForceWithLease.Text = "&Force with lease";
             this.ckForceWithLease.UseVisualStyleBackColor = true;
             this.ckForceWithLease.CheckedChanged += new System.EventHandler(this.ForceWithLeaseCheckedChanged);
             // 
@@ -104,7 +104,7 @@
             this.ForcePushBranches.Name = "ForcePushBranches";
             this.ForcePushBranches.Size = new System.Drawing.Size(79, 17);
             this.ForcePushBranches.TabIndex = 1;
-            this.ForcePushBranches.Text = "&Force Push";
+            this.ForcePushBranches.Text = "F&orce push";
             this.ForcePushBranches.UseVisualStyleBackColor = true;
             this.ForcePushBranches.CheckedChanged += new System.EventHandler(this.ForcePushBranchesCheckedChanged);
             // 
@@ -115,7 +115,7 @@
             this.PushToUrl.Name = "PushToUrl";
             this.PushToUrl.Size = new System.Drawing.Size(38, 17);
             this.PushToUrl.TabIndex = 3;
-            this.PushToUrl.Text = "Url";
+            this.PushToUrl.Text = "U&rl";
             this.toolTip1.SetToolTip(this.PushToUrl, "Url to push to");
             this.PushToUrl.UseVisualStyleBackColor = true;
             this.PushToUrl.CheckedChanged += new System.EventHandler(this.PushToUrlCheckedChanged);
@@ -129,7 +129,7 @@
             this.PushToRemote.Size = new System.Drawing.Size(62, 17);
             this.PushToRemote.TabIndex = 0;
             this.PushToRemote.TabStop = true;
-            this.PushToRemote.Text = "Remote";
+            this.PushToRemote.Text = "&Remote";
             this.toolTip1.SetToolTip(this.PushToRemote, "Remote repository to push to");
             this.PushToRemote.UseVisualStyleBackColor = true;
             // 
@@ -219,7 +219,7 @@
             this.labelTo.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
             this.labelTo.Size = new System.Drawing.Size(17, 22);
             this.labelTo.TabIndex = 1;
-            this.labelTo.Text = "to";
+            this.labelTo.Text = "&to";
             this.labelTo.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // RemoteBranch
@@ -268,7 +268,7 @@
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(113, 13);
             this.label2.TabIndex = 0;
-            this.label2.Text = "Recursive submodules";
+            this.label2.Text = "Recursive &submodules";
             // 
             // RecursiveSubmodules
             // 
@@ -291,7 +291,7 @@
             this.ReplaceTrackingReference.Name = "ReplaceTrackingReference";
             this.ReplaceTrackingReference.Size = new System.Drawing.Size(155, 17);
             this.ReplaceTrackingReference.TabIndex = 1;
-            this.ReplaceTrackingReference.Text = "Replace tracking reference";
+            this.ReplaceTrackingReference.Text = "R&eplace tracking reference";
             this.ReplaceTrackingReference.UseVisualStyleBackColor = true;
             // 
             // _createPullRequestCB
@@ -301,7 +301,7 @@
             this._createPullRequestCB.Name = "_createPullRequestCB";
             this._createPullRequestCB.Size = new System.Drawing.Size(171, 17);
             this._createPullRequestCB.TabIndex = 3;
-            this._createPullRequestCB.Text = "Create pull request after push";
+            this._createPullRequestCB.Text = "&Create pull request after push";
             this._createPullRequestCB.UseVisualStyleBackColor = true;
             // 
             // labelFrom
@@ -311,7 +311,7 @@
             this.labelFrom.Name = "labelFrom";
             this.labelFrom.Size = new System.Drawing.Size(79, 13);
             this.labelFrom.TabIndex = 0;
-            this.labelFrom.Text = "Branch to push";
+            this.labelFrom.Text = "&Branch to push";
             // 
             // TagTab
             // 
@@ -334,7 +334,7 @@
             this.ForcePushTags.Name = "ForcePushTags";
             this.ForcePushTags.Size = new System.Drawing.Size(79, 17);
             this.ForcePushTags.TabIndex = 2;
-            this.ForcePushTags.Text = "&Force Push";
+            this.ForcePushTags.Text = "&Force push";
             this.ForcePushTags.UseVisualStyleBackColor = true;
             // 
             // label1
@@ -344,7 +344,7 @@
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(64, 13);
             this.label1.TabIndex = 0;
-            this.label1.Text = "Tag to push";
+            this.label1.Text = "&Tag to push";
             // 
             // TagComboBox
             // 
@@ -491,7 +491,7 @@
             this.AddRemote.Name = "AddRemote";
             this.AddRemote.Size = new System.Drawing.Size(150, 25);
             this.AddRemote.TabIndex = 2;
-            this.AddRemote.Text = "Manage remotes";
+            this.AddRemote.Text = "&Manage remotes";
             this.AddRemote.UseVisualStyleBackColor = true;
             this.AddRemote.Click += new System.EventHandler(this.AddRemoteClick);
             // 
@@ -527,7 +527,7 @@
             this.Pull.Name = "Pull";
             this.Pull.Size = new System.Drawing.Size(101, 25);
             this.Pull.TabIndex = 2;
-            this.Pull.Text = "Pull";
+            this.Pull.Text = "P&ull";
             this.Pull.UseVisualStyleBackColor = true;
             this.Pull.Click += new System.EventHandler(this.PullClick);
             // 

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -723,9 +723,9 @@ namespace GitUI.CommandsDialogs
                 _NO_TRANSLATE_Branch.Items.Add(head);
             }
 
-            _NO_TRANSLATE_Branch.Text = curBranch;
-
             _NO_TRANSLATE_Branch.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
+
+            _NO_TRANSLATE_Branch.Text = curBranch;
         }
 
         private IEnumerable<IGitRef> GetLocalBranches()
@@ -775,6 +775,9 @@ namespace GitUI.CommandsDialogs
             }
 
             RemoteBranch.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
+
+            // Set text again as workaround for appearing focused after setting DropDownWidth
+            RemoteBranch.Text = RemoteBranch.Text;
         }
 
         private void BranchSelectedValueChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormRevertCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRevertCommit.Designer.cs
@@ -66,8 +66,8 @@
             this.ParentsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.ParentsLabel.Name = "ParentsLabel";
             this.ParentsLabel.Size = new System.Drawing.Size(298, 23);
-            this.ParentsLabel.TabIndex = 15;
-            this.ParentsLabel.Text = "This commit is a merge, select parent:";
+            this.ParentsLabel.TabIndex = 14;
+            this.ParentsLabel.Text = "This commit is a merge, select &parent:";
             // 
             // ParentsList
             // 
@@ -85,7 +85,7 @@
             this.ParentsList.MultiSelect = false;
             this.ParentsList.Name = "ParentsList";
             this.ParentsList.Size = new System.Drawing.Size(668, 75);
-            this.ParentsList.TabIndex = 14;
+            this.ParentsList.TabIndex = 15;
             this.ParentsList.UseCompatibleStateImageBehavior = false;
             this.ParentsList.View = System.Windows.Forms.View.Details;
             // 
@@ -118,7 +118,7 @@
             this.AutoCommit.Name = "AutoCommit";
             this.AutoCommit.Size = new System.Drawing.Size(265, 27);
             this.AutoCommit.TabIndex = 11;
-            this.AutoCommit.Text = "Automatically create a commit";
+            this.AutoCommit.Text = "&Automatically create a commit";
             this.AutoCommit.UseVisualStyleBackColor = true;
             // 
             // Revert
@@ -130,7 +130,7 @@
             this.Revert.Name = "Revert";
             this.Revert.Size = new System.Drawing.Size(171, 33);
             this.Revert.TabIndex = 10;
-            this.Revert.Text = "Revert this commit";
+            this.Revert.Text = "&Revert this commit";
             this.Revert.UseVisualStyleBackColor = true;
             this.Revert.Click += new System.EventHandler(this.Revert_Click);
             // 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2886,11 +2886,11 @@ Are you sure?</source>
         <target />
       </trans-unit>
       <trans-unit id="Force.Text">
-        <source>Force (reset local changes)</source>
+        <source>&amp;Force (reset local changes)</source>
         <target />
       </trans-unit>
       <trans-unit id="OkCheckout.Text">
-        <source>Checkout</source>
+        <source>&amp;Checkout</source>
         <target />
       </trans-unit>
       <trans-unit id="_noRevisionSelectedMsgBox.Text">
@@ -2902,7 +2902,7 @@ Are you sure?</source>
         <target />
       </trans-unit>
       <trans-unit id="label2.Text">
-        <source>Checkout this revision</source>
+        <source>Checkout this &amp;revision</source>
         <target />
       </trans-unit>
     </body>
@@ -2914,7 +2914,7 @@ Are you sure?</source>
         <target />
       </trans-unit>
       <trans-unit id="AutoCommit.Text">
-        <source>Automatically create a commit</source>
+        <source>&amp;Automatically create a commit</source>
         <target />
       </trans-unit>
       <trans-unit id="BranchInfo.Text">
@@ -2922,11 +2922,11 @@ Are you sure?</source>
         <target />
       </trans-unit>
       <trans-unit id="ParentsLabel.Text">
-        <source>This commit is a merge, select parent:</source>
+        <source>This commit is a merge, select &amp;parent:</source>
         <target />
       </trans-unit>
       <trans-unit id="Pick.Text">
-        <source>Cherry pick</source>
+        <source>&amp;Cherry pick</source>
         <target />
       </trans-unit>
       <trans-unit id="_noneParentSelectedText.Text">
@@ -2934,7 +2934,7 @@ Are you sure?</source>
         <target />
       </trans-unit>
       <trans-unit id="checkAddReference.Text">
-        <source>Add commit reference to commit message</source>
+        <source>A&amp;dd commit reference to commit message</source>
         <target />
       </trans-unit>
       <trans-unit id="columnHeader1.Text">
@@ -2954,7 +2954,7 @@ Are you sure?</source>
         <target />
       </trans-unit>
       <trans-unit id="label2.Text">
-        <source>Choose another
+        <source>C&amp;hoose another
 revision:</source>
         <target />
       </trans-unit>
@@ -5383,7 +5383,7 @@ This will initialize and update all submodules recursive.</source>
         <target />
       </trans-unit>
       <trans-unit id="AddRemote.Text">
-        <source>Manage remotes</source>
+        <source>&amp;Manage remotes</source>
         <target />
       </trans-unit>
       <trans-unit id="BranchTab.Text">
@@ -5403,11 +5403,11 @@ This will initialize and update all submodules recursive.</source>
         <target />
       </trans-unit>
       <trans-unit id="ForcePushBranches.Text">
-        <source>&amp;Force Push</source>
+        <source>F&amp;orce push</source>
         <target />
       </trans-unit>
       <trans-unit id="ForcePushTags.Text">
-        <source>&amp;Force Push</source>
+        <source>&amp;Force push</source>
         <target />
       </trans-unit>
       <trans-unit id="LoadSSHKey.Text">
@@ -5427,7 +5427,7 @@ This will initialize and update all submodules recursive.</source>
         <target />
       </trans-unit>
       <trans-unit id="Pull.Text">
-        <source>Pull</source>
+        <source>P&amp;ull</source>
         <target />
       </trans-unit>
       <trans-unit id="PushColumn.HeaderText">
@@ -5435,11 +5435,11 @@ This will initialize and update all submodules recursive.</source>
         <target />
       </trans-unit>
       <trans-unit id="PushToRemote.Text">
-        <source>Remote</source>
+        <source>&amp;Remote</source>
         <target />
       </trans-unit>
       <trans-unit id="PushToUrl.Text">
-        <source>Url</source>
+        <source>U&amp;rl</source>
         <target />
       </trans-unit>
       <trans-unit id="RecursiveSubmodules.Item0">
@@ -5459,7 +5459,7 @@ This will initialize and update all submodules recursive.</source>
         <target />
       </trans-unit>
       <trans-unit id="ReplaceTrackingReference.Text">
-        <source>Replace tracking reference</source>
+        <source>R&amp;eplace tracking reference</source>
         <target />
       </trans-unit>
       <trans-unit id="ShowOptions.Text">
@@ -5485,7 +5485,7 @@ Would you like to do it now?</source>
         <target />
       </trans-unit>
       <trans-unit id="_createPullRequestCB.Text">
-        <source>Create pull request after push</source>
+        <source>&amp;Create pull request after push</source>
         <target />
       </trans-unit>
       <trans-unit id="_dontShowAgain.Text">
@@ -5577,7 +5577,7 @@ Would you like to do it now?</source>
         <target />
       </trans-unit>
       <trans-unit id="ckForceWithLease.Text">
-        <source>Force With &amp;Lease</source>
+        <source>&amp;Force with lease</source>
         <target />
       </trans-unit>
       <trans-unit id="groupBox2.Text">
@@ -5585,19 +5585,19 @@ Would you like to do it now?</source>
         <target />
       </trans-unit>
       <trans-unit id="label1.Text">
-        <source>Tag to push</source>
+        <source>&amp;Tag to push</source>
         <target />
       </trans-unit>
       <trans-unit id="label2.Text">
-        <source>Recursive submodules</source>
+        <source>Recursive &amp;submodules</source>
         <target />
       </trans-unit>
       <trans-unit id="labelFrom.Text">
-        <source>Branch to push</source>
+        <source>&amp;Branch to push</source>
         <target />
       </trans-unit>
       <trans-unit id="labelTo.Text">
-        <source>to</source>
+        <source>&amp;to</source>
         <target />
       </trans-unit>
       <trans-unit id="selectAllToolStripMenuItem.Text">
@@ -6702,7 +6702,7 @@ Do you want to use this custom merge script?</source>
         <target />
       </trans-unit>
       <trans-unit id="AutoCommit.Text">
-        <source>Automatically create a commit</source>
+        <source>&amp;Automatically create a commit</source>
         <target />
       </trans-unit>
       <trans-unit id="BranchInfo.Text">
@@ -6710,11 +6710,11 @@ Do you want to use this custom merge script?</source>
         <target />
       </trans-unit>
       <trans-unit id="ParentsLabel.Text">
-        <source>This commit is a merge, select parent:</source>
+        <source>This commit is a merge, select &amp;parent:</source>
         <target />
       </trans-unit>
       <trans-unit id="Revert.Text">
-        <source>Revert this commit</source>
+        <source>&amp;Revert this commit</source>
         <target />
       </trans-unit>
       <trans-unit id="_noneParentSelectedText.Text">


### PR DESCRIPTION
## Proposed changes

- Add mnemonics to
  - `FormCheckoutRevision`
  - `FormCherryPick`
  - `FormRevertCommit`
  - `FormPush`
- `FormPush`: Avoid `ComboBox`es appearing focused after `ResizeDropDownWidth`
  Fixes #9192 3.

## Screenshots <!-- Remove this section if PR does not change UI -->
Before|After
-|-
![grafik](https://user-images.githubusercontent.com/36601201/121756000-0301c280-cb19-11eb-8594-ae5dd8f7114b.png)|![grafik](https://user-images.githubusercontent.com/36601201/121756017-0eed8480-cb19-11eb-9d4c-2cc927bb270f.png)
![grafik](https://user-images.githubusercontent.com/36601201/121756043-27f63580-cb19-11eb-8864-b3a302775f98.png)|![grafik](https://user-images.githubusercontent.com/36601201/121756065-37757e80-cb19-11eb-8f42-16aa2b9946d9.png)
![grafik](https://user-images.githubusercontent.com/36601201/121756324-ff227000-cb19-11eb-84cf-27609b5a1b0a.png)|![grafik](https://user-images.githubusercontent.com/36601201/121756345-0ba6c880-cb1a-11eb-9ffe-d82d51979a00.png)
![grafik](https://user-images.githubusercontent.com/36601201/121756149-73a8df00-cb19-11eb-9b2b-4d15018feaef.png)|![grafik](https://user-images.githubusercontent.com/36601201/121773767-4cd0c400-cb7e-11eb-87c5-b9b1873b2da3.png)
![grafik](https://user-images.githubusercontent.com/36601201/121756239-b9fe3e00-cb19-11eb-9b7a-eac791afcb09.png)|![grafik](https://user-images.githubusercontent.com/36601201/121756254-c7b3c380-cb19-11eb-999f-dd9c2da5bb75.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 607a1b4bc424fa1667bf532b3c4b3c1827661cb5
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.6
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
