### PR TITLE
Fix build

### DIFF
--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SplitterPersistenceTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SplitterPersistenceTests.cs
@@ -78,7 +78,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                 {
                     FormBrowse.TestAccessor ta = form.GetTestAccessor();
 
-                    ProcessUntil(() => ta.RevisionGrid.GetTestAccessor().IsRefreshingRevisions, false);
+                    WaitForRevisionsToBeLoaded(ta.RevisionGrid);
 
                     form.MainSplitContainer.SplitterDistance = LeftPanelWidth;
                     ta.RevisionsSplitContainer.SplitterDistance = ta.RevisionsSplitContainer.Width - CommitInfoWidth;
@@ -92,7 +92,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                 {
                     FormBrowse.TestAccessor ta = form.GetTestAccessor();
 
-                    ProcessUntil(() => ta.RevisionGrid.GetTestAccessor().IsRefreshingRevisions, false);
+                    WaitForRevisionsToBeLoaded(ta.RevisionGrid);
                     Thread.Sleep(1000);
 
                     form.MainSplitContainer.Panel1Collapsed.Should().Be(leftPanelVisible);
@@ -138,6 +138,11 @@ namespace GitExtensions.UITests.CommandsDialogs
             }
 
             Assert.Fail($"{current} != {expected} in {maxIterations} iterations");
+        }
+
+        private static void WaitForRevisionsToBeLoaded(RevisionGridControl revisionGridControl)
+        {
+            UITest.ProcessUntil("Loading Revisions", () => revisionGridControl.GetTestAccessor().IsUiStable);
         }
     }
 }


### PR DESCRIPTION
Addendum to #8809
Addendum to #9639

Test of #9664 without reverting the submodule `ICSharpCode.TextEditor`.

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).