### PR TITLE
fix: Show current branch resets when switch repos

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -316,6 +316,7 @@ namespace GitUI.CommandsDialogs
             InitializeComplete();
 
             ToolStripFilters.Bind(() => Module, RevisionGrid);
+            ToolStripFilters.UpdateBranchFilterItems();
             ToolStripFilters.SetRevisionFilter(filter);
 
             _aheadBehindDataProvider = GitVersion.Current.SupportAheadBehindData ? new AheadBehindDataProvider(() => Module.GitExecutable) : null;
@@ -2023,6 +2024,7 @@ namespace GitUI.CommandsDialogs
                 RevisionInfo.SetRevisionWithChildren(null, Array.Empty<ObjectId>());
                 UICommands.RepoChangedNotifier.Notify();
                 RevisionGrid.IndexWatcher.Reset();
+                ToolStripFilters.UpdateBranchFilterItems();
             }
             else
             {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -213,7 +213,9 @@ namespace GitUI.CommandsDialogs
                 if (e.RefFilterOptions.HasFlag(RefFilterOptions.All | RefFilterOptions.Boundary))
                 {
                     // This means show all branches
-                    ToolStripFilters.SetBranchFilter(string.Empty, refresh: false);
+                    ToolStripFilters.ClearFilters();
+                    AppSettings.BranchFilterEnabled =
+                        AppSettings.ShowCurrentBranchOnly = false;
                 }
             };
             RevisionGrid.SelectionChanged += (sender, e) =>
@@ -1991,8 +1993,11 @@ namespace GitUI.CommandsDialogs
             PluginRegistry.Unregister(UICommands);
             _gitStatusMonitor.InvalidateGitWorkingDirectoryStatus();
             _submoduleStatusProvider.Init();
-            ToolStripFilters.SetBranchFilter(string.Empty, refresh: false);
-            ToolStripFilters.SetRevisionFilter(string.Empty);
+
+            // If we're applying custom branch or revision filters - reset them
+            ToolStripFilters.ClearFilters();
+            AppSettings.BranchFilterEnabled = AppSettings.BranchFilterEnabled && AppSettings.ShowCurrentBranchOnly;
+
             RevisionGrid.DisableFilters();
 
             UICommands = new GitUICommands(module);
@@ -3219,20 +3224,18 @@ namespace GitUI.CommandsDialogs
         {
             private readonly FormBrowse _form;
 
-            public FullBleedTabControl CommitInfoTabControl => _form.CommitInfoTabControl;
-
-            public TabPage DiffTabPage => _form.DiffTabPage;
-
-            public RevisionDiffControl RevisionDiffControl => _form.revisionDiff;
-
-            public TabPage TreeTabPage => _form.TreeTabPage;
-
             public TestAccessor(FormBrowse form)
             {
                 _form = form;
             }
 
+            public FullBleedTabControl CommitInfoTabControl => _form.CommitInfoTabControl;
+            public TabPage DiffTabPage => _form.DiffTabPage;
             public RepoObjectsTree RepoObjectsTree => _form.repoObjectsTree;
+            public RevisionDiffControl RevisionDiffControl => _form.revisionDiff;
+            public RevisionGridControl RevisionGrid => _form.RevisionGridControl;
+            public TabPage TreeTabPage => _form.TreeTabPage;
+            public FilterToolBar ToolStripFilters => _form.ToolStripFilters;
 
             public void PopulateFavouriteRepositoriesMenu(ToolStripDropDownItem container, IList<Repository> repositoryHistory)
             {

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -30,9 +30,6 @@ namespace GitUI.UserControls
 
             InitBranchSelectionFilter();
 
-            tscboBranchFilter.Leave += (s, e) => ApplyCustomBranchFilter(refresh: true);
-
-            tstxtRevisionFilter.Leave += (s, e) => ApplyRevisionFilter();
             tstxtRevisionFilter.KeyUp += (s, e) =>
             {
                 if (e.KeyValue == (char)Keys.Enter)
@@ -165,6 +162,12 @@ namespace GitUI.UserControls
             tscboBranchFilter.Items.Clear();
             tscboBranchFilter.Items.AddRange(matches);
             tscboBranchFilter.SelectionStart = index;
+        }
+
+        public void ClearFilters()
+        {
+            tscboBranchFilter.Text =
+                tstxtRevisionFilter.Text = string.Empty;
         }
 
         private IGitModule GetModule()
@@ -427,6 +430,8 @@ namespace GitUI.UserControls
             public IGitModule GetModule() => _control.GetModule();
 
             public bool SetUnitTestsMode() => _control._isUnitTests = true;
+
+            public void UpdateBranchFilterItems() => _control.UpdateBranchFilterItems();
         }
     }
 }

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -141,7 +141,7 @@ namespace GitUI.UserControls
             _revisionGridFilter.FilterChanged += revisionGridFilter_FilterChanged;
         }
 
-        public void BindBranches(string[] branches)
+        private void BindBranches(string[] branches)
         {
             var autoCompleteList = tscboBranchFilter.AutoCompleteCustomSource.Cast<string>();
             if (!autoCompleteList.SequenceEqual(branches))
@@ -289,7 +289,7 @@ namespace GitUI.UserControls
             ApplyRevisionFilter();
         }
 
-        private void UpdateBranchFilterItems()
+        public void UpdateBranchFilterItems()
         {
             tscboBranchFilter.Items.Clear();
 
@@ -430,8 +430,6 @@ namespace GitUI.UserControls
             public IGitModule GetModule() => _control.GetModule();
 
             public bool SetUnitTestsMode() => _control._isUnitTests = true;
-
-            public void UpdateBranchFilterItems() => _control.UpdateBranchFilterItems();
         }
     }
 }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -125,8 +125,6 @@ namespace GitExtensions.UITests.CommandsDialogs
                 {
                     try
                     {
-                        form.GetTestAccessor().ToolStripFilters.GetTestAccessor().UpdateBranchFilterItems();
-
                         // 1. Cycle between "Show all branches" > "Show current branch" > "Show filterd branches"
                         // ------------------------------------------------------------------------------------------------
 

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -100,7 +100,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         [Test]
         public void Should_display_branch_and_no_remote_info_in_statusbar()
         {
-            _referenceRepository.CheckoutMaster();
+            _referenceRepository.CheckoutBranch("master");
             RunFormTest(async form =>
             {
                 await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);

--- a/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
@@ -112,7 +112,7 @@ namespace GitUITests.GitUICommandsTests
         [Test]
         public void RunCommandBasedOnArgument_branch()
         {
-            _referenceRepository.CheckoutMaster();
+            _referenceRepository.CheckoutBranch("master");
             RunCommandBasedOnArgument<FormCreateBranch>(new string[] { "ge.exe", "branch" }, runTest: form =>
             {
                 SetText(form, "BranchNameTextBox", "branchname");

--- a/UnitTests/CommonTestUtils/ReferenceRepository.cs
+++ b/UnitTests/CommonTestUtils/ReferenceRepository.cs
@@ -9,8 +9,8 @@ namespace CommonTestUtils
 {
     public class ReferenceRepository : IDisposable
     {
-        private static GitModuleTestHelper _moduleTestHelper;
-        private static string _commitHash;
+        private GitModuleTestHelper _moduleTestHelper;
+        private string _commitHash;
 
         public ReferenceRepository()
         {
@@ -63,10 +63,10 @@ namespace CommonTestUtils
             Commands.Checkout(repository, CommitHash, new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
         }
 
-        public void CheckoutMaster()
+        public void CheckoutBranch(string branchName)
         {
             using LibGit2Sharp.Repository repository = new(Module.WorkingDir);
-            Commands.Checkout(repository, "master", new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
+            Commands.Checkout(repository, branchName, new CheckoutOptions { CheckoutModifiers = CheckoutModifiers.Force });
         }
 
         public void CreateRemoteForMasterBranch()


### PR DESCRIPTION
Fixes #9517
Relates to https://github.com/gitextensions/gitextensions/pull/9551

A regression introduced in #8489 that resets filters when repos are switched.
However it didn't account for the "Show current branch" setting.
