### PR TITLE
Fix #9634: Minor PR template issue: body text being rendered as a header

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,9 @@ Fixes #
 - To be decided later.
 The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
 -->
+
 I agree that the maintainer squash merge this PR (if the commit message is clear).
+
 ----
 
 :black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9634: Minor PR template issue: body text being rendered as a header

## Proposed changes

- Add a new line above and below "I agree that the maintainer squash merge this PR (if the commit message is clear)." in order to render it as a section body text, rather than as a new section header.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/14078392/136668193-34247a1f-c4c4-4632-a688-da7da036fba7.png)

### After

![image](https://user-images.githubusercontent.com/14078392/136668013-d1e092fc-dcb9-49c4-979b-e0a63f0b00e3.png)

## Test methodology <!-- How did you ensure quality? -->

- viewed the previous template and the updated template in GitHub's markdown viewer
- viewed the previous template and the updated template in VS Code's markdown viewer

## Test environment(s) <!-- Remove any that don't apply -->

- github.com
- Visual Studio Code

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
