### PR TITLE
Preparations for exceptions on git error (part 3 of 4)

### DIFF
--- a/GitCommands/Git/AheadBehindDataProvider.cs
+++ b/GitCommands/Git/AheadBehindDataProvider.cs
@@ -60,13 +60,13 @@ namespace GitCommands.Git
                 "refs/heads/" + branchName
             };
 
-            var result = GetGitExecutable().GetOutput(aheadBehindGitCommand, outputEncoding: encoding);
-            if (string.IsNullOrEmpty(result))
+            ExecutionResult result = GetGitExecutable().Execute(aheadBehindGitCommand, outputEncoding: encoding);
+            if (!result.ExitedSuccessfully || string.IsNullOrEmpty(result.StandardOutput))
             {
                 return null;
             }
 
-            var matches = _aheadBehindRegEx.Matches(result);
+            var matches = _aheadBehindRegEx.Matches(result.StandardOutput);
             Dictionary<string, AheadBehindData> aheadBehindForBranchesData = new();
             foreach (Match match in matches)
             {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1833,7 +1833,7 @@ namespace GitCommands
         {
             var bytes = EncodingHelper.ConvertTo(
                 SystemEncoding,
-                $"{inputWriter.NewLine}\"{filename.ToPosixPath()}\"");
+                $"\"{filename.ToPosixPath()}\"{inputWriter.NewLine}");
 
             inputWriter.BaseStream.Write(bytes, 0, bytes.Length);
         }

--- a/UnitTests/GitCommands.Tests/Git/AheadBehindDataProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/AheadBehindDataProviderTests.cs
@@ -36,7 +36,7 @@ namespace GitCommandsTests.Git
             _process.StandardError.Returns(x => _errorStreamReader);
 
             _executable = Substitute.For<IExecutable>();
-            _executable.Start(Arg.Any<ArgumentString>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<Encoding>()).Returns(x => _process);
+            _executable.Start(Arg.Any<ArgumentString>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<Encoding>(), Arg.Any<bool>()).Returns(x => _process);
 
             _provider = new AheadBehindDataProvider(() => _executable);
         }


### PR DESCRIPTION
Some of the preparations for #9056 contributed by @gerhardol and me

## Proposed changes

- Fixup `GitModule.UpdateIndex`: output the newline after the file name
  in order to avoid a git error message on the first file name being empty
- `AheadBehindDataProvider`: Return `null` on non-zero git exit code

## Screenshots <!-- Remove this section if PR does not change UI -->

not affected

## Test methodology <!-- How did you ensure quality? -->

- NUnit tests
- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 35632c7562a986c041ccd632ebee1d8816e6b14e
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.7
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).