### PR TITLE
"--format" must be quoted

### DIFF
--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -112,7 +112,7 @@ namespace GitCommands.Git.Commands
                 string order = sortOrder == GitRefsSortOrder.Ascending ? string.Empty : "-";
                 if (!needTags)
                 {
-                    return $"--sort={order}{sortBy}";
+                    return $@"--sort=""{order}{sortBy}""";
                 }
 
                 // Sort by dereferenced data
@@ -124,7 +124,7 @@ namespace GitCommands.Git.Commands
                 // ref ordering (i.e. local and remote branches), and this is generally a significantly
                 // greater of two evils.
                 // Refer to https://github.com/gitextensions/gitextensions/issues/8621 for more info.
-                return $"--sort={order}*{sortBy} --sort={order}{sortBy}";
+                return $@"--sort=""{order}*{sortBy}"" --sort=""{order}{sortBy}""";
             }
 
             static ArgumentString GitRefsFormat(bool needTags)
@@ -303,7 +303,7 @@ namespace GitCommands.Git.Commands
         {
             return new GitArgumentBuilder("branch")
             {
-                { fullRefname, "--format=%(refname)" },
+                { fullRefname, @"--format=""%(refname)""" },
                 { includeRemote, "-a" },
                 "--merged",
                 commit

--- a/GitUI/CommandsDialogs/FormArchive.cs
+++ b/GitUI/CommandsDialogs/FormArchive.cs
@@ -140,7 +140,7 @@ namespace GitUI.CommandsDialogs
             {
                 string format = GetSelectedOutputFormat() == OutputFormat.Zip ? "zip" : "tar";
 
-                var arguments = string.Format("archive --format={0} {1} --output \"{2}\" {3}", format, revision, saveFileDialog.FileName, GetPathArgumentFromGui());
+                var arguments = string.Format(@"archive --format=""{0}"" {1} --output ""{2}"" {3}", format, revision, saveFileDialog.FileName, GetPathArgumentFromGui());
                 FormProcess.ShowDialog(this, arguments, Module.WorkingDir, input: null, useDialogSettings: true);
                 Close();
             }

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -234,8 +234,8 @@ namespace GitUI.CommitInfo
         {
             GitArgumentBuilder args = new("for-each-ref")
             {
-                "--sort=-taggerdate",
-                "--format=\"%(refname)\"",
+                @"--sort=""-taggerdate""",
+                @"--format=""%(refname)""",
                 "refs/tags/"
             };
 

--- a/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.cs
@@ -56,7 +56,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
         {
             RunCommitInfoTest(commitInfo =>
             {
-                _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
+                _gitExecutable.StageOutput(@"for-each-ref --sort=""-taggerdate"" --format=""%(refname)"" refs/tags/",
                     "refs/heads/master\nwarning: message");
 
                 ((Action)(() => commitInfo.GetTestAccessor().GetSortedTags())).Should().Throw<RefsWarningException>();
@@ -68,7 +68,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
         {
             RunCommitInfoTest(commitInfo =>
             {
-                _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
+                _gitExecutable.StageOutput(@"for-each-ref --sort=""-taggerdate"" --format=""%(refname)"" refs/tags/",
                     "refs/remotes/origin/master\nrefs/heads/master\nrefs/heads/warning"); // does not contain "warning:"
 
                 Dictionary<string, int> expected = new()
@@ -90,7 +90,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
         {
             RunCommitInfoTest(commitInfo =>
             {
-                _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
+                _gitExecutable.StageOutput(@"for-each-ref --sort=""-taggerdate"" --format=""%(refname)"" refs/tags/",
                     "refs/remotes/origin/master\nrefs/heads/master\nrefs/remotes/origin/bugfix/YS-38651-test-twist-changes-r100-on-s375\nrefs/remotes/origin/bugfix/ys-38651-test-twist-changes-r100-on-s375"); // case sensitive duplicates
 
                 Dictionary<string, int> expected = new()
@@ -113,7 +113,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
         {
             RunCommitInfoTest(commitInfo =>
             {
-                _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
+                _gitExecutable.StageOutput(@"for-each-ref --sort=""-taggerdate"" --format=""%(refname)"" refs/tags/",
                     "refs/remotes/origin/master\nrefs/heads/master\nrefs/tags/v3.1\nrefs/tags/v3.1 \n refs/tags/v3.1"); // have leading and trailing spaces
 
                 Dictionary<string, int> expected = new()
@@ -137,7 +137,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
         {
             RunCommitInfoTest(commitInfo =>
             {
-                _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/",
+                _gitExecutable.StageOutput(@"for-each-ref --sort=""-taggerdate"" --format=""%(refname)"" refs/tags/",
                     "refs/remotes/origin/master\nrefs/remotes/foo/duplicate\nrefs/remotes/foo/bar\nrefs/remotes/foo/duplicate\nrefs/remotes/foo/last"); // exact duplicates
 
                 Dictionary<string, int> expected = new()
@@ -164,7 +164,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
                     uiCommandsSource.UICommands.Returns(x => _commands);
 
                     // the following assignment of CommitInfo.UICommandsSource will already call this command
-                    _gitExecutable.StageOutput("for-each-ref --sort=-taggerdate --format=\"%(refname)\" refs/tags/", "");
+                    _gitExecutable.StageOutput(@"for-each-ref --sort=""-taggerdate"" --format=""%(refname)"" refs/tags/", "");
 
                     return new GitUI.CommitInfo.CommitInfo
                     {

--- a/Plugins/FindLargeFiles/FindLargeFilesForm.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesForm.cs
@@ -213,7 +213,7 @@ namespace GitExtensions.Plugins.FindLargeFiles
                         AppSettings.GitCommand, gitObject.Path));
                 }
 
-                sb.AppendLine(string.Format("for /f %%a IN ('\"{0}\" for-each-ref --format=%%^(refname^) refs/original/') DO \"{0}\" update-ref -d %%a",
+                sb.AppendLine(string.Format(@"for /f %%a IN ('""{0}"" for-each-ref --format=""%%^(refname^)"" refs/original/') DO ""{0}"" update-ref -d %%a",
                     AppSettings.GitCommand));
                 sb.AppendLine(string.Format("\"{0}\" reflog expire --expire=now --all",
                     AppSettings.GitCommand));

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -124,7 +124,7 @@ namespace GitCommandsTests.Git.Commands
         public void TestMergedBranchesCmd([Values(true, false)] bool includeRemote, [Values(true, false)] bool fullRefname,
             [Values(null, "", " ", "HEAD", "1234567890")] string commit)
         {
-            string formatArg = fullRefname ? " --format=%(refname)" : string.Empty;
+            string formatArg = fullRefname ? @" --format=""%(refname)""" : string.Empty;
             string remoteArg = includeRemote ? " -a" : string.Empty;
             string commitArg = string.IsNullOrWhiteSpace(commit) ? string.Empty : $" {commit}";
             string expected = $"branch{formatArg}{remoteArg} --merged{commitArg}";
@@ -653,8 +653,8 @@ namespace GitCommandsTests.Git.Commands
                         else
                         {
                             string prefix = sortOrder == GitRefsSortOrder.Ascending ? string.Empty : "-";
-                            sortCondition = $" --sort={prefix}{sortBy}";
-                            sortConditionRef = $" --sort={prefix}*{sortBy}";
+                            sortCondition = $@" --sort=""{prefix}{sortBy}""";
+                            sortConditionRef = $@" --sort=""{prefix}*{sortBy}""";
                         }
 
                         yield return new TestCaseData(RefsFilter.Tags | RefsFilter.Heads | RefsFilter.Remotes, /* noLocks */ false, sortBy, sortOrder, 0,


### PR DESCRIPTION
Contributes to #8172

## Proposed changes

Arguments to `--format=` and `--sort` may contain shell specific characters like `(` and `*`.
A command like `branch --format="%(refname)"` will fail if the commandline is involved if the quotes are not added.,
like it is when using WSL Git.

Other occurrences are not known to create any issues, but I have not run all combinations of sort options etc and this should be uniform.

Strings that was changed were modified to use interpolated verbatim `$@` strings. 

## Test methodology <!-- How did you ensure quality? -->

Tests are updated

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
