### PR TITLE
Fixup partial graph rendering

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/ColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/ColumnProvider.cs
@@ -24,16 +24,20 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
         public int Index => Column.Index;
 
+        public virtual void Clear()
+        {
+        }
+
+        public virtual void LoadingCompleted()
+        {
+        }
+
         /// <summary>Renders the content of a cell in this column.</summary>
         public abstract void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style);
 
         /// <summary>Formats the textual representation of a cell in this column.</summary>
         /// <remarks>Implementations may set <c>e.Value</c> to the required string, and then set <c>e.FormattingApplied</c> to <c>true</c>.</remarks>
         public virtual void OnCellFormatting(DataGridViewCellFormattingEventArgs e, GitRevision revision)
-        {
-        }
-
-        public virtual void Clear()
         {
         }
 

--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -410,6 +410,11 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             _graphCache.Reset();
         }
 
+        public override void LoadingCompleted()
+        {
+            _revisionGraph.LoadingCompleted();
+        }
+
         public override void Refresh(int rowHeight, in VisibleRowRange range)
         {
             // Hide graph column when there it is disabled OR when a filter is active

--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -240,7 +240,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
                     void DrawItem()
                     {
-                        if (index > _revisionGraph.GetCachedCount())
+                        if (index >= _revisionGraph.GetCachedCount())
                         {
                             return;
                         }

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -22,6 +22,8 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         private ConcurrentDictionary<ObjectId, RevisionGraphRevision> _nodeByObjectId = new();
         private ImmutableList<RevisionGraphRevision> _nodes = ImmutableList<RevisionGraphRevision>.Empty;
 
+        private bool _loadingCompleted;
+
         /// <summary>
         /// The max score is used to keep a chronological order during the graph building.
         /// It is cheaper than doing <c>_nodes.Max(n => n.Score)</c>.
@@ -48,11 +50,17 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
         public void Clear()
         {
+            _loadingCompleted = false;
             _maxScore = 0;
             _nodeByObjectId = new ConcurrentDictionary<ObjectId, RevisionGraphRevision>();
             _nodes = ImmutableList<RevisionGraphRevision>.Empty;
             _orderedNodesCache = null;
             _orderedRowCache = null;
+        }
+
+        public void LoadingCompleted()
+        {
+            _loadingCompleted = true;
         }
 
         public int Count => _nodes.Count;
@@ -73,7 +81,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             }
 
             int cachedCount = _orderedRowCache.Count;
-            return cachedCount == Count ? cachedCount : cachedCount - _straightenLanesLookAhead;
+            return _loadingCompleted ? cachedCount : cachedCount - _straightenLanesLookAhead;
         }
 
         /// <summary>

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -337,6 +337,14 @@ namespace GitUI.UserControls.RevisionGrid
             StartBackgroundProcessingTask(cancellationToken);
         }
 
+        public void LoadingCompleted()
+        {
+            foreach (ColumnProvider columnProvider in _columnProviders)
+            {
+                columnProvider.LoadingCompleted();
+            }
+        }
+
         /// <summary>
         /// Checks whether the given hash is present in the graph.
         /// </summary>

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1111,6 +1111,7 @@ namespace GitUI
                     {
                         await this.SwitchToMainThreadAsync();
 
+                        _gridView.LoadingCompleted();
                         SetPage(_gridView);
                         _isRefreshingRevisions = false;
                         CheckAndRepairInitialRevision();

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -930,12 +930,12 @@ namespace GitUI
                     predicate = null;
                 }
 
+                _isReadingRevisions = true;
                 Subject<GitRevision> revisions = new();
                 _revisionSubscription?.Dispose();
                 _revisionSubscription = revisions
                     .ObserveOn(ThreadPoolScheduler.Instance)
                     .Subscribe(OnRevisionRead, OnRevisionReaderError, OnRevisionReadCompleted);
-                _isReadingRevisions = true;
 
                 _revisionReader ??= new RevisionReader();
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2783,6 +2783,8 @@ namespace GitUI
             public RefFilterOptions RefFilterOptions => _revisionGridControl.RefFilterOptions;
 
             public int VisibleRevisionCount => _revisionGridControl._gridView.RowCount;
+
+            public bool IsRefreshingRevisions => _revisionGridControl._isRefreshingRevisions;
         }
     }
 }

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
@@ -32,6 +32,8 @@ namespace GitUITests.UserControls.RevisionGrid
             _revisionGraph.CacheTo(4, 4);
             Assert.AreEqual(5, _revisionGraph.GetCachedCount());
             _revisionGraph.CacheTo(400, 400);
+            Assert.AreEqual(6, _revisionGraph.GetCachedCount());
+            _revisionGraph.LoadingCompleted();
             Assert.AreEqual(6 + LookAhead, _revisionGraph.GetCachedCount());
         }
 


### PR DESCRIPTION
Fixes #9108

## Proposed changes

- Fixup `RevisionGraph.GetCachedCount`: return full `cachedCount` only if loading has really finished
- Fixup condition in `DrawItem` of `RevisionGraphColumnProvider`
- Fixup theoretical race condition with `RevisionGridControl._isReadingRevisions`

## Screenshots <!-- Remove this section if PR does not change UI -->

see issue

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 7287ca7ff5688e23ef3b0a0d242a80e744996e89
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.6
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).