### PR TITLE
Blame/filter in Browse, replace formfilehistory

### DIFF
--- a/GitCommands/AppTitleGenerator.cs
+++ b/GitCommands/AppTitleGenerator.cs
@@ -16,7 +16,9 @@ namespace GitCommands
         /// <param name="workingDir">Path to repository.</param>
         /// <param name="isValidWorkingDir">Indicates whether the given path contains a valid repository.</param>
         /// <param name="branchName">Current branch name.</param>
-        string Generate(string? workingDir = null, bool isValidWorkingDir = false, string? branchName = null);
+        /// <param name="defaultBranchName">Default branch name if <paramref name="branchName"/> is null (but not empty).</param>
+        /// <param name="pathName">Current pathfilter.</param>
+        string Generate(string? workingDir = null, bool isValidWorkingDir = false, string? branchName = null, string defaultBranchName = "", string? pathName = null);
     }
 
     /// <summary>
@@ -36,27 +38,29 @@ namespace GitCommands
             _descriptionProvider = descriptionProvider;
         }
 
-        /// <summary>
-        /// Generates main window title according to given repository.
-        /// </summary>
-        /// <param name="workingDir">Path to repository.</param>
-        /// <param name="isValidWorkingDir">Indicates whether the given path contains a valid repository.</param>
-        /// <param name="branchName">Current branch name.</param>
-        public string Generate(string? workingDir = null, bool isValidWorkingDir = false, string? branchName = null)
+        /// <inheritdoc />
+        public string Generate(string? workingDir = null, bool isValidWorkingDir = false, string? branchName = null, string defaultBranchName = "", string? pathName = null)
         {
             if (string.IsNullOrWhiteSpace(workingDir) || !isValidWorkingDir)
             {
                 return AppSettings.ApplicationName;
             }
 
-            branchName = branchName?.Trim('(', ')') ?? "no branch";
+            branchName = branchName?.Trim('(', ')') ?? defaultBranchName;
+
+            // Pathname normally have quotes already
+            pathName = string.IsNullOrWhiteSpace(pathName)
+                ? ""
+                    : pathName.StartsWith(@"""") && pathName.EndsWith(@"""")
+                        ? $"{pathName} "
+                        : $"{pathName.Quote()} ";
 
             var description = _descriptionProvider.Get(workingDir);
 
 #if DEBUG
-            return $"{description} ({branchName}) - {AppSettings.ApplicationName}{_extraInfo}";
+            return $"{description} ({branchName}) {pathName}- {AppSettings.ApplicationName}{_extraInfo}";
 #else
-            return $"{description} ({branchName}) - {AppSettings.ApplicationName}";
+            return $"{description} ({branchName}) {pathName}- {AppSettings.ApplicationName}";
 #endif
         }
 

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -469,6 +469,7 @@ namespace GitCommands
         public static ISetting<bool> ShowConEmuTab => Setting.Create(DetailedSettingsPath, nameof(ShowConEmuTab), true);
         public static ISetting<string> ConEmuStyle => Setting.Create(DetailedSettingsPath, nameof(ConEmuStyle), "<Solarized Light>");
         public static ISetting<string> ConEmuTerminal => Setting.Create(DetailedSettingsPath, nameof(ConEmuTerminal), "bash");
+        public static ISetting<bool> UseBrowseForFileHistory => Setting.Create(DetailedSettingsPath, nameof(UseBrowseForFileHistory), true);
         public static ISetting<bool> ShowGpgInformation => Setting.Create(DetailedSettingsPath, nameof(ShowGpgInformation), true);
 
         public static CommitInfoPosition CommitInfoPosition

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -703,6 +703,7 @@ namespace GitUI.CommandsDialogs
                         })
                     .FileAndForget();
             };
+            RevisionGrid.PathFilterChanged += revisionGrid_PathFilterChanged;
             UpdateSubmodulesStructure();
             UpdateStashCount();
 
@@ -845,6 +846,11 @@ namespace GitUI.CommandsDialogs
             ThreadHelper.JoinableTaskFactory.RunAsync(() => FillGpgInfoAsync(selectedRevision));
             FillBuildReport(selectedRevision);
             repoObjectsTree.SelectionChanged(selectedRevisions);
+        }
+
+        private void revisionGrid_PathFilterChanged(object? sender, EventArgs e)
+        {
+            Text = _appTitleGenerator.Generate(Module.WorkingDir, Module.IsValidGitWorkingDir(), branchSelect.Text, TranslatedStrings.NoBranch, RevisionGrid.GetPathFilter());
         }
 
         #region IBrowseRepo
@@ -1109,8 +1115,7 @@ namespace GitUI.CommandsDialogs
                 }
 
                 RefreshWorkingDirComboText();
-                var branchName = !string.IsNullOrEmpty(branchSelect.Text) ? branchSelect.Text : TranslatedStrings.NoBranch;
-                Text = _appTitleGenerator.Generate(Module.WorkingDir, validBrowseDir, branchName);
+                Text = _appTitleGenerator.Generate(Module.WorkingDir, validBrowseDir, branchSelect.Text, TranslatedStrings.NoBranch, RevisionGrid.GetPathFilter());
 
                 OnActivate();
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -859,6 +859,15 @@ namespace GitUI.CommandsDialogs
 
         #endregion
 
+        public void SetPathFilter(string pathFilter)
+        {
+            RevisionGrid.SetPathFilter(pathFilter.QuoteNE());
+            revisionDiff.FallbackFollowedFile = pathFilter;
+            fileTree.FallbackFollowedFile = pathFilter;
+            Text = _appTitleGenerator.Generate(Module.WorkingDir, Module.IsValidGitWorkingDir(), branchSelect.Text, TranslatedStrings.NoBranch, RevisionGrid.GetPathFilter());
+            RevisionGrid.ForceRefreshRevisions();
+        }
+
         private void ShowDashboard()
         {
             toolPanel.SuspendLayout();

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -131,10 +131,11 @@ namespace GitUI.CommandsDialogs
         /// Open Browse - main GUI including dashboard.
         /// </summary>
         /// <param name="commands">commands in the current form.</param>
-        /// <param name="filter">filter to apply to browse.</param>
+        /// <param name="revFilter">revision filter to apply to browse.</param>
+        /// <param name="pathFilter">path filter to apply to browse.</param>
         /// <param name="selectedId">Currently (last) selected commit id.</param>
         /// <param name="firstId">First selected commit id (as in a diff).</param>
-        public FormBrowse(GitUICommands commands, string filter, ObjectId? selectedId = null, ObjectId? firstId = null)
+        public FormBrowse(GitUICommands commands, string revFilter, string pathFilter, ObjectId? selectedId = null, ObjectId? firstId = null)
             : base(commands)
         {
             InitializeComponent();
@@ -196,6 +197,9 @@ namespace GitUI.CommandsDialogs
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 RegisterPlugins();
             }).FileAndForget();
+
+            _appTitleGenerator = ManagedExtensibility.GetExport<IAppTitleGenerator>().Value;
+            _windowsJumpListManager = ManagedExtensibility.GetExport<IWindowsJumpListManager>().Value;
 
             _appTitleGenerator = ManagedExtensibility.GetExport<IAppTitleGenerator>().Value;
             _windowsJumpListManager = ManagedExtensibility.GetExport<IWindowsJumpListManager>().Value;
@@ -317,7 +321,8 @@ namespace GitUI.CommandsDialogs
 
             ToolStripFilters.Bind(() => Module, RevisionGrid);
             ToolStripFilters.UpdateBranchFilterItems();
-            ToolStripFilters.SetRevisionFilter(filter);
+            ToolStripFilters.SetRevisionFilter(revFilter);
+            SetPathFilter(pathFilter);
 
             _aheadBehindDataProvider = GitVersion.Current.SupportAheadBehindData ? new AheadBehindDataProvider(() => Module.GitExecutable) : null;
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -798,6 +798,7 @@ namespace GitUI.CommandsDialogs
 
         private void UICommands_PostRepositoryChanged(object sender, GitUIEventArgs e)
         {
+            SetPathFilter(null);
             this.InvokeAsync(RefreshRevisions).FileAndForget();
             UpdateSubmodulesStructure();
             UpdateStashCount();

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -502,7 +502,7 @@ namespace GitUI.CommandsDialogs
             return !string.IsNullOrEmpty(url);
         }
 
-        internal TestAccessor GetTestAccessor() => new TestAccessor(this);
+        internal TestAccessor GetTestAccessor() => new(this);
 
         internal readonly struct TestAccessor
         {

--- a/GitUI/CommandsDialogs/FormCommandlineHelp.resx
+++ b/GitUI/CommandsDialogs/FormCommandlineHelp.resx
@@ -119,7 +119,7 @@
   </resheader>
   <data name="_NO_TRANSLATE_commands.Text" xml:space="preserve">
     <value>[path]
-browse [path] [-filter=] [-commit=&lt;selectedSha&gt;[,&lt;firstSha&gt;]]
+browse [path] [-filter=] [--pathFilter=&lt;filepath&gt;] [-commit=&lt;selectedSha&gt;[,&lt;firstSha&gt;]]
 about
 add [filename]
 addfiles [filename]

--- a/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
@@ -54,6 +54,7 @@ namespace GitUI.CommandsDialogs
             this.copyFilenameToClipboardToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.openContainingFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.diffShowInFileTreeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.diffFilterFileInGridToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator33 = new System.Windows.Forms.ToolStripSeparator();
             this.fileHistoryDiffToolstripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.blameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -136,8 +137,9 @@ namespace GitUI.CommandsDialogs
             this.diffToolStripSeparator13,
             this.copyFilenameToClipboardToolStripMenuItem1,
             this.openContainingFolderToolStripMenuItem,
-            this.diffShowInFileTreeToolStripMenuItem,
             this.toolStripSeparator33,
+            this.diffShowInFileTreeToolStripMenuItem,
+            this.diffFilterFileInGridToolStripMenuItem,
             this.fileHistoryDiffToolstripMenuItem,
             this.blameToolStripMenuItem,
             this.findInDiffToolStripMenuItem});
@@ -394,6 +396,11 @@ namespace GitUI.CommandsDialogs
             this.openContainingFolderToolStripMenuItem.Text = "Show &in folder";
             this.openContainingFolderToolStripMenuItem.Click += new System.EventHandler(this.openContainingFolderToolStripMenuItem_Click);
             // 
+            // toolStripSeparator33
+            // 
+            this.toolStripSeparator33.Name = "toolStripSeparator33";
+            this.toolStripSeparator33.Size = new System.Drawing.Size(293, 6);
+            // 
             // diffShowInFileTreeToolStripMenuItem
             // 
             this.diffShowInFileTreeToolStripMenuItem.Image = global::GitUI.Properties.Images.FileTree;
@@ -402,10 +409,12 @@ namespace GitUI.CommandsDialogs
             this.diffShowInFileTreeToolStripMenuItem.Text = "Show in File &tree";
             this.diffShowInFileTreeToolStripMenuItem.Click += new System.EventHandler(this.diffShowInFileTreeToolStripMenuItem_Click);
             // 
-            // toolStripSeparator33
+            // diffFilterFileInGridToolStripMenuItem
             // 
-            this.toolStripSeparator33.Name = "toolStripSeparator33";
-            this.toolStripSeparator33.Size = new System.Drawing.Size(293, 6);
+            this.diffFilterFileInGridToolStripMenuItem.Image = global::GitUI.Properties.Images.FunnelPencil;
+            this.diffFilterFileInGridToolStripMenuItem.Name = "diffFilterFileInGridToolStripMenuItem";
+            this.diffFilterFileInGridToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.diffFilterFileInGridToolStripMenuItem.Click += new System.EventHandler(this.diffFilterFileInGridToolStripMenuItem_Click);
             // 
             // fileHistoryDiffToolstripMenuItem
             // 
@@ -477,6 +486,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem firstToLocalToolStripMenuItem;
         private ToolStripMenuItem firstToSelectedToolStripMenuItem;
         private ToolStripMenuItem findInDiffToolStripMenuItem;
+        private ToolStripMenuItem diffFilterFileInGridToolStripMenuItem;
         private ToolStripMenuItem blameToolStripMenuItem;
         private ToolStripMenuItem fileHistoryDiffToolstripMenuItem;
         private ToolStripSeparator toolStripSeparator33;

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
@@ -44,6 +44,7 @@
             this.fileTreeArchiveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fileTreeCleanWorkingTreeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparatorFileNameActions = new System.Windows.Forms.ToolStripSeparator();
+            this.filterFileInGridToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fileHistoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.blameToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparatorTopActions = new System.Windows.Forms.ToolStripSeparator();
@@ -124,6 +125,7 @@
             this.copyFilenameToClipboardToolStripMenuItem,
             this.fileTreeOpenContainingFolderToolStripMenuItem,
             this.toolStripSeparatorFileNameActions,
+            this.filterFileInGridToolStripMenuItem,
             this.fileHistoryToolStripMenuItem,
             this.blameToolStripMenuItem1,
             this.fileTreeArchiveToolStripMenuItem,
@@ -226,6 +228,13 @@
             // 
             this.toolStripSeparatorFileNameActions.Name = "toolStripSeparatorFileNameActions";
             this.toolStripSeparatorFileNameActions.Size = new System.Drawing.Size(322, 6);
+            // 
+            // filterFileInGridToolStripMenuItem
+            // 
+            this.filterFileInGridToolStripMenuItem.Image = global::GitUI.Properties.Images.FunnelPencil;
+            this.filterFileInGridToolStripMenuItem.Name = "filterFileInGridToolStripMenuItem";
+            this.filterFileInGridToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
+            this.filterFileInGridToolStripMenuItem.Click += new System.EventHandler(this.filterFileInGridToolStripMenuItem_Click);
             // 
             // fileHistoryToolStripMenuItem
             // 
@@ -385,6 +394,7 @@
         private System.Windows.Forms.ToolStripMenuItem fileTreeArchiveToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem fileTreeCleanWorkingTreeToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparatorFileNameActions;
+        private System.Windows.Forms.ToolStripMenuItem filterFileInGridToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem fileHistoryToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem blameToolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem findToolStripMenuItem;

--- a/GitUI/CommandsDialogs/RevisionFileTreeController.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeController.cs
@@ -149,7 +149,7 @@ namespace GitUI.CommandsDialogs
         /// <inheritdoc/>
         public bool SelectFileOrFolder(NativeTreeView tree, string fileSubPath)
         {
-            Queue<string> pathParts = new(fileSubPath.Split(Path.DirectorySeparatorChar));
+            Queue<string> pathParts = new(fileSubPath.Split(Delimiters.PathSeparators));
             var foundNode = FindSubNode(tree.Nodes, pathParts);
             if (foundNode is null)
             {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
@@ -32,6 +32,7 @@
             this.chkChowConsoleTab = new System.Windows.Forms.CheckBox();
             this.cboTerminal = new System.Windows.Forms.ComboBox();
             this.label2 = new System.Windows.Forms.Label();
+            this.chkUseBrowseForFileHistory = new System.Windows.Forms.CheckBox();
             this.gbGeneral = new System.Windows.Forms.GroupBox();
             this.gbTabs = new System.Windows.Forms.GroupBox();
             this.gbGeneral.SuspendLayout();
@@ -44,7 +45,7 @@
             this.chkShowGpgInformation.Location = new System.Drawing.Point(9, 48);
             this.chkShowGpgInformation.Name = "chkShowGpgInformation";
             this.chkShowGpgInformation.Size = new System.Drawing.Size(212, 17);
-            this.chkShowGpgInformation.TabIndex = 6;
+            this.chkShowGpgInformation.TabIndex = 7;
             this.chkShowGpgInformation.Text = "Show GPG information";
             this.chkShowGpgInformation.UseVisualStyleBackColor = true;
             // 
@@ -54,7 +55,7 @@
             this.chkChowConsoleTab.Location = new System.Drawing.Point(9, 25);
             this.chkChowConsoleTab.Name = "chkChowConsoleTab";
             this.chkChowConsoleTab.Size = new System.Drawing.Size(209, 17);
-            this.chkChowConsoleTab.TabIndex = 5;
+            this.chkChowConsoleTab.TabIndex = 6;
             this.chkChowConsoleTab.Text = "Show the Console tab";
             this.chkChowConsoleTab.UseVisualStyleBackColor = true;
             // 
@@ -77,15 +78,26 @@
             this.label2.TabIndex = 2;
             this.label2.Text = "Default shell";
             // 
+            // chkUseBrowseForFileHistory
+            // 
+            this.chkUseBrowseForFileHistory.AutoSize = true;
+            this.chkUseBrowseForFileHistory.Location = new System.Drawing.Point(9, 48);
+            this.chkUseBrowseForFileHistory.Name = "chkUseBrowseForFileHistory";
+            this.chkUseBrowseForFileHistory.Size = new System.Drawing.Size(212, 17);
+            this.chkUseBrowseForFileHistory.TabIndex = 4;
+            this.chkUseBrowseForFileHistory.Text = "Use Browse For FileHistory";
+            this.chkUseBrowseForFileHistory.UseVisualStyleBackColor = true;
+            // 
             // gbGeneral
             // 
             this.gbGeneral.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.gbGeneral.Controls.Add(this.cboTerminal);
             this.gbGeneral.Controls.Add(this.label2);
+            this.gbGeneral.Controls.Add(this.chkUseBrowseForFileHistory);
             this.gbGeneral.Location = new System.Drawing.Point(11, 11);
             this.gbGeneral.Name = "gbGeneral";
-            this.gbGeneral.Size = new System.Drawing.Size(1487, 56);
+            this.gbGeneral.Size = new System.Drawing.Size(1487, 81);
             this.gbGeneral.TabIndex = 1;
             this.gbGeneral.TabStop = false;
             this.gbGeneral.Text = "General";
@@ -99,7 +111,7 @@
             this.gbTabs.Location = new System.Drawing.Point(11, 86);
             this.gbTabs.Name = "gbTabs";
             this.gbTabs.Size = new System.Drawing.Size(1487, 82);
-            this.gbTabs.TabIndex = 4;
+            this.gbTabs.TabIndex = 5;
             this.gbTabs.TabStop = false;
             this.gbTabs.Text = "Tabs (restart required)";
             // 
@@ -126,6 +138,7 @@
         private System.Windows.Forms.CheckBox chkChowConsoleTab;
         private System.Windows.Forms.ComboBox cboTerminal;
         private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.CheckBox chkUseBrowseForFileHistory;
         private System.Windows.Forms.GroupBox gbGeneral;
         private System.Windows.Forms.GroupBox gbTabs;
     }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
@@ -25,6 +25,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void PageToSettings()
         {
             AppSettings.ShowConEmuTab.Value = chkChowConsoleTab.Checked;
+            AppSettings.UseBrowseForFileHistory.Value = chkUseBrowseForFileHistory.Checked;
             AppSettings.ShowGpgInformation.Value = chkShowGpgInformation.Checked;
 
             AppSettings.ConEmuTerminal.Value = ((IShellDescriptor)cboTerminal.SelectedItem).Name.ToLowerInvariant();
@@ -34,6 +35,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void SettingsToPage()
         {
             chkChowConsoleTab.Checked = AppSettings.ShowConEmuTab.Value;
+            chkUseBrowseForFileHistory.Checked = AppSettings.UseBrowseForFileHistory.Value;
             chkShowGpgInformation.Checked = AppSettings.ShowGpgInformation.Value;
 
             foreach (IShellDescriptor shell in _shellProvider.GetShells())

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -27,6 +27,7 @@ namespace GitUI
         private const string FileHistoryCommand = "filehistory";
 
         private const string FilterByRevisionArg = "--filter-by-revision";
+        private const string PathFilterArg = "--pathFilter";
 
         private readonly ICommitTemplateManager _commitTemplateManager;
         private readonly IFullPathResolver _fullPathResolver;
@@ -1123,12 +1124,13 @@ namespace GitUI
         /// Open Browse - main GUI including dashboard.
         /// </summary>
         /// <param name="owner">current window owner.</param>
-        /// <param name="filter">filter to apply to browse.</param>
+        /// <param name="revFilter">revision filter to apply to browse.</param>
+        /// <param name="pathFilter">path filter to apply to browse.</param>
         /// <param name="selectedId">Currently (last) selected commit id.</param>
         /// <param name="firstId">First selected commit id (as in a diff).</param>
-        public bool StartBrowseDialog(IWin32Window? owner = null, string filter = "", ObjectId? selectedId = null, ObjectId? firstId = null)
+        public bool StartBrowseDialog(IWin32Window? owner = null, string revFilter = "", string pathFilter = "", ObjectId? selectedId = null, ObjectId? firstId = null)
         {
-            FormBrowse form = new(this, filter, selectedId, firstId);
+            FormBrowse form = new(this, revFilter, pathFilter, selectedId, firstId);
 
             if (Application.MessageLoop)
             {
@@ -1562,12 +1564,18 @@ namespace GitUI
             var arg = GetParameterOrEmptyStringAsDefault(args, "-commit");
             if (arg == "")
             {
-                return StartBrowseDialog(null, GetParameterOrEmptyStringAsDefault(args, "-filter"));
+                return StartBrowseDialog(null,
+                    GetParameterOrEmptyStringAsDefault(args, "-filter"),
+                    GetParameterOrEmptyStringAsDefault(args, PathFilterArg));
             }
 
             if (TryGetObjectIds(arg, Module, out var selectedId, out var firstId))
             {
-                return StartBrowseDialog(null, GetParameterOrEmptyStringAsDefault(args, "-filter"), selectedId, firstId);
+                return StartBrowseDialog(null,
+                    GetParameterOrEmptyStringAsDefault(args, "-filter"),
+                    GetParameterOrEmptyStringAsDefault(args, PathFilterArg),
+                    selectedId,
+                    firstId);
             }
 
             Console.Error.WriteLine($"No commit found matching: {arg}");
@@ -1632,7 +1640,7 @@ namespace GitUI
                 }
             }
 
-            return c.StartBrowseDialog(null, GetParameterOrEmptyStringAsDefault(args, "-filter"));
+            return c.StartBrowseDialog(null, GetParameterOrEmptyStringAsDefault(args, "-filter"), GetParameterOrEmptyStringAsDefault(args, PathFilterArg));
         }
 
         private bool RunSynchronizeCommand(IReadOnlyDictionary<string, string?> arguments)

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1146,7 +1146,8 @@ namespace GitUI
 
         public void StartFileHistoryDialog(IWin32Window? owner, string fileName, GitRevision? revision = null, bool filterByRevision = false, bool showBlame = false)
         {
-            string arguments = $"{(showBlame ? BlameHistoryCommand : FileHistoryCommand)} {fileName.Quote()} {revision?.ObjectId} {(filterByRevision ? FilterByRevisionArg : string.Empty)}";
+            string arguments = AppSettings.UseBrowseForFileHistory.Value ? $"browse {PathFilterArg}={fileName.Quote()} -commit={revision?.ObjectId}"
+                : $"{(showBlame ? BlameHistoryCommand : FileHistoryCommand)} {fileName.Quote()} {revision?.ObjectId} {(filterByRevision ? FilterByRevisionArg : string.Empty)}";
             Launch(arguments, Module.WorkingDir);
         }
 

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -353,7 +353,8 @@ namespace GitUI.Hotkey
                     Hk(RevisionDiffControl.Command.ResetSelectedFiles, Keys.R),
                     Hk(RevisionDiffControl.Command.StageSelectedFile, Keys.S),
                     Hk(RevisionDiffControl.Command.UnStageSelectedFile, Keys.U),
-                    Hk(RevisionDiffControl.Command.ShowFileTree, Keys.T)),
+                    Hk(RevisionDiffControl.Command.ShowFileTree, Keys.T),
+                    Hk(RevisionDiffControl.Command.FilterFileInGrid, Keys.F)),
                 new HotkeySettings(
                     RevisionFileTreeControl.HotkeySettingsName,
                     Hk(RevisionFileTreeControl.Command.Blame, BlameHotkey),
@@ -361,7 +362,8 @@ namespace GitUI.Hotkey
                     Hk(RevisionFileTreeControl.Command.OpenAsTempFile, OpenAsTempFileHotkey),
                     Hk(RevisionFileTreeControl.Command.OpenAsTempFileWith, OpenAsTempFileWithHotkey),
                     Hk(RevisionFileTreeControl.Command.OpenWithDifftool, OpenWithDifftoolHotkey),
-                    Hk(RevisionFileTreeControl.Command.ShowHistory, ShowHistoryHotkey)),
+                    Hk(RevisionFileTreeControl.Command.ShowHistory, ShowHistoryHotkey),
+                    Hk(RevisionFileTreeControl.Command.FilterFileInGrid, Keys.F)),
                 new HotkeySettings(
                     FormStash.HotkeySettingsName,
                     Hk(FormStash.Command.NextStash, Keys.Control | Keys.N),

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -106,6 +106,7 @@ namespace GitUI
         private readonly TranslationString _workingDirectoryText = new("Working directory");
         private readonly TranslationString _reportBugText = new("If you think this was caused by Git Extensions, you can report a bug for the team to investigate.");
 
+        private readonly TranslationString _filterFileInGrid = new("Filter file in &grid");
         private readonly TranslationString _openInVisualStudioFailureText = new("Could not find this file in any open solution. Ensure you have a project containing this file open before trying again.");
         private readonly TranslationString _openInVisualStudioFailureCaption = new("Unable to open file");
 
@@ -174,6 +175,7 @@ namespace GitUI
         public static string Tag => _instance.Value._tag.Text;
         public static string Remote => _instance.Value._remote.Text;
         public static string OpenWithGitExtensions => _instance.Value._openWithGitExtensions.Text;
+        public static string FilterFileInGrid => _instance.Value._filterFileInGrid.Text;
         public static string OpenInVisualStudio => _instance.Value._openInVisualStudio.Text;
         public static string ContScrollToNextFileOnlyWithAlt => _instance.Value._contScrollToNextFileOnlyWithAlt.Text;
         public static string NoRevision => _instance.Value._noRevision.Text;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3290,6 +3290,10 @@ Do you want to continue?</source>
         <source>Show GPG information</source>
         <target />
       </trans-unit>
+      <trans-unit id="chkUseBrowseForFileHistory.Text">
+        <source>Use Browse For FileHistory</source>
+        <target />
+      </trans-unit>
       <trans-unit id="gbGeneral.Text">
         <source>General</source>
         <target />

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9317,6 +9317,10 @@ To show all branches, right click the revision grid, select 'view' and then the 
         <source>&amp;Edit working directory file</source>
         <target />
       </trans-unit>
+      <trans-unit id="diffFilterFileInGridToolStripMenuItem.Text">
+        <source>Filter file in &amp;grid</source>
+        <target />
+      </trans-unit>
       <trans-unit id="diffOpenRevisionFileToolStripMenuItem.Text">
         <source>Ope&amp;n this revision (temp file)</source>
         <target />
@@ -9513,6 +9517,10 @@ See the changes in the commit form.</source>
       </trans-unit>
       <trans-unit id="fileTreeOpenContainingFolderToolStripMenuItem.Text">
         <source>Show in folder</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="filterFileInGridToolStripMenuItem.Text">
+        <source>Filter file in &amp;grid</source>
         <target />
       </trans-unit>
       <trans-unit id="findToolStripMenuItem.Text">
@@ -10646,6 +10654,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_exitCodeText.Text">
         <source>Exit code</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_filterFileInGrid.Text">
+        <source>Filter file in &amp;grid</source>
         <target />
       </trans-unit>
       <trans-unit id="_findGitExecutable.Text">

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -49,6 +49,7 @@ namespace GitUI.UserControls.RevisionGrid
             Author.Enabled = AuthorCheck.Checked;
             Committer.Enabled = CommitterCheck.Checked;
             Message.Enabled = MessageCheck.Checked;
+            IgnoreCase.Enabled = Author.Enabled || Committer.Enabled || MessageCheck.Checked;
             _NO_TRANSLATE_Limit.Enabled = LimitCheck.Checked;
             FileFilter.Enabled = FileFilterCheck.Checked;
 
@@ -169,9 +170,14 @@ namespace GitUI.UserControls.RevisionGrid
             return true;
         }
 
-        public void SetPathFilter(string filter)
+        public void SetPathFilter(string? filter)
         {
-            FileFilter.Text = filter?.Trim();
+            // If null the value is set from forms, then just uncheck
+            if (filter is not null)
+            {
+                FileFilter.Text = filter;
+            }
+
             FileFilterCheck.Checked = !string.IsNullOrWhiteSpace(filter);
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -63,6 +63,7 @@ namespace GitUI
     {
         public event EventHandler<DoubleClickRevisionEventArgs>? DoubleClickRevision;
         public event EventHandler? FilterChanged;
+        public event EventHandler? PathFilterChanged;
         public event EventHandler? RevisionGraphLoaded;
         public event EventHandler? SelectionChanged;
 
@@ -422,6 +423,11 @@ namespace GitUI
             _formRevisionFilter.SetPathFilter(path);
         }
 
+        public string GetPathFilter()
+        {
+            return _formRevisionFilter.GetPathFilter();
+        }
+
         private void InitiateRefAction(IReadOnlyList<IGitRef>? refs, Action<IGitRef> action, FormQuickGitRefSelector.Action actionLabel)
         {
             if (refs is null || refs.Count < 1)
@@ -651,6 +657,11 @@ namespace GitUI
         private void OnFilterChanged()
         {
             FilterChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void OnPathFilterChanged()
+        {
+            PathFilterChanged?.Invoke(this, EventArgs.Empty);
         }
 
         public new void Load()
@@ -1879,6 +1890,7 @@ namespace GitUI
         public void ShowRevisionFilterDialog()
         {
             _formRevisionFilter.ShowDialog(ParentForm);
+            OnPathFilterChanged();
             ForceRefreshRevisions();
         }
 

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/Mocks/MockAppTitleGenerator.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/Mocks/MockAppTitleGenerator.cs
@@ -9,6 +9,6 @@ namespace GitExtensions.UITests.CommandsDialogs
     [Export(typeof(IAppTitleGenerator))]
     internal class MockAppTitleGenerator : IAppTitleGenerator
     {
-        public string Generate(string? workingDir = null, bool isValidWorkingDir = false, string? branchName = null) => "Mock title";
+        public string Generate(string? workingDir = null, bool isValidWorkingDir = false, string? branchName = null, string defaultBranchName = "", string? pathName = null) => "Mock title";
     }
 }

--- a/UnitTests/GitCommands.Tests/AppTitleGeneratorTests.cs
+++ b/UnitTests/GitCommands.Tests/AppTitleGeneratorTests.cs
@@ -15,6 +15,7 @@ namespace GitCommandsTests
     {
         private TestComposition _composition;
         private IAppTitleGenerator _appTitleGenerator;
+        private string _defaultBranchName = "no branch";
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
@@ -52,16 +53,33 @@ namespace GitCommandsTests
         [Test]
         public void Generate_should_include_no_branch_if_supplied()
         {
-            string title = _appTitleGenerator.Generate("a", true, null);
-            title.Should().StartWith($"{MockRepositoryDescriptionProvider.ShortName} (no branch) - {AppSettings.ApplicationName}");
+            string title = _appTitleGenerator.Generate("a", true, null, defaultBranchName: _defaultBranchName);
+            title.Should().StartWith($"{MockRepositoryDescriptionProvider.ShortName} ({_defaultBranchName}) - {AppSettings.ApplicationName}");
         }
 
         [Test]
         public void Generate_should_include_supplied_branch_without_braces()
         {
             string branchName = "feature/my_(test)_branch";
-            string title = _appTitleGenerator.Generate("a", true, "(" + branchName + ")");
+            string title = _appTitleGenerator.Generate("a", true, branchName: "(" + branchName + ")", defaultBranchName: _defaultBranchName);
             title.Should().StartWith($"{MockRepositoryDescriptionProvider.ShortName} ({branchName}) - {AppSettings.ApplicationName}");
+        }
+
+        [Test]
+        public void Generate_should_include_supplied_pathname()
+        {
+            string branchName = "feature/my_(test)_branch";
+            string pathName = "folder/folder/file";
+            string title = _appTitleGenerator.Generate("a", true, branchName: "(" + branchName + ")", pathName: pathName);
+            title.Should().StartWith($@"{MockRepositoryDescriptionProvider.ShortName} ({branchName}) ""{pathName}"" - {AppSettings.ApplicationName}");
+        }
+
+        [Test]
+        public void Generate_should_not_quote_already_quoted_pathname()
+        {
+            string pathName = @"""folder/folder/file""";
+            string title = _appTitleGenerator.Generate("a", true, pathName: pathName, defaultBranchName: _defaultBranchName);
+            title.Should().StartWith($@"{MockRepositoryDescriptionProvider.ShortName} ({_defaultBranchName}) {pathName} - {AppSettings.ApplicationName}");
         }
 
 #if DEBUG
@@ -70,9 +88,9 @@ namespace GitCommandsTests
         {
             string buildBranch = "build_branch";
             AppTitleGenerator.Initialise(buildSha, buildBranch);
-            string title = _appTitleGenerator.Generate("a", true, null);
+            string title = _appTitleGenerator.Generate("a", true, null, defaultBranchName: _defaultBranchName);
 
-            title.Should().Be($"{MockRepositoryDescriptionProvider.ShortName} (no branch) - {AppSettings.ApplicationName} [DEBUG]");
+            title.Should().Be($"{MockRepositoryDescriptionProvider.ShortName} ({_defaultBranchName}) - {AppSettings.ApplicationName} [DEBUG]");
         }
 
         [Test]
@@ -81,9 +99,9 @@ namespace GitCommandsTests
             string buildSha = "1234567812345678123456781234567812345678";
             string buildBranch = "build_branch";
             AppTitleGenerator.Initialise(buildSha, buildBranch);
-            string title = _appTitleGenerator.Generate("a", true, null);
+            string title = _appTitleGenerator.Generate("a", true, null, defaultBranchName: _defaultBranchName);
 
-            title.Should().Be($"{MockRepositoryDescriptionProvider.ShortName} (no branch) - {AppSettings.ApplicationName} {buildSha.Substring(0, 8)} ({buildBranch})");
+            title.Should().Be($"{MockRepositoryDescriptionProvider.ShortName} ({_defaultBranchName}) - {AppSettings.ApplicationName} {buildSha.Substring(0, 8)} ({buildBranch})");
         }
 #endif
     }


### PR DESCRIPTION
Closes #7598

Based on #9424.
This PR could be split in several PRs, submitted as is to describe the "initial completion" of #7598 and describe what could be improved.

I consider this to be ready for review, but may tweak the functionality until #9424 is merged.

## Proposed changes

* See screenshots below

* RevDiff and FileTree selects filtered files by default when changing commits, the filtered file is "followed" when switching commits (unless another file is selected and it exists in the next commit, as already implemented).

* Some refactoring to allow for new functionality separated.

Future:
* Present active filters better. Some way to deactivate filters in a simple way. (Some discussion in #7598).
* A few tests could be added (some added)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

### After

Show path filter in title (last part is due to Debug build, unchanged)
![image](https://user-images.githubusercontent.com/6248932/128436478-32a5a9c5-0262-40b7-97c2-c5743f53ff8f.png)

Separator changed as T/F/H/B hotkey commands are related

![image](https://user-images.githubusercontent.com/6248932/128781499-c2b4d391-2f76-4a87-bfda-477f10eac852.png)

Context command, hotkey `F` to filter a file in the grid
(similar to open a new instance)

![image](https://user-images.githubusercontent.com/6248932/128781554-8478a4e9-5de3-40e6-8f25-7f6c9272b4d2.png)

![image](https://user-images.githubusercontent.com/6248932/128781827-f36a6214-1d24-4072-ab5c-286bd9042a99.png)

Configuration to open a Browse with filter instead of FileHistory.
Enabled by default.
This is put in Browse as Appearance is too busy already

![image](https://user-images.githubusercontent.com/6248932/128436980-ba9a5c26-f4b5-4d49-8261-b581ffc068fd.png)

## Test methodology <!-- How did you ensure quality? -->

manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
