### PR TITLE
Reinstate SmartFormat legacy error handling

### DIFF
--- a/ResourceManager/TranslatedStrings.cs
+++ b/ResourceManager/TranslatedStrings.cs
@@ -1,6 +1,7 @@
 using System;
 using GitCommands;
 using SmartFormat;
+using SmartFormat.Core.Settings;
 
 namespace ResourceManager
 {
@@ -50,6 +51,10 @@ Yes, I allow telemetry!");
         // public only because of FormTranslate
         public TranslatedStrings()
         {
+            // Our original implementations were create against SmartFormat.NET pre-dating v2.0.0.
+            // In v2.5.0 the default error action was changed to ThrowError. See https://github.com/axuno/SmartFormat/issues/192.
+            Smart.Default.Settings.FormatErrorAction = ErrorAction.Ignore;
+
             Translator.Translate(this, AppSettings.CurrentTranslation);
         }
 


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Relates to https://github.com/axuno/SmartFormat/issues/192.

## Proposed changes

Our original implementations were create against SmartFormat.NET pre-dating v2.0.0. In v2.5.0 the default error action was changed to ThrowError. 
An attempt to use the Russian translation would fail with the following (likely true for other translations):
```
SmartFormat.Core.Formatting.FormattingException
  HResult=0x80131500
  Message=Error parsing format string: Invalid number of plural parameters at 17
{0:Child|Children}
-----------------^
  Source=SmartFormat
  StackTrace:
   at SmartFormat.SmartFormatter.FormatError(FormatItem errorItem, Exception innerException, Int32 startIndex, FormattingInfo formattingInfo)
   at SmartFormat.SmartFormatter.Format(FormattingInfo formattingInfo)
   at SmartFormat.SmartFormatter.Format(FormatDetails formatDetails, Format format, Object current)
   at SmartFormat.SmartFormatter.Format(IFormatProvider provider, String format, Object[] args)
   at SmartFormat.Smart.Format(IFormatProvider provider, String format, Object[] args)
   at ResourceManager.TranslatedStrings.GetChildren(Int32 value) in D:\Development\gitextensions2\ResourceManager\TranslatedStrings.cs:line 96
   at ResourceManager.CommitDataRenders.TabbedHeaderRenderStyleProvider..ctor() in D:\Development\gitextensions2\ResourceManager\CommitDataRenders\TabbedHeaderRenderStyleProvider.cs:line 15
   at GitUI.CommitInfo.CommitInfoHeader..ctor() in D:\Development\gitextensions2\GitUI\CommitInfo\CommitInfoHeader.cs:line 32
   at GitUI.CommitInfo.CommitInfo.InitializeComponent() in D:\Development\gitextensions2\GitUI\CommitInfo\CommitInfo.Designer.cs:line 38
   at GitUI.CommitInfo.CommitInfo..ctor() in D:\Development\gitextensions2\GitUI\CommitInfo\CommitInfo.cs:line 93
   at GitUI.CommandsDialogs.FormBrowse.InitializeComponent() in D:\Development\gitextensions2\GitUI\CommandsDialogs\FormBrowse.Designer.cs:line 70
   at GitUI.CommandsDialogs.FormBrowse..ctor(GitUICommands commands, String filter, ObjectId selectedId, ObjectId firstId) in D:\Development\gitextensions2\GitUI\CommandsDialogs\FormBrowse.cs:line 140
   at GitUI.GitUICommands.StartBrowseDialog(IWin32Window owner, String filter, ObjectId selectedId, ObjectId firstId) in D:\Development\gitextensions2\GitUI\GitUICommands.cs:line 1131
   at GitUI.GitUICommands.RunBrowseCommand(IReadOnlyList`1 args) in D:\Development\gitextensions2\GitUI\GitUICommands.cs:line 1565
   at GitUI.GitUICommands.RunCommandBasedOnArgument(IReadOnlyList`1 args, IReadOnlyDictionary`2 arguments) in D:\Development\gitextensions2\GitUI\GitUICommands.cs:line 1419
   at GitUI.GitUICommands.RunCommand(IReadOnlyList`1 args) in D:\Development\gitextensions2\GitUI\GitUICommands.cs:line 1392
   at GitExtensions.Program.RunApplication() in D:\Development\gitextensions2\GitExtensions\Program.cs:line 190
   at GitExtensions.Program.Main() in D:\Development\gitextensions2\GitExtensions\Program.cs:line 93
```

❕ It is likely that there are other artifacts and side-effects from the v2.0->v2.7 migration, however those are outside the scope of this fix. E.g. I observed the following for 72c68245dbdba641e229d6f713d7874545773708, which may be related:
![image](https://user-images.githubusercontent.com/4403806/131252164-8aaedb5a-4930-4b55-a1f3-ad0d1ee23caa.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

