### PR TITLE
Commit: Unstage new files did not display the worktree file

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1744,20 +1744,7 @@ namespace GitUI.CommandsDialogs
                             continue;
                         }
 
-                        var item2 = item;
-                        if (unstagedFiles.Exists(i => i.Name == item2.Name))
-                        {
-                            continue;
-                        }
-
-                        if (item.IsNew && !item.IsChanged && !item.IsDeleted)
-                        {
-                            item.IsTracked = false;
-                        }
-                        else
-                        {
-                            item.IsTracked = true;
-                        }
+                        item.IsTracked = item.IsNew && !item.IsChanged && !item.IsDeleted ? false : true;
 
                         if (item.IsRenamed)
                         {
@@ -1778,7 +1765,16 @@ namespace GitUI.CommandsDialogs
                         }
 
                         item.Staged = StagedStatus.WorkTree;
-                        unstagedFiles.Add(item);
+                        int index = unstagedFiles.FindIndex(i => i.Name == item.Name);
+
+                        if (index >= 0)
+                        {
+                            unstagedFiles[index] = item;
+                        }
+                        else
+                        {
+                            unstagedFiles.Add(item);
+                        }
                     }
 
                     var (headRev, indexRev, workTreeRev) = GetHeadRevisions();

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1744,7 +1744,17 @@ namespace GitUI.CommandsDialogs
                             continue;
                         }
 
-                        item.IsTracked = item.IsNew && !item.IsChanged && !item.IsDeleted ? false : true;
+                        item.IsTracked = !item.IsNew || item.IsChanged || item.IsDeleted;
+                        int index = unstagedFiles.FindIndex(i => i.Name == item.Name);
+
+                        if (index >= 0)
+                        {
+                            unstagedFiles[index].IsNew = item.IsNew;
+                            unstagedFiles[index].IsDeleted = item.IsDeleted;
+                            unstagedFiles[index].IsTracked = item.IsTracked;
+                            unstagedFiles[index].IsChanged = item.IsChanged;
+                            continue;
+                        }
 
                         if (item.IsRenamed)
                         {
@@ -1765,16 +1775,7 @@ namespace GitUI.CommandsDialogs
                         }
 
                         item.Staged = StagedStatus.WorkTree;
-                        int index = unstagedFiles.FindIndex(i => i.Name == item.Name);
-
-                        if (index >= 0)
-                        {
-                            unstagedFiles[index] = item;
-                        }
-                        else
-                        {
-                            unstagedFiles.Add(item);
-                        }
+                        unstagedFiles.Add(item);
                     }
 
                     var (headRev, indexRev, workTreeRev) = GetHeadRevisions();


### PR DESCRIPTION
Fixes #9283

## Proposed changes

The git status was not updated correctly for new files in the index
that also were changed in the worktree. The worktree file could therefore
not be displayed.

## Screenshots <!-- Remove this section if PR does not change UI -->

See issue

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
