### PR TITLE
CommitDiff: Do not Join() in Dispose()

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -152,8 +152,7 @@ namespace GitUI.CommitInfo
         {
             if (disposing)
             {
-                _asyncLoadCancellation.CancelCurrent();
-                ThreadHelper.JoinPendingOperations(); // those run with FileAndForget
+                _asyncLoadCancellation.Dispose();
 
                 components?.Dispose();
             }


### PR DESCRIPTION
The direct cause of #9440 as it was submitted, required for a general solution too.
This is required to be able to add cancellable Git commands (at least to see the effect...).

## Proposed changes

#9405 407928a20cb395d846c6b6c07b00f102aaad199e added `ThreadHelper.JoinPendingOperations()` in Dispose for CommitInfo.
This will cause Dispose in the control to await any tasks started in the application, not just the tasks in this control.

There may be some cancellation tokens required in the existing tasks, I have not seen any obvious candidates.
For now I propose to remove the join

## Test methodology <!-- How did you ensure quality? -->

There are tests for this.

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->
I agree that the maintainer squash merge this PR (if the commit message is clear).
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
