### PR TITLE
Rename detection for Advanced filter

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -12,7 +12,7 @@ namespace GitUI.CommandsDialogs
         {
             this.components = new System.ComponentModel.Container();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-            this.FileChanges = new GitUI.RevisionGridControl();
+            this.RevisionGrid = new GitUI.RevisionGridControl();
             this.FileHistoryContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.copyToClipboardToolStripMenuItem = new GitUI.UserControls.RevisionGrid.CopyContextMenuItem();
             this.separatorAfterCopySubmenu = new System.Windows.Forms.ToolStripSeparator();
@@ -91,7 +91,7 @@ namespace GitUI.CommandsDialogs
             // 
             // splitContainer1.Panel1
             // 
-            this.splitContainer1.Panel1.Controls.Add(this.FileChanges);
+            this.splitContainer1.Panel1.Controls.Add(this.RevisionGrid);
             // 
             // splitContainer1.Panel2
             // 
@@ -102,13 +102,13 @@ namespace GitUI.CommandsDialogs
             // 
             // FileChanges
             // 
-            this.FileChanges.ContextMenuStrip = this.FileHistoryContextMenu;
-            this.FileChanges.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.FileChanges.Location = new System.Drawing.Point(0, 0);
-            this.FileChanges.Name = "FileChanges";
-            this.FileChanges.Size = new System.Drawing.Size(748, 101);
-            this.FileChanges.TabIndex = 2;
-            this.FileChanges.DoubleClick += new System.EventHandler(this.FileChangesDoubleClick);
+            this.RevisionGrid.ContextMenuStrip = this.FileHistoryContextMenu;
+            this.RevisionGrid.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.RevisionGrid.Location = new System.Drawing.Point(0, 0);
+            this.RevisionGrid.Name = "FileChanges";
+            this.RevisionGrid.Size = new System.Drawing.Size(748, 101);
+            this.RevisionGrid.TabIndex = 2;
+            this.RevisionGrid.DoubleClick += new System.EventHandler(this.FileChangesDoubleClick);
             // 
             // FileHistoryContextMenu
             // 
@@ -633,7 +633,7 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.TabPage BlameTab;
         private FileViewer View;
         private FileViewer Diff;
-        private RevisionGridControl FileChanges;
+        private RevisionGridControl RevisionGrid;
         private System.Windows.Forms.ContextMenuStrip FileHistoryContextMenu;
         private System.Windows.Forms.ToolStripMenuItem openWithDifftoolToolStripMenuItem;
         private Blame.BlameControl Blame;

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -116,7 +116,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         public string GetPathFilter()
         {
-            return FileFilterCheck.Checked ? $" {FileFilter.Text.ToPosixPath()}" : "";
+            return FileFilterCheck.Checked ? FileFilter.Text : "";
         }
 
         public string GetInMemAuthorFilter()
@@ -147,6 +147,12 @@ namespace GitUI.UserControls.RevisionGrid
         public void SetBranchFilter(string filter)
         {
             BranchFilter.Text = filter?.Trim();
+        }
+
+        public void SetPathFilter(string filter)
+        {
+            FileFilter.Text = filter?.Trim();
+            FileFilterCheck.Checked = !string.IsNullOrWhiteSpace(filter);
         }
 
         private void OkClick(object sender, EventArgs e)


### PR DESCRIPTION
See long term goals in #7598

## Proposed changes

- Refactor FileChanges -> RevisionGrid (the normal name for the control in other forms)

- Do not try to `--follow` for folders. Something like `Bin/` is OK, but `GitUI` will give too many files and too long command lines. (This could be solved in other ways but do not bother.)
Note that 3.5 does not follow folders (or Submodules) so not limiting functionality. History for folders is useless in 3.5 as well.
Note: There is no enforcing of using the ending "/" in the Advanced filter, manual input.

- Move detection of renamed files from FileHistory to RevisionGrid, to use the handling also for Advanced filters (with slightly more general rules).

## Test methodology <!-- How did you ensure quality? -->

Add an advanced filter like "\*\*/Rev\*Diff\*" to see that GitUI\CommandsDialogs\RevisionDiffControl.cs was renamed

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
