### PR TITLE
Make showing commit message body in the revision graph optional

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1259,6 +1259,12 @@ namespace GitCommands
             set => SetInt("revisiongridquicksearchtimeout", value);
         }
 
+        public static bool ShowMultiLineCommitMessages
+        {
+            get => GetBool("showmultilinecommitmessages", true);
+            set => SetBool("showmultilinecommitmessages", value);
+        }
+
         /// <summary>Gets or sets the path to the git application executable.</summary>
         public static string GitBinDir
         {

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1259,10 +1259,10 @@ namespace GitCommands
             set => SetInt("revisiongridquicksearchtimeout", value);
         }
 
-        public static bool ShowMultiLineCommitMessages
+        public static bool ShowCommitBodyInRevisionGrid
         {
-            get => GetBool("showmultilinecommitmessages", true);
-            set => SetBool("showmultilinecommitmessages", value);
+            get => GetBool("showcommitbodyinrevisiongrid", true);
+            set => SetBool("showcommitbodyinrevisiongrid", value);
         }
 
         /// <summary>Gets or sets the path to the git application executable.</summary>

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1261,8 +1261,8 @@ namespace GitCommands
 
         public static bool ShowCommitBodyInRevisionGrid
         {
-            get => GetBool("showcommitbodyinrevisiongrid", true);
-            set => SetBool("showcommitbodyinrevisiongrid", value);
+            get => GetBool("ShowCommitBodyInRevisionGrid", true);
+            set => SetBool("ShowCommitBodyInRevisionGrid", value);
         }
 
         /// <summary>Gets or sets the path to the git application executable.</summary>

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -849,7 +849,7 @@ namespace GitUI.CommandsDialogs
             FillCommitInfo(selectedRevision);
 
             // If the revision's body has been updated then the grid needs to be refreshed to display it
-            if (AppSettings.ShowMultiLineCommitMessages && selectedRevision is not null && selectedRevision.HasMultiLineMessage && oldBody != selectedRevision.Body)
+            if (AppSettings.ShowCommitBodyInRevisionGrid && selectedRevision is not null && selectedRevision.HasMultiLineMessage && oldBody != selectedRevision.Body)
             {
                 RevisionGrid.Refresh();
             }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -849,7 +849,7 @@ namespace GitUI.CommandsDialogs
             FillCommitInfo(selectedRevision);
 
             // If the revision's body has been updated then the grid needs to be refreshed to display it
-            if (selectedRevision is not null && selectedRevision.HasMultiLineMessage && oldBody != selectedRevision.Body)
+            if (AppSettings.ShowMultiLineCommitMessages && selectedRevision is not null && selectedRevision.HasMultiLineMessage && oldBody != selectedRevision.Body)
             {
                 RevisionGrid.Refresh();
             }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8867,6 +8867,10 @@ See the changes in the commit form.</source>
         <source>Show build status text</source>
         <target />
       </trans-unit>
+      <trans-unit id="showCommitMessageBodyToolStripMenuItem.Text">
+        <source>Show commit message body</source>
+        <target />
+      </trans-unit>
       <trans-unit id="showDateColumnToolStripMenuItem.Text">
         <source>Show date column</source>
         <target />
@@ -8897,10 +8901,6 @@ See the changes in the commit form.</source>
       </trans-unit>
       <trans-unit id="showTagsToolStripMenuItem.Text">
         <source>Show tags</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="showMultiLineCommitMessagesToolStripMenuItem.Text">
-        <source>Show multi-line commit messages</source>
         <target />
       </trans-unit>
     </body>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8899,6 +8899,10 @@ See the changes in the commit form.</source>
         <source>Show tags</source>
         <target />
       </trans-unit>
+      <trans-unit id="showMultiLineCommitMessagesToolStripMenuItem.Text">
+        <source>Show multi-line commit messages</source>
+        <target />
+      </trans-unit>
     </body>
   </file>
   <file datatype="plaintext" original="RevisionGridControl" source-language="en">

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -404,7 +404,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 return;
             }
 
-            if (lines.Length > 1)
+            if (lines.Length > 1 && AppSettings.ShowCommitBodyInRevisionGrid)
             {
                 var commitBody = string.Concat(lines.Skip(1).Select(_ => " " + _));
                 var bodyBounds = messageBounds.ReduceLeft(offset);

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2185,6 +2185,13 @@ namespace GitUI
             ForceRefreshRevisions();
         }
 
+        internal void ToggleShowMultiLineCommit()
+        {
+            AppSettings.ShowMultiLineCommitMessages = !AppSettings.ShowMultiLineCommitMessages;
+            MenuCommands.TriggerMenuChanged();
+            Refresh();
+        }
+
         internal void ShowFirstParent()
         {
             AppSettings.ShowFirstParent = !AppSettings.ShowFirstParent;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2185,7 +2185,7 @@ namespace GitUI
             ForceRefreshRevisions();
         }
 
-        internal void ShowCommitBodyInRevisionGrid()
+        internal void ToggleShowCommitBodyInRevisionGrid()
         {
             AppSettings.ShowCommitBodyInRevisionGrid = !AppSettings.ShowCommitBodyInRevisionGrid;
             MenuCommands.TriggerMenuChanged();

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2185,9 +2185,9 @@ namespace GitUI
             ForceRefreshRevisions();
         }
 
-        internal void ToggleShowMultiLineCommit()
+        internal void ShowCommitBodyInRevisionGrid()
         {
-            AppSettings.ShowMultiLineCommitMessages = !AppSettings.ShowMultiLineCommitMessages;
+            AppSettings.ShowCommitBodyInRevisionGrid = !AppSettings.ShowCommitBodyInRevisionGrid;
             MenuCommands.TriggerMenuChanged();
             Refresh();
         }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -358,7 +358,7 @@ namespace GitUI.UserControls.RevisionGrid
                 {
                     Name = "showCommitMessageBodyToolStripMenuItem",
                     Text = "Show commit message body",
-                    ExecuteAction = () => _revisionGrid.ShowCommitBodyInRevisionGrid(),
+                    ExecuteAction = () => _revisionGrid.ToggleShowCommitBodyInRevisionGrid(),
                     IsCheckedFunc = () => AppSettings.ShowCommitBodyInRevisionGrid
                 },
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -354,6 +354,13 @@ namespace GitUI.UserControls.RevisionGrid
                     ExecuteAction = () => _revisionGrid.ToggleShowGitNotes(),
                     IsCheckedFunc = () => AppSettings.ShowGitNotes
                 },
+                new MenuCommand
+                {
+                    Name = "showMultiLineCommitMessagesToolStripMenuItem",
+                    Text = "Show multi-line commit messages",
+                    ExecuteAction = () => _revisionGrid.ToggleShowMultiLineCommit(),
+                    IsCheckedFunc = () => AppSettings.ShowMultiLineCommitMessages
+                },
 
                 MenuCommand.CreateSeparator(),
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -356,10 +356,10 @@ namespace GitUI.UserControls.RevisionGrid
                 },
                 new MenuCommand
                 {
-                    Name = "showMultiLineCommitMessagesToolStripMenuItem",
-                    Text = "Show multi-line commit messages",
-                    ExecuteAction = () => _revisionGrid.ToggleShowMultiLineCommit(),
-                    IsCheckedFunc = () => AppSettings.ShowMultiLineCommitMessages
+                    Name = "showCommitMessageBodyToolStripMenuItem",
+                    Text = "Show commit message body",
+                    ExecuteAction = () => _revisionGrid.ShowCommitBodyInRevisionGrid(),
+                    IsCheckedFunc = () => AppSettings.ShowCommitBodyInRevisionGrid
                 },
 
                 MenuCommand.CreateSeparator(),

--- a/contributors.txt
+++ b/contributors.txt
@@ -158,3 +158,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/03/31, darkcamper, Rubén Ruiz, darkcamper(at)gmail.com
 2021/05/05, mrjithil, Jithil P Ponnan, jithil(at)outlook.com
 2021/05/07, dasiths, Dasith Wijesiriwardena, gitextensions.github(at)dasith.me
+2021/06/18, jwfx, Jörg Winkler, jwfx at bitmx.net


### PR DESCRIPTION
Original code by @FodderMK

Fixes #9298


## Proposed changes

- Readd revision graph configuration option that was previously removed
- Enabled by default as it currently is without the option

## Screenshots <!-- Remove this section if PR does not change UI -->

![image](https://user-images.githubusercontent.com/39484381/122618451-90e82b00-d08e-11eb-8216-85453e51bc0b.png)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
