### PR TITLE
Added option in the GitFlow plugin to use the Git Flow commands for all submodules as well

### DIFF
--- a/Plugins/GitFlow/GitFlowForm.Designer.cs
+++ b/Plugins/GitFlow/GitFlowForm.Designer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace GitFlow
+﻿namespace GitFlow
 {
     partial class GitFlowForm
     {
@@ -118,7 +116,7 @@ namespace GitFlow
             // 
             // btnFinish
             // 
-            this.btnFinish.Location = new System.Drawing.Point(490, 72);
+            this.btnFinish.Location = new System.Drawing.Point(490, 65);
             this.btnFinish.Name = "btnFinish";
             this.btnFinish.Size = new System.Drawing.Size(82, 23);
             this.btnFinish.TabIndex = 0;
@@ -130,7 +128,7 @@ namespace GitFlow
             // 
             this.gbManage.Controls.Add(this.pnlManageBranch);
             this.gbManage.Controls.Add(this.cbManageType);
-            this.gbManage.Location = new System.Drawing.Point(13, 149);
+            this.gbManage.Location = new System.Drawing.Point(13, 169);
             this.gbManage.Name = "gbManage";
             this.gbManage.Size = new System.Drawing.Size(628, 162);
             this.gbManage.TabIndex = 6;
@@ -151,13 +149,13 @@ namespace GitFlow
             this.pnlManageBranch.Controls.Add(this.btnFinish);
             this.pnlManageBranch.Location = new System.Drawing.Point(10, 30);
             this.pnlManageBranch.Name = "pnlManageBranch";
-            this.pnlManageBranch.Size = new System.Drawing.Size(610, 131);
+            this.pnlManageBranch.Size = new System.Drawing.Size(610, 126);
             this.pnlManageBranch.TabIndex = 7;
             // 
             // cbSquash
             // 
             this.cbSquash.AutoSize = true;
-            this.cbSquash.Location = new System.Drawing.Point(492, 113);
+            this.cbSquash.Location = new System.Drawing.Point(492, 106);
             this.cbSquash.Name = "cbSquash";
             this.cbSquash.Size = new System.Drawing.Size(62, 17);
             this.cbSquash.TabIndex = 9;
@@ -167,7 +165,7 @@ namespace GitFlow
             // cbPushAfterFinish
             // 
             this.cbPushAfterFinish.AutoSize = true;
-            this.cbPushAfterFinish.Location = new System.Drawing.Point(492, 97);
+            this.cbPushAfterFinish.Location = new System.Drawing.Point(492, 90);
             this.cbPushAfterFinish.Name = "cbPushAfterFinish";
             this.cbPushAfterFinish.Size = new System.Drawing.Size(101, 17);
             this.cbPushAfterFinish.TabIndex = 8;
@@ -250,7 +248,7 @@ namespace GitFlow
             // 
             // btnPublish
             // 
-            this.btnPublish.Location = new System.Drawing.Point(31, 72);
+            this.btnPublish.Location = new System.Drawing.Point(34, 65);
             this.btnPublish.Name = "btnPublish";
             this.btnPublish.Size = new System.Drawing.Size(81, 23);
             this.btnPublish.TabIndex = 0;
@@ -315,7 +313,7 @@ namespace GitFlow
             this.gbStart.Controls.Add(this.lblPrefixName);
             this.gbStart.Controls.Add(this.label10);
             this.gbStart.Controls.Add(this.btnCreateBranch);
-            this.gbStart.Location = new System.Drawing.Point(12, 41);
+            this.gbStart.Location = new System.Drawing.Point(12, 61);
             this.gbStart.Name = "gbStart";
             this.gbStart.Size = new System.Drawing.Size(629, 100);
             this.gbStart.TabIndex = 8;
@@ -433,9 +431,9 @@ namespace GitFlow
             this.panel3.Controls.Add(this.txtResult);
             this.panel3.Controls.Add(this.lblRunCommand);
             this.panel3.Controls.Add(this.label2);
-            this.panel3.Location = new System.Drawing.Point(12, 319);
+            this.panel3.Location = new System.Drawing.Point(12, 339);
             this.panel3.Name = "panel3";
-            this.panel3.Size = new System.Drawing.Size(629, 200);
+            this.panel3.Size = new System.Drawing.Size(629, 180);
             this.panel3.TabIndex = 11;
             this.panel3.TabStop = false;
             this.panel3.Text = "Result of git flow command run";
@@ -449,7 +447,7 @@ namespace GitFlow
             this.txtResult.Name = "txtResult";
             this.txtResult.ReadOnly = true;
             this.txtResult.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this.txtResult.Size = new System.Drawing.Size(617, 162);
+            this.txtResult.Size = new System.Drawing.Size(617, 142);
             this.txtResult.TabIndex = 2;
             this.txtResult.Text = " -";
             // 
@@ -465,11 +463,11 @@ namespace GitFlow
             // cbApplyToSubmodules
             // 
             this.cbApplyToSubmodules.AutoSize = true;
-            this.cbApplyToSubmodules.Location = new System.Drawing.Point(433, 16);
+            this.cbApplyToSubmodules.Location = new System.Drawing.Point(12, 38);
             this.cbApplyToSubmodules.Name = "cbApplyToSubmodules";
-            this.cbApplyToSubmodules.Size = new System.Drawing.Size(122, 17);
+            this.cbApplyToSubmodules.Size = new System.Drawing.Size(203, 17);
             this.cbApplyToSubmodules.TabIndex = 4;
-            this.cbApplyToSubmodules.Text = "Include Submodules";
+            this.cbApplyToSubmodules.Text = "Apply the command to all submodules";
             this.cbApplyToSubmodules.UseVisualStyleBackColor = true;
             // 
             // GitFlowForm

--- a/Plugins/GitFlow/GitFlowForm.Designer.cs
+++ b/Plugins/GitFlow/GitFlowForm.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace GitFlow
+﻿using System;
+
+namespace GitFlow
 {
     partial class GitFlowForm
     {
@@ -68,6 +70,7 @@
             this.panel3 = new System.Windows.Forms.GroupBox();
             this.txtResult = new System.Windows.Forms.TextBox();
             this.lblRunCommand = new System.Windows.Forms.Label();
+            this.cbApplyToSubmodules = new System.Windows.Forms.CheckBox();
             this.gbManage.SuspendLayout();
             this.pnlManageBranch.SuspendLayout();
             this.pnlPull.SuspendLayout();
@@ -459,11 +462,22 @@
             this.lblRunCommand.TabIndex = 1;
             this.lblRunCommand.Text = "-";
             // 
+            // cbApplyToSubmodules
+            // 
+            this.cbApplyToSubmodules.AutoSize = true;
+            this.cbApplyToSubmodules.Location = new System.Drawing.Point(433, 16);
+            this.cbApplyToSubmodules.Name = "cbApplyToSubmodules";
+            this.cbApplyToSubmodules.Size = new System.Drawing.Size(122, 17);
+            this.cbApplyToSubmodules.TabIndex = 4;
+            this.cbApplyToSubmodules.Text = "Include Submodules";
+            this.cbApplyToSubmodules.UseVisualStyleBackColor = true;
+            // 
             // GitFlowForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(653, 556);
+            this.Controls.Add(this.cbApplyToSubmodules);
             this.Controls.Add(this.panel3);
             this.Controls.Add(this.pbResultCommand);
             this.Controls.Add(this.lnkGitFlow);
@@ -536,5 +550,6 @@
         private System.Windows.Forms.TextBox txtResult;
         private System.Windows.Forms.CheckBox cbPushAfterFinish;
         private System.Windows.Forms.CheckBox cbSquash;
+        private System.Windows.Forms.CheckBox cbApplyToSubmodules;
     }
 }

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -279,6 +279,20 @@ namespace GitFlow
             RunCommand(args);
         }
 
+        private void ApplyCommandToAllSubmodules(ArgumentString args)
+        {
+            if (cbApplyToSubmodules.Checked)
+            {
+                RunOutputCommand(new GitArgumentBuilder("submodule")
+                {
+                    "foreach",
+                    "--recursive",
+                    "git",
+                    args.Arguments
+                });
+            }
+        }
+
         private void btnPull_Click(object sender, EventArgs e)
         {
             var args = new GitArgumentBuilder("flow")
@@ -337,7 +351,35 @@ namespace GitFlow
 
             txtResult.Text = resultText;
 
+            ApplyCommandToAllSubmodules(commandText);
+
             return result.ExitCode == 0;
+        }
+
+        private void RunOutputCommand(ArgumentString commandText)
+        {
+            pbResultCommand.Image = DpiUtil.Scale(Resource.StatusHourglass);
+            ShowToolTip(pbResultCommand, "running command : git " + commandText);
+            ForceRefresh(pbResultCommand);
+            lblRunCommand.Text = "git " + commandText;
+            ForceRefresh(lblRunCommand);
+            txtResult.Text = "running...";
+            ForceRefresh(txtResult);
+
+            var result = _gitUiCommands.GitModule.GitExecutable.GetOutput(commandText);
+
+            IsRefreshNeeded = true;
+
+            ttDebug.RemoveAll();
+
+            ttDebug.SetToolTip(lblDebug, "cmd: git " + commandText + "\n");
+            var resultText = Regex.Replace(result, @"\r\n?|\n", Environment.NewLine);
+
+            pbResultCommand.Image = DpiUtil.Scale(Resource.success);
+            ShowToolTip(pbResultCommand, resultText);
+            DisplayHead();
+
+            txtResult.Text = resultText;
         }
 
         #endregion


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- When using the GitFlow plugin there now is an option to use the GitFlow options for all submodules as well.
This could be helpfull on a project with a lot of submodules so you don't have to create a feature branch for everysubmodule.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/86287344/127287925-525ac2c5-b661-4d58-8159-725db3aa4998.png)

### After

![image](https://user-images.githubusercontent.com/86287344/127300659-75e55289-1a5d-41e7-b476-cdd028051dbf.png)



## Test methodology <!-- How did you ensure quality? -->

- Create a repository with multiple submodules
- Use the GitFlow plugin with the new "Include submodules" checkbox enabled to init Git Flow for all submodules
- Make random changes to the main repo and submodules, commit these.
- Use the Git Flow plugin again to Publish, Pull and Finish all submodules and the main repo


## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 9b2011f707ca142f8ff0609489bf7f0a5a823d2a
- Git 2.32.0.windows.1
- Microsoft Windows NT 10.0.19043.0
- .NET Framework 4.8.4390.0
- DPI 96dpi (no scaling)


<!-- Mention language, UI scaling, or anything else that might be relevant -->


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
