### PR TITLE
Stash: Keyboard navigation

### DIFF
--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -30,6 +30,7 @@ namespace GitUI.CommandsDialogs
             this.StashKeepIndex = new System.Windows.Forms.CheckBox();
             this.Apply = new System.Windows.Forms.Button();
             this.Clear = new System.Windows.Forms.Button();
+            this.messageLabel = new System.Windows.Forms.Label();
             this.StashMessage = new System.Windows.Forms.RichTextBox();
             this.panel1 = new System.Windows.Forms.Panel();
             this.Loading = new LoadingControl();
@@ -40,7 +41,6 @@ namespace GitUI.CommandsDialogs
             this.showToolStripLabel = new System.Windows.Forms.ToolStripLabel();
             this.Stashes = new System.Windows.Forms.ToolStripComboBox();
             this.refreshToolStripButton = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButton_customMessage = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.View = new GitUI.Editor.FileViewer();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
@@ -86,17 +86,19 @@ namespace GitUI.CommandsDialogs
             // 
             this.tableLayoutPanel2.ColumnCount = 1;
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel1, 0, 2);
-            this.tableLayoutPanel2.Controls.Add(this.StashMessage, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel1, 0, 3);
+            this.tableLayoutPanel2.Controls.Add(this.StashMessage, 0, 2);
+            this.tableLayoutPanel2.Controls.Add(this.messageLabel, 0, 2);
             this.tableLayoutPanel2.Controls.Add(this.panel1, 0, 1);
             this.tableLayoutPanel2.Controls.Add(this.toolStrip1, 0, 0);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(0);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 3;
+            this.tableLayoutPanel2.RowCount = 5;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.Size = new System.Drawing.Size(280, 1040);
@@ -209,6 +211,12 @@ namespace GitUI.CommandsDialogs
             this.Clear.UseVisualStyleBackColor = true;
             this.Clear.Click += new System.EventHandler(this.ClearClick);
             // 
+            // messageLabel
+            // 
+            this.messageLabel.Name = "messageLabel";
+            this.messageLabel.Size = new System.Drawing.Size(280, 37);
+            this.messageLabel.Text = "&Message:";
+            // 
             // StashMessage
             // 
             this.StashMessage.BackColor = System.Drawing.SystemColors.Info;
@@ -221,7 +229,6 @@ namespace GitUI.CommandsDialogs
             this.StashMessage.Size = new System.Drawing.Size(280, 150);
             this.StashMessage.TabIndex = 3;
             this.StashMessage.Text = "";
-            this.StashMessage.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.StashMessage_MouseDoubleClick);
             // 
             // panel1
             // 
@@ -287,7 +294,6 @@ namespace GitUI.CommandsDialogs
             this.showToolStripLabel,
             this.Stashes,
             this.refreshToolStripButton,
-            this.toolStripButton_customMessage,
             this.toolStripSeparator1});
             this.toolStrip1.Location = new System.Drawing.Point(0, 0);
             this.toolStrip1.Name = "toolStrip1";
@@ -326,22 +332,6 @@ namespace GitUI.CommandsDialogs
             this.refreshToolStripButton.Size = new System.Drawing.Size(36, 37);
             this.refreshToolStripButton.Text = "Refresh";
             this.refreshToolStripButton.Click += new System.EventHandler(this.RefreshClick);
-            // 
-            // toolStripButton_customMessage
-            // 
-            this.toolStripButton_customMessage.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.toolStripButton_customMessage.CheckOnClick = true;
-            this.toolStripButton_customMessage.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripButton_customMessage.Enabled = false;
-            this.toolStripButton_customMessage.Image = global::GitUI.Properties.Images.FileStatusModified;
-            this.toolStripButton_customMessage.ImageTransparentColor = System.Drawing.Color.White;
-            this.toolStripButton_customMessage.Name = "toolStripButton_customMessage";
-            this.toolStripButton_customMessage.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
-            this.toolStripButton_customMessage.Size = new System.Drawing.Size(36, 37);
-            this.toolStripButton_customMessage.Text = "Custom stash message";
-            this.toolStripButton_customMessage.ToolTipText = "Write custom stash message";
-            this.toolStripButton_customMessage.Click += new System.EventHandler(this.toolStripButton_customMessage_Click);
-            this.toolStripButton_customMessage.EnabledChanged += new System.EventHandler(this.toolStripButton_customMessage_EnabledChanged);
             // 
             // toolStripSeparator1
             // 
@@ -400,6 +390,7 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.SplitContainer splitContainer1;
         private FileStatusList Stashed;
         private System.Windows.Forms.BindingSource gitStashBindingSource;
+        private System.Windows.Forms.Label messageLabel;
         private System.Windows.Forms.RichTextBox StashMessage;
         private FileViewer View;
         private ToolStripEx toolStrip1;
@@ -408,7 +399,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.ToolStripComboBox Stashes;
         private GitUI.UserControls.RevisionGrid.LoadingControl Loading;
         private CheckBox StashKeepIndex;
-        private ToolStripButton toolStripButton_customMessage;
         private ToolStripSeparator toolStripSeparator1;
         private CheckBox chkIncludeUntrackedFiles;
         private TableLayoutPanel tableLayoutPanel2;

--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -136,7 +136,7 @@ namespace GitUI.CommandsDialogs
             this.StashSelectedFiles.Name = "StashSelectedFiles";
             this.StashSelectedFiles.Size = new System.Drawing.Size(274, 50);
             this.StashSelectedFiles.TabIndex = 18;
-            this.StashSelectedFiles.Text = "Stash selected changes";
+            this.StashSelectedFiles.Text = "Stash &selected changes";
             this.toolTip.SetToolTip(this.StashSelectedFiles, "Stash changes for the selected files, then revert them to the original state");
             this.StashSelectedFiles.UseVisualStyleBackColor = true;
             this.StashSelectedFiles.Click += new System.EventHandler(this.StashSelectedFiles_Click);
@@ -150,7 +150,7 @@ namespace GitUI.CommandsDialogs
             this.Stash.Name = "Stash";
             this.Stash.Size = new System.Drawing.Size(274, 50);
             this.Stash.TabIndex = 15;
-            this.Stash.Text = "Stash all changes";
+            this.Stash.Text = "S&tash all changes";
             this.toolTip.SetToolTip(this.Stash, "Save local changes to a new stash, then revert local changes");
             this.Stash.UseVisualStyleBackColor = true;
             this.Stash.Click += new System.EventHandler(this.StashClick);
@@ -164,7 +164,7 @@ namespace GitUI.CommandsDialogs
             this.chkIncludeUntrackedFiles.Name = "chkIncludeUntrackedFiles";
             this.chkIncludeUntrackedFiles.Size = new System.Drawing.Size(128, 29);
             this.chkIncludeUntrackedFiles.TabIndex = 14;
-            this.chkIncludeUntrackedFiles.Text = "Include untracked files";
+            this.chkIncludeUntrackedFiles.Text = "&Include untracked files";
             this.toolTip.SetToolTip(this.chkIncludeUntrackedFiles, "All untracked files are also stashed and then cleaned");
             this.chkIncludeUntrackedFiles.UseVisualStyleBackColor = true;
             // 
@@ -177,7 +177,7 @@ namespace GitUI.CommandsDialogs
             this.StashKeepIndex.Name = "StashKeepIndex";
             this.StashKeepIndex.Size = new System.Drawing.Size(128, 29);
             this.StashKeepIndex.TabIndex = 13;
-            this.StashKeepIndex.Text = "Keep index";
+            this.StashKeepIndex.Text = "&Keep index";
             this.toolTip.SetToolTip(this.StashKeepIndex, "All changes already added to the index are left intact");
             this.StashKeepIndex.UseVisualStyleBackColor = true;
             // 
@@ -190,7 +190,7 @@ namespace GitUI.CommandsDialogs
             this.Apply.Name = "Apply";
             this.Apply.Size = new System.Drawing.Size(274, 50);
             this.Apply.TabIndex = 17;
-            this.Apply.Text = "Apply Selected Stash";
+            this.Apply.Text = "&Apply Selected Stash";
             this.toolTip.SetToolTip(this.Apply, "Apply the selected stash on top of the current working directory state");
             this.Apply.UseVisualStyleBackColor = true;
             this.Apply.Click += new System.EventHandler(this.ApplyClick);
@@ -204,7 +204,7 @@ namespace GitUI.CommandsDialogs
             this.Clear.Name = "Clear";
             this.Clear.Size = new System.Drawing.Size(274, 50);
             this.Clear.TabIndex = 16;
-            this.Clear.Text = "Drop Selected Stash";
+            this.Clear.Text = "&Drop Selected Stash";
             this.toolTip.SetToolTip(this.Clear, "Remove the selected stash from the list");
             this.Clear.UseVisualStyleBackColor = true;
             this.Clear.Click += new System.EventHandler(this.ClearClick);
@@ -273,7 +273,7 @@ namespace GitUI.CommandsDialogs
             this.cherryPickFileChangesToolStripMenuItem.Image = global::GitUI.Properties.Resources.CherryPick;
             this.cherryPickFileChangesToolStripMenuItem.Name = "cherryPickFileChangesToolStripMenuItem";
             this.cherryPickFileChangesToolStripMenuItem.Size = new System.Drawing.Size(208, 22);
-            this.cherryPickFileChangesToolStripMenuItem.Text = "Cherry pick file changes";
+            this.cherryPickFileChangesToolStripMenuItem.Text = "&Cherry pick file changes";
             this.cherryPickFileChangesToolStripMenuItem.Click += new System.EventHandler(this.CherryPickFileChangesToolStripMenuItem_Click);
             // 
             // toolStrip1
@@ -301,7 +301,7 @@ namespace GitUI.CommandsDialogs
             this.showToolStripLabel.Name = "showToolStripLabel";
             this.showToolStripLabel.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
             this.showToolStripLabel.Size = new System.Drawing.Size(78, 37);
-            this.showToolStripLabel.Text = "Show:";
+            this.showToolStripLabel.Text = "S&how:";
             // 
             // Stashes
             // 

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -183,10 +183,10 @@ namespace GitUI.CommandsDialogs
             Loading.IsAnimating = true;
             Stashes.Enabled = false;
             refreshToolStripButton.Enabled = false;
-            toolStripButton_customMessage.Enabled = false;
+            StashMessage.ReadOnly = true;
             if (gitStash == _currentWorkingDirStashItem)
             {
-                toolStripButton_customMessage.Enabled = true;
+                StashMessage.ReadOnly = false;
                 _asyncLoader.LoadAsync(() => Module.GetAllChangedFiles(), LoadGitItemStatuses);
                 Clear.Enabled = false; // disallow Drop  (of current working directory)
                 Apply.Enabled = false; // disallow Apply (of current working directory)
@@ -295,7 +295,7 @@ namespace GitUI.CommandsDialogs
 
         private void ResizeStashesWidth()
         {
-            Stashes.Size = new Size(toolStrip1.Width - 15 - refreshToolStripButton.Width - showToolStripLabel.Width - toolStripButton_customMessage.Width, Stashes.Size.Height);
+            Stashes.Size = new Size(toolStrip1.Width - 15 - refreshToolStripButton.Width - showToolStripLabel.Width, Stashes.Size.Height);
         }
 
         private void StashedSelectedIndexChanged(object sender, EventArgs e)
@@ -315,7 +315,7 @@ namespace GitUI.CommandsDialogs
 
             using (WaitCursorScope.Enter())
             {
-                var msg = toolStripButton_customMessage.Checked ? " " + StashMessage.Text.Trim() : string.Empty;
+                var msg = !string.IsNullOrWhiteSpace(StashMessage.Text) ? " " + StashMessage.Text.Trim() : string.Empty;
                 UICommands.StashSave(this, chkIncludeUntrackedFiles.Checked, StashKeepIndex.Checked, msg);
                 Initialize();
             }
@@ -331,7 +331,7 @@ namespace GitUI.CommandsDialogs
 
             using (WaitCursorScope.Enter())
             {
-                var msg = toolStripButton_customMessage.Checked ? " " + StashMessage.Text.Trim() : string.Empty;
+                var msg = !string.IsNullOrWhiteSpace(StashMessage.Text) ? " " + StashMessage.Text.Trim() : string.Empty;
                 UICommands.StashSave(this, chkIncludeUntrackedFiles.Checked, StashKeepIndex.Checked, msg, Stashed.SelectedItems.Select(i => i.Item.Name).ToList());
                 Initialize();
             }
@@ -400,9 +400,9 @@ namespace GitUI.CommandsDialogs
             {
                 InitializeSoft();
 
-                if (Stashes.SelectedItem is not null)
+                if (Stashes.SelectedItem is GitStash gitStash)
                 {
-                    StashMessage.Text = ((GitStash)Stashes.SelectedItem).Message;
+                    StashMessage.Text = gitStash != _currentWorkingDirStashItem ? gitStash.Message : "";
                 }
 
                 if (Stashes.Items.Count == 1)
@@ -455,52 +455,6 @@ namespace GitUI.CommandsDialogs
         private void FormStash_Resize(object sender, EventArgs e)
         {
             ResizeStashesWidth();
-        }
-
-        private void toolStripButton_customMessage_Click(object sender, EventArgs e)
-        {
-            if (toolStripButton_customMessage.Enabled)
-            {
-                if (((ToolStripButton)sender).Checked)
-                {
-                    StashMessage.ReadOnly = false;
-                    StashMessage.Focus();
-                    StashMessage.SelectAll();
-                }
-                else
-                {
-                    StashMessage.ReadOnly = true;
-                }
-            }
-        }
-
-        private void StashMessage_MouseDoubleClick(object sender, MouseEventArgs e)
-        {
-            if (e.Button != MouseButtons.Left)
-            {
-                return;
-            }
-
-            if (toolStripButton_customMessage.Enabled)
-            {
-                if (!toolStripButton_customMessage.Checked)
-                {
-                    toolStripButton_customMessage.PerformClick();
-                }
-            }
-        }
-
-        private void toolStripButton_customMessage_EnabledChanged(object sender, EventArgs e)
-        {
-            var button = (ToolStripButton)sender;
-            if (!button.Enabled)
-            {
-                StashMessage.ReadOnly = true;
-            }
-            else if (button.Checked)
-            {
-                StashMessage.ReadOnly = false;
-            }
         }
 
         private void View_KeyUp(object sender, KeyEventArgs e)

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -362,6 +362,11 @@ namespace GitUI.Hotkey
                     Hk(RevisionFileTreeControl.Command.OpenWithDifftool, OpenWithDifftoolHotkey),
                     Hk(RevisionFileTreeControl.Command.ShowHistory, ShowHistoryHotkey)),
                 new HotkeySettings(
+                    FormStash.HotkeySettingsName,
+                    Hk(FormStash.Command.NextStash, Keys.Control | Keys.N),
+                    Hk(FormStash.Command.PreviousStash, Keys.Control | Keys.P),
+                    Hk(FormStash.Command.Refresh, Keys.F5)),
+                new HotkeySettings(
                     FormSettings.HotkeySettingsName,
                     LoadScriptHotkeys())
             };

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6858,23 +6858,23 @@ Therefore the Cancel button does NOT revert any changes made.</source>
         <target />
       </trans-unit>
       <trans-unit id="Apply.Text">
-        <source>Apply Selected Stash</source>
+        <source>&amp;Apply Selected Stash</source>
         <target />
       </trans-unit>
       <trans-unit id="Clear.Text">
-        <source>Drop Selected Stash</source>
+        <source>&amp;Drop Selected Stash</source>
         <target />
       </trans-unit>
       <trans-unit id="Stash.Text">
-        <source>Stash all changes</source>
+        <source>S&amp;tash all changes</source>
         <target />
       </trans-unit>
       <trans-unit id="StashKeepIndex.Text">
-        <source>Keep index</source>
+        <source>&amp;Keep index</source>
         <target />
       </trans-unit>
       <trans-unit id="StashSelectedFiles.Text">
-        <source>Stash selected changes</source>
+        <source>Stash &amp;selected changes</source>
         <target />
       </trans-unit>
       <trans-unit id="Stashes.ToolTipText">
@@ -6914,11 +6914,11 @@ Therefore the Cancel button does NOT revert any changes made.</source>
         <target />
       </trans-unit>
       <trans-unit id="cherryPickFileChangesToolStripMenuItem.Text">
-        <source>Cherry pick file changes</source>
+        <source>&amp;Cherry pick file changes</source>
         <target />
       </trans-unit>
       <trans-unit id="chkIncludeUntrackedFiles.Text">
-        <source>Include untracked files</source>
+        <source>&amp;Include untracked files</source>
         <target />
       </trans-unit>
       <trans-unit id="refreshToolStripButton.Text">
@@ -6926,7 +6926,7 @@ Therefore the Cancel button does NOT revert any changes made.</source>
         <target />
       </trans-unit>
       <trans-unit id="showToolStripLabel.Text">
-        <source>Show:</source>
+        <source>S&amp;how:</source>
         <target />
       </trans-unit>
       <trans-unit id="toolStripButton_customMessage.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6921,20 +6921,16 @@ Therefore the Cancel button does NOT revert any changes made.</source>
         <source>&amp;Include untracked files</source>
         <target />
       </trans-unit>
+      <trans-unit id="messageLabel.Text">
+        <source>&amp;Message:</source>
+        <target />
+      </trans-unit>
       <trans-unit id="refreshToolStripButton.Text">
         <source>Refresh</source>
         <target />
       </trans-unit>
       <trans-unit id="showToolStripLabel.Text">
         <source>S&amp;how:</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="toolStripButton_customMessage.Text">
-        <source>Custom stash message</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="toolStripButton_customMessage.ToolTipText">
-        <source>Write custom stash message</source>
         <target />
       </trans-unit>
     </body>


### PR DESCRIPTION
Fixes #8108

## Proposed changes

- HotKeys for next/previous stash and refresh
Ctrl-P navigates to next older stash item, similar to how navigation in RevGrid.

- Mnemonics for the form. 
As `Stashes` control gets a specific hotkey, it is possible to navigate in the stashes list with Alt-H arrow /PageUp/etc too
"&Apply stash" but "S&tash all changes" as I expect Ctrl-Alt-Up to be used for stash in current worktree.

- Stash: Keep position when dropping a stash 
Simplify deleting stashes, unless deleting the first, you would have to search for the stash close to where you just deleted the stash.

- Remove button for custom message, just make it writeable for worktree.
Add label for mnemonics 

## Screenshots <!-- Remove this section if PR does not change UI -->

### After

![image](https://user-images.githubusercontent.com/6248932/123526325-66721f80-d6d7-11eb-8f73-48b686aba278.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
