### PR TITLE
Remove `Rename` menu item for remote branches from Repo Tree

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.RemoteBranchNode.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.RemoteBranchNode.cs
@@ -11,7 +11,7 @@ namespace GitUI.BranchTreePanel
     public partial class RepoObjectsTree
     {
         [DebuggerDisplay("(Remote) FullPath = {FullPath}, Hash = {ObjectId}, Visible: {Visible}")]
-        private sealed class RemoteBranchNode : BaseBranchLeafNode, IGitRefActions, ICanDelete, ICanRename
+        private sealed class RemoteBranchNode : BaseBranchLeafNode, IGitRefActions, ICanDelete
         {
             public RemoteBranchNode(Tree tree, in ObjectId objectId, string fullPath, bool visible)
                 : base(tree, objectId, fullPath, visible, nameof(Images.BranchRemote), nameof(Images.BranchRemoteMerged))
@@ -57,11 +57,6 @@ namespace GitUI.BranchTreePanel
             {
                 var remoteBranchInfo = GetRemoteBranchInfo();
                 return UICommands.StartDeleteRemoteBranchDialog(TreeViewNode.TreeView, remoteBranchInfo.Remote + '/' + remoteBranchInfo.BranchName);
-            }
-
-            public bool Rename()
-            {
-                return UICommands.StartRenameDialog(TreeViewNode.TreeView, FullPath);
             }
 
             public bool Checkout()


### PR DESCRIPTION
## Proposed changes

- Turns out it is impossible to rename remote branches thus remote branch nodes should not have a `Rename` menu item

## Test methodology <!-- How did you ensure quality? -->

- Manually - context menu for remote branch no longer has `Rename`

### Before
![image](https://user-images.githubusercontent.com/483659/136515699-a4e08859-1b1e-487a-ac85-e30c49441649.png)

### After
![image](https://user-images.githubusercontent.com/483659/136515446-3873802e-63e0-4fb9-9d58-dcb648911078.png)

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 3.4.3
- Build a5af9274b032d83063d12ea7aa9b46dc36382644 (Dirty)
- Git 2.33.0.windows.2
- Microsoft Windows NT 10.0.19043.0
- .NET Framework 4.8.4420.0
- DPI 192dpi (200% scaling)

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
