### PR TITLE
Add Shortcut for Create Branch in Commit Form

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -670,7 +670,8 @@ namespace GitUI.CommandsDialogs
             OpenFile = 13,
             OpenFileWith = 14,
             EditFile = 15,
-            AddSelectionToCommitMessage = 16
+            AddSelectionToCommitMessage = 16,
+            CreateBranch = 17
         }
 
         private string GetShortcutKeyDisplayString(Command cmd)
@@ -857,6 +858,7 @@ namespace GitUI.CommandsDialogs
                 case Command.OpenFileWith: openWithToolStripMenuItem.PerformClick(); return true;
                 case Command.EditFile: editFileToolStripMenuItem.PerformClick(); return true;
                 case Command.AddSelectionToCommitMessage: return AddSelectionToCommitMessage();
+                case Command.CreateBranch: createBranchToolStripButton.PerformClick(); return true;
                 default: return base.ExecuteCommand(cmd);
             }
         }

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -227,6 +227,7 @@ namespace GitUI.Hotkey
                     FormCommit.HotkeySettingsName,
                     Hk(FormCommit.Command.AddSelectionToCommitMessage, Keys.C),
                     Hk(FormCommit.Command.AddToGitIgnore, Keys.None),
+                    Hk(FormCommit.Command.CreateBranch, Keys.Control | Keys.B),
                     Hk(FormCommit.Command.DeleteSelectedFiles, Keys.Delete),
                     Hk(FormCommit.Command.EditFile, EditFileHotkey),
                     Hk(FormCommit.Command.FocusUnstagedFiles, Keys.Control | Keys.D1),

--- a/contributors.txt
+++ b/contributors.txt
@@ -168,3 +168,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/10/04, Timwi, Timwi Heizmann, github(at)timwi.de
 2021/10/12, simonmckenzie, Simon McKenzie, simonmckenzie(at)alumni.unimelb.edu.au
 2021/10/22, calebnhay, Caleb N. Hay, caleb(at)calebnhay(dot)com
+2021/10/28, matthiaslischka, Matthias Lischka, matthias.lischka(at)gmx.at


### PR DESCRIPTION
The main form already had the shortcut `Ctrl + B` for creating a new branch. 

![image](https://user-images.githubusercontent.com/12046115/139130786-d1c9bcd1-4381-4a42-8c56-0f5bea6ddb58.png)

The commit form only had the "windows convention" shortcut with the underlined `b`.
Text "Create &branch" --> `Alt + b`.

![image](https://user-images.githubusercontent.com/12046115/139130865-a82c651b-2695-47f8-bee6-3354986ee5c1.png)

In order to improve usability this PR adds the same shortcut from the main form `Ctrl + B` to the commit form _in addition_ to the existing `Alt + b`.

This PR follows #9692

BR Matthias

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
