### PR TITLE
 RevisionReader allow empty subject

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -475,7 +475,8 @@ namespace GitCommands
 
             public (string? subject, string? body, bool hasMultiLineMessage) PeakToEnd(bool skipBody)
             {
-                if (_index >= _s.Length)
+                // Empty subject is allowed
+                if (_index > _s.Length)
                 {
                     return (null, null, false);
                 }

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test.ForScenario.empty_commit.approved.json
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test.ForScenario.empty_commit.approved.json
@@ -1,0 +1,34 @@
+﻿{
+    "ObjectId": {
+        "IsArtificial": false
+    },
+    "Guid": "af0537262373a24bcf2b8b1f68447540776f3703",
+    "Refs": [],
+    "ParentIds": [
+        {
+            "IsArtificial": false
+        }
+    ],
+    "TreeGuid": {
+        "IsArtificial": false
+    },
+    "Author": "Gerhard Olsson",
+    "AuthorEmail": "gerhardol@users.noreply.github.com",
+    "AuthorUnixTime": 1625916262,
+    "AuthorDate": "2021-07-10T11:24:22Z",
+    "Committer": "Gerhard Olsson",
+    "CommitterEmail": "gerhardol@users.noreply.github.com",
+    "CommitUnixTime": 1625916262,
+    "CommitDate": "2021-07-10T11:24:22Z",
+    "BuildStatus": null,
+    "Subject": "",
+    "Body": "",
+    "HasMultiLineMessage": false,
+    "HasNotes": false,
+    "MessageEncoding": null,
+    "IsArtificial": false,
+    "HasParent": true,
+    "FirstParentId": {
+        "IsArtificial": false
+    }
+}

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
@@ -137,6 +137,7 @@ namespace GitCommandsTests
         [TestCase("short_sha", false)]
         [TestCase("simple_pathfilter", true)]
         [TestCase("subject_no_body", true)]
+        [TestCase("empty_commit", true)]
         public void TryParseRevision_test(string testName, bool expectedReturn, bool serialThrows = false)
         {
             using (ApprovalResults.ForScenario(testName.Replace(' ', '_')))

--- a/UnitTests/GitCommands.Tests/TestData/RevisionReader/empty_commit.bin
+++ b/UnitTests/GitCommands.Tests/TestData/RevisionReader/empty_commit.bin
@@ -1,0 +1,8 @@
+af0537262373a24bcf2b8b1f68447540776f37036f6651ae69bd61e51ecbf2aa0a9ed32f2f8836f62fbf1076c0a6b37ee42f0c9d29c552648ee38a6e
+1625916262
+1625916262
+
+Gerhard Olsson
+gerhardol@users.noreply.github.com
+Gerhard Olsson
+gerhardol@users.noreply.github.com


### PR DESCRIPTION
Fixes #9354

## Proposed changes

Allow that a subject in a commit is empty

## Test methodology <!-- How did you ensure quality? -->

Test case added

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
