### PR TITLE
Reduce window flicker and loss of focus

### DIFF
--- a/GitUI/CommandsDialogs/FormRebase.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRebase.Designer.cs
@@ -601,7 +601,6 @@ namespace GitUI.CommandsDialogs
             this.Name = "FormRebase";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Rebase";
-            this.Load += new System.EventHandler(this.FormRebaseLoad);
             this.flowLayoutPanel2.ResumeLayout(false);
             this.flowLayoutPanel2.PerformLayout();
             this.OptionsPanel.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -75,8 +75,10 @@ namespace GitUI.CommandsDialogs
             _startRebaseImmediately = startRebaseImmediately;
         }
 
-        private void FormRebaseLoad(object sender, EventArgs e)
+        protected override void OnShown(EventArgs e)
         {
+            base.OnShown(e);
+
             var selectedHead = Module.GetSelectedBranch();
             Currentbranch.Text = selectedHead;
 


### PR DESCRIPTION
(cherry picked from commit 8f9d901ef6f7c6bea5aa1495eed136b05b95f73a)

## Proposed changes

Reduce window flicker and loss of focus

1. Force child window ownership to FormBrowse

2. Show the rebase dialog *before* starting any operations. This is what appears to be the main cause of the loss of focus. The dialog isn't yet shown when we invoke the progress dialog, which is then gets closed but the window that spawned it is not visible. MS Windows gets confused and pushes another window to the foreground, thus causing the app to lose focus.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![rebase-before](https://user-images.githubusercontent.com/4403806/123568745-4db55700-d808-11eb-99d0-a42d6ab703c5.gif)

### After

![rebase-after](https://user-images.githubusercontent.com/4403806/123568747-5017b100-d808-11eb-9213-bf0660e57e9f.gif)


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
