### PR TITLE
Fixup GDI object leaks

### DIFF
--- a/GitUI/BitmapExtensions.cs
+++ b/GitUI/BitmapExtensions.cs
@@ -1,0 +1,34 @@
+﻿#nullable enable
+
+using System;
+using System.Drawing;
+
+namespace GitUI
+{
+    public static class BitmapExtensions
+    {
+        public static Icon BitmapToIcon(this Bitmap bitmap)
+        {
+            if (bitmap is null)
+            {
+                throw new ArgumentNullException(nameof(bitmap));
+            }
+
+            IntPtr handle = IntPtr.Zero;
+            try
+            {
+                handle = bitmap.GetHicon();
+                var icon = Icon.FromHandle(handle);
+
+                return (Icon)icon.Clone();
+            }
+            finally
+            {
+                if (handle != IntPtr.Zero)
+                {
+                    NativeMethods.DestroyIcon(handle);
+                }
+            }
+        }
+    }
+}

--- a/GitUI/BitmapExtensions.cs
+++ b/GitUI/BitmapExtensions.cs
@@ -7,7 +7,7 @@ namespace GitUI
 {
     public static class BitmapExtensions
     {
-        public static Icon BitmapToIcon(this Bitmap bitmap)
+        public static Icon ToIcon(this Bitmap bitmap)
         {
             if (bitmap is null)
             {
@@ -18,7 +18,7 @@ namespace GitUI
             try
             {
                 handle = bitmap.GetHicon();
-                var icon = Icon.FromHandle(handle);
+                Icon icon = Icon.FromHandle(handle);
 
                 return (Icon)icon.Clone();
             }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -104,6 +104,8 @@ namespace GitUI.CommandsDialogs
 
         [CanBeNull] private TabPage _consoleTabPage;
 
+        private Dictionary<Brush, Icon> _overlayIconByBrush = new();
+
         [Flags]
         private enum UpdateTargets
         {
@@ -407,16 +409,21 @@ namespace GitUI.CommandsDialogs
                         {
                             lastBrush = brush;
 
-                            const int imgDim = 32;
-                            const int dotDim = 15;
-                            const int pad = 2;
-                            using Bitmap bmp = new(imgDim, imgDim);
-                            using Graphics g = Graphics.FromImage(bmp);
-                            g.SmoothingMode = SmoothingMode.AntiAlias;
-                            g.Clear(Color.Transparent);
-                            g.FillEllipse(brush, new Rectangle(imgDim - dotDim - pad, imgDim - dotDim - pad, dotDim, dotDim));
+                            if (!_overlayIconByBrush.TryGetValue(brush, out Icon overlay))
+                            {
+                                const int imgDim = 32;
+                                const int dotDim = 15;
+                                const int pad = 2;
+                                using Bitmap bmp = new(imgDim, imgDim);
+                                using Graphics g = Graphics.FromImage(bmp);
+                                g.SmoothingMode = SmoothingMode.AntiAlias;
+                                g.Clear(Color.Transparent);
+                                g.FillEllipse(brush, new Rectangle(imgDim - dotDim - pad, imgDim - dotDim - pad, dotDim, dotDim));
 
-                            using Icon overlay = bmp.ToIcon();
+                                overlay = bmp.ToIcon();
+                                _overlayIconByBrush.Add(brush, overlay);
+                            }
+
                             TaskbarManager.Instance.SetOverlayIcon(overlay, "");
 
                             var repoStateVisualiser = new RepoStateVisualiser();

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -410,20 +410,14 @@ namespace GitUI.CommandsDialogs
                             const int imgDim = 32;
                             const int dotDim = 15;
                             const int pad = 2;
-                            using (var bmp = new Bitmap(imgDim, imgDim))
-                            {
-                                using (var g = Graphics.FromImage(bmp))
-                                {
-                                    g.SmoothingMode = SmoothingMode.AntiAlias;
-                                    g.Clear(Color.Transparent);
-                                    g.FillEllipse(brush, new Rectangle(imgDim - dotDim - pad, imgDim - dotDim - pad, dotDim, dotDim));
-                                }
+                            using var bmp = new Bitmap(imgDim, imgDim);
+                            using var g = Graphics.FromImage(bmp);
+                            g.SmoothingMode = SmoothingMode.AntiAlias;
+                            g.Clear(Color.Transparent);
+                            g.FillEllipse(brush, new Rectangle(imgDim - dotDim - pad, imgDim - dotDim - pad, dotDim, dotDim));
 
-                                using (var overlay = Icon.FromHandle(bmp.GetHicon()))
-                                {
-                                    TaskbarManager.Instance.SetOverlayIcon(overlay, "");
-                                }
-                            }
+                            using Icon overlay = bmp.BitmapToIcon();
+                            TaskbarManager.Instance.SetOverlayIcon(overlay, "");
 
                             var repoStateVisualiser = new RepoStateVisualiser();
                             var (image, _) = repoStateVisualiser.Invoke(status);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -410,13 +410,13 @@ namespace GitUI.CommandsDialogs
                             const int imgDim = 32;
                             const int dotDim = 15;
                             const int pad = 2;
-                            using var bmp = new Bitmap(imgDim, imgDim);
-                            using var g = Graphics.FromImage(bmp);
+                            using Bitmap bmp = new(imgDim, imgDim);
+                            using Graphics g = Graphics.FromImage(bmp);
                             g.SmoothingMode = SmoothingMode.AntiAlias;
                             g.Clear(Color.Transparent);
                             g.FillEllipse(brush, new Rectangle(imgDim - dotDim - pad, imgDim - dotDim - pad, dotDim, dotDim));
 
-                            using Icon overlay = bmp.BitmapToIcon();
+                            using Icon overlay = bmp.ToIcon();
                             TaskbarManager.Instance.SetOverlayIcon(overlay, "");
 
                             var repoStateVisualiser = new RepoStateVisualiser();

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -104,7 +104,7 @@ namespace GitUI.CommandsDialogs
 
         [CanBeNull] private TabPage _consoleTabPage;
 
-        private Dictionary<Brush, Icon> _overlayIconByBrush = new();
+        private readonly Dictionary<Brush, Icon> _overlayIconByBrush = new();
 
         [Flags]
         private enum UpdateTargets

--- a/GitUI/HelperDialogs/FormStatus.cs
+++ b/GitUI/HelperDialogs/FormStatus.cs
@@ -170,25 +170,6 @@ namespace GitUI.HelperDialogs
             ConsoleOutput.AppendMessageFreeThreaded(text);
         }
 
-        private static Icon BitmapToIcon(Bitmap bitmap)
-        {
-            IntPtr handle = IntPtr.Zero;
-            try
-            {
-                handle = bitmap.GetHicon();
-                var icon = Icon.FromHandle(handle);
-
-                return (Icon)icon.Clone();
-            }
-            finally
-            {
-                if (handle != IntPtr.Zero)
-                {
-                    NativeMethods.DestroyIcon(handle);
-                }
-            }
-        }
-
         private protected void Done(bool isSuccess)
         {
             try
@@ -230,7 +211,7 @@ namespace GitUI.HelperDialogs
         private void SetIcon(Bitmap image)
         {
             Icon oldIcon = Icon;
-            Icon = BitmapToIcon(image);
+            Icon = image.BitmapToIcon();
             oldIcon?.Dispose();
         }
 

--- a/GitUI/HelperDialogs/FormStatus.cs
+++ b/GitUI/HelperDialogs/FormStatus.cs
@@ -211,7 +211,7 @@ namespace GitUI.HelperDialogs
         private void SetIcon(Bitmap image)
         {
             Icon oldIcon = Icon;
-            Icon = image.BitmapToIcon();
+            Icon = image.ToIcon();
             oldIcon?.Dispose();
         }
 

--- a/GitUI/Interops/User32/ReleaseDC.cs
+++ b/GitUI/Interops/User32/ReleaseDC.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    internal static partial class NativeMethods
+    {
+        [DllImport(Libraries.User32)]
+        public static extern void ReleaseDC(IntPtr hwnd, IntPtr dc);
+    }
+}

--- a/GitUI/UserControls/TextBoxEx.cs
+++ b/GitUI/UserControls/TextBoxEx.cs
@@ -60,23 +60,21 @@ namespace GitUI.UserControls
             {
                 case NativeMethods.WM_NCPAINT:
                 case NativeMethods.WM_PAINT:
-                    var penColor = _borderDefaultColor;
+                    Color penColor = Focused ? _borderFocusedColor
+                        : _hovered ? _borderHoveredColor
+                        : _borderDefaultColor;
 
-                    if (Focused)
+                    IntPtr windowDC = NativeMethods.GetWindowDC(Handle);
+                    try
                     {
-                        penColor = _borderFocusedColor;
-                    }
-                    else if (_hovered)
-                    {
-                        penColor = _borderHoveredColor;
-                    }
-
-                    var windowDC = NativeMethods.GetWindowDC(Handle);
-                    {
-                        using var graphics = Graphics.FromHdc(windowDC);
-                        using var pen = new Pen(penColor);
+                        using Graphics graphics = Graphics.FromHdc(windowDC);
+                        using Pen pen = new(penColor);
 
                         ControlPaint.DrawBorder(graphics, ClientRectangle, penColor, ButtonBorderStyle.Solid);
+                    }
+                    finally
+                    {
+                        NativeMethods.ReleaseDC(Handle, windowDC);
                     }
 
                     break;

--- a/GitUI/WindowsJumpListManager.cs
+++ b/GitUI/WindowsJumpListManager.cs
@@ -255,7 +255,7 @@ namespace GitUI
 
             // following line would work directly on any image, but then
             // it wouldn't look as nice.
-            return Icon.FromHandle(square.GetHicon());
+            return square.BitmapToIcon();
         }
 
         private static void SafeInvoke(Action action, string callerName)

--- a/GitUI/WindowsJumpListManager.cs
+++ b/GitUI/WindowsJumpListManager.cs
@@ -213,8 +213,8 @@ namespace GitUI
         /// <returns>An icon!!</returns>
         private static Icon MakeIcon(Image img, int size, bool keepAspectRatio)
         {
-            var square = new Bitmap(size, size); // create new bitmap
-            Graphics g = Graphics.FromImage(square); // allow drawing to it
+            using Bitmap square = new(size, size); // create new bitmap
+            using Graphics g = Graphics.FromImage(square); // allow drawing to it
 
             int x, y, w, h; // dimensions for new image
 

--- a/GitUI/WindowsJumpListManager.cs
+++ b/GitUI/WindowsJumpListManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
@@ -24,6 +25,7 @@ namespace GitUI
         private ThumbnailToolBarButton _pushButton;
         private ThumbnailToolBarButton _pullButton;
         private string _deferredAddToRecent;
+        private static Dictionary<Image, Icon> _iconByImage = new();
         private bool ToolbarButtonsCreated => _commitButton is not null;
         private readonly IRepositoryDescriptionProvider _repositoryDescriptionProvider;
 
@@ -213,6 +215,11 @@ namespace GitUI
         /// <returns>An icon!!</returns>
         private static Icon MakeIcon(Image img, int size, bool keepAspectRatio)
         {
+            if (_iconByImage.TryGetValue(img, out Icon icon))
+            {
+                return icon;
+            }
+
             using Bitmap square = new(size, size); // create new bitmap
             using Graphics g = Graphics.FromImage(square); // allow drawing to it
 
@@ -255,7 +262,9 @@ namespace GitUI
 
             // following line would work directly on any image, but then
             // it wouldn't look as nice.
-            return square.ToIcon();
+            icon = square.ToIcon();
+            _iconByImage.Add(img, icon);
+            return icon;
         }
 
         private static void SafeInvoke(Action action, string callerName)

--- a/GitUI/WindowsJumpListManager.cs
+++ b/GitUI/WindowsJumpListManager.cs
@@ -255,7 +255,7 @@ namespace GitUI
 
             // following line would work directly on any image, but then
             // it wouldn't look as nice.
-            return square.BitmapToIcon();
+            return square.ToIcon();
         }
 
         private static void SafeInvoke(Action action, string callerName)

--- a/GitUI/WindowsJumpListManager.cs
+++ b/GitUI/WindowsJumpListManager.cs
@@ -25,7 +25,7 @@ namespace GitUI
         private ThumbnailToolBarButton _pushButton;
         private ThumbnailToolBarButton _pullButton;
         private string _deferredAddToRecent;
-        private static Dictionary<Image, Icon> _iconByImage = new();
+        private static readonly Dictionary<Image, Icon> _iconByImage = new();
         private bool ToolbarButtonsCreated => _commitButton is not null;
         private readonly IRepositoryDescriptionProvider _repositoryDescriptionProvider;
 

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RevisionFileTreeControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RevisionFileTreeControllerTests.cs
@@ -6,6 +6,7 @@ using System.Windows.Forms;
 using FluentAssertions;
 using GitCommands;
 using GitCommands.Git;
+using GitUI;
 using GitUI.CommandsDialogs;
 using GitUI.UserControls;
 using GitUIPluginInterfaces;
@@ -184,7 +185,7 @@ namespace GitUITests.CommandsDialogs
             var item = new GitItem(0, GitObjectType.Tree, ObjectId.Random(), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
             using var bitmap = new Bitmap(1, 1);
-            using var icon = Icon.FromHandle(bitmap.GetHicon());
+            using var icon = bitmap.BitmapToIcon();
             _iconProvider.Get(Arg.Any<string>(), Arg.Is<string>(x => x.EndsWith(".txt"))).Returns(icon);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RevisionFileTreeControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RevisionFileTreeControllerTests.cs
@@ -184,8 +184,8 @@ namespace GitUITests.CommandsDialogs
             var items = new[] { new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file1.txt"), new GitItem(0, GitObjectType.Blob, ObjectId.Random(), "file2.txt") };
             var item = new GitItem(0, GitObjectType.Tree, ObjectId.Random(), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
-            using var bitmap = new Bitmap(1, 1);
-            using var icon = bitmap.BitmapToIcon();
+            using Bitmap bitmap = new(1, 1);
+            using Icon icon = bitmap.ToIcon();
             _iconProvider.Get(Arg.Any<string>(), Arg.Is<string>(x => x.EndsWith(".txt"))).Returns(icon);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);


### PR DESCRIPTION
Fixes #9166

## Proposed changes

Fixup GDI object leaks:
- Release DC retrieved using `GetWindowDC`
- Dispose resources in `WindowsJumpListManager.MakeIcon`
- Correctly convert `Bitmap` to `Icon`
- Cache `Icons` drawn for Taskbar overlay / Jump List

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 99649dc430eb85fbacda92046a639af8d1c552dc
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4360.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).