### PR TITLE
NBug: Include GE specific exception info

### DIFF
--- a/BugReporter/BugReportForm.cs
+++ b/BugReporter/BugReportForm.cs
@@ -39,6 +39,7 @@ Send report anyway?");
         private static readonly GitHubUrlBuilder UrlBuilder;
         private SerializableException? _lastException;
         private Report? _lastReport;
+        private string _exceptionInfo;
         private string? _environmentInfo;
 
         static BugReportForm()
@@ -78,10 +79,11 @@ Send report anyway?");
             mainTabs.TabPages.Remove(mainTabs.TabPages["reportContentsTabPage"]);
         }
 
-        public DialogResult ShowDialog(IWin32Window? owner, SerializableException exception, string environmentInfo, bool canIgnore, bool showIgnore, bool focusDetails)
+        public DialogResult ShowDialog(IWin32Window? owner, SerializableException exception, string exceptionInfo, string environmentInfo, bool canIgnore, bool showIgnore, bool focusDetails)
         {
             _lastException = exception;
             _lastReport = new Report(_lastException);
+            _exceptionInfo = exceptionInfo;
             _environmentInfo = environmentInfo;
 
             Validates.NotNull(_lastReport.GeneralInfo);
@@ -158,8 +160,8 @@ Send report anyway?");
 
             Validates.NotNull(_lastException);
 
-            string? url = UrlBuilder.Build("https://github.com/gitextensions/gitextensions/issues/new", _lastException, _environmentInfo, descriptionTextBox.Text);
-            new Executable(url!).Start(useShellExecute: true);
+            string? url = UrlBuilder.Build("https://github.com/gitextensions/gitextensions/issues/new", _lastException, _exceptionInfo, _environmentInfo, descriptionTextBox.Text);
+            new Executable(url!).Start(useShellExecute: true, throwOnErrorExit: false);
 
             DialogResult = DialogResult.Abort;
             Close();
@@ -169,7 +171,7 @@ Send report anyway?");
         {
             Validates.NotNull(_lastException);
 
-            var report = ErrorReportBodyBuilder.Build(_lastException, _environmentInfo, descriptionTextBox.Text);
+            var report = ErrorReportBodyBuilder.Build(_lastException, _exceptionInfo, _environmentInfo, descriptionTextBox.Text);
             if (string.IsNullOrWhiteSpace(report))
             {
                 return;

--- a/BugReporter/ErrorReportMarkDownBodyBuilder.cs
+++ b/BugReporter/ErrorReportMarkDownBodyBuilder.cs
@@ -6,12 +6,12 @@ namespace BugReporter
 {
     public interface IErrorReportMarkDownBodyBuilder
     {
-        string Build(SerializableException exception, string? environmentInfo, string? additionalInfo);
+        string Build(SerializableException exception, string exceptionInfo, string? environmentInfo, string? additionalInfo);
     }
 
     public sealed class ErrorReportMarkDownBodyBuilder : IErrorReportMarkDownBodyBuilder
     {
-        public string Build(SerializableException exception, string? environmentInfo, string? additionalInfo)
+        public string Build(SerializableException exception, string exceptionInfo, string? environmentInfo, string? additionalInfo)
         {
             if (exception is null)
             {
@@ -40,6 +40,12 @@ namespace BugReporter
 
 
 ## Error Details");
+            if (!string.IsNullOrEmpty(exceptionInfo))
+            {
+                sb.AppendLine();
+                sb.AppendLine(exceptionInfo);
+            }
+
             sb.AppendLine("```");
             sb.AppendLine(exception.ToString());
             sb.AppendLine("```");

--- a/BugReporter/GitHubUrlBuilder.cs
+++ b/BugReporter/GitHubUrlBuilder.cs
@@ -20,9 +20,15 @@ namespace BugReporter
 
         /// <summary>
         /// Generates a URL to create a new issue on GitHub.
-        /// </summary>
         /// <see href="https://help.github.com/en/articles/about-automation-for-issues-and-pull-requests-with-query-parameters"/>
-        public string? Build(string url, SerializableException exception, string? environmentInfo, string? additionalInfo)
+        /// </summary>
+        /// <param name="url">url to create a new issue for the project.</param>
+        /// <param name="exception">The exception to report.</param>
+        /// <param name="exceptionInfo">Info string for GE specific exceptions (like GitExtUtils.ExternalOperationException) unknown in BugReporter.</param>
+        /// <param name="environmentInfo">Git version, directory etc.</param>
+        /// <param name="additionalInfo">Information from the popup textbox.</param>
+        /// <returns>The URL as a string</returns>
+        public string? Build(string url, SerializableException exception, string exceptionInfo, string? environmentInfo, string? additionalInfo)
         {
             if (string.IsNullOrWhiteSpace(url) || exception is null)
             {
@@ -44,7 +50,7 @@ namespace BugReporter
                 subject = subject.Substring(0, 66) + "...";
             }
 
-            string body = Uri.EscapeDataString(_errorReportMarkDownBodyBuilder.Build(exception, environmentInfo, additionalInfo));
+            string body = Uri.EscapeDataString(_errorReportMarkDownBodyBuilder.Build(exception, exceptionInfo, environmentInfo, additionalInfo));
 
             return $"{validatedUri}{separator}title={Uri.EscapeDataString(subject)}&body={body}";
         }

--- a/BugReporter/Program.cs
+++ b/BugReporter/Program.cs
@@ -56,9 +56,11 @@ namespace BugReporter
                 }
             }
 
+            // No specific info extracted from these exceptions
+            string exceptionInfo = "";
             exception ??= new(new Exception("Missing error payload"));
 
-            new BugReportForm().ShowDialog(owner: null, exception, UserEnvironmentInformation.GetInformation(), canIgnore: true, showIgnore: false, focusDetails: false);
+            new BugReportForm().ShowDialog(owner: null, exception, exceptionInfo, UserEnvironmentInformation.GetInformation(), canIgnore: true, showIgnore: false, focusDetails: false);
         }
 
         private static string Base64Decode(string base64EncodedData)

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1945,6 +1945,7 @@ namespace GitCommands
         // Return false whilst we're in the designer.
         public static bool IsPortable() => !IsDesignMode && Properties.Settings.Default.IsPortable;
 
+        // Set manually in settings file
         public static bool WriteErrorLog
         {
             get => GetBool("WriteErrorLog", false);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -354,6 +354,10 @@ namespace GitUI.BranchTreePanel
                         catch (OperationCanceledException)
                         {
                         }
+                        //// Comment out to debug BugReporter
+                        ////catch (GitExtUtils.ExternalOperationException)
+                        ////{
+                        ////}
                     });
 #pragma warning restore VSTHRD101 // Avoid unsupported async delegates
             }

--- a/IntegrationTests/BugReporter.IntegrationTests/BugReportFormTests.cs
+++ b/IntegrationTests/BugReporter.IntegrationTests/BugReportFormTests.cs
@@ -75,10 +75,11 @@ namespace GitExtensions.UITests.NBugReports
                     Assert.AreEqual(listView.Items.Count - 1, index);
                 },
                 exception,
-                null);
+                exceptionInfo: "",
+                environmentInfo: "");
         }
 
-        private void RunFormTest(Action<BugReportForm> testDriver, SerializableException exception, string environmentInfo)
+        private void RunFormTest(Action<BugReportForm> testDriver, SerializableException exception, string exceptionInfo, string environmentInfo)
         {
             RunFormTest(
                 form =>
@@ -86,16 +87,16 @@ namespace GitExtensions.UITests.NBugReports
                     testDriver(form);
                     return Task.CompletedTask;
                 },
-                exception, environmentInfo,
+                exception, exceptionInfo, environmentInfo,
                 expected: DialogResult.Cancel);
         }
 
-        private void RunFormTest(Func<BugReportForm, Task> testDriverAsync, SerializableException exception, string environmentInfo, DialogResult expected)
+        private void RunFormTest(Func<BugReportForm, Task> testDriverAsync, SerializableException exception, string exceptionInfo, string environmentInfo, DialogResult expected)
         {
             UITest.RunForm(
                 () =>
                 {
-                    Assert.AreEqual(expected, _form.ShowDialog(owner: null, exception, environmentInfo, canIgnore: true, showIgnore: false, focusDetails: false));
+                    Assert.AreEqual(expected, _form.ShowDialog(owner: null, exception, exceptionInfo, environmentInfo, canIgnore: true, showIgnore: false, focusDetails: false));
                 },
                 testDriverAsync);
         }

--- a/UnitTests/GitUI.Tests/NBugReports/BugReportInvokerTests.cs
+++ b/UnitTests/GitUI.Tests/NBugReports/BugReportInvokerTests.cs
@@ -14,8 +14,8 @@ namespace GitUITests.NBugReports
         [Test, TestCaseSource(typeof(TestExceptions), "TestCases")]
         public void Append(Exception exception, string expectedRootError, string expectedText)
         {
-            StringBuilder text = new();
-            string rootError = BugReportInvoker.Append(text, exception);
+            StringBuilder text = BugReportInvoker.GetExceptionInfo(exception);
+            string rootError = BugReportInvoker.GetRootError(exception);
             rootError.Should().Be(expectedRootError);
             text.ToString().Should().Be(expectedText);
         }
@@ -49,7 +49,7 @@ namespace GitUITests.NBugReports
                     new ExternalOperationException(_command, _arguments, _directory, _exitCode, new Exception(_messageOuter, new Exception(_messageInner)))),
                     _messageInner,
                     $"{_context}{Environment.NewLine}"
-                    + $"Exit code: {_exitCode}{Environment.NewLine}{Environment.NewLine}"
+                    + $"Exit code: {_exitCode}{Environment.NewLine}"
                     + $"Command: {_command}{Environment.NewLine}"
                     + $"Arguments: {_arguments}{Environment.NewLine}"
                     + $"Working directory: {_directory}{Environment.NewLine}");


### PR DESCRIPTION
Debug info for #9560 etc , needed after #9056

## Proposed changes

* Fix regression: Separated BugReporter and #9056 was done in separate branches.

When a Git command exits with errors, info about current directory, arguments etc is collected and presented in a popup.
This info is now also included in rthe NBug report.

Note: StandardError should be included as well as in Git Command Log, this a separate PR.

The popup is unchanged:

![image](https://user-images.githubusercontent.com/6248932/132759910-53d3bcc5-172f-45b3-8fa1-9b55da1b2680.png)

A cut exception below (as well as modified formatting), adding the three lines below `## Error Details`

```
## Error Details

Command: C:\Program Files\Git\bin\git.exe
Arguments: -c color.ui=never -c diff.submodule=short -c diff.noprefix=false -c diff.mnemonicprefix=false -c diff.ignoreSubmodules=none -c core.safecrlf=false diff --find-renames --find-copies --name-status "07f7352af399f9da9923327abde3988d528c4205" "7caf16f7fcd2398b05b7d25de8e61d7205200094"
Working directory: C:\dev\gc\gitextensions_4\Externals\conemu-insidew\

GitExtUtils.ExternalOperationException: The directory name is invalid.
   at ExecutionResult GitCommands.GitModule.GetDiffFiles(string firstRevision, string secondRevision, bool noCache, bool nullSeparated) in C:/dev/gc/gitextensions_4/GitCommands/Git/GitModule.cs:line 2388
   at string ResourceManager.LocalizationHelpers.ProcessSubmoduleStatus(GitModule module, GitSubmoduleStatus status, bool moduleIsParent, bool limitOutput) in C:/dev/gc/gitextensions_4/ResourceManager/LocalizationHelpers.cs:line 289
   at async Task GitUI.GitUIExtensions.ViewChangesAsync(FileViewer fileViewer, FileStatusItem item, CancellationToken cancellationToken, string defaultText, Action openWithDiffTool)+GetSelectedPatchAsync(?) in C:/dev/gc/gitextensions_4/GitUI/GitUIExtensions.cs:line 146
   at async Task GitUI.GitUIExtensions.ViewChangesAsync(FileViewer fileViewer, FileStatusItem item, CancellationToken cancellationToken, string defaultText, Action openWithDiffTool) in C:/dev/gc/gitextensions_4/GitUI/GitUIExtensions.cs:line 94
   at async Task GitUI.CommandsDialogs.RevisionDiffControl.ShowSelectedFileDiffAsync() in C:/dev/gc/gitextensions_4/GitUI/CommandsDialogs/RevisionDiffControl.cs:line 479
   at async void GitUI.CommandsDialogs.RevisionDiffControl.DiffFiles_SelectedIndexChanged(object sender, EventArgs e)+(?) => { } in C:/dev/gc/gitextensions_4/GitUI/CommandsDialogs/RevisionDiffControl.cs:line 488
   at async void GitUI.ThreadHelper.FileAndForget(Task task, Func<Exception, bool> fileOnlyIf)+(?) => { } in C:/dev/gc/gitextensions_4/GitExtUtils/GitUI/ThreadHelper.cs:line 100
```

## Test methodology <!-- How did you ensure quality? -->

Tests adapted

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
