### PR TITLE
Add support for Del key to RepoObjectsTree nodes

### DIFF
--- a/GitUI/BranchTreePanel/ContextMenu/MenuItemsGenerator.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/MenuItemsGenerator.cs
@@ -107,9 +107,10 @@ namespace GitUI.BranchTreePanel.ContextMenu
         {
             if (Implements<ICanDelete>())
             {
-                yield return _menuItemFactory.CreateMenuItem<ToolStripMenuItem, TNode>(
-                    node => ((ICanDelete)node).Delete(), Strings.Delete, GetTooltip(MenuItemKey.Delete), Properties.Images.BranchDelete)
-                    .WithKey(MenuItemKey.Delete);
+                ToolStripMenuItem item = _menuItemFactory.CreateMenuItem<ToolStripMenuItem, TNode>(
+                    node => ((ICanDelete)node).Delete(), Strings.Delete, GetTooltip(MenuItemKey.Delete), Properties.Images.BranchDelete);
+                item.ShortcutKeys = Keys.Delete;
+                yield return item.WithKey(MenuItemKey.Delete);
             }
         }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.LocalBranchNode.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.LocalBranchNode.cs
@@ -55,6 +55,11 @@ namespace GitUI.BranchTreePanel
                 Rename();
             }
 
+            internal override void OnDelete()
+            {
+                Delete();
+            }
+
             public bool Checkout()
             {
                 return UICommands.StartCheckoutBranch(ParentWindow(), branch: FullPath, remote: false);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -41,6 +41,11 @@ namespace GitUI.BranchTreePanel
                 CreateBranch();
             }
 
+            internal override void OnDelete()
+            {
+                Delete();
+            }
+
             public bool CreateBranch()
             {
                 return UICommands.StartCreateBranchDialog(TreeViewNode.TreeView, ObjectId);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -506,6 +506,10 @@ namespace GitUI.BranchTreePanel
             {
             }
 
+            internal virtual void OnDelete()
+            {
+            }
+
             public static Node GetNode(TreeNode treeNode)
             {
                 return (Node)treeNode.Tag;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.RemoteBranchNode.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.RemoteBranchNode.cs
@@ -48,6 +48,11 @@ namespace GitUI.BranchTreePanel
                 return new RemoteBranchInfo(remote, branch);
             }
 
+            internal override void OnDelete()
+            {
+                Delete();
+            }
+
             public bool CreateBranch()
             {
                 return UICommands.StartCreateBranchDialog(TreeViewNode.TreeView, FullPath);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -531,6 +531,9 @@ namespace GitUI.BranchTreePanel
                 case Keys.F3:
                     OnBtnSearchClicked(this, EventArgs.Empty);
                     break;
+                case Keys.Delete:
+                    Node.OnNode<Node>(treeMain.SelectedNode, node => node.OnDelete());
+                    break;
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Motivation

When cleaning up branches it is very convenient to do that from the repo objects tree panel as the branches are sorted by date and it's easy to choose unnecessary ones. However having to open a context menu and click on `Delete` menu item is a big hurdle when compared to the whole process. It's actually easier to click on a line in a rev-grid and press `del` when focus is there. Enabling `del` key in repo objects tree panel solves that.

## Proposed changes

- Enable triggering `Delete` form for repo objects tree items with a `del` key
- Implementation is exactly the same as is already done for triggering `Rename` form with `F2` key

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/483659/136575419-09517b69-3075-481d-8554-93496f89bb56.png)

![image](https://user-images.githubusercontent.com/483659/136575430-624a528d-5262-4e10-aa3e-3e0454ae9fcb.png)

![image](https://user-images.githubusercontent.com/483659/136575442-0d9a8192-a06e-41b9-96c9-827231b53d5a.png)


### After

![image](https://user-images.githubusercontent.com/483659/136574697-26b39acb-5c2f-45d7-b9bb-4d7366364683.png)

![image](https://user-images.githubusercontent.com/483659/136574722-31abbd8b-7191-4e69-87ed-af3bee578264.png)

![image](https://user-images.githubusercontent.com/483659/136574731-03bff5f3-a74b-4f15-bd86-02aba2f2e738.png)


## Test methodology <!-- How did you ensure quality? -->

- Manually. Pressing `del` key on a local branch, remote branch and tag opens up delete form

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 28321b06951cfcd0c54683feec189564808e209a
- Git 2.33.0.windows.2
- Microsoft Windows NT 10.0.19043.0
- .NET 5.0.10
- DPI 96dpi (no scaling)

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->
I agree that the maintainer squash merge this PR (if the commit message is clear).
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
