### PR TITLE
`Rebase --onto`: Display only the current branch to make selection easier

### DIFF
--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -360,10 +360,23 @@ namespace GitUI.CommandsDialogs
 
         private void btnChooseFromRevision_Click(object sender, EventArgs e)
         {
-            using FormChooseCommit chooseForm = new(UICommands, txtFrom.Text);
-            if (chooseForm.ShowDialog(this) == DialogResult.OK && chooseForm.SelectedRevision is not null)
+            bool previousValueBranchFilterEnabled = AppSettings.BranchFilterEnabled;
+            bool previousValueShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
+            bool previousValueShowReflogReferences = AppSettings.ShowReflogReferences;
+
+            try
             {
-                txtFrom.Text = chooseForm.SelectedRevision.ObjectId.ToShortString();
+                using FormChooseCommit chooseForm = new(UICommands, txtFrom.Text, showCurrentBranchOnly: true);
+                if (chooseForm.ShowDialog(this) == DialogResult.OK && chooseForm.SelectedRevision is not null)
+                {
+                    txtFrom.Text = chooseForm.SelectedRevision.ObjectId.ToShortString();
+                }
+            }
+            finally
+            {
+                AppSettings.BranchFilterEnabled = previousValueBranchFilterEnabled;
+                AppSettings.ShowCurrentBranchOnly = previousValueShowCurrentBranchOnly;
+                AppSettings.ShowReflogReferences = previousValueShowReflogReferences;
             }
         }
 

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -20,11 +20,15 @@ namespace GitUI.HelperDialogs
             InitializeComplete();
         }
 
-        public FormChooseCommit(GitUICommands commands, string? preselectCommit, bool showArtificial = false)
+        public FormChooseCommit(GitUICommands commands, string? preselectCommit, bool showArtificial = false, bool showCurrentBranchOnly = false)
             : this(commands)
         {
             revisionGrid.MultiSelect = false;
             revisionGrid.ShowUncommittedChangesIfPossible = showArtificial;
+            if (showCurrentBranchOnly)
+            {
+                revisionGrid.ShowCurrentBranchOnly();
+            }
 
             if (!string.IsNullOrEmpty(preselectCommit))
             {


### PR DESCRIPTION
## Proposed changes

Because a commit should be selected in the history of the current branch, display only this current branch to make the selection easier.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/138769009-cb296c2b-243f-4f15-bcbb-cbb320b7d213.png)
### After

![image](https://user-images.githubusercontent.com/460196/138769068-d0e369c3-80c1-4262-8e78-fbef08e32954.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 9f8c00c90d7b232b5a5271ff87e9cdb880ef44b9 (Dirty)
- Git 2.28.0.windows.1 (recommended: 2.30.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.11
- DPI 192dpi (200% scaling)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
