### PR TITLE
Attempt to fix tests failure for MEF

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -558,6 +558,11 @@ namespace GitUI.UserControls.RevisionGrid
                 int curCount;
                 do
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return Task.CompletedTask;
+                    }
+
                     scrollTo = _backgroundScrollTo;
                     curCount = _revisionGraph.GetCachedCount();
                     UpdateGraph(curCount, scrollTo);
@@ -574,6 +579,11 @@ namespace GitUI.UserControls.RevisionGrid
 
             void UpdateGraph(int fromIndex, int toIndex)
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 // Cache the next item
                 _revisionGraph.CacheTo(toIndex, Math.Min(fromIndex + 1500, toIndex));
 
@@ -584,6 +594,11 @@ namespace GitUI.UserControls.RevisionGrid
 
                 void UpdateRowCount(int row)
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
                     if (RowCount < _revisionGraph.Count)
                     {
                         SetRowCountAndSelectRowsIfReady(_revisionGraph.Count);

--- a/IntegrationTests/UI.IntegrationTests/Script/ScriptRunnerTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/Script/ScriptRunnerTests.cs
@@ -245,6 +245,13 @@ namespace GitExtensions.UITests.Script
 
         private void RunFormTest(Func<FormBrowse, Task> testDriverAsync)
         {
+            // Needed for FormBrowse, ScriptOptionsParser
+            ManagedExtensibility.Initialise(new[]
+            {
+                typeof(GitUI.GitExtensionsForm).Assembly,
+                typeof(GitCommands.GitModule).Assembly
+            });
+
             UITest.RunForm(
                 showForm: () => _uiCommands.StartBrowseDialog(owner: null).Should().BeTrue(),
                 testDriverAsync);

--- a/IntegrationTests/UI.IntegrationTests/UI.IntegrationTests.csproj
+++ b/IntegrationTests/UI.IntegrationTests/UI.IntegrationTests.csproj
@@ -4,6 +4,8 @@
     
     <!-- TODO once all project migrated to SDK-style, remove this and move properties to Directory.Build.props -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+
+    <DefineConstants>$(DefineConstants);GITUI;</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/IntegrationTests/UI.IntegrationTests/UITest.cs
+++ b/IntegrationTests/UI.IntegrationTests/UITest.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using CommonTestUtils;
 using GitUI;
+using GitUIPluginInterfaces;
 using NUnit.Framework;
 
 namespace GitExtensions.UITests
@@ -34,6 +35,15 @@ namespace GitExtensions.UITests
             where T : Form
         {
             Assert.IsEmpty(Application.OpenForms.OfType<T>(), $"{Application.OpenForms.OfType<T>().Count()} open form(s) before test");
+
+            // Needed for FormBrowse, ScriptOptionsParser
+            ManagedExtensibility.Initialise(new[]
+            {
+#if GITUI
+                typeof(GitUI.GitExtensionsForm).Assembly,
+#endif
+                typeof(GitCommands.GitModule).Assembly
+            });
 
             T form = null;
             try


### PR DESCRIPTION
## Proposed changes

A few test changes to fix flaky tests

Integration tests fail after a clean, for instance ToggleBetweenArtificialAndHeadCommits_no_index_change.

In AppVeyor the tests time out.
Locally you get a popup
```
GitExtUtils.ExternalOperationException: fatal: not a git repository (or any of the parent directories): .git
 ---> System.Exception: fatal: not a git repository (or any of the parent directories): .git
   --- End of inner exception stack trace ---
   at void Microsoft.VisualStudio.Threading.JoinableTask.CompleteOnCurrentThread()
   at T Microsoft.VisualStudio.Threading.JoinableTask<T>.CompleteOnCurrentThread()
   at T Microsoft.VisualStudio.Threading.JoinableTaskFactory.Run<T>(Func<Task<T>> asyncMethod, JoinableTaskCreationOptions creationOptions) x 2
   at int GitCommands.Executable+ProcessWrapper.WaitForExit() in C:/dev/gc/gitextensions_4/GitCommands/Git/Executable.cs:line 238
   at IEnumerable<string> GitCommands.ExecutableExtensions.GetOutputLines(IExecutable executable, ArgumentString arguments, byte[] input, Encoding outputEncoding, bool stripAnsiEscapeCodes, bool throwOnErrorOutput, bool includeErrorOutput)+MoveNext() in C:/dev/gc/gitextensions_4/GitCommands/Git/ExecutableExtensions.cs:line 288
   at List<TSource> System.Linq.Enumerable+WhereEnumerableIterator<TSource>.ToList()
   at List<TSource> System.Linq.Enumerable.ToList<TSource>(IEnumerable<TSource> source)
   at IReadOnlyList<string> GitCommands.GitModule.GetRemoteNames() in C:/dev/gc/gitextensions_4/GitCommands/Git/GitModule.cs:line 2137
   at IReadOnlyList<string> GitCommands.Remotes.ConfigFileRemoteSettingsManager.GetEnabledRemoteNames() in C:/dev/gc/gitextensions_4/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs:line 198
   at IReadOnlyList<string> GitCommands.Remotes.ConfigFileRemoteSettingsManager.GetEnabledRemoteNamesWithoutBranches() in C:/dev/gc/gitextensions_4/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs:line 210
   at async Task<Nodes> GitUI.BranchTreePanel.RepoObjectsTree+RemoteBranchTree.FillBranchTreeAsync(IReadOnlyList<IGitRef> branches, CancellationToken token) in C:/dev/gc/gitextensions_4/GitUI/BranchTreePanel/RepoObjectsTree.RemoteBranchTree.cs:line 105
   at async Task<Nodes> GitUI.BranchTreePanel.RepoObjectsTree+RemoteBranchTree.LoadNodesAsync(CancellationToken token) in C:/dev/gc/gitextensions_4/GitUI/BranchTreePanel/RepoObjectsTree.RemoteBranchTree.cs:line 58
   at async Task GitUI.BranchTreePanel.RepoObjectsTree+Tree.ReloadNodesAsync(Func<CancellationToken, Task<Nodes>> loadNodesTask) in C:/dev/gc/gitextensions_4/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs:line 287
   at async void GitUI.BranchTreePanel.RepoObjectsTree.AddTree(Tree tree)+(?) => { } [1] in C:/dev/gc/gitextensions_4/GitUI/BranchTreePanel/RepoObjectsTree.cs:line 399
   at async void GitUI.ThreadHelper.FileAndForget(Task task, Func<Exception, bool> fileOnlyIf)+(?) => { } in C:/dev/gc/gitextensions_4/GitExtUtils/GitUI/ThreadHelper.cs:line 100
```

If you debug, you see the exception in ManagedExtenisibility.cs CreateExportProvider as _aggregateCatalog is null.

This occurs after MEF in Program.cs RunApplication() ab9ba807442d045445319069bc0c8aa55c5fd969
MEF are not init in tests. 

Not sure if this is the best solution.

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
