### PR TITLE
Make reset "Soft" the default option

### DIFF
--- a/GitUI/HelperDialogs/FormResetCurrentBranch.Designer.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.Designer.cs
@@ -92,6 +92,7 @@
             // 
             this.Soft.AutoSize = true;
             this.Soft.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(128)))), ((int)(((byte)(255)))), ((int)(((byte)(128)))));
+            this.Soft.Checked = true;
             this.Soft.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Soft.ForeColor = System.Drawing.Color.Black;
             this.Soft.Location = new System.Drawing.Point(3, 3);
@@ -106,7 +107,6 @@
             // 
             this.Mixed.AutoSize = true;
             this.Mixed.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(128)))));
-            this.Mixed.Checked = true;
             this.Mixed.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Mixed.ForeColor = System.Drawing.Color.Black;
             this.Mixed.Location = new System.Drawing.Point(3, 45);

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -23,7 +23,7 @@ namespace GitUI.HelperDialogs
             Hard
         }
 
-        public static FormResetCurrentBranch Create(GitUICommands commands, GitRevision revision, ResetType resetType = ResetType.Mixed)
+        public static FormResetCurrentBranch Create(GitUICommands commands, GitRevision revision, ResetType resetType = ResetType.Soft)
             => new(commands, revision ?? throw new NotSupportedException(TranslatedStrings.NoRevision), resetType);
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]


### PR DESCRIPTION
because that's the one where less information is reverted.
If the user wanted to do a "Mixed", he has just to unstage all.

The contrary is not possible, so Soft is a better default.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes one or two comments in some issues but I'm not able to find them again...

## Proposed changes

- Soft is the default value in reset form because that's the one the less dangerous (otherwise, why it is with green background color?)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/138368437-c545ef7a-8b7e-49f6-858e-b6af0e1ef3c4.png)

### After

![image](https://user-images.githubusercontent.com/460196/138368402-07da9444-262e-4dbd-bdb2-167deada0b31.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build ab47e391eb4a12064f3639d379d665b112cb06e6 (Dirty)
- Git 2.28.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.11
- DPI 192dpi (200% scaling)
