### PR TITLE
Ensure all grid views could be sorted

### DIFF
--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -17,6 +19,69 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormReflog : GitModuleForm
     {
+        private sealed class SortableRefLineList : BindingList<RefLine>
+        {
+            public void AddRange(IEnumerable<RefLine> refLines)
+            {
+                RefLines.AddRange(refLines);
+
+                // NOTE: adding items via wrapper's AddRange doesn't generate ListChanged event, so DataGridView doesn't update itself
+                // There are two solutions:
+                //  0. Add items one by one using direct this.Add method (without IList<T> wrapper).
+                //     Too many ListChanged events will be generated (one per item), too many updates for gridview. Bad performance.
+                //  1. Batch add items through Items wrapper's AddRange method.
+                //     One reset event will be generated, one batch update for gridview. Ugly but fast code.
+                OnListChanged(new ListChangedEventArgs(ListChangedType.Reset, -1));
+            }
+
+            protected override bool SupportsSortingCore => true;
+
+            protected override void ApplySortCore(PropertyDescriptor propertyDescriptor, ListSortDirection direction)
+            {
+                RefLines.Sort(RefLineComparer.Create(propertyDescriptor, direction == ListSortDirection.Descending));
+            }
+
+            private List<RefLine> RefLines => (List<RefLine>)Items;
+
+            private static class RefLineComparer
+            {
+                private static readonly Dictionary<string, Comparison<RefLine>> PropertyComparers = new Dictionary<string, Comparison<RefLine>>();
+
+                static RefLineComparer()
+                {
+                    AddSortableProperty(refLine => refLine.Sha, (x, y) => x.Sha.CompareTo(y.Sha));
+                    AddSortableProperty(refLine => refLine.Ref, (x, y) => string.Compare(x.Ref, y.Ref, StringComparison.Ordinal));
+                    AddSortableProperty(refLine => refLine.Action, (x, y) => string.Compare(x.Action, y.Action, StringComparison.CurrentCulture));
+                }
+
+                /// <summary>
+                /// Creates a comparer to sort lostObjects by specified property.
+                /// </summary>
+                /// <param name="propertyDescriptor">Property to sort by.</param>
+                /// <param name="isReversedComparing">Use reversed sorting order.</param>
+                public static Comparison<RefLine> Create(PropertyDescriptor propertyDescriptor, bool isReversedComparing)
+                {
+                    if (PropertyComparers.TryGetValue(propertyDescriptor.Name, out var comparer))
+                    {
+                        return isReversedComparing ? (x, y) => comparer(y, x) : comparer;
+                    }
+
+                    throw new NotSupportedException(string.Format("Custom sort by {0} property is not supported.", propertyDescriptor.Name));
+                }
+
+                /// <summary>
+                /// Adds custom property comparer.
+                /// </summary>
+                /// <typeparam name="T">Property type.</typeparam>
+                /// <param name="expr">Property to sort by.</param>
+                /// <param name="propertyComparer">Property values comparer.</param>
+                private static void AddSortableProperty<T>(Expression<Func<RefLine, T>> expr, Comparison<RefLine> propertyComparer)
+                {
+                    PropertyComparers[((MemberExpression)expr.Body).Member.Name] = propertyComparer;
+                }
+            }
+        }
+
         private readonly TranslationString _continueResetCurrentBranchEvenWithChangesText = new("You have changes in your working directory that could be lost.\n\nDo you want to continue?");
         private readonly TranslationString _continueResetCurrentBranchCaptionText = new("Changes not committed...");
 
@@ -81,7 +146,9 @@ namespace GitUI.CommandsDialogs
                 var refLines = ConvertReflogOutput().ToList();
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 _lastHitRowIndex = 0;
-                gridReflog.DataSource = refLines;
+                var refLinesList = new SortableRefLineList();
+                refLinesList.AddRange(refLines);
+                gridReflog.DataSource = refLinesList;
 
                 IEnumerable<RefLine> ConvertReflogOutput()
                     => from line in output.Split('\n')

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Config;
@@ -17,6 +19,69 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormRemotes : GitModuleForm
     {
+        private sealed class SortableGitRefList : BindingList<IGitRef>
+        {
+            public void AddRange(IEnumerable<IGitRef> gitRefs)
+            {
+                GitRefs.AddRange(gitRefs);
+
+                // NOTE: adding items via wrapper's AddRange doesn't generate ListChanged event, so DataGridView doesn't update itself
+                // There are two solutions:
+                //  0. Add items one by one using direct this.Add method (without IList<T> wrapper).
+                //     Too many ListChanged events will be generated (one per item), too many updates for gridview. Bad performance.
+                //  1. Batch add items through Items wrapper's AddRange method.
+                //     One reset event will be generated, one batch update for gridview. Ugly but fast code.
+                OnListChanged(new ListChangedEventArgs(ListChangedType.Reset, -1));
+            }
+
+            protected override bool SupportsSortingCore => true;
+
+            protected override void ApplySortCore(PropertyDescriptor propertyDescriptor, ListSortDirection direction)
+            {
+                GitRefs.Sort(GitRefsComparer.Create(propertyDescriptor, direction == ListSortDirection.Descending));
+            }
+
+            private List<IGitRef> GitRefs => (List<IGitRef>)Items;
+
+            private static class GitRefsComparer
+            {
+                private static readonly Dictionary<string, Comparison<IGitRef>> PropertyComparers = new Dictionary<string, Comparison<IGitRef>>();
+
+                static GitRefsComparer()
+                {
+                    AddSortableProperty(gitRef => gitRef.LocalName, (x, y) => string.Compare(x.LocalName, y.LocalName, StringComparison.Ordinal));
+                    AddSortableProperty(gitRef => gitRef.TrackingRemote, (x, y) => string.Compare(x.TrackingRemote, y.TrackingRemote, StringComparison.Ordinal));
+                    AddSortableProperty(gitRef => gitRef.MergeWith, (x, y) => string.Compare(x.MergeWith, y.MergeWith, StringComparison.Ordinal));
+                }
+
+                /// <summary>
+                /// Creates a comparer to sort lostObjects by specified property.
+                /// </summary>
+                /// <param name="propertyDescriptor">Property to sort by.</param>
+                /// <param name="isReversedComparing">Use reversed sorting order.</param>
+                public static Comparison<IGitRef> Create(PropertyDescriptor propertyDescriptor, bool isReversedComparing)
+                {
+                    if (PropertyComparers.TryGetValue(propertyDescriptor.Name, out var comparer))
+                    {
+                        return isReversedComparing ? (x, y) => comparer(y, x) : comparer;
+                    }
+
+                    throw new NotSupportedException(string.Format("Custom sort by {0} property is not supported.", propertyDescriptor.Name));
+                }
+
+                /// <summary>
+                /// Adds custom property comparer.
+                /// </summary>
+                /// <typeparam name="T">Property type.</typeparam>
+                /// <param name="expr">Property to sort by.</param>
+                /// <param name="propertyComparer">Property values comparer.</param>
+                private static void AddSortableProperty<T>(Expression<Func<IGitRef, T>> expr, Comparison<IGitRef> propertyComparer)
+                {
+                    PropertyComparers[((MemberExpression)expr.Body).Member.Name] = propertyComparer;
+                }
+            }
+        }
+
         private readonly FormRemotesController _formRemotesController = new();
         private IConfigFileRemoteSettingsManager _remotesManager;
         private ConfigFileRemote _selectedRemote;
@@ -276,6 +341,8 @@ Inactive remote is completely invisible to git.");
         private void InitialiseTabDefaultPullBehaviors(string preselectLocal = null)
         {
             var heads = Module.GetRefs(false, true).OrderBy(r => r.LocalName).ToList();
+            var headsList = new SortableGitRefList();
+            headsList.AddRange(heads);
 
             RemoteRepositoryCombo.Sorted = false;
             RemoteRepositoryCombo.DataSource = new[] { new ConfigFileRemote() }.Union(UserGitRemotes).ToList();
@@ -284,7 +351,7 @@ Inactive remote is completely invisible to git.");
             RemoteBranches.AutoGenerateColumns = false;
             RemoteBranches.SelectionChanged -= RemoteBranchesSelectionChanged;
             RemoteBranches.DataError += RemoteBranchesDataError;
-            RemoteBranches.DataSource = heads;
+            RemoteBranches.DataSource = headsList;
             RemoteBranches.ClearSelection();
             RemoteBranches.SelectionChanged += RemoteBranchesSelectionChanged;
             var preselectLocalRow = RemoteBranches.Rows.Cast<DataGridViewRow>().

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text;
 using System.Windows.Forms;
 using GitCommands;
@@ -11,6 +14,69 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormViewPatch : GitModuleForm
     {
+        private sealed class SortablePatchesList : BindingList<Patch>
+        {
+            public void AddRange(IEnumerable<Patch> patches)
+            {
+                Patches.AddRange(patches);
+
+                // NOTE: adding items via wrapper's AddRange doesn't generate ListChanged event, so DataGridView doesn't update itself
+                // There are two solutions:
+                //  0. Add items one by one using direct this.Add method (without IList<T> wrapper).
+                //     Too many ListChanged events will be generated (one per item), too many updates for gridview. Bad performance.
+                //  1. Batch add items through Items wrapper's AddRange method.
+                //     One reset event will be generated, one batch update for gridview. Ugly but fast code.
+                OnListChanged(new ListChangedEventArgs(ListChangedType.Reset, -1));
+            }
+
+            protected override bool SupportsSortingCore => true;
+
+            protected override void ApplySortCore(PropertyDescriptor propertyDescriptor, ListSortDirection direction)
+            {
+                Patches.Sort(PatchesComparer.Create(propertyDescriptor, direction == ListSortDirection.Descending));
+            }
+
+            private List<Patch> Patches => (List<Patch>)Items;
+
+            private static class PatchesComparer
+            {
+                private static readonly Dictionary<string, Comparison<Patch>> PropertyComparers = new Dictionary<string, Comparison<Patch>>();
+
+                static PatchesComparer()
+                {
+                    AddSortableProperty(patch => patch.FileNameA, (x, y) => string.Compare(x.FileNameA, y.FileNameA, StringComparison.Ordinal));
+                    AddSortableProperty(patch => patch.ChangeType, (x, y) => string.Compare(x.ChangeType.ToString(), y.ChangeType.ToString(), StringComparison.Ordinal));
+                    AddSortableProperty(patch => patch.FileType, (x, y) => string.Compare(x.FileType.ToString(), y.FileType.ToString(), StringComparison.Ordinal));
+                }
+
+                /// <summary>
+                /// Creates a comparer to sort lostObjects by specified property.
+                /// </summary>
+                /// <param name="propertyDescriptor">Property to sort by.</param>
+                /// <param name="isReversedComparing">Use reversed sorting order.</param>
+                public static Comparison<Patch> Create(PropertyDescriptor propertyDescriptor, bool isReversedComparing)
+                {
+                    if (PropertyComparers.TryGetValue(propertyDescriptor.Name, out var comparer))
+                    {
+                        return isReversedComparing ? (x, y) => comparer(y, x) : comparer;
+                    }
+
+                    throw new NotSupportedException(string.Format("Custom sort by {0} property is not supported.", propertyDescriptor.Name));
+                }
+
+                /// <summary>
+                /// Adds custom property comparer.
+                /// </summary>
+                /// <typeparam name="T">Property type.</typeparam>
+                /// <param name="expr">Property to sort by.</param>
+                /// <param name="propertyComparer">Property values comparer.</param>
+                private static void AddSortableProperty<T>(Expression<Func<Patch, T>> expr, Comparison<Patch> propertyComparer)
+                {
+                    PropertyComparers[((MemberExpression)expr.Body).Member.Name] = propertyComparer;
+                }
+            }
+        }
+
         private readonly TranslationString _patchFileFilterString = new("Patch file (*.Patch)");
         private readonly TranslationString _patchFileFilterTitle = new("Select patch file");
 
@@ -85,8 +151,9 @@ namespace GitUI.CommandsDialogs
             {
                 var text = System.IO.File.ReadAllText(PatchFileNameEdit.Text, GitModule.LosslessEncoding);
                 var patches = PatchProcessor.CreatePatchesFromString(text, new Lazy<Encoding>(() => Module.FilesEncoding)).ToList();
-
-                GridChangedFiles.DataSource = patches;
+                var patchesList = new SortablePatchesList();
+                patchesList.AddRange(patches);
+                GridChangedFiles.DataSource = patchesList;
             }
             catch
             {

--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Windows.Forms;
 using GitCommands.Patches;
 using GitExtUtils.GitUI;
@@ -13,6 +14,71 @@ namespace GitUI
 {
     public partial class PatchGrid : GitModuleControl
     {
+        private sealed class SortablePatchFilesList : BindingList<PatchFile>
+        {
+            public void AddRange(IEnumerable<PatchFile> lostObjects)
+            {
+                PatchFiles.AddRange(lostObjects);
+
+                // NOTE: adding items via wrapper's AddRange doesn't generate ListChanged event, so DataGridView doesn't update itself
+                // There are two solutions:
+                //  0. Add items one by one using direct this.Add method (without IList<T> wrapper).
+                //     Too many ListChanged events will be generated (one per item), too many updates for gridview. Bad performance.
+                //  1. Batch add items through Items wrapper's AddRange method.
+                //     One reset event will be generated, one batch update for gridview. Ugly but fast code.
+                OnListChanged(new ListChangedEventArgs(ListChangedType.Reset, -1));
+            }
+
+            protected override bool SupportsSortingCore => true;
+
+            protected override void ApplySortCore(PropertyDescriptor propertyDescriptor, ListSortDirection direction)
+            {
+                PatchFiles.Sort(PatchFilesComparer.Create(propertyDescriptor, direction == ListSortDirection.Descending));
+            }
+
+            private List<PatchFile> PatchFiles => (List<PatchFile>)Items;
+
+            private static class PatchFilesComparer
+            {
+                private static readonly Dictionary<string, Comparison<PatchFile>> PropertyComparers = new Dictionary<string, Comparison<PatchFile>>();
+
+                static PatchFilesComparer()
+                {
+                    AddSortableProperty(patchFile => patchFile.Status, (x, y) => string.Compare(x.Status, y.Status, StringComparison.CurrentCulture));
+                    AddSortableProperty(patchFile => patchFile.Name, (x, y) => string.Compare(x.Name, y.Name, StringComparison.CurrentCulture));
+                    AddSortableProperty(patchFile => patchFile.Subject, (x, y) => string.Compare(x.Subject, y.Subject, StringComparison.CurrentCulture));
+                    AddSortableProperty(patchFile => patchFile.Author, (x, y) => string.Compare(x.Author, y.Author, StringComparison.CurrentCulture));
+                    AddSortableProperty(patchFile => patchFile.Date, (x, y) => string.Compare(x.Date, y.Date, StringComparison.CurrentCulture));
+                }
+
+                /// <summary>
+                /// Creates a comparer to sort lostObjects by specified property.
+                /// </summary>
+                /// <param name="propertyDescriptor">Property to sort by.</param>
+                /// <param name="isReversedComparing">Use reversed sorting order.</param>
+                public static Comparison<PatchFile> Create(PropertyDescriptor propertyDescriptor, bool isReversedComparing)
+                {
+                    if (PropertyComparers.TryGetValue(propertyDescriptor.Name, out var comparer))
+                    {
+                        return isReversedComparing ? (x, y) => comparer(y, x) : comparer;
+                    }
+
+                    throw new NotSupportedException(string.Format("Custom sort by {0} property is not supported.", propertyDescriptor.Name));
+                }
+
+                /// <summary>
+                /// Adds custom property comparer.
+                /// </summary>
+                /// <typeparam name="T">Property type.</typeparam>
+                /// <param name="expr">Property to sort by.</param>
+                /// <param name="propertyComparer">Property values comparer.</param>
+                private static void AddSortableProperty<T>(Expression<Func<PatchFile, T>> expr, Comparison<PatchFile> propertyComparer)
+                {
+                    PropertyComparers[((MemberExpression)expr.Body).Member.Name] = propertyComparer;
+                }
+            }
+        }
+
         private readonly TranslationString _unableToShowPatchDetails = new("Unable to show details of patch file.");
 
         private List<PatchFile> _skipped;
@@ -110,7 +176,9 @@ namespace GitUI
         private void DisplayPatches(IReadOnlyList<PatchFile> patchFiles)
         {
             PatchFiles = patchFiles;
-            Patches.DataSource = patchFiles;
+            SortablePatchFilesList patchFilesList = new SortablePatchFilesList();
+            patchFilesList.AddRange(patchFiles);
+            Patches.DataSource = patchFilesList;
 
             if (patchFiles.Any())
             {


### PR DESCRIPTION
When it is not the case, pressing F3 is throwing an exception, killing the app.

Fixes #9534 (and all similar use cases in the code)

## Proposed changes

- Ensure a proper `SortableBindingList` instance is used for all `DataGridView`s `DataSource` property where sort could occur

### Before

Pressing F3 on any of the modified screen grids were throwing an `InvalidOperationException` with `DataGridView control must be bound to an IBindingList object to be sorted.` message

### After

Pressing F3 on any of the modified screen grids is sorting based on the column

## Test methodology 
- Manual tests

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 10
- 3.5 release branch (a trivial merge is needed for master)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->
I agree that the maintainer squash merge this PR (if the commit message is clear).
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
