### PR TITLE
FormRebase: Avoid list refs if not advanced

### DIFF
--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -81,7 +81,9 @@ namespace GitUI.CommandsDialogs
             Currentbranch.Text = selectedHead;
 
             // Offer rebase on refs also for tags (but not stash, notes etc)
-            var refs = Module.GetRefs(RefsFilter.Heads | RefsFilter.Remotes | RefsFilter.Tags).OfType<GitRef>().ToList();
+            List<GitRef> refs = _startRebaseImmediately
+                ? new()
+                : Module.GetRefs(RefsFilter.Heads | RefsFilter.Remotes | RefsFilter.Tags).OfType<GitRef>().ToList();
             Branches.DataSource = refs;
             Branches.DisplayMember = nameof(GitRef.Name);
 
@@ -92,7 +94,7 @@ namespace GitUI.CommandsDialogs
 
             Branches.Select();
 
-            refs = Module.GetRefs(RefsFilter.Heads).OfType<GitRef>().ToList();
+            refs = refs.Where(h => h.IsHead).ToList();
             cboTo.DataSource = refs;
             cboTo.DisplayMember = nameof(GitRef.Name);
 


### PR DESCRIPTION
## Proposed changes

git-for-each-ref requires up to 300 ms, this command is executed twice when in non advanced mode (when FormRebase is not used, though it will be shown in #9311 ).

Also no need to run the command twice when the form is shown reuse the existing Git ref list.

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
