### PR TITLE
Remove custom ToHashSet() methods. Fixes #9159

### DIFF
--- a/GitCommands/Git/GitRef.cs
+++ b/GitCommands/Git/GitRef.cs
@@ -202,7 +202,8 @@ namespace GitCommands
             return refs
                 .GroupBy(r => r.Name)
                 .Where(group => group.Count() > 1)
-                .ToHashSet(e => e.Key);
+                .Select(e => e.Key)
+                .ToHashSet();
         }
 
         public bool IsTrackingRemote(IGitRef? remote)

--- a/GitExtUtils/Linq/LinqExtensions.cs
+++ b/GitExtUtils/Linq/LinqExtensions.cs
@@ -7,41 +7,6 @@ namespace System.Linq
 {
     public static class LinqExtensions
     {
-        [MustUseReturnValue]
-        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T>? comparer = null) => new(source, comparer ?? EqualityComparer<T>.Default);
-
-        [MustUseReturnValue]
-        public static HashSet<TKey> ToHashSet<TSource, TKey>(
-            this IEnumerable<TSource> source,
-            Func<TSource, TKey> keySelector)
-        {
-            if (keySelector is null)
-            {
-                throw new ArgumentNullException(nameof(keySelector));
-            }
-
-            HashSet<TKey> result = new();
-
-            foreach (var element in source)
-            {
-                var key = keySelector(element);
-
-                if (key is null)
-                {
-                    throw new ArgumentException(
-                        "Key selector produced a key that is null. See exception data for source.",
-                        nameof(keySelector))
-                    {
-                        Data = { { "source", element } }
-                    };
-                }
-
-                result.Add(key);
-            }
-
-            return result;
-        }
-
         [Pure]
         public static string Join(this IEnumerable<string> source, string separator)
         {

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1101,7 +1101,7 @@ namespace GitUI.CommandsDialogs
 
             Validates.NotNull(lastSelection);
             var newItems = _currentFilesList == Staged ? stagedFiles : unstagedFiles;
-            var names = lastSelection.ToHashSet(x => x.Name);
+            var names = lastSelection.Select(x => x.Name).ToHashSet();
             var newSelection = newItems.Where(x => names.Contains(x.Name)).ToList();
 
             if (newSelection.Any())

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -762,7 +762,7 @@ namespace GitUI.CommandsDialogs
                     }
                 }
 
-                var remoteBranchesSet = GetRemoteBranches(_selectedRemote.Name).ToHashSet(b => b.LocalName);
+                var remoteBranchesSet = GetRemoteBranches(_selectedRemote.Name).Select(b => b.LocalName).ToHashSet();
                 var onlyLocalBranches = GetLocalBranches().Where(b => !remoteBranchesSet.Contains(b.LocalName));
 
                 foreach (var head in onlyLocalBranches)

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -891,7 +891,8 @@ namespace GitUI
             if (updateCausedByFilter)
             {
                 previouslySelectedItems = FileStatusListView.SelectedItems()
-                    .ToHashSet(i => i.Tag<FileStatusItem>().Item);
+                    .Select(i => i.Tag<FileStatusItem>().Item)
+                    .ToHashSet();
 
                 DataSourceChanged?.Invoke(this, EventArgs.Empty);
             }

--- a/Plugins/Statistics/GitStatistics/LineCounter.cs
+++ b/Plugins/Statistics/GitStatistics/LineCounter.cs
@@ -21,7 +21,7 @@ namespace GitExtensions.Plugins.GitStatistics
 
         public void FindAndAnalyzeCodeFiles(string filePattern, string directoriesToIgnore, IEnumerable<string> filesToCheck)
         {
-            var extensions = LinqExtensions.ToHashSet(filePattern.Replace("*", "").Split(';'), StringComparer.InvariantCultureIgnoreCase);
+            var extensions = filePattern.Replace("*", "").Split(';').ToHashSet(StringComparer.InvariantCultureIgnoreCase);
             var directoryFilter = directoriesToIgnore.Split(';');
             var lastUpdate = DateTime.Now;
             var timer = TimeSpan.FromMilliseconds(500);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9159.


## Proposed changes

- Removed custom methods.
- Started using methods from .NET 5.
 
## Test methodology <!-- How did you ensure quality? -->

- Existing tests are used for now.
- 
- 


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.21.0.windows.1
- Windows 10



----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
