### PR TITLE
Do not check if path exists before settings GIT_SSH

### DIFF
--- a/GitCommands/Git/GitSshHelpers.cs
+++ b/GitCommands/Git/GitSshHelpers.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 
 namespace GitCommands
 {
@@ -30,11 +29,6 @@ namespace GitCommands
         public static void SetSsh(string? path)
         {
             // Git will use the embedded OpenSSH ssh.exe if empty/unset
-            if (!string.IsNullOrEmpty(path) && !File.Exists(path))
-            {
-                path = "";
-            }
-
             if (!string.IsNullOrEmpty(path))
             {
                 // OpenSSH uses empty path, compatibility with path set in 3.4
@@ -48,6 +42,7 @@ namespace GitCommands
             Environment.SetEnvironmentVariable("GIT_SSH", path, EnvironmentVariableTarget.Process);
         }
 
+        // Note that variants like TortoisePlink.exe are supported too
         public static bool Plink()
             => AppSettings.SshPath.EndsWith("plink.exe", StringComparison.CurrentCultureIgnoreCase);
     }


### PR DESCRIPTION
Attempt to handle #9355 #9360 #9348

## Proposed changes

3.4 added a check if the GIT_SSH path exists before setting the variable, to avoid that old incorrect settings are persistent. (This reverts to the Git bundled OpenSSH ssh.exe).

This check may be a reason to why some configurations does not work in 3.5.1.
~~Adding a trace printout to confirm this too.~~
Adding cherry-picked info from master

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
