### PR TITLE
Fix interactive add for new files

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1819,12 +1819,12 @@ namespace GitCommands
             return shouldRescanChanges;
         }
 
-        public async Task<bool> ExpressIntentToAddAsync(GitItemStatus file)
+        private async Task<bool> ExpressIntentToAddAsync(GitItemStatus file)
         {
             return await _gitExecutable.RunCommandAsync(
                 new GitArgumentBuilder("add")
                 {
-                    "-N",
+                    "--intent-to-add",
                     file.Name.Quote()
                 });
         }
@@ -1842,7 +1842,7 @@ namespace GitCommands
 
             GitArgumentBuilder args = new("add")
             {
-                "-p",
+                "--patch",
                 file.Name.Quote()
             };
 


### PR DESCRIPTION
## Proposed changes

Fix triggering **Interactive add** from within `FormCommit` for new files

- For new files first initiate `git add -N` where `-N` is also known as `--intent-to-add`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before/After

Showing the effect that `git add -N file.txt` has
![image](https://user-images.githubusercontent.com/483659/139108562-b593b038-cc79-4a91-ad66-a0b4c051d130.png)

## Test methodology <!-- How did you ensure quality? -->

- Manually tested various scenarios with adding/resetting/staging/unstaging new files both with `Interactive add` and regular staging

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build ee6eaa3f5a33644450e158fd2fd93128d84de613 (Dirty)
- Git 2.33.0.windows.2
- Microsoft Windows NT 10.0.19043.0
- .NET 5.0.11
- DPI 192dpi (200% scaling)

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
