### PR TITLE
Fix/9166 gdi objects

### DIFF
--- a/GitUI/BitmapExtensions.cs
+++ b/GitUI/BitmapExtensions.cs
@@ -1,0 +1,34 @@
+﻿#nullable enable
+
+using System;
+using System.Drawing;
+
+namespace GitUI
+{
+    public static class BitmapExtensions
+    {
+        public static Icon ToIcon(this Bitmap bitmap)
+        {
+            if (bitmap is null)
+            {
+                throw new ArgumentNullException(nameof(bitmap));
+            }
+
+            IntPtr handle = IntPtr.Zero;
+            try
+            {
+                handle = bitmap.GetHicon();
+                Icon icon = Icon.FromHandle(handle);
+
+                return (Icon)icon.Clone();
+            }
+            finally
+            {
+                if (handle != IntPtr.Zero)
+                {
+                    NativeMethods.DestroyIcon(handle);
+                }
+            }
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -417,18 +417,14 @@ namespace GitUI.CommandsDialogs
                             const int imgDim = 32;
                             const int dotDim = 15;
                             const int pad = 2;
-                            using (var bmp = new Bitmap(imgDim, imgDim))
-                            {
-                                using (var g = Graphics.FromImage(bmp))
-                                {
-                                    g.SmoothingMode = SmoothingMode.AntiAlias;
-                                    g.Clear(Color.Transparent);
-                                    g.FillEllipse(brush, new Rectangle(imgDim - dotDim - pad, imgDim - dotDim - pad, dotDim, dotDim));
-                                }
+                            using Bitmap bmp = new(imgDim, imgDim);
+                            using Graphics g = Graphics.FromImage(bmp);
+                            g.SmoothingMode = SmoothingMode.AntiAlias;
+                            g.Clear(Color.Transparent);
+                            g.FillEllipse(brush, new Rectangle(imgDim - dotDim - pad, imgDim - dotDim - pad, dotDim, dotDim));
 
-                                using var overlay = Icon.FromHandle(bmp.GetHicon());
-                                TaskbarManager.Instance.SetOverlayIcon(overlay, "");
-                            }
+                            using Icon overlay = bmp.ToIcon();
+                            TaskbarManager.Instance.SetOverlayIcon(overlay, "");
 
                             RepoStateVisualiser repoStateVisualiser = new();
                             var (image, _) = repoStateVisualiser.Invoke(status);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -104,6 +104,8 @@ namespace GitUI.CommandsDialogs
 
         private TabPage? _consoleTabPage;
 
+        private readonly Dictionary<Brush, Icon> _overlayIconByBrush = new();
+
         [Flags]
         private enum UpdateTargets
         {
@@ -414,16 +416,21 @@ namespace GitUI.CommandsDialogs
                         {
                             lastBrush = brush;
 
-                            const int imgDim = 32;
-                            const int dotDim = 15;
-                            const int pad = 2;
-                            using Bitmap bmp = new(imgDim, imgDim);
-                            using Graphics g = Graphics.FromImage(bmp);
-                            g.SmoothingMode = SmoothingMode.AntiAlias;
-                            g.Clear(Color.Transparent);
-                            g.FillEllipse(brush, new Rectangle(imgDim - dotDim - pad, imgDim - dotDim - pad, dotDim, dotDim));
+                            if (!_overlayIconByBrush.TryGetValue(brush, out Icon overlay))
+                            {
+                                const int imgDim = 32;
+                                const int dotDim = 15;
+                                const int pad = 2;
+                                using Bitmap bmp = new(imgDim, imgDim);
+                                using Graphics g = Graphics.FromImage(bmp);
+                                g.SmoothingMode = SmoothingMode.AntiAlias;
+                                g.Clear(Color.Transparent);
+                                g.FillEllipse(brush, new Rectangle(imgDim - dotDim - pad, imgDim - dotDim - pad, dotDim, dotDim));
 
-                            using Icon overlay = bmp.ToIcon();
+                                overlay = bmp.ToIcon();
+                                _overlayIconByBrush.Add(brush, overlay);
+                            }
+
                             TaskbarManager.Instance.SetOverlayIcon(overlay, "");
 
                             RepoStateVisualiser repoStateVisualiser = new();

--- a/GitUI/HelperDialogs/FormStatus.cs
+++ b/GitUI/HelperDialogs/FormStatus.cs
@@ -166,25 +166,6 @@ namespace GitUI.HelperDialogs
             ConsoleOutput.AppendMessageFreeThreaded(text);
         }
 
-        private static Icon BitmapToIcon(Bitmap bitmap)
-        {
-            IntPtr handle = IntPtr.Zero;
-            try
-            {
-                handle = bitmap.GetHicon();
-                var icon = Icon.FromHandle(handle);
-
-                return (Icon)icon.Clone();
-            }
-            finally
-            {
-                if (handle != IntPtr.Zero)
-                {
-                    NativeMethods.DestroyIcon(handle);
-                }
-            }
-        }
-
         private protected void Done(bool isSuccess)
         {
             try
@@ -226,7 +207,7 @@ namespace GitUI.HelperDialogs
         private void SetIcon(Bitmap image)
         {
             Icon oldIcon = Icon;
-            Icon = BitmapToIcon(image);
+            Icon = image.ToIcon();
             oldIcon?.Dispose();
         }
 

--- a/GitUI/Interops/User32/ReleaseDC.cs
+++ b/GitUI/Interops/User32/ReleaseDC.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    internal static partial class NativeMethods
+    {
+        [DllImport(Libraries.User32)]
+        public static extern void ReleaseDC(IntPtr hwnd, IntPtr dc);
+    }
+}

--- a/GitUI/UserControls/TextBoxEx.cs
+++ b/GitUI/UserControls/TextBoxEx.cs
@@ -60,23 +60,21 @@ namespace GitUI.UserControls
             {
                 case NativeMethods.WM_NCPAINT:
                 case NativeMethods.WM_PAINT:
-                    var penColor = _borderDefaultColor;
+                    Color penColor = Focused ? _borderFocusedColor
+                        : _hovered ? _borderHoveredColor
+                        : _borderDefaultColor;
 
-                    if (Focused)
+                    IntPtr windowDC = NativeMethods.GetWindowDC(Handle);
+                    try
                     {
-                        penColor = _borderFocusedColor;
-                    }
-                    else if (_hovered)
-                    {
-                        penColor = _borderHoveredColor;
-                    }
-
-                    var windowDC = NativeMethods.GetWindowDC(Handle);
-                    {
-                        using var graphics = Graphics.FromHdc(windowDC);
+                        using Graphics graphics = Graphics.FromHdc(windowDC);
                         using Pen pen = new(penColor);
 
                         ControlPaint.DrawBorder(graphics, ClientRectangle, penColor, ButtonBorderStyle.Solid);
+                    }
+                    finally
+                    {
+                        NativeMethods.ReleaseDC(Handle, windowDC);
                     }
 
                     break;

--- a/GitUI/WindowsJumpListManager.cs
+++ b/GitUI/WindowsJumpListManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
@@ -24,6 +25,7 @@ namespace GitUI
         private ThumbnailToolBarButton? _pushButton;
         private ThumbnailToolBarButton? _pullButton;
         private string? _deferredAddToRecent;
+        private static readonly Dictionary<Image, Icon> _iconByImage = new();
         private bool ToolbarButtonsCreated => _commitButton is not null;
         private readonly IRepositoryDescriptionProvider _repositoryDescriptionProvider;
 
@@ -220,6 +222,11 @@ namespace GitUI
         /// <returns>An icon!!.</returns>
         private static Icon MakeIcon(Image img, int size, bool keepAspectRatio)
         {
+            if (_iconByImage.TryGetValue(img, out Icon icon))
+            {
+                return icon;
+            }
+
             using Bitmap square = new(size, size); // create new bitmap
             using Graphics g = Graphics.FromImage(square); // allow drawing to it
 
@@ -262,7 +269,9 @@ namespace GitUI
 
             // following line would work directly on any image, but then
             // it wouldn't look as nice.
-            return square.ToIcon();
+            icon = square.ToIcon();
+            _iconByImage.Add(img, icon);
+            return icon;
         }
 
         private static void SafeInvoke(Action action, string callerName)

--- a/GitUI/WindowsJumpListManager.cs
+++ b/GitUI/WindowsJumpListManager.cs
@@ -220,8 +220,8 @@ namespace GitUI
         /// <returns>An icon!!.</returns>
         private static Icon MakeIcon(Image img, int size, bool keepAspectRatio)
         {
-            Bitmap square = new(size, size); // create new bitmap
-            Graphics g = Graphics.FromImage(square); // allow drawing to it
+            using Bitmap square = new(size, size); // create new bitmap
+            using Graphics g = Graphics.FromImage(square); // allow drawing to it
 
             int x, y, w, h; // dimensions for new image
 

--- a/GitUI/WindowsJumpListManager.cs
+++ b/GitUI/WindowsJumpListManager.cs
@@ -262,7 +262,7 @@ namespace GitUI
 
             // following line would work directly on any image, but then
             // it wouldn't look as nice.
-            return Icon.FromHandle(square.GetHicon());
+            return square.ToIcon();
         }
 
         private static void SafeInvoke(Action action, string callerName)

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RevisionFileTreeControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RevisionFileTreeControllerTests.cs
@@ -5,6 +5,7 @@ using System.Windows.Forms;
 using FluentAssertions;
 using GitCommands;
 using GitCommands.Git;
+using GitUI;
 using GitUI.CommandsDialogs;
 using GitUI.UserControls;
 using GitUIPluginInterfaces;
@@ -183,7 +184,7 @@ namespace GitUITests.CommandsDialogs
             GitItem item = new(0, GitObjectType.Tree, ObjectId.Random(), "folder");
             _revisionInfoProvider.LoadChildren(item).Returns(items);
             using Bitmap bitmap = new(1, 1);
-            using var icon = Icon.FromHandle(bitmap.GetHicon());
+            using Icon icon = bitmap.ToIcon();
             _iconProvider.Get(Arg.Any<string>(), Arg.Is<string>(x => x.EndsWith(".txt"))).Returns(icon);
 
             _controller.LoadChildren(item, _rootNode.Nodes, _imageList.Images);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9166
#9321 for master branch
original branch: mstv/fix/9166_gdi_objects-3.5 / mstv/fix/9166_gdi_objects-3.5-squashed

## Proposed changes

Fixup GDI object leaks:
- Release DC retrieved using `GetWindowDC`
- Dispose resources in `WindowsJumpListManager.MakeIcon`
- Correctly convert `Bitmap` to `Icon`
- Cache `Icons` drawn for Taskbar overlay / Jump List

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build aa7138c94cd9d21640a7e72c754325d03ee0a4ec
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.7
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).