### PR TITLE
ConEmu require ExecutableCommandLine to be set

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2982,7 +2982,7 @@ namespace GitUI.CommandsDialogs
                     WhenConsoleProcessExits = WhenConsoleProcessExits.CloseConsoleEmulator
                 };
 
-                string? shellType = AppSettings.ConEmuTerminal.Value;
+                string shellType = AppSettings.ConEmuTerminal.Value;
                 startInfo.ConsoleProcessCommandLine = _shellProvider.GetShellCommandLine(shellType);
 
                 // Set path to git in this window (actually, effective with CMD only)

--- a/GitUI/Shells/ShellProvider.cs
+++ b/GitUI/Shells/ShellProvider.cs
@@ -13,12 +13,13 @@ namespace GitUI.Shells
 
         public IShellDescriptor GetShell(string? name) => Shells.FirstOrDefault(s => s.Name == name) ?? DefaultShell;
 
-        public string? GetShellCommandLine(string? shellType)
+        public string GetShellCommandLine(string? shellType)
         {
             var shell = GetShell(shellType);
 
-            if (!shell.HasExecutable)
+            if (!shell.HasExecutable || shell.ExecutableCommandLine is null)
             {
+                // Fallback to default if ExecutableCommandLine is not set
                 return ConEmuConstants.DefaultConsoleCommandLine;
             }
 


### PR DESCRIPTION
Fixes #9471

## Proposed changes

ConEmuStartInfo.ConsoleProcessCommandLine cannot be assigned with null.
It seems like #8213 changes does not assign ExecutableCommandLine in all situations.

To be cherry-picked to 3.5

## Test methodology <!-- How did you ensure quality? -->

review

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
