### PR TITLE
Fix toolbar dpi scaling issue

### DIFF
--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -226,10 +226,6 @@ namespace GitUI.UserControls
             tscboBranchFilter.ForeColor = toolForeColor;
             tstxtRevisionFilter.BackColor = toolTextBoxBackColor;
             tstxtRevisionFilter.ForeColor = toolForeColor;
-
-            // Scale tool strip items according to DPI
-            tscboBranchFilter.Size = DpiUtil.Scale(tscboBranchFilter.Size);
-            tstxtRevisionFilter.Size = DpiUtil.Scale(tstxtRevisionFilter.Size);
         }
 
         public void PreventToolStripSplitButtonClosing(ToolStripSplitButton? control)


### PR DESCRIPTION
## Proposed changes

- Scaling is not good for filter toolstrip

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/138760380-bc749f00-d543-48b1-80ae-67dd2cb0880e.png)

### After

![image](https://user-images.githubusercontent.com/460196/138905995-1117684f-a2a0-401e-8d70-fcc33d40e881.png)

## Test methodology <!-- How did you ensure quality? -->

- 👀 

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build b90b64806ca1ef404c432e6244130c9a5560dc02 (Dirty)
- Git 2.28.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.11
- DPI 192dpi (200% scaling)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
