### PR TITLE
Diff to actual parent in filtered grids

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -79,6 +79,12 @@ namespace GitCommands
                     });
         }
 
+        /// <summary>
+        /// The parents for commits are replaced with the parent in the graph (as all commits may not be included)
+        /// See https://git-scm.com/docs/git-log#Documentation/git-log.txt---parents
+        /// </summary>
+        public bool ParentsAreRewritten { get; private set; } = false;
+
         private async Task ExecuteAsync(
             GitModule module,
             IReadOnlyList<IGitRef> refs,
@@ -161,7 +167,7 @@ namespace GitCommands
             string revisionFilter,
             string pathFilter)
         {
-            bool needParentRewrite = !string.IsNullOrWhiteSpace(pathFilter) || !string.IsNullOrWhiteSpace(revisionFilter);
+            ParentsAreRewritten = !string.IsNullOrWhiteSpace(pathFilter) || !string.IsNullOrWhiteSpace(revisionFilter);
             return new GitArgumentBuilder("log")
             {
                 { maxCount > 0, $"--max-count={maxCount}" },
@@ -200,7 +206,7 @@ namespace GitCommands
                 },
                 revisionFilter,
                 {
-                    needParentRewrite,
+                    ParentsAreRewritten,
                     new ArgumentBuilder
                     {
                         { AppSettings.FullHistoryInFileHistory, $"--full-history" },

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -212,7 +212,7 @@ namespace GitUI.CommandsDialogs
 
             var item = DiffFiles.SelectedItem;
             var oldDiffItem = DiffFiles.FirstGroupItems.Contains(item) ? item : null;
-            DiffFiles.SetDiffs(revisions, _revisionGrid.GetRevision);
+            DiffFiles.SetDiffs(revisions, _revisionGrid.CurrentCheckout);
 
             // Try to restore previous item
             if (oldDiffItem is not null && DiffFiles.FirstGroupItems.Any(i => i.Item.Name.Equals(oldDiffItem.Item.Name)))
@@ -226,6 +226,7 @@ namespace GitUI.CommandsDialogs
             _revisionGrid = revisionGrid;
             _revisionFileTree = revisionFileTree;
             _refreshGitStatus = refreshGitStatus;
+            DiffFiles.Bind(objectId => DescribeRevision(objectId), _revisionGrid.GetActualRevision);
         }
 
         public void InitSplitterManager(SplitterManager splitterManager)
@@ -235,7 +236,6 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnRuntimeLoad()
         {
-            DiffFiles.DescribeRevision = objectId => DescribeRevision(objectId);
             DiffText.SetFileLoader(GetNextPatchFile);
             DiffText.Font = AppSettings.FixedWidthFont;
             ReloadHotkeys();

--- a/GitUI/UserControls/FileStatusDiffCalculator.FileStatusDiffCalculatorInfo.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.FileStatusDiffCalculatorInfo.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using GitUIPluginInterfaces;
+
+namespace GitUI
+{
+    partial class FileStatusDiffCalculator
+    {
+        private struct FileStatusDiffCalculatorInfo
+        {
+            public IReadOnlyList<GitRevision> Revisions { get; set; }
+            public ObjectId? HeadId { get; set; }
+        }
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/GitRevision.cs
+++ b/Plugins/GitUIPluginInterfaces/GitRevision.cs
@@ -32,6 +32,15 @@ namespace GitUIPluginInterfaces
             ObjectId = objectId ?? throw new ArgumentNullException(nameof(objectId));
         }
 
+        /// <summary>
+        /// Make a shallow clone of the object.
+        /// </summary>
+        /// <returns>A shallow copy.</returns>
+        public GitRevision Clone()
+        {
+            return (GitRevision)MemberwiseClone();
+        }
+
         public ObjectId ObjectId { get; }
 
         public string Guid => ObjectId.ToString();


### PR DESCRIPTION
Contributes to #7598

## Proposed changes

Review commit by commit, could maybe be squashed before merge.

- Diff to actual parent in filtered grids

If the grid is filtered, the commit parents are rewritten to show the
displayed parent commit.
The diff in RevDiff should show the diff for the actual commit rather than
the diff to the previous node.

In FileHistory, this is not really a problem as the separate CommitInfo shows the diff for the current commit anyway, you cannot see custom diff for more than the selected file anyway.

- Diff: Avoid calculate HEAD
Optimization: HEAD is calculated in some situations (when selecting artificial commits, to present range-diff).
This is not necessary, the info is available in RevGrid

- Refactoring the diffCalculator reload handling (more info is added with the HEAD and actual parent)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Filtered for GitUI/CommandsDialogs/RevisionDiffControl.cs, showing differences from selected fe38534e51ccc8d98a5f3b038b60741432b1c548 to previous commit with the file: aea9e1bb75ef461d3a0ff3da58edaa8c13676126

![image](https://user-images.githubusercontent.com/6248932/127407452-e3bff343-8e15-43a3-b094-d4c315ab6ca9.png)

Same info (unchanged by this PR)

![image](https://user-images.githubusercontent.com/6248932/127407671-a64f5785-5c6c-497b-ac30-883ffc9fee9c.png)

### After

![image](https://user-images.githubusercontent.com/6248932/127407763-ad10851d-f1a7-4c2a-8454-40e14e498d6a.png)


## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
