### PR TITLE
Fix leaking brushes

### DIFF
--- a/GitExtUtils/GitUI/Theming/BrushScope.cs
+++ b/GitExtUtils/GitUI/Theming/BrushScope.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Drawing;
+
+namespace GitExtUtils.GitUI.Theming
+{
+    public class BrushScope : IDisposable
+    {
+        private readonly bool _isSystemBrush;
+
+        public static BrushScope ForSystemBrush(Brush brush) =>
+            new(brush, isSystemBrush: true);
+
+        public static BrushScope ForRegularBrush(Brush brush) =>
+            new(brush, isSystemBrush: false);
+
+        private BrushScope(Brush brush, bool isSystemBrush)
+        {
+            Brush = brush;
+            _isSystemBrush = isSystemBrush;
+        }
+
+        public Brush Brush { get; }
+
+        public void Dispose()
+        {
+            if (!_isSystemBrush)
+            {
+                Brush.Dispose();
+            }
+
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/GitExtUtils/GitUI/Theming/TabControlPaintContext.cs
+++ b/GitExtUtils/GitUI/Theming/TabControlPaintContext.cs
@@ -106,7 +106,10 @@ namespace GitExtUtils.GitUI.Theming
         {
             using var borderPen = CreateBorderPen();
             var outerRect = GetOuterTabRect(index);
-            _graphics.FillRectangle(GetBackgroundBrush(index), outerRect);
+            using (var backgroundBrush = CreateBackgroundBrusScope(index))
+            {
+                _graphics.FillRectangle(backgroundBrush.Brush, outerRect);
+            }
 
             List<Point> points = new(4);
             if (index <= _selectedIndex)
@@ -262,8 +265,12 @@ namespace GitExtUtils.GitUI.Theming
                 return;
             }
 
-            _graphics.FillRectangle(GetBackgroundBrush(_selectedIndex), pageRect);
-            using var borderPen = CreateBorderPen();
+            using (var backgroundBrush = CreateBackgroundBrusScope(_selectedIndex))
+            {
+                _graphics.FillRectangle(backgroundBrush.Brush, pageRect);
+            }
+
+            using (var borderPen = CreateBorderPen())
             {
                 _graphics.DrawRectangle(borderPen, pageRect);
             }
@@ -285,17 +292,17 @@ namespace GitExtUtils.GitUI.Theming
             return SystemColors.Window;
         }
 
-        private Brush GetBackgroundBrush(int index)
+        private BrushScope CreateBackgroundBrusScope(int index)
         {
             if (index == _selectedIndex)
             {
-                return SystemBrushes.Window;
+                return BrushScope.ForSystemBrush(SystemBrushes.Window);
             }
 
             bool isHighlighted = _tabRects[index].Contains(_mouseCursor);
             return isHighlighted
-                ? new SolidBrush(ColorHelper.Lerp(SystemColors.Control, SystemColors.HotTrack, 64f / 255f))
-                : SystemBrushes.Control;
+                ? BrushScope.ForRegularBrush(new SolidBrush(ColorHelper.Lerp(SystemColors.Control, SystemColors.HotTrack, 64f / 255f)))
+                : BrushScope.ForSystemBrush(SystemBrushes.Control);
         }
 
         private Pen CreateBorderPen() =>

--- a/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
+++ b/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
@@ -87,25 +87,16 @@ namespace GitUI.Editor.Diff
                 var diffLine = _diffLines[curLine + 1];
                 if (diffLine.LineType != DiffLineType.Context)
                 {
-                    var brush = default(Brush);
-                    switch (diffLine.LineType)
+                    using Brush brush = diffLine.LineType switch
                     {
-                        case DiffLineType.Context:
-                            break;
-                        case DiffLineType.Plus:
-                            brush = new SolidBrush(AppColor.DiffAdded.GetThemeColor());
-                            break;
-                        case DiffLineType.Minus:
-                            brush = new SolidBrush(AppColor.DiffRemoved.GetThemeColor());
-                            break;
-                        case DiffLineType.Header:
-                            brush = new SolidBrush(AppColor.DiffSection.GetThemeColor());
-                            break;
-                    }
+                        DiffLineType.Plus => new SolidBrush(AppColor.DiffAdded.GetThemeColor()),
+                        DiffLineType.Minus => new SolidBrush(AppColor.DiffRemoved.GetThemeColor()),
+                        DiffLineType.Header => new SolidBrush(AppColor.DiffSection.GetThemeColor()),
+                        _ => default(Brush)
+                    };
 
                     Debug.Assert(brush is not null, string.Format("brush is not null, unknow diff line style {0}", diffLine.LineType));
                     g.FillRectangle(brush, new Rectangle(0, backgroundRectangle.Top, leftWidth, backgroundRectangle.Height));
-
                     g.FillRectangle(brush, new Rectangle(leftWidth, backgroundRectangle.Top, rightWidth, backgroundRectangle.Height));
                 }
 

--- a/GitUI/Interops/Gdi32/DeleteObject.cs
+++ b/GitUI/Interops/Gdi32/DeleteObject.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices;
+using static System.Interop;
+
+namespace System
+{
+    internal static partial class NativeMethods
+    {
+        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
+        public static extern BOOL DeleteObject(IntPtr hObject);
+    }
+}

--- a/GitUI/Theming/Renderers/EditRenderer.cs
+++ b/GitUI/Theming/Renderers/EditRenderer.cs
@@ -15,7 +15,8 @@ namespace GitUI.Theming
             {
                 case Parts.EP_EDITTEXT:
                     return RenderEditText(ctx, stateid, prect);
-
+                case Parts.EP_BACKGROUND:
+                    return RenderProperBackground(ctx, stateid, prect);
                 case Parts.EP_EDITBORDER_NOSCROLL:
                     return RenderEditBorderNoScroll(ctx, stateid, prect);
             }
@@ -94,6 +95,31 @@ namespace GitUI.Theming
             ctx.Graphics.FillRectangle(backBrush, prect);
             ctx.Graphics.DrawRectangle(borderPen, prect.Inclusive());
 
+            return Handled;
+        }
+
+        private int RenderProperBackground(Context ctx, int stateid, Rectangle prect)
+        {
+            Brush backBrush;
+            switch ((State.Background)stateid)
+            {
+                case State.Background.EBS_NORMAL:
+                case State.Background.EBS_HOT:
+                case State.Background.EBS_FOCUSED:
+                case State.Background.EBS_READONLY:
+                    // fix numeric updown border
+                    backBrush = SystemBrushes.Window;
+                    break;
+
+                case State.Background.EBS_DISABLED:
+                    backBrush = SystemBrushes.Control;
+                    break;
+
+                default:
+                    return Unhandled;
+            }
+
+            ctx.Graphics.FillRectangle(backBrush, prect);
             return Handled;
         }
 

--- a/GitUI/Theming/SystemBrushesCache.cs
+++ b/GitUI/Theming/SystemBrushesCache.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using static System.NativeMethods;
+
+namespace GitUI.Theming
+{
+    internal class SystemBrushesCache : IDisposable
+    {
+        private readonly Dictionary<int, HandleRef> _cache = new();
+
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+            foreach (int key in _cache.Keys)
+            {
+                DeleteObject(_cache[key].Handle);
+            }
+
+            _cache.Clear();
+        }
+
+        public IntPtr GetBrush(int colorref)
+        {
+            if (!_cache.TryGetValue(colorref, out var handle))
+            {
+                IntPtr hbrush = CreateSolidBrush(colorref);
+                handle = new HandleRef(this, hbrush);
+
+                _cache.Add(colorref, handle);
+            }
+
+            return handle.Handle;
+        }
+    }
+}

--- a/GitUI/Theming/Win32ThemeHooks.cs
+++ b/GitUI/Theming/Win32ThemeHooks.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -40,6 +39,7 @@ namespace GitUI.Theming
         internal static ThemeSettings ThemeSettings { private get; set; } = ThemeSettings.Default;
 
         private static readonly HashSet<NativeListView> InitializingListViews = new HashSet<NativeListView>();
+        private static readonly SystemBrushesCache _systemBrushesCache = new();
         private static ScrollBarRenderer _scrollBarRenderer;
         private static ListViewRenderer _listViewRenderer;
         private static HeaderRenderer _headerRenderer;
@@ -136,6 +136,7 @@ namespace GitUI.Theming
             var editorHandle = new ICSharpCode.TextEditor.TextEditorControl().Handle;
             var listViewHandle = new NativeListView().Handle;
             var treeViewHandle = new NativeTreeView().Handle;
+
             _scrollBarRenderer.AddThemeData(editorHandle);
             _scrollBarRenderer.AddThemeData(listViewHandle);
             _headerRenderer.AddThemeData(listViewHandle);
@@ -153,6 +154,7 @@ namespace GitUI.Theming
             _drawThemeTextHook?.Dispose();
             _drawThemeTextExHook?.Dispose();
             _createWindowExHook?.Dispose();
+            _systemBrushesCache.Dispose();
 
             if (_renderers is not null)
             {
@@ -213,8 +215,7 @@ namespace GitUI.Theming
                 if (color != Color.Empty)
                 {
                     int colorref = ColorTranslator.ToWin32(color);
-                    var hbrush = NativeMethods.CreateSolidBrush(colorref);
-                    return hbrush;
+                    return _systemBrushesCache.GetBrush(colorref);
                 }
             }
 


### PR DESCRIPTION
Fixes #9429

## Proposed changes

1. Return brush wrapper in situations when brush consumer is not certain whether it should dispose the brush.
  wrapper.Dispose method will not touch the underlying brush if it is system brush.
2. Cache the native brushes returned by Win32 GetSysColorBrush override
3. Render text input backround explicitly, because 2. somehow breaks default system rendering.

## Test methodology

- run GitExtensions
- scroll revision grid back and forth, click on different revisions
- observe GDI objects count using [GDIView](https://www.nirsoft.net/utils/gdi_handles.html) (thank you @pmiossec)

## Test environment(s)

Windows 10

## Merge strategy

- Rebase merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
