### PR TITLE
fix: Show current branch resets when switch repos

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2000,7 +2000,12 @@ namespace GitUI.CommandsDialogs
             RevisionGrid.InvalidateCount();
             _gitStatusMonitor.InvalidateGitWorkingDirectoryStatus();
             _submoduleStatusProvider.Init();
-            _filterBranchHelper.SetBranchFilter(string.Empty, refresh: false);
+
+            // Reset, if we're filtering but not showing the current branch (check SetShowBranches implementation).
+            if (AppSettings.BranchFilterEnabled && !AppSettings.ShowCurrentBranchOnly)
+            {
+                _filterBranchHelper.SetBranchFilter(string.Empty, refresh: false);
+            }
 
             UICommands = new GitUICommands(module);
             if (Module.IsValidGitWorkingDir())


### PR DESCRIPTION
Fixes #9517

A regression introduced in #8489 that resets filters when repos are switched.
However it didn't account for the "Show current branch" setting.

