### PR TITLE
Change Revision Links separator (#9668)

### DIFF
--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -15,6 +15,8 @@ namespace GitUI.Editor.RichTextBoxExtension
 {
     internal static class RichTextBoxXhtmlSupportExtension
     {
+        private const string LinkSeparator = "|||";
+
         /// <summary>
         /// Maintains performance while updating.
         /// </summary>
@@ -1143,10 +1145,9 @@ namespace GitUI.Editor.RichTextBoxExtension
                     ++to;
                 }
 
-                if (to < text.Length && text[to] == '#')
+                if (to < text.Length && DoesMatchLinkSeparatorPattern(text, to))
                 {
-                    ++to;
-                    from = to;
+                    from = to + LinkSeparator.Length;
                     while (to < text.Length && !char.IsWhiteSpace(text[to]) && text[to] != ',')
                     {
                         ++to;
@@ -1156,7 +1157,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                 // prior to net47 links were created via hidden text, and had the following format: "text#link"
                 // extract the link portion only
                 string linkOldFormat = text.Substring(from, to - from);
-                return linkOldFormat.Substring(linkOldFormat.IndexOf("#") + 1);
+                return linkOldFormat.Substring(linkOldFormat.IndexOf(LinkSeparator) + LinkSeparator.Length);
             }
             catch
             {
@@ -1171,6 +1172,19 @@ namespace GitUI.Editor.RichTextBoxExtension
                 rtb.EndUpdate(oldMask);
                 rtb.Invalidate();
             }
+        }
+
+        private static bool DoesMatchLinkSeparatorPattern(string text, int index)
+        {
+            for (int ls = 0; ls < LinkSeparator.Length && index < text.Length; ls++, index++)
+            {
+                if (text[index] != LinkSeparator[ls])
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -1519,7 +1533,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                             {
                                 string head = rtfText.Substring(0, idx);
                                 string tail = rtfText.Substring(idx);
-                                RtbSetSelectedRtf(rtb, head + @"\v #" + cs.hyperlink + @"\v0" + tail);
+                                RtbSetSelectedRtf(rtb, head + @"\v " + LinkSeparator + cs.hyperlink + @"\v0" + tail);
                                 length = rtb.TextLength - cs.hyperlinkStart;
                             }
                         }

--- a/UnitTests/GitUI.Tests/Editor/RichTextBoxXhtmlSupportExtensionTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/RichTextBoxXhtmlSupportExtensionTests.cs
@@ -15,6 +15,7 @@ namespace GitUITests.Editor
         private const string _defaultLinkUri = "https://uri.org";
         private const string _defaultPrefix = "pre ";
         private const string _defaultSuffix = " suf";
+        private const string _linkSeparator = "|||";
 
         private RichTextBox _rtb;
         private ILinkFactory _linkFactory;
@@ -86,10 +87,33 @@ namespace GitUITests.Editor
         public void GetLink_should_return_null_if_right_of_link()
         {
             SetupDefaultLink();
-            for (int index = _defaultPrefix.Length + _defaultLinkText.Length + _defaultLinkUri.Length + 1; index < _rtb.Text.Length; ++index)
+            for (int index = _defaultPrefix.Length + _defaultLinkText.Length + _defaultLinkUri.Length + _linkSeparator.Length; index < _rtb.Text.Length; ++index)
             {
                 _rtb.GetLink(index).Should().BeNull();
             }
+        }
+
+        [Test]
+        public void GetLink_should_return_uri_if_text_contains_hash()
+        {
+            SetupLink(prefix: string.Empty, linkText: "#hash", uri: _defaultLinkUri, suffix: string.Empty);
+            _rtb.GetLink(0).Should().Be(_defaultLinkUri);
+        }
+
+        [Test]
+        public void GetLink_should_return_uri_if_uri_contains_hash()
+        {
+            string uri = _defaultLinkUri + "#hash";
+            SetupLink(prefix: string.Empty, linkText: _defaultLinkText, uri: uri, suffix: string.Empty);
+            _rtb.GetLink(0).Should().Be(uri);
+        }
+
+        [Test]
+        public void GetLink_should_return_uri_if_text_and_uri_contain_hash()
+        {
+            string uri = _defaultLinkUri + "#hash";
+            SetupLink(prefix: string.Empty, linkText: "#text", uri: uri, suffix: string.Empty);
+            _rtb.GetLink(0).Should().Be(uri);
         }
 
         [Test]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9668

## Proposed changes

- use `|||` instead of `#` to separate link text and link, because both potentially could contain hash symbol `#`
- move out hardcoded separator to a variable, so it could be easily customized if needed

### Before

Incorrect links that contain `#` symbol in the text.

### After

Native behaviour.

## Test methodology <!-- How did you ensure quality? -->

- Manual
- Unit tests

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.33.1.windows.1
- Windows 10.0.19043

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
