### PR TITLE
Execution interface cleanup

### DIFF
--- a/GitCommands/FileHelper.cs
+++ b/GitCommands/FileHelper.cs
@@ -75,8 +75,13 @@ namespace GitCommands
                 "--",
                 fileName.Quote()
             };
-            string result = module.GitExecutable.GetOutput(cmd, throwOnErrorOutput: false);
-            var lines = result.Split(Delimiters.NullAndLineFeed);
+            GitUIPluginInterfaces.ExecutionResult result = module.GitExecutable.Execute(cmd, throwOnErrorOutput: false);
+            if (!result.ExitedSuccessfully)
+            {
+                return null;
+            }
+
+            var lines = result.StandardOutput.Split(Delimiters.NullAndLineFeed);
             Dictionary<string, string> attributes = new();
             for (int i = 0; i < lines.Length - 2; i += 3)
             {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -880,7 +880,7 @@ namespace GitCommands
                 { !string.IsNullOrWhiteSpace(fileName), "--" },
                 fileName.ToPosixPath().QuoteNE()
             };
-            using var process = _gitExecutable.Start(args, createWindow: true, throwOnErrorOutput: true);
+            using var process = _gitExecutable.Start(args, createWindow: true);
             process.WaitForExit();
         }
 
@@ -2152,8 +2152,7 @@ namespace GitCommands
 
             static IReadOnlyList<Remote> ParseRemotes(ExecutionResult result)
             {
-                IEnumerable<string> lines = result.StandardOutput.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries)
-                    .Concat(result.StandardError.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries));
+                IEnumerable<string> lines = result.StandardOutput.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries);
                 List<Remote> remotes = new();
 
                 // See tests for explanation of the format

--- a/GitCommands/Git/SystemEncodingReader.cs
+++ b/GitCommands/Git/SystemEncodingReader.cs
@@ -48,7 +48,8 @@ namespace GitCommands.Git
                     controlStr
                 };
 
-                string? s = _module.GitExecutable.GetOutput(arguments, outputEncoding: Encoding.UTF8, throwOnErrorOutput: false);
+                ExecutionResult result = _module.GitExecutable.Execute(arguments, outputEncoding: Encoding.UTF8, throwOnErrorOutput: false);
+                string? s = result.AllOutput;
                 if (s is not null && s.IndexOf(controlStr) != -1)
                 {
                     systemEncoding = new UTF8Encoding(false);

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -572,7 +572,7 @@ namespace GitUI.CommandsDialogs
 
                     // Check exitcode AND timestamp of the file. If exitcode is success and
                     // time timestamp is changed, we are pretty sure the merge was done.
-                    if (res.ExitCode == 0 && lastWriteTimeBeforeMerge != lastWriteTimeAfterMerge)
+                    if (res.ExitedSuccessfully && lastWriteTimeBeforeMerge != lastWriteTimeAfterMerge)
                     {
                         StageFile(item.Filename);
                     }

--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -134,7 +134,8 @@ namespace GitUI.Script
                 command = command.Replace(NavigateToPrefix, string.Empty);
                 if (!string.IsNullOrEmpty(command))
                 {
-                    string revisionRef = new Executable(command, module.WorkingDir).GetOutputLines(argument).FirstOrDefault();
+                    ExecutionResult result = new Executable(command, module.WorkingDir).Execute(argument);
+                    string revisionRef = result.StandardOutput.Split('\n').FirstOrDefault();
 
                     if (revisionRef is not null)
                     {

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1156,7 +1156,8 @@ namespace GitUI
                 };
 
                 HashSet<string?> setOfFileNames = new();
-                var lines = Module.GitExecutable.GetOutputLines(args, outputEncoding: GitModule.LosslessEncoding, throwOnErrorOutput: false);
+                ExecutionResult result = Module.GitExecutable.Execute(args, outputEncoding: GitModule.LosslessEncoding, throwOnErrorOutput: false);
+                var lines = result.StandardOutput.LazySplit('\n');
 
                 // TODO Check the exit code and warn the user that rename detection could not be done.
 
@@ -1497,7 +1498,8 @@ namespace GitUI
                 objectId
             };
 
-            foreach (var line in Module.GitExecutable.GetOutputLines(args, throwOnErrorOutput: false))
+            ExecutionResult result = Module.GitExecutable.Execute(args, throwOnErrorOutput: false);
+            foreach (var line in result.StandardOutput.LazySplit('\n'))
             {
                 if (ObjectId.TryParse(line, out var parentId))
                 {

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -136,7 +136,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
                  context.ReferenceBranch
             };
 
-            var result = context.Commands.GitExecutable.Execute(args);
+            var result = context.Commands.GitExecutable.Execute(args, throwOnErrorOutput: false);
 
             if (!result.ExitedSuccessfully)
             {
@@ -144,7 +144,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
                 return Array.Empty<string>();
             }
 
-            return _commandOutputParser.GetBranchNames(result.AllOutput)
+            return _commandOutputParser.GetBranchNames(result.StandardOutput)
                                         .Where(branchName => branchName != curBranch && branchName != context.ReferenceBranch)
                                         .Where(branchName => (!context.IncludeRemotes || branchName.StartsWith(context.RemoteRepositoryName + "/"))
                                                             && (regex is null || regex.IsMatch(branchName) == regexMustMatch));

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -149,7 +149,7 @@ namespace GitExtensions.Plugins.GitFlow
             GitArgumentBuilder args = new("flow") { typeBranch };
             var result = _gitUiCommands.GitModule.GitExecutable.Execute(args);
 
-            if (result.ExitCode != 0 || result.StandardOutput is null)
+            if (!result.ExitedSuccessfully || result.StandardOutput is null)
             {
                 return Array.Empty<string>();
             }
@@ -312,7 +312,7 @@ namespace GitExtensions.Plugins.GitFlow
             txtResult.Text = "running...";
             ForceRefresh(txtResult);
 
-            var result = _gitUiCommands.GitModule.GitExecutable.Execute(commandText);
+            var result = _gitUiCommands.GitModule.GitExecutable.Execute(commandText, throwOnErrorOutput: false);
 
             IsRefreshNeeded = true;
 
@@ -321,7 +321,7 @@ namespace GitExtensions.Plugins.GitFlow
 
             var resultText = Regex.Replace(result.AllOutput, @"\r\n?|\n", Environment.NewLine);
 
-            if (result.ExitCode == 0)
+            if (result.ExitedSuccessfully)
             {
                 pbResultCommand.Image = DpiUtil.Scale(Resource.success);
                 ShowToolTip(pbResultCommand, resultText);
@@ -335,7 +335,7 @@ namespace GitExtensions.Plugins.GitFlow
 
             txtResult.Text = resultText;
 
-            return result.ExitCode == 0;
+            return result.ExitedSuccessfully;
         }
 
         #endregion

--- a/Plugins/Statistics/GitImpact/ImpactLoader.cs
+++ b/Plugins/Statistics/GitImpact/ImpactLoader.cs
@@ -146,7 +146,8 @@ namespace GitExtensions.Plugins.GitImpact
 
         private void LoadModuleInfo(string command, IGitModule module, CancellationToken token)
         {
-            using var lineEnumerator = module.GitExecutable.GetOutputLines(command).GetEnumerator();
+            ExecutionResult result = module.GitExecutable.Execute(command);
+            using var lineEnumerator = result.StandardOutput.Split('\n').ToList().GetEnumerator();
 
             // Analyze commit listing
             while (!token.IsCancellationRequested && lineEnumerator.MoveNext())

--- a/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
+++ b/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
@@ -136,7 +136,7 @@ namespace CommonTestUtils
             // Submodules require at least one commit
             subModuleHelper.Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Initial empty commit""");
 
-            Module.GitExecutable.GetOutput(GitCommandHelpers.AddSubmoduleCmd(subModuleHelper.Module.WorkingDir.ToPosixPath(), path, null, true), throwOnErrorOutput: false);
+            Module.GitExecutable.Execute(GitCommandHelpers.AddSubmoduleCmd(subModuleHelper.Module.WorkingDir.ToPosixPath(), path, null, true), throwOnErrorOutput: false);
             Module.GitExecutable.GetOutput(@"commit -am ""Add submodule""");
         }
 
@@ -146,7 +146,7 @@ namespace CommonTestUtils
         /// <returns>All submodule Modules</returns>
         public IEnumerable<GitModule> GetSubmodulesRecursive()
         {
-            Module.GitExecutable.GetOutput(@"submodule update --init --recursive", throwOnErrorOutput: false);
+            Module.GitExecutable.Execute(@"submodule update --init --recursive", throwOnErrorOutput: false);
             var paths = Module.GetSubmodulesLocalPaths(recursive: true);
             return paths.Select(path =>
             {

--- a/UnitTests/GitCommands.Tests/Config/ConfigFileTest.cs
+++ b/UnitTests/GitCommands.Tests/Config/ConfigFileTest.cs
@@ -55,7 +55,7 @@ namespace GitCommandsTests.Config
                 // Quote the key without unescaping internal quotes
                 $"\"{key}\""
             };
-            return Module.GitExecutable.GetOutput(args, throwOnErrorOutput: false).TrimEnd('\n');
+            return Module.GitExecutable.Execute(args, throwOnErrorOutput: false).StandardOutput.TrimEnd('\n');
         }
 
         private void CheckValueIsEqual(ConfigFile configFile, string key, string expectedValue)

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -482,31 +482,6 @@ namespace GitCommandsTests
             Assert.AreEqual(headId, objectId.ToString());
         }
 
-        [TestCase("fatal: not a git repository (or any of the parent directories): .git")] // git version 2.20.1 (Apple Git-117)
-        [TestCase("fatal: Not a git repository (or any of the parent directories): .git")] // git version 2.16.1.windows.4
-        public void GetRemotes_should_return_empty_list_not_inside_git_repo(string warning)
-        {
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
-            {
-                using (_executable.StageOutput("remote -v", warning))
-                {
-                    var remotes = await _gitModule.GetRemotesAsync();
-
-                    remotes.Should().BeEmpty();
-                }
-            });
-        }
-
-        [TestCase("fatal: not a git repository (or any of the parent directories): .git")] // git version 2.20.1 (Apple Git-117)
-        [TestCase("fatal: Not a git repository (or any of the parent directories): .git")] // git version 2.16.1.windows.4
-        public void GetRemotes_should_not_throw_if_not_inside_git_repo(string warning)
-        {
-            using (_executable.StageOutput("remote -v", warning))
-            {
-                Assert.DoesNotThrowAsync(async () => await _gitModule.GetRemotesAsync());
-            }
-        }
-
         [TestCase("ignorenopush\tgit@github.com:drewnoakes/gitextensions.git (fetch)")]
         [TestCase("ignorenopull\tgit@github.com:drewnoakes/gitextensions.git (push)")]
         public async Task GetRemotes_should_throw_if_not_pairs(string line)
@@ -745,13 +720,13 @@ namespace GitCommandsTests
                     var child = moduleTestHelpers[i];
 
                     // Add child as submodule of parent
-                    parent.Module.GitExecutable.GetOutput(GitCommandHelpers.AddSubmoduleCmd(child.Module.WorkingDir.ToPosixPath(), $"repo{i}", null, true), throwOnErrorOutput: false);
+                    parent.Module.GitExecutable.Execute(GitCommandHelpers.AddSubmoduleCmd(child.Module.WorkingDir.ToPosixPath(), $"repo{i}", null, true), throwOnErrorOutput: false);
                     parent.Module.GitExecutable.GetOutput(@"commit -am ""Add submodule""");
                 }
 
                 // Init all modules of root
                 var root = moduleTestHelpers[0];
-                root.Module.GitExecutable.GetOutput(@"submodule update --init --recursive", throwOnErrorOutput: false);
+                root.Module.GitExecutable.Execute(@"submodule update --init --recursive", throwOnErrorOutput: false);
 
                 var paths = root.Module.GetSubmodulesLocalPaths(recursive: true);
                 Assert.AreEqual(new string[] { "repo1", "repo1/repo2", "repo1/repo2/repo3" }, paths, $"Modules: {string.Join(" ", paths)}");

--- a/UnitTests/GitCommands.Tests/Submodules/SubmoduleStatusProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/Submodules/SubmoduleStatusProviderTests.cs
@@ -183,7 +183,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
 
             // Revert the change
-            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -219,7 +219,7 @@ namespace GitCommandsTests.Submodules
 
             // Revert the change
             File.Delete(Path.Combine(_repo2Module.WorkingDir, "test.txt"));
-            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -302,7 +302,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
 
             // Revert the change
-            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -337,7 +337,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
 
             // Revert the change
-            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo3Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -401,7 +401,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Should().BeNull();
 
             // Revert the change
-            _repo1Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo1Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -500,7 +500,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.IsDirty.Should().BeTrue();
 
             // Revert the change
-            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo3Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -561,7 +561,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Should().BeNull();
 
             // Revert the change
-            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo3Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -590,7 +590,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Should().BeNull();
 
             // Revert the change
-            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -678,7 +678,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.IsDirty.Should().BeTrue();
 
             // Revert the change
-            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
             await CheckRevertedStatus(result);
         }
 
@@ -705,11 +705,11 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Should().BeNull();
 
             // Revert the change
-            _repo1Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo1Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
             File.Delete(Path.Combine(_repo1Module.WorkingDir, "test.txt"));
-            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
             File.Delete(Path.Combine(_repo2Module.WorkingDir, "test.txt"));
-            _repo3Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo3Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
             File.Delete(Path.Combine(_repo3Module.WorkingDir, "test.txt"));
             await CheckRevertedStatus(result);
         }
@@ -744,7 +744,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.IsDirty.Should().BeTrue();
 
             // Revert the change
-            _repo2Module.GitExecutable.GetOutput(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
             File.Delete(Path.Combine(_repo3Module.WorkingDir, "test.txt"));
             await CheckRevertedStatus(result);
         }


### PR DESCRIPTION
Follow up to #9056, some discussions in #9476 too

## Proposed changes

* Execution: Adjust use of exit status, alloutput
Review that stderr (included in AllOutput) is not included in parsing of output data

* GetOutput only to be used where exit code is 0 and no error output

* GetOutputlines() removed, all callsites hanged on the call anyway.

Replace calls with throwOnErrorOutput:false with Execute()
Parse only StandardOutput for the replaced calls,
also where throwOnErrorOutput:false was set before.


## Test methodology <!-- How did you ensure quality? -->

manual

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
