### PR TITLE
revDiff: Separate group for both changed

### DIFF
--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -77,6 +77,7 @@ namespace GitUI
         private readonly TranslationString _diffWithParent = new("Diff with a/");
         private readonly TranslationString _diffBaseToB = new("Unique diff BASE with b/");
         private readonly TranslationString _diffCommonBase = new("Common diff with BASE a/");
+        private readonly TranslationString _diffBothChanged = new("Both changed to BASE");
         private readonly TranslationString _diffRange = new("Range diff");
         private readonly TranslationString _combinedDiff = new("Combined diff");
 
@@ -208,6 +209,7 @@ namespace GitUI
         public static string DiffWithParent => _instance.Value._diffWithParent.Text;
         public static string DiffBaseToB => _instance.Value._diffBaseToB.Text;
         public static string DiffCommonBase => _instance.Value._diffCommonBase.Text;
+        public static string DiffBothChanged => _instance.Value._diffBothChanged.Text;
         public static string DiffRange => _instance.Value._diffRange.Text;
         public static string CombinedDiff => _instance.Value._combinedDiff.Text;
         public static string ShowDiffForAllParentsText => _instance.Value._showDiffForAllParentsText.Text;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -10600,6 +10600,10 @@ Select this commit to populate the full message.</source>
         <source>Unique diff BASE with b/</source>
         <target />
       </trans-unit>
+      <trans-unit id="_diffBothChanged.Text">
+        <source>Both changed to BASE</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_diffCommonBase.Text">
         <source>Common diff with BASE a/</source>
         <target />

--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -167,8 +167,14 @@ namespace GitUI
 
             GitItemStatusNameEqualityComparer comparer = new();
             var commonBaseToAandB = allBaseToB.Intersect(allBaseToA, comparer).Except(allAToB, comparer).ToList();
+            var bothChangedAandB = allAToB.Intersect(allBaseToB, comparer).Intersect(allBaseToA, comparer).ToList();
 
             GitRevision revBase = new(baseRevGuid);
+            fileStatusDescs.Add(new FileStatusWithDescription(
+                firstRev: firstRev,
+                secondRev: selectedRev,
+                summary: TranslatedStrings.DiffBothChanged,
+                statuses: bothChangedAandB));
             fileStatusDescs.Add(new FileStatusWithDescription(
                 firstRev: revBase,
                 secondRev: selectedRev,


### PR DESCRIPTION
Follow up to #7923

## Proposed changes

PR for discussion

If two commits are selected, #7923 (and more) added more diffs than just the diff between the two commits.
The extra categories can be disabled with ShowDiffForAllParents.

This helps me in checking differences between branches, for merging etc.
However, I am often interested in changes done in both branches that are not identical.
In the example in the screenshots it is `ab` that is modified in both that is most interesting, there are conflicts there.
`a` and `b` have unique changes in each of the branches.
`c` has the same change in both.

The following adds yet another section with the "conflict" changes.

Yet another category seem a little much. The files in the first category appears in "Both changed" and the two "Unique diff with BASE" and is not really needed (except that files changed in both branches are in all  three lists).
But removing this category may confuse some users.

If the category headers had some visual indication of the number of changes, the categories could be collapsed by default. That is probably a separate PR but may be discussed here.

Some possibilities:
* Add another category as in this PR. If so, the category need to be named better. What is proposed. 
* Collapse the "duplicate" (current first group) by default. (Of course can `ShowDiffForAllParents` be used to show only the diff). Remembering the collapse state in a session would be good use but requires a visual indicator of number of changes and is a separate PR.
* A new setting in addition to `ShowDiffForAllParents` that skips the common diff. (I say no, too many settings already)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/139603281-700bd371-9c4f-4555-af63-4154d51c4076.png)

### After

![image](https://user-images.githubusercontent.com/6248932/139604516-1fbc51be-1653-46e2-8f0c-4227167bcc02.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
