### PR TITLE
Submodules: ignore bad submodules instead of crashing

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -404,6 +404,12 @@ namespace GitUI.BranchTreePanel
                 foreach (var submoduleInfo in result.AllSubmodules)
                 {
                     string superPath = GetSubmoduleSuperPath(submoduleInfo.Path);
+                    if (string.IsNullOrEmpty(superPath))
+                    {
+                        // Ignore bad paths defined as submodule.
+                        continue;
+                    }
+
                     string localPath = Path.GetDirectoryName(submoduleInfo.Path.Substring(superPath.Length)).ToPosixPath();
 
                     var isCurrent = submoduleInfo.Bold;
@@ -420,7 +426,6 @@ namespace GitUI.BranchTreePanel
                 string GetSubmoduleSuperPath(string submodulePath)
                 {
                     var superPath = modulePaths.Find(path => submodulePath != path && submodulePath.Contains(path));
-                    Validates.NotNull(superPath);
                     return superPath;
                 }
             }


### PR DESCRIPTION
Fixes #8366

## Proposed changes

- Ignore submodules with an invalid path

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/135766459-a92393f6-516f-435c-801c-ed65d13cb3b0.png)

### After

No exception

## Test methodology <!-- How did you ensure quality? -->

Manual:
* Create a bad `.gitmodules` file in an existing repository (like described in  https://github.com/gitextensions/gitextensions/issues/8366#issuecomment-930570854)  with following content:
 
```
[submodule "C:/Project/x/y"]
path = C:/Project/x/y
url = C:/Project/x/y
branch = release/201705
```

* Open the repository in GitExtensions

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 621c094b6300b177874ae721616f9e3aab9875d8 (Dirty)
- Git 2.28.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.10
- DPI 192dpi (200% scaling)


