### PR TITLE
Do not throw if process exits with 0

### DIFF
--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -217,7 +217,7 @@ namespace GitCommands
 
             ExecutionResult exec = GetModule().GitExecutable.Execute(arguments,
                 outputEncoding: GitModule.LosslessEncoding,
-                cache: cache ? GitModule.GitCommandCache : null, throwOnErrorOutput: false);
+                cache: cache ? GitModule.GitCommandCache : null, throwOnErrorExit: false);
 
             if (!exec.ExitedSuccessfully)
             {

--- a/GitCommands/FileHelper.cs
+++ b/GitCommands/FileHelper.cs
@@ -75,7 +75,7 @@ namespace GitCommands
                 "--",
                 fileName.Quote()
             };
-            GitUIPluginInterfaces.ExecutionResult result = module.GitExecutable.Execute(cmd, throwOnErrorOutput: false);
+            GitUIPluginInterfaces.ExecutionResult result = module.GitExecutable.Execute(cmd, throwOnErrorExit: false);
             if (!result.ExitedSuccessfully)
             {
                 return null;

--- a/GitCommands/Git/AheadBehindDataProvider.cs
+++ b/GitCommands/Git/AheadBehindDataProvider.cs
@@ -60,7 +60,7 @@ namespace GitCommands.Git
                 "refs/heads/" + branchName
             };
 
-            ExecutionResult result = GetGitExecutable().Execute(aheadBehindGitCommand, outputEncoding: encoding, throwOnErrorOutput: false);
+            ExecutionResult result = GetGitExecutable().Execute(aheadBehindGitCommand, outputEncoding: encoding, throwOnErrorExit: false);
             if (!result.ExitedSuccessfully || string.IsNullOrEmpty(result.StandardOutput))
             {
                 return null;

--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -35,7 +35,7 @@ namespace GitCommands
                               bool redirectOutput = false,
                               Encoding? outputEncoding = null,
                               bool useShellExecute = false,
-                              bool throwOnErrorOutput = true)
+                              bool throwOnErrorExit = true)
         {
             // TODO should we set these on the child process only?
             EnvironmentConfiguration.SetEnvironmentVariables();
@@ -44,7 +44,7 @@ namespace GitCommands
 
             var fileName = _fileNameProvider();
 
-            return new ProcessWrapper(fileName, args, _workingDir, createWindow, redirectInput, redirectOutput, outputEncoding, useShellExecute, throwOnErrorOutput);
+            return new ProcessWrapper(fileName, args, _workingDir, createWindow, redirectInput, redirectOutput, outputEncoding, useShellExecute, throwOnErrorExit);
         }
 
         #region ProcessWrapper
@@ -64,7 +64,7 @@ namespace GitCommands
             private readonly ProcessOperation _logOperation;
             private readonly bool _redirectInput;
             private readonly bool _redirectOutput;
-            private readonly bool _throwOnErrorOutput;
+            private readonly bool _throwOnErrorExit;
 
             private MemoryStream? _emptyStream;
             private StreamReader? _emptyReader;
@@ -79,15 +79,15 @@ namespace GitCommands
                                   bool redirectOutput,
                                   Encoding? outputEncoding,
                                   bool useShellExecute,
-                                  bool throwOnErrorOutput)
+                                  bool throwOnErrorExit)
             {
                 Debug.Assert(redirectOutput == (outputEncoding is not null), "redirectOutput == (outputEncoding is not null)");
                 _redirectInput = redirectInput;
                 _redirectOutput = redirectOutput;
-                _throwOnErrorOutput = throwOnErrorOutput;
+                _throwOnErrorExit = throwOnErrorExit;
 
                 Encoding errorEncoding = outputEncoding;
-                if (throwOnErrorOutput)
+                if (throwOnErrorExit)
                 {
                     errorEncoding ??= Encoding.Default;
                 }
@@ -103,7 +103,7 @@ namespace GitCommands
                         CreateNoWindow = !createWindow,
                         RedirectStandardInput = redirectInput,
                         RedirectStandardOutput = redirectOutput,
-                        RedirectStandardError = redirectOutput || throwOnErrorOutput,
+                        RedirectStandardError = redirectOutput || throwOnErrorExit,
                         StandardOutputEncoding = outputEncoding,
                         StandardErrorEncoding = errorEncoding,
                         FileName = fileName,
@@ -151,20 +151,17 @@ namespace GitCommands
                             int exitCode = _process.ExitCode;
                             _logOperation.LogProcessEnd(exitCode);
 
-                            if (_throwOnErrorOutput)
+                            if (_throwOnErrorExit && exitCode != 0)
                             {
                                 string errorOutput = _process.StandardError.ReadToEnd().Trim();
-                                if (exitCode != 0 || errorOutput.Length > 0)
-                                {
-                                    ExternalOperationException ex
-                                        = new(command: _process.StartInfo.FileName,
-                                              _process.StartInfo.Arguments,
-                                              _process.StartInfo.WorkingDirectory,
-                                              exitCode,
-                                              new Exception(errorOutput));
-                                    _logOperation.LogProcessEnd(ex);
-                                    _exitTaskCompletionSource.TrySetException(ex);
-                                }
+                                ExternalOperationException ex
+                                    = new(command: _process.StartInfo.FileName,
+                                            _process.StartInfo.Arguments,
+                                            _process.StartInfo.WorkingDirectory,
+                                            exitCode,
+                                            new Exception(errorOutput));
+                                _logOperation.LogProcessEnd(ex);
+                                _exitTaskCompletionSource.TrySetException(ex);
                             }
 
                             _exitTaskCompletionSource.TrySetResult(exitCode);
@@ -211,12 +208,12 @@ namespace GitCommands
             {
                 get
                 {
-                    if (!_redirectOutput && !_throwOnErrorOutput)
+                    if (!_redirectOutput && !_throwOnErrorExit)
                     {
                         throw new InvalidOperationException("Process was not created with redirected output.");
                     }
 
-                    if (!_throwOnErrorOutput)
+                    if (!_throwOnErrorExit)
                     {
                         return _process.StandardError;
                     }

--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -111,7 +111,7 @@ namespace GitCommands
                 redirectInput: input is not null,
                 redirectOutput: true,
                 outputEncoding,
-                throwOnErrorOutput: true);
+                throwOnErrorExit: true);
             if (input is not null)
             {
                 await process.StandardInput.BaseStream.WriteAsync(input, 0, input.Length);
@@ -239,7 +239,7 @@ namespace GitCommands
         /// <param name="writeInput">A callback that writes bytes to the process's standard input stream, or <c>null</c> if no input is required.</param>
         /// <param name="outputEncoding">The text encoding to use when decoding bytes read from the process's standard output and standard error streams, or <c>null</c> if the default encoding is to be used.</param>
         /// <param name="stripAnsiEscapeCodes">A flag indicating whether ANSI escape codes should be removed from output strings.</param>
-        /// <param name="throwOnErrorOutput">A flag configuring whether to throw an exception if the exit code is not 0 or if the output to StandardError is not empty.</param>
+        /// <param name="throwOnErrorExit">A flag configuring whether to throw an exception if the exit code is not 0.</param>
         /// <param name="cancellationToken">An optional token to cancel the asynchronous operation.</param>
         /// <returns>An <see cref="ExecutionResult"/> object that gives access to exit code, standard output and standard error values.</returns>
         [MustUseReturnValue("If execution result is not required, use " + nameof(RunCommand) + " instead")]
@@ -250,11 +250,11 @@ namespace GitCommands
             Encoding? outputEncoding = null,
             CommandCache? cache = null,
             bool stripAnsiEscapeCodes = true,
-            bool throwOnErrorOutput = true,
+            bool throwOnErrorExit = true,
             CancellationToken cancellationToken = default)
         {
             return GitUI.ThreadHelper.JoinableTaskFactory.Run(
-                () => executable.ExecuteAsync(arguments, writeInput, outputEncoding, cache, stripAnsiEscapeCodes, throwOnErrorOutput, cancellationToken));
+                () => executable.ExecuteAsync(arguments, writeInput, outputEncoding, cache, stripAnsiEscapeCodes, throwOnErrorExit, cancellationToken));
         }
 
         /// <summary>
@@ -265,7 +265,7 @@ namespace GitCommands
         /// <param name="writeInput">A callback that writes bytes to the process's standard input stream, or <c>null</c> if no input is required.</param>
         /// <param name="outputEncoding">The text encoding to use when decoding bytes read from the process's standard output and standard error streams, or <c>null</c> if the default encoding is to be used.</param>
         /// <param name="stripAnsiEscapeCodes">A flag indicating whether ANSI escape codes should be removed from output strings.</param>
-        /// <param name="throwOnErrorOutput">A flag configuring whether to throw an exception if the exit code is not 0 or if the output to StandardError is not empty.</param>
+        /// <param name="throwOnErrorExit">A flag configuring whether to throw an exception if the exit code is not 0.</param>
         /// <param name="cancellationToken">An optional token to cancel the asynchronous operation.</param>
         /// <returns>A task that yields an <see cref="ExecutionResult"/> object that gives access to exit code, standard output and standard error values.</returns>
         public static async Task<ExecutionResult> ExecuteAsync(
@@ -275,7 +275,7 @@ namespace GitCommands
             Encoding? outputEncoding = null,
             CommandCache? cache = null,
             bool stripAnsiEscapeCodes = true,
-            bool throwOnErrorOutput = true,
+            bool throwOnErrorExit = true,
             CancellationToken cancellationToken = default)
         {
             outputEncoding ??= _defaultOutputEncoding.Value;
@@ -288,7 +288,7 @@ namespace GitCommands
                     exitCode: 0);
             }
 
-            using IProcess process = executable.Start(arguments, createWindow: false, redirectInput: writeInput is not null, redirectOutput: true, outputEncoding, throwOnErrorOutput: throwOnErrorOutput);
+            using IProcess process = executable.Start(arguments, createWindow: false, redirectInput: writeInput is not null, redirectOutput: true, outputEncoding, throwOnErrorExit: throwOnErrorExit);
             MemoryStream outputBuffer = new();
             MemoryStream errorBuffer = new();
             var outputTask = process.StandardOutput.BaseStream.CopyToAsync(outputBuffer);

--- a/GitCommands/Git/SubmoduleHelpers.cs
+++ b/GitCommands/Git/SubmoduleHelpers.cs
@@ -127,8 +127,8 @@ namespace GitCommands.Git
                     var submodule = module.GetSubmodule(fileName);
                     if (submodule.IsValidGitWorkingDir())
                     {
-                        addedCommits = submodule.GetCommitCount(commitId.ToString(), oldCommitId.ToString(), cache: true, throwOnErrorOutput: false);
-                        removedCommits = submodule.GetCommitCount(oldCommitId.ToString(), commitId.ToString(), cache: true, throwOnErrorOutput: false);
+                        addedCommits = submodule.GetCommitCount(commitId.ToString(), oldCommitId.ToString(), cache: true, throwOnErrorExit: false);
+                        removedCommits = submodule.GetCommitCount(oldCommitId.ToString(), commitId.ToString(), cache: true, throwOnErrorExit: false);
                     }
                 }
             }

--- a/GitCommands/Git/SystemEncodingReader.cs
+++ b/GitCommands/Git/SystemEncodingReader.cs
@@ -48,7 +48,7 @@ namespace GitCommands.Git
                     controlStr
                 };
 
-                ExecutionResult result = _module.GitExecutable.Execute(arguments, outputEncoding: Encoding.UTF8, throwOnErrorOutput: false);
+                ExecutionResult result = _module.GitExecutable.Execute(arguments, outputEncoding: Encoding.UTF8, throwOnErrorExit: false);
                 string? s = result.AllOutput;
                 if (s is not null && s.IndexOf(controlStr) != -1)
                 {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1498,7 +1498,7 @@ namespace GitUI.CommandsDialogs
                 Validates.NotNull(shell.ExecutablePath);
 
                 Executable executable = new(shell.ExecutablePath, Module.WorkingDir);
-                executable.Start(createWindow: true, throwOnErrorOutput: false); // throwOnErrorOutput would redirect the output
+                executable.Start(createWindow: true, throwOnErrorExit: false); // throwOnErrorExit would redirect the output
             }
             catch (Exception exception)
             {

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -570,7 +570,7 @@ namespace GitUI.CommandsDialogs
                     GitUIPluginInterfaces.ExecutionResult res;
                     try
                     {
-                        res = new Executable(_mergetoolPath, Module.WorkingDir).Execute(arguments, throwOnErrorOutput: false);
+                        res = new Executable(_mergetoolPath, Module.WorkingDir).Execute(arguments, throwOnErrorExit: false);
                     }
                     catch (Exception)
                     {

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1563,7 +1563,7 @@ namespace GitUI.Editor
 
         private void ProcessApplyOutput(GitArgumentBuilder args, byte[] patch, bool patchUpdateDiff = false)
         {
-            ExecutionResult result = Module.GitExecutable.Execute(args, inputWriter => inputWriter.BaseStream.Write(patch), throwOnErrorOutput: false);
+            ExecutionResult result = Module.GitExecutable.Execute(args, inputWriter => inputWriter.BaseStream.Write(patch), throwOnErrorExit: false);
             string output = result.AllOutput.Trim();
             if (EnvUtils.RunningOnWindows())
             {

--- a/GitUI/OsShellUtil.cs
+++ b/GitUI/OsShellUtil.cs
@@ -13,7 +13,7 @@ namespace GitUI
         {
             try
             {
-                new Executable(filePath).Start(useShellExecute: true, throwOnErrorOutput: false);
+                new Executable(filePath).Start(useShellExecute: true, throwOnErrorExit: false);
             }
             catch (Exception)
             {
@@ -48,7 +48,7 @@ namespace GitUI
         {
             if (!string.IsNullOrWhiteSpace(url))
             {
-                new Executable(url).Start(useShellExecute: true, throwOnErrorOutput: false);
+                new Executable(url).Start(useShellExecute: true, throwOnErrorExit: false);
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1171,7 +1171,7 @@ namespace GitUI
                 };
 
                 HashSet<string?> setOfFileNames = new();
-                ExecutionResult result = Module.GitExecutable.Execute(args, outputEncoding: GitModule.LosslessEncoding, throwOnErrorOutput: false);
+                ExecutionResult result = Module.GitExecutable.Execute(args, outputEncoding: GitModule.LosslessEncoding, throwOnErrorExit: false);
                 var lines = result.StandardOutput.LazySplit('\n');
 
                 // TODO Check the exit code and warn the user that rename detection could not be done.
@@ -1513,7 +1513,7 @@ namespace GitUI
                 objectId
             };
 
-            ExecutionResult result = Module.GitExecutable.Execute(args, throwOnErrorOutput: false);
+            ExecutionResult result = Module.GitExecutable.Execute(args, throwOnErrorExit: false);
             foreach (var line in result.StandardOutput.LazySplit('\n'))
             {
                 if (ObjectId.TryParse(line, out var parentId))

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -136,7 +136,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
                  context.ReferenceBranch
             };
 
-            var result = context.Commands.GitExecutable.Execute(args, throwOnErrorOutput: false);
+            var result = context.Commands.GitExecutable.Execute(args, throwOnErrorExit: false);
 
             if (!result.ExitedSuccessfully)
             {

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -312,7 +312,7 @@ namespace GitExtensions.Plugins.GitFlow
             txtResult.Text = "running...";
             ForceRefresh(txtResult);
 
-            var result = _gitUiCommands.GitModule.GitExecutable.Execute(commandText, throwOnErrorOutput: false);
+            var result = _gitUiCommands.GitModule.GitExecutable.Execute(commandText, throwOnErrorExit: false);
 
             IsRefreshNeeded = true;
 

--- a/Plugins/GitUIPluginInterfaces/IExecutable.cs
+++ b/Plugins/GitUIPluginInterfaces/IExecutable.cs
@@ -23,7 +23,7 @@ namespace GitUIPluginInterfaces
         /// <param name="outputEncoding">The <see cref="Encoding"/> to use when interpreting standard output and standard
         /// error, or <c>null</c> if <paramref name="redirectOutput"/> is <c>false</c>.</param>
         /// <param name="useShellExecute">The value for the flag <c>ProcessStartInfo.UseShellExecute</c>.</param>
-        /// <param name="throwOnErrorOutput">A flag configuring whether to throw an exception if the exit code is not 0
+        /// <param name="throwOnErrorExit">A flag configuring whether to throw an exception if the exit code is not 0
         /// or if the output to StandardError is not empty.</param>
         /// <returns>The started process.</returns>
         [MustUseReturnValue]
@@ -33,6 +33,6 @@ namespace GitUIPluginInterfaces
                        bool redirectOutput = false,
                        Encoding? outputEncoding = null,
                        bool useShellExecute = false,
-                       bool throwOnErrorOutput = true);
+                       bool throwOnErrorExit = true);
     }
 }

--- a/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
+++ b/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
@@ -136,7 +136,7 @@ namespace CommonTestUtils
             // Submodules require at least one commit
             subModuleHelper.Module.GitExecutable.GetOutput(@"commit --allow-empty -m ""Initial empty commit""");
 
-            Module.GitExecutable.Execute(GitCommandHelpers.AddSubmoduleCmd(subModuleHelper.Module.WorkingDir.ToPosixPath(), path, null, true), throwOnErrorOutput: false);
+            Module.GitExecutable.Execute(GitCommandHelpers.AddSubmoduleCmd(subModuleHelper.Module.WorkingDir.ToPosixPath(), path, null, true), throwOnErrorExit: false);
             Module.GitExecutable.GetOutput(@"commit -am ""Add submodule""");
         }
 
@@ -146,7 +146,7 @@ namespace CommonTestUtils
         /// <returns>All submodule Modules</returns>
         public IEnumerable<GitModule> GetSubmodulesRecursive()
         {
-            Module.GitExecutable.Execute(@"submodule update --init --recursive", throwOnErrorOutput: false);
+            Module.GitExecutable.Execute(@"submodule update --init --recursive", throwOnErrorExit: false);
             var paths = Module.GetSubmodulesLocalPaths(recursive: true);
             return paths.Select(path =>
             {

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -73,7 +73,7 @@ namespace CommonTestUtils
             }
         }
 
-        public IProcess Start(ArgumentString arguments, bool createWindow, bool redirectInput, bool redirectOutput, Encoding outputEncoding, bool useShellExecute = false, bool throwOnErrorOutput = true)
+        public IProcess Start(ArgumentString arguments, bool createWindow, bool redirectInput, bool redirectOutput, Encoding outputEncoding, bool useShellExecute = false, bool throwOnErrorExit = true)
         {
             System.Diagnostics.Debug.WriteLine($"mock-git {arguments}");
 

--- a/UnitTests/GitCommands.Tests/Config/ConfigFileTest.cs
+++ b/UnitTests/GitCommands.Tests/Config/ConfigFileTest.cs
@@ -55,7 +55,7 @@ namespace GitCommandsTests.Config
                 // Quote the key without unescaping internal quotes
                 $"\"{key}\""
             };
-            return Module.GitExecutable.Execute(args, throwOnErrorOutput: false).StandardOutput.TrimEnd('\n');
+            return Module.GitExecutable.Execute(args, throwOnErrorExit: false).StandardOutput.TrimEnd('\n');
         }
 
         private void CheckValueIsEqual(ConfigFile configFile, string key, string expectedValue)

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -720,13 +720,13 @@ namespace GitCommandsTests
                     var child = moduleTestHelpers[i];
 
                     // Add child as submodule of parent
-                    parent.Module.GitExecutable.Execute(GitCommandHelpers.AddSubmoduleCmd(child.Module.WorkingDir.ToPosixPath(), $"repo{i}", null, true), throwOnErrorOutput: false);
+                    parent.Module.GitExecutable.Execute(GitCommandHelpers.AddSubmoduleCmd(child.Module.WorkingDir.ToPosixPath(), $"repo{i}", null, true), throwOnErrorExit: false);
                     parent.Module.GitExecutable.GetOutput(@"commit -am ""Add submodule""");
                 }
 
                 // Init all modules of root
                 var root = moduleTestHelpers[0];
-                root.Module.GitExecutable.Execute(@"submodule update --init --recursive", throwOnErrorOutput: false);
+                root.Module.GitExecutable.Execute(@"submodule update --init --recursive", throwOnErrorExit: false);
 
                 var paths = root.Module.GetSubmodulesLocalPaths(recursive: true);
                 Assert.AreEqual(new string[] { "repo1", "repo1/repo2", "repo1/repo2/repo3" }, paths, $"Modules: {string.Join(" ", paths)}");

--- a/UnitTests/GitCommands.Tests/Submodules/SubmoduleStatusProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/Submodules/SubmoduleStatusProviderTests.cs
@@ -183,7 +183,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
 
             // Revert the change
-            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorExit: false);
             await CheckRevertedStatus(result);
         }
 
@@ -219,7 +219,7 @@ namespace GitCommandsTests.Submodules
 
             // Revert the change
             File.Delete(Path.Combine(_repo2Module.WorkingDir, "test.txt"));
-            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorExit: false);
             await CheckRevertedStatus(result);
         }
 
@@ -302,7 +302,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
 
             // Revert the change
-            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorExit: false);
             await CheckRevertedStatus(result);
         }
 
@@ -337,7 +337,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Status.Should().BeEquivalentTo(SubmoduleStatus.Unknown);
 
             // Revert the change
-            _repo3Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo3Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorExit: false);
             await CheckRevertedStatus(result);
         }
 
@@ -401,7 +401,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Should().BeNull();
 
             // Revert the change
-            _repo1Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo1Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorExit: false);
             await CheckRevertedStatus(result);
         }
 
@@ -500,7 +500,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.IsDirty.Should().BeTrue();
 
             // Revert the change
-            _repo3Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo3Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorExit: false);
             await CheckRevertedStatus(result);
         }
 
@@ -561,7 +561,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Should().BeNull();
 
             // Revert the change
-            _repo3Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo3Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorExit: false);
             await CheckRevertedStatus(result);
         }
 
@@ -590,7 +590,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Should().BeNull();
 
             // Revert the change
-            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorExit: false);
             await CheckRevertedStatus(result);
         }
 
@@ -678,7 +678,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.IsDirty.Should().BeTrue();
 
             // Revert the change
-            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorExit: false);
             await CheckRevertedStatus(result);
         }
 
@@ -705,11 +705,11 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.Should().BeNull();
 
             // Revert the change
-            _repo1Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo1Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorExit: false);
             File.Delete(Path.Combine(_repo1Module.WorkingDir, "test.txt"));
-            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorExit: false);
             File.Delete(Path.Combine(_repo2Module.WorkingDir, "test.txt"));
-            _repo3Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo3Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorExit: false);
             File.Delete(Path.Combine(_repo3Module.WorkingDir, "test.txt"));
             await CheckRevertedStatus(result);
         }
@@ -744,7 +744,7 @@ namespace GitCommandsTests.Submodules
             result.TopProject.Detailed.IsDirty.Should().BeTrue();
 
             // Revert the change
-            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorOutput: false);
+            _repo2Module.GitExecutable.Execute(@"checkout HEAD^", throwOnErrorExit: false);
             File.Delete(Path.Combine(_repo3Module.WorkingDir, "test.txt"));
             await CheckRevertedStatus(result);
         }


### PR DESCRIPTION
Fixes #9462 
Replaces #9489 (no changes at PR submit). @mstv has been missing a few weeks...
When approved, will rename the remaining throwOnErrorOutput arguments (that was added in #9056) after approval https://github.com/gitextensions/gitextensions/pull/9489#discussion_r704691119
See #9489 for further PR explanation

## Proposed changes

Only throw on error exit, not on output in stderror.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
