### PR TITLE
Add mnemonics to context menu of `RevisionDiffControl`

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
@@ -151,7 +151,7 @@ namespace GitUI.CommandsDialogs
             this.openWithDifftoolToolStripMenuItem.Image = global::GitUI.Properties.Images.Diff;
             this.openWithDifftoolToolStripMenuItem.Name = "openWithDifftoolToolStripMenuItem";
             this.openWithDifftoolToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.openWithDifftoolToolStripMenuItem.Text = "Open with difftool";
+            this.openWithDifftoolToolStripMenuItem.Text = "Open with &difftool";
             this.openWithDifftoolToolStripMenuItem.DropDownOpening += new System.EventHandler(this.openWithDifftoolToolStripMenuItem_DropDownOpening);
             // 
             // diffRememberStripSeparator
@@ -163,7 +163,7 @@ namespace GitUI.CommandsDialogs
             // 
             this.diffTwoSelectedDifftoolToolStripMenuItem.Name = "diffTwoSelectedDifftoolToolStripMenuItem";
             this.diffTwoSelectedDifftoolToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.diffTwoSelectedDifftoolToolStripMenuItem.Text = "Diff the selected files";
+            this.diffTwoSelectedDifftoolToolStripMenuItem.Text = "&Diff the selected files";
             this.diffTwoSelectedDifftoolToolStripMenuItem.Click += new System.EventHandler(this.diffTwoSelectedDiffToolToolStripMenuItem_Click);
             // 
             // diffWithRememberedDifftoolToolStripMenuItem
@@ -176,14 +176,14 @@ namespace GitUI.CommandsDialogs
             // 
             this.rememberSecondRevDiffToolStripMenuItem.Name = "rememberSecondRevDiffToolStripMenuItem";
             this.rememberSecondRevDiffToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.rememberSecondRevDiffToolStripMenuItem.Text = "Remember Second for diff";
+            this.rememberSecondRevDiffToolStripMenuItem.Text = "&Remember Second for diff";
             this.rememberSecondRevDiffToolStripMenuItem.Click += new System.EventHandler(this.rememberSecondDiffToolToolStripMenuItem_Click);
             // 
             // rememberFirstRevDiffToolStripMenuItem
             // 
             this.rememberFirstRevDiffToolStripMenuItem.Name = "rememberFirstRevDiffToolStripMenuItem";
             this.rememberFirstRevDiffToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.rememberFirstRevDiffToolStripMenuItem.Text = "Remember First for diff";
+            this.rememberFirstRevDiffToolStripMenuItem.Text = "R&emember First for diff";
             this.rememberFirstRevDiffToolStripMenuItem.Click += new System.EventHandler(this.rememberFirstDiffToolToolStripMenuItem_Click);
             // 
             // firstDiffCaptionMenuItem
@@ -202,21 +202,21 @@ namespace GitUI.CommandsDialogs
             // 
             this.firstToSelectedToolStripMenuItem.Name = "firstToSelectedToolStripMenuItem";
             this.firstToSelectedToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
-            this.firstToSelectedToolStripMenuItem.Text = "First -> Second";
+            this.firstToSelectedToolStripMenuItem.Text = "&First -> Second";
             this.firstToSelectedToolStripMenuItem.Click += new System.EventHandler(this.firstToSelectedToolStripMenuItem_Click);
             // 
             // firstToLocalToolStripMenuItem
             // 
             this.firstToLocalToolStripMenuItem.Name = "firstToLocalToolStripMenuItem";
             this.firstToLocalToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
-            this.firstToLocalToolStripMenuItem.Text = "First -> Working directory";
+            this.firstToLocalToolStripMenuItem.Text = "First -> &Working directory";
             this.firstToLocalToolStripMenuItem.Click += new System.EventHandler(this.firstToLocalToolStripMenuItem_Click);
             // 
             // selectedToLocalToolStripMenuItem
             // 
             this.selectedToLocalToolStripMenuItem.Name = "selectedToLocalToolStripMenuItem";
             this.selectedToLocalToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
-            this.selectedToLocalToolStripMenuItem.Text = "Second -> Working directory";
+            this.selectedToLocalToolStripMenuItem.Text = "&Second -> Working directory";
             this.selectedToLocalToolStripMenuItem.Click += new System.EventHandler(this.selectedToLocalToolStripMenuItem_Click);
             // 
             // saveAsToolStripMenuItem1
@@ -225,7 +225,7 @@ namespace GitUI.CommandsDialogs
             this.saveAsToolStripMenuItem1.Name = "saveAsToolStripMenuItem1";
             this.saveAsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
             this.saveAsToolStripMenuItem1.Size = new System.Drawing.Size(296, 22);
-            this.saveAsToolStripMenuItem1.Text = "Save selected as...";
+            this.saveAsToolStripMenuItem1.Text = "S&ave selected as...";
             this.saveAsToolStripMenuItem1.Click += new System.EventHandler(this.saveAsToolStripMenuItem1_Click);
             // 
             // resetFileToToolStripMenuItem
@@ -236,7 +236,7 @@ namespace GitUI.CommandsDialogs
             this.resetFileToToolStripMenuItem.Image = global::GitUI.Properties.Images.ResetWorkingDirChanges;
             this.resetFileToToolStripMenuItem.Name = "resetFileToToolStripMenuItem";
             this.resetFileToToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.resetFileToToolStripMenuItem.Text = "Reset file(s) to";
+            this.resetFileToToolStripMenuItem.Text = "&Reset file(s) to";
             this.resetFileToToolStripMenuItem.DropDownOpening += new System.EventHandler(this.resetFileToToolStripMenuItem_DropDownOpening);
             // 
             // resetFileToSelectedToolStripMenuItem
@@ -256,7 +256,7 @@ namespace GitUI.CommandsDialogs
             this.stageFileToolStripMenuItem.Image = global::GitUI.Properties.Images.Stage;
             this.stageFileToolStripMenuItem.Name = "stageFileToolStripMenuItem";
             this.stageFileToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.stageFileToolStripMenuItem.Text = "Stage file(s)";
+            this.stageFileToolStripMenuItem.Text = "Sta&ge file(s)";
             this.stageFileToolStripMenuItem.Click += new System.EventHandler(this.StageFileToolStripMenuItemClick);
             // 
             // unstageFileToolStripMenuItem
@@ -264,7 +264,7 @@ namespace GitUI.CommandsDialogs
             this.unstageFileToolStripMenuItem.Image = global::GitUI.Properties.Images.Unstage;
             this.unstageFileToolStripMenuItem.Name = "unstageFileToolStripMenuItem";
             this.unstageFileToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.unstageFileToolStripMenuItem.Text = "Unstage file(s)";
+            this.unstageFileToolStripMenuItem.Text = "&Unstage file(s)";
             this.unstageFileToolStripMenuItem.Click += new System.EventHandler(this.UnstageFileToolStripMenuItemClick);
             // 
             // cherryPickSelectedDiffFileToolStripMenuItem
@@ -272,7 +272,7 @@ namespace GitUI.CommandsDialogs
             this.cherryPickSelectedDiffFileToolStripMenuItem.Image = global::GitUI.Properties.Images.CherryPick;
             this.cherryPickSelectedDiffFileToolStripMenuItem.Name = "cherryPickSelectedDiffFileToolStripMenuItem";
             this.cherryPickSelectedDiffFileToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.cherryPickSelectedDiffFileToolStripMenuItem.Text = "Cherry pick changes";
+            this.cherryPickSelectedDiffFileToolStripMenuItem.Text = "Cherr&y pick changes";
             this.cherryPickSelectedDiffFileToolStripMenuItem.Click += new System.EventHandler(this.cherryPickSelectedDiffFileToolStripMenuItem_Click);
             // 
             // toolStripSeparator32
@@ -285,7 +285,7 @@ namespace GitUI.CommandsDialogs
             this.diffEditWorkingDirectoryFileToolStripMenuItem.Image = global::GitUI.Properties.Images.EditFile;
             this.diffEditWorkingDirectoryFileToolStripMenuItem.Name = "diffEditWorkingDirectoryFileToolStripMenuItem";
             this.diffEditWorkingDirectoryFileToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.diffEditWorkingDirectoryFileToolStripMenuItem.Text = "Edit working directory file";
+            this.diffEditWorkingDirectoryFileToolStripMenuItem.Text = "&Edit working directory file";
             this.diffEditWorkingDirectoryFileToolStripMenuItem.Click += new System.EventHandler(this.diffEditWorkingDirectoryFileToolStripMenuItem_Click);
             // 
             // diffOpenWorkingDirectoryFileWithToolStripMenuItem
@@ -294,7 +294,7 @@ namespace GitUI.CommandsDialogs
             this.diffOpenWorkingDirectoryFileWithToolStripMenuItem.Name = "diffOpenWorkingDirectoryFileWithToolStripMenuItem";
             this.diffOpenWorkingDirectoryFileWithToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
             this.diffOpenWorkingDirectoryFileWithToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.diffOpenWorkingDirectoryFileWithToolStripMenuItem.Text = "Open working directory file with...";
+            this.diffOpenWorkingDirectoryFileWithToolStripMenuItem.Text = "&Open working directory file with...";
             this.diffOpenWorkingDirectoryFileWithToolStripMenuItem.Click += new System.EventHandler(this.diffOpenWorkingDirectoryFileWithToolStripMenuItem_Click);
             // 
             // diffOpenRevisionFileToolStripMenuItem
@@ -302,7 +302,7 @@ namespace GitUI.CommandsDialogs
             this.diffOpenRevisionFileToolStripMenuItem.Image = global::GitUI.Properties.Images.ViewFile;
             this.diffOpenRevisionFileToolStripMenuItem.Name = "diffOpenRevisionFileToolStripMenuItem";
             this.diffOpenRevisionFileToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.diffOpenRevisionFileToolStripMenuItem.Text = "Open this revision (temp file)";
+            this.diffOpenRevisionFileToolStripMenuItem.Text = "Ope&n this revision (temp file)";
             this.diffOpenRevisionFileToolStripMenuItem.Click += new System.EventHandler(this.diffOpenRevisionFileToolStripMenuItem_Click);
             // 
             // diffOpenRevisionFileWithToolStripMenuItem
@@ -310,7 +310,7 @@ namespace GitUI.CommandsDialogs
             this.diffOpenRevisionFileWithToolStripMenuItem.Image = global::GitUI.Properties.Images.ViewFile;
             this.diffOpenRevisionFileWithToolStripMenuItem.Name = "diffOpenRevisionFileWithToolStripMenuItem";
             this.diffOpenRevisionFileWithToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.diffOpenRevisionFileWithToolStripMenuItem.Text = "Open this revision with... (temp file)";
+            this.diffOpenRevisionFileWithToolStripMenuItem.Text = "Open this revision &with... (temp file)";
             this.diffOpenRevisionFileWithToolStripMenuItem.Click += new System.EventHandler(this.diffOpenRevisionFileWithToolStripMenuItem_Click);
             // 
             // diffDeleteFileToolStripMenuItem
@@ -318,7 +318,7 @@ namespace GitUI.CommandsDialogs
             this.diffDeleteFileToolStripMenuItem.Image = global::GitUI.Properties.Images.DeleteFile;
             this.diffDeleteFileToolStripMenuItem.Name = "diffDeleteFileToolStripMenuItem";
             this.diffDeleteFileToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.diffDeleteFileToolStripMenuItem.Text = "Delete file";
+            this.diffDeleteFileToolStripMenuItem.Text = "De&lete file";
             this.diffDeleteFileToolStripMenuItem.Click += new System.EventHandler(this.diffDeleteFileToolStripMenuItem_Click);
             // 
             // diffCommitSubmoduleChanges
@@ -326,7 +326,7 @@ namespace GitUI.CommandsDialogs
             this.diffCommitSubmoduleChanges.Image = global::GitUI.Properties.Images.RepoStateDirtySubmodules;
             this.diffCommitSubmoduleChanges.Name = "diffCommitSubmoduleChanges";
             this.diffCommitSubmoduleChanges.Size = new System.Drawing.Size(296, 22);
-            this.diffCommitSubmoduleChanges.Text = "Commit submodule changes";
+            this.diffCommitSubmoduleChanges.Text = "&Commit submodule changes";
             this.diffCommitSubmoduleChanges.Click += new System.EventHandler(this.diffCommitSubmoduleChanges_Click);
             // 
             // diffResetSubmoduleChanges
@@ -334,7 +334,7 @@ namespace GitUI.CommandsDialogs
             this.diffResetSubmoduleChanges.Image = global::GitUI.Properties.Images.ResetWorkingDirChanges;
             this.diffResetSubmoduleChanges.Name = "diffResetSubmoduleChanges";
             this.diffResetSubmoduleChanges.Size = new System.Drawing.Size(296, 22);
-            this.diffResetSubmoduleChanges.Text = "Reset submodule changes";
+            this.diffResetSubmoduleChanges.Text = "R&eset submodule changes";
             this.diffResetSubmoduleChanges.Click += new System.EventHandler(this.diffResetSubmoduleChanges_Click);
             // 
             // diffStashSubmoduleChangesToolStripMenuItem
@@ -342,7 +342,7 @@ namespace GitUI.CommandsDialogs
             this.diffStashSubmoduleChangesToolStripMenuItem.Image = global::GitUI.Properties.Images.Stash;
             this.diffStashSubmoduleChangesToolStripMenuItem.Name = "diffStashSubmoduleChangesToolStripMenuItem";
             this.diffStashSubmoduleChangesToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.diffStashSubmoduleChangesToolStripMenuItem.Text = "Stash submodule changes";
+            this.diffStashSubmoduleChangesToolStripMenuItem.Text = "S&tash submodule changes";
             this.diffStashSubmoduleChangesToolStripMenuItem.Click += new System.EventHandler(this.diffStashSubmoduleChangesToolStripMenuItem_Click);
             // 
             // diffUpdateSubmoduleMenuItem
@@ -351,7 +351,7 @@ namespace GitUI.CommandsDialogs
             this.diffUpdateSubmoduleMenuItem.Name = "diffUpdateSubmoduleMenuItem";
             this.diffUpdateSubmoduleMenuItem.Size = new System.Drawing.Size(296, 22);
             this.diffUpdateSubmoduleMenuItem.Tag = "1";
-            this.diffUpdateSubmoduleMenuItem.Text = "Update submodule";
+            this.diffUpdateSubmoduleMenuItem.Text = "&Update submodule";
             this.diffUpdateSubmoduleMenuItem.Click += new System.EventHandler(this.diffUpdateSubmoduleMenuItem_Click);
             // 
             // submoduleStripSeparator
@@ -372,7 +372,7 @@ namespace GitUI.CommandsDialogs
             this.copyFilenameToClipboardToolStripMenuItem1.Name = "copyFilenameToClipboardToolStripMenuItem1";
             this.copyFilenameToClipboardToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
             this.copyFilenameToClipboardToolStripMenuItem1.Size = new System.Drawing.Size(296, 22);
-            this.copyFilenameToClipboardToolStripMenuItem1.Text = "Copy full path(s)";
+            this.copyFilenameToClipboardToolStripMenuItem1.Text = "Copy full &path(s)";
             this.copyFilenameToClipboardToolStripMenuItem1.Click += new System.EventHandler(this.copyFilenameToClipboardToolStripMenuItem1_Click);
             // 
             // openContainingFolderToolStripMenuItem
@@ -380,7 +380,7 @@ namespace GitUI.CommandsDialogs
             this.openContainingFolderToolStripMenuItem.Image = global::GitUI.Properties.Images.BrowseFileExplorer;
             this.openContainingFolderToolStripMenuItem.Name = "openContainingFolderToolStripMenuItem";
             this.openContainingFolderToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.openContainingFolderToolStripMenuItem.Text = "Show in folder";
+            this.openContainingFolderToolStripMenuItem.Text = "Show &in folder";
             this.openContainingFolderToolStripMenuItem.Click += new System.EventHandler(this.openContainingFolderToolStripMenuItem_Click);
             // 
             // diffShowInFileTreeToolStripMenuItem
@@ -388,7 +388,7 @@ namespace GitUI.CommandsDialogs
             this.diffShowInFileTreeToolStripMenuItem.Image = global::GitUI.Properties.Images.FileTree;
             this.diffShowInFileTreeToolStripMenuItem.Name = "diffShowInFileTreeToolStripMenuItem";
             this.diffShowInFileTreeToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.diffShowInFileTreeToolStripMenuItem.Text = "Show in File tree";
+            this.diffShowInFileTreeToolStripMenuItem.Text = "Show in File &tree";
             this.diffShowInFileTreeToolStripMenuItem.Click += new System.EventHandler(this.diffShowInFileTreeToolStripMenuItem_Click);
             // 
             // toolStripSeparator33
@@ -401,7 +401,7 @@ namespace GitUI.CommandsDialogs
             this.fileHistoryDiffToolstripMenuItem.Image = global::GitUI.Properties.Images.FileHistory;
             this.fileHistoryDiffToolstripMenuItem.Name = "fileHistoryDiffToolstripMenuItem";
             this.fileHistoryDiffToolstripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.fileHistoryDiffToolstripMenuItem.Text = "File history";
+            this.fileHistoryDiffToolstripMenuItem.Text = "File &history";
             this.fileHistoryDiffToolstripMenuItem.Click += new System.EventHandler(this.fileHistoryDiffToolstripMenuItem_Click);
             // 
             // blameToolStripMenuItem
@@ -409,7 +409,7 @@ namespace GitUI.CommandsDialogs
             this.blameToolStripMenuItem.Image = global::GitUI.Properties.Images.Blame;
             this.blameToolStripMenuItem.Name = "blameToolStripMenuItem";
             this.blameToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.blameToolStripMenuItem.Text = "Blame";
+            this.blameToolStripMenuItem.Text = "&Blame";
             this.blameToolStripMenuItem.Click += new System.EventHandler(this.blameToolStripMenuItem_Click);
             // 
             // findInDiffToolStripMenuItem
@@ -418,7 +418,7 @@ namespace GitUI.CommandsDialogs
             this.findInDiffToolStripMenuItem.Name = "findInDiffToolStripMenuItem";
             this.findInDiffToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
             this.findInDiffToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.findInDiffToolStripMenuItem.Text = "Find";
+            this.findInDiffToolStripMenuItem.Text = "&Find";
             this.findInDiffToolStripMenuItem.Click += new System.EventHandler(this.findInDiffToolStripMenuItem_Click);
             // 
             // DiffText

--- a/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
@@ -256,7 +256,7 @@ namespace GitUI.CommandsDialogs
             this.stageFileToolStripMenuItem.Image = global::GitUI.Properties.Images.Stage;
             this.stageFileToolStripMenuItem.Name = "stageFileToolStripMenuItem";
             this.stageFileToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
-            this.stageFileToolStripMenuItem.Text = "Sta&ge file(s)";
+            this.stageFileToolStripMenuItem.Text = "&Stage file(s)";
             this.stageFileToolStripMenuItem.Click += new System.EventHandler(this.StageFileToolStripMenuItemClick);
             // 
             // unstageFileToolStripMenuItem

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -46,8 +46,8 @@ namespace GitUI
         private readonly TranslationString _local = new("Local");
         private readonly TranslationString _tag = new("Tag");
         private readonly TranslationString _remote = new("Remote");
-        private readonly TranslationString _openWithGitExtensions = new("Open with Git Extensions");
-        private readonly TranslationString _openInVisualStudio = new("Open in Visual Studio");
+        private readonly TranslationString _openWithGitExtensions = new("&Open with Git Extensions");
+        private readonly TranslationString _openInVisualStudio = new("Open in &Visual Studio");
         private readonly TranslationString _contScrollToNextFileOnlyWithAlt = new("Enable automatic continuous scroll (without ALT button)");
         private readonly TranslationString _noRevision = new("No revision");
 
@@ -72,7 +72,7 @@ namespace GitUI
         private readonly TranslationString _sortBy = new("&Sort by...");
         private readonly TranslationString _sortOrder = new("&Sort order...");
 
-        private readonly TranslationString _diffSelectedWithRememberedFile = new("Diff with \"{0}\"");
+        private readonly TranslationString _diffSelectedWithRememberedFile = new("&Diff with \"{0}\"");
         private readonly TranslationString _diffWithParent = new("Diff with a/");
         private readonly TranslationString _diffBaseToB = new("Unique diff BASE with b/");
         private readonly TranslationString _diffCommonBase = new("Common diff with BASE a/");

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8558,7 +8558,7 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <target />
       </trans-unit>
       <trans-unit id="stageFileToolStripMenuItem.Text">
-        <source>Sta&amp;ge file(s)</source>
+        <source>&amp;Stage file(s)</source>
         <target />
       </trans-unit>
       <trans-unit id="unstageFileToolStripMenuItem.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8454,99 +8454,99 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <target />
       </trans-unit>
       <trans-unit id="blameToolStripMenuItem.Text">
-        <source>Blame</source>
+        <source>&amp;Blame</source>
         <target />
       </trans-unit>
       <trans-unit id="cherryPickSelectedDiffFileToolStripMenuItem.Text">
-        <source>Cherry pick changes</source>
+        <source>Cherr&amp;y pick changes</source>
         <target />
       </trans-unit>
       <trans-unit id="copyFilenameToClipboardToolStripMenuItem1.Text">
-        <source>Copy full path(s)</source>
+        <source>Copy full &amp;path(s)</source>
         <target />
       </trans-unit>
       <trans-unit id="diffCommitSubmoduleChanges.Text">
-        <source>Commit submodule changes</source>
+        <source>&amp;Commit submodule changes</source>
         <target />
       </trans-unit>
       <trans-unit id="diffDeleteFileToolStripMenuItem.Text">
-        <source>Delete file</source>
+        <source>De&amp;lete file</source>
         <target />
       </trans-unit>
       <trans-unit id="diffEditWorkingDirectoryFileToolStripMenuItem.Text">
-        <source>Edit working directory file</source>
+        <source>&amp;Edit working directory file</source>
         <target />
       </trans-unit>
       <trans-unit id="diffOpenRevisionFileToolStripMenuItem.Text">
-        <source>Open this revision (temp file)</source>
+        <source>Ope&amp;n this revision (temp file)</source>
         <target />
       </trans-unit>
       <trans-unit id="diffOpenRevisionFileWithToolStripMenuItem.Text">
-        <source>Open this revision with... (temp file)</source>
+        <source>Open this revision &amp;with... (temp file)</source>
         <target />
       </trans-unit>
       <trans-unit id="diffOpenWorkingDirectoryFileWithToolStripMenuItem.Text">
-        <source>Open working directory file with...</source>
+        <source>&amp;Open working directory file with...</source>
         <target />
       </trans-unit>
       <trans-unit id="diffResetSubmoduleChanges.Text">
-        <source>Reset submodule changes</source>
+        <source>R&amp;eset submodule changes</source>
         <target />
       </trans-unit>
       <trans-unit id="diffShowInFileTreeToolStripMenuItem.Text">
-        <source>Show in File tree</source>
+        <source>Show in File &amp;tree</source>
         <target />
       </trans-unit>
       <trans-unit id="diffStashSubmoduleChangesToolStripMenuItem.Text">
-        <source>Stash submodule changes</source>
+        <source>S&amp;tash submodule changes</source>
         <target />
       </trans-unit>
       <trans-unit id="diffTwoSelectedDifftoolToolStripMenuItem.Text">
-        <source>Diff the selected files</source>
+        <source>&amp;Diff the selected files</source>
         <target />
       </trans-unit>
       <trans-unit id="diffUpdateSubmoduleMenuItem.Text">
-        <source>Update submodule</source>
+        <source>&amp;Update submodule</source>
         <target />
       </trans-unit>
       <trans-unit id="fileHistoryDiffToolstripMenuItem.Text">
-        <source>File history</source>
+        <source>File &amp;history</source>
         <target />
       </trans-unit>
       <trans-unit id="findInDiffToolStripMenuItem.Text">
-        <source>Find</source>
+        <source>&amp;Find</source>
         <target />
       </trans-unit>
       <trans-unit id="firstToLocalToolStripMenuItem.Text">
-        <source>First -&gt; Working directory</source>
+        <source>First -&gt; &amp;Working directory</source>
         <target />
       </trans-unit>
       <trans-unit id="firstToSelectedToolStripMenuItem.Text">
-        <source>First -&gt; Second</source>
+        <source>&amp;First -&gt; Second</source>
         <target />
       </trans-unit>
       <trans-unit id="openContainingFolderToolStripMenuItem.Text">
-        <source>Show in folder</source>
+        <source>Show &amp;in folder</source>
         <target />
       </trans-unit>
       <trans-unit id="openWithDifftoolToolStripMenuItem.Text">
-        <source>Open with difftool</source>
+        <source>Open with &amp;difftool</source>
         <target />
       </trans-unit>
       <trans-unit id="rememberFirstRevDiffToolStripMenuItem.Text">
-        <source>Remember First for diff</source>
+        <source>R&amp;emember First for diff</source>
         <target />
       </trans-unit>
       <trans-unit id="rememberSecondRevDiffToolStripMenuItem.Text">
-        <source>Remember Second for diff</source>
+        <source>&amp;Remember Second for diff</source>
         <target />
       </trans-unit>
       <trans-unit id="resetFileToToolStripMenuItem.Text">
-        <source>Reset file(s) to</source>
+        <source>&amp;Reset file(s) to</source>
         <target />
       </trans-unit>
       <trans-unit id="saveAsToolStripMenuItem1.Text">
-        <source>Save selected as...</source>
+        <source>S&amp;ave selected as...</source>
         <target />
       </trans-unit>
       <trans-unit id="saveToolStripMenuItem.Text">
@@ -8554,15 +8554,15 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <target />
       </trans-unit>
       <trans-unit id="selectedToLocalToolStripMenuItem.Text">
-        <source>Second -&gt; Working directory</source>
+        <source>&amp;Second -&gt; Working directory</source>
         <target />
       </trans-unit>
       <trans-unit id="stageFileToolStripMenuItem.Text">
-        <source>Stage file(s)</source>
+        <source>Sta&amp;ge file(s)</source>
         <target />
       </trans-unit>
       <trans-unit id="unstageFileToolStripMenuItem.Text">
-        <source>Unstage file(s)</source>
+        <source>&amp;Unstage file(s)</source>
         <target />
       </trans-unit>
     </body>
@@ -8688,7 +8688,7 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="openSubmoduleMenuItem.Text">
-        <source>Open with Git Extensions</source>
+        <source>&amp;Open with Git Extensions</source>
         <target />
       </trans-unit>
       <trans-unit id="openWithDifftoolToolStripMenuItem.Text">
@@ -9675,7 +9675,7 @@ Select this commit to populate the full message.</source>
         <target />
       </trans-unit>
       <trans-unit id="_diffSelectedWithRememberedFile.Text">
-        <source>Diff with "{0}"</source>
+        <source>&amp;Diff with "{0}"</source>
         <target />
       </trans-unit>
       <trans-unit id="_diffWithParent.Text">
@@ -9803,7 +9803,7 @@ Select this commit to populate the full message.</source>
         <target />
       </trans-unit>
       <trans-unit id="_openInVisualStudio.Text">
-        <source>Open in Visual Studio</source>
+        <source>Open in &amp;Visual Studio</source>
         <target />
       </trans-unit>
       <trans-unit id="_openInVisualStudioFailureCaption.Text">
@@ -9819,7 +9819,7 @@ Select this commit to populate the full message.</source>
         <target />
       </trans-unit>
       <trans-unit id="_openWithGitExtensions.Text">
-        <source>Open with Git Extensions</source>
+        <source>&amp;Open with Git Extensions</source>
         <target />
       </trans-unit>
       <trans-unit id="_parentsText.Text">


### PR DESCRIPTION
## Proposed changes

- Add mnemonics to the context menu of the `RevisionDiffControl`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The same without most of the mnemonics

### After

- for commit file(s)

![grafik](https://user-images.githubusercontent.com/36601201/121805568-0d70a900-cc4c-11eb-8fe0-f5c167f42daa.png)

![grafik](https://user-images.githubusercontent.com/36601201/121805615-36913980-cc4c-11eb-8218-29b27306244b.png)

- for unstaged file

![grafik](https://user-images.githubusercontent.com/36601201/121956380-59f9d880-cd61-11eb-8143-c55c1efbca23.png)

- for staged file

![grafik](https://user-images.githubusercontent.com/36601201/121805716-9ee01b00-cc4c-11eb-85ad-c6bba60cb03e.png)

- for unstaged submodule

![grafik](https://user-images.githubusercontent.com/36601201/121956658-ae04bd00-cd61-11eb-98ab-c23d7c790a7e.png)

- for staged submodule

![grafik](https://user-images.githubusercontent.com/36601201/121805803-0c8c4700-cc4d-11eb-98f4-3c81124eaa91.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 33032a04a860c1b4a2a438dc1742e9215b1902e8
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.6
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).