### PR TITLE
Fix revision lane order

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -320,13 +320,14 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
                 // The list containing the segments is created later. We can set the correct capacity then, to prevent resizing
                 List<RevisionGraphSegment> segments;
+                RevisionGraphSegment[] revisionStartSegments = revision.GetStartSegments();
 
                 if (nextIndex == 0)
                 {
                     // This is the first row. Start with only the startsegments of this row
-                    segments = new List<RevisionGraphSegment>(revision.StartSegments);
+                    segments = new List<RevisionGraphSegment>(revisionStartSegments);
 
-                    foreach (var startSegment in revision.StartSegments)
+                    foreach (var startSegment in revisionStartSegments)
                     {
                         startSegment.LaneInfo = new LaneInfo(startSegment, derivedFrom: null);
                     }
@@ -337,7 +338,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                     RevisionGraphRow previousRevisionGraphRow = localOrderedRowCache[nextIndex - 1];
 
                     // Create segments list with te correct capacity
-                    segments = new List<RevisionGraphSegment>(previousRevisionGraphRow.Segments.Count + revision.StartSegments.Count);
+                    segments = new List<RevisionGraphSegment>(previousRevisionGraphRow.Segments.Count + revisionStartSegments.Length);
 
                     // Loop through all segments that do not end in the previous row
                     foreach (var segment in previousRevisionGraphRow.Segments.Where(s => s.Parent != previousRevisionGraphRow.Revision))
@@ -351,12 +352,12 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                             if (!startSegmentsAdded)
                             {
                                 startSegmentsAdded = true;
-                                segments.AddRange(revision.StartSegments);
+                                segments.AddRange(revisionStartSegments);
                             }
 
-                            foreach (var startSegment in revision.StartSegments)
+                            foreach (var startSegment in revisionStartSegments)
                             {
-                                if (startSegment == revision.StartSegments.First())
+                                if (startSegment == revisionStartSegments[0])
                                 {
                                     if (startSegment.LaneInfo is null || startSegment.LaneInfo.StartScore > segment.LaneInfo?.StartScore)
                                     {
@@ -378,9 +379,9 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                     if (!startSegmentsAdded)
                     {
                         // Add new segments started by this revision to the end
-                        segments.AddRange(revision.StartSegments);
+                        segments.AddRange(revisionStartSegments);
 
-                        foreach (var startSegment in revision.StartSegments)
+                        foreach (var startSegment in revisionStartSegments)
                         {
                             startSegment.LaneInfo = new LaneInfo(startSegment, derivedFrom: null);
                         }

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -16,13 +16,11 @@ namespace GitUI.UserControls.RevisionGrid.Graph
     {
         private ImmutableStack<RevisionGraphRevision> _parents = ImmutableStack<RevisionGraphRevision>.Empty;
         private ImmutableStack<RevisionGraphRevision> _children = ImmutableStack<RevisionGraphRevision>.Empty;
+        private ConcurrentQueue<RevisionGraphSegment> _startSegments = new();
 
         public RevisionGraphRevision(ObjectId objectId, int guessScore)
         {
             Objectid = objectId;
-
-            StartSegments = new ConcurrentQueue<RevisionGraphSegment>();
-
             Score = guessScore;
         }
 
@@ -93,7 +91,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
         public ImmutableStack<RevisionGraphRevision> Parents => _parents;
         public ImmutableStack<RevisionGraphRevision> Children => _children;
-        public ConcurrentQueue<RevisionGraphSegment> StartSegments { get; }
+        public RevisionGraphSegment[] GetStartSegments() => _startSegments.ToArray();
 
         // Mark this commit, and all its parents, as relative. Used for branch highlighting.
         // By default, the current checkout will be marked relative.
@@ -143,7 +141,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
             maxScore = parent.EnsureScoreIsAbove(Score + 1);
 
-            StartSegments.Enqueue(new RevisionGraphSegment(parent, this));
+            _startSegments.Enqueue(new RevisionGraphSegment(parent, this));
         }
 
         private void AddChild(RevisionGraphRevision child)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## The Story

I am running custom build periodically rebased off of `master` at work and for some time now I've felt there is something confusing/wrong with revision graph lanes but couldn't put a finger on it. Until today. Today I've created a feature branch off of `master` and merged it in immediately and revision graph looked clearly wrong - I expected `master` branch to be on the left and feature branch commit on the right but that wasn't the case (screenshots below).

What ensued was 1.5h of bisecting 7 months worth of commits with `git clean -xdf` in between some of checkouts as switching between .net 5, .net 3.1 and so on comes heavy on VS.

It turned out (at least I suspect so..) that this got introduced completely by accident here https://github.com/gitextensions/gitextensions/commit/02f6edaba7628987609b2cf5642fa7dd1146e025#diff-e0c72dee0a616951e33a8b95092faa5d18fa54019f17002bbf8150edaa11b3b6L95-L96 as `SynchronizedCollection` is no longer available int .net core

## Proposed changes

- Use `BlockingCollection` instead of `ConcurrentBag`. Before the mentioned commit `SynchronizedCollection` was used there and it is based on `List<T>` which means order is important and that a bag is not a suitable replacement.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/483659/137512503-42f1f2e6-6e40-46f2-ad1d-65f9db1b8db7.png)

### After

![image](https://user-images.githubusercontent.com/483659/137518409-1830ee11-3921-4dc6-8874-129d171f3868.png)

## Test methodology <!-- How did you ensure quality? -->

- Manually inspected revision graph

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build e683a364f1049441e251e21d7ff3b0a552e6d8b5
- Git 2.33.0.windows.2
- Microsoft Windows NT 10.0.19043.0
- .NET 5.0.11
- DPI 120dpi (125% scaling)

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
