### PR TITLE
Preparations for exceptions on git error (part 4 of 4)

### DIFF
--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -280,28 +280,6 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// Launches a process for the executable and returns output lines as they become available.
-        /// </summary>
-        /// <param name="executable">The executable from which to launch a process.</param>
-        /// <param name="arguments">The arguments to pass to the executable.</param>
-        /// <param name="writeInput">A callback that writes bytes to the process's standard input stream, or <c>null</c> if no input is required.</param>
-        /// <param name="outputEncoding">The text encoding to use when decoding bytes read from the process's standard output and standard error streams, or <c>null</c> if the default encoding is to be used.</param>
-        /// <param name="stripAnsiEscapeCodes">A flag indicating whether ANSI escape codes should be removed from output strings.</param>
-        /// <returns>An enumerable sequence of lines that yields lines as they become available. Lines from standard output are returned first, followed by lines from standard error.</returns>
-        [MustUseReturnValue("If output lines are not required, use " + nameof(RunCommand) + " instead")]
-        public static async Task<IEnumerable<string>> GetOutputLinesAsync(
-            this IExecutable executable,
-            ArgumentString arguments = default,
-            Action<StreamWriter>? writeInput = null,
-            Encoding? outputEncoding = null,
-            CommandCache? cache = null,
-            bool stripAnsiEscapeCodes = true)
-        {
-            var result = await executable.ExecuteAsync(arguments, writeInput, outputEncoding, cache, stripAnsiEscapeCodes);
-            return result.StandardOutput.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries).Concat(result.StandardError.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries));
-        }
-
-        /// <summary>
         /// Launches a process for the executable and returns an object detailing exit code, standard output and standard error values.
         /// </summary>
         /// <remarks>

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2929,10 +2929,13 @@ namespace GitCommands
         }
 
         public async Task<string[]> GetMergedBranchesAsync(bool includeRemote = false, bool fullRefname = false, string? commit = null)
-            => (await _gitExecutable
-                .GetOutputAsync(GitCommandHelpers.MergedBranchesCmd(includeRemote, fullRefname, commit))
-                .ConfigureAwait(false))
-                .Split(Delimiters.LineFeed, StringSplitOptions.RemoveEmptyEntries);
+        {
+            ExecutionResult result = await _gitExecutable
+                .ExecuteAsync(GitCommandHelpers.MergedBranchesCmd(includeRemote, fullRefname, commit))
+                .ConfigureAwait(false);
+            ////TODO: Handle non-empty result.StandardError
+            return result.StandardOutput.Split(Delimiters.LineFeed, StringSplitOptions.RemoveEmptyEntries);
+        }
 
         public IEnumerable<string> GetMergedBranches(bool includeRemote = false)
         {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2914,9 +2914,12 @@ namespace GitCommands
             // Assume that all GetRefs() are done in the background, which may not be correct in the future.
             const bool noLocks = true;
 
-            var cmd = GitCommandHelpers.GetRefsCmd(getRef, noLocks, AppSettings.RefsSortBy, AppSettings.RefsSortOrder);
-            var refList = _gitExecutable.GetOutput(cmd);
-            return ParseRefs(refList);
+            ArgumentString cmd = GitCommandHelpers.GetRefsCmd(getRef, noLocks, AppSettings.RefsSortBy, AppSettings.RefsSortOrder);
+            ExecutionResult result = _gitExecutable.Execute(cmd);
+            ////TODO: Handle non-empty result.StandardError
+            return result.ExitedSuccessfully
+                ? ParseRefs(result.StandardOutput)
+                : Array.Empty<IGitRef>();
         }
 
         public async Task<string[]> GetMergedBranchesAsync(bool includeRemote = false, bool fullRefname = false, string? commit = null)


### PR DESCRIPTION
Some of the preparations for #9056 contributed by @gerhardol

## Proposed changes

- `GetMergedBranchesAsync`: Ignore (git exit code and) `StandardError`
- `GetRemotesAsync`: Return empty list on non-zero git exit code
- `GetRefs`: Return empty list on non-zero git exit code

**I am not really convinced that we should swallow errors from these commands.** That's why:

- Add `TODO`s for later generic handling of `StandardError`

## Screenshots <!-- Remove this section if PR does not change UI -->

not affected

## Test methodology <!-- How did you ensure quality? -->

- NUnit tests
- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build e6c851cfefa2e47a30f46d194c59f5e95017acbc
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.7
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).