### PR TITLE
Fixup user scripts running PS in foreground

### DIFF
--- a/GitUI/Script/PowerShellHelper.cs
+++ b/GitUI/Script/PowerShellHelper.cs
@@ -12,7 +12,7 @@ namespace GitUI.Script
             EnvironmentConfiguration.SetEnvironmentVariables();
 
             IExecutable executable = new Executable(filename, workingDir);
-            executable.Start(arguments);
+            executable.Start(arguments, createWindow: !runInBackground);
         }
     }
 }


### PR DESCRIPTION
(#9351 for 3.6)
Fixes #9347

## Proposed changes

- Tell `Executable.Start` to create a window for user scripts which shall run PS in the foreground

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build e5583961130d5ad7060c9f0397d983cbd6aedecf
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4360.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).