### PR TITLE
Create empty settings file if missing

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -108,14 +108,38 @@ namespace GitCommands
                 return path;
             });
 
+            bool newFile = CreateEmptySettingsFileIfMissing();
+
             SettingsContainer = new RepoDistSettings(null, GitExtSettingsCache.FromCache(SettingsFilePath), SettingLevel.Unknown);
 
-            if (!File.Exists(SettingsFilePath))
+            if (newFile || !File.Exists(SettingsFilePath))
             {
                 ImportFromRegistry();
             }
 
             MigrateAvatarSettings();
+
+            return;
+
+            static bool CreateEmptySettingsFileIfMissing()
+            {
+                try
+                {
+                    string dir = Path.GetDirectoryName(SettingsFilePath);
+                    if (!Directory.Exists(dir) || File.Exists(SettingsFilePath))
+                    {
+                        return false;
+                    }
+                }
+                catch (ArgumentException)
+                {
+                    // Illegal characters in the filename
+                    return false;
+                }
+
+                File.WriteAllText(SettingsFilePath, "<?xml version=\"1.0\" encoding=\"utf-8\"?><dictionary />", Encoding.UTF8);
+                return true;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #9288

## Proposed changes

- If missing, create a minimum settings file instead of skipping the activation of the `FileSystemWatcher` (#9003)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 202d4f1678f0cd15822432fdbe60800d3fbb7085
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4360.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).