### PR TITLE
GetRangeDiff() should be Async

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -9,6 +9,7 @@ using System.Net.Mail;
 using System.Security;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using GitCommands.Config;
 using GitCommands.Git;
@@ -2314,12 +2315,13 @@ namespace GitCommands
             return GetPatch(patches, fileName, oldFileName);
         }
 
-        public string GetRangeDiff(
+        public async Task<string> GetRangeDiffAsync(
             ObjectId firstId,
             ObjectId secondId,
             ObjectId? firstBase,
             ObjectId? secondBase,
-            string extraDiffArguments)
+            string extraDiffArguments,
+            CancellationToken cancellationToken)
         {
             if (firstId.IsArtificial
                 || secondId.IsArtificial
@@ -2339,12 +2341,12 @@ namespace GitCommands
                 { firstBase is null || secondBase is null,  $"{firstId}...{secondId}", $"{firstBase}..{firstId} {secondBase}..{secondId}" }
             };
 
-            var patch = _gitExecutable.GetOutput(
+            ExecutionResult result = await _gitExecutable.ExecuteAsync(
                 args,
                 cache: GitCommandCache,
                 outputEncoding: LosslessEncoding);
 
-            return patch;
+            return result.StandardOutput;
         }
 
         private static Patch? GetPatch(IReadOnlyList<Patch> patches, string? fileName, string? oldFileName)

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -73,12 +73,13 @@ namespace GitUI
 
                 await fileViewer.ViewTextAsync("range-diff.sh", $"git range-diff {range}");
 
-                string output = fileViewer.Module.GetRangeDiff(
+                string output = await fileViewer.Module.GetRangeDiffAsync(
                         firstId,
                         item.SecondRevision.ObjectId,
                         item.BaseA,
                         item.BaseB,
-                        fileViewer.GetExtraDiffArguments(isRangeDiff: true));
+                        fileViewer.GetExtraDiffArguments(isRangeDiff: true),
+                        cancellationToken);
 
                 // Try set highlighting from first found filename
                 Match match = new Regex(@"\n\s*(@@|##)\s+(?<file>[^#:\n]+)").Match(output ?? "");


### PR DESCRIPTION
Follow up to #8923 

## Proposed changes

#8923 changed the "get patch" routines to be async, except for git-range-diff.
git-range-diff can take a long time (cubic to commits) and before this PR the Git command ran to completion.
On my home PC this takes about 25s, on the (newer) work PC with viruses I assume this will take several minutes.

Note: This is related to #9522, the Executable() should also have a cancellation token so the Git command is actually cancelled too.
I expect that that PR is merged after this, will add it there.

## Test methodology <!-- How did you ensure quality? -->

- Select commits in branches master and release/3.5
- Select range-diff (in the bottom)
- Select another file, notice that the FileViewer is updated immediately
<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
