### PR TITLE
Reset another branch to here path format

### DIFF
--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -211,7 +211,7 @@ namespace GitCommands.Git.Commands
         {
             return new GitArgumentBuilder("push")
             {
-                $@"""file://{repoDir}""",
+                $@"""file://{repoDir.ToPosixPath()}""",
                 $"{targetId}:{gitRef}".QuoteNE(),
                 { force, "--force" }
             };

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -498,6 +498,7 @@ namespace GitCommandsTests.Git.Commands
 
         [TestCase("mybranch", ".", false, ExpectedResult = @"push ""file://."" ""1111111111111111111111111111111111111111:mybranch""")]
         [TestCase("branch2", "/my/path", true, ExpectedResult = @"push ""file:///my/path"" ""1111111111111111111111111111111111111111:branch2"" --force")]
+        [TestCase("branchx", @"c:\my\path", true, ExpectedResult = @"push ""file://c:/my/path"" ""1111111111111111111111111111111111111111:branchx"" --force")]
         public string PushLocalCmd(string gitRef, string repoDir, bool force)
         {
             return GitCommandHelpers.PushLocalCmd(gitRef, ObjectId.WorkTreeId, repoDir, force).Arguments;


### PR DESCRIPTION
Regression from #9678  8066c59a7b286f5b791d29cfee8c2209bb27b6db

## Proposed changes

Set path in posix format for Git

## Test methodology <!-- How did you ensure quality? -->

Added testcase

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
