### PR TITLE
Enable use of the designer

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1919,10 +1919,9 @@ namespace GitCommands
             set => SetBool("Log.CaptureCallStacks", value);
         }
 
-        public static bool IsPortable()
-        {
-            return Properties.Settings.Default.IsPortable;
-        }
+        // There is a bug in .NET/.NET Designer that fails to execute Properties.Settings.Default call.
+        // Return false whilst we're in the designer.
+        public static bool IsPortable() => !IsDesignMode && Properties.Settings.Default.IsPortable;
 
         public static bool WriteErrorLog
         {
@@ -2126,6 +2125,22 @@ namespace GitCommands
             string availableEncodings = AvailableEncodings.Values.Select(e => e.HeaderName).Join(";");
             availableEncodings = availableEncodings.Replace(Encoding.Default.HeaderName, "Default");
             SetString("AvailableEncodings", availableEncodings);
+        }
+
+        private static bool? _isDesignMode;
+
+        private static bool IsDesignMode
+        {
+            get
+            {
+                if (_isDesignMode is null)
+                {
+                    string processName = Process.GetCurrentProcess().ProcessName.ToLowerInvariant();
+                    _isDesignMode = processName.Contains("devenv") || processName.Contains("designtoolsserver");
+                }
+
+                return _isDesignMode.Value;
+            }
         }
 
         internal static TestAccessor GetTestAccessor() => new();

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -191,7 +191,7 @@ namespace GitUI.Editor
 
             HotkeysEnabled = true;
 
-            if (!IsDesignModeActive && ContextMenuStrip is null)
+            if (!IsDesignMode && ContextMenuStrip is null)
             {
                 ContextMenuStrip = contextMenu;
             }

--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -71,7 +71,7 @@ namespace GitUI
             // Should be called after restoring position
             base.OnLoad(e);
 
-            if (!IsDesignModeActive)
+            if (!IsDesignMode)
             {
                 OnRuntimeLoad(e);
             }

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -53,7 +53,7 @@ namespace GitUI
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         protected GitModuleForm()
         {
-            if (LicenseManager.UsageMode != LicenseUsageMode.Designtime && !IsUnitTestActive)
+            if (!IsDesignMode && !IsUnitTestActive)
             {
                 throw new InvalidOperationException(
                     "This constructor is only to be called by the Visual Studio designer, and the translation unit tests.");

--- a/ResourceManager/GitExtensionsControl.cs
+++ b/ResourceManager/GitExtensionsControl.cs
@@ -28,7 +28,7 @@ namespace ResourceManager
             set => base.Font = value;
         }
 
-        public bool IsDesignModeActive => _initialiser.IsDesignModeActive;
+        protected bool IsDesignMode => _initialiser.IsDesignMode;
 
         protected virtual void OnRuntimeLoad()
         {
@@ -38,7 +38,7 @@ namespace ResourceManager
         {
             base.OnLoad(e);
 
-            if (!_initialiser.IsDesignModeActive)
+            if (!IsDesignMode)
             {
                 OnRuntimeLoad();
             }
@@ -53,6 +53,12 @@ namespace ResourceManager
         protected void InitializeComplete()
         {
             _initialiser.InitializeComplete();
+
+            if (IsDesignMode)
+            {
+                return;
+            }
+
             this.FixVisualStyle();
         }
 

--- a/ResourceManager/GitExtensionsFormBase.cs
+++ b/ResourceManager/GitExtensionsFormBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
@@ -26,11 +27,16 @@ namespace ResourceManager
         {
             _initialiser = new GitExtensionsControlInitialiser(this);
 
+            if (IsDesignMode)
+            {
+                return;
+            }
+
             ShowInTaskbar = Application.OpenForms.Count <= 0;
             Icon = Resources.GitExtensionsLogoIcon;
         }
 
-        protected bool IsDesignModeActive => _initialiser.IsDesignModeActive;
+        protected bool IsDesignMode => _initialiser.IsDesignMode;
 
         #region Hotkeys
 
@@ -43,7 +49,7 @@ namespace ResourceManager
         /// <summary>Overridden: Checks if a hotkey wants to handle the key before letting the message propagate</summary>
         protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
         {
-            if (HotkeysEnabled && Hotkeys is not null)
+            if (!IsDesignMode && HotkeysEnabled && Hotkeys is not null)
             {
                 foreach (var hotkey in Hotkeys)
                 {
@@ -77,9 +83,12 @@ namespace ResourceManager
 
         protected override void WndProc(ref Message m)
         {
-            if (m.Msg == NativeMethods.WM_ACTIVATEAPP && m.WParam != IntPtr.Zero)
+            if (!IsDesignMode)
             {
-                OnApplicationActivated();
+                if (m.Msg == NativeMethods.WM_ACTIVATEAPP && m.WParam != IntPtr.Zero)
+                {
+                    OnApplicationActivated();
+                }
             }
 
             base.WndProc(ref m);
@@ -95,6 +104,11 @@ namespace ResourceManager
         protected void InitializeComplete()
         {
             _initialiser.InitializeComplete();
+
+            if (IsDesignMode)
+            {
+                return;
+            }
 
             AutoScaleMode = AppSettings.EnableAutoScale
                 ? AutoScaleMode.Dpi


### PR DESCRIPTION
This is likely an ongoing work where we'll need to check every form and/or control we edit and apply `IsDesignMode` check to avoid executing unnecessary code in the Windows Forms designer.

Resolves #9388