### PR TITLE
Check that directory exists before running submodule command

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2378,6 +2378,13 @@ namespace GitCommands
         {
             noCache = noCache || firstRevision.IsArtificial() || secondRevision.IsArtificial();
 
+            // It is possible that a commit does not exist, should not raise an error to the user:
+            // * Create a commit in a submodule, do not push
+            // * Commit submodule changes
+            // * Open the repo in a worktree clone
+            // * Checkout the commit
+            // * Select the submodule in the diff tab
+            // This should not raise a popup to the user, but describe the error message
             return _gitExecutable.Execute(
                 new GitArgumentBuilder("diff")
                 {

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -91,7 +91,7 @@ namespace GitUI
                 return;
             }
 
-            string selectedPatch = (await GetSelectedPatchAsync(fileViewer, firstId, item.SecondRevision.ObjectId, item.Item))
+            string selectedPatch = (await GetSelectedPatchAsync(fileViewer, firstId, item.SecondRevision.ObjectId, item.Item, cancellationToken))
                 ?? defaultText;
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -121,13 +121,15 @@ namespace GitUI
                 FileViewer fileViewer,
                 ObjectId firstId,
                 ObjectId selectedId,
-                GitItemStatus file)
+                GitItemStatus file,
+                CancellationToken cancellationToken)
             {
                 if (firstId == ObjectId.CombinedDiffId)
                 {
                     var diffOfConflict = fileViewer.Module.GetCombinedDiffContent(selectedId, file.Name,
                         fileViewer.GetExtraDiffArguments(), fileViewer.Encoding);
 
+                    cancellationToken.ThrowIfCancellationRequested();
                     return string.IsNullOrWhiteSpace(diffOfConflict)
                         ? TranslatedStrings.UninterestingDiffOmitted
                         : diffOfConflict;
@@ -140,6 +142,7 @@ namespace GitUI
                     // Patch already evaluated
                     var status = await task;
 
+                    cancellationToken.ThrowIfCancellationRequested();
                     return status is not null
                         ? LocalizationHelpers.ProcessSubmoduleStatus(fileViewer.Module, status)
                         : $"Failed to get status for submodule \"{file.Name}\"";
@@ -148,6 +151,7 @@ namespace GitUI
                 var patch = await GetItemPatchAsync(fileViewer.Module, file, firstId, selectedId,
                     fileViewer.GetExtraDiffArguments(), fileViewer.Encoding);
 
+                cancellationToken.ThrowIfCancellationRequested();
                 return file.IsSubmodule
                     ? LocalizationHelpers.ProcessSubmodulePatch(fileViewer.Module, file.Name, patch)
                     : patch?.Text;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9560 (first two parts, but third is for troubleshooting)

## Proposed changes

- Check if the submodule directory exists before executing git-diff (as done for the other commands)
- Cancellation checks in ViewChanges

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

- Rebase merge (PR submitter must change the commit message for the last commit).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
