### PR TITLE
Fix: Prevent the find-replace dialog from blocking Windows shutdown

### DIFF
--- a/GitUI/Editor/FindAndReplaceForm.cs
+++ b/GitUI/Editor/FindAndReplaceForm.cs
@@ -291,7 +291,7 @@ namespace GitUI
         private void FindAndReplaceForm_FormClosing(object sender, FormClosingEventArgs e)
         {
             // Prevent dispose, as this form can be re-used
-            if (e.CloseReason != CloseReason.FormOwnerClosing)
+            if (e.CloseReason == CloseReason.UserClosing)
             {
                 Owner?.Select(); // prevent another app from being activated instead
 


### PR DESCRIPTION
Fixes #9649, where Git Extensions prevents logout/shutdown if the find/replace dialog has been initialised at any time in the user's session (regardless of whether the dialog is visible)

![This app is preventing shutdown](https://user-images.githubusercontent.com/17579442/137470935-c86c711a-21eb-4d35-bff0-95b2fdd9e7fb.png)

## Proposed changes
- Update the "prevent disposal" code in `FindAndReplaceForm` to only block user-initiated close operations. This ensures that when the operating system requests shutdown (specifically, by sending the `WM_QUERYENDSESSION` message), the app will not block shutdown

## Test methodology
- Manual testing - to validate this change via tests would be excessive, as it would require the sending of window messages to the application, which, to my mind, is too low-level. Instead, I performed many manual tests. In all test sessions (many combinations of open/close app, repo, find/replace etc.), the only `CloseReasons` received were `UserClosing`, `FormOwnerClosing`, and `WindowsShutdown`. Even terminating through the task manager still sent a message of `FormOwnerClosing` 🤷. The code change handles all of these options correctly.
- Consideration of _all_ `enum` values for `CloseReason` and what the form should do for each:
    - `None` - this reason is never actually received, it's just a sensible default value, so there's no need for special processing
    - `WindowsShutDown`, `TaskManagerClosing`, `ApplicationExitCall` - the app should definitely terminate
    - `FormOwnerClosing` - the owner is `FormBrowse`, so when the owner closes, the form should close too
    - `MdiFormClosing` - not applicable. There is no `MdiParent`
    - `UserClosing` - this is the only case where the form's `Close` should be blocked for the purpose of later reuse

## Test environment(s)

- GIT `git version 2.33.0.windows.2`
- Windows 10 21H1

## Merge strategy

- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
