### PR TITLE
Allow to select and delete multiple branches in the revision grid

### DIFF
--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -20,7 +20,7 @@ namespace GitUI.CommandsDialogs
             new("At least one remote branch is unmerged. Are you sure you want to delete it?" + Environment.NewLine + "Deleting a branch can cause commits to be deleted too!");
 
         private readonly HashSet<string> _mergedBranches = new();
-        private readonly string _defaultRemoteBranch;
+        private readonly IEnumerable<string> _defaultBranches;
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -30,10 +30,10 @@ namespace GitUI.CommandsDialogs
             InitializeComponent();
         }
 
-        public FormDeleteRemoteBranch(GitUICommands commands, string defaultRemoteBranch)
+        public FormDeleteRemoteBranch(GitUICommands commands, IEnumerable<string> defaultBranches)
             : base(commands)
         {
-            _defaultRemoteBranch = defaultRemoteBranch;
+            _defaultBranches = defaultBranches;
             InitializeComponent();
             InitializeComplete();
         }
@@ -46,9 +46,9 @@ namespace GitUI.CommandsDialogs
                 _mergedBranches.Add(branch);
             }
 
-            if (_defaultRemoteBranch is not null)
+            if (_defaultBranches is not null)
             {
-                Branches.SetSelectedText(_defaultRemoteBranch);
+                Branches.SetSelectedText(_defaultBranches.Join(" "));
             }
         }
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -157,7 +157,17 @@ namespace GitUI
         {
             return DoActionOnRepo(owner, action: () =>
             {
-                using FormDeleteRemoteBranch form = new(this, remoteBranch);
+                using FormDeleteRemoteBranch form = new(this, new[] { remoteBranch });
+                form.ShowDialog(owner);
+                return true;
+            }, changesRepo: false);
+        }
+
+        public bool StartDeleteRemoteBranchDialog(IWin32Window? owner, IEnumerable<string> remoteBranches)
+        {
+            return DoActionOnRepo(owner, action: () =>
+            {
+                using FormDeleteRemoteBranch form = new(this, remoteBranches);
                 form.ShowDialog(owner);
                 return true;
             }, changesRepo: false);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

Allow to select and delete multiple local and remote branches in the revision grid.

If there is only a single commit selected - the logic is unchanged.
If there are multiple commits selected then the logic for deciding which dialog to invoke is as follows:
- if all selected commits contain a remote branch - show `FormDeleteRemoteBranch`,
- else show `FormDeleteBranch`


## Screenshots <!-- Remove this section if PR does not change UI -->



### After

![multi-delete-local](https://user-images.githubusercontent.com/4403806/126868863-6133a5ba-a694-4913-a527-57d4b0706a69.gif)
![multi-delete-remote](https://user-images.githubusercontent.com/4403806/126868860-59b25ff7-0f77-4a41-ab43-c008370c5dec.gif)


## Test methodology <!-- How did you ensure quality? -->

- TBD
- 
- 

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
