### PR TITLE
Truncate tooltips for blame commit long summary

### DIFF
--- a/GitCommands/Git/GitBlame.cs
+++ b/GitCommands/Git/GitBlame.cs
@@ -61,7 +61,17 @@ namespace GitCommands
             FileName = fileName;
         }
 
+        public string ToString(Func<string?, string?> summaryBuilderFunc)
+        {
+            return ToString(summaryBuilderFunc(Summary) ?? Summary);
+        }
+
         public override string ToString()
+        {
+            return ToString(Summary);
+        }
+
+        private string ToString(string summary)
         {
             StringBuilder s = new();
 
@@ -74,7 +84,7 @@ namespace GitCommands
             }
 
             s.Append("Commit hash: ").AppendLine(ObjectId.ToShortString());
-            s.Append("Summary: ").AppendLine(Summary);
+            s.Append("Summary: ").AppendLine(summary);
             s.AppendLine();
             s.Append("FileName: ").Append(FileName);
 

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -160,23 +160,6 @@ namespace GitUI.Blame
             }
         }
 
-        private string GetBlameToolTipText(GitBlameCommit blameCommit)
-        {
-            GitBlameCommit commitWithTruncatedSummary = new(blameCommit.ObjectId,
-                blameCommit.Author,
-                blameCommit.AuthorMail,
-                blameCommit.AuthorTime,
-                blameCommit.AuthorTimeZone,
-                blameCommit.Committer,
-                blameCommit.CommitterMail,
-                blameCommit.CommitterTime,
-                blameCommit.CommitterTimeZone,
-                summaryBuilder.BuildSummary(blameCommit.Summary),
-                blameCommit.FileName);
-
-            return commitWithTruncatedSummary.ToString();
-        }
-
         private void BlameFile_MouseMove(object sender, MouseEventArgs e)
         {
             if (_blame is null)
@@ -683,8 +666,6 @@ namespace GitUI.Blame
                 => _control.BuildAuthorLine(line, lineBuilder, dateTimeFormat, filename, showAuthor, showAuthorDate, showOriginalFilePath, displayAuthorFirst);
 
             public (string gutter, string body, List<GitBlameEntry> avatars) BuildBlameContents(string filename) => _control.BuildBlameContents(filename, avatarSize: 10);
-
-            public string GetBlameToolTipText(GitBlameCommit commit, IGitRevisionSummaryBuilder summaryBuilder) => _control.GetBlameToolTipText(commit, summaryBuilder);
 
             public List<GitBlameEntry> CalculateBlameGutterData(IReadOnlyList<GitBlameLine> blameLines)
                 => _control.CalculateBlameGutterData(blameLines);

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -156,12 +156,11 @@ namespace GitUI.Blame
                 _tooltipCommit = blameCommit;
                 _lastTooltipX = newTooltipX;
                 _lastTooltipY = newTooltipY;
-                blameTooltip.Show(GetBlameToolTipText(blameCommit, _gitRevisionSummaryBuilder), this, newTooltipX, newTooltipY);
+                blameTooltip.Show(blameCommit.ToString(_gitRevisionSummaryBuilder.BuildSummary), this, newTooltipX, newTooltipY);
             }
         }
 
-        private string GetBlameToolTipText(GitBlameCommit blameCommit,
-            IGitRevisionSummaryBuilder summaryBuilder)
+        private string GetBlameToolTipText(GitBlameCommit blameCommit)
         {
             GitBlameCommit commitWithTruncatedSummary = new(blameCommit.ObjectId,
                 blameCommit.Author,

--- a/UnitTests/GitCommands.Tests/Git/GitBlameCommitTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitBlameCommitTests.cs
@@ -50,7 +50,7 @@ namespace GitCommandsTests.Git
             var authorTime = DateTime.Now;
             var commitHash = ObjectId.Random();
 
-            Func<string?, string?> summaryBuilder = (input) => "SOME BUILDER TEXT: " + input;
+            Func<string?, string?> summaryBuilder = (input) => $"SOME BUILDER TEXT: {input}";
 
             StringBuilder str = new();
 

--- a/UnitTests/GitCommands.Tests/Git/GitBlameCommitTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitBlameCommitTests.cs
@@ -19,10 +19,10 @@ namespace GitCommandsTests.Git
             StringBuilder str = new();
 
             str.AppendLine("Author: Author");
-            str.AppendLine("Author date: " + authorTime);
+            str.AppendLine($"Author date: {authorTime}");
             str.AppendLine("Committer: committer");
-            str.AppendLine("Commit date: " + committerTime);
-            str.AppendLine("Commit hash: " + commitHash.ToShortString());
+            str.AppendLine($"Commit date: {committerTime}");
+            str.AppendLine($"Commit hash: {commitHash.ToShortString()}");
             str.AppendLine("Summary: test summary");
             str.AppendLine();
             str.Append("FileName: fileName.txt");
@@ -55,10 +55,10 @@ namespace GitCommandsTests.Git
             StringBuilder str = new();
 
             str.AppendLine("Author: Author");
-            str.AppendLine("Author date: " + authorTime);
+            str.AppendLine($"Author date: {authorTime}");
             str.AppendLine("Committer: committer");
-            str.AppendLine("Commit date: " + committerTime);
-            str.AppendLine("Commit hash: " + commitHash.ToShortString());
+            str.AppendLine($"Commit date: {committerTime}");
+            str.AppendLine($"Commit hash: {commitHash.ToShortString()}");
             str.AppendLine("Summary: SOME BUILDER TEXT: test summary");
             str.AppendLine();
             str.Append("FileName: fileName.txt");
@@ -91,10 +91,10 @@ namespace GitCommandsTests.Git
             StringBuilder str = new();
 
             str.AppendLine("Author: Author");
-            str.AppendLine("Author date: " + authorTime);
+            str.AppendLine($"Author date: {authorTime}");
             str.AppendLine("Committer: committer");
-            str.AppendLine("Commit date: " + committerTime);
-            str.AppendLine("Commit hash: " + commitHash.ToShortString());
+            str.AppendLine($"Commit date: {committerTime}");
+            str.AppendLine($"Commit hash: {commitHash.ToShortString()}");
             str.AppendLine("Summary: test summary");
             str.AppendLine();
             str.Append("FileName: fileName.txt");

--- a/UnitTests/GitCommands.Tests/Git/GitBlameCommitTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitBlameCommitTests.cs
@@ -42,5 +42,77 @@ namespace GitCommandsTests.Git
 
             Assert.AreEqual(str.ToString(), commit.ToString());
         }
+
+        [Test]
+        public void ToString_When_Not_Null_Returns_Output()
+        {
+            var committerTime = DateTime.Now;
+            var authorTime = DateTime.Now;
+            var commitHash = ObjectId.Random();
+
+            Func<string?, string?> summaryBuilder = (input) => "SOME BUILDER TEXT: " + input;
+
+            StringBuilder str = new();
+
+            str.AppendLine("Author: Author");
+            str.AppendLine("Author date: " + authorTime);
+            str.AppendLine("Committer: committer");
+            str.AppendLine("Commit date: " + committerTime);
+            str.AppendLine("Commit hash: " + commitHash.ToShortString());
+            str.AppendLine("Summary: SOME BUILDER TEXT: test summary");
+            str.AppendLine();
+            str.Append("FileName: fileName.txt");
+
+            GitBlameCommit commit = new(
+                commitHash,
+                "Author",
+                "author@authormail.com",
+                authorTime,
+                "authorTimeZone",
+                "committer",
+                "committer@authormail.com",
+                committerTime,
+                "committerTimeZone",
+                "test summary",
+                "fileName.txt");
+
+            Assert.AreEqual(str.ToString(), commit.ToString(summaryBuilder));
+        }
+
+        [Test]
+        public void ToString_When_Null_Returns_Input()
+        {
+            var committerTime = DateTime.Now;
+            var authorTime = DateTime.Now;
+            var commitHash = ObjectId.Random();
+
+            Func<string?, string?> summaryBuilder = (input) => null;
+
+            StringBuilder str = new();
+
+            str.AppendLine("Author: Author");
+            str.AppendLine("Author date: " + authorTime);
+            str.AppendLine("Committer: committer");
+            str.AppendLine("Commit date: " + committerTime);
+            str.AppendLine("Commit hash: " + commitHash.ToShortString());
+            str.AppendLine("Summary: test summary");
+            str.AppendLine();
+            str.Append("FileName: fileName.txt");
+
+            GitBlameCommit commit = new(
+                commitHash,
+                "Author",
+                "author@authormail.com",
+                authorTime,
+                "authorTimeZone",
+                "committer",
+                "committer@authormail.com",
+                committerTime,
+                "committerTimeZone",
+                "test summary",
+                "fileName.txt");
+
+            Assert.AreEqual(str.ToString(), commit.ToString(summaryBuilder));
+        }
     }
 }

--- a/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
@@ -254,33 +254,5 @@ namespace GitUITests.UserControls
             blameEntries[6].AgeBucketIndex.Should().Be(6);
             blameEntries[7].AgeBucketIndex.Should().Be(6);
         }
-
-        [Test]
-        public void GetBlameToolTipText_When_commit_present_Then_uses_summary_builder_to_truncate_summary()
-        {
-            // Given
-            var summaryBuilder = Substitute.For<IGitRevisionSummaryBuilder>();
-
-            var mockBody = "test long long long summary line";
-            summaryBuilder.BuildSummary(mockBody).Returns("test truncated summary line");
-            GitBlameCommit blameCommitForTooltip = new(
-                ObjectId.Random(),
-                "author1",
-                "author1@mail.fake",
-                new DateTime(2010, 3, 22, 12, 01, 02),
-                "authorTimeZone",
-                "committer1",
-                "committer1@authormail.com",
-                new DateTime(2010, 3, 22, 13, 01, 02),
-                "committerTimeZone",
-                mockBody,
-                "fileName.txt");
-
-            // When
-            var result = _blameControl.GetTestAccessor().GetBlameToolTipText(blameCommitForTooltip, summaryBuilder);
-
-            // Then
-            result.Should().Contain("Summary: test truncated summary line");
-        }
     }
 }

--- a/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using GitCommands;
 using GitUI.Blame;
 using GitUIPluginInterfaces;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace GitUITests.UserControls
@@ -252,6 +253,34 @@ namespace GitUITests.UserControls
             blameEntries[5].AgeBucketIndex.Should().Be(5);
             blameEntries[6].AgeBucketIndex.Should().Be(6);
             blameEntries[7].AgeBucketIndex.Should().Be(6);
+        }
+
+        [Test]
+        public void GetBlameToolTipText_When_commit_present_Then_uses_summary_builder_to_truncate_summary()
+        {
+            // Given
+            var summaryBuilder = Substitute.For<IGitRevisionSummaryBuilder>();
+
+            var mockBody = "test long long long summary line";
+            summaryBuilder.BuildSummary(mockBody).Returns("test truncated summary line");
+            GitBlameCommit blameCommitForTooltip = new(
+                ObjectId.Random(),
+                "author1",
+                "author1@mail.fake",
+                new DateTime(2010, 3, 22, 12, 01, 02),
+                "authorTimeZone",
+                "committer1",
+                "committer1@authormail.com",
+                new DateTime(2010, 3, 22, 13, 01, 02),
+                "committerTimeZone",
+                mockBody,
+                "fileName.txt");
+
+            // When
+            var result = _blameControl.GetTestAccessor().GetBlameToolTipText(blameCommitForTooltip, summaryBuilder);
+
+            // Then
+            result.Should().Contain("Summary: test truncated summary line");
         }
     }
 }

--- a/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
@@ -8,7 +8,6 @@ using FluentAssertions;
 using GitCommands;
 using GitUI.Blame;
 using GitUIPluginInterfaces;
-using NSubstitute;
 using NUnit.Framework;
 
 namespace GitUITests.UserControls


### PR DESCRIPTION
Fixes #9168

## Proposed changes

I used GitRevisionSummaryBuilder.BuildSummary on the blame commit's summary based on the approach from Revision Grid.
Also added a test to cover this truncation.
See the [PR to sign the contributors.txt](https://github.com/gitextensions/gitextensions/pull/9518).

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/89172096/130015261-f9c2e466-27fa-4bb2-bc66-ccf3c775d802.png)

### After
![image](https://user-images.githubusercontent.com/89172096/130015889-b4d9ffc7-a3cf-48c2-89ca-b2e910280804.png)

<!-- TODO -->

## Test methodology <!-- How did you ensure quality? -->

- added a unit test to cover the truncation
- manually confirmed the UI changes

## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 3.5.3.12551
- Build 00604a59a673142a3d34a22aa657466a922977f3
- Git 2.33.0.windows.1
- Microsoft Windows NT 10.0.19043.0
- .NET Framework 4.8.4300.0
- DPI 120dpi (125% scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->
I agree that the maintainer squash merge this PR (if the commit message is clear).
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
