### PR TITLE
Do not allow duplicate submodule paths

### DIFF
--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -240,6 +241,12 @@ namespace GitCommands.Submodules
                 {
                     result.CurrentSubmoduleName = currentModule.GetCurrentSubmoduleLocalPath();
                     bold = true;
+                }
+
+                if (string.IsNullOrWhiteSpace(path) || result.AllSubmodules.Any(info => info.Path == path))
+                {
+                    Trace.WriteLine($"Ignoring duplicate submodule path: {path} ({name})");
+                    continue;
                 }
 
                 SubmoduleInfo smi = new(text: name, path, bold);

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using GitCommands.Git;
+using GitCommands.Utils;
 using GitUI;
 using GitUIPluginInterfaces;
 using Microsoft;
@@ -244,7 +245,8 @@ namespace GitCommands.Submodules
                 }
 
                 if (string.IsNullOrWhiteSpace(path)
-                    || result.AllSubmodules.Any(info => path.Equals(info.Path, StringComparison.OrdinalIgnoreCase)))
+                    || (EnvUtils.RunningOnWindows()
+                        && result.AllSubmodules.Any(info => path.Equals(info.Path, StringComparison.OrdinalIgnoreCase))))
                 {
                     Trace.WriteLine($"Ignoring duplicate submodule path: {path} ({name})");
                     continue;

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -243,7 +243,8 @@ namespace GitCommands.Submodules
                     bold = true;
                 }
 
-                if (string.IsNullOrWhiteSpace(path) || result.AllSubmodules.Any(info => info.Path == path))
+                if (string.IsNullOrWhiteSpace(path)
+                    || result.AllSubmodules.Any(info => path.Equals(info.Path, StringComparison.OrdinalIgnoreCase)))
                 {
                     Trace.WriteLine($"Ignoring duplicate submodule path: {path} ({name})");
                     continue;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2922,7 +2922,6 @@ namespace GitUI.CommandsDialogs
                 else
                 {
                     Debug.Fail($"Status info for {path} ({1 + result.AllSubmodules.Count} records) has no match in current nodes ({_currentSubmoduleMenuItems.Count})");
-                    break;
                 }
             }
         }


### PR DESCRIPTION
Fixes #9343

## Proposed changes

Check that submodule paths are not empty and unique.
This should already be the case, but non unique paths occurs in #9343 and should in a similar .ToDictionary() for the sidepanel.

The removed break in FormBrowse is not necessary - following submodules should be updated.

To be cherry-picked to release/3.5 after merge to master

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
