### PR TITLE
Add support for setting console emulator font name

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -467,7 +467,6 @@ namespace GitCommands
         public static ISetting<bool> ShowConEmuTab => Setting.Create(DetailedSettingsPath, nameof(ShowConEmuTab), true);
         public static ISetting<string> ConEmuStyle => Setting.Create(DetailedSettingsPath, nameof(ConEmuStyle), "<Solarized Light>");
         public static ISetting<string> ConEmuTerminal => Setting.Create(DetailedSettingsPath, nameof(ConEmuTerminal), "bash");
-        public static ISetting<string> ConEmuFontSize => Setting.Create(DetailedSettingsPath, nameof(ConEmuFontSize), "12");
         public static ISetting<bool> ShowGpgInformation => Setting.Create(DetailedSettingsPath, nameof(ShowGpgInformation), true);
 
         public static CommitInfoPosition CommitInfoPosition
@@ -1451,6 +1450,12 @@ namespace GitCommands
         {
             get => GetFont("font", SystemFonts.MessageBoxFont);
             set => SetFont("font", value);
+        }
+
+        public static Font ConEmuConsoleFont
+        {
+            get => GetFont("conemuconsolefont", new Font("Consolas", 12));
+            set => SetFont("conemuconsolefont", value);
         }
 
         #endregion

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -3051,7 +3052,7 @@ namespace GitUI.CommandsDialogs
 
                 try
                 {
-                    _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, AppSettings.ConEmuStyle.Value, AppSettings.ConEmuFontSize.Value);
+                    _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, AppSettings.ConEmuStyle.Value, AppSettings.ConEmuConsoleFont.Name, AppSettings.ConEmuConsoleFont.Size.ToString(CultureInfo.InvariantCulture));
                 }
                 catch (InvalidOperationException)
                 {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.Designer.cs
@@ -29,10 +29,11 @@
         private void InitializeComponent()
         {
             this.groupBoxConsoleSettings = new System.Windows.Forms.GroupBox();
-            this.label3 = new System.Windows.Forms.Label();
-            this.cboFontSize = new System.Windows.Forms.ComboBox();
+            this.consoleFontChangeButton = new System.Windows.Forms.Button();
+            this.lblFontName = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_cboStyle = new System.Windows.Forms.ComboBox();
+            this.consoleFontDialog = new System.Windows.Forms.FontDialog();
             this.groupBoxConsoleSettings.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -41,56 +42,46 @@
             this.groupBoxConsoleSettings.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBoxConsoleSettings.AutoSize = true;
-            this.groupBoxConsoleSettings.Controls.Add(this.label3);
-            this.groupBoxConsoleSettings.Controls.Add(this.cboFontSize);
+            this.groupBoxConsoleSettings.Controls.Add(this.consoleFontChangeButton);
+            this.groupBoxConsoleSettings.Controls.Add(this.lblFontName);
             this.groupBoxConsoleSettings.Controls.Add(this.label1);
             this.groupBoxConsoleSettings.Controls.Add(this._NO_TRANSLATE_cboStyle);
             this.groupBoxConsoleSettings.Location = new System.Drawing.Point(8, 10);
             this.groupBoxConsoleSettings.Margin = new System.Windows.Forms.Padding(17, 2, 3, 2);
             this.groupBoxConsoleSettings.Name = "groupBoxConsoleSettings";
             this.groupBoxConsoleSettings.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.groupBoxConsoleSettings.Size = new System.Drawing.Size(1653, 89);
+            this.groupBoxConsoleSettings.Size = new System.Drawing.Size(1653, 95);
             this.groupBoxConsoleSettings.TabIndex = 1;
             this.groupBoxConsoleSettings.TabStop = false;
             this.groupBoxConsoleSettings.Text = "Console settings (restart required)";
             // 
-            // label3
+            // consoleFontChangeButton
             // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(6, 54);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(49, 13);
-            this.label3.TabIndex = 4;
-            this.label3.Text = "Font size";
+            this.consoleFontChangeButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.consoleFontChangeButton.Location = new System.Drawing.Point(118, 54);
+            this.consoleFontChangeButton.Margin = new System.Windows.Forms.Padding(0);
+            this.consoleFontChangeButton.Name = "consoleFontChangeButton";
+            this.consoleFontChangeButton.Size = new System.Drawing.Size(262, 23);
+            this.consoleFontChangeButton.TabIndex = 6;
+            this.consoleFontChangeButton.Text = "font name";
+            this.consoleFontChangeButton.UseVisualStyleBackColor = true;
+            this.consoleFontChangeButton.Click += new System.EventHandler(this.consoleFontChangeButton_Click);
             // 
-            // cboFontSize
+            // lblFontName
             // 
-            this.cboFontSize.FormattingEnabled = true;
-            this.cboFontSize.Items.AddRange(new object[] {
-            "8",
-            "9",
-            "10",
-            "11",
-            "12",
-            "13",
-            "14",
-            "16",
-            "18",
-            "19",
-            "20",
-            "24"});
-            this.cboFontSize.Location = new System.Drawing.Point(118, 51);
-            this.cboFontSize.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.cboFontSize.Name = "cboFontSize";
-            this.cboFontSize.Size = new System.Drawing.Size(262, 21);
-            this.cboFontSize.TabIndex = 5;
+            this.lblFontName.AutoSize = true;
+            this.lblFontName.Location = new System.Drawing.Point(5, 58);
+            this.lblFontName.Name = "lblFontName";
+            this.lblFontName.Size = new System.Drawing.Size(31, 15);
+            this.lblFontName.TabIndex = 4;
+            this.lblFontName.Text = "Font";
             // 
             // label1
             // 
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(5, 28);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(69, 13);
+            this.label1.Size = new System.Drawing.Size(77, 15);
             this.label1.TabIndex = 2;
             this.label1.Text = "Console style";
             // 
@@ -129,17 +120,22 @@
             this._NO_TRANSLATE_cboStyle.Location = new System.Drawing.Point(118, 26);
             this._NO_TRANSLATE_cboStyle.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this._NO_TRANSLATE_cboStyle.Name = "_NO_TRANSLATE_cboStyle";
-            this._NO_TRANSLATE_cboStyle.Size = new System.Drawing.Size(262, 21);
+            this._NO_TRANSLATE_cboStyle.Size = new System.Drawing.Size(262, 23);
             this._NO_TRANSLATE_cboStyle.TabIndex = 3;
+            // 
+            // consoleFontDialog
+            // 
+            this.consoleFontDialog.AllowVerticalFonts = false;
+            this.consoleFontDialog.Color = System.Drawing.SystemColors.ControlText;
             // 
             // ConsoleStyleSettingsPage
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.ClientSize = new System.Drawing.Size(1679, 477);
             this.Controls.Add(this.groupBoxConsoleSettings);
             this.Name = "ConsoleStyleSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
-            this.Size = new System.Drawing.Size(1711, 555);
             this.groupBoxConsoleSettings.ResumeLayout(false);
             this.groupBoxConsoleSettings.PerformLayout();
             this.ResumeLayout(false);
@@ -150,9 +146,10 @@
         #endregion
 
         private System.Windows.Forms.GroupBox groupBoxConsoleSettings;
-        private System.Windows.Forms.Label label3;
-        private System.Windows.Forms.ComboBox cboFontSize;
+        private System.Windows.Forms.Label lblFontName;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.ComboBox _NO_TRANSLATE_cboStyle;
+        private System.Windows.Forms.Button consoleFontChangeButton;
+        private System.Windows.Forms.FontDialog consoleFontDialog;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.cs
@@ -1,9 +1,14 @@
-﻿using GitCommands;
+﻿using System.Drawing;
+using System.Windows.Forms;
+using GitCommands;
+using Microsoft;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class ConsoleStyleSettingsPage : SettingsPageWithHeader
     {
+        private Font? _consoleFont;
+
         public ConsoleStyleSettingsPage()
         {
             InitializeComponent();
@@ -11,18 +16,46 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             InitializeComplete();
         }
 
-        protected override void Init(ISettingsPageHost pageHost)
+        protected override void SettingsToPage()
         {
-            base.Init(pageHost);
-
             // Bind settings with controls
             AddSettingBinding(AppSettings.ConEmuStyle, _NO_TRANSLATE_cboStyle);
-            AddSettingBinding(AppSettings.ConEmuFontSize, cboFontSize);
+            SetCurrentConsoleFont(AppSettings.ConEmuConsoleFont);
+        }
+
+        protected override void PageToSettings()
+        {
+            Validates.NotNull(_consoleFont);
+            AppSettings.ConEmuConsoleFont = _consoleFont;
         }
 
         public static SettingsPageReference GetPageReference()
         {
             return new SettingsPageReferenceByType(typeof(ConsoleStyleSettingsPage));
+        }
+
+        private void consoleFontChangeButton_Click(object sender, System.EventArgs e)
+        {
+            consoleFontDialog.Font = _consoleFont;
+            DialogResult result = consoleFontDialog.ShowDialog(this);
+
+            if (result is (DialogResult.OK or DialogResult.Yes))
+            {
+                Validates.NotNull(consoleFontDialog.Font);
+                SetCurrentConsoleFont(consoleFontDialog.Font);
+            }
+        }
+
+        private void SetCurrentConsoleFont(Font newFont)
+        {
+            _consoleFont = newFont;
+            SetFontButtonText(newFont, consoleFontChangeButton);
+        }
+
+        private static void SetFontButtonText(Font font, Button button)
+        {
+            button.Text = string.Format("{0}, {1}", font.FontFamily.Name, (int)(font.Size + 0.5f));
+            button.Font = font;
         }
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.resx
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.resx
@@ -1,64 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
+﻿<root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -117,4 +57,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="consoleFontDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>192, 17</value>
+  </metadata>
 </root>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1251,6 +1251,10 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Console style</source>
         <target />
       </trans-unit>
+      <trans-unit id="consoleFontChangeButton.Text">
+        <source>font name</source>
+        <target />
+      </trans-unit>
       <trans-unit id="groupBoxConsoleSettings.Text">
         <source>Console settings (restart required)</source>
         <target />
@@ -1259,8 +1263,8 @@ Please make sure git (Git for Windows or cygwin) is installed or set the correct
         <source>Console style</source>
         <target />
       </trans-unit>
-      <trans-unit id="label3.Text">
-        <source>Font size</source>
+      <trans-unit id="lblFontName.Text">
+        <source>Font</source>
         <target />
       </trans-unit>
     </body>

--- a/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
+++ b/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using ConEmu.WinForms;
@@ -127,7 +128,7 @@ namespace GitUI.UserControls
                 };
 
                 Validates.NotNull(_terminal);
-                _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, AppSettings.ConEmuStyle.Value, AppSettings.ConEmuFontSize.Value);
+                _terminal.Start(startInfo, ThreadHelper.JoinableTaskFactory, AppSettings.ConEmuStyle.Value, AppSettings.ConEmuConsoleFont.Name, AppSettings.ConEmuConsoleFont.Size.ToString(CultureInfo.InvariantCulture));
             }
             catch (Exception ex)
             {

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -175,7 +175,6 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.ShowConEmuTab)], true, false, true);
                 yield return (properties[nameof(AppSettings.ConEmuStyle)], "<Solarized Light>", true, true);
                 yield return (properties[nameof(AppSettings.ConEmuTerminal)], "bash", true, true);
-                yield return (properties[nameof(AppSettings.ConEmuFontSize)], "12", true, true);
                 yield return (properties[nameof(AppSettings.ShowGpgInformation)], true, false, true);
 
                 yield return (properties[nameof(AppSettings.ShowSplitViewLayout)], true, false, false);


### PR DESCRIPTION
# Add Support For Setting Console Emulator Font Name

This is the 2nd part supplementing the PR to the ConEmu fork https://github.com/gitextensions/conemu-inside/pull/28. The idea  is to allow powerline supported fonts.

As shown on the screenshot below, setting the font name to a powerline supported font resulted in this nice rendering.
![image](https://user-images.githubusercontent.com/16128850/124713371-cd979b80-df43-11eb-931b-a5cab5014ec8.png)

![image](https://user-images.githubusercontent.com/16128850/124379958-8750fb00-dcfd-11eb-88c7-39100f099dc0.png)

I could not get the design view for `ConsoleStyleSettingsPage` to load in Visual Studio 2019 but I hand edited the `ConsoleStyleSettingsPage.designer.cs` file directly. It build, runs and renders fine but as an improvement I would like to use the standard button based font selection and combine font name + size. I'll do it as a separate PR next.

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
