### PR TITLE
GitStatusMonitor could start multiple commands

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitorState.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitorState.cs
@@ -2,9 +2,16 @@
 {
     public enum GitStatusMonitorState
     {
+        // Not running
         Stopped = 0,
+
+        // Normal operation
         Running,
+
+        // Timer is running, not starting new commands
         Inactive,
+
+        // Timer and file monitoring temporarily paused
         Paused
     }
 }


### PR DESCRIPTION
Fixes #9615

See also #9700 for 3.5, with the essential correction (most of the changes was done first to find the problem).

## Proposed changes

If If the monitor was inactivated while a status command was running
(minimizing/restoring the app, start a modal dialog) the current command
is canceled to give the latest data.
lock() will ensure that more than one "active" command is not running.
However, one control variable was reset also if the command was canceled
which allowed the canceled command to be followed by another.

Also changed to not request a new status command if a command is already
 running. (current status should be good enough, if there are pending
 changes they will be requested later).

Some refactoring and cleanups.

## Test methodology <!-- How did you ensure quality? -->

Manual testing

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
