### PR TITLE
GitHub PR template - merge strategies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,13 +2,11 @@
 
 Fixes #
 
-
 ## Proposed changes
 
 - 
 - 
 - 
-
 
 ## Screenshots <!-- Remove this section if PR does not change UI -->
 
@@ -20,13 +18,11 @@ Fixes #
 
 <!-- TODO -->
 
-
 ## Test methodology <!-- How did you ensure quality? -->
 
 - 
 - 
 - 
-
 
 ## Test environment(s) <!-- Remove any that don't apply -->
 
@@ -35,6 +31,12 @@ Fixes #
 
 <!-- Mention language, UI scaling, or anything else that might be relevant -->
 
+## Merge strategy
+
+- [x] Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
+- [ ] Rebase merge (PR submitter must change the commit message for the last commit).
+- [ ] Merge commit.
+- [ ] To be decided later.
 
 ----
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,11 +33,14 @@ Fixes #
 
 ## Merge strategy
 
-- [x] Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
-- [ ] Rebase merge (PR submitter must change the commit message for the last commit).
-- [ ] Merge commit.
-- [ ] To be decided later.
-
+<!-- Change the following if the merge strategy should be changed:
+- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
+- Rebase merge (PR submitter must change the commit message for the last commit).
+- Merge commit. (PR submitter to rebase and squash before merges).
+- To be decided later.
+The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
+-->
+I agree that the maintainer squash merge this PR (if the commit message is clear).
 ----
 
 :black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).


### PR DESCRIPTION
## Proposed changes

Add PR template section about merge strategy, setting squash merge as default.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->
I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
