### PR TITLE
RevFileTree: Blame instead of View

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -871,6 +871,12 @@ namespace GitCommands
             set => SetBool("opensubmodulediffinseparatewindow", value);
         }
 
+        public static bool RevisionFileTreeShowBlame
+        {
+            get => GetBool("RevisionFileTreeShowBlame", true);
+            set => SetBool("RevisionFileTreeShowBlame", value);
+        }
+
         /// <summary>
         /// Gets or sets whether to show artificial commits in the revision graph.
         /// </summary>

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -319,8 +319,8 @@ namespace GitUI.CommandsDialogs
             _aheadBehindDataProvider = GitVersion.Current.SupportAheadBehindData ? new AheadBehindDataProvider(() => Module.GitExecutable) : null;
 
             repoObjectsTree.Initialize(_aheadBehindDataProvider, branchFilterAction: ToolStripFilters.SetBranchFilter, RevisionGrid, RevisionGrid, RevisionGrid);
-            revisionDiff.Bind(RevisionGrid, fileTree, () => RequestRefresh());
-            fileTree.Bind(() => RequestRefresh());
+            revisionDiff.Bind(RevisionGrid, fileTree, RequestRefresh);
+            fileTree.Bind(RevisionGrid, RequestRefresh);
 
             UpdateCommitButtonAndGetBrush(null, AppSettings.ShowGitStatusInBrowseToolbar);
             RestorePosition();

--- a/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
@@ -59,6 +59,7 @@ namespace GitUI.CommandsDialogs
             this.blameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.findInDiffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.DiffText = new GitUI.Editor.FileViewer();
+            this.BlameControl = new Blame.BlameControl();
             this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.DiffSplitContainer)).BeginInit();
             this.DiffSplitContainer.Panel1.SuspendLayout();
@@ -83,6 +84,7 @@ namespace GitUI.CommandsDialogs
             // DiffSplitContainer.Panel2
             // 
             this.DiffSplitContainer.Panel2.Controls.Add(this.DiffText);
+            this.DiffSplitContainer.Panel2.Controls.Add(this.BlameControl);
             this.DiffSplitContainer.Size = new System.Drawing.Size(729, 360);
             this.DiffSplitContainer.SplitterDistance = 300;
             this.DiffSplitContainer.SplitterWidth = 6;
@@ -101,6 +103,15 @@ namespace GitUI.CommandsDialogs
             this.DiffFiles.SelectedIndexChanged += new System.EventHandler(this.DiffFiles_SelectedIndexChanged);
             this.DiffFiles.DataSourceChanged += new System.EventHandler(this.DiffFiles_DataSourceChanged);
             this.DiffFiles.DoubleClick += new System.EventHandler(this.DiffFiles_DoubleClick);
+            // 
+            // BlameControl
+            // 
+            this.BlameControl.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.BlameControl.Location = new System.Drawing.Point(0, 0);
+            this.BlameControl.Margin = new System.Windows.Forms.Padding(0);
+            this.BlameControl.Name = "BlameControl";
+            this.BlameControl.Size = new System.Drawing.Size(300, 360);
+            this.BlameControl.TabIndex = 1;
             // 
             // DiffContextMenu
             // 
@@ -406,6 +417,7 @@ namespace GitUI.CommandsDialogs
             // 
             // blameToolStripMenuItem
             // 
+            this.blameToolStripMenuItem.Checked = false;
             this.blameToolStripMenuItem.Image = global::GitUI.Properties.Images.Blame;
             this.blameToolStripMenuItem.Name = "blameToolStripMenuItem";
             this.blameToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
@@ -495,6 +507,7 @@ namespace GitUI.CommandsDialogs
         private ContextMenuStrip DiffContextMenu;
         private FileStatusList DiffFiles;
         private Editor.FileViewer DiffText;
+        private Blame.BlameControl BlameControl;
         private ToolStripMenuItem diffEditWorkingDirectoryFileToolStripMenuItem;
         private ToolStripMenuItem diffOpenWorkingDirectoryFileWithToolStripMenuItem;
         private ToolStripMenuItem diffOpenRevisionFileToolStripMenuItem;

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -462,12 +462,14 @@ namespace GitUI.CommandsDialogs
 
         private void BlameSelectedFileDiff()
         {
+            int? line = DiffText.Visible ? DiffText.CurrentFileLine : null;
+
             BlameControl.Visible = true;
             DiffText.Visible = false;
             GitRevision rev = DiffFiles.SelectedItem.SecondRevision.IsArtificial
                 ? _revisionGrid.GetActualRevision(_revisionGrid.CurrentCheckout)
                 : DiffFiles.SelectedItem.SecondRevision;
-            BlameControl.LoadBlame(rev, children: null, DiffFiles.SelectedItem.Item.Name, _revisionGrid, controlToMask: null, DiffText.Encoding);
+            BlameControl.LoadBlame(rev, children: null, DiffFiles.SelectedItem.Item.Name, _revisionGrid, controlToMask: null, DiffText.Encoding, line);
         }
 
         private async Task ShowSelectedFileDiffAsync()

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -469,7 +469,7 @@ namespace GitUI.CommandsDialogs
             GitRevision rev = DiffFiles.SelectedItem.SecondRevision.IsArtificial
                 ? _revisionGrid.GetActualRevision(_revisionGrid.CurrentCheckout)
                 : DiffFiles.SelectedItem.SecondRevision;
-            BlameControl.LoadBlame(rev, children: null, DiffFiles.SelectedItem.Item.Name, _revisionGrid, controlToMask: null, DiffText.Encoding, line);
+            BlameControl.LoadBlame(rev, children: null, DiffFiles.SelectedItem.Item.Name, _revisionGrid, controlToMask: null, DiffText.Encoding, line, cancellationToken: _viewChangesSequence.Next());
         }
 
         private async Task ShowSelectedFileDiffAsync()

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -121,6 +121,7 @@ namespace GitUI.CommandsDialogs
             ResetSelectedFiles = 9,
             StageSelectedFile = 10,
             UnStageSelectedFile = 11,
+            ShowFileTree = 12
         }
 
         public CommandStatus ExecuteCommand(Command cmd)
@@ -151,6 +152,7 @@ namespace GitUI.CommandsDialogs
                 case Command.ResetSelectedFiles: return ResetSelectedFilesWithConfirmation();
                 case Command.StageSelectedFile: return StageSelectedFiles();
                 case Command.UnStageSelectedFile: return UnstageSelectedFiles();
+                case Command.ShowFileTree: diffShowInFileTreeToolStripMenuItem.PerformClick(); break;
 
                 default: return base.ExecuteCommand(cmd);
             }
@@ -173,6 +175,7 @@ namespace GitUI.CommandsDialogs
             resetFileToParentToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.ResetSelectedFiles);
             stageFileToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.StageSelectedFile);
             unstageFileToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.UnStageSelectedFile);
+            diffShowInFileTreeToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.ShowFileTree);
 
             DiffText.ReloadHotkeys();
         }

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
@@ -59,6 +59,7 @@
             this.expandToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.collapseAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.FileText = new GitUI.Editor.FileViewer();
+            this.BlameControl = new Blame.BlameControl();
             ((System.ComponentModel.ISupportInitialize)(this.FileTreeSplitContainer)).BeginInit();
             this.FileTreeSplitContainer.Panel1.SuspendLayout();
             this.FileTreeSplitContainer.Panel2.SuspendLayout();
@@ -81,6 +82,7 @@
             // FileTreeSplitContainer.Panel2
             // 
             this.FileTreeSplitContainer.Panel2.Controls.Add(this.FileText);
+            this.FileTreeSplitContainer.Panel2.Controls.Add(this.BlameControl);
             this.FileTreeSplitContainer.Size = new System.Drawing.Size(793, 303);
             this.FileTreeSplitContainer.SplitterDistance = 300;
             this.FileTreeSplitContainer.SplitterWidth = 6;
@@ -339,6 +341,15 @@
             this.FileText.Size = new System.Drawing.Size(487, 303);
             this.FileText.TabIndex = 0;
             // 
+            // BlameControl
+            // 
+            this.BlameControl.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.BlameControl.Location = new System.Drawing.Point(0, 0);
+            this.BlameControl.Margin = new System.Windows.Forms.Padding(0);
+            this.BlameControl.Name = "blameControl";
+            this.BlameControl.Size = new System.Drawing.Size(487, 303);
+            this.BlameControl.TabIndex = 0;
+            // 
             // RevisionFileTreeControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -360,6 +371,7 @@
         private System.Windows.Forms.SplitContainer FileTreeSplitContainer;
         private UserControls.NativeTreeView tvGitTree;
         private Editor.FileViewer FileText;
+        private Blame.BlameControl BlameControl;
         private System.Windows.Forms.ContextMenuStrip FileTreeContextMenu;
         private System.Windows.Forms.ToolStripMenuItem openWithDifftoolToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem diffWithRememberedFileToolStripMenuItem;

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -374,7 +374,7 @@ See the changes in the commit form.");
 
                         BlameControl.Visible = true;
                         FileText.Visible = false;
-                        BlameControl.LoadBlame(_revision, null, gitItem.FileName, _revisionGrid, null, FileText.Encoding);
+                        BlameControl.LoadBlame(_revision, children: null, gitItem.FileName, _revisionGrid, controlToMask: null, FileText.Encoding);
                         return Task.CompletedTask;
                     }
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -372,9 +372,10 @@ See the changes in the commit form.");
                             return ViewGitItemAsync(gitItem);
                         }
 
+                        int? line = FileText.Visible ? FileText.CurrentFileLine : null;
                         BlameControl.Visible = true;
                         FileText.Visible = false;
-                        BlameControl.LoadBlame(_revision, children: null, gitItem.FileName, _revisionGrid, controlToMask: null, FileText.Encoding);
+                        BlameControl.LoadBlame(_revision, children: null, gitItem.FileName, _revisionGrid, controlToMask: null, FileText.Encoding, line);
                         return Task.CompletedTask;
                     }
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -51,11 +51,12 @@ See the changes in the commit form.");
         private readonly Stack<string> _lastSelectedNodes = new();
         private readonly IRevisionFileTreeController _revisionFileTreeController;
         private readonly IFullPathResolver _fullPathResolver;
-        private readonly IFindFilePredicateProvider _findFilePredicateProvider;
+        private readonly IFindFilePredicateProvider _findFilePredicateProvider = new FindFilePredicateProvider();
         private GitRevision? _revision;
         private readonly RememberFileContextMenuController _rememberFileContextMenuController
             = RememberFileContextMenuController.Default;
         private Action? _refreshGitStatus;
+        private RevisionGridControl? _revisionGrid;
 
         public RevisionFileTreeControl()
         {
@@ -63,14 +64,15 @@ See the changes in the commit form.");
             InitializeComplete();
             HotkeysEnabled = true;
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
-            _findFilePredicateProvider = new FindFilePredicateProvider();
             _revisionFileTreeController = new RevisionFileTreeController(() => Module.WorkingDir,
                                                                          new GitRevisionInfoProvider(() => Module),
                                                                          new FileAssociatedIconProvider());
+            blameToolStripMenuItem1.Checked = AppSettings.RevisionFileTreeShowBlame;
         }
 
-        public void Bind(Action refreshGitStatus)
+        public void Bind(RevisionGridControl revisionGrid, Action? refreshGitStatus)
         {
+            _revisionGrid = revisionGrid;
             _refreshGitStatus = refreshGitStatus;
         }
 
@@ -212,6 +214,8 @@ See the changes in the commit form.");
 
                 if (tvGitTree.SelectedNode is null)
                 {
+                    BlameControl.Visible = false;
+                    FileText.Visible = true;
                     FileText.Clear();
                 }
             }
@@ -351,33 +355,57 @@ See the changes in the commit form.");
             Task ViewItem()
             {
                 return e.Node?.Tag is GitItem gitItem
-                    ? ViewGitItemAsync(gitItem)
-                    : Task.CompletedTask;
+                    ? ShowGitItemAsync(gitItem)
+                    : ClearOutputAsync();
+            }
+        }
+
+        private Task ShowGitItemAsync(GitItem gitItem)
+        {
+            switch (gitItem.ObjectType)
+            {
+                case GitObjectType.Blob:
+                    {
+                        if (!blameToolStripMenuItem1.Checked)
+                        {
+                            return ViewGitItemAsync(gitItem);
+                        }
+
+                        BlameControl.Visible = true;
+                        FileText.Visible = false;
+                        BlameControl.LoadBlame(_revision, null, gitItem.FileName, _revisionGrid, null, FileText.Encoding);
+                        return Task.CompletedTask;
+                    }
+
+                case GitObjectType.Commit:
+                    {
+                        return ViewGitItemAsync(gitItem);
+                    }
+
+                default:
+                    return ClearOutputAsync();
             }
 
             Task ViewGitItemAsync(GitItem gitItem)
             {
-                switch (gitItem.ObjectType)
+                GitItemStatus file = new(name: gitItem.FileName)
                 {
-                    case GitObjectType.Blob:
-                    case GitObjectType.Commit:
-                    {
-                        GitItemStatus file = new(name: gitItem.FileName)
-                        {
-                            IsTracked = true,
-                            TreeGuid = gitItem.ObjectId,
-                            IsSubmodule = gitItem.ObjectType == GitObjectType.Commit
-                        };
+                    IsTracked = true,
+                    TreeGuid = gitItem.ObjectId,
+                    IsSubmodule = gitItem.ObjectType == GitObjectType.Commit
+                };
 
-                        return FileText.ViewGitItemAsync(file, gitItem.ObjectId);
-                    }
-
-                    default:
-                    {
-                        return FileText.ViewTextAsync("", "");
-                    }
-                }
+                BlameControl.Visible = false;
+                FileText.Visible = true;
+                return FileText.ViewGitItemAsync(file, gitItem.ObjectId);
             }
+        }
+
+        private Task ClearOutputAsync()
+        {
+            BlameControl.Visible = false;
+            FileText.Visible = true;
+            return FileText.ViewTextAsync("", "");
         }
 
         private void tvGitTree_BeforeExpand(object sender, TreeViewCancelEventArgs e)
@@ -428,10 +456,15 @@ See the changes in the commit form.");
 
         private void blameMenuItem_Click(object sender, EventArgs e)
         {
-            if (tvGitTree.SelectedNode?.Tag is GitItem gitItem)
+            if (tvGitTree.SelectedNode?.Tag is not GitItem gitItem)
             {
-                UICommands.StartFileHistoryDialog(this, gitItem.FileName, _revision, true, true);
+                return;
             }
+
+            blameToolStripMenuItem1.Checked = !blameToolStripMenuItem1.Checked;
+            AppSettings.RevisionFileTreeShowBlame = blameToolStripMenuItem1.Checked;
+
+            ThreadHelper.JoinableTaskFactory.RunAsync(() => ShowGitItemAsync(gitItem));
         }
 
         private void copyFilenameToClipboardToolStripMenuItem_Click(object sender, EventArgs e)
@@ -827,7 +860,14 @@ See the changes in the commit form.");
         {
             if (alreadyContainedFocus && tvGitTree.Focused)
             {
-                FileText.Focus();
+                if (BlameControl.Visible)
+                {
+                    BlameControl.Focus();
+                }
+                else
+                {
+                    FileText.Focus();
+                }
             }
             else
             {

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -67,6 +67,7 @@ See the changes in the commit form.");
             _revisionFileTreeController = new RevisionFileTreeController(() => Module.WorkingDir,
                                                                          new GitRevisionInfoProvider(() => Module),
                                                                          new FileAssociatedIconProvider());
+            BlameControl.HideCommitInfo();
             blameToolStripMenuItem1.Checked = AppSettings.RevisionFileTreeShowBlame;
         }
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeController.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeController.cs
@@ -58,10 +58,7 @@ namespace GitUI.CommandsDialogs
             _iconProvider = iconProvider;
         }
 
-        /// <summary>
-        /// Locates the node by the label.
-        /// </summary>
-        /// <returns>The first node matching the label, if one found; otherwise <see langword="null"/>.</returns>
+        /// <inheritdoc/>
         public TreeNode? Find(TreeNodeCollection nodes, string label)
         {
             for (var i = 0; i < nodes.Count; i++)
@@ -149,6 +146,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
+        /// <inheritdoc/>
         public bool SelectFileOrFolder(NativeTreeView tree, string fileSubPath)
         {
             Queue<string> pathParts = new(fileSubPath.Split(Path.DirectorySeparatorChar));
@@ -185,9 +183,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        /// <summary>
-        /// Clears the cache of the current revision's loaded children items.
-        /// </summary>
+        /// <inheritdoc/>
         public void ResetCache()
         {
             _cachedItems.Clear();

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -396,6 +396,8 @@ namespace GitUI.Editor
             return internalFileViewer.GetLineFromVisualPosY(visualPosY);
         }
 
+        public int CurrentFileLine => internalFileViewer.CurrentFileLine(IsDiffView(_viewMode));
+
         public void HighlightLines(int startLine, int endLine, Color color)
         {
             internalFileViewer.HighlightLines(startLine, endLine, color);

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -227,6 +227,14 @@ namespace GitUI.Editor
             set => internalFileViewer.IsReadOnly = value;
         }
 
+        [DefaultValue(true)]
+        [Category("Behavior")]
+        public bool EnableAutomaticContinuousScroll
+        {
+            get => automaticContinuousScrollToolStripMenuItem.Visible;
+            set => automaticContinuousScrollToolStripMenuItem.Visible = value;
+        }
+
         [DefaultValue(null)]
         [Description("If true line numbers are shown in the textarea")]
         [Category("Appearance")]

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -482,6 +482,12 @@ namespace GitUI.Editor
 
         public int MaxLineNumber => TextEditor.ShowLineNumbers ? TotalNumberOfLines : _lineNumbersControl.MaxLineNumber;
 
+        public int CurrentFileLine(bool isDiff)
+        {
+            _currentViewPositionCache.Capture();
+            return _currentViewPositionCache.CurrentFileLine(isDiff);
+        }
+
         public int LineAtCaret
         {
             get => TextEditor.ActiveTextAreaControl.Caret.Position.Line;
@@ -688,6 +694,25 @@ namespace GitUI.Editor
                         _viewer.FirstVisibleLine = line;
                     }
                 }
+            }
+
+            public int CurrentFileLine(bool isDiff)
+            {
+                if (_viewer.TotalNumberOfLines <= 1)
+                {
+                    return 0;
+                }
+
+                var viewPosition = _currentViewPosition;
+                if (isDiff && _viewer.GetLineText(0) == viewPosition.FirstLine && viewPosition.ActiveLineNum is not null)
+                {
+                    // prefer the LeftLineNum because the base revision will not change
+                    return viewPosition.ActiveLineNum.LeftLineNumber != DiffLineInfo.NotApplicableLineNum
+                        ? viewPosition.ActiveLineNum.LeftLineNumber
+                        : viewPosition.ActiveLineNum.RightLineNumber;
+                }
+
+                return viewPosition.CaretPosition.Line;
             }
 
             internal readonly struct TestAccessor

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -352,7 +352,8 @@ namespace GitUI.Hotkey
                     Hk(RevisionDiffControl.Command.ShowHistory, ShowHistoryHotkey),
                     Hk(RevisionDiffControl.Command.ResetSelectedFiles, Keys.R),
                     Hk(RevisionDiffControl.Command.StageSelectedFile, Keys.S),
-                    Hk(RevisionDiffControl.Command.UnStageSelectedFile, Keys.U)),
+                    Hk(RevisionDiffControl.Command.UnStageSelectedFile, Keys.U),
+                    Hk(RevisionDiffControl.Command.ShowFileTree, Keys.T)),
                 new HotkeySettings(
                     RevisionFileTreeControl.HotkeySettingsName,
                     Hk(RevisionFileTreeControl.Command.Blame, BlameHotkey),

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -85,6 +85,13 @@ namespace GitUI.Blame
             BlameAuthor.ShowLineNumbers = AppSettings.BlameShowLineNumbers;
         }
 
+        public void HideCommitInfo()
+        {
+            splitContainer1.Panel1Collapsed = true;
+            CommitInfo.Visible = false;
+            CommitInfo.CommandClicked -= commitInfo_CommandClicked;
+        }
+
         public void LoadBlame(GitRevision revision, IReadOnlyList<ObjectId>? children, string? fileName, RevisionGridControl? revGrid, Control? controlToMask, Encoding encoding, int? initialLine = null, bool force = false)
         {
             var objectId = revision.ObjectId;
@@ -306,7 +313,10 @@ namespace GitUI.Blame
             _clickedBlameLine = null;
 
             _blameId = revision.ObjectId;
-            CommitInfo.SetRevisionWithChildren(revision, children);
+            if (CommitInfo.Visible)
+            {
+                CommitInfo.SetRevisionWithChildren(revision, children);
+            }
 
             controlToMask?.UnMask();
         }

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -69,6 +69,7 @@ namespace GitUI.Blame
             BlameFile.RequestDiffView += ActiveTextAreaControlDoubleClick;
             BlameFile.MouseMove += BlameFile_MouseMove;
             BlameFile.EscapePressed += () => EscapePressed?.Invoke();
+            BlameFile.EnableAutomaticContinuousScroll = false;
 
             CommitInfo.CommandClicked += commitInfo_CommandClicked;
         }
@@ -232,7 +233,6 @@ namespace GitUI.Blame
                 return;
             }
 
-            // TODO: Request GitRevision from RevisionGrid that contain all commits
             var newBlameLine = _blame.Lines[selectedLine];
 
             if (ReferenceEquals(_lastBlameLine?.Commit, newBlameLine.Commit))
@@ -241,7 +241,7 @@ namespace GitUI.Blame
             }
 
             _lastBlameLine = newBlameLine;
-            CommitInfo.Revision = Module.GetRevision(_lastBlameLine.Commit.ObjectId);
+            CommitInfo.Revision = _revGrid.GetActualRevision(_lastBlameLine.Commit.ObjectId);
         }
 
         private void BlameAuthor_HScrollPositionChanged(object sender, EventArgs e)


### PR DESCRIPTION
Part of #7598
Closes #9435
Closes #9437 

## Proposed changes

- RevFileTree: Blame instead of View
Show blame for object type blobs (files), as is available in FileHistory.
Note that object type commit (submodules) are shown as text, as before.
It is possible to toggle the view to show file contents, as before.

In FileHistory the commit info is available in a header. This is excluded in RevFileTree. The info for the selected commit can be seen in Commit, Diff tabs, overview is available in tooltip for otyher commits.
This could be configurable.

- RevDiff: HotKey to view FileTree
A menu command existed to view the file, this as a hotkey.

Note that `T` was selected as key, `F` is to be used to add the filepath to the Advanced filter in the grid.

- RevDiff: `B` to view Blame instead of Diff
Note that this is just for the current file, selecting another (or the same) file will show Diff by default.
For artificial, HEAD is blamed, worktree/index changes cannot be shown


- When blaming in RevDiff or FileTree, select the current line in fileviewer in Blame (especially useful in RevDiff)

- Cancellation support in LoadBlame() (in between operations, not in methods)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/127392826-0f0da687-7ed4-46e6-b413-3ae19651da12.png)

For reference - FileHistory Blame tab, unchanged by this PR
![image](https://user-images.githubusercontent.com/6248932/127396308-6b386241-2228-4b1c-90e3-dbc4ede5dec9.png)

(RevDiff `B` opened FileHistory in a new instance, no screenshot.)

### After

![image](https://user-images.githubusercontent.com/6248932/127396404-ca3491e2-9329-45b6-acef-870b4e0591bb.png)

Only the hotkey added
![image](https://user-images.githubusercontent.com/6248932/127394925-5e676a30-3573-4627-a832-dbffb12d5e2f.png)

Context menu and hotkey `B` toggle Diff/Blame.

![image](https://user-images.githubusercontent.com/6248932/128437735-2b819e45-e440-4acb-8f86-ac2fec417ff2.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
