### PR TITLE
Fix running scripts without arguments

### DIFF
--- a/GitUI/Script/ScriptRunner.cs
+++ b/GitUI/Script/ScriptRunner.cs
@@ -91,8 +91,6 @@ namespace GitUI.Script
                     new ExternalOperationException(scriptInfo.Command, arguments, module.WorkingDir));
             }
 
-            Validates.NotNull(argument);
-
             string command = OverrideCommandWhenNecessary(originalCommand);
             command = ExpandCommandVariables(command, module);
 


### PR DESCRIPTION
Fixes #9660

because when there are no arguments, `argument` value is null
and the check is throwing an exception.

Remove the check because it doesn't cause a problem to the process
if null is passed...

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/138756896-245eb08b-0dc8-4472-883c-d951d0ae05cc.png)

### After

No error

## Test methodology <!-- How did you ensure quality? -->

- Manual:
   - **Create** a new script **with no arguments** (arguments is `null ` and so, not serialized)
   - Launch this script

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 24f71be8a1af42aca5ba595b846a9a11b15c7e73 (Dirty)
- Git 2.28.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.11
- DPI 192dpi (200% scaling)

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
