### PR TITLE
Recent repo search

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -48,6 +48,14 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             userRepositoriesList.HeaderHeight = pnlLogo.Height;
         }
 
+        protected override void OnVisibleChanged(EventArgs e)
+        {
+            base.OnVisibleChanged(e);
+
+            // Focus the control in order for the search bar to have focus once the dashboard is shown
+            userRepositoriesList.Focus();
+        }
+
         // need this to stop flickering of the background images, nothing else works
         protected override CreateParams CreateParams
         {

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
@@ -35,6 +35,7 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(UserRepositoriesList));
             System.Windows.Forms.ListViewGroup listViewGroup1 = new System.Windows.Forms.ListViewGroup("Most Recent", System.Windows.Forms.HorizontalAlignment.Left);
             System.Windows.Forms.ListViewGroup listViewGroup2 = new System.Windows.Forms.ListViewGroup("Less Recent", System.Windows.Forms.HorizontalAlignment.Left);
             System.Windows.Forms.ListViewGroup listViewGroup3 = new System.Windows.Forms.ListViewGroup("Other", System.Windows.Forms.HorizontalAlignment.Left);
@@ -42,35 +43,37 @@
             "C:\\Users\\russkie\\AppData\\Roaming\\GitExtensions\\GitExtensions",
             "refs/heads/master",
             "Favourite"}, 0);
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(UserRepositoriesList));
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
             this.pnlHeader = new System.Windows.Forms.Panel();
-            this.pnlBody = new System.Windows.Forms.Panel();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.lblRecentRepositories = new System.Windows.Forms.Label();
+            this.pnlBody = new System.Windows.Forms.Panel();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.contextMenuStripRepository = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.tsmiOpenFolder = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiCategories = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiCategoryNone = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiCategoryAdd = new System.Windows.Forms.ToolStripMenuItem();
-            this.contextMenuStripRepository = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.contextMenuStripCategory = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.tsmiRemoveFromList = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiRemoveMissingReposFromList = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsmiOpenFolder = new System.Windows.Forms.ToolStripMenuItem();
+            this.imageList1 = new System.Windows.Forms.ImageList(this.components);
+            this.textBoxSearch = new System.Windows.Forms.TextBox();
+            this.contextMenuStripCategory = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.tsmiCategoryRename = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiCategoryDelete = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiCategoryClear = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuStripRecentMenu = new System.Windows.Forms.MenuStrip();
+            this.mnuTop = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnuConfigure = new System.Windows.Forms.ToolStripMenuItem();
             this.listView1 = new GitUI.UserControls.NativeListView();
             this.clmhdrPath = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.clmhdrBranch = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.clmhdrCategory = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.imageList1 = new System.Windows.Forms.ImageList(this.components);
-            this.menuStripRecentMenu = new System.Windows.Forms.MenuStrip();
-            this.mnuTop = new System.Windows.Forms.ToolStripMenuItem();
-            this.mnuConfigure = new System.Windows.Forms.ToolStripMenuItem();
             this.pnlHeader.SuspendLayout();
-            this.pnlBody.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
+            this.pnlBody.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
             this.contextMenuStripRepository.SuspendLayout();
             this.contextMenuStripCategory.SuspendLayout();
             this.menuStripRecentMenu.SuspendLayout();
@@ -79,12 +82,12 @@
             // toolStripMenuItem1
             // 
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(221, 6);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(270, 6);
             // 
             // toolStripMenuItem2
             // 
             this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(221, 6);
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(270, 6);
             // 
             // pnlHeader
             // 
@@ -97,17 +100,6 @@
             this.pnlHeader.Padding = new System.Windows.Forms.Padding(20, 0, 20, 11);
             this.pnlHeader.Size = new System.Drawing.Size(451, 73);
             this.pnlHeader.TabIndex = 0;
-            // 
-            // pnlBody
-            // 
-            this.pnlBody.Controls.Add(this.listView1);
-            this.pnlBody.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pnlBody.Location = new System.Drawing.Point(0, 0);
-            this.pnlBody.Margin = new System.Windows.Forms.Padding(0);
-            this.pnlBody.Name = "pnlBody";
-            this.pnlBody.Padding = new System.Windows.Forms.Padding(20);
-            this.pnlBody.Size = new System.Drawing.Size(451, 73);
-            this.pnlBody.TabIndex = 1;
             // 
             // tableLayoutPanel1
             // 
@@ -136,8 +128,56 @@
             this.lblRecentRepositories.Margin = new System.Windows.Forms.Padding(0);
             this.lblRecentRepositories.Name = "lblRecentRepositories";
             this.lblRecentRepositories.Size = new System.Drawing.Size(411, 32);
-            this.lblRecentRepositories.TabIndex = 1;
+            this.lblRecentRepositories.TabIndex = 2;
             this.lblRecentRepositories.Text = "Recent Repositories";
+            // 
+            // pnlBody
+            // 
+            this.pnlBody.Controls.Add(this.tableLayoutPanel2);
+            this.pnlBody.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pnlBody.Location = new System.Drawing.Point(0, 73);
+            this.pnlBody.Margin = new System.Windows.Forms.Padding(0);
+            this.pnlBody.Name = "pnlBody";
+            this.pnlBody.Padding = new System.Windows.Forms.Padding(20, 18, 20, 3);
+            this.pnlBody.Size = new System.Drawing.Size(451, 210);
+            this.pnlBody.TabIndex = 1;
+            // 
+            // tableLayoutPanel2
+            // 
+            this.tableLayoutPanel2.ColumnCount = 1;
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel2.Controls.Add(this.listView1, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.textBoxSearch, 0, 0);
+            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(20, 3);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            this.tableLayoutPanel2.RowCount = 2;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 45F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(411, 204);
+            this.tableLayoutPanel2.TabIndex = 4;
+            // 
+            // contextMenuStripRepository
+            // 
+            this.contextMenuStripRepository.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.tsmiOpenFolder,
+            this.toolStripMenuItem1,
+            this.tsmiCategories,
+            this.toolStripMenuItem2,
+            this.tsmiRemoveFromList,
+            this.tsmiRemoveMissingReposFromList});
+            this.contextMenuStripRepository.Name = "contextMenuStripRepository";
+            this.contextMenuStripRepository.Size = new System.Drawing.Size(274, 104);
+            this.contextMenuStripRepository.Closed += new System.Windows.Forms.ToolStripDropDownClosedEventHandler(this.contextMenuStrip_Closed);
+            this.contextMenuStripRepository.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStrip_Opening);
+            // 
+            // tsmiOpenFolder
+            // 
+            this.tsmiOpenFolder.Image = global::GitUI.Properties.Images.BrowseFileExplorer;
+            this.tsmiOpenFolder.Name = "tsmiOpenFolder";
+            this.tsmiOpenFolder.Size = new System.Drawing.Size(273, 22);
+            this.tsmiOpenFolder.Text = "Show in folder";
+            this.tsmiOpenFolder.Click += new System.EventHandler(this.tsmiOpenFolder_Click);
             // 
             // tsmiCategories
             // 
@@ -145,7 +185,7 @@
             this.tsmiCategoryNone,
             this.tsmiCategoryAdd});
             this.tsmiCategories.Name = "tsmiCategories";
-            this.tsmiCategories.Size = new System.Drawing.Size(224, 22);
+            this.tsmiCategories.Size = new System.Drawing.Size(273, 22);
             this.tsmiCategories.Text = "Categories";
             this.tsmiCategories.DropDownOpening += new System.EventHandler(this.tsmiCategories_DropDownOpening);
             // 
@@ -164,74 +204,93 @@
             this.tsmiCategoryAdd.Text = "Add new...";
             this.tsmiCategoryAdd.Click += new System.EventHandler(this.tsmiCategoryAdd_Click);
             // 
-            // contextMenuStripRepository
-            // 
-            this.contextMenuStripRepository.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsmiOpenFolder,
-            this.toolStripMenuItem1,
-            this.tsmiCategories,
-            this.toolStripMenuItem2,
-            this.tsmiRemoveFromList,
-            this.tsmiRemoveMissingReposFromList});
-            this.contextMenuStripRepository.Name = "contextMenuStripRepository";
-            this.contextMenuStripRepository.Size = new System.Drawing.Size(225, 126);
-            this.contextMenuStripRepository.Closed += new System.Windows.Forms.ToolStripDropDownClosedEventHandler(this.contextMenuStrip_Closed);
-            this.contextMenuStripRepository.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStrip_Opening);
-            // 
-            // contextMenuStripCategory
-            // 
-            this.contextMenuStripCategory.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-                this.tsmiCategoryRename,
-                this.tsmiCategoryDelete,
-                this.tsmiCategoryClear});
-            this.contextMenuStripCategory.Name = "contextMenuStripCategory";
-            this.contextMenuStripRepository.Size = new System.Drawing.Size(225, 66);
-            // 
             // tsmiRemoveFromList
             // 
             this.tsmiRemoveFromList.Name = "tsmiRemoveFromList";
-            this.tsmiRemoveFromList.Size = new System.Drawing.Size(224, 22);
+            this.tsmiRemoveFromList.Size = new System.Drawing.Size(273, 22);
             this.tsmiRemoveFromList.Text = "Remove project from the list";
             this.tsmiRemoveFromList.Click += new System.EventHandler(this.tsmiRemoveFromList_Click);
             // 
             // tsmiRemoveMissingReposFromList
             // 
             this.tsmiRemoveMissingReposFromList.Name = "tsmiRemoveMissingReposFromList";
-            this.tsmiRemoveMissingReposFromList.Size = new System.Drawing.Size(224, 22);
+            this.tsmiRemoveMissingReposFromList.Size = new System.Drawing.Size(273, 22);
             this.tsmiRemoveMissingReposFromList.Text = "Remove missing projects from the list";
             this.tsmiRemoveMissingReposFromList.Click += new System.EventHandler(this.tsmiRemoveMissingReposFromList_Click);
             // 
-            // tsmiOpenFolder
+            // imageList1
             // 
-            this.tsmiOpenFolder.Image = global::GitUI.Properties.Images.BrowseFileExplorer;
-            this.tsmiOpenFolder.Name = "tsmiOpenFolder";
-            this.tsmiOpenFolder.Size = new System.Drawing.Size(224, 22);
-            this.tsmiOpenFolder.Text = "Show in folder";
-            this.tsmiOpenFolder.Click += new System.EventHandler(this.tsmiOpenFolder_Click);
+            this.imageList1.ImageStream = ((System.Windows.Forms.ImageListStreamer)(resources.GetObject("imageList1.ImageStream")));
+            this.imageList1.TransparentColor = System.Drawing.Color.Transparent;
+            this.imageList1.Images.SetKeyName(0, "source_code.png");
+            // 
+            // textBoxSearch
+            // 
+            this.textBoxSearch.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.textBoxSearch.Location = new System.Drawing.Point(3, 3);
+            this.textBoxSearch.Name = "textBoxSearch";
+            this.textBoxSearch.Size = new System.Drawing.Size(439, 20);
+            this.textBoxSearch.TabIndex = 0;
+            this.textBoxSearch.TextChanged += TextBoxSearch_TextChanged;
+            this.textBoxSearch.KeyDown += TextBoxSearch_KeyDown;
+            // 
+            // contextMenuStripCategory
+            // 
+            this.contextMenuStripCategory.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.tsmiCategoryRename,
+            this.tsmiCategoryDelete,
+            this.tsmiCategoryClear});
+            this.contextMenuStripCategory.Name = "contextMenuStripCategory";
+            this.contextMenuStripCategory.Size = new System.Drawing.Size(217, 70);
             // 
             // tsmiCategoryRename
             // 
             this.tsmiCategoryRename.Image = global::GitUI.Properties.Images.FileStatusModified;
             this.tsmiCategoryRename.Name = "tsmiCategoryRename";
-            this.tsmiCategoryRename.Size = new System.Drawing.Size(224, 22);
+            this.tsmiCategoryRename.Size = new System.Drawing.Size(216, 22);
             this.tsmiCategoryRename.Text = "Rename category";
             this.tsmiCategoryRename.Click += new System.EventHandler(this.tsmiCategoryRename_Click);
-            // 
-            // tsmiCategoryClear
-            // 
-            this.tsmiCategoryClear.Image = global::GitUI.Properties.Images.CleanupRepo;
-            this.tsmiCategoryClear.Name = "tsmiCategoryClear";
-            this.tsmiCategoryClear.Size = new System.Drawing.Size(224, 22);
-            this.tsmiCategoryClear.Text = "Clear all recent repositories";
-            this.tsmiCategoryClear.Click += new System.EventHandler(this.tsmiCategoryClear_Click);
             // 
             // tsmiCategoryDelete
             // 
             this.tsmiCategoryDelete.Image = global::GitUI.Properties.Images.StarRemove;
             this.tsmiCategoryDelete.Name = "tsmiCategoryDelete";
-            this.tsmiCategoryDelete.Size = new System.Drawing.Size(224, 22);
+            this.tsmiCategoryDelete.Size = new System.Drawing.Size(216, 22);
             this.tsmiCategoryDelete.Text = "Delete category";
             this.tsmiCategoryDelete.Click += new System.EventHandler(this.tsmiCategoryDelete_Click);
+            // 
+            // tsmiCategoryClear
+            // 
+            this.tsmiCategoryClear.Image = global::GitUI.Properties.Images.CleanupRepo;
+            this.tsmiCategoryClear.Name = "tsmiCategoryClear";
+            this.tsmiCategoryClear.Size = new System.Drawing.Size(216, 22);
+            this.tsmiCategoryClear.Text = "Clear all recent repositories";
+            this.tsmiCategoryClear.Click += new System.EventHandler(this.tsmiCategoryClear_Click);
+            // 
+            // menuStripRecentMenu
+            // 
+            this.menuStripRecentMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.mnuTop});
+            this.menuStripRecentMenu.Location = new System.Drawing.Point(0, 73);
+            this.menuStripRecentMenu.Name = "menuStripRecentMenu";
+            this.menuStripRecentMenu.Size = new System.Drawing.Size(451, 24);
+            this.menuStripRecentMenu.TabIndex = 3;
+            this.menuStripRecentMenu.Visible = false;
+            // 
+            // mnuTop
+            // 
+            this.mnuTop.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.mnuConfigure});
+            this.mnuTop.Name = "mnuTop";
+            this.mnuTop.Size = new System.Drawing.Size(12, 20);
+            // 
+            // mnuConfigure
+            // 
+            this.mnuConfigure.Image = global::GitUI.Properties.Images.Settings;
+            this.mnuConfigure.Name = "mnuConfigure";
+            this.mnuConfigure.Size = new System.Drawing.Size(218, 22);
+            this.mnuConfigure.Text = "&Recent repositories settings";
+            this.mnuConfigure.Click += new System.EventHandler(this.mnuConfigure_Click);
             // 
             // listView1
             // 
@@ -259,22 +318,22 @@
             this.listView1.Items.AddRange(new System.Windows.Forms.ListViewItem[] {
             listViewItem1});
             this.listView1.LargeImageList = this.imageList1;
-            this.listView1.Location = new System.Drawing.Point(24, 80);
-            this.listView1.Margin = new System.Windows.Forms.Padding(24, 3, 24, 3);
+            this.listView1.Location = new System.Drawing.Point(0, 33);
+            this.listView1.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
             this.listView1.MultiSelect = false;
             this.listView1.Name = "listView1";
             this.listView1.OwnerDraw = true;
             this.listView1.ShowItemToolTips = true;
-            this.listView1.Size = new System.Drawing.Size(403, 195);
-            this.listView1.TabIndex = 2;
+            this.listView1.Size = new System.Drawing.Size(445, 168);
+            this.listView1.TabIndex = 1;
             this.listView1.TileSize = new System.Drawing.Size(350, 50);
             this.listView1.UseCompatibleStateImageBehavior = false;
             this.listView1.View = System.Windows.Forms.View.Tile;
+            this.listView1.GroupTaskLinkClick += new System.EventHandler<System.Windows.Forms.ListViewGroupEventArgs>(this.ListView1_GroupTaskLinkClick);
             this.listView1.DrawItem += new System.Windows.Forms.DrawListViewItemEventHandler(this.listView1_DrawItem);
             this.listView1.MouseClick += new System.Windows.Forms.MouseEventHandler(this.listView1_MouseClick);
-            this.listView1.MouseMove += new System.Windows.Forms.MouseEventHandler(this.listView1_MouseMove);
             this.listView1.MouseLeave += new System.EventHandler(this.listView1_MouseLeave);
-            this.listView1.GroupTaskLinkClick += new System.EventHandler<System.Windows.Forms.ListViewGroupEventArgs>(this.ListView1_GroupTaskLinkClick);
+            this.listView1.MouseMove += new System.Windows.Forms.MouseEventHandler(this.listView1_MouseMove);
             // 
             // clmhdrPath
             // 
@@ -288,38 +347,7 @@
             // 
             this.clmhdrCategory.Text = "Category";
             // 
-            // imageList1
-            // 
-            this.imageList1.ImageStream = ((System.Windows.Forms.ImageListStreamer)(resources.GetObject("imageList1.ImageStream")));
-            this.imageList1.TransparentColor = System.Drawing.Color.Transparent;
-            this.imageList1.Images.SetKeyName(0, "source_code.png");
-            // 
-            // menuStripRecentMenu
-            // 
-            this.menuStripRecentMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.mnuTop});
-            this.menuStripRecentMenu.Location = new System.Drawing.Point(0, 73);
-            this.menuStripRecentMenu.Name = "menuStripRecentMenu";
-            this.menuStripRecentMenu.Size = new System.Drawing.Size(451, 24);
-            this.menuStripRecentMenu.TabIndex = 3;
-            this.menuStripRecentMenu.Visible = false;
-            // 
-            // mnuTop
-            // 
-            this.mnuTop.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.mnuConfigure});
-            this.mnuTop.Name = "mnuTop";
-            this.mnuTop.Size = new System.Drawing.Size(71, 20);
-            // 
-            // mnuConfigure
-            // 
-            this.mnuConfigure.Image = global::GitUI.Properties.Images.Settings;
-            this.mnuConfigure.Name = "mnuConfigure";
-            this.mnuConfigure.Size = new System.Drawing.Size(218, 22);
-            this.mnuConfigure.Text = "&Recent repositories settings";
-            this.mnuConfigure.Click += new System.EventHandler(this.mnuConfigure_Click);
-            // 
-            // RecentRepositoriesList
+            // UserRepositoriesList
             // 
             this.AllowDrop = true;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -328,15 +356,16 @@
             this.Controls.Add(this.pnlBody);
             this.Controls.Add(this.pnlHeader);
             this.DoubleBuffered = true;
-            this.Name = "RecentRepositoriesList";
+            this.Name = "UserRepositoriesList";
             this.Size = new System.Drawing.Size(451, 283);
             this.Load += new System.EventHandler(this.RecentRepositoriesList_Load);
             this.pnlHeader.ResumeLayout(false);
             this.pnlHeader.PerformLayout();
-            this.pnlBody.ResumeLayout(false);
-            this.pnlBody.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
+            this.pnlBody.ResumeLayout(false);
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
             this.contextMenuStripRepository.ResumeLayout(false);
             this.contextMenuStripCategory.ResumeLayout(false);
             this.menuStripRecentMenu.ResumeLayout(false);
@@ -373,5 +402,7 @@
         private System.Windows.Forms.MenuStrip menuStripRecentMenu;
         private System.Windows.Forms.ToolStripMenuItem mnuTop;
         private System.Windows.Forms.ToolStripMenuItem mnuConfigure;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private System.Windows.Forms.TextBox textBoxSearch;
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
@@ -13,14 +13,20 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         Task AssignCategoryAsync(Repository repository, string? category);
         string GetCurrentBranchName(string path);
         bool IsValidGitWorkingDir(string path);
-        (IReadOnlyList<RecentRepoInfo> recentRepositories, IReadOnlyList<RecentRepoInfo> favouriteRepositories) PreRenderRepositories(Graphics g);
+        (IReadOnlyList<RecentRepoInfo> recentRepositories, IReadOnlyList<RecentRepoInfo> favouriteRepositories) PreRenderRepositories(Graphics g, string filter);
         bool RemoveInvalidRepository(string path);
+        void ClearCache();
     }
 
     public sealed class UserRepositoriesListController : IUserRepositoriesListController
     {
         private readonly ILocalRepositoryManager _localRepositoryManager;
         private readonly IInvalidRepositoryRemover _invalidRepositoryRemover;
+
+        // Holds the raw, unfiltered list of repositories.
+        // This is done to allow fast filtering of all known repos.
+        private IList<Repository>? _allRecentRepositories;
+        private IList<Repository>? _allFavoriteRepositories;
 
         public UserRepositoriesListController(ILocalRepositoryManager localRepositoryManager, IInvalidRepositoryRemover invalidRepositoryRemover)
         {
@@ -38,6 +44,15 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             await _localRepositoryManager.AssignCategoryAsync(repository, category);
         }
 
+        /// <summary>
+        /// Clears the repository cache. After this call the repository list will be loaded from disk.
+        /// </summary>
+        public void ClearCache()
+        {
+            _allRecentRepositories = null;
+            _allFavoriteRepositories = null;
+        }
+
         public string GetCurrentBranchName(string path)
         {
             if (!AppSettings.ShowRepoCurrentBranch || GitModule.IsBareRepository(path))
@@ -53,7 +68,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             return GitModule.IsValidGitWorkingDir(path);
         }
 
-        public (IReadOnlyList<RecentRepoInfo> recentRepositories, IReadOnlyList<RecentRepoInfo> favouriteRepositories) PreRenderRepositories(Graphics g)
+        public (IReadOnlyList<RecentRepoInfo> recentRepositories, IReadOnlyList<RecentRepoInfo> favouriteRepositories) PreRenderRepositories(Graphics g, string pattern)
         {
             List<RecentRepoInfo> mostRecentRepos = new();
             List<RecentRepoInfo> lessRecentRepos = new();
@@ -70,11 +85,13 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 SortMostRecentRepos = AppSettings.SortMostRecentRepos
             };
 
-            var repositories = ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.LoadRecentHistoryAsync());
+            _allRecentRepositories ??= ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.LoadRecentHistoryAsync());
+            var repositories = Filter(_allRecentRepositories, pattern);
             splitter.SplitRecentRepos(repositories, mostRecentRepos, lessRecentRepos);
             var recentRepositories = mostRecentRepos.Union(lessRecentRepos).ToList();
 
-            repositories = ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.LoadFavouriteHistoryAsync());
+            _allFavoriteRepositories ??= ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.LoadFavouriteHistoryAsync());
+            repositories = Filter(_allFavoriteRepositories, pattern);
             mostRecentRepos.Clear();
             lessRecentRepos.Clear();
             splitter.SplitRecentRepos(repositories, mostRecentRepos, lessRecentRepos);
@@ -85,5 +102,26 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         public bool RemoveInvalidRepository(string path)
            => _invalidRepositoryRemover.ShowDeleteInvalidRepositoryDialog(path);
+
+        private static IList<Repository> Filter(IList<Repository> repositories, string pattern)
+        {
+            if (pattern.Length == 0)
+            {
+                return repositories;
+            }
+
+            List<Repository> repos = new();
+            for (var i = repositories.Count - 1; i >= 0; i--)
+            {
+                var repo = repositories[i];
+                if (repo.Path.Contains(pattern, StringComparison.CurrentCultureIgnoreCase))
+                {
+                    repos.Add(repo);
+                    continue;
+                }
+            }
+
+            return repos;
+        }
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8797,98 +8797,6 @@ This will just checkout on the submodule the commit determined by the superproje
       </trans-unit>
     </body>
   </file>
-  <file datatype="plaintext" original="RecentRepositoriesList" source-language="en">
-    <body>
-      <trans-unit id="_cannotOpenTheFolder.Text">
-        <source>Cannot open the folder</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_clearRecentCategoryCaption.Text">
-        <source>Clear recent repositories</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_clearRecentCategoryQuestion.Text">
-        <source>Do you want to clear the list of recent repositories?
-
-The action cannot be undone.</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_deleteCategoryCaption.Text">
-        <source>Delete Category</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_deleteCategoryQuestion.Text">
-        <source>Do you want to delete category "{0}" with {1} repositories?
-
-The action cannot be undone.</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_groupActions.Text">
-        <source>Actions</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_groupRecentRepositories.Text">
-        <source>Recent repositories</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="clmhdrBranch.Text">
-        <source>Branch</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="clmhdrCategory.Text">
-        <source>Category</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="clmhdrPath.Text">
-        <source>Path</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="lblRecentRepositories.Text">
-        <source>Recent Repositories</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="mnuConfigure.Text">
-        <source>&amp;Recent repositories settings</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="tsmiCategories.Text">
-        <source>Categories</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="tsmiCategoryAdd.Text">
-        <source>Add new...</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="tsmiCategoryClear.Text">
-        <source>Clear all recent repositories</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="tsmiCategoryDelete.Text">
-        <source>Delete category</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="tsmiCategoryNone.Text">
-        <source>(none)</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="tsmiCategoryRename.Text">
-        <source>Rename category</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="tsmiOpenFolder.Text">
-        <source>Show in folder</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="tsmiRemoveFromList.Text">
-        <source>Remove project from the list</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="tsmiRemoveMissingReposFromList.Text">
-        <source>Remove missing projects from the list</source>
-        <target />
-      </trans-unit>
-    </body>
-  </file>
   <file datatype="plaintext" original="ReleaseNotesGeneratorForm" source-language="en">
     <body>
       <trans-unit id="$this.Text">
@@ -10957,6 +10865,102 @@ Yes, I allow telemetry!</source>
       </trans-unit>
       <trans-unit id="_yes.Text">
         <source>Yes</source>
+        <target />
+      </trans-unit>
+    </body>
+  </file>
+  <file datatype="plaintext" original="UserRepositoriesList" source-language="en">
+    <body>
+      <trans-unit id="_cannotOpenTheFolder.Text">
+        <source>Cannot open the folder</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_clearRecentCategoryCaption.Text">
+        <source>Clear recent repositories</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_clearRecentCategoryQuestion.Text">
+        <source>Do you want to clear the list of recent repositories?
+
+The action cannot be undone.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_deleteCategoryCaption.Text">
+        <source>Delete Category</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_deleteCategoryQuestion.Text">
+        <source>Do you want to delete category "{0}" with {1} repositories?
+
+The action cannot be undone.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_groupActions.Text">
+        <source>Actions</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_groupRecentRepositories.Text">
+        <source>Recent repositories</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_repositorySearchPlaceholder.Text">
+        <source>Search repositories</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="clmhdrBranch.Text">
+        <source>Branch</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="clmhdrCategory.Text">
+        <source>Category</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="clmhdrPath.Text">
+        <source>Path</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="lblRecentRepositories.Text">
+        <source>Recent Repositories</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnuConfigure.Text">
+        <source>&amp;Recent repositories settings</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiCategories.Text">
+        <source>Categories</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiCategoryAdd.Text">
+        <source>Add new...</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiCategoryClear.Text">
+        <source>Clear all recent repositories</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiCategoryDelete.Text">
+        <source>Delete category</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiCategoryNone.Text">
+        <source>(none)</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiCategoryRename.Text">
+        <source>Rename category</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiOpenFolder.Text">
+        <source>Show in folder</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiRemoveFromList.Text">
+        <source>Remove project from the list</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiRemoveMissingReposFromList.Text">
+        <source>Remove missing projects from the list</source>
         <target />
       </trans-unit>
     </body>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9302


## Proposed changes

- A new searchbar for filtering the recent / favorite repositories
   - Pressing return will open the first search result
- The default focus has been changed to focus the search textbox once the dashboard gets visible
   -  This allows immediate search when opening gitextensions or when going back (strg+w) to the dashboard
- A new interface has been added for filtering repositories


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/3924958/125766864-92c2638f-f9dd-4509-a355-6979e28e7a3d.png)



### After

![image](https://user-images.githubusercontent.com/3924958/125766810-6ee060c3-9de3-4228-bfe2-b699b040b189.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual tests:
  - Search for repo, press return
  - Search for random text (no search results), press return
  - Search for non existing repo, press return


## Test environment(s) <!-- Remove any that don't apply -->

- Windows 10
- UI Scaling 100%


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
