### PR TITLE
Improve handling of encodings with conflicting names

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3957,7 +3957,7 @@ namespace GitCommands
         [return: NotNullIfNotNull("s")]
         public static string? ReEncodeString(string? s, Encoding fromEncoding, Encoding toEncoding)
         {
-            if (s is null || fromEncoding.HeaderName == toEncoding.HeaderName)
+            if (s is null || fromEncoding.WebName == toEncoding.WebName)
             {
                 return s;
             }
@@ -4014,7 +4014,7 @@ namespace GitCommands
                 {
                     return Encoding.UTF8;
                 }
-                else if (encodingName.Equals(LosslessEncoding.HeaderName, StringComparison.InvariantCultureIgnoreCase))
+                else if (encodingName.Equals(LosslessEncoding.WebName, StringComparison.InvariantCultureIgnoreCase))
                 {
                     // no recoding is needed
                     return null;

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -2021,7 +2021,7 @@ namespace GitCommands
         {
             void AddEncoding(Encoding e)
             {
-                AvailableEncodings[e.HeaderName] = e;
+                AvailableEncodings[e.WebName] = e;
             }
 
             void AddEncodingByName(string s)
@@ -2062,14 +2062,14 @@ namespace GitCommands
                 var utf8 = new UTF8Encoding(false);
                 foreach (var encodingName in availableEncodings.Split(';'))
                 {
-                    if (encodingName == Encoding.UTF7.HeaderName)
+                    if (encodingName == Encoding.UTF7.WebName)
                     {
                         // UTF-7 is no longer supported, see: https://github.com/dotnet/docs/issues/19274
                         continue;
                     }
 
                     // create utf-8 without BOM
-                    if (encodingName == utf8.HeaderName)
+                    if (encodingName == utf8.WebName)
                     {
                         AddEncoding(utf8);
                     }
@@ -2091,8 +2091,8 @@ namespace GitCommands
 
         private static void SaveEncodings()
         {
-            string availableEncodings = AvailableEncodings.Values.Select(e => e.HeaderName).Join(";");
-            availableEncodings = availableEncodings.Replace(Encoding.Default.HeaderName, "Default");
+            string availableEncodings = AvailableEncodings.Values.Select(e => e.WebName).Join(";");
+            availableEncodings = availableEncodings.Replace(Encoding.Default.WebName, "Default");
             SetString("AvailableEncodings", availableEncodings);
         }
 

--- a/GitCommands/Settings/ConfigFileSettings.cs
+++ b/GitCommands/Settings/ConfigFileSettings.cs
@@ -170,7 +170,7 @@ namespace GitCommands.Settings
 
         private void SetEncoding(string settingName, Encoding? encoding)
         {
-            SetValue(settingName, encoding?.HeaderName);
+            SetValue(settingName, encoding?.WebName);
         }
     }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
@@ -32,7 +32,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             var availableEncoding = Encoding.GetEncodings()
                 .Select(ei => ei.GetEncoding())
                 .Where(e => e != Encoding.UTF7) // UTF-7 is no longer supported, see: https://github.com/dotnet/docs/issues/19274
-                .Where(e => !includedEncoding.ContainsKey(e.HeaderName))
+                .Where(e => !includedEncoding.ContainsKey(e.WebName))
                 .ToList();
 
             // If exists utf-8, then replace to utf-8 without BOM
@@ -59,9 +59,22 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         {
             if (ListAvailableEncodings.SelectedItem is not null)
             {
-                var index = ListAvailableEncodings.SelectedIndex;
+                Encoding selected = (Encoding)ListAvailableEncodings.SelectedItem;
+                foreach (Encoding included in ListIncludedEncodings.Items)
+                {
+                    if (included.WebName == selected.WebName)
+                    {
+                        MessageBox.Show(this,
+                            string.Format("The encoding '{0}' has the same WebName '{1}' as the already included '{2}' - ignoring.",
+                                selected.EncodingName,
+                                selected.WebName,
+                                included.EncodingName));
+                        return;
+                    }
+                }
+
                 ListIncludedEncodings.Items.Add(ListAvailableEncodings.SelectedItem);
-                ListAvailableEncodings.Items.RemoveAt(index);
+                ListAvailableEncodings.Items.RemoveAt(ListAvailableEncodings.SelectedIndex);
             }
         }
 
@@ -70,7 +83,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             AppSettings.AvailableEncodings.Clear();
             foreach (Encoding encoding in ListIncludedEncodings.Items)
             {
-                AppSettings.AvailableEncodings.Add(encoding.HeaderName, encoding);
+                AppSettings.AvailableEncodings.Add(encoding.WebName, encoding);
             }
 
             DialogResult = DialogResult.OK;

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -721,13 +721,13 @@ namespace GitUI.Editor
                 encodingToolStripComboBox.Items.AddRange(encodings);
                 encodingToolStripComboBox.ResizeDropDownWidth(50, 250);
 
-                var defaultEncodingName = Encoding.Default.EncodingName;
+                string defaultEncodingName = Encoding.Default.EncodingName;
 
                 for (int i = 0; i < encodings.Length; i++)
                 {
                     if (string.Equals(encodings[i], defaultEncodingName, StringComparison.OrdinalIgnoreCase))
                     {
-                        encodingToolStripComboBox.Items[i] = "Default (" + Encoding.Default.HeaderName + ")";
+                        encodingToolStripComboBox.Items[i] = $"Default ({defaultEncodingName})";
                         break;
                     }
                 }


### PR DESCRIPTION
Fixes #9395

## Proposed changes

- Use `Encoding.WebName` instead of `Encoding.HeaderName` in order to reduce conflicts (Japanese and Korean)
  https://github.com/gitextensions/gitextensions/issues/9395#issuecomment-885231492
- Fill `ListAvailableEncodings` only with the first occurrence of a `WebName`

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 3cd5063e30b6f2c5b19e123954d51bdb3de5ec5e
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4360.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).