### PR TITLE
StreamExtensions: Read double null terminated records

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -960,6 +960,7 @@ namespace GitUI
                     _branchFilter,
                     _revisionFilter.GetRevisionFilter() + QuickRevisionFilter + _fixedRevisionFilter,
                     _revisionFilter.GetPathFilter() + _fixedPathFilter,
+                    !string.IsNullOrEmpty(_fixedPathFilter),
                     predicate);
 
                 if (_initialLoad)

--- a/UnitTests/GitCommands.Tests/StreamExtensionsTests.cs
+++ b/UnitTests/GitCommands.Tests/StreamExtensionsTests.cs
@@ -10,38 +10,57 @@ namespace GitCommandsTests
         private const byte nil = 0;
 
         [TestCase(
-            new byte[] { })]
+            new byte[] { },
+            false)]
         [TestCase(
             new byte[] { 1 },
+            false,
             new byte[] { 1 })]
         [TestCase(
             new byte[] { nil },
+            false,
             new byte[0])]
         [TestCase(
             new byte[] { nil, nil },
+            false,
             new byte[0], new byte[0])]
         [TestCase(
             new byte[] { 1, 2, 3, 4, 5, 6 },
+            false,
             new byte[] { 1, 2, 3, 4, 5, 6 })]
         [TestCase(
             new byte[] { 2, 3, 4, 5, 6, nil },
+            false,
             new byte[] { 2, 3, 4, 5, 6 })]
         [TestCase(
             new byte[] { nil, 1, 2, 3, 4, 5, 6 },
+            false,
             new byte[0], new byte[] { 1, 2, 3, 4, 5, 6 })]
         [TestCase(
             new byte[] { 1, 2, 3, nil, 4, 5, 6 },
+            false,
             new byte[] { 1, 2, 3 }, new byte[] { 4, 5, 6 })]
         [TestCase(
             new byte[] { 1, 2, 3, nil, nil, 4, 5, 6 },
+            false,
             new byte[] { 1, 2, 3 }, new byte[0], new byte[] { 4, 5, 6 })]
         [TestCase(
             new byte[] { 1, 2, 3, nil, 4, 5, 6, nil, 7, 8, 9 },
+            false,
             new byte[] { 1, 2, 3 }, new byte[] { 4, 5, 6 }, new byte[] { 7, 8, 9 })]
         [TestCase(
             new byte[] { nil, 1, nil, 2, 3, nil, 4, 5, 6, nil, 7, 8, 9, 10 },
+            false,
             new byte[0], new byte[] { 1 }, new byte[] { 2, 3 }, new byte[] { 4, 5, 6 }, new byte[] { 7, 8, 9, 10 })]
-        public void ReadNullTerminatedLines(byte[] input, params byte[][] expectedChunks)
+        [TestCase(
+            new byte[] { nil, 1, nil, 2, 3, nil, nil, 4, 5, 6, nil, 7, 8, 9, 10 },
+            true,
+            new byte[] { nil, 1, nil, 2, 3, nil }, new byte[] { 4, 5, 6, nil, 7, 8, 9, 10 })]
+        [TestCase(
+            new byte[] { nil, nil, 1, nil, 2, 3, nil, nil, 4, 5, 6, nil, 7, 8, 9, 10 },
+            true,
+            new byte[] { nil }, new byte[] { 1, nil, 2, 3, nil }, new byte[] { 4, 5, 6, nil, 7, 8, 9, 10 })]
+        public void ReadNullTerminatedLines(byte[] input, bool useDoubleNull, params byte[][] expectedChunks)
         {
             MemoryStream stream = new(input);
 
@@ -53,7 +72,7 @@ namespace GitCommandsTests
 
                 stream.Position = 0;
 
-                using var e = stream.ReadNullTerminatedChunks(ref buffer).GetEnumerator();
+                using var e = stream.ReadNullTerminatedChunks(ref buffer, useDoubleNull).GetEnumerator();
                 for (var chunkIndex = 0; chunkIndex < expectedChunks.Length; chunkIndex++)
                 {
                     var expected = expectedChunks[chunkIndex];


### PR DESCRIPTION
Related to #9243 

I actually want this to be merged before #9243, it eliminates a parse error for git-log.
There is a merge conflict for these PRs.

## Proposed changes

FormFileHistory adds "--name-info" for "git-log -z". This adds all file names matched in the commit, all separated by additional null characters.
A record with --name-status is therefore terminated with double null.
ReadNullTerminatedChunks() tried to deliver all null terminated records as results. If only one filename matched, this was mostly OK
as a zero size buffer was parsed. With more than one filename matched, the parsing would silently fail.

With "--name-status" a double null end the record, but the 'null' terminating each filename is still included.
Only the first filename is used (as before), others are ignored.

Note: EndOfNull handling can be simplified, the special marker can be removed. That will be done in #9243 or a follow up.
This is actually the primary reason for the PR.

git-log also offers "--log-size" that will include a line “log size <number>” to inform of the size of the header, without files.
This will still not help to find the end of the filenames though, not included in the size.
So most of the complexity of the parsing, including the extra logic added here will have to remain.

Also, there must be a pathfilter to be able to parse the output. For instance stashes may not have any files at all, then the record will be ended by a single null.
That could maybe be fixed with a double null StartofRecord (that will appear before "log size" if that is implemented), that will be quite complex for something without a usecase.

## Test methodology <!-- How did you ensure quality? -->

Added tests for ReadNullTerminatedChunks() and debug printouts when parsing fails. (GE and linux repos parse without failure.)
The testcases for RevisionReader is not updated, they are slightly broken currently in master anyway, #9243 adds tests for TryParseRevision().

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
