### PR TITLE
Improve handling of encodings with conflicting names

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3883,7 +3883,7 @@ namespace GitCommands
         [return: NotNullIfNotNull("s")]
         public static string? ReEncodeString(string? s, Encoding fromEncoding, Encoding toEncoding)
         {
-            if (s is null || fromEncoding.HeaderName == toEncoding.HeaderName)
+            if (s is null || fromEncoding.WebName == toEncoding.WebName)
             {
                 return s;
             }
@@ -3940,7 +3940,7 @@ namespace GitCommands
                 {
                     return Encoding.UTF8;
                 }
-                else if (encodingName.Equals(LosslessEncoding.HeaderName, StringComparison.InvariantCultureIgnoreCase))
+                else if (encodingName.Equals(LosslessEncoding.WebName, StringComparison.InvariantCultureIgnoreCase))
                 {
                     // no recoding is needed
                     return null;

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -2056,7 +2056,7 @@ namespace GitCommands
         {
             void AddEncoding(Encoding e)
             {
-                AvailableEncodings[e.HeaderName] = e;
+                AvailableEncodings[e.WebName] = e;
             }
 
             void AddEncodingByName(string s)
@@ -2098,7 +2098,7 @@ namespace GitCommands
                 foreach (var encodingName in availableEncodings.LazySplit(';'))
                 {
 #pragma warning disable SYSLIB0001 // Type or member is obsolete
-                    if (encodingName == Encoding.UTF7.HeaderName)
+                    if (encodingName == Encoding.UTF7.WebName)
 #pragma warning restore SYSLIB0001 // Type or member is obsolete
                     {
                         // UTF-7 is no longer supported, see: https://github.com/dotnet/docs/issues/19274
@@ -2106,7 +2106,7 @@ namespace GitCommands
                     }
 
                     // create utf-8 without BOM
-                    if (encodingName == utf8.HeaderName)
+                    if (encodingName == utf8.WebName)
                     {
                         AddEncoding(utf8);
                     }
@@ -2128,8 +2128,8 @@ namespace GitCommands
 
         private static void SaveEncodings()
         {
-            string availableEncodings = AvailableEncodings.Values.Select(e => e.HeaderName).Join(";");
-            availableEncodings = availableEncodings.Replace(Encoding.Default.HeaderName, "Default");
+            string availableEncodings = AvailableEncodings.Values.Select(e => e.WebName).Join(";");
+            availableEncodings = availableEncodings.Replace(Encoding.Default.WebName, "Default");
             SetString("AvailableEncodings", availableEncodings);
         }
 

--- a/GitCommands/Settings/ConfigFileSettings.cs
+++ b/GitCommands/Settings/ConfigFileSettings.cs
@@ -169,7 +169,7 @@ namespace GitCommands.Settings
 
         private void SetEncoding(string settingName, Encoding? encoding)
         {
-            SetValue(settingName, encoding?.HeaderName);
+            SetValue(settingName, encoding?.WebName);
         }
     }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
@@ -29,26 +29,21 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                 ListIncludedEncodings.EndUpdate();
             }
 
-            var availableEncoding = Encoding.GetEncodings()
+            object[] selectableEncodings = Encoding.GetEncodings()
                 .Select(ei => ei.GetEncoding())
+                .Select(e => e.GetType() == typeof(UTF8Encoding) ? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false) : e) // If exists utf-8, then replace to utf-8 without BOM
 #pragma warning disable SYSLIB0001 // Type or member is obsolete
                 .Where(e => e != Encoding.UTF7) // UTF-7 is no longer supported, see: https://github.com/dotnet/docs/issues/19274
 #pragma warning restore SYSLIB0001 // Type or member is obsolete
-                .Where(e => !includedEncoding.ContainsKey(e.HeaderName))
-                .ToList();
-
-            // If exists utf-8, then replace to utf-8 without BOM
-            var utf8 = availableEncoding.FirstOrDefault(e => typeof(UTF8Encoding) == e.GetType());
-            if (utf8 is not null)
-            {
-                availableEncoding.Remove(utf8);
-                availableEncoding.Add(new UTF8Encoding(false));
-            }
+                .Where(e => !includedEncoding.ContainsKey(e.WebName))
+                .GroupBy(e => e.WebName)
+                .Select(group => group.First()) // ignore encodings which cannot be distinguished, keep first only
+                .ToArray<object>();
 
             ListAvailableEncodings.BeginUpdate();
             try
             {
-                ListAvailableEncodings.Items.AddRange(availableEncoding.ToArray<object>());
+                ListAvailableEncodings.Items.AddRange(selectableEncodings);
                 ListAvailableEncodings.DisplayMember = nameof(Encoding.EncodingName);
             }
             finally
@@ -61,9 +56,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         {
             if (ListAvailableEncodings.SelectedItem is not null)
             {
-                var index = ListAvailableEncodings.SelectedIndex;
                 ListIncludedEncodings.Items.Add(ListAvailableEncodings.SelectedItem);
-                ListAvailableEncodings.Items.RemoveAt(index);
+                ListAvailableEncodings.Items.RemoveAt(ListAvailableEncodings.SelectedIndex);
             }
         }
 
@@ -72,7 +66,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             AppSettings.AvailableEncodings.Clear();
             foreach (Encoding encoding in ListIncludedEncodings.Items)
             {
-                AppSettings.AvailableEncodings.Add(encoding.HeaderName, encoding);
+                AppSettings.AvailableEncodings.Add(encoding.WebName, encoding);
             }
 
             DialogResult = DialogResult.OK;


### PR DESCRIPTION
Fixes #9395
#9396 for `master`

## Proposed changes

- Use `Encoding.WebName` instead of `Encoding.HeaderName` in order to reduce conflicts (Japanese and Korean)
  https://github.com/gitextensions/gitextensions/issues/9395#issuecomment-885231492
- Fill `ListAvailableEncodings` only with the first occurrence of a `WebName`

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 095acfd6fc9b751d95d6ce430d36f57e9be8ad2f
- Git 2.31.1.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET Framework 4.8.4360.0
- DPI 96dpi (no scaling)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).