### PR TITLE
Fix loading user plugins.

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -105,10 +105,11 @@ namespace GitExtensions
             }
 
             ManagedExtensibility.Initialise(new[]
-            {
-                typeof(GitUI.GitExtensionsForm).Assembly,
-                typeof(GitCommands.GitModule).Assembly
-            });
+                {
+                    typeof(GitUI.GitExtensionsForm).Assembly,
+                    typeof(GitCommands.GitModule).Assembly
+                },
+                AppSettings.UserPluginsPath);
 
             AppSettings.LoadSettings();
 

--- a/GitUI/Plugin/PluginRegistry.cs
+++ b/GitUI/Plugin/PluginRegistry.cs
@@ -29,8 +29,6 @@ namespace GitUI
 
                 try
                 {
-                    ManagedExtensibility.SetUserPluginsPath(AppSettings.UserPluginsPath);
-
                     foreach (var plugin in ManagedExtensibility.GetExports<IGitPlugin>().Select(lazy => lazy.Value))
                     {
                         Validates.NotNull(plugin.Description);

--- a/Plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
+++ b/Plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
@@ -104,8 +104,10 @@ namespace GitUIPluginInterfaces
             }
         }
 
-        public static void Initialise(IEnumerable<Assembly> assemblies)
+        public static void Initialise(IEnumerable<Assembly> assemblies, string userPluginsPath = null)
         {
+            SetUserPluginsPath(userPluginsPath);
+
             PartDiscovery? discovery = PartDiscovery.Combine(
               new AttributedPartDiscoveryV1(Resolver.DefaultInstance),
               new AttributedPartDiscovery(Resolver.DefaultInstance, isNonPublicSupported: true));


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes gitextensions/gitextensions.pluginmanager#57

## Proposed changes

Before this change the user plugins path was set in the PluginRegistry, which was initialized in the FormBrowse and the FormCommit. The MEF catalog is initialized earlier in the Program.RunApplication and so user plugins are never loaded.

This change moves initialization of user plugins path to the MEF initialization.

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.31.1.windows.1
- Windows 10.0.19043.0

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
