### PR TITLE
Exclude vimdiff1 from custom difftools

### DIFF
--- a/GitCommands/CustomDiffMergeToolCache.cs
+++ b/GitCommands/CustomDiffMergeToolCache.cs
@@ -119,7 +119,7 @@ namespace GitCommands
                 }
 
                 // Ignore (known) tools that must run in a terminal
-                string[] ignoredTools = { "vimdiff", "vimdiff2", "vimdiff3" };
+                string[] ignoredTools = { "vimdiff", "vimdiff1", "vimdiff2", "vimdiff3" };
                 var toolName = tool[0];
                 if (!string.IsNullOrWhiteSpace(toolName) && !tools.Contains(toolName) && !ignoredTools.Contains(toolName))
                 {


### PR DESCRIPTION

## Proposed changes

vimdiff1 is a console only application included since Git 2.31
It should be excluded from the default difftools

This is a little annoying if you only have one difftool

This could be a hidden setting too, to allow the user to override the GE defaults.
For now this is good enough, new tools are not added that often.

To be cherry-picked for 3.5.1

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/123665325-78b79f00-d838-11eb-8252-b37f971b334e.png)

### After

With one tool only, the rightmost submenu is not added

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
