### PR TITLE
Make showing commit message body in the revision graph optional

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1267,6 +1267,12 @@ namespace GitCommands
             set => SetInt("revisiongridquicksearchtimeout", value);
         }
 
+        public static bool ShowCommitBodyInRevisionGrid
+        {
+            get => GetBool("ShowCommitBodyInRevisionGrid", true);
+            set => SetBool("ShowCommitBodyInRevisionGrid", value);
+        }
+
         /// <summary>Gets or sets the path to the git application executable.</summary>
         public static string GitBinDir
         {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -845,7 +845,7 @@ namespace GitUI.CommandsDialogs
             FillCommitInfo(selectedRevision);
 
             // If the revision's body has been updated then the grid needs to be refreshed to display it
-            if (selectedRevision is not null && selectedRevision.HasMultiLineMessage && oldBody != selectedRevision.Body)
+            if (AppSettings.ShowCommitBodyInRevisionGrid && selectedRevision is not null && selectedRevision.HasMultiLineMessage && oldBody != selectedRevision.Body)
             {
                 RevisionGrid.Refresh();
             }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8866,6 +8866,10 @@ See the changes in the commit form.</source>
         <source>Show build status text</source>
         <target />
       </trans-unit>
+      <trans-unit id="showCommitMessageBodyToolStripMenuItem.Text">
+        <source>Show commit message body</source>
+        <target />
+      </trans-unit>
       <trans-unit id="showDateColumnToolStripMenuItem.Text">
         <source>Show date column</source>
         <target />

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -406,16 +406,13 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 return;
             }
 
-            if (lines.Length == 1)
+            if (lines.Length > 1 && AppSettings.ShowCommitBodyInRevisionGrid)
             {
-                indicator.Render();
-                return;
+                var commitBody = string.Concat(lines.Skip(1).Select(_ => " " + _));
+                var bodyBounds = messageBounds.ReduceLeft(offset);
+                var bodyWidth = _grid.DrawColumnText(e, commitBody, font, style.CommitBodyForeColor, bodyBounds);
+                offset += bodyWidth;
             }
-
-            var commitBody = string.Concat(lines.Skip(1).Select(_ => " " + _));
-            var bodyBounds = messageBounds.ReduceLeft(offset);
-            var bodyWidth = _grid.DrawColumnText(e, commitBody, font, style.CommitBodyForeColor, bodyBounds);
-            offset += bodyWidth;
 
             // Draw the multi-line indicator
             indicator.Render();

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2225,6 +2225,13 @@ namespace GitUI
             ForceRefreshRevisions();
         }
 
+        internal void ToggleShowCommitBodyInRevisionGrid()
+        {
+            AppSettings.ShowCommitBodyInRevisionGrid = !AppSettings.ShowCommitBodyInRevisionGrid;
+            MenuCommands.TriggerMenuChanged();
+            Refresh();
+        }
+
         internal void ShowFirstParent()
         {
             AppSettings.ShowFirstParent = !AppSettings.ShowFirstParent;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -355,6 +355,13 @@ namespace GitUI.UserControls.RevisionGrid
                     ExecuteAction = () => _revisionGrid.ToggleShowGitNotes(),
                     IsCheckedFunc = () => AppSettings.ShowGitNotes
                 },
+                new MenuCommand
+                {
+                    Name = "showCommitMessageBodyToolStripMenuItem",
+                    Text = "Show commit message body",
+                    ExecuteAction = () => _revisionGrid.ToggleShowCommitBodyInRevisionGrid(),
+                    IsCheckedFunc = () => AppSettings.ShowCommitBodyInRevisionGrid
+                },
 
                 MenuCommand.CreateSeparator(),
 

--- a/contributors.txt
+++ b/contributors.txt
@@ -153,3 +153,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/01/25, guybark, Guy Barker, guybark(at)microsoft.com
 2021/02/10, mabako, Marcus Bauer, mabako(at)gmail.com
 2021/03/20, nyankoframe, Damit Senanayake, damit(at)outlook.com
+2021/06/18, jwfx, Jörg Winkler, jwfx at bitmx.net


### PR DESCRIPTION
Original code by @FodderMK
#9301 for 3.5.2
Fixes #9298

## Proposed changes

- Read revision graph configuration option that was previously removed
- Enabled by default as it currently is without the option

## Screenshots <!-- Remove this section if PR does not change UI -->

![image](https://user-images.githubusercontent.com/39484381/122618451-90e82b00-d08e-11eb-8216-85453e51bc0b.png)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).