### PR TITLE
PushLocalCmd: path must be absolute

### DIFF
--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -204,13 +204,14 @@ namespace GitCommands.Git.Commands
         /// </summary>
         /// <param name="gitRef">The branch to move.</param>
         /// <param name="targetId">The commit to move to.</param>
+        /// <param name="repoDir">Directory to the current repo.</param>
         /// <param name="force">Push the reference also if commits are lost.</param>
         /// <returns>The Git command to execute.</returns>
-        public static ArgumentString PushLocalCmd(string gitRef, ObjectId targetId, bool force = false)
+        public static ArgumentString PushLocalCmd(string gitRef, ObjectId targetId, string repoDir, bool force = false)
         {
             return new GitArgumentBuilder("push")
             {
-                ".",
+                $@"""file://{repoDir}""",
                 $"{targetId}:{gitRef}".QuoteNE(),
                 { force, "--force" }
             };

--- a/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -93,7 +93,7 @@ namespace GitUI.HelperDialogs
                 return;
             }
 
-            var command = GitCommandHelpers.PushLocalCmd(gitRefToReset.CompleteName, _revision.ObjectId, ForceReset.Checked);
+            var command = GitCommandHelpers.PushLocalCmd(gitRefToReset.CompleteName, _revision.ObjectId, Module.WorkingDir, ForceReset.Checked);
             bool success = FormProcess.ShowDialog(this, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
             if (success)
             {

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -496,11 +496,11 @@ namespace GitCommandsTests.Git.Commands
                 () => GitCommandHelpers.ResetCmd(ResetMode.ResetIndex, commit: hash, file: "file.txt"));
         }
 
-        [TestCase("mybranch", false, ExpectedResult = @"push . ""1111111111111111111111111111111111111111:mybranch""")]
-        [TestCase("branch2", true, ExpectedResult = @"push . ""1111111111111111111111111111111111111111:branch2"" --force")]
-        public string PushLocalCmd(string gitRef, bool force)
+        [TestCase("mybranch", ".", false, ExpectedResult = @"push ""file://."" ""1111111111111111111111111111111111111111:mybranch""")]
+        [TestCase("branch2", "/my/path", true, ExpectedResult = @"push ""file:///my/path"" ""1111111111111111111111111111111111111111:branch2"" --force")]
+        public string PushLocalCmd(string gitRef, string repoDir, bool force)
         {
-            return GitCommandHelpers.PushLocalCmd(gitRef, ObjectId.WorkTreeId, force).Arguments;
+            return GitCommandHelpers.PushLocalCmd(gitRef, ObjectId.WorkTreeId, repoDir, force).Arguments;
         }
 
         [TestCase(ResetMode.ResetIndex, "tree-ish", null, @"reset ""tree-ish"" --")]


### PR DESCRIPTION
Contributes to #8172 

## Proposed changes

"Reset another branch" uses "push .".
This is not supported in the documentation or with other than Windows Git.
This therefore fails with WSL Git, must use "file://" prefix.

## Test methodology <!-- How did you ensure quality? -->

Tests updated

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
