### PR TITLE
GitRef: Remote may be as long as Name

### DIFF
--- a/GitCommands/Git/GitRef.cs
+++ b/GitCommands/Git/GitRef.cs
@@ -126,7 +126,7 @@ namespace GitCommands
 
         public bool IsOther => !IsHead && !IsRemote && !IsTag;
 
-        public string LocalName => IsRemote ? Name.Substring(Remote.Length + 1) : Name;
+        public string LocalName => IsRemote && Name.StartsWith($"{Remote}/") ? Name.Substring(Remote.Length + 1) : Name;
 
         public string Remote { get; }
 


### PR DESCRIPTION
Fixes #9338 

## Proposed changes

Check string length before using a substring.
Use full Name if not possible to remove the Remote prefix.

For the FormCreateBranch example, this may return an unexpected name, but that is just a suggestion for the user anyway.
Similar effects for a few other random usages I saw.
So this should be safe.

## Test methodology <!-- How did you ensure quality? -->

Code review

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
