### PR TITLE
Log RevisionReader parse errors

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -308,17 +308,24 @@ namespace GitCommands
 
             var parentIds = new ObjectId[noParents];
 
-            for (int parentIndex = 0; parentIndex < noParents; parentIndex++)
+            if (noParents == 0)
             {
-                if (!ObjectId.TryParseAsciiHexReadOnlySpan(array.Slice(offset, ObjectId.Sha1CharCount), out ObjectId parentId))
+                offset++;
+            }
+            else
+            {
+                for (int parentIndex = 0; parentIndex < noParents; parentIndex++)
                 {
-                    ParseAssert($"Log parse error, parent {parentIndex} for {objectId}");
-                    revision = default;
-                    return false;
-                }
+                    if (!ObjectId.TryParseAsciiHexReadOnlySpan(array.Slice(offset, ObjectId.Sha1CharCount), out ObjectId parentId))
+                    {
+                        ParseAssert($"Log parse error, parent {parentIndex} for {objectId}");
+                        revision = default;
+                        return false;
+                    }
 
-                parentIds[parentIndex] = parentId;
-                offset += ObjectId.Sha1CharCount + 1;
+                    parentIds[parentIndex] = parentId;
+                    offset += ObjectId.Sha1CharCount + 1;
+                }
             }
 
             #endregion
@@ -430,7 +437,7 @@ namespace GitCommands
             {
                 _noOfParseError++;
                 Debug.Assert(_noOfParseError > 1, message);
-                Trace.WriteLineIf(_noOfParseError > 10, message);
+                Trace.WriteLineIf(_noOfParseError < 10, message);
             }
         }
 
@@ -522,6 +529,12 @@ namespace GitCommands
 
             internal static bool TryParseRevision(ArraySegment<byte> chunk, Func<string?, Encoding?> getEncodingByGitName, Encoding logOutputEncoding, long sixMonths, [NotNullWhen(returnValue: true)] out GitRevision? revision) =>
                 RevisionReader.TryParseRevision(chunk, getEncodingByGitName, logOutputEncoding, sixMonths, out revision);
+
+            internal static int NoOfParseError
+            {
+                get { return _noOfParseError; }
+                set { _noOfParseError = value; }
+            }
         }
     }
 }

--- a/Plugins/GitUIPluginInterfaces/ObjectId.cs
+++ b/Plugins/GitUIPluginInterfaces/ObjectId.cs
@@ -290,12 +290,9 @@ namespace GitUIPluginInterfaces
         /// <returns><c>true</c> if parsing succeeded, otherwise <c>false</c>.</returns>
         [MustUseReturnValue]
         public static bool TryParseAsciiHexBytes(ArraySegment<byte> bytes, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
-        {
-            ReadOnlySpan<byte> array = bytes.AsSpan();
-            return TryParseAsciiHexReadOnlySpan(array, out objectId);
-        }
+            => TryParseAsciiHexReadOnlySpan(bytes.AsSpan(), out objectId);
 
-        public static bool TryParseAsciiHexReadOnlySpan(ReadOnlySpan<byte> array, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
+        public static bool TryParseAsciiHexReadOnlySpan(in ReadOnlySpan<byte> array, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
         {
             if (array.Length != Sha1CharCount)
             {
@@ -305,11 +302,11 @@ namespace GitUIPluginInterfaces
 
             var success = true;
 
-            var i1 = HexAsciiBytesToUInt32(ref array, 0);
-            var i2 = HexAsciiBytesToUInt32(ref array, 8);
-            var i3 = HexAsciiBytesToUInt32(ref array, 16);
-            var i4 = HexAsciiBytesToUInt32(ref array, 24);
-            var i5 = HexAsciiBytesToUInt32(ref array, 32);
+            var i1 = HexAsciiBytesToUInt32(in array, 0);
+            var i2 = HexAsciiBytesToUInt32(in array, 8);
+            var i3 = HexAsciiBytesToUInt32(in array, 16);
+            var i4 = HexAsciiBytesToUInt32(in array, 24);
+            var i5 = HexAsciiBytesToUInt32(in array, 32);
 
             if (success)
             {
@@ -320,7 +317,7 @@ namespace GitUIPluginInterfaces
             objectId = default;
             return false;
 
-            uint HexAsciiBytesToUInt32(ref ReadOnlySpan<byte> array, int j)
+            uint HexAsciiBytesToUInt32(in ReadOnlySpan<byte> array, int j)
             {
                 return (uint)(HexAsciiByteToInt(array[j]) << 28 |
                               HexAsciiByteToInt(array[j + 1]) << 24 |

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
@@ -145,6 +145,8 @@ namespace GitCommandsTests
                 string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData/RevisionReader", testName + ".bin");
                 ArraySegment<byte> chunk = File.ReadAllBytes(path);
 
+                // Set to a high value so Debug.Assert do not raise exceptions
+                RevisionReader.TestAccessor.NoOfParseError = 100;
                 RevisionReader.TestAccessor.TryParseRevision(chunk, _getEncodingByGitName, _logOutputEncoding, _sixMonths, out GitRevision rev)
                     .Should().Be(expectedReturn);
 


### PR DESCRIPTION
Followup to #9354 #9243

## Proposed changes

* A few minor optimizations, mostly using `in` parameters (likely not noticeable)
The log parsing is probably the most important code to optimize for opening a repo.

* Log parse errors (with limitations)

Before #9243 parse errors had to be ignored as the input data was incorrectly split for FileHistory.
In #9354 the parsing failed (introduced in #9243), only seen in DEBUG though.

If there are other parse errors (likely existing from before, not much of the actual parsing logging has been changed), the visibility is improved by Debug.Assert the first occurrence and Trace.Assert the first 10 errors. Printouts include the commit sha if available.
This will notify DEBUG users and give a way for production users to provide information, but avoid that the log or popups overwhelming the user.

Also removed the trace printout about time to parse the log information.

Note: TRACE is set by default in GE.

Note 2: Debug.Assert seem to abort execution in master, not giving the popup to allow continuing as before (.NET5 or BugReporter?)

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
