### PR TITLE
Show artificial commits also for filtered grid

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
@@ -28,10 +28,6 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
         public LaneInfo? LaneInfo { get; set; }
 
-        public int StartScore => Child.Score;
-
-        public int EndScore => Parent.Score;
-
         public RevisionGraphRevision Parent { get; }
         public RevisionGraphRevision Child { get; }
     }

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -299,9 +299,16 @@ namespace GitUI.UserControls.RevisionGrid
             e.Handled = true;
         }
 
-        public void Add(GitRevision revision, RevisionNodeFlags types = RevisionNodeFlags.None)
+        /// <summary>
+        /// Add a single revision from the git log to the graph, including segments to parents.
+        /// Update visible rows if needed.
+        /// </summary>
+        /// <param name="revision">The revision to add.</param>
+        /// <param name="types">The graph node flags.</param>
+        /// <param name="insertAsFirst">Insert the (artificial) revision first in the graph.</param>
+        public void Add(GitRevision revision, RevisionNodeFlags types = RevisionNodeFlags.None, bool insertAsFirst = false)
         {
-            _revisionGraph.Add(revision, types);
+            _revisionGraph.Add(revision, types, insertAsFirst);
 
             if (ToBeSelectedObjectIds.Contains(revision.ObjectId))
             {

--- a/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
@@ -33,6 +33,8 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
 
             // We don't want avatars during tests, otherwise we will be attempting to download them from gravatar.
             AppSettings.ShowAuthorAvatarColumn = false;
+
+            AppSettings.RevisionGraphShowWorkingDirChanges = true;
         }
 
         [SetUp]
@@ -124,7 +126,7 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                     RefreshRevisions(revisionGridControl);
 
                     // Confirm the filter has been applied
-                    ta.VisibleRevisionCount.Should().Be(2);
+                    ta.VisibleRevisionCount.Should().Be(4);
                     ProcessUntil(() => revisionGridControl.LatestSelectedRevision.ObjectId.ToString(), _branch1Commit);
                 });
         }
@@ -141,7 +143,7 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                 {
                     var ta = revisionGridControl.GetTestAccessor();
                     Assert.True(revisionGridControl.IsShowFilteredBranchesChecked);
-                    ta.VisibleRevisionCount.Should().Be(2);
+                    ta.VisibleRevisionCount.Should().Be(4);
 
                     // Verify the view hasn't changed until we refresh
                     revisionGridControl.LatestSelectedRevision.ObjectId.ToString().Should().Be(_branch1Commit);


### PR DESCRIPTION
Follow up to #9335
See long term goals in #7598 (comment)

## Proposed changes

Artificial commits are added to the HEAD. If commits are filtered, HEAD may not appear.
This occurs both for files filtered in Browse and FileHistory.
Note that FileHistory for a file in HEAD would show Artificial, but not history for any other file.

This change inserts the artificial commits first if not added to the commits.

Also change the confusing diff message (especially when selecting artificial commits without changes).

Note that the first seen parent to HEAD could be queried, the artificial commits be inserted there. This adds another for a call that may delay display which is not worth it. 

~~Note: For filters where the file do exist in HEAD this is a minor regression, the Index is no longer connected to the head.~~
~~If HEAD is not displayed, the artificial commits could be connected to next commit too.~~
~~This was ignored as either all commits have to be parsed before they are displayed or the rendered grid will have to recalculated when the commits are reinserted.~~

~~If "follow renamed files" is moved from FileHistory to RevisionReader (or RevisionGridControl) so it can be used by Browse filters too,~~
~~this info is mostly calculated (even if --follow seem to drop some commits, seen in #9392 so not in every situation).~~
 
## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

file in HEAD

![image](https://user-images.githubusercontent.com/6248932/126083748-59bf48ba-d4b6-4673-949f-9767a9cea7cf.png)

No changes in Index

![image](https://user-images.githubusercontent.com/6248932/126083763-745f35d9-4875-412b-b00d-77f4c1e25448.png)

not in HEAD

![image](https://user-images.githubusercontent.com/6248932/126083783-cf8f161f-8fef-45f6-9ccf-9f16d31fe11f.png)

### After

(not updated screenshot, artificial is connected to HEAD)

![image](https://user-images.githubusercontent.com/6248932/126083819-754fd11e-088f-4b33-9ea8-8639fede9c7a.png)

![image](https://user-images.githubusercontent.com/6248932/126083830-7c754194-ea3e-48cb-a698-f0dc69755496.png)

![image](https://user-images.githubusercontent.com/6248932/126083845-4e835743-4127-4c78-9578-7e12f42b6a7f.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
