### PR TITLE
Package plugins

### DIFF
--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -25,7 +25,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="WiX" />
+    <!-- This is needed for scripts\Publish.targets to resolve .NET references -->
+    <PackageReference Include="NETStandard.Library" IsImplicitlyDefined="true" GeneratePathProperty="true">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="WiX">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/GitExtensions/Project.Publish.targets
+++ b/GitExtensions/Project.Publish.targets
@@ -83,6 +83,8 @@
     -->
   <Target Name="CreatePortable" BeforeTargets="Publish" DependsOnTargets="_RetrieveCurrentBuildVersion;_PublishTranslations;_DownloadPluginManager">
     <PropertyGroup>
+      <ContinuousIntegrationBuild Condition="'$(ContinuousIntegrationBuild)' == ''">false</ContinuousIntegrationBuild>
+
       <_TargetAppConfig>@(AppConfigFileDestination)</_TargetAppConfig>
 
       <_UserDictionariesSourceDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'Bin', 'Dictionaries'))</_UserDictionariesSourceDir>
@@ -110,13 +112,13 @@
       <_PublishedPath>$([MSBuild]::NormalizeDirectory('$(PublishDir)'))</_PublishedPath>
     </PropertyGroup>
 
-    <!-- Determine plugins assemblies and their required references
+    <!-- Determine plugins assemblies and their required references -->
     <_GetPluginAssembliesCodeTask
           SolutionPath="$(SolutionPath)"
           BuildConfiguration="$(Configuration)"
           IsContinuousIntegrationBuild="$(ContinuousIntegrationBuild)">
       <Output ItemName="CollectedPluginAssemblies" TaskParameter="Output"/>
-    </_GetPluginAssembliesCodeTask> -->
+    </_GetPluginAssembliesCodeTask>
 
     <ItemGroup>
       <UserDictionaries Include="$(_UserDictionariesSourceDir)\*.dic" />

--- a/Packages.props
+++ b/Packages.props
@@ -32,6 +32,7 @@
 
     <!-- Setup infra -->
     <PackageReference Update="WiX" Version="3.11.2" />
+    <PackageReference Update="NETStandard.Library" Version="2.0.0" />
 
     <!-- Test infra -->
     <PackageReference Update="ApprovalTests" Version="4.4.0" />

--- a/Plugins/AutoCompileSubmodules/GitExtensions.Plugins.AutoCompileSubmodules.csproj
+++ b/Plugins/AutoCompileSubmodules/GitExtensions.Plugins.AutoCompileSubmodules.csproj
@@ -12,9 +12,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj" />
-    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/BackgroundFetch/GitExtensions.Plugins.BackgroundFetch.csproj
+++ b/Plugins/BackgroundFetch/GitExtensions.Plugins.BackgroundFetch.csproj
@@ -16,10 +16,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj" />
-    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj" />
-    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/Bitbucket/GitExtensions.Plugins.Bitbucket.csproj
+++ b/Plugins/Bitbucket/GitExtensions.Plugins.Bitbucket.csproj
@@ -11,10 +11,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj" />
-    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj" />
-    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorIntegration.csproj
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorIntegration.csproj
@@ -10,10 +10,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\GitCommands\GitCommands.csproj" />
-    <ProjectReference Include="..\..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj" />
-    <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\..\GitCommands\GitCommands.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsIntegration.csproj
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsIntegration.csproj
@@ -11,10 +11,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\GitCommands\GitCommands.csproj" />
-    <ProjectReference Include="..\..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj" />
-    <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\..\GitCommands\GitCommands.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsIntegration.csproj
+++ b/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsIntegration.csproj
@@ -11,10 +11,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\GitCommands\GitCommands.csproj" />
-    <ProjectReference Include="..\..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj" />
-    <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\..\GitCommands\GitCommands.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityIntegration.csproj
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityIntegration.csproj
@@ -9,10 +9,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\GitCommands\GitCommands.csproj" />
-    <ProjectReference Include="..\..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj" />
-    <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\..\GitCommands\GitCommands.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/CreateLocalBranches/GitExtensions.Plugins.CreateLocalBranches.csproj
+++ b/Plugins/CreateLocalBranches/GitExtensions.Plugins.CreateLocalBranches.csproj
@@ -1,9 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
-    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj" />
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/DeleteUnusedBranches/GitExtensions.Plugins.DeleteUnusedBranches.csproj
+++ b/Plugins/DeleteUnusedBranches/GitExtensions.Plugins.DeleteUnusedBranches.csproj
@@ -5,11 +5,26 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj" />
-    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\GitUI\GitUI.csproj" />
-    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj" />
-    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitUI\GitUI.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/Directory.Build.props
+++ b/Plugins/Directory.Build.props
@@ -5,6 +5,9 @@
   <PropertyGroup>
     <!-- To be removed when NRT annotations are complete -->
     <Nullable>annotations</Nullable>
+
+    <!-- Any NuGet package dependencies are copied to the output directory -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <!--

--- a/Plugins/FindLargeFiles/GitExtensions.Plugins.FindLargeFiles.csproj
+++ b/Plugins/FindLargeFiles/GitExtensions.Plugins.FindLargeFiles.csproj
@@ -1,11 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj" />
-    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\GitUI\GitUI.csproj" />
-    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj" />
-    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitUI\GitUI.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/GitFlow/GitExtensions.Plugins.GitFlow.csproj
+++ b/Plugins/GitFlow/GitExtensions.Plugins.GitFlow.csproj
@@ -1,10 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj" />
-    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
-    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj" />
+    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/GitHub3/GitExtensions.Plugins.GitHub3.csproj
+++ b/Plugins/GitHub3/GitExtensions.Plugins.GitHub3.csproj
@@ -5,10 +5,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Externals\Git.hub\Git.hub\Git.hub.csproj" />
-    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj" />
-    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj" />
-    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\Externals\Git.hub\Git.hub\Git.hub.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/Gource/GitExtensions.Plugins.Gource.csproj
+++ b/Plugins/Gource/GitExtensions.Plugins.Gource.csproj
@@ -8,10 +8,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\GitUI\GitUI.csproj" />
-    <ProjectReference Include="..\..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
-    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj" />
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitUI\GitUI.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/JiraCommitHintPlugin/GitExtensions.Plugins.JiraCommitHintPlugin.csproj
+++ b/Plugins/JiraCommitHintPlugin/GitExtensions.Plugins.JiraCommitHintPlugin.csproj
@@ -10,9 +10,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj" />
-    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/ProxySwitcher/GitExtensions.Plugins.ProxySwitcher.csproj
+++ b/Plugins/ProxySwitcher/GitExtensions.Plugins.ProxySwitcher.csproj
@@ -1,10 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj" />
-    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj" />
-    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/ReleaseNotesGenerator/GitExtensions.Plugins.ReleaseNotesGenerator.csproj
+++ b/Plugins/ReleaseNotesGenerator/GitExtensions.Plugins.ReleaseNotesGenerator.csproj
@@ -1,10 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj" />
-    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj" />
-    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\GitCommands\GitCommands.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/Statistics/GitImpact/GitExtensions.Plugins.GitImpact.csproj
+++ b/Plugins/Statistics/GitImpact/GitExtensions.Plugins.GitImpact.csproj
@@ -5,9 +5,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj" />
-    <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/Statistics/GitStatistics/GitExtensions.Plugins.GitStatistics.csproj
+++ b/Plugins/Statistics/GitStatistics/GitExtensions.Plugins.GitStatistics.csproj
@@ -5,11 +5,26 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\GitCommands\GitCommands.csproj" />
-    <ProjectReference Include="..\..\..\GitExtUtils\GitExtUtils.csproj" />
-    <ProjectReference Include="..\..\..\GitUI\GitUI.csproj" />
-    <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj" />
-    <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+    <ProjectReference Include="..\..\..\GitCommands\GitCommands.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\GitExtUtils\GitExtUtils.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\GitUI\GitUI.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\ResourceManager\ResourceManager.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj">
+      <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTests/Plugins/BuildServerIntegration/AzureDevOpsIntegration.Tests/AzureDevOpsIntegration.Tests.csproj
+++ b/UnitTests/Plugins/BuildServerIntegration/AzureDevOpsIntegration.Tests/AzureDevOpsIntegration.Tests.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Plugins\BuildServerIntegration\AzureDevOpsIntegration\AzureDevOpsIntegration.csproj" />
+    <ProjectReference Include="..\..\..\..\ResourceManager\ResourceManager.csproj" />
     <ProjectReference Include="..\..\..\CommonTestUtils\CommonTestUtils.csproj" />
   </ItemGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,7 +82,7 @@ test_script:
 after_test:
 - ps: |
     Write-Host "Preparing build artifacts..."
-    dotnet publish -c Release --no-build /bl:.\artifacts\log\publish.binlog
+    dotnet publish -c Release --no-build /bl:.\artifacts\log\publish.binlog /p:ContinuousIntegrationBuild=true
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 
 

--- a/scripts/Publish.targets
+++ b/scripts/Publish.targets
@@ -10,6 +10,8 @@
       <Output ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true"/>
     </ParameterGroup>
     <Task>
+      <Reference Include="$(PkgNETStandard_Library)\build\netstandard2.0\ref\System.Runtime.dll"/>
+      <Reference Include="$(PkgNETStandard_Library)\build\netstandard2.0\ref\System.Xml.ReaderWriter.dll"/>
       <Reference Include="Microsoft.Build"/>
       <Using Namespace="Microsoft.Build.Construction"/>
       <Using Namespace="Microsoft.Build.Evaluation"/>


### PR DESCRIPTION
Resolves #9614

NB: `CopyLocalLockFileAssemblies` slightly increases the size of `\artifacts\Release\bin\GitExtensions\net5.0-windows\Plugins\` folder ~78MB -> ~130MB. There are few possible tweaks to reduce the size back, but this isn't blocking.