### PR TITLE
BashShell: Try git-bash.exe first

### DIFF
--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -217,7 +217,13 @@ namespace GitCommands
         {
             try
             {
-                shellPath = Path.Combine(EnvironmentAbstraction.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Git", shell);
+                shellPath = Path.Combine(EnvironmentAbstraction.GetEnvironmentVariable("ProgramW6432"), "Git", shell);
+                if (File.Exists(shellPath))
+                {
+                    return true;
+                }
+
+                shellPath = Path.Combine(EnvironmentAbstraction.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Git", shell);
                 if (File.Exists(shellPath))
                 {
                     return true;

--- a/GitUI/Shells/BashShell.cs
+++ b/GitUI/Shells/BashShell.cs
@@ -7,7 +7,8 @@ namespace GitUI.Shells
 {
     public class BashShell : ShellDescriptor
     {
-        private const string BashExe = "bash.exe"; // Generic bash, should generally be in the git dir
+        private const string GitBashExe = "git-bash.exe"; // Bash with git in the path, should generally be in the git dir
+        private const string BashExe = "bash.exe"; // Fallback to generic bash, should generally be in the git bin dir
         private const string ShExe = "sh.exe";     // Fallback to SH
         public const string ShellName = "bash";
 
@@ -16,17 +17,28 @@ namespace GitUI.Shells
             Name = ShellName;
             Icon = Images.GitForWindows;
 
-            ExecutableName = BashExe;
-            if (PathUtil.TryFindShellPath(ExecutableName, out var exePath))
+            if (PathUtil.TryFindShellPath(GitBashExe, out var exePath))
             {
+                ExecutableName = GitBashExe;
                 ExecutablePath = exePath;
-                ExecutableCommandLine = $"{exePath.Quote()} --login -i";
+
+                // Try to find bash or sh below to set ExecutableCommandLine, as git-bash.exe cannot be connected to the built-in console.
             }
-            else if (PathUtil.TryFindShellPath(ShExe, out exePath))
+
+            foreach (string shellExecutableName in new string[] { BashExe, ShExe })
             {
-                ExecutableName = ShExe;
-                ExecutablePath = exePath;
-                ExecutableCommandLine = $"{exePath.Quote()} --login -i";
+                if (PathUtil.TryFindShellPath(shellExecutableName, out exePath))
+                {
+                    if (ExecutablePath is null)
+                    {
+                        ExecutableName = shellExecutableName;
+                        ExecutablePath = exePath;
+                    }
+
+                    ExecutableCommandLine = $"{exePath.Quote()} --login -i";
+
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
#9416 for master
Fixes #9353
not completely - but the regression from #8213
`git-bash.exe` cannot be used for the built-in console.
As I explained in https://github.com/gitextensions/gitextensions/issues/9353#issuecomment-881975596, `bash.exe` ignores the path to `git.exe` added by GE to `PATH`.

## Proposed changes

- `BashShell`: Try `git-bash.exe` first for stand-alone shell
- search also in the 64-bit-programs folder

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/36601201/127064786-0fef5a29-cf5d-4cb9-b8fe-df086a98f414.png)

### After

![image](https://user-images.githubusercontent.com/36601201/127064798-4d8cd074-f8f2-4e22-a3d4-e5555fbe1693.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build e54cd4e7fd2df1ce5ad2525a95bac74d87b96f76
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4360.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).