### PR TITLE
Fixed Commit info varying indents. Fixes #9164

### DIFF
--- a/ResourceManager/CommitDataRenders/TabbedHeaderLabelFormatter.cs
+++ b/ResourceManager/CommitDataRenders/TabbedHeaderLabelFormatter.cs
@@ -18,7 +18,7 @@ namespace ResourceManager.CommitDataRenders
                 if (input.Length < desiredLength)
                 {
                     int l = desiredLength - input.Length;
-                    return input + new string('\t', (l / tabSize) + (l % tabSize == 0 ? 0 : 1));
+                    return input + new string('\t', l / tabSize);
                 }
 
                 return input;

--- a/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererIntegrationTests.cs
+++ b/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererIntegrationTests.cs
@@ -49,12 +49,12 @@ namespace ResourceManagerTests.CommitDataRenders
         [Test]
         public void Render_with_tabs_and_links()
         {
-            var expectedHeader = "Author:			<a href='mailto:John.Doe@test.com'>John Doe (Acme Inc) &lt;John.Doe@test.com&gt;</a>" + Environment.NewLine +
-                                 "Author date:	3 days ago (" + LocalizationHelpers.GetFullDateString(_data.AuthorDate) + ")" + Environment.NewLine +
-                                 "Committer:		<a href='mailto:Jane.Doe@test.com'>Jane Doe &lt;Jane.Doe@test.com&gt;</a>" + Environment.NewLine +
+            var expectedHeader = "Author:		<a href='mailto:John.Doe@test.com'>John Doe (Acme Inc) &lt;John.Doe@test.com&gt;</a>" + Environment.NewLine +
+                                    "Author date:	3 days ago (" + LocalizationHelpers.GetFullDateString(_data.AuthorDate) + ")" + Environment.NewLine +
+                                 "Committer:	<a href='mailto:Jane.Doe@test.com'>Jane Doe &lt;Jane.Doe@test.com&gt;</a>" + Environment.NewLine +
                                  "Commit date:	2 days ago (" + LocalizationHelpers.GetFullDateString(_data.CommitDate) + ")" + Environment.NewLine +
                                  "Commit hash:	" + _data.ObjectId + Environment.NewLine +
-                                 "Children:		" +
+                                 "Children:	" +
                                    "<a href='gitext://gotocommit/" + _data.ChildIds[0] + "'>" + _data.ChildIds[0].ToShortString() + "</a> " +
                                    "<a href='gitext://gotocommit/" + _data.ChildIds[1] + "'>" + _data.ChildIds[1].ToShortString() + "</a> " +
                                    "<a href='gitext://gotocommit/" + _data.ChildIds[2] + "'>" + _data.ChildIds[2].ToShortString() + "</a>" + Environment.NewLine +
@@ -70,12 +70,12 @@ namespace ResourceManagerTests.CommitDataRenders
         [Test]
         public void Render_with_tabs_no_links()
         {
-            var expectedHeader = "Author:			<a href='mailto:John.Doe@test.com'>John Doe (Acme Inc) &lt;John.Doe@test.com&gt;</a>" + Environment.NewLine +
+            var expectedHeader = "Author:		<a href='mailto:John.Doe@test.com'>John Doe (Acme Inc) &lt;John.Doe@test.com&gt;</a>" + Environment.NewLine +
                                  "Author date:	3 days ago (" + LocalizationHelpers.GetFullDateString(_data.AuthorDate) + ")" + Environment.NewLine +
-                                 "Committer:		<a href='mailto:Jane.Doe@test.com'>Jane Doe &lt;Jane.Doe@test.com&gt;</a>" + Environment.NewLine +
+                                 "Committer:	<a href='mailto:Jane.Doe@test.com'>Jane Doe &lt;Jane.Doe@test.com&gt;</a>" + Environment.NewLine +
                                  "Commit date:	2 days ago (" + LocalizationHelpers.GetFullDateString(_data.CommitDate) + ")" + Environment.NewLine +
                                  "Commit hash:	" + _data.ObjectId + Environment.NewLine +
-                                 "Children:		" +
+                                 "Children:	" +
                                    _data.ChildIds[0].ToShortString() + " " +
                                    _data.ChildIds[1].ToShortString() + " " +
                                    _data.ChildIds[2].ToShortString() + Environment.NewLine +
@@ -133,9 +133,9 @@ namespace ResourceManagerTests.CommitDataRenders
         [Test]
         public void RenderPlain_with_tabs()
         {
-            var expectedHeader = "Author:			John Doe (Acme Inc) <John.Doe@test.com>" + Environment.NewLine +
+            var expectedHeader = "Author:		John Doe (Acme Inc) <John.Doe@test.com>" + Environment.NewLine +
                                  "Author date:	3 days ago (" + LocalizationHelpers.GetFullDateString(_data.AuthorDate) + ")" + Environment.NewLine +
-                                 "Committer:		Jane Doe <Jane.Doe@test.com>" + Environment.NewLine +
+                                 "Committer:	Jane Doe <Jane.Doe@test.com>" + Environment.NewLine +
                                  "Commit date:	2 days ago (" + LocalizationHelpers.GetFullDateString(_data.CommitDate) + ")" + Environment.NewLine +
                                  "Commit hash:	" + _data.ObjectId;
 

--- a/UnitTests/ResourceManager.Tests/CommitDataRenders/TabbedHeaderLabelFormatterTests.cs
+++ b/UnitTests/ResourceManager.Tests/CommitDataRenders/TabbedHeaderLabelFormatterTests.cs
@@ -15,15 +15,15 @@ namespace ResourceManagerTests.CommitDataRenders
             _formatter = new TabbedHeaderLabelFormatter();
         }
 
-        [TestCase(null, 10, ":			")]
-        [TestCase("", 10, ":			")]
-        [TestCase("", 16, ":				")]
+        [TestCase(null, 10, ":		")]
+        [TestCase("", 10, ":		")]
+        [TestCase("", 16, ":			")]
         [TestCase(" ", 10, " :		")]
         [TestCase("a", 10, "a:		")]
-        [TestCase("a", 8, "a:		")]
+        [TestCase("a", 8, "a:	")]
         [TestCase("abc", 1, "abc:")]
-        [TestCase("John Doe <John.Doe@test.com>", 38, "John Doe &lt;John.Doe@test.com&gt;:	")]
-        [TestCase("John Doe <John.Doe@test.com>", 40, "John Doe &lt;John.Doe@test.com&gt;:		")]
+        [TestCase("John Doe <John.Doe@test.com>", 38, "John Doe &lt;John.Doe@test.com&gt;:")]
+        [TestCase("John Doe <John.Doe@test.com>", 40, "John Doe &lt;John.Doe@test.com&gt;:	")]
         public void FormatLabel_should_render_correctly(string given, int desiredLength, string expected)
         {
             _formatter.FormatLabel(given, desiredLength).Should().Be(expected);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9164

## Proposed changes

- Removed an expression that gives us an extra tab.
- Fixed tests.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/20372363/128375506-b2237516-5def-411a-941c-ad56254f03a1.png)
![image](https://user-images.githubusercontent.com/20372363/128375564-b4405d70-0e25-4501-9b86-b83fba0c3da4.png)
![image](https://user-images.githubusercontent.com/20372363/128375680-5b5111ba-a595-4503-8e17-41a41e3a06f2.png)

### After
![image](https://user-images.githubusercontent.com/20372363/128375974-08bc7add-8474-4af6-aa94-0f598d32da32.png)
![image](https://user-images.githubusercontent.com/20372363/128376000-3010e46b-fa5f-4be4-9b4a-19f964a621f7.png)
![image](https://user-images.githubusercontent.com/20372363/128376053-3bfa4c77-b01b-45f1-8797-ff2711c6a048.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Used existing tests.

## Test environment(s) <!-- Remove any that don't apply -->

GIT 2.21.0.windows.1
Windows 10

<!-- Mention language, UI scaling, or anything else that might be relevant -->
This PR does not fix the submodule status here: [link](https://github.com/gitextensions/gitextensions/issues/9164#issuecomment-881846792).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
