### PR TITLE
Do not check if path exists before settings GIT_SSH

### DIFF
--- a/GitCommands/Git/GitSshHelpers.cs
+++ b/GitCommands/Git/GitSshHelpers.cs
@@ -28,14 +28,10 @@ namespace GitCommands
         public static void SetSsh(string path)
         {
             // Git will use the embedded OpenSSH ssh.exe if empty/unset
-            if (!string.IsNullOrEmpty(path) && !File.Exists(path))
-            {
-                path = "";
-            }
-
             Environment.SetEnvironmentVariable("GIT_SSH", path, EnvironmentVariableTarget.Process);
         }
 
+        // Note that variants like TortoisePlink.exe are supported too
         public static bool Plink()
             => AppSettings.SshPath.EndsWith("plink.exe", StringComparison.CurrentCultureIgnoreCase);
     }


### PR DESCRIPTION
Related to #9355 #9360 #9348

Similar to #9369 that still have trace printouts and therefore is WIP (and should get cherry-pick comment when this merged).

## Proposed changes

The path in GIT_SSH may be accessible for git.exe even if not for GE

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
