### PR TITLE
Cancellation for Executable

### DIFF
--- a/GitCommands/CustomDiffMergeToolCache.cs
+++ b/GitCommands/CustomDiffMergeToolCache.cs
@@ -73,6 +73,14 @@ namespace GitCommands
                     _tools = ParseCustomDiffMergeTool(output, defaultTool);
                 }
             }
+            catch
+            {
+                if (_tools is null)
+                {
+                    // Parsing has failed, just provide an empty list, no user notification
+                    _tools = Array.Empty<string>();
+                }
+            }
             finally
             {
                 _mutex.Release();

--- a/GitCommands/CustomDiffMergeToolCache.cs
+++ b/GitCommands/CustomDiffMergeToolCache.cs
@@ -26,23 +26,20 @@ namespace GitCommands
         public static CustomDiffMergeToolCache MergeToolCache { get; } = new(false);
 
         /// <summary>
-        /// Clear the existing caches
+        /// Clear the existing caches (await current calculation to finsh first)
         /// </summary>
-        public void Clear()
+        public async Task ClearAsync()
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-            {
-                await _mutex.WaitAsync().ConfigureAwait(false);
+            await _mutex.WaitAsync().ConfigureAwait(false);
 
-                try
-                {
-                    _tools = null;
-                }
-                finally
-                {
-                    _mutex.Release();
-                }
-            }).FileAndForget();
+            try
+            {
+                _tools = null;
+            }
+            finally
+            {
+                _mutex.Release();
+            }
         }
 
         /// <summary>

--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using GitCommands.Logging;
 using GitExtUtils;
@@ -231,6 +232,12 @@ namespace GitCommands
 
             /// <inheritdoc />
             public Task<int> WaitForExitAsync() => _exitTaskCompletionSource.Task;
+
+            /// <inheritdoc />
+            public Task WaitForProcessExitAsync(CancellationToken token)
+            {
+                return _process.WaitForExitAsync(token);
+            }
 
             /// <inheritdoc />
             public int WaitForExit()

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2344,7 +2344,8 @@ namespace GitCommands
             ExecutionResult result = await _gitExecutable.ExecuteAsync(
                 args,
                 cache: GitCommandCache,
-                outputEncoding: LosslessEncoding);
+                outputEncoding: LosslessEncoding,
+                cancellationToken: cancellationToken);
 
             return result.StandardOutput;
         }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3568,11 +3568,12 @@ namespace GitCommands
         /// </summary>
         /// <param name="isDiff">diff or merge.</param>
         /// <returns>the Git output.</returns>
-        public string GetCustomDiffMergeTools(bool isDiff)
+        public string GetCustomDiffMergeTools(bool isDiff, CancellationToken cancellationToken)
         {
             // Note that --gui has no effect here
             GitArgumentBuilder args = new(isDiff ? "difftool" : "mergetool") { "--tool-help" };
-            return _gitExecutable.GetOutput(args);
+            ExecutionResult result = _gitExecutable.Execute(args, cancellationToken: cancellationToken);
+            return result.StandardOutput;
         }
 
         public string OpenWithDifftoolDirDiff(string? firstRevision, string? secondRevision, string? customTool = null)

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -293,8 +293,8 @@ namespace GitCommands.Submodules
         private async Task UpdateSubmodulesStatusAsync(GitModule module, IReadOnlyList<GitItemStatus>? gitStatus, CancellationToken cancelToken)
         {
             _previousSubmoduleUpdateTime = DateTime.Now;
-            cancelToken.ThrowIfCancellationRequested();
             await TaskScheduler.Default;
+            cancelToken.ThrowIfCancellationRequested();
 
             if (!_submoduleInfos.ContainsKey(module.WorkingDir) || _submoduleInfos[module.WorkingDir] is null)
             {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -188,7 +188,6 @@ namespace GitUI.BranchTreePanel
                 }
 
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(token);
-                token.ThrowIfCancellationRequested();
                 TreeViewNode.ToolTipText = toolTip;
             }
         }
@@ -322,7 +321,6 @@ namespace GitUI.BranchTreePanel
             private async Task LoadNodeDetailsAsync(Nodes loadedNodes, CancellationToken token)
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(token);
-                token.ThrowIfCancellationRequested();
 
                 if (TreeViewNode.TreeView is not null)
                 {

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -162,6 +162,7 @@ namespace GitUI.CommandsDialogs
         private readonly ToolStripMenuItem _addSelectionToCommitMessageToolStripMenuItem;
         private readonly AsyncLoader _unstagedLoader = new();
         private readonly bool _useFormCommitMessage = AppSettings.UseFormCommitMessage;
+        private readonly CancellationTokenSequence _customDiffToolsSequence = new();
         private readonly CancellationTokenSequence _interactiveAddSequence = new();
         private readonly CancellationTokenSequence _viewChangesSequence = new();
         private readonly SplitterManager _splitterManager = new(new AppSettingsPath("CommitDialog"));
@@ -411,6 +412,7 @@ namespace GitUI.CommandsDialogs
             if (disposing)
             {
                 _unstagedLoader.Dispose();
+                _customDiffToolsSequence.Dispose();
                 _interactiveAddSequence.Dispose();
                 _viewChangesSequence.Dispose();
                 components?.Dispose();
@@ -629,7 +631,7 @@ namespace GitUI.CommandsDialogs
                 new(stagedOpenDifftoolToolStripMenuItem9, stagedOpenDifftoolToolStripMenuItem9_Click),
             };
 
-            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true);
+            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true, cancellationToken: _customDiffToolsSequence.Next());
         }
 
         private void FileViewer_TopScrollReached(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -31,6 +31,7 @@ namespace GitUI.CommandsDialogs
         private readonly FormBrowseMenus _formBrowseMenus;
         private readonly IFullPathResolver _fullPathResolver;
         private readonly FormFileHistoryController _controller = new();
+        private readonly CancellationTokenSequence _customDiffToolsSequence = new();
         private readonly CancellationTokenSequence _viewChangesSequence = new();
 
         private BuildReportTabPageExtension? _buildReportTabPageExtension;
@@ -177,6 +178,7 @@ namespace GitUI.CommandsDialogs
             if (disposing)
             {
                 _asyncLoader.Dispose();
+                _customDiffToolsSequence.Dispose();
                 _viewChangesSequence.Dispose();
 
                 // if the form was instantiated by the translation app, all of the following would be null
@@ -215,7 +217,7 @@ namespace GitUI.CommandsDialogs
             };
 
             const int ToolDelay = 10000;
-            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true, ToolDelay);
+            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true, ToolDelay, cancellationToken: _customDiffToolsSequence.Next());
         }
 
         private void LoadFileHistory()

--- a/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
@@ -9,19 +9,6 @@ namespace GitUI.CommandsDialogs
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components is not null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         #region Windows Form Designer generated code
 
         /// <summary>

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -117,6 +117,7 @@ namespace GitUI.CommandsDialogs
         private int _filesDeletedLocallyAndModifiedRemotelySolved;
         private int _filesModifiedLocallyAndDeletedRemotelySolved;
         private int _conflictItemsCount;
+        private readonly CancellationTokenSequence _customDiffToolsSequence = new();
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -147,6 +148,17 @@ namespace GitUI.CommandsDialogs
 
             HotkeysEnabled = true;
             Hotkeys = HotkeySettingsManager.LoadHotkeys(HotkeySettingsName);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _customDiffToolsSequence.Dispose();
+                components?.Dispose();
+            }
+
+            base.Dispose(disposing);
         }
 
         private void Mergetool_Click(object sender, EventArgs e)
@@ -302,8 +314,8 @@ namespace GitUI.CommandsDialogs
                 new(customMergetool, customMergetool_Click),
             };
 
-            const int ToolDelay = 5000;
-            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: false, ToolDelay);
+            const int ToolDelay = 500;
+            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: false, ToolDelay, cancellationToken: _customDiffToolsSequence.Next());
         }
 
         private readonly Dictionary<string, string> _mergeScripts = new()

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -43,6 +43,7 @@ namespace GitUI.CommandsDialogs
         private readonly IFullPathResolver _fullPathResolver;
         private readonly IFindFilePredicateProvider _findFilePredicateProvider;
         private readonly IGitRevisionTester _gitRevisionTester;
+        private readonly CancellationTokenSequence _customDiffToolsSequence = new();
         private readonly CancellationTokenSequence _viewChangesSequence = new();
         private readonly RememberFileContextMenuController _rememberFileContextMenuController
             = RememberFileContextMenuController.Default;
@@ -187,7 +188,7 @@ namespace GitUI.CommandsDialogs
                 new(diffTwoSelectedDifftoolToolStripMenuItem, diffTwoSelectedDiffToolToolStripMenuItem_Click)
             };
 
-            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true);
+            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true, cancellationToken: _customDiffToolsSequence.Next());
         }
 
         public void CancelLoadCustomDifftools()
@@ -257,6 +258,7 @@ namespace GitUI.CommandsDialogs
         {
             if (disposing)
             {
+                _customDiffToolsSequence.Dispose();
                 _viewChangesSequence.Dispose();
                 components?.Dispose();
             }

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -190,6 +190,11 @@ namespace GitUI.CommandsDialogs
             new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true);
         }
 
+        public void CancelLoadCustomDifftools()
+        {
+            _customDiffToolsSequence.CancelCurrent();
+        }
+
         private string GetShortcutKeyDisplayString(Command cmd)
         {
             return GetShortcutKeys((int)cmd).ToShortcutKeyDisplayString();

--- a/GitUI/CustomDiffMergeToolProvider.cs
+++ b/GitUI/CustomDiffMergeToolProvider.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 
@@ -18,10 +19,17 @@ namespace GitUI
         /// <summary>
         /// Clear the existing caches.
         /// </summary>
-        public void Clear()
+        /// <param name="isDiff">True if diff, false if merge.</param>
+        public async Task ClearAsync(bool isDiff)
         {
-            CustomDiffMergeToolCache.DiffToolCache.Clear();
-            CustomDiffMergeToolCache.MergeToolCache.Clear();
+            if (isDiff)
+            {
+                await CustomDiffMergeToolCache.DiffToolCache.ClearAsync();
+            }
+            else
+            {
+                await CustomDiffMergeToolCache.MergeToolCache.ClearAsync();
+            }
         }
 
         /// <summary>

--- a/GitUI/CustomDiffMergeToolProvider.cs
+++ b/GitUI/CustomDiffMergeToolProvider.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
@@ -40,7 +41,7 @@ namespace GitUI
         /// <param name="components">The calling Form components, to dispose correctly.</param>
         /// <param name="isDiff">True if diff, false if merge.</param>
         /// <param name="delay">The delay before starting the operation.</param>
-        public void LoadCustomDiffMergeTools(GitModule module, IList<CustomDiffMergeTool> menus, IContainer components, bool isDiff, int delay = FormBrowseToolDelay)
+        public void LoadCustomDiffMergeTools(GitModule module, IList<CustomDiffMergeTool> menus, IContainer components, bool isDiff, int delay = FormBrowseToolDelay, CancellationToken cancellationToken = default)
         {
             InitMenus(menus);
 
@@ -54,16 +55,17 @@ namespace GitUI
                 // get the tools, possibly with a delay as requesting requires considerable time
                 // cache is shared
                 List<string> tools = (await (isDiff ? CustomDiffMergeToolCache.DiffToolCache : CustomDiffMergeToolCache.MergeToolCache)
-                    .GetToolsAsync(module, delay))
+                    .GetToolsAsync(module, delay, cancellationToken))
                     .ToList();
 
-                if (tools.Count() <= 1)
+                if (tools.Count <= 1)
                 {
                     // No need to show the menu
                     return;
                 }
 
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
                 foreach (var menu in menus)
                 {
                     menu.MenuItem.DropDown = new ContextMenuStrip(components);

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -664,6 +664,11 @@ namespace GitUI
             new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true);
         }
 
+        public void CancelLoadCustomDifftools()
+        {
+            _customDiffToolsSequence.CancelCurrent();
+        }
+
         private void SetSelectedIndex(int index, bool toggleSelection = false)
         {
             try

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -108,6 +108,7 @@ namespace GitUI
         private DataGridViewColumn? _lastVisibleResizableColumn;
         private readonly ArtificialCommitChangeCount _workTreeChangeCount = new();
         private readonly ArtificialCommitChangeCount _indexChangeCount = new();
+        private readonly CancellationTokenSequence _customDiffToolsSequence = new();
 
         private RefFilterOptions _DONT_USE_ME_DIRECTLY_refFilterOptions = RefFilterOptions.All | RefFilterOptions.Boundary;
 
@@ -299,6 +300,7 @@ namespace GitUI
                 //// _revisionGraphColumnProvider not disposable
                 //// _selectionTimer handled by this.components
                 _buildServerWatcher?.Dispose();
+                _customDiffToolsSequence.Dispose();
 
                 if (_indexWatcher.IsValueCreated)
                 {
@@ -661,7 +663,7 @@ namespace GitUI
                 new(openCommitsWithDiffToolMenuItem, diffSelectedCommitsMenuItem_Click)
             };
 
-            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true);
+            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true, cancellationToken: _customDiffToolsSequence.Next());
         }
 
         public void CancelLoadCustomDifftools()

--- a/Plugins/GitUIPluginInterfaces/IProcess.cs
+++ b/Plugins/GitUIPluginInterfaces/IProcess.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace GitUIPluginInterfaces
@@ -54,6 +55,14 @@ namespace GitUIPluginInterfaces
         /// </summary>
         /// <returns>A task that yields the process's exit code, or <c>null</c> if this object was disposed before the process exited.</returns>
         Task<int> WaitForExitAsync();
+
+        /// <summary>
+        /// Instructs the process component to wait for the associated process to exit, or for the cancellationToken to be cancelled (cancells the process).
+        /// Note that the exit task must be awaited too.
+        /// </summary>
+        /// <param name="token">An optional token to cancel the asynchronous operation.</param>
+        /// <returns>A task that will complete when the process has exited, cancellation has been requested, or an error occurs.</returns>
+        Task WaitForProcessExitAsync(CancellationToken token);
 
         /// <summary>
         /// Waits for the process to reach an idle state.

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -144,6 +144,11 @@ namespace CommonTestUtils
                 }
             }
 
+            public Task WaitForProcessExitAsync(CancellationToken token)
+            {
+                return Task.CompletedTask;
+            }
+
             public void WaitForInputIdle()
             {
                 // TODO implement if needed


### PR DESCRIPTION
Fixes #9440
#9440 is mostly closed in #9505, this handles a few effects
Closes #9501

## Proposed changes

Long running process like "git difftool --tool-help" are currently never cancelled, they must run to exit.
I have seen this command require over a minute at work.
After #9505, there is no major problem due to this, it is possible to open the console and close GE quickly after opening, but it could be a potential issue.

- CancellationToken for Executable
Possibility to cancel processes, not hanging until closing.
There may be other ways to do this too.

- CancellationToken handling for CustomDiffMergeTools
Runs in the background and was never cancelled before. This add cancellation token handling and also cancels the Git command.
A few other cleanups, review commit by commit

## Test methodology <!-- How did you ensure quality? -->

Manual

* Start Settings to clear the cache for merge/diff tools
* F12 for command log
* Open `Solve merge conflicts...` form
* Notice `mergetool --tool-help` in the list
* Close ResolveConflicts
* Notice that the time is updated immediately, no exit code is written (before the command always ran to completion

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
