### PR TITLE
Support `git-bash.exe` again

### DIFF
--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -272,7 +272,13 @@ namespace GitCommands
         {
             try
             {
-                shellPath = Path.Combine(EnvironmentAbstraction.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Git", shell);
+                shellPath = Path.Combine(EnvironmentAbstraction.GetEnvironmentVariable("ProgramW6432"), "Git", shell);
+                if (File.Exists(shellPath))
+                {
+                    return true;
+                }
+
+                shellPath = Path.Combine(EnvironmentAbstraction.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Git", shell);
                 if (File.Exists(shellPath))
                 {
                     return true;

--- a/GitUI/Shells/BashShell.cs
+++ b/GitUI/Shells/BashShell.cs
@@ -9,7 +9,8 @@ namespace GitUI.Shells
 {
     public class BashShell : ShellDescriptor
     {
-        private const string BashExe = "bash.exe"; // Generic bash, should generally be in the git dir
+        private const string GitBashExe = "git-bash.exe"; // Bash with git in the path, should generally be in the git dir
+        private const string BashExe = "bash.exe"; // Fallback to generic bash, should generally be in the git bin dir
         private const string ShExe = "sh.exe";     // Fallback to SH
         public const string ShellName = "bash";
 
@@ -18,16 +19,32 @@ namespace GitUI.Shells
             Name = ShellName;
             Icon = Images.GitForWindows;
 
-            ExecutableName = BashExe;
-            if (PathUtil.TryFindShellPath(ExecutableName, out var exePath))
+            if (PathUtil.TryFindShellPath(GitBashExe, out var exePath))
             {
+                ExecutableName = GitBashExe;
                 ExecutablePath = exePath;
+
+                // Try to find bash or sh below to set ExecutableCommandLine, as git-bash.exe cannot be connected to the built-in console.
+            }
+
+            if (PathUtil.TryFindShellPath(BashExe, out exePath))
+            {
+                if (ExecutablePath is null)
+                {
+                    ExecutableName = BashExe;
+                    ExecutablePath = exePath;
+                }
+
                 ExecutableCommandLine = $"{exePath.Quote()} --login -i";
             }
             else if (PathUtil.TryFindShellPath(ShExe, out exePath))
             {
-                ExecutableName = ShExe;
-                ExecutablePath = exePath;
+                if (ExecutablePath is null)
+                {
+                    ExecutableName = ShExe;
+                    ExecutablePath = exePath;
+                }
+
                 ExecutableCommandLine = $"{exePath.Quote()} --login -i";
             }
         }

--- a/GitUI/Shells/BashShell.cs
+++ b/GitUI/Shells/BashShell.cs
@@ -27,25 +27,20 @@ namespace GitUI.Shells
                 // Try to find bash or sh below to set ExecutableCommandLine, as git-bash.exe cannot be connected to the built-in console.
             }
 
-            if (PathUtil.TryFindShellPath(BashExe, out exePath))
+            foreach (string shellExecutableName in new string[] { BashExe, ShExe })
             {
-                if (ExecutablePath is null)
+                if (PathUtil.TryFindShellPath(shellExecutableName, out exePath))
                 {
-                    ExecutableName = BashExe;
-                    ExecutablePath = exePath;
-                }
+                    if (ExecutablePath is null)
+                    {
+                        ExecutableName = shellExecutableName;
+                        ExecutablePath = exePath;
+                    }
 
-                ExecutableCommandLine = $"{exePath.Quote()} --login -i";
-            }
-            else if (PathUtil.TryFindShellPath(ShExe, out exePath))
-            {
-                if (ExecutablePath is null)
-                {
-                    ExecutableName = ShExe;
-                    ExecutablePath = exePath;
-                }
+                    ExecutableCommandLine = $"{exePath.Quote()} --login -i";
 
-                ExecutableCommandLine = $"{exePath.Quote()} --login -i";
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #9353
not completely - but the regression from #8213
`git-bash.exe` cannot be used for the built-in console.
As I explained in https://github.com/gitextensions/gitextensions/issues/9353#issuecomment-881975596, `bash.exe` ignores the path to `git.exe` added by GE to `PATH`.

## Proposed changes

- `BashShell`: Try `git-bash.exe` first for stand-alone shell
- search also in the 64-bit-programs folder

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/36601201/127064786-0fef5a29-cf5d-4cb9-b8fe-df086a98f414.png)

### After

![image](https://user-images.githubusercontent.com/36601201/127064798-4d8cd074-f8f2-4e22-a3d4-e5555fbe1693.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build d4b3e13e80fd0f094fecd9f153f0fe135c4d4d09 (Dirty)
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4360.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).