### PR TITLE
Do not blame folders

### DIFF
--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -450,7 +450,13 @@ See the changes in the commit form.");
         {
             if (tvGitTree.SelectedNode?.Tag is GitItem gitItem)
             {
-                UICommands.StartFileHistoryDialog(this, gitItem.FileName, _revision);
+                string name = gitItem.FileName;
+                if (gitItem.ObjectType == GitObjectType.Tree)
+                {
+                    name += "/";
+                }
+
+                UICommands.StartFileHistoryDialog(this, name, _revision);
             }
         }
 


### PR DESCRIPTION
Needed with #9056

Follow up to #9335 
See long term goals in https://github.com/gitextensions/gitextensions/issues/7598#issuecomment-864561070
(FileHistory is a sidetrack)

## Proposed changes

It is possible to blame Git Tree objects (folders) from File tree.
GE shows the history for all commits affecting the folder, but just display the file and blame for one of them (the first reported file).
The name for the displayed/blamed file is added to the title bar.

If no files are seen for a certain commit, GE uses the "FileHistory" path for blame, which is not possible for a folder.
Also the first file in the folder is viewed, not matching the folder name in the title bar.
Diff tab could have been displayed but parsing of multiple diffs fail why this is hidden too.
(So no tabs shown for folder and aritificial commits.)

With #9056, this will raise an exception (that PR will show many issues in GE, a number has already been handled...)
(no popup though)

Note: That the filenames for a commit is not reported is a problem itself that likely occurs due to "--follow" option.
See https://stackoverflow.com/questions/46487476/git-log-follow-graph-skips-commits
That is ignored in this PR, the core case should be handled regardless.

Note 2: It is still possible to get the old behavior from the command line, that is ignored in this PR.

## Screenshots <!-- Remove this section if PR does not change UI -->

"Bin/" is used in these examples

![image](https://user-images.githubusercontent.com/6248932/126048301-e71d90ab-4e70-41c0-a7fa-de10edbf1c62.png)

### Before #9335 

(for all commits, no file viewed)

![image](https://user-images.githubusercontent.com/6248932/126048544-9f8f7a3a-21a9-4b50-a458-f6746b287f03.png)

### Before in master

![image](https://user-images.githubusercontent.com/6248932/126048724-3018fa16-795a-4af6-969e-4b6ea37663eb.png)

### #9056

![image](https://user-images.githubusercontent.com/6248932/126048826-9979e5f0-3205-457e-a1b7-f7e3e27cc7de.png)

![image](https://user-images.githubusercontent.com/6248932/126048845-12507a37-3783-4923-873c-44eb49293b08.png)

### After

![image](https://user-images.githubusercontent.com/6248932/126050312-560e7d5f-c316-426b-8670-8bb18a26ed55.png)

Slightly different commits, changes in HEAD so artificial commits are shown - no tabs available

![image](https://user-images.githubusercontent.com/6248932/126050574-3e3275ae-7fee-4df6-8949-53f9f9716a15.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
