### PR TITLE
SHIFT+DEL = quick delete branch

### DIFF
--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -21,6 +21,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _useReflogHint = new("Did you know you can use reflog to restore deleted branches?");
 
         private readonly IEnumerable<string> _defaultBranches;
+        private readonly bool _forceDeleteUnmergedBranch;
         private readonly HashSet<string> _mergedBranches = new();
         private string? _currentBranch;
 
@@ -32,11 +33,11 @@ namespace GitUI.CommandsDialogs
             InitializeComponent();
         }
 
-        public FormDeleteBranch(GitUICommands commands, IEnumerable<string> defaultBranches)
+        public FormDeleteBranch(GitUICommands commands, IEnumerable<string> defaultBranches, bool forceDeleteUnmergedBranch = false)
             : base(commands, enablePositionRestore: false)
         {
             _defaultBranches = defaultBranches;
-
+            _forceDeleteUnmergedBranch = forceDeleteUnmergedBranch;
             InitializeComponent();
 
             // work-around the designer bug that can't add controls to FlowLayoutPanel
@@ -106,7 +107,7 @@ namespace GitUI.CommandsDialogs
 
             // always treat branches as unmerged if there is no current branch (HEAD is detached)
             bool hasUnmergedBranches = _currentBranch is null || selectedBranches.Any(branch => !_mergedBranches.Contains(branch.Name));
-            if (hasUnmergedBranches && !AppSettings.DontConfirmDeleteUnmergedBranch)
+            if (hasUnmergedBranches && !AppSettings.DontConfirmDeleteUnmergedBranch && !_forceDeleteUnmergedBranch)
             {
                 TaskDialogPage page = new()
                 {

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -23,6 +23,7 @@ namespace GitUI.CommandsDialogs
 
         private readonly HashSet<string> _mergedBranches = new();
         private readonly string _defaultRemoteBranch;
+        private readonly bool _forceDeleteRemote;
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -32,10 +33,11 @@ namespace GitUI.CommandsDialogs
             InitializeComponent();
         }
 
-        public FormDeleteRemoteBranch(GitUICommands commands, string defaultRemoteBranch)
+        public FormDeleteRemoteBranch(GitUICommands commands, string defaultRemoteBranch, bool forceDeleteRemote)
             : base(commands, enablePositionRestore: false)
         {
             _defaultRemoteBranch = defaultRemoteBranch;
+            _forceDeleteRemote = forceDeleteRemote;
             InitializeComponent();
 
             // work-around the designer bug that can't add controls to FlowLayoutPanel
@@ -43,6 +45,8 @@ namespace GitUI.CommandsDialogs
             AcceptButton = Delete;
 
             InitializeComplete();
+
+            DeleteRemote.Checked = _forceDeleteRemote;
         }
 
         protected override void OnRuntimeLoad(EventArgs e)
@@ -92,7 +96,7 @@ namespace GitUI.CommandsDialogs
             List<IGitRef> selectedBranches = Branches.GetSelectedBranches().ToList();
 
             bool hasUnmergedBranches = selectedBranches.Any(branch => !_mergedBranches.Contains(branch.CompleteName));
-            if (hasUnmergedBranches)
+            if (hasUnmergedBranches && !_forceDeleteRemote)
             {
                 if (MessageBox.Show(this,
                                     _confirmDeleteUnmergedRemoteBranchMessage.Text,

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -138,26 +138,26 @@ namespace GitUI
             FormProcess.ShowDialog(owner, process: null, arguments, Module.WorkingDir, input: null, useDialogSettings: true);
         }
 
-        public bool StartDeleteBranchDialog(IWin32Window? owner, string branch)
+        public bool StartDeleteBranchDialog(IWin32Window? owner, string branch, bool forceDeleteUnmergedBranch = false)
         {
-            return StartDeleteBranchDialog(owner, new[] { branch });
+            return StartDeleteBranchDialog(owner, new[] { branch }, forceDeleteUnmergedBranch);
         }
 
-        public bool StartDeleteBranchDialog(IWin32Window? owner, IEnumerable<string> branches)
+        public bool StartDeleteBranchDialog(IWin32Window? owner, IEnumerable<string> branches, bool forceDeleteUnmergedBranch = false)
         {
             return DoActionOnRepo(owner, action: () =>
             {
-                using FormDeleteBranch form = new(this, branches);
+                using FormDeleteBranch form = new(this, branches, forceDeleteUnmergedBranch);
                 form.ShowDialog(owner);
                 return true;
             }, changesRepo: false);
         }
 
-        public bool StartDeleteRemoteBranchDialog(IWin32Window? owner, string remoteBranch)
+        public bool StartDeleteRemoteBranchDialog(IWin32Window? owner, string remoteBranch, bool forceDeleteRemote = false)
         {
             return DoActionOnRepo(owner, action: () =>
             {
-                using FormDeleteRemoteBranch form = new(this, remoteBranch);
+                using FormDeleteRemoteBranch form = new(this, remoteBranch, forceDeleteRemote);
                 form.ShowDialog(owner);
                 return true;
             }, changesRepo: false);

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1602,7 +1602,7 @@ namespace GitUI
             }
 
             // https://github.com/gitextensions/gitextensions/issues/5636
-            if (e.Modifiers != Keys.None)
+            if (e.Modifiers != Keys.None && e.Modifiers != Keys.Shift)
             {
                 return;
             }
@@ -1620,8 +1620,18 @@ namespace GitUI
 
                 case Keys.Delete:
                     {
+                        var gitRefListsForRevision = new GitRefListsForRevision(selectedRevision).GetDeletableRefs(Module.GetSelectedBranch());
+
+                        // Shift key enables quick and forcible delete
+                        var forceDelete = e.Modifiers == Keys.Shift;
+
+                        if (forceDelete)
+                        {
+                            gitRefListsForRevision = new IGitRef[] { gitRefListsForRevision.FirstOrDefault() };
+                        }
+
                         InitiateRefAction(
-                            new GitRefListsForRevision(selectedRevision).GetDeletableRefs(Module.GetSelectedBranch()),
+                            gitRefListsForRevision,
                             gitRef =>
                             {
                                 if (gitRef.IsTag)
@@ -1630,11 +1640,11 @@ namespace GitUI
                                 }
                                 else if (gitRef.IsRemote)
                                 {
-                                    UICommands.StartDeleteRemoteBranchDialog(ParentForm, gitRef.Name);
+                                    UICommands.StartDeleteRemoteBranchDialog(ParentForm, gitRef.Name, forceDelete);
                                 }
                                 else
                                 {
-                                    UICommands.StartDeleteBranchDialog(ParentForm, gitRef.Name);
+                                    UICommands.StartDeleteBranchDialog(ParentForm, gitRef.Name, forceDelete);
                                 }
                             },
                             FormQuickGitRefSelector.Action.Delete);


### PR DESCRIPTION
Currently it is a hassle to remove a number of obsolete branches.
There is so much clicking and confirming necessary.
With this PR you simply press SHIFT+DEL it will:
  - choose the first available branch for the current commit for deletion
  - enable the "delete remote branch" checkbox
  - suppress (quietly confirm) confirmation dialogs

Despite not having signed the "The Developer Certificate of Origin", 
I'd like to share my changes. Use them as you may see fit. Thus:

Hereby, I declare that I claim no rights on this commit.
Instead I donate my changes free of charge and free of demands of any kind.
Any developer may use, rebase, or merge these changes.
