### PR TITLE
Support Git in WSL

### DIFF
--- a/GitCommands/DiffMergeTools/DiffMergeToolConfigurationManager.cs
+++ b/GitCommands/DiffMergeTools/DiffMergeToolConfigurationManager.cs
@@ -36,6 +36,7 @@ namespace GitCommands.DiffMergeTools
         {
             get
             {
+                // Only used in settings, returns native (Windows) Git tool
                 string? mergetool = "";
                 if (GitVersion.Current.SupportGuiMergeTool)
                 {

--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -393,7 +393,7 @@ namespace GitCommands.Git.Commands
         }
 
         public static ArgumentString RebaseCmd(
-            string? branch, bool interactive, bool preserveMerges, bool autosquash, bool autoStash, bool ignoreDate, bool committerDateIsAuthorDate, string? from = null, string? onto = null)
+            string? branch, bool interactive, bool preserveMerges, bool autosquash, bool autoStash, bool ignoreDate, bool committerDateIsAuthorDate, string? from = null, string? onto = null, bool supportRebaseMerges = true)
         {
             // TODO-NULLABLE does it make sense for 'branch' to be null here?
 
@@ -421,7 +421,7 @@ namespace GitCommands.Git.Commands
 
                 if (preserveMerges)
                 {
-                    builder.Add(GitVersion.Current.SupportRebaseMerges ? "--rebase-merges" : "--preserve-merges");
+                    builder.Add(supportRebaseMerges ? "--rebase-merges" : "--preserve-merges");
                 }
             }
 

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -904,7 +904,9 @@ namespace GitCommands
 
         public void RunMergeTool(string? fileName = "", string? customTool = null)
         {
-            var gui = GitVersion.Current.SupportGuiMergeTool ? "--gui" : string.Empty;
+            // Use Windows Git if custom tool is selected as the list is native to the application.
+            bool isWindowsGit = !string.IsNullOrWhiteSpace(customTool);
+            string gui = (isWindowsGit ? GitVersion.Current : GitVersion).SupportGuiMergeTool ? "--gui" : string.Empty;
             GitArgumentBuilder args = new("mergetool")
             {
                 { string.IsNullOrWhiteSpace(customTool), gui, $"--tool={customTool}" },
@@ -912,8 +914,7 @@ namespace GitCommands
                 fileName.ToPosixPath().QuoteNE()
             };
 
-            // Use native (Windows) Git if custom tool is selected as the list is native
-            using var process = (string.IsNullOrWhiteSpace(customTool) ? _gitExecutable : _gitNativeExecutable).Start(args, createWindow: true);
+            using IProcess process = (isWindowsGit ? _gitWindowsExecutable : _gitExecutable).Start(args, createWindow: true);
             process.WaitForExit();
         }
 

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -514,7 +514,8 @@ namespace GitCommands
                 "-z",
                 "--unmerged"
             };
-            return !string.IsNullOrEmpty(_gitExecutable.GetOutput(args));
+            var result = _gitExecutable.Execute(args);
+            return result.ExitedSuccessfully && !string.IsNullOrEmpty(result.StandardOutput);
         }
 
         public bool HandleConflictSelectSide(string fileName, string side)

--- a/GitCommands/Git/Tag/GitTagController.cs
+++ b/GitCommands/Git/Tag/GitTagController.cs
@@ -55,7 +55,7 @@ namespace GitCommands.Git.Tag
                 _fileSystem.File.WriteAllText(tagMessageFileName, args.TagMessage);
             }
 
-            GitCreateTagCmd createTagCmd = new(args, tagMessageFileName);
+            GitCreateTagCmd createTagCmd = new(args, _uiCommands.GitModule.GetGitExecPath(tagMessageFileName));
             try
             {
                 return _uiCommands.StartCommandLineProcessDialog(parentWindow, createTagCmd);

--- a/GitCommands/Logging/CommandLog.cs
+++ b/GitCommands/Logging/CommandLog.cs
@@ -97,7 +97,11 @@ namespace GitCommands.Logging
 
                 var fileName = FileName;
 
-                if (fileName.EndsWith("git.exe"))
+                if (fileName.StartsWith("wsl "))
+                {
+                    fileName = "wsl";
+                }
+                else if (fileName.EndsWith("git.exe"))
                 {
                     fileName = "git";
                 }

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -389,6 +389,18 @@ namespace GitCommands
             }
         }
 
+        // Currently not configurable
+        public static bool WslGitEnabled
+        {
+            get => GetBool("WslGitEnabled", true);
+        }
+
+        // Currently not configurable
+        public static string WslGitCommand
+        {
+            get => GetString("WslGitCommand", "wsl");
+        }
+
         public static bool StashKeepIndex
         {
             get => GetBool("stashkeepindex", false);

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -196,14 +196,16 @@ namespace GitUI.CommandsDialogs
 
                 if (PatchFileMode.Checked)
                 {
+                    string gitPatch = Module.GetGitExecPath(patchFile);
                     var arguments = IsDiffFile(patchFile)
-                        ? GitCommandHelpers.ApplyDiffPatchCmd(ignoreWhiteSpace, patchFile)
-                        : GitCommandHelpers.ApplyMailboxPatchCmd(signOff, ignoreWhiteSpace, patchFile);
+                        ? GitCommandHelpers.ApplyDiffPatchCmd(ignoreWhiteSpace, gitPatch)
+                        : GitCommandHelpers.ApplyMailboxPatchCmd(signOff, ignoreWhiteSpace, gitPatch);
 
                     FormProcess.ShowDialog(this, arguments, Module.WorkingDir, input: null, useDialogSettings: true);
                 }
                 else
                 {
+                    // No need for PathUtil.GetRepoPath(), file streamed
                     var arguments = GitCommandHelpers.ApplyMailboxPatchCmd(signOff, ignoreWhiteSpace);
 
                     Module.ApplyPatch(dirText, arguments);

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -245,9 +245,11 @@ namespace GitUI.CommandsDialogs
                     branch = null;
                 }
 
-                string sourceRepo = _NO_TRANSLATE_From.Text;
+                string sourceRepo = PathUtil.IsLocalFile(_NO_TRANSLATE_From.Text)
+                    ? UICommands.Module.GetGitExecPath(_NO_TRANSLATE_From.Text)
+                    : _NO_TRANSLATE_From.Text;
                 var cloneCmd = GitCommandHelpers.CloneCmd(sourceRepo,
-                    dirTo,
+                    UICommands.Module.GetGitExecPath(dirTo),
                     CentralRepository.Checked,
                     cbIntializeAllSubmodules.Checked,
                     branch, depth, isSingleBranch);

--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -108,11 +108,10 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            string savePatchesToDir = OutputPath.Text;
+            string savePatchesToDir = SaveToDir.Checked ? OutputPath.Text : Path.Combine(Module.WorkingDirGitDir, "PatchesToMail");
 
             if (!SaveToDir.Checked)
             {
-                savePatchesToDir = Path.Combine(Module.WorkingDirGitDir, "PatchesToMail");
                 if (Directory.Exists(savePatchesToDir))
                 {
                     foreach (string file in Directory.GetFiles(savePatchesToDir, "*.patch"))

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -120,7 +120,7 @@ namespace GitUI.CommandsDialogs
                                                             noCommit.Checked,
                                                             _NO_TRANSLATE_mergeStrategy.Text,
                                                             allowUnrelatedHistories.Checked,
-                                                            mergeMessagePath,
+                                                            Module.GetGitExecPath(mergeMessagePath),
                                                             addLogMessages.Checked ? (int)nbMessages.Value : (int?)null);
             success = FormProcess.ShowDialog(this, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
 

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -533,7 +533,8 @@ namespace GitUI.CommandsDialogs
                 {
                     if (!form.ProcessArguments.Contains(" -f ") && !form.ProcessArguments.Contains(" --force"))
                     {
-                        Trace.Assert(form.ProcessArguments.StartsWith("push "), "Arguments should start with 'push' command");
+                        // Note that WSL may add other arguments prior to the actual command so "push" may not be first.
+                        Debug.Assert(form.ProcessArguments.Contains("push "), "Arguments should start with 'push' command");
 
                         form.ProcessArguments = form.ProcessArguments.Insert("push".Length, " --force-with-lease");
                     }

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -632,6 +632,7 @@ namespace GitUI.CommandsDialogs
 
         private bool InitMergetool()
         {
+            // All _mergetool related is for native ("Windows")
             if (GitVersion.Current.SupportGuiMergeTool)
             {
                 _mergetool = Module.GetEffectiveSetting(SettingKeyString.MergeToolKey);

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -391,11 +391,15 @@ namespace GitUI.CommandsDialogs.RepoHosting
                 return;
             }
 
-            string repoSrc = repo.CloneReadWriteUrl;
+            GitUICommands uiCommands = new(new GitModule(null));
 
-            var cmd = GitCommandHelpers.CloneCmd(repoSrc, targetDir, depth: GetDepth());
+            string repoSrc = PathUtil.IsLocalFile(repo.CloneReadWriteUrl)
+                ? uiCommands.Module.GetGitExecPath(repo.CloneReadWriteUrl)
+                : repo.CloneReadWriteUrl;
 
-            FormRemoteProcess formRemoteProcess = new(new GitUICommands(new GitModule(null)), cmd)
+            var cmd = GitCommandHelpers.CloneCmd(repoSrc, uiCommands.Module.GetGitExecPath(targetDir), depth: GetDepth());
+
+            FormRemoteProcess formRemoteProcess = new(uiCommands, cmd)
             {
                 Remote = repoSrc
             };

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -45,7 +45,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private readonly TranslationString _solveGitCommandFailed =
             new("The command to run git could not be determined automatically." + Environment.NewLine +
-                "Please make sure git (Git for Windows or cygwin) is installed or set the correct command manually.");
+                "Please make sure that Git for Windows is installed or set the correct command manually.");
 
         private readonly TranslationString _shellExtRegistered =
             new("Shell extensions registered properly.");

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.Designer.cs
@@ -73,7 +73,7 @@
             tlpnlEnvironment.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlEnvironment.RowStyles.Add(new System.Windows.Forms.RowStyle());
             tlpnlEnvironment.Size = new System.Drawing.Size(609, 98);
-            tlpnlEnvironment.TabIndex = 0;
+            tlpnlEnvironment.TabIndex = 8;
             // 
             // ChangeHomeButton
             // 
@@ -81,7 +81,7 @@
             this.ChangeHomeButton.Location = new System.Drawing.Point(3, 70);
             this.ChangeHomeButton.Name = "ChangeHomeButton";
             this.ChangeHomeButton.Size = new System.Drawing.Size(90, 25);
-            this.ChangeHomeButton.TabIndex = 2;
+            this.ChangeHomeButton.TabIndex = 9;
             this.ChangeHomeButton.Text = "Change HOME";
             this.ChangeHomeButton.UseVisualStyleBackColor = true;
             this.ChangeHomeButton.Click += new System.EventHandler(this.ChangeHomeButton_Click);
@@ -142,8 +142,7 @@
             this.label50.Name = "label50";
             this.label50.Size = new System.Drawing.Size(603, 13);
             this.label50.TabIndex = 0;
-            this.label50.Text = "Git Extensions can use Git for Windows or cygwin to access git repositories. Set " +
-    "the correct paths below.";
+            this.label50.Text = "Set the correct paths to Git for Windows. (WSL Git will be used for WSL repositories).";
             this.label50.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // downloadGitForWindows

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -108,7 +108,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             GitArgumentBuilder args = new("worktree")
             {
                 "add",
-                WorktreeDirectory.Quote(),
+                Path.GetRelativePath(Module.WorkingDir, WorktreeDirectory).ToPosixPath().Quote(),
                 {
                     radioButtonCreateNewBranch.Checked,
                     $"-b {textBoxNewBranchName.Text}",

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -64,7 +64,12 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         private void Initialize()
         {
-            var lines = Module.GitExecutable.GetOutput("worktree list --porcelain");
+            GitArgumentBuilder args = new("worktree")
+            {
+                "list",
+                "--porcelain"
+            };
+            string lines = Module.GitExecutable.GetOutput(args);
 
             _worktrees = new List<WorkTree>();
             WorkTree? currentWorktree = null;
@@ -78,7 +83,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
                 var strings = line.Split(' ');
                 if (strings[0] == "worktree")
                 {
-                    currentWorktree = new WorkTree { Path = line.Substring(9) };
+                    currentWorktree = new WorkTree { Path = Module.GetWindowsPath(line.Substring(9)) };
                     currentWorktree.IsDeleted = !Directory.Exists(currentWorktree.Path);
                     _worktrees.Add(currentWorktree);
                 }

--- a/GitUI/HelperDialogs/FormProcess.cs
+++ b/GitUI/HelperDialogs/FormProcess.cs
@@ -36,11 +36,22 @@ namespace GitUI.HelperDialogs
         {
             ProcessCallback = ProcessStart;
             AbortCallback = ProcessAbort;
-            ProcessString = process ?? AppSettings.GitCommand;
-            ProcessArguments = arguments;
             Remote = "";
             ProcessInput = input;
             WorkingDirectory = workingDirectory;
+
+            if (process is null)
+            {
+                string wslDistro = AppSettings.WslGitEnabled ? PathUtil.GetWslDistro(workingDirectory) : "";
+                if (!string.IsNullOrEmpty(wslDistro))
+                {
+                    process = AppSettings.WslGitCommand;
+                    arguments = $"-d {wslDistro} git {arguments}";
+                }
+            }
+
+            ProcessString = process ?? AppSettings.GitCommand;
+            ProcessArguments = arguments;
 
             var displayPath = PathUtil.GetDisplayPath(WorkingDirectory);
             if (!string.IsNullOrWhiteSpace(displayPath))

--- a/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Windows.Forms;
+using GitCommands;
 using GitCommands.Git;
 using GitCommands.Git.Commands;
 using GitExtUtils.GitUI;
@@ -93,7 +94,7 @@ namespace GitUI.HelperDialogs
                 return;
             }
 
-            var command = GitCommandHelpers.PushLocalCmd(gitRefToReset.CompleteName, _revision.ObjectId, Module.WorkingDir, ForceReset.Checked);
+            var command = GitCommandHelpers.PushLocalCmd(gitRefToReset.CompleteName, _revision.ObjectId, Module.GetGitExecPath(Module.WorkingDir), ForceReset.Checked);
             bool success = FormProcess.ShowDialog(this, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
             if (success)
             {

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -919,7 +919,7 @@ Please make sure there are linux tools installed (through Git for Windows or cyg
       </trans-unit>
       <trans-unit id="_solveGitCommandFailed.Text">
         <source>The command to run git could not be determined automatically.
-Please make sure git (Git for Windows or cygwin) is installed or set the correct command manually.</source>
+Please make sure that Git for Windows is installed or set the correct command manually.</source>
         <target />
       </trans-unit>
       <trans-unit id="_solveGitCommandFailedCaption.Text">
@@ -8294,7 +8294,7 @@ Check if file is accessible.</source>
         <target />
       </trans-unit>
       <trans-unit id="label50.Text">
-        <source>Git Extensions can use Git for Windows or cygwin to access git repositories. Set the correct paths below.</source>
+        <source>Set the correct paths to Git for Windows. (WSL Git will be used for WSL repositories).</source>
         <target />
       </trans-unit>
       <trans-unit id="lblGitCommand.Text">

--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -185,7 +185,7 @@ namespace GitUI
                 summary: TranslatedStrings.DiffCommonBase + GetDescriptionForRevision(baseRevGuid),
                 statuses: commonBaseToAandB));
 
-            if (!GitVersion.Current.SupportRangeDiffTool)
+            if (!module.GitVersion.SupportRangeDiffTool)
             {
                 return fileStatusDescs;
             }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2645,7 +2645,7 @@ namespace GitUI
 
             string rebaseCmd = GitCommandHelpers.RebaseCmd(
                 LatestSelectedRevision.FirstParentId?.ToString(), interactive: true, preserveMerges: false,
-                autosquash: false, autoStash: true, ignoreDate: false, committerDateIsAuthorDate: false);
+                autosquash: false, autoStash: true, ignoreDate: false, committerDateIsAuthorDate: false, supportRebaseMerges: Module.GitVersion.SupportRebaseMerges);
 
             using (FormProcess formProcess = new(UICommands, arguments: rebaseCmd, Module.WorkingDir, input: null, useDialogSettings: true))
             {

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -38,16 +38,20 @@ namespace GitUIPluginInterfaces
         void SetSetting(string setting, string value);
         void UnsetSetting(string setting);
 
-        /// <summary>Gets the directory which contains the git repository.</summary>
+        /// <summary>
+        /// Gets the directory which contains the git repository.
+        /// </summary>
         string WorkingDir { get; }
 
         /// <summary>
-        /// Gets the access to the current git executable associated with this module.
+        /// Gets the default Git executable associated with this module.
+        /// This executable can be non-native (i.e. WSL).
         /// </summary>
         IExecutable GitExecutable { get; }
 
         /// <summary>
         /// Gets the access to the current git executable associated with this module.
+        /// This commandrunner can be non-native (i.e. WSL).
         /// </summary>
         IGitCommandRunner GitCommandRunner { get; }
 
@@ -69,6 +73,20 @@ namespace GitUIPluginInterfaces
 
         /// <summary>Indicates HEAD is not pointing to a branch (i.e. it is detached).</summary>
         bool IsDetachedHead();
+
+        /// <summary>
+        /// Convert the path for the Git executable. For WSL Git, the path will be adjusted.
+        /// </summary>
+        /// <param name="path">The Windows (native) path as seen by the application.</param>
+        /// <returns>The Posix path if Windows Git, WSL path for WSL Git.</returns>
+        public string GetGitExecPath(string? path);
+
+        /// <summary>
+        /// Convert a path to Windows application (native) format.
+        /// </summary>
+        /// <param name="path">Path as seen by the Git executable, possibly WSL Git.</param>
+        /// <returns>The path in Windows format with native file separators.</returns>
+        public string GetWindowsPath(string path);
 
         bool TryResolvePartialCommitId(string objectIdPrefix, [NotNullWhen(returnValue: true)] out ObjectId? objectId);
 

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -418,8 +418,8 @@ namespace GitCommandsTests.Git.Commands
                 "-c rebase.autoSquash=false rebase -i --no-autosquash \"branch\"",
                 GitCommandHelpers.RebaseCmd("branch", interactive: true, preserveMerges: false, autosquash: false, autoStash: false, ignoreDate: false, committerDateIsAuthorDate: false).Arguments);
             Assert.AreEqual(
-                GitVersion.Current.SupportRebaseMerges ? "-c rebase.autoSquash=false rebase --rebase-merges \"branch\"" : "-c rebase.autoSquash=false rebase --preserve-merges \"branch\"",
-                GitCommandHelpers.RebaseCmd("branch", interactive: false, preserveMerges: true, autosquash: false, autoStash: false, ignoreDate: false, committerDateIsAuthorDate: false).Arguments);
+                "-c rebase.autoSquash=false rebase --rebase-merges \"branch\"",
+                GitCommandHelpers.RebaseCmd("branch", interactive: false, preserveMerges: true, autosquash: false, autoStash: false, ignoreDate: false, committerDateIsAuthorDate: false, supportRebaseMerges: true).Arguments);
             Assert.AreEqual(
                 "-c rebase.autoSquash=false rebase \"branch\"",
                 GitCommandHelpers.RebaseCmd("branch", interactive: false, preserveMerges: false, autosquash: true, autoStash: false, ignoreDate: false, committerDateIsAuthorDate: false).Arguments);
@@ -448,8 +448,8 @@ namespace GitCommandsTests.Git.Commands
                 "-c rebase.autoSquash=false rebase --committer-date-is-author-date --autostash \"branch\"",
                 GitCommandHelpers.RebaseCmd("branch", interactive: true, preserveMerges: true, autosquash: true, autoStash: true, ignoreDate: false, committerDateIsAuthorDate: true).Arguments);
             Assert.AreEqual(
-                GitVersion.Current.SupportRebaseMerges ? "-c rebase.autoSquash=false rebase -i --autosquash --rebase-merges --autostash \"branch\"" : "-c rebase.autoSquash=false rebase -i --autosquash --preserve-merges --autostash \"branch\"",
-                GitCommandHelpers.RebaseCmd("branch", interactive: true, preserveMerges: true, autosquash: true, autoStash: true, ignoreDate: false, committerDateIsAuthorDate: false).Arguments);
+                "-c rebase.autoSquash=false rebase -i --autosquash --rebase-merges --autostash \"branch\"",
+                GitCommandHelpers.RebaseCmd("branch", interactive: true, preserveMerges: true, autosquash: true, autoStash: true, ignoreDate: false, committerDateIsAuthorDate: false, supportRebaseMerges: true).Arguments);
 
             // TODO quote 'onto'?
 

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -193,7 +193,7 @@ namespace GitCommandsTests.Git.Commands
                 GitCommandHelpers.CloneCmd("from", "to").Arguments);
             Assert.AreEqual(
                 "clone -v --progress \"from/path\" \"to/path\"",
-                GitCommandHelpers.CloneCmd("from\\path", "to\\path").Arguments);
+                GitCommandHelpers.CloneCmd("from/path", "to/path").Arguments);
             Assert.AreEqual(
                 "clone -v --bare --progress \"from\" \"to\"",
                 GitCommandHelpers.CloneCmd("from", "to", central: true).Arguments);
@@ -489,7 +489,7 @@ namespace GitCommandsTests.Git.Commands
 
         [TestCase("mybranch", ".", false, ExpectedResult = @"push ""file://."" ""1111111111111111111111111111111111111111:mybranch""")]
         [TestCase("branch2", "/my/path", true, ExpectedResult = @"push ""file:///my/path"" ""1111111111111111111111111111111111111111:branch2"" --force")]
-        [TestCase("branchx", @"c:\my\path", true, ExpectedResult = @"push ""file://c:/my/path"" ""1111111111111111111111111111111111111111:branchx"" --force")]
+        [TestCase("branchx", @"c:/my/path", true, ExpectedResult = @"push ""file://c:/my/path"" ""1111111111111111111111111111111111111111:branchx"" --force")]
         public string PushLocalCmd(string gitRef, string repoDir, bool force)
         {
             return GitCommandHelpers.PushLocalCmd(gitRef, ObjectId.WorkTreeId, repoDir, force).Arguments;

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -542,9 +542,9 @@ namespace GitCommandsTests
                     Assert.AreEqual("https://github.com/gitextensions/push.git", remotes[3].PushUrls[0]);
 
                     Assert.AreEqual("with-space", remotes[4].Name);
-                    Assert.AreEqual("c:\\Bare Repo", remotes[4].FetchUrl);
+                    Assert.AreEqual("c:/Bare Repo", remotes[4].FetchUrl);
                     Assert.AreEqual(1, remotes[4].PushUrls.Count);
-                    Assert.AreEqual("c:\\Bare Repo", remotes[4].PushUrls[0]);
+                    Assert.AreEqual("c:/Bare Repo", remotes[4].PushUrls[0]);
 
                     Assert.AreEqual("multi", remotes[5].Name);
                     Assert.AreEqual("git@github.com:drewnoakes/gitextensions.git", remotes[5].FetchUrl);

--- a/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
@@ -231,6 +231,64 @@ namespace GitCommandsTests.Helpers
             PathUtil.IsWslPath(path).Should().Be(expected);
         }
 
+        [TestCase(@"\\Wsl$/Ubuntu\work\..\GitExtensions\", false)]
+        public void IsWslPath_unexpected_usage(string path, bool expected)
+        {
+            PathUtil.IsWslPath(path).Should().Be(expected);
+        }
+
+        [TestCase(@"\\Wsl$\Ubuntu\work\..\GitExtensions\", "Ubuntu")]
+        [TestCase(@"\\wsl$\Ubuntu/work/../GitExtensions", "Ubuntu")]
+        [TestCase(@"\\wsl$\Ubuntu-20.04\work\..\GitExtensions\", "Ubuntu-20.04")]
+        [TestCase(@"C:\work\..\GitExtensions\", "")]
+        public void GetWslDistro(string path, string expected)
+        {
+            PathUtil.GetWslDistro(path).Should().Be(expected);
+        }
+
+        [TestCase(@"\\wsl$/Ubuntu/work/../GitExtensions", "")]
+        public void GetWslDistro_unexpected_usage(string path, string expected)
+        {
+            PathUtil.GetWslDistro(path).Should().Be(expected);
+        }
+
+        [TestCase(@"\\wsl$\Ubuntu\work\..\GitExtensions\", "", @"//wsl$/Ubuntu/work/../GitExtensions/")]
+        [TestCase(@"C:\work\..\GitExtensions\", "", @"C:/work/../GitExtensions/")]
+        [TestCase(@"work\..\GitExtensions\", "", @"work/../GitExtensions/")]
+        public void GetGitExecPath_GetWindowsPath_default(string path, string wslDistro, string expected)
+        {
+            PathUtil.GetGitExecPath(path, wslDistro).Should().Be(expected);
+            PathUtil.GetWindowsPath(expected, wslDistro).Should().Be(path);
+        }
+
+        [TestCase(@"\\Wsl$\Ubuntu\work\..\GitExtensions\", "Ubuntu", @"/work/../GitExtensions/")]
+        [TestCase(@"\\wsl$\Ubuntu\work/../GitExtensions", "Ubuntu", @"/work/../GitExtensions")]
+        [TestCase(@"\\wsl$\Ubuntu-20.04\work\..\GitExtensions\", "Ubuntu-20.04", @"/work/../GitExtensions/")]
+        [TestCase(@"C:\work\..\GitExtensions\", "Ubuntu", @"/mnt/c/work/../GitExtensions/")]
+        [TestCase(@"work\..\GitExtensions\", "Ubuntu", @"work/../GitExtensions/")]
+        public void GetGitExecPath_wsl(string path, string wslDistro, string expected)
+        {
+            PathUtil.GetGitExecPath(path, wslDistro).Should().Be(expected);
+        }
+
+        [TestCase(@"\\wsl$/Ubuntu/work/../GitExtensions", "Ubuntu", @"//wsl$/Ubuntu/work/../GitExtensions")]
+        [TestCase(@"\\wsl$\Ubuntu-20.04\work\..\GitExtensions\", "Ubuntu", @"//wsl$/Ubuntu-20.04/work/../GitExtensions/")]
+        public void GetGitExecPath_unexpected_usage(string path, string wslDistro, string expected)
+        {
+            PathUtil.GetGitExecPath(path, wslDistro).Should().Be(expected);
+        }
+
+        // Mostly opposite to GetRepoPath_wsl
+        [TestCase(@"\\wsl$\Ubuntu\work\..\GitExtensions\", "Ubuntu", @"/work/../GitExtensions/")]
+        [TestCase(@"\\wsl$\Ubuntu\work\..\GitExtensions", "Ubuntu", @"/work/../GitExtensions")]
+        [TestCase(@"\\wsl$\Ubuntu-20.04\work\..\GitExtensions\", "Ubuntu-20.04", @"/work/../GitExtensions/")]
+        [TestCase(@"C:\work\..\GitExtensions\", "Ubuntu", @"/mnt/c/work/../GitExtensions/")]
+        [TestCase(@"\\wsl$\Ubuntu\work\..\GitExtensions\", "Ubuntu", @"work/../GitExtensions/")]
+        public void GetWindowsPath_wsl(string expected, string wslDistro, string path)
+        {
+            PathUtil.GetWindowsPath(path, wslDistro).Should().Be(expected);
+        }
+
         [Platform(Include = "Win")]
         [TestCase(null)]
         [TestCase("")]


### PR DESCRIPTION
Fixes #8172

## Proposed changes

For Git repos stored in WSL2 directories, execute the Git executable in WSL
where possible to improve performance. WSL Git commands are several
times faster when executed by the WSL Git executable instead of the
Git Extensions native (Windows) executable.

The paths internal to Git Extensions are always native (Windows).
Using the WSL executable requires that paths provided to WSL Git
are adjusted from/to Git Extensions native/internal (Windows) format to WSL, like
\\wsl$\Ubunto\repo to /repo and c:\repo to /mnt/c/repo.

The Git Extensions native (Windows) Git executable is still used in some situations:
* All handling and settings related to Git in Settings. This includes
display of Git version as well.
However, if the Git version is too old to be supported, the GitVersion
check added in #9680 will report that the version is too old.
* Custom merge implementation in FormResolveConflicts
* Custom difftool/mergetool, the tools are only extracted in Windows.
Default git-difftool is using the Git executable, which could be separate
for WSL Git.
* Some built-in plugins etc, ScriptRunner and FindLargeFiles always use
 native Git

Some additional known limitations:
* The dialog that offers "--force-with-lease" for push do not appear as the output is not redirected. (So the Push dialog appears and --force-with-lease has to manually selected).
* GitHub plugin do not use the Windows token

Note: All commands are not tried in WSL, there may be a few more changes needed.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

See additions below
![image](https://user-images.githubusercontent.com/6248932/139748280-2b9563b3-40fb-4a79-a5ee-cbd029fde062.png)

### After

![image](https://user-images.githubusercontent.com/6248932/139748142-714b0cba-3f3d-48b7-b7e4-a5b27cb5e98a.png)

WSL is shown separately in Git command log
![image](https://user-images.githubusercontent.com/6248932/139602445-51df27c3-55ca-4834-83e1-a0ebc65981bb.png)

## Test methodology <!-- How did you ensure quality? -->

Tests added for PathUtil.
For the few changed commands, something could be added. There are no current tests for the commands.

## Merge strategy

Rebase merge (PR submitter must change the commit message for the last commit).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
