### PR TITLE
Reduce amount of TaskCanceledException

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -475,6 +475,23 @@ namespace GitUI.UserControls.RevisionGrid
 
                 try
                 {
+                    if (_backgroundQueue.IsEmpty)
+                    {
+                        if (_backgroundQueue.IsCompleted)
+                        {
+                            // Normal completion of background work
+                            return;
+                        }
+
+                        continue;
+                    }
+
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        // Normal cancellation of background queue during clear
+                        return;
+                    }
+
                     CancellationToken timeoutToken = CancellationToken.None;
                     Func<CancellationToken, Task> backgroundOperation;
                     CancellationToken backgroundOperationCancellation;


### PR DESCRIPTION
We're endlessly spamming TaskCanceledException exceptions when `_backgroundQueue` is empty while executing
```cs
    await _backgroundQueue.DequeueAsync(linkedCancellation.Token)
```
Add a check for an empty queue to avoid unnecessary attempts to dequeue, and as a result unnecessary timeout exceptions.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/132098508-2a0ceb8f-0cf1-4981-b147-b77738fbd87a.png)


### After

Try to guess at which point I added the check 😄 

![image](https://user-images.githubusercontent.com/4403806/132098543-b3c81f56-9207-4360-a571-e24ac93b2937.png)
