### PR TITLE
Select HOME where .gitconfig is accessible first

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -46,9 +46,15 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     return true;
                 }
 
-                if (File.Exists(Path.Combine(home, ".gitconfig")))
+                try
                 {
+                    using FileStream fs = File.Open(Path.Combine(home, ".gitconfig"), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
+                    // file is readable, no further checks
                     return false;
+                }
+                catch (IOException)
+                {
                 }
 
                 string[] candidates =


### PR DESCRIPTION
Fixes #9573

## Proposed changes

Try reading the .gitconfig file at startup as File.Exists() will not catch access changes.

For me this increases the startup time of the application with about 0.1 ms (normally either 0.0 -> 0.1 ms or 0.1 -> 0.2 ms) in the normal case returning false (measured with Stopwatch).
I have a SSD, I would expect this is similar for a traditional HD as the added OH is more for exception handling then I/O.

## Test methodology <!-- How did you ensure quality? -->

Manual, see the issue

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
