### PR TITLE
Fix Clone URL Population

### DIFF
--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -468,12 +468,11 @@ namespace GitUI.CommandsDialogs
         }
 
         /// <summary>
-        /// Check whether the given string contains one or more valid URLs and extracts
+        /// Check whether the given string contains one or more valid git URLs and extracts
         /// the first URL that exists, if any.
         /// </summary>
         /// <remarks>
-        /// Uri.IsWellFormedUriString is used instead of Uri.TryCreate as file URIs
-        /// of the form X:\\directory\\filename should not be treated as URLs.
+        /// PathUtil.CanBeGitURL is used as a standard way to detect a git URL.
         /// The first URL extracted from <paramref name="contents"/> is assigned to
         /// <paramref name="url"/>. If <paramref name="contents"/> contains more than one URL,
         /// subsequent URLs are not extracted.

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -493,7 +493,7 @@ namespace GitUI.CommandsDialogs
             var parts = contents.Split(' ');
             foreach (string s in parts)
             {
-                if (Uri.IsWellFormedUriString(s, UriKind.Absolute))
+                if (PathUtil.CanBeGitURL(s))
                 {
                     url = s;
                     break;

--- a/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
@@ -318,6 +318,7 @@ namespace GitCommandsTests.Helpers
         [TestCase("github.com/gitextensions/gitextensions.git", true)]
         [TestCase("HTTPS://MYPRIVATEGITHUB.COM:8080/LOUDREPO.GIT", true)]
         [TestCase("git://myurl/myrepo.git", true)]
+        [TestCase("git@github.com:gitextensions/gitextensions.git", true)]
         [TestCase("github.com/gitextensions", false)]
         [TestCase("github.com/gitextensions/gitextensions/pull/9018", false)]
         [TestCase("http://", false)]

--- a/contributors.txt
+++ b/contributors.txt
@@ -162,3 +162,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/07/15, davidgiga1993, David Schumann, davidgiga1993(at)gmail.com
 2021/07/20, ransontech, Nicholas Ranson, nickjranson(at)gmail.com
 2021/08/18, yerudako, Yelyzaveta Rudakova, yelyzaveta.rudakova(at)gmail.com
+2021/08/19, BlythMeister, Chris Blyth, chris(at)blyth.me.uk


### PR DESCRIPTION
Fixes #9520

## Proposed changes

- Re-use the PathUtil.CanBeGitURL when checking parts of the string rather than only looking for a valid URL.

### Before

Clipboard had to contain a valid URL, not a valid Git URL.
This meant that urls like 'git@github.com:gitextensions/gitextensions.git' were not pulled from the clipboard.

### After

URL loaded from clipboard

## Test methodology

- Manual test
- 
- 

## Test environment(s) 

- GIT 2.33.0.windows.1
- Windows 10

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->
I agree that the maintainer squash merge this PR (if the commit message is clear).
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
