### PR TITLE
Open Delete Tag dialog from Left Panel with full tag name

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -48,7 +48,7 @@ namespace GitUI.BranchTreePanel
 
             public bool Delete()
             {
-                return UICommands.StartDeleteTagDialog(TreeViewNode.TreeView, Name);
+                return UICommands.StartDeleteTagDialog(TreeViewNode.TreeView, FullPath);
             }
 
             public bool Merge()


### PR DESCRIPTION
Fixes #9291


## Proposed changes

- Prepopulate Delete Tag dialog with the `FullName` of the tag

## Screenshots <!-- Remove this section if PR does not change UI -->

### After

![grafik](https://user-images.githubusercontent.com/36601201/122833419-3c8eb680-d2ed-11eb-80b5-fe5857c5d369.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 55dec49de1d4b378f27687d36b47b90ab8c6250d
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.7
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).