### PR TITLE
ToggleBetweenArtificialAndHeadCommits: Go to WorkTree if HEAD is hidden

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -406,9 +406,6 @@ namespace GitUI.CommandsDialogs
                     RevisionGrid.UpdateArtificialCommitCount(countArtificial ? status : null);
                     toolStripButtonLevelUp.Image = Module.SuperprojectModule is not null ? Images.NavigateUp : Images.SubmodulesManage;
 
-                    // The diff filelist is not updated, as the selected diff is unset
-                    ////_revisionDiff.RefreshArtificial();
-
                     if (countToolbar || countArtificial)
                     {
                         if (!ReferenceEquals(brush, lastBrush)
@@ -1997,7 +1994,6 @@ namespace GitUI.CommandsDialogs
             var module = e.GitModule;
             HideVariableMainMenuItems();
             PluginRegistry.Unregister(UICommands);
-            RevisionGrid.InvalidateCount();
             _gitStatusMonitor.InvalidateGitWorkingDirectoryStatus();
             _submoduleStatusProvider.Init();
             _filterBranchHelper.SetBranchFilter(string.Empty, refresh: false);

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -364,7 +364,7 @@ namespace GitUI.CommandsDialogs
                 };
                 var revisions = RevisionGrid.GetSelectedRevisions();
                 FileStatusItem item = new(firstRev: revisions.Skip(1).LastOrDefault(), secondRev: revisions.FirstOrDefault(), file);
-                _ = Diff.ViewChangesAsync(item, defaultText: "You need to select at least one revision to view diff.",
+                _ = Diff.ViewChangesAsync(item, defaultText: TranslatedStrings.NoChanges,
                     cancellationToken: _viewChangesSequence.Next());
             }
             else if (tabControl1.SelectedTab == CommitInfoTabPage)

--- a/GitUI/CommandsDialogs/FormLog.Designer.cs
+++ b/GitUI/CommandsDialogs/FormLog.Designer.cs
@@ -60,7 +60,6 @@ namespace GitUI.CommandsDialogs
             this.RevisionGrid.Location = new System.Drawing.Point(0, 0);
             this.RevisionGrid.Margin = new System.Windows.Forms.Padding(4);
             this.RevisionGrid.Name = "RevisionGrid";
-            this.RevisionGrid.ShowUncommittedChangesIfPossible = true;
             this.RevisionGrid.Size = new System.Drawing.Size(750, 205);
             this.RevisionGrid.TabIndex = 1;
             this.RevisionGrid.SelectionChanged += new System.EventHandler(this.RevisionGridSelectionChanged);

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -24,7 +24,7 @@ namespace GitUI.HelperDialogs
             : this(commands)
         {
             revisionGrid.MultiSelect = false;
-            revisionGrid.ShowUncommittedChangesIfPossible = showArtificial && !revisionGrid.Module.IsBareRepository();
+            revisionGrid.ShowUncommittedChangesIfPossible = showArtificial;
 
             if (!string.IsNullOrEmpty(preselectCommit))
             {

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -111,6 +111,8 @@ namespace GitUI
 
         private readonly TranslationString _remoteInError = new("{0}\n\nRemote: {1}");
 
+        private readonly TranslationString _noChanges = new("No changes");
+
         // public only because of FormTranslate
         public TranslatedStrings()
         {
@@ -226,6 +228,7 @@ namespace GitUI
         public static string OpenInVisualStudioFailureText => _instance.Value._openInVisualStudioFailureText.Text;
         public static string OpenInVisualStudioFailureCaption => _instance.Value._openInVisualStudioFailureCaption.Text;
         public static string RemoteInError => _instance.Value._remoteInError.Text;
+        public static string NoChanges => _instance.Value._noChanges.Text;
 
         #region Scripts
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -10760,6 +10760,10 @@ Select this commit to populate the full message.</source>
         <source>no branch</source>
         <target />
       </trans-unit>
+      <trans-unit id="_noChanges.Text">
+        <source>No changes</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_noResultsFound.Text">
         <source>&lt;No results found&gt;</source>
         <target />

--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -84,7 +84,6 @@
             this.NoFiles.Name = "NoFiles";
             this.NoFiles.Size = new System.Drawing.Size(65, 13);
             this.NoFiles.TabIndex = 5;
-            this.NoFiles.Text = "No changes";
             // 
             // FilterComboBox
             // 

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -90,6 +90,7 @@ namespace GitUI
             FileStatusListView.LargeImageList = FileStatusListView.SmallImageList;
 
             HandleVisibility_NoFilesLabel_FilterComboBox(filesPresent: true);
+            NoFiles.Text = TranslatedStrings.NoChanges;
             Controls.SetChildIndex(NoFiles, 0);
             NoFiles.Font = new Font(NoFiles.Font, FontStyle.Italic);
             FilterWatermarkLabel.Font = new Font(FilterWatermarkLabel.Font, FontStyle.Italic);

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -138,8 +138,6 @@ namespace GitUI
         private bool _initialLoad = true;
         private bool _isReadingRevisions = true;
 
-        /// <summary>Tracks status for the artificial commits while the revision graph is reloading.</summary>
-        private IReadOnlyList<GitItemStatus>? _artificialStatus;
         private RevisionReader? _revisionReader;
         private IDisposable? _revisionSubscription;
         private GitRevision? _baseCommitToCompare;
@@ -2199,11 +2197,6 @@ namespace GitUI
             Refresh();
         }
 
-        public void InvalidateCount()
-        {
-            _artificialStatus = null;
-        }
-
         #region Artificial commit change counters
 
         public ArtificialCommitChangeCount? GetChangeCount(ObjectId objectId)
@@ -2221,9 +2214,6 @@ namespace GitUI
 
             UpdateChangeCount(ObjectId.WorkTreeId, status);
             UpdateChangeCount(ObjectId.IndexId, status);
-
-            // cache the status for a refresh
-            _artificialStatus = status;
 
             _gridView.Invalidate();
             return;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2331,6 +2331,12 @@ namespace GitUI
                     if (idToSelect is not null
                         && (!idToSelect.IsArtificial || !AppSettings.ShowGitStatusForArtificialCommits || GetChangeCount(idToSelect)?.HasChanges == true))
                     {
+                        if (idToSelect == CurrentCheckout && AppSettings.ShowGitStatusForArtificialCommits && _gridView.GetRevision(idToSelect) is null)
+                        {
+                            // HEAD is not in revision grid (filtered)
+                            return ObjectId.WorkTreeId;
+                        }
+
                         return idToSelect;
                     }
                 }

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -602,16 +602,14 @@ namespace GitCommandsTests
         [Test]
         public void GetParents_calls_correct_command_and_parses_response()
         {
-            GitArgumentBuilder args = new("log")
+            GitArgumentBuilder args = new("rev-parse")
             {
-                "-n 1",
-                "--format=format:%P",
-                Sha1
+                $"{Sha1}^@"
             };
 
             using (_executable.StageOutput(
                 args.ToString(),
-                $"{Sha2} {Sha3}"))
+                $"{Sha2}\n{Sha3}\n"))
             {
                 var parents = _gitModule.GetParents(Sha1);
 


### PR DESCRIPTION
Contributes to #7598

## Proposed changes

A few unrelated changes related to filtered commits

- From #9393 change the confusing diff message (especially when selecting artificial commits without changes).

- From #9393 squash! Use default value for ShowUncommittedChangesIfPossible

- Improve performance for GitModule.GetParents
git-rev-parse is faster than git-log
For me in GE it is about 0.18 s vs 0.30 s.
Also check input and cache results

The command will be used when calculating the Diff for filtered commits in a later PR.

- ToggleBetweenArtificialAndHeadCommits: Go to WorkTree if HEAD is hidden
Note: This has no effect until #9393 is merged as artificial commits are not shown

If HEAD is not visible (in a filtered view) nothing happens for Ctrl-< as there is nowhere to go
In this case go to WorkTree commit instead.

- squash! Browse: Remove unused _artificialStatus
_artificialStatus was previously used to cache the commit-count over operations, to quickly display the old info.
Since som time ago, this has no effect as null status is distributed before the cache is distributed.
(This was not a good idea in the first place, possibly incorrect data should not be shown.)


## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
