### PR TITLE
SetDiff: Init for CommitDiff

### DIFF
--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -131,17 +131,19 @@ namespace GitUI.CommandsDialogs
             lblHeadCommit.Text = _headCommitDisplayStr;
 
             Validates.NotNull(_headRevision);
-
+            GitRevision[] revisions;
             if (ckCompareToMergeBase.Checked)
             {
                 Validates.NotNull(_mergeBase);
-                DiffFiles.SetDiffs(new[] { _headRevision, _mergeBase });
+                revisions = new[] { _headRevision, _mergeBase };
             }
             else
             {
                 Validates.NotNull(_baseRevision);
-                DiffFiles.SetDiffs(new[] { _headRevision, _baseRevision });
+                revisions = new[] { _headRevision, _baseRevision };
             }
+
+            DiffFiles.SetDiffs(revisions, _headRevision.ObjectId);
 
             // Bug in git-for-windows: Comparing working directory to any branch, fails, due to -R
             // I.e., git difftool --gui --no-prompt --dir-diff -R HEAD fails, but

--- a/GitUI/CommandsDialogs/FormLog.cs
+++ b/GitUI/CommandsDialogs/FormLog.cs
@@ -60,7 +60,7 @@ namespace GitUI.CommandsDialogs
         {
             using (WaitCursorScope.Enter())
             {
-                DiffFiles.SetDiffs(RevisionGrid.GetSelectedRevisions());
+                DiffFiles.SetDiffs(RevisionGrid.GetSelectedRevisions(), RevisionGrid.CurrentCheckout);
             }
         }
 

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -52,7 +52,7 @@ namespace GitUI.UserControls
 
             if (revision is not null)
             {
-                DiffFiles.SetDiffs(new[] { revision });
+                DiffFiles.SetDiffs(new[] { revision }, null);
                 if (fileToSelect is not null)
                 {
                     var itemToSelect = DiffFiles.AllItems.FirstOrDefault(i => i.Item.Name == fileToSelect);

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -52,7 +52,7 @@ namespace GitUI.UserControls
 
             if (revision is not null)
             {
-                DiffFiles.SetDiffs(new[] { revision }, null);
+                DiffFiles.SetDiffs(new[] { revision }, headId: null);
                 if (fileToSelect is not null)
                 {
                     var itemToSelect = DiffFiles.AllItems.FirstOrDefault(i => i.Item.Name == fileToSelect);

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -197,7 +197,7 @@ namespace GitUI
             }
         }
 
-        public void Bind(Func<ObjectId?, string>? describeRevision, Func<GitRevision, GitRevision> getActualRevision)
+        public void Bind(Func<ObjectId, string> describeRevision, Func<GitRevision, GitRevision> getActualRevision)
         {
             DescribeRevision = describeRevision;
             _diffCalculator.DescribeRevision = describeRevision;
@@ -673,7 +673,7 @@ namespace GitUI
             _nextIndexToSelect = -1;
         }
 
-        public void SetDiffs(IReadOnlyList<GitRevision> revisions, ObjectId? headId = null)
+        public void SetDiffs(IReadOnlyList<GitRevision> revisions, ObjectId? headId)
         {
             _enableDisablingShowDiffForAllParents = true;
             GitItemStatusesWithDescription = _diffCalculator.SetDiffs(revisions, headId);


### PR DESCRIPTION
Followup to regression in #9426 (in master only)
Second part of https://github.com/gitextensions/gitextensions/pull/9393#issuecomment-896725634

## Proposed changes

Function GetActualRevision was not set in CommitDiff form, causing a NRE

## Test methodology <!-- How did you ensure quality? -->

Manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
