### PR TITLE
Show ChecklistSettings also for settings without an autosolver

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -156,7 +156,7 @@ namespace GitExtensions
                         using var checklistSettingsPage = SettingsPageBase.Create<ChecklistSettingsPage>(fakePageHost);
                         if (!checklistSettingsPage.CheckSettings())
                         {
-                            if (!checkSettingsLogic.AutoSolveAllSettings())
+                            if (!checkSettingsLogic.AutoSolveAllSettings() && !checklistSettingsPage.CheckSettings())
                             {
                                 uiCommands.StartSettingsDialog();
                             }

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -156,7 +156,7 @@ namespace GitExtensions
                         using var checklistSettingsPage = SettingsPageBase.Create<ChecklistSettingsPage>(fakePageHost);
                         if (!checklistSettingsPage.CheckSettings())
                         {
-                            if (!checkSettingsLogic.AutoSolveAllSettings() && !checklistSettingsPage.CheckSettings())
+                            if (!checkSettingsLogic.AutoSolveAllSettings() || !checklistSettingsPage.CheckSettings())
                             {
                                 uiCommands.StartSettingsDialog();
                             }


### PR DESCRIPTION
See https://github.com/gitextensions/gitextensions/issues/9464#issuecomment-898202703

## Proposed changes

CkecklistSettings at startup was not solved if the "autosolver" was successful (see `AutoSolveAllSettings()` for settings like Git).

For settings without an autosolve like SSH the page was not shown.

## Screenshots <!-- Remove this section if PR does not change UI -->

The settings page as seen in the issue is shown after startup.

Note that some paths in %windir% are not checked correctly (see #9355), the user must uncheck "Check at startup" manually.

To be cherry picked to 3.5.

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
