### PR TITLE
Generate .NET installer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,6 +28,12 @@
     <DeterministicSourcePaths>false</DeterministicSourcePaths>
   </PropertyGroup>
 
+  <!-- Exclude *.resources
+       https://docs.microsoft.com/dotnet/core/project-sdk/msbuild-props#satelliteresourcelanguages -->
+  <PropertyGroup>
+    <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
+  </PropertyGroup>
+
   <!-- For the purposes of generating code coverage as part of the build -->
   <PropertyGroup Condition="'$(Coverage)' == 'true'">
     <!-- Coverlet assumes PDB files exist on disk https://github.com/tonerdo/coverlet/issues/362 -->

--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -33,7 +33,10 @@
     <PackageReference Include="NETStandard.Library" IsImplicitlyDefined="true" GeneratePathProperty="true">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="WiX">
+    <PackageReference Include="vswhere" IsImplicitlyDefined="true" GeneratePathProperty="true">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="WiX" IsImplicitlyDefined="true">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -21,6 +21,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DotnetRuntimeBootstrapper">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="GitInfo">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/GitExtensions/Project.Publish.targets
+++ b/GitExtensions/Project.Publish.targets
@@ -73,19 +73,44 @@
 
   <!--
     ============================================================
-                       CreatePortable
+                       _CleanupBeforePack
 
-    Creates a portable archive.
+    Removes all files not eligible for packing.
     ============================================================
     -->
-  <!-- Any errors in targets that executed as 'AfterTargets' don't break the build: https://github.com/microsoft/msbuild/issues/3345
-       A fix is going out in VS16.6p3, but it is way too long for us to wait.
+  <Target Name="_CleanupBeforePack">
+    <PropertyGroup>
+      <_AppPluginsPublishDir>$([MSBuild]::NormalizeDirectory('$(AppPublishDir)', 'Plugins'))</_AppPluginsPublishDir>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <UnnecessaryFiles Include="$(AppPublishDir)\*.pdb"/>
+      <UnnecessaryFiles Include="$(AppPublishDir)\*.exe.config"/>
+      <UnnecessaryFiles Include="$(AppPublishDir)\*.dll.config"/>
+      <UnnecessaryFiles Include="$(AppPublishDir)\*.xml"/>
+      <UnnecessaryFiles Include="$(AppPublishDir)\TranslationApp.*"/>
+      <UnnecessaryFiles Include="$(AppPublishDir)\ApplicationInsights.config"/>
+      <!-- Duplicates -->
+      <UnnecessaryFiles Include="$(_AppPluginsPublishDir)\Newtonsoft.Json.dll"/>
+
+      <!-- Keep this one -->
+      <UnnecessaryFiles Remove="$(AppPublishDir)\GitExtensions.dll.*"/>
+    </ItemGroup>
+
+    <Delete Files="@(UnnecessaryFiles)" />
+
+  </Target>
+
+  <!--
+    ============================================================
+                       _EnsureBundleContent
+
+    Copies all necessary files for the pack step.
+    ============================================================
     -->
-  <Target Name="CreatePortable" BeforeTargets="Publish" DependsOnTargets="_RetrieveCurrentBuildVersion;_PublishTranslations;_DownloadPluginManager">
+  <Target Name="_EnsureBundleContent">
     <PropertyGroup>
       <ContinuousIntegrationBuild Condition="'$(ContinuousIntegrationBuild)' == ''">false</ContinuousIntegrationBuild>
-
-      <_TargetAppConfig>@(AppConfigFileDestination)</_TargetAppConfig>
 
       <_UserDictionariesSourceDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'Bin', 'Dictionaries'))</_UserDictionariesSourceDir>
       <_UserDictionariesPublishDir>$([MSBuild]::NormalizeDirectory('$(AppPublishDir)', 'Dictionaries'))</_UserDictionariesPublishDir>
@@ -93,23 +118,9 @@
       <_AppPluginsPublishDir>$([MSBuild]::NormalizeDirectory('$(AppPublishDir)', 'Plugins'))</_AppPluginsPublishDir>
       <_AppUserPluginsPublishDir>$([MSBuild]::NormalizeDirectory('$(AppPublishDir)', 'UserPlugins'))</_AppUserPluginsPublishDir>
 
-      <!-- Resolve app.config, so we can set/unset "portable" flag -->
-      <_PublishAppConfig>$([System.IO.Path]::GetFileName('$(_TargetAppConfig)'))</_PublishAppConfig>
-      <_PublishAppConfigPath>$([System.IO.Path]::Combine('$(PublishDir)', '$(_PublishAppConfig)'))</_PublishAppConfigPath>
-
-      <!-- Resolve the output file -->
-      <_PublishPortableVersionSuffix>-$(CurrentBuildVersion.ToString())</_PublishPortableVersionSuffix>
-      <_PublishPortableCommitHashSuffix Condition="'$(GitCommit)' != ''">-$(GitCommit)</_PublishPortableCommitHashSuffix>
-      <_PublishPortableCommitHashSuffix Condition="'$(env:APPVEYOR_REPO_COMMIT)' != ''">-$(env:APPVEYOR_REPO_COMMIT)</_PublishPortableCommitHashSuffix>
-      <_PublishPortableCommitHashSuffix Condition="'$(env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)' != ''">-$(env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)</_PublishPortableCommitHashSuffix>
-      <_PublishPortableFileName>GitExtensions-Portable$(_PublishPortableVersionSuffix)$(_PublishPortableCommitHashSuffix).zip</_PublishPortableFileName>
-      <_PublishPortablePath>$([MSBuild]::NormalizePath('$(ArtifactsPublishDir)', '$(_PublishPortableFileName)'))</_PublishPortablePath>
 
       <_PluginManagerBinPath>$([MSBuild]::NormalizeDirectory('$(_PluginManagerPath)', 'Output'))</_PluginManagerBinPath>
       <_PluginManagerPublishDir>$([MSBuild]::NormalizeDirectory('$(_AppUserPluginsPublishDir)', 'GitExtensions.PluginManager'))</_PluginManagerPublishDir>
-
-      <!-- We want to archive the whole publish folder, so get one level up -->
-      <_PublishedPath>$([MSBuild]::NormalizeDirectory('$(PublishDir)'))</_PublishedPath>
     </PropertyGroup>
 
     <!-- Determine plugins assemblies and their required references -->
@@ -147,6 +158,18 @@
             ContinueOnError="ErrorAndStop"
           />
 
+    <ItemGroup>
+      <NativeAssemblies Include="$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'GitExtSshAskPass'))\*.dll" />
+      <NativeAssemblies Include="$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'GitExtensionsShellEx'))\*.dll" />
+    </ItemGroup>
+
+    <!-- Copy the native components -->
+    <Copy
+            SourceFiles="@(NativeAssemblies)"
+            DestinationFolder="$(AppPublishDir)"
+            ContinueOnError="ErrorAndStop"
+          />
+
     <!-- Copy the plugins to the Plugins folder -->
     <Copy
             SourceFiles="@(PluginAssemblies)"
@@ -165,6 +188,38 @@
             DestinationFolder="$(_PluginManagerPublishDir)\%(RecursiveDir)"
             ContinueOnError="ErrorAndStop"
           />
+
+  </Target>
+
+  <!--
+    ============================================================
+                       CreatePortable
+
+    Creates a portable archive.
+    ============================================================
+    -->
+  <!-- Any errors in targets that executed as 'AfterTargets' don't break the build: https://github.com/microsoft/msbuild/issues/3345
+       A fix is going out in VS16.6p3, but it is way too long for us to wait.
+    -->
+  <Target Name="CreatePortable" AfterTargets="Publish" DependsOnTargets="_RetrieveCurrentBuildVersion;_PublishTranslations;_DownloadPluginManager;_EnsureBundleContent;_CleanupBeforePack">
+    <PropertyGroup>
+      <_TargetAppConfig>@(AppConfigFileDestination)</_TargetAppConfig>
+
+      <!-- Resolve app.config, so we can set/unset "portable" flag -->
+      <_PublishAppConfig>$([System.IO.Path]::GetFileName('$(_TargetAppConfig)'))</_PublishAppConfig>
+      <_PublishAppConfigPath>$([System.IO.Path]::Combine('$(PublishDir)', '$(_PublishAppConfig)'))</_PublishAppConfigPath>
+
+      <!-- Resolve the output file -->
+      <_PublishPortableVersionSuffix>-$(CurrentBuildVersion.ToString())</_PublishPortableVersionSuffix>
+      <_PublishPortableCommitHashSuffix Condition="'$(GitCommit)' != ''">-$(GitCommit)</_PublishPortableCommitHashSuffix>
+      <_PublishPortableCommitHashSuffix Condition="'$(env:APPVEYOR_REPO_COMMIT)' != ''">-$(env:APPVEYOR_REPO_COMMIT)</_PublishPortableCommitHashSuffix>
+      <_PublishPortableCommitHashSuffix Condition="'$(env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)' != ''">-$(env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)</_PublishPortableCommitHashSuffix>
+      <_PublishPortableFileName>GitExtensions-Portable$(_PublishPortableVersionSuffix)$(_PublishPortableCommitHashSuffix).zip</_PublishPortableFileName>
+      <_PublishPortablePath>$([MSBuild]::NormalizePath('$(ArtifactsPublishDir)', '$(_PublishPortableFileName)'))</_PublishPortablePath>
+
+      <!-- We want to archive the whole publish folder, so get one level up -->
+      <_PublishedPath>$([MSBuild]::NormalizeDirectory('$(PublishDir)'))</_PublishedPath>
+    </PropertyGroup>
 
     <!-- Mark the package as "portable" -->
     <XmlPoke XmlInputPath="$(_PublishAppConfigPath)"
@@ -197,11 +252,12 @@
     -->
   <Target Name="CreateMsi" AfterTargets="CreatePortable">
     <PropertyGroup>
-      <_PublishMsiVersionSuffix>-$(CurrentBuildVersion.ToString())</_PublishMsiVersionSuffix>
+      <_AppVeyorSuffix>$(ARTIFACT_BUILD_SUFFIX)</_AppVeyorSuffix>
+      <_PublishMsiVersionSuffix>-$(CurrentBuildVersion.ToString())$(_AppVeyorSuffix)</_PublishMsiVersionSuffix>
       <_PublishMsiCommitHashSuffix Condition="'$(GitCommit)' != ''">-$(GitCommit)</_PublishMsiCommitHashSuffix>
       <_PublishMsiCommitHashSuffix Condition="'$(env:APPVEYOR_REPO_COMMIT)' != ''">-$(env:APPVEYOR_REPO_COMMIT)</_PublishMsiCommitHashSuffix>
       <_PublishMsiCommitHashSuffix Condition="'$(env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)' != ''">-$(env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)</_PublishMsiCommitHashSuffix>
-      <_PublishMsiFileName>GitExtensions$(_PublishPortableVersionSuffix)$(_PublishPortableCommitHashSuffix)</_PublishMsiFileName>
+      <_PublishMsiFileName>GitExtensions$(_PublishMsiVersionSuffix)$(_PublishMsiCommitHashSuffix)</_PublishMsiFileName>
       <_PublishMsiPath>$([MSBuild]::NormalizePath('$(ArtifactsPublishDir)'))</_PublishMsiPath>
     </PropertyGroup>
 
@@ -210,17 +266,50 @@
       <_WiX Include="@(PackageReference)"  Condition="$([System.String]::Copy('%(Identity)')) == 'WiX'" />
     </ItemGroup>
     <Error Text="WiX package reference can't be found" Condition="'@(_WiX->Count())' != 1" />
+
     <PropertyGroup>
       <_WiXVersion>%(_WiX.Version)</_WiXVersion>
     </PropertyGroup>
 
-    <!-- WiX isn't yet compatible with .NET. See: https://github.com/wixtoolset/issues/issues/5627 -->
-    <!-- <MSBuild 
+    <!-- Work out VS installation path, so we can find MSBuild.exe -->
+    <PropertyGroup>
+      <VSWherePath>$([MSBuild]::NormalizePath('$(Pkgvswhere)', 'tools'))</VSWherePath>
+    </PropertyGroup>
+
+    <Exec
+        Command="vswhere.exe -latest -prerelease -property installationPath -requires Microsoft.Component.MSBuild"
+        WorkingDirectory="$(VSWherePath)"
+        EchoOff="true"
+        ConsoleToMsBuild="true"
+        StandardOutputImportance="Low">
+        <Output TaskParameter="ConsoleOutput" PropertyName="_VSInstallPath" />
+    </Exec>
+
+    <PropertyGroup>
+      <_MSBuildCurrentPath>$([MSBuild]::NormalizePath('$(_VSInstallPath)', 'MSBuild', 'Current', 'Bin'))</_MSBuildCurrentPath>
+      <_SetupArgs>/p:Configuration=$(Configuration);Platform=x86;WiXVersion=$(_WiXVersion);Version=$(CurrentBuildVersion);ArtifactsBinPath=$(ArtifactsBinDir);ArtifactsPublishPath=$(AppPublishDir);OutputPath=$(_PublishMsiPath.TrimEnd('\'));TargetName=$(_PublishMsiFileName)</_SetupArgs>
+    </PropertyGroup>
+
+    <!-- WiX isn't yet compatible with .NET. See: https://github.com/wixtoolset/issues/issues/5627 
+         So can't use the normal tool chain (i.e. dotnet publish or MSBuild task) and must fall back
+         to manually invoke msbuild.exe.
+
+         When WiX becomes .NET compatible we may be able to invoke the following:
+
+    <MSBuild 
         Projects="$(ProjectDir)\..\Setup\Setup.wixproj"
         Targets="Build"
         Properties="Configuration=$(Configuration);Platform=x86;WiXVersion=$(_WiXVersion);Version=$(CurrentBuildVersion);ArtifactsBinPath=$(ArtifactsBinDir);ArtifactsPublishPath=$(AppPublishDir);OutputPath=$(_PublishMsiPath.TrimEnd('\'));TargetName=$(_PublishMsiFileName)"
         StopOnFirstFailure="true"
-        /> -->
+        />
+      -->
+    <Exec
+        Command="msbuild.exe $(ProjectDir)\..\Setup\Setup.wixproj /v:q /t:Build $(_SetupArgs) /bl:$(ArtifactsLogDir)\setup.binlog"
+        WorkingDirectory="$(_MSBuildCurrentPath)"
+        EchoOff="true"
+        ConsoleToMsBuild="true"
+        StandardOutputImportance="High">
+    </Exec>
   </Target>
 
 </Project>

--- a/GitExtensions/app.config
+++ b/GitExtensions/app.config
@@ -5,12 +5,6 @@
       <section name="GitCommands.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
     </sectionGroup>
   </configSections>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
-  </startup>
-  <appSettings>
-    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
-  </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <probing privatePath="plugins" />
@@ -27,9 +21,7 @@
         <bindingRedirect oldVersion="0.0.0.0-106.11.4.0" newVersion="106.11.4.0" />
       </dependentAssembly>
     </assemblyBinding>
-    <AppContextSwitchOverrides value="Switch.UseLegacyAccessibilityFeatures=false;Switch.UseLegacyAccessibilityFeatures.2=false;Switch.UseLegacyAccessibilityFeatures.3=false;Switch.UseLegacyAccessibilityFeatures.4=false" />
   </runtime>
-  <connectionStrings></connectionStrings>
   <applicationSettings>
     <GitCommands.Properties.Settings>
       <!--Set this setting to True to store settings with the application, False to  store settings in user's application data path.-->

--- a/Packages.props
+++ b/Packages.props
@@ -7,6 +7,7 @@
     <PackageReference Update="AppInsights.WindowsDesktop" Version="2.17.10" />
     <PackageReference Update="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Update="ConEmu.Core" Version="21.7.18" />
+    <PackageReference Update="DotnetRuntimeBootstrapper" Version="1.1.2" />
     <PackageReference Update="EnvDTE" Version="16.10.31320.204" />
     <PackageReference Update="ExCSS" Version="4.1.0" />
     <PackageReference Update="GitInfo" Version="2.1.2" />

--- a/Packages.props
+++ b/Packages.props
@@ -32,8 +32,9 @@
     <PackageReference Update="System.ValueTuple" Version="4.5.0" /> <!-- Required? -->
 
     <!-- Setup infra -->
-    <PackageReference Update="WiX" Version="3.11.2" />
     <PackageReference Update="NETStandard.Library" Version="2.0.0" />
+    <PackageReference Update="vswhere" Version="2.8.4" />
+    <PackageReference Update="WiX" Version="3.11.2" />
 
     <!-- Test infra -->
     <PackageReference Update="ApprovalTests" Version="4.4.0" />

--- a/Setup/Config.wxi
+++ b/Setup/Config.wxi
@@ -11,4 +11,7 @@
   <!-- upgrade code never changes -->
   <?define UpgradeCode = "140e80ea-5053-42dc-ab0e-6ff0e49e6bcf" ?>
 
+  <!-- Prevent upgrade from previous versions. This is the minimum required version to install -->
+  <?define MinSupportedVersion = '4.0.0' ?>
+
 </Include>

--- a/Setup/EnableUpgrades.wxi
+++ b/Setup/EnableUpgrades.wxi
@@ -1,14 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
 
-  <Property Id="PREVIOUSVERSIONSINSTALLED" Secure="yes"/>
+  <Upgrade Id="$(var.UpgradeCode)">
+    <UpgradeVersion Property="UPGRADE" Minimum="$(var.MinSupportedVersion)" Maximum="$(var.Version)" />
+    <UpgradeVersion Property="DONTUPGRADE" Maximum="$(var.MinSupportedVersion)" IncludeMaximum="no" />
+    <UpgradeVersion Minimum="0.0.0" Property="PREVIOUSVERSIONSINSTALLED" MigrateFeatures="yes" IncludeMinimum="yes" />
+  </Upgrade>
 
-  <!-- Upgrade WiX installations -->
+  <Condition Message="The installed version is not upgradeable to $(var.Version).&#13;&#10;Uninstall the previous version first.&#13;&#10;&#13;&#10;Setup will now exit.">
+    <![CDATA[NOT (PREVIOUSVERSIONSINSTALLED AND DONTUPGRADE)]]>
+  </Condition>
+
+   <!-- Upgrade WiX installations -->
   <MajorUpgrade
     Schedule="afterInstallInitialize"
     DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit."
     AllowSameVersionUpgrades="yes"/>
-
 
   <SetProperty After="FindRelatedProducts" Id="FirstInstall" Value="true">
       NOT Installed AND NOT WIX_UPGRADE_DETECTED AND NOT WIX_DOWNGRADE_DETECTED

--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -5,10 +5,6 @@
     <Package InstallerVersion="200" Compressed="yes" Description="$(var.ProductName)" />
     <Media Id="1" Cabinet="media1.cab" EmbedCab="yes" />
     <Property Id="ALLUSERS" Value="1" />
-    <PropertyRef Id="WIX_IS_NETFRAMEWORK_461_OR_LATER_INSTALLED" />
-    <Condition Message=".NET Framework 4.6.1 must be installed prior to installation of Git Extensions.">
-      Installed OR WIX_IS_NETFRAMEWORK_461_OR_LATER_INSTALLED
-    </Condition>
     <!--
       Read the currently configured value.
      -->
@@ -36,44 +32,11 @@
       <Directory Id="ProgramFilesFolder">
         <Directory Id="INSTALLDIR" Name="$(var.InstallName)">
           <Directory Id="PuttyDir" Name="PuTTY" />
-          <Directory Id="PluginsDir" Name="Plugins">
-            <Directory Id="Plugins_de" Name="de" />
-            <Directory Id="Plugins_es" Name="es" />
-            <Directory Id="Plugins_fr" Name="fr" />
-            <Directory Id="Plugins_it" Name="it" />
-            <Directory Id="Plugins_ja" Name="ja" />
-            <Directory Id="Plugins_ko" Name="ko" />
-            <Directory Id="Plugins_pl" Name="pl" />
-            <Directory Id="Plugins_pt_BR" Name="pt-BR" />
-            <Directory Id="Plugins_cs" Name="cs" />
-            <Directory Id="Plugins_tr" Name="tr" />
-            <Directory Id="Plugins_ru" Name="ru" />
-            <Directory Id="Plugins_zh_Hans" Name="zh-Hans" />
-            <Directory Id="Plugins_zh_Hant" Name="zh-Hant" />
-          </Directory>
-          <Directory Id="InstallerDir" Name="Installer" />
+          <Directory Id="PluginsDir" Name="Plugins" />
           <Directory Id="DictionariesDir" Name="Dictionaries" />
           <Directory Id="TranslationsDir" Name="Translation" />
           <Directory Id="DiffScriptsDir" Name="Diff-Scripts" />
           <Directory Id="DirConEmu" Name="ConEmu" />
-          <Directory Id="cs" Name="cs" />
-          <Directory Id="de" Name="de" />
-          <Directory Id="es" Name="es" />
-          <Directory Id="es_MX" Name="es-MX" />
-          <Directory Id="fi_FI" Name="fi-FI" />
-          <Directory Id="fr" Name="fr" />
-          <Directory Id="hr" Name="hr" />
-          <Directory Id="it" Name="it" />
-          <Directory Id="ja" Name="ja" />
-          <Directory Id="ko" Name="ko" />
-          <Directory Id="ko_KR" Name="ko-KR" />
-          <Directory Id="pl" Name="pl" />
-          <Directory Id="pt_BR" Name="pt-BR" />
-          <Directory Id="ru" Name="ru" />
-          <Directory Id="tr" Name="tr" />
-          <Directory Id="zh_Hans" Name="zh-Hans" />
-          <Directory Id="zh_Hant" Name="zh-Hant" />
-          <Directory Id="ru_RU" Name="ru-RU" />
           <Directory Id="ThemesDir" Name="Themes" />
         </Directory>
       </Directory>
@@ -120,89 +83,32 @@
             <Verb Id="open" Command="Open Git Extentions Repository" TargetFile="GitExtensions.exe" Argument="openrepo &quot;%1&quot;" />
           </Extension>
         </ProgId>
-        <File Id="ICSharpCode.TextEditor.dll" Name="ICSharpCode.TextEditor.dll" Source="$(var.ArtifactsPublishPath)\ICSharpCode.TextEditor.dll" />
-      </Component>
-      <Component Id="GitExtensions.exe.config" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\GitExtensions.exe.config" />
-      </Component>
-      <Component Id="System.IO.Abstractions.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.IO.Abstractions.dll" />
-      </Component>
-      <Component Id="GitCommands.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\GitCommands.dll" />
-      </Component>
-      <Component Id="GitExtUtils.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\GitExtUtils.dll" />
       </Component>
       <Component Id="AdysTech.CredentialManager.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\AdysTech.CredentialManager.dll" />
       </Component>
-      <Component Id="GitUI.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\GitUI.dll" />
-      </Component>
-      <Component Id="ConEmu.WinForms.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\ConEmu.WinForms.dll" />
-      </Component>
-      <Component Id="NetSpell.SpellChecker.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\NetSpell.SpellChecker.dll" />
-      </Component>
-      <Component Id="ResourceManager.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\ResourceManager.dll" />
-      </Component>
-      <Component Id="GitUIPluginInterfaces.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\GitUIPluginInterfaces.dll" />
-      </Component>
-      <Component Id="ICSharpCode.SharpZipLib.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ICSharpCode.SharpZipLib.dll" />
-      </Component>
-      <Component Id="Git.hub.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Git.hub.dll" />
-      </Component>
-      <Component Id="RestSharp.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\RestSharp.dll" />
-      </Component>
-      <Component Id="Microsoft.VisualStudio.Composition.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Microsoft.VisualStudio.Composition.dll" />
-      </Component>
-      <Component Id="Microsoft.VisualStudio.Threading.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Microsoft.VisualStudio.Threading.dll" />
-      </Component>
-      <Component Id="Microsoft.VisualStudio.Validation.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Microsoft.VisualStudio.Validation.dll" />
-      </Component>
       <Component Id="AppInsights.WindowsDesktop.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\AppInsights.WindowsDesktop.dll" />
-      </Component>
-      <Component Id="Microsoft.ApplicationInsights.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Microsoft.ApplicationInsights.dll" />
-      </Component>
-      <Component Id="Microsoft.WindowsAPICodePack.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Microsoft.WindowsAPICodePack.dll" />
-      </Component>
-      <Component Id="Microsoft.WindowsAPICodePack.Shell.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Microsoft.WindowsAPICodePack.Shell.dll" />
-      </Component>
-      <Component Id="SmartFormat.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\SmartFormat.dll" />
       </Component>
       <Component Id="Ben.Demystifier.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Ben.Demystifier.dll" />
       </Component>
-      <Component Id="System.Reactive.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Reactive.dll" />
+      <Component Id="BugReporter.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\BugReporter.dll" />
       </Component>
-      <Component Id="System.Reactive.Interfaces.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Reactive.Interfaces.dll" />
+      <Component Id="BugReporter.exe" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\BugReporter.exe" />
       </Component>
-      <Component Id="System.Reactive.Linq.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Reactive.Linq.dll" />
+      <Component Id="BugReporter.runtimeconfig.json" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\BugReporter.runtimeconfig.json" />
       </Component>
-      <Component Id="System.ValueTuple.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.ValueTuple.dll" />
+      <Component Id="ConEmuWinForms.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\ConEmuWinForms.dll" />
       </Component>
-      <Component Id="System.Runtime.InteropServices.RuntimeInformation.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Runtime.InteropServices.RuntimeInformation.dll" />
+      <Component Id="EnvDTE.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\EnvDTE.dll" />
       </Component>
+      <!--
       <Component Id="EasyHook.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\EasyHook.dll" />
       </Component>
@@ -212,41 +118,93 @@
       <Component Id="EasyHook64.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\EasyHook64.dll" />
       </Component>
-      <Component Id="Microsoft.Win32.Primitives.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Microsoft.Win32.Primitives.dll" />
+      -->
+      <Component Id="ExCSS.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\ExCSS.dll" />
       </Component>
-      <Component Id="netstandard.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\netstandard.dll" />
+      <Component Id="Git.hub.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\Git.hub.dll" />
       </Component>
-      <Component Id="System.AppContext.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.AppContext.dll" />
+      <Component Id="GitCommands.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\GitCommands.dll" />
       </Component>
-      <Component Id="System.Collections.Concurrent.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Collections.Concurrent.dll" />
+      <Component Id="GitExtensions.deps.json" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\GitExtensions.deps.json" />
       </Component>
-      <Component Id="System.Collections.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Collections.dll" />
+      <!-- <Component Id="GitExtensions.exe.config" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\GitExtensions.exe.config" />
+      </Component> -->
+      <Component Id="GitExtensions.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\GitExtensions.dll" />
       </Component>
-      <Component Id="System.Collections.Immutable.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Collections.Immutable.dll" />
+      <Component Id="GitExtensions.dll.config" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\GitExtensions.dll.config" />
       </Component>
-      <Component Id="System.Collections.NonGeneric.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Collections.NonGeneric.dll" />
+      <Component Id="GitExtensions.runtimeconfig.json" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\GitExtensions.runtimeconfig.json" />
       </Component>
-      <Component Id="System.Collections.Specialized.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Collections.Specialized.dll" />
+      <Component Id="GitExtUtils.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\GitExtUtils.dll" />
       </Component>
-      <Component Id="System.ComponentModel.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.ComponentModel.dll" />
+      <Component Id="GitUI.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\GitUI.dll" />
       </Component>
-      <Component Id="System.ComponentModel.EventBasedAsync.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.ComponentModel.EventBasedAsync.dll" />
+      <Component Id="GitUIPluginInterfaces.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\GitUIPluginInterfaces.dll" />
       </Component>
-      <Component Id="System.ComponentModel.Primitives.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.ComponentModel.Primitives.dll" />
+      <Component Id="ICSharpCode.TextEditor.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\ICSharpCode.TextEditor.dll" />
       </Component>
-      <Component Id="System.ComponentModel.TypeConverter.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.ComponentModel.TypeConverter.dll" />
+      <Component Id="Microsoft.AI.DependencyCollector.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\Microsoft.AI.DependencyCollector.dll" />
+      </Component>
+      <Component Id="Microsoft.ApplicationInsights.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\Microsoft.ApplicationInsights.dll" />
+      </Component>
+      <Component Id="Microsoft.Bcl.AsyncInterfaces.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\Microsoft.Bcl.AsyncInterfaces.dll" />
+      </Component>
+      <Component Id="Microsoft.Toolkit.HighPerformance.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\Microsoft.Toolkit.HighPerformance.dll" />
+      </Component>
+      <Component Id="Microsoft.VisualStudio.Composition.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\Microsoft.VisualStudio.Composition.dll" />
+      </Component>
+      <Component Id="Microsoft.VisualStudio.Composition.NetFxAttributes.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\Microsoft.VisualStudio.Composition.NetFxAttributes.dll" />
+      </Component>
+      <Component Id="Microsoft.VisualStudio.Threading.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\Microsoft.VisualStudio.Threading.dll" />
+      </Component>
+      <Component Id="Microsoft.VisualStudio.Validation.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\Microsoft.VisualStudio.Validation.dll" />
+      </Component>
+      <Component Id="Microsoft.WindowsAPICodePack.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\Microsoft.WindowsAPICodePack.dll" />
+      </Component>
+      <Component Id="Microsoft.WindowsAPICodePack.Shell.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\Microsoft.WindowsAPICodePack.Shell.dll" />
+      </Component>
+      <Component Id="Newtonsoft.Json.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\Newtonsoft.Json.dll" />
+      </Component>
+      <Component Id="ResourceManager.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\ResourceManager.dll" />
+      </Component>
+      <Component Id="RestSharp.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\RestSharp.dll" />
+      </Component>
+      <Component Id="SmartFormat.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\SmartFormat.dll" />
+      </Component>
+      <Component Id="SpellChecker.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\SpellChecker.dll" />
+      </Component>
+      <Component Id="stdole.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\stdole.dll" />
+      </Component>
+      <Component Id="System.ComponentModel.Composition.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\System.ComponentModel.Composition.dll" />
       </Component>
       <Component Id="System.Composition.AttributedModel.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\System.Composition.AttributedModel.dll" />
@@ -263,284 +221,37 @@
       <Component Id="System.Composition.TypedParts.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\System.Composition.TypedParts.dll" />
       </Component>
-      <Component Id="System.Console.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Console.dll" />
+      <Component Id="System.IO.Abstractions.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\System.IO.Abstractions.dll" />
       </Component>
-      <Component Id="System.Data.Common.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Data.Common.dll" />
+      <Component Id="System.Reactive.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\System.Reactive.dll" />
       </Component>
-      <Component Id="System.Diagnostics.Contracts.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Diagnostics.Contracts.dll" />
+      <Component Id="System.Reactive.Interfaces.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\System.Reactive.Interfaces.dll" />
       </Component>
-      <Component Id="System.Diagnostics.Debug.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Diagnostics.Debug.dll" />
+      <Component Id="System.Reactive.Linq.dll" Guid="*">
+        <File Source="$(var.ArtifactsPublishPath)\System.Reactive.Linq.dll" />
       </Component>
-      <Component Id="System.Diagnostics.FileVersionInfo.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Diagnostics.FileVersionInfo.dll" />
-      </Component>
-      <Component Id="System.Diagnostics.Process.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Diagnostics.Process.dll" />
-      </Component>
-      <Component Id="System.Diagnostics.StackTrace.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Diagnostics.StackTrace.dll" />
-      </Component>
-      <Component Id="System.Diagnostics.TextWriterTraceListener.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Diagnostics.TextWriterTraceListener.dll" />
-      </Component>
-      <Component Id="System.Diagnostics.Tools.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Diagnostics.Tools.dll" />
-      </Component>
-      <Component Id="System.Diagnostics.TraceSource.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Diagnostics.TraceSource.dll" />
-      </Component>
-      <Component Id="System.Diagnostics.Tracing.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Diagnostics.Tracing.dll" />
-      </Component>
-      <Component Id="System.Drawing.Primitives.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Drawing.Primitives.dll" />
-      </Component>
-      <Component Id="System.Dynamic.Runtime.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Dynamic.Runtime.dll" />
-      </Component>
-      <Component Id="System.Globalization.Calendars.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Globalization.Calendars.dll" />
-      </Component>
-      <Component Id="System.Globalization.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Globalization.dll" />
-      </Component>
-      <Component Id="System.Globalization.Extensions.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Globalization.Extensions.dll" />
-      </Component>
-      <Component Id="System.IO.Compression.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.IO.Compression.dll" />
-      </Component>
-      <Component Id="System.IO.Compression.ZipFile.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.IO.Compression.ZipFile.dll" />
-      </Component>
-      <Component Id="System.IO.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.IO.dll" />
-      </Component>
-      <Component Id="System.IO.FileSystem.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.IO.FileSystem.dll" />
-      </Component>
-      <Component Id="System.IO.FileSystem.DriveInfo.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.IO.FileSystem.DriveInfo.dll" />
-      </Component>
-      <Component Id="System.IO.FileSystem.Primitives.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.IO.FileSystem.Primitives.dll" />
-      </Component>
-      <Component Id="System.IO.FileSystem.Watcher.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.IO.FileSystem.Watcher.dll" />
-      </Component>
-      <Component Id="System.IO.IsolatedStorage.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.IO.IsolatedStorage.dll" />
-      </Component>
-      <Component Id="System.IO.MemoryMappedFiles.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.IO.MemoryMappedFiles.dll" />
-      </Component>
-      <Component Id="System.IO.Pipes.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.IO.Pipes.dll" />
-      </Component>
-      <Component Id="System.IO.UnmanagedMemoryStream.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.IO.UnmanagedMemoryStream.dll" />
-      </Component>
-      <Component Id="System.Linq.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Linq.dll" />
-      </Component>
-      <Component Id="System.Linq.Expressions.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Linq.Expressions.dll" />
-      </Component>
-      <Component Id="System.Linq.Parallel.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Linq.Parallel.dll" />
-      </Component>
-      <Component Id="System.Linq.Queryable.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Linq.Queryable.dll" />
-      </Component>
-      <Component Id="System.Net.Http.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Net.Http.dll" />
-      </Component>
-      <Component Id="System.Net.NameResolution.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Net.NameResolution.dll" />
-      </Component>
-      <Component Id="System.Net.NetworkInformation.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Net.NetworkInformation.dll" />
-      </Component>
-      <Component Id="System.Net.Ping.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Net.Ping.dll" />
-      </Component>
-      <Component Id="System.Net.Primitives.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Net.Primitives.dll" />
-      </Component>
-      <Component Id="System.Net.Requests.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Net.Requests.dll" />
-      </Component>
-      <Component Id="System.Net.Security.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Net.Security.dll" />
-      </Component>
-      <Component Id="System.Net.Sockets.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Net.Sockets.dll" />
-      </Component>
-      <Component Id="System.Net.WebHeaderCollection.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Net.WebHeaderCollection.dll" />
-      </Component>
-      <Component Id="System.Net.WebSockets.Client.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Net.WebSockets.Client.dll" />
-      </Component>
-      <Component Id="System.Net.WebSockets.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Net.WebSockets.dll" />
-      </Component>
-      <Component Id="System.ObjectModel.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.ObjectModel.dll" />
-      </Component>
-      <Component Id="System.Reflection.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Reflection.dll" />
-      </Component>
-      <Component Id="System.Reflection.Extensions.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Reflection.Extensions.dll" />
-      </Component>
-      <Component Id="System.Reflection.Primitives.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Reflection.Primitives.dll" />
-      </Component>
-      <Component Id="System.Resources.Reader.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Resources.Reader.dll" />
-      </Component>
-      <Component Id="System.Resources.ResourceManager.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Resources.ResourceManager.dll" />
-      </Component>
-      <Component Id="System.Resources.Writer.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Resources.Writer.dll" />
-      </Component>
-      <Component Id="System.Runtime.CompilerServices.VisualC.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Runtime.CompilerServices.VisualC.dll" />
-      </Component>
-      <Component Id="System.Runtime.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Runtime.dll" />
-      </Component>
-      <Component Id="System.Runtime.Extensions.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Runtime.Extensions.dll" />
-      </Component>
-      <Component Id="System.Runtime.Handles.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Runtime.Handles.dll" />
-      </Component>
-      <Component Id="System.Runtime.InteropServices.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Runtime.InteropServices.dll" />
-      </Component>
-      <Component Id="System.Runtime.Numerics.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Runtime.Numerics.dll" />
-      </Component>
-      <Component Id="System.Runtime.Serialization.Formatters.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Runtime.Serialization.Formatters.dll" />
-      </Component>
-      <Component Id="System.Runtime.Serialization.Json.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Runtime.Serialization.Json.dll" />
-      </Component>
-      <Component Id="System.Runtime.Serialization.Primitives.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Runtime.Serialization.Primitives.dll" />
-      </Component>
-      <Component Id="System.Runtime.Serialization.Xml.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Runtime.Serialization.Xml.dll" />
-      </Component>
-      <Component Id="System.Security.Claims.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Security.Claims.dll" />
-      </Component>
-      <Component Id="System.Security.Cryptography.Algorithms.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Security.Cryptography.Algorithms.dll" />
-      </Component>
-      <Component Id="System.Security.Cryptography.Csp.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Security.Cryptography.Csp.dll" />
-      </Component>
-      <Component Id="System.Security.Cryptography.Encoding.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Security.Cryptography.Encoding.dll" />
-      </Component>
-      <Component Id="System.Security.Cryptography.Primitives.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Security.Cryptography.Primitives.dll" />
-      </Component>
-      <Component Id="System.Security.Cryptography.X509Certificates.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Security.Cryptography.X509Certificates.dll" />
-      </Component>
-      <Component Id="System.Security.Principal.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Security.Principal.dll" />
-      </Component>
-      <Component Id="System.Security.SecureString.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Security.SecureString.dll" />
-      </Component>
-      <Component Id="System.Text.Encoding.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Text.Encoding.dll" />
-      </Component>
-      <Component Id="System.Text.Encoding.Extensions.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Text.Encoding.Extensions.dll" />
-      </Component>
-      <Component Id="System.Text.RegularExpressions.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Text.RegularExpressions.dll" />
-      </Component>
-      <Component Id="System.Threading.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Threading.dll" />
-      </Component>
-      <Component Id="System.Threading.Overlapped.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Threading.Overlapped.dll" />
-      </Component>
-      <Component Id="System.Threading.Tasks.Dataflow.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Threading.Tasks.Dataflow.dll" />
-      </Component>
-      <Component Id="System.Threading.Tasks.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Threading.Tasks.dll" />
-      </Component>
-      <Component Id="System.Threading.Tasks.Parallel.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Threading.Tasks.Parallel.dll" />
-      </Component>
-      <Component Id="System.Threading.Thread.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Threading.Thread.dll" />
-      </Component>
-      <Component Id="System.Threading.ThreadPool.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Threading.ThreadPool.dll" />
-      </Component>
-      <Component Id="System.Threading.Timer.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Threading.Timer.dll" />
-      </Component>
-      <Component Id="System.Xml.ReaderWriter.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Xml.ReaderWriter.dll" />
-      </Component>
-      <Component Id="System.Xml.XDocument.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Xml.XDocument.dll" />
-      </Component>
-      <Component Id="System.Xml.XmlDocument.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Xml.XmlDocument.dll" />
-      </Component>
-      <Component Id="System.Xml.XmlSerializer.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Xml.XmlSerializer.dll" />
-      </Component>
-      <Component Id="System.Xml.XPath.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Xml.XPath.dll" />
-      </Component>
-      <Component Id="System.Xml.XPath.XDocument.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\System.Xml.XPath.XDocument.dll" />
-      </Component>
-      <Component Id="ExCSS.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\ExCSS.dll" />
-      </Component>
-      <Component Id="Newtonsoft.Json.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Newtonsoft.Json.dll" />
-      </Component>
-      <!-- Remove unused dll, installed in versions <= 2.31 -->
-      <Component Id="GithubSharp.Core.dll" Guid="08F2D539-54CE-4895-ACA5-A7FBA73CA172">
-        <RemoveFile Name="GithubSharp.Core.dll" Id="GithubSharp.Core.dll" On="both" />
-      </Component>
+
+      <!-- Shell extensions -->
       <?define ShellExCLSID = "{3C16B20A-BA16-4156-916F-0A375ECFFE24}"?>
       <Component Id="GitExtensionsShellEx32.dll" Guid="*">
-        <File Name="GitExtensionsShellEx32.dll" Source="$(var.ArtifactsBinPath)\GitExtensionsShellEx\Win32\$(var.Configuration)\GitExtensionsShellEx32.dll" KeyPath="yes" />
+        <File Name="GitExtensionsShellEx32.dll" Source="$(var.ArtifactsBinPath)\GitExtensionsShellEx\GitExtensionsShellEx32.dll" KeyPath="yes" />
         <?foreach ShellExFileName in GitExtensionsShellEx32.dll?>
         <?include RegisterShellExtension.wxi?>
         <?endforeach ?>
       </Component>
       <Component Id="GitExtensionsShellEx64.dll" Guid="*" Win64="yes">
         <Condition>VersionNT64</Condition>
-        <File Name="GitExtensionsShellEx64.dll" Source="$(var.ArtifactsBinPath)\GitExtensionsShellEx\x64\$(var.Configuration)\GitExtensionsShellEx64.dll" KeyPath="yes" />
+        <File Name="GitExtensionsShellEx64.dll" Source="$(var.ArtifactsBinPath)\GitExtensionsShellEx\GitExtensionsShellEx64.dll" KeyPath="yes" />
         <?foreach ShellExFileName in GitExtensionsShellEx64.dll?>
         <?include RegisterShellExtension.wxi?>
         <?endforeach ?>
       </Component>
+      <!-- End shell extensions -->
       <Component Id="GitExtSshAskPass.exe" Guid="*">
-        <File Source="$(var.ArtifactsBinPath)\SshAskPass\Win32\$(var.Configuration)\GitExtSshAskPass.exe" />
+        <File Source="$(var.ArtifactsBinPath)\GitExtSshAskPass\GitExtSshAskPass.exe" />
       </Component>
       <Component Id="checksettings.reg" Guid="*">
         <RegistryValue Name="CheckSettings" Value="true" Root="HKCU" Key="$(var.AppRegKey)" Type="string" />
@@ -627,8 +338,9 @@
       <Component Id="GitImpact.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Plugins\GitExtensions.Plugins.GitImpact.dll" />
       </Component>
-      <Component Id="Gource.dll" Guid="*">
+      <Component Id="Gource.dll" Guid="52F03345-7A36-5CFC-9287-94F03E72556B">
         <File Source="$(var.ArtifactsPublishPath)\Plugins\GitExtensions.Plugins.Gource.dll" />
+        <File Source="$(var.ArtifactsPublishPath)\Plugins\ICSharpCode.SharpZipLib.dll" />
       </Component>
       <Component Id="Github3.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Plugins\GitExtensions.Plugins.GitHub3.dll" />
@@ -648,22 +360,6 @@
       <Component Id="NString.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Plugins\NString.dll" />
       </Component>
-      <!-- Remove unused dll, installed in versions <= 2.31 -->
-      <Component Id="Github.dll" Guid="0DA13691-140A-4490-8B4C-8AF537DAEB67">
-        <RemoveFile Name="Github.dll" Id="Github.dll" On="both" />
-        <RemoveFile Name="System.Net.Http.dll" Id="System.Net.Http.dll" On="both" />
-        <RemoveFile Name="System.Net.Http.Extensions.dll" Id="System.Net.Http.Extensions.dll" On="both" />
-        <RemoveFile Name="System.Net.Http.Primitives.dll" Id="System.Net.Http.Primitives.dll" On="both" />
-        <RemoveFile Name="System.Net.Http.WebRequest.dll" Id="System.Net.Http.WebRequest.dll" On="both" />
-        <RemoveRegistryValue Id="GithubAPIToken" Root="HKCU" Key="$(var.AppRegKey)" Name="Githubapitoken" />
-        <RemoveRegistryValue Id="GithubUsername" Root="HKCU" Key="$(var.AppRegKey)" Name="Githubusername" />
-        <RemoveRegistryValue Id="GithubPassword" Root="HKCU" Key="$(var.AppRegKey)" Name="Githubpassword" />
-        <RemoveRegistryValue Id="GithubAccess" Root="HKCU" Key="$(var.AppRegKey)" Name="Githubpreferred access method" />
-      </Component>
-      <!-- Remove unused dll, installed in versions < 4.0 -->
-      <Component Id="Gerrit.dll" Guid="8890FF91-05DA-5F64-91BC-C22112C7EC0F">
-        <RemoveFile Name="Gerrit.dll" Id="Gerrit.dll" On="both" />
-      </Component>
       <Component Id="FindLargeFiles.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Plugins\GitExtensions.Plugins.FindLargeFiles.dll" />
       </Component>
@@ -672,8 +368,6 @@
       </Component>
       <Component Id="Bitbucket.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Plugins\GitExtensions.Plugins.Bitbucket.dll" />
-        <!--Renamed dll, installed in versions <= 2.50.02-->
-        <RemoveFile Name="Stash.dll" Id="Stash.dll" On="both" />
       </Component>
       <Component Id="TeamCityIntegration.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Plugins\TeamCityIntegration.dll" />
@@ -684,38 +378,8 @@
       <Component Id="JenkinsIntegration.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Plugins\JenkinsIntegration.dll" />
       </Component>
-      <Component Id="TfsIntegration.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\TfsIntegration.dll" />
-      </Component>
-      <Component Id="TfsInterop.Vs2012.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\TfsInterop.Vs2012.dll" />
-      </Component>
-      <!-- Component Id="TfsInterop.Vs2013.dll" Guid="*">
-                <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2013\bin\$(var.Configuration)\TfsInterop.Vs2013.dll" />
-            </Component -->
-      <Component Id="TfsInterop.Vs2015.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\TfsInterop.Vs2015.dll" />
-      </Component>
       <Component Id="AzureDevOpsIntegration.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Plugins\AzureDevOpsIntegration.dll" />
-      </Component>
-      <Component Id="Microsoft.VisualStudio.Services.WebApi.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\Microsoft.VisualStudio.Services.WebApi.dll" />
-      </Component>
-      <Component Id="Microsoft.TeamFoundation.Build2.WebApi.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\Microsoft.TeamFoundation.Build2.WebApi.dll" />
-      </Component>
-      <Component Id="Microsoft.TeamFoundation.Common.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\Microsoft.TeamFoundation.Common.dll" />
-      </Component>
-      <Component Id="Microsoft.TeamFoundation.Core.WebApi.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\Microsoft.TeamFoundation.Core.WebApi.dll" />
-      </Component>
-      <Component Id="Microsoft.VisualStudio.Services.Common.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\Microsoft.VisualStudio.Services.Common.dll" />
-      </Component>
-      <Component Id="System.Net.Http.Formatting.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\System.Net.Http.Formatting.dll" />
       </Component>
     </DirectoryRef>
     <DirectoryRef Id="PluginManagerDir">
@@ -957,569 +621,19 @@
       <ComponentRef Id="File.CER09" />
       <ComponentRef Id="File.CER10" />
     </ComponentGroup>
-    <ComponentGroup Id="Component.NetStandard">
-      <ComponentRef Id="Microsoft.Win32.Primitives.dll" />
-      <ComponentRef Id="netstandard.dll" />
-      <ComponentRef Id="System.AppContext.dll" />
-      <ComponentRef Id="System.Collections.Concurrent.dll" />
-      <ComponentRef Id="System.Collections.dll" />
-      <ComponentRef Id="System.Collections.Immutable.dll" />
-      <ComponentRef Id="System.Collections.NonGeneric.dll" />
-      <ComponentRef Id="System.Collections.Specialized.dll" />
-      <ComponentRef Id="System.ComponentModel.dll" />
-      <ComponentRef Id="System.ComponentModel.EventBasedAsync.dll" />
-      <ComponentRef Id="System.ComponentModel.Primitives.dll" />
-      <ComponentRef Id="System.ComponentModel.TypeConverter.dll" />
-      <ComponentRef Id="System.Composition.AttributedModel.dll" />
-      <ComponentRef Id="System.Composition.Convention.dll" />
-      <ComponentRef Id="System.Composition.Hosting.dll" />
-      <ComponentRef Id="System.Composition.Runtime.dll" />
-      <ComponentRef Id="System.Composition.TypedParts.dll" />
-      <ComponentRef Id="System.Console.dll" />
-      <ComponentRef Id="System.Data.Common.dll" />
-      <ComponentRef Id="System.Diagnostics.Contracts.dll" />
-      <ComponentRef Id="System.Diagnostics.Debug.dll" />
-      <ComponentRef Id="System.Diagnostics.FileVersionInfo.dll" />
-      <ComponentRef Id="System.Diagnostics.Process.dll" />
-      <ComponentRef Id="System.Diagnostics.StackTrace.dll" />
-      <ComponentRef Id="System.Diagnostics.TextWriterTraceListener.dll" />
-      <ComponentRef Id="System.Diagnostics.Tools.dll" />
-      <ComponentRef Id="System.Diagnostics.TraceSource.dll" />
-      <ComponentRef Id="System.Diagnostics.Tracing.dll" />
-      <ComponentRef Id="System.Drawing.Primitives.dll" />
-      <ComponentRef Id="System.Dynamic.Runtime.dll" />
-      <ComponentRef Id="System.Globalization.Calendars.dll" />
-      <ComponentRef Id="System.Globalization.dll" />
-      <ComponentRef Id="System.Globalization.Extensions.dll" />
-      <ComponentRef Id="System.IO.Compression.dll" />
-      <ComponentRef Id="System.IO.Compression.ZipFile.dll" />
-      <ComponentRef Id="System.IO.dll" />
-      <ComponentRef Id="System.IO.FileSystem.dll" />
-      <ComponentRef Id="System.IO.FileSystem.DriveInfo.dll" />
-      <ComponentRef Id="System.IO.FileSystem.Primitives.dll" />
-      <ComponentRef Id="System.IO.FileSystem.Watcher.dll" />
-      <ComponentRef Id="System.IO.IsolatedStorage.dll" />
-      <ComponentRef Id="System.IO.MemoryMappedFiles.dll" />
-      <ComponentRef Id="System.IO.Pipes.dll" />
-      <ComponentRef Id="System.IO.UnmanagedMemoryStream.dll" />
-      <ComponentRef Id="System.Linq.dll" />
-      <ComponentRef Id="System.Linq.Expressions.dll" />
-      <ComponentRef Id="System.Linq.Parallel.dll" />
-      <ComponentRef Id="System.Linq.Queryable.dll" />
-      <ComponentRef Id="System.Net.Http.dll" />
-      <ComponentRef Id="System.Net.NameResolution.dll" />
-      <ComponentRef Id="System.Net.NetworkInformation.dll" />
-      <ComponentRef Id="System.Net.Ping.dll" />
-      <ComponentRef Id="System.Net.Primitives.dll" />
-      <ComponentRef Id="System.Net.Requests.dll" />
-      <ComponentRef Id="System.Net.Security.dll" />
-      <ComponentRef Id="System.Net.Sockets.dll" />
-      <ComponentRef Id="System.Net.WebHeaderCollection.dll" />
-      <ComponentRef Id="System.Net.WebSockets.Client.dll" />
-      <ComponentRef Id="System.Net.WebSockets.dll" />
-      <ComponentRef Id="System.ObjectModel.dll" />
-      <ComponentRef Id="System.Reflection.dll" />
-      <ComponentRef Id="System.Reflection.Extensions.dll" />
-      <ComponentRef Id="System.Reflection.Primitives.dll" />
-      <ComponentRef Id="System.Resources.Reader.dll" />
-      <ComponentRef Id="System.Resources.ResourceManager.dll" />
-      <ComponentRef Id="System.Resources.Writer.dll" />
-      <ComponentRef Id="System.Runtime.CompilerServices.VisualC.dll" />
-      <ComponentRef Id="System.Runtime.dll" />
-      <ComponentRef Id="System.Runtime.Extensions.dll" />
-      <ComponentRef Id="System.Runtime.Handles.dll" />
-      <ComponentRef Id="System.Runtime.InteropServices.dll" />
-      <ComponentRef Id="System.Runtime.Numerics.dll" />
-      <ComponentRef Id="System.Runtime.Serialization.Formatters.dll" />
-      <ComponentRef Id="System.Runtime.Serialization.Json.dll" />
-      <ComponentRef Id="System.Runtime.Serialization.Primitives.dll" />
-      <ComponentRef Id="System.Runtime.Serialization.Xml.dll" />
-      <ComponentRef Id="System.Security.Claims.dll" />
-      <ComponentRef Id="System.Security.Cryptography.Algorithms.dll" />
-      <ComponentRef Id="System.Security.Cryptography.Csp.dll" />
-      <ComponentRef Id="System.Security.Cryptography.Encoding.dll" />
-      <ComponentRef Id="System.Security.Cryptography.Primitives.dll" />
-      <ComponentRef Id="System.Security.Cryptography.X509Certificates.dll" />
-      <ComponentRef Id="System.Security.Principal.dll" />
-      <ComponentRef Id="System.Security.SecureString.dll" />
-      <ComponentRef Id="System.Text.Encoding.dll" />
-      <ComponentRef Id="System.Text.Encoding.Extensions.dll" />
-      <ComponentRef Id="System.Text.RegularExpressions.dll" />
-      <ComponentRef Id="System.Threading.dll" />
-      <ComponentRef Id="System.Threading.Overlapped.dll" />
-      <ComponentRef Id="System.Threading.Tasks.Dataflow.dll" />
-      <ComponentRef Id="System.Threading.Tasks.dll" />
-      <ComponentRef Id="System.Threading.Tasks.Parallel.dll" />
-      <ComponentRef Id="System.Threading.Thread.dll" />
-      <ComponentRef Id="System.Threading.ThreadPool.dll" />
-      <ComponentRef Id="System.Threading.Timer.dll" />
-      <ComponentRef Id="System.Xml.ReaderWriter.dll" />
-      <ComponentRef Id="System.Xml.XDocument.dll" />
-      <ComponentRef Id="System.Xml.XmlDocument.dll" />
-      <ComponentRef Id="System.Xml.XmlSerializer.dll" />
-      <ComponentRef Id="System.Xml.XPath.dll" />
-      <ComponentRef Id="System.Xml.XPath.XDocument.dll" />
+    <ComponentGroup Id="Component.Themes">
+      <ComponentRef Id="Themes.README.md" />
+      <ComponentRef Id="Themes.invariant.css" />
+      <ComponentRef Id="Themes.dark.css" />
+      <ComponentRef Id="Themes.darksilver.css" />
+      <ComponentRef Id="Themes.bright.css" />
     </ComponentGroup>
-    <ComponentGroup Id="Component.Resources">
-      <ComponentRef Id="cs_Microsoft.VisualStudio.Composition.resources.dll" />
-      <ComponentRef Id="cs_Microsoft.VisualStudio.Threading.resources.dll" />
-      <ComponentRef Id="cs_Microsoft.VisualStudio.Validation.resources.dll" />
-      <ComponentRef Id="de_Microsoft.VisualStudio.Composition.resources.dll" />
-      <ComponentRef Id="de_Microsoft.VisualStudio.Threading.resources.dll" />
-      <ComponentRef Id="de_Microsoft.VisualStudio.Validation.resources.dll" />
-      <ComponentRef Id="es_Microsoft.VisualStudio.Composition.resources.dll" />
-      <ComponentRef Id="es_Microsoft.VisualStudio.Threading.resources.dll" />
-      <ComponentRef Id="es_Microsoft.VisualStudio.Validation.resources.dll" />
-      <ComponentRef Id="fr_Microsoft.VisualStudio.Composition.resources.dll" />
-      <ComponentRef Id="fr_Microsoft.VisualStudio.Threading.resources.dll" />
-      <ComponentRef Id="fr_Microsoft.VisualStudio.Validation.resources.dll" />
-      <ComponentRef Id="it_Microsoft.VisualStudio.Composition.resources.dll" />
-      <ComponentRef Id="it_Microsoft.VisualStudio.Threading.resources.dll" />
-      <ComponentRef Id="it_Microsoft.VisualStudio.Validation.resources.dll" />
-      <ComponentRef Id="ja_Microsoft.VisualStudio.Composition.resources.dll" />
-      <ComponentRef Id="ja_Microsoft.VisualStudio.Threading.resources.dll" />
-      <ComponentRef Id="ja_Microsoft.VisualStudio.Validation.resources.dll" />
-      <ComponentRef Id="ko_Microsoft.VisualStudio.Composition.resources.dll" />
-      <ComponentRef Id="ko_Microsoft.VisualStudio.Threading.resources.dll" />
-      <ComponentRef Id="ko_Microsoft.VisualStudio.Validation.resources.dll" />
-      <ComponentRef Id="pl_Microsoft.VisualStudio.Composition.resources.dll" />
-      <ComponentRef Id="pl_Microsoft.VisualStudio.Threading.resources.dll" />
-      <ComponentRef Id="pl_Microsoft.VisualStudio.Validation.resources.dll" />
-      <ComponentRef Id="pt_BR_Microsoft.VisualStudio.Composition.resources.dll" />
-      <ComponentRef Id="Plugins_pt_BR_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      <ComponentRef Id="Plugins_pt_BR_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      <ComponentRef Id="pt_BR_Microsoft.VisualStudio.Threading.resources.dll" />
-      <ComponentRef Id="pt_BR_Microsoft.VisualStudio.Validation.resources.dll" />
-      <ComponentRef Id="Plugins_ru_Microsoft.TeamFoundation.Common.resources.dll" />
-      <ComponentRef Id="Plugins_ru_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_ru_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      <ComponentRef Id="ru_Microsoft.VisualStudio.Composition.resources.dll" />
-      <ComponentRef Id="Plugins_ru_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      <ComponentRef Id="Plugins_ru_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      <ComponentRef Id="ru_Microsoft.VisualStudio.Threading.resources.dll" />
-      <ComponentRef Id="ru_Microsoft.VisualStudio.Validation.resources.dll" />
-      <ComponentRef Id="Plugins_tr_Microsoft.TeamFoundation.Common.resources.dll" />
-      <ComponentRef Id="Plugins_tr_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_tr_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      <ComponentRef Id="tr_Microsoft.VisualStudio.Composition.resources.dll" />
-      <ComponentRef Id="Plugins_tr_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      <ComponentRef Id="Plugins_tr_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      <ComponentRef Id="tr_Microsoft.VisualStudio.Threading.resources.dll" />
-      <ComponentRef Id="tr_Microsoft.VisualStudio.Validation.resources.dll" />
-      <ComponentRef Id="zh_Hans_Microsoft.VisualStudio.Composition.resources.dll" />
-      <ComponentRef Id="zh_Hans_Microsoft.VisualStudio.Threading.resources.dll" />
-      <ComponentRef Id="zh_Hans_Microsoft.VisualStudio.Validation.resources.dll" />
-      <ComponentRef Id="zh_Hant_Microsoft.VisualStudio.Composition.resources.dll" />
-      <ComponentRef Id="zh_Hant_Microsoft.VisualStudio.Threading.resources.dll" />
-      <ComponentRef Id="zh_Hant_Microsoft.VisualStudio.Validation.resources.dll" />
+    <ComponentGroup Id="Component.Translation">
+      <ComponentRef Id="English.gif" />
+      <ComponentRef Id="English.xlf" />
+      <ComponentRef Id="English.Plugins.xlf" />
     </ComponentGroup>
-    <ComponentGroup Id="Component.PluginResources">
-      <ComponentRef Id="Plugins_cs_Microsoft.TeamFoundation.Common.resources.dll" />
-      <ComponentRef Id="Plugins_cs_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_cs_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      <ComponentRef Id="Plugins_cs_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_de_Microsoft.TeamFoundation.Common.resources.dll" />
-      <ComponentRef Id="Plugins_de_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_de_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_de_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      <ComponentRef Id="Plugins_de_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_es_Microsoft.TeamFoundation.Common.resources.dll" />
-      <ComponentRef Id="Plugins_es_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_es_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_es_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      <ComponentRef Id="Plugins_es_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_fr_Microsoft.TeamFoundation.Common.resources.dll" />
-      <ComponentRef Id="Plugins_fr_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_fr_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_fr_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      <ComponentRef Id="Plugins_fr_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_it_Microsoft.TeamFoundation.Common.resources.dll" />
-      <ComponentRef Id="Plugins_it_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_it_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_it_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      <ComponentRef Id="Plugins_it_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_ja_Microsoft.TeamFoundation.Common.resources.dll" />
-      <ComponentRef Id="Plugins_ja_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_ja_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_ja_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      <ComponentRef Id="Plugins_ja_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_ko_Microsoft.TeamFoundation.Common.resources.dll" />
-      <ComponentRef Id="Plugins_ko_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_ko_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_ko_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      <ComponentRef Id="Plugins_ko_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_pl_Microsoft.TeamFoundation.Common.resources.dll" />
-      <ComponentRef Id="Plugins_pl_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_pl_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      <ComponentRef Id="Plugins_pl_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_pt_BR_Microsoft.TeamFoundation.Common.resources.dll" />
-      <ComponentRef Id="Plugins_pt_BR_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_zh_Hant_Microsoft.TeamFoundation.Common.resources.dll" />
-      <ComponentRef Id="Plugins_zh_Hans_Microsoft.TeamFoundation.Common.resources.dll" />
-      <ComponentRef Id="Plugins_zh_Hans_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_zh_Hans_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_zh_Hans_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      <ComponentRef Id="Plugins_zh_Hans_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_zh_Hant_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_zh_Hant_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      <ComponentRef Id="Plugins_zh_Hant_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      <ComponentRef Id="Plugins_zh_Hant_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-    </ComponentGroup>
-    <DirectoryRef Id="cs">
-      <Component Id="cs_Microsoft.VisualStudio.Composition.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\cs\Microsoft.VisualStudio.Composition.resources.dll" Id="cs_Microsoft.VisualStudio.Composition.resources.dll" />
-      </Component>
-      <Component Id="cs_Microsoft.VisualStudio.Threading.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\cs\Microsoft.VisualStudio.Threading.resources.dll" Id="cs_Microsoft.VisualStudio.Threading.resources.dll" />
-      </Component>
-      <Component Id="cs_Microsoft.VisualStudio.Validation.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\cs\Microsoft.VisualStudio.Validation.resources.dll" Id="cs_Microsoft.VisualStudio.Validation.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="de">
-      <Component Id="de_Microsoft.VisualStudio.Composition.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\de\Microsoft.VisualStudio.Composition.resources.dll" Id="de_Microsoft.VisualStudio.Composition.resources.dll" />
-      </Component>
-      <Component Id="de_Microsoft.VisualStudio.Threading.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\de\Microsoft.VisualStudio.Threading.resources.dll" Id="de_Microsoft.VisualStudio.Threading.resources.dll" />
-      </Component>
-      <Component Id="de_Microsoft.VisualStudio.Validation.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\de\Microsoft.VisualStudio.Validation.resources.dll" Id="de_Microsoft.VisualStudio.Validation.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="es">
-      <Component Id="es_Microsoft.VisualStudio.Composition.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\es\Microsoft.VisualStudio.Composition.resources.dll" Id="es_Microsoft.VisualStudio.Composition.resources.dll" />
-      </Component>
-      <Component Id="es_Microsoft.VisualStudio.Threading.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\es\Microsoft.VisualStudio.Threading.resources.dll" Id="es_Microsoft.VisualStudio.Threading.resources.dll" />
-      </Component>
-      <Component Id="es_Microsoft.VisualStudio.Validation.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\es\Microsoft.VisualStudio.Validation.resources.dll" Id="es_Microsoft.VisualStudio.Validation.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="fr">
-      <Component Id="fr_Microsoft.VisualStudio.Composition.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\fr\Microsoft.VisualStudio.Composition.resources.dll" Id="fr_Microsoft.VisualStudio.Composition.resources.dll" />
-      </Component>
-      <Component Id="fr_Microsoft.VisualStudio.Threading.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\fr\Microsoft.VisualStudio.Threading.resources.dll" Id="fr_Microsoft.VisualStudio.Threading.resources.dll" />
-      </Component>
-      <Component Id="fr_Microsoft.VisualStudio.Validation.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\fr\Microsoft.VisualStudio.Validation.resources.dll" Id="fr_Microsoft.VisualStudio.Validation.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="it">
-      <Component Id="it_Microsoft.VisualStudio.Composition.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\it\Microsoft.VisualStudio.Composition.resources.dll" Id="it_Microsoft.VisualStudio.Composition.resources.dll" />
-      </Component>
-      <Component Id="it_Microsoft.VisualStudio.Threading.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\it\Microsoft.VisualStudio.Threading.resources.dll" Id="it_Microsoft.VisualStudio.Threading.resources.dll" />
-      </Component>
-      <Component Id="it_Microsoft.VisualStudio.Validation.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\it\Microsoft.VisualStudio.Validation.resources.dll" Id="it_Microsoft.VisualStudio.Validation.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="ja">
-      <Component Id="ja_Microsoft.VisualStudio.Composition.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\ja\Microsoft.VisualStudio.Composition.resources.dll" Id="ja_Microsoft.VisualStudio.Composition.resources.dll" />
-      </Component>
-      <Component Id="ja_Microsoft.VisualStudio.Threading.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\ja\Microsoft.VisualStudio.Threading.resources.dll" Id="ja_Microsoft.VisualStudio.Threading.resources.dll" />
-      </Component>
-      <Component Id="ja_Microsoft.VisualStudio.Validation.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\ja\Microsoft.VisualStudio.Validation.resources.dll" Id="ja_Microsoft.VisualStudio.Validation.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="ko">
-      <Component Id="ko_Microsoft.VisualStudio.Composition.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\ko\Microsoft.VisualStudio.Composition.resources.dll" Id="ko_Microsoft.VisualStudio.Composition.resources.dll" />
-      </Component>
-      <Component Id="ko_Microsoft.VisualStudio.Threading.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\ko\Microsoft.VisualStudio.Threading.resources.dll" Id="ko_Microsoft.VisualStudio.Threading.resources.dll" />
-      </Component>
-      <Component Id="ko_Microsoft.VisualStudio.Validation.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\ko\Microsoft.VisualStudio.Validation.resources.dll" Id="ko_Microsoft.VisualStudio.Validation.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="pl">
-      <Component Id="pl_Microsoft.VisualStudio.Composition.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\pl\Microsoft.VisualStudio.Composition.resources.dll" Id="pl_Microsoft.VisualStudio.Composition.resources.dll" />
-      </Component>
-      <Component Id="pl_Microsoft.VisualStudio.Threading.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\pl\Microsoft.VisualStudio.Threading.resources.dll" Id="pl_Microsoft.VisualStudio.Threading.resources.dll" />
-      </Component>
-      <Component Id="pl_Microsoft.VisualStudio.Validation.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\pl\Microsoft.VisualStudio.Validation.resources.dll" Id="pl_Microsoft.VisualStudio.Validation.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="Plugins_cs">
-      <Component Id="Plugins_cs_Microsoft.TeamFoundation.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\cs\Microsoft.TeamFoundation.Common.resources.dll" Id="Plugins_cs_Microsoft.TeamFoundation.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_cs_Microsoft.TeamFoundation.Core.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\cs\Microsoft.TeamFoundation.Core.WebApi.resources.dll" Id="Plugins_cs_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_cs_Microsoft.VisualStudio.Services.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\cs\Microsoft.VisualStudio.Services.Common.resources.dll" Id="Plugins_cs_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_cs_Microsoft.VisualStudio.Services.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\cs\Microsoft.VisualStudio.Services.WebApi.resources.dll" Id="Plugins_cs_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="Plugins_de">
-      <Component Id="Plugins_de_Microsoft.TeamFoundation.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\de\Microsoft.TeamFoundation.Common.resources.dll" Id="Plugins_de_Microsoft.TeamFoundation.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_de_Microsoft.TeamFoundation.Core.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\de\Microsoft.TeamFoundation.Core.WebApi.resources.dll" Id="Plugins_de_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_de_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\de\Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Id="Plugins_de_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_de_Microsoft.VisualStudio.Services.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\de\Microsoft.VisualStudio.Services.Common.resources.dll" Id="Plugins_de_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_de_Microsoft.VisualStudio.Services.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\de\Microsoft.VisualStudio.Services.WebApi.resources.dll" Id="Plugins_de_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="Plugins_es">
-      <Component Id="Plugins_es_Microsoft.TeamFoundation.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\es\Microsoft.TeamFoundation.Common.resources.dll" Id="Plugins_es_Microsoft.TeamFoundation.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_es_Microsoft.TeamFoundation.Core.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\es\Microsoft.TeamFoundation.Core.WebApi.resources.dll" Id="Plugins_es_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_es_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\es\Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Id="Plugins_es_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_es_Microsoft.VisualStudio.Services.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\es\Microsoft.VisualStudio.Services.Common.resources.dll" Id="Plugins_es_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_es_Microsoft.VisualStudio.Services.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\es\Microsoft.VisualStudio.Services.WebApi.resources.dll" Id="Plugins_es_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="Plugins_fr">
-      <Component Id="Plugins_fr_Microsoft.TeamFoundation.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\fr\Microsoft.TeamFoundation.Common.resources.dll" Id="Plugins_fr_Microsoft.TeamFoundation.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_fr_Microsoft.TeamFoundation.Core.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\fr\Microsoft.TeamFoundation.Core.WebApi.resources.dll" Id="Plugins_fr_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_fr_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\fr\Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Id="Plugins_fr_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_fr_Microsoft.VisualStudio.Services.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\fr\Microsoft.VisualStudio.Services.Common.resources.dll" Id="Plugins_fr_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_fr_Microsoft.VisualStudio.Services.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\fr\Microsoft.VisualStudio.Services.WebApi.resources.dll" Id="Plugins_fr_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="Plugins_it">
-      <Component Id="Plugins_it_Microsoft.TeamFoundation.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\it\Microsoft.TeamFoundation.Common.resources.dll" Id="Plugins_it_Microsoft.TeamFoundation.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_it_Microsoft.TeamFoundation.Core.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\it\Microsoft.TeamFoundation.Core.WebApi.resources.dll" Id="Plugins_it_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_it_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\it\Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Id="Plugins_it_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_it_Microsoft.VisualStudio.Services.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\it\Microsoft.VisualStudio.Services.Common.resources.dll" Id="Plugins_it_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_it_Microsoft.VisualStudio.Services.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\it\Microsoft.VisualStudio.Services.WebApi.resources.dll" Id="Plugins_it_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="Plugins_ja">
-      <Component Id="Plugins_ja_Microsoft.TeamFoundation.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ja\Microsoft.TeamFoundation.Common.resources.dll" Id="Plugins_ja_Microsoft.TeamFoundation.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_ja_Microsoft.TeamFoundation.Core.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ja\Microsoft.TeamFoundation.Core.WebApi.resources.dll" Id="Plugins_ja_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_ja_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ja\Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Id="Plugins_ja_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_ja_Microsoft.VisualStudio.Services.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ja\Microsoft.VisualStudio.Services.Common.resources.dll" Id="Plugins_ja_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_ja_Microsoft.VisualStudio.Services.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ja\Microsoft.VisualStudio.Services.WebApi.resources.dll" Id="Plugins_ja_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="Plugins_ko">
-      <Component Id="Plugins_ko_Microsoft.TeamFoundation.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ko\Microsoft.TeamFoundation.Common.resources.dll" Id="Plugins_ko_Microsoft.TeamFoundation.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_ko_Microsoft.TeamFoundation.Core.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ko\Microsoft.TeamFoundation.Core.WebApi.resources.dll" Id="Plugins_ko_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_ko_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ko\Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Id="Plugins_ko_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_ko_Microsoft.VisualStudio.Services.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ko\Microsoft.VisualStudio.Services.Common.resources.dll" Id="Plugins_ko_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_ko_Microsoft.VisualStudio.Services.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ko\Microsoft.VisualStudio.Services.WebApi.resources.dll" Id="Plugins_ko_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="Plugins_pl">
-      <Component Id="Plugins_pl_Microsoft.TeamFoundation.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\pl\Microsoft.TeamFoundation.Common.resources.dll" Id="Plugins_pl_Microsoft.TeamFoundation.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_pl_Microsoft.TeamFoundation.Core.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\pl\Microsoft.TeamFoundation.Core.WebApi.resources.dll" Id="Plugins_pl_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_pl_Microsoft.VisualStudio.Services.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\pl\Microsoft.VisualStudio.Services.Common.resources.dll" Id="Plugins_pl_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_pl_Microsoft.VisualStudio.Services.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\pl\Microsoft.VisualStudio.Services.WebApi.resources.dll" Id="Plugins_pl_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="Plugins_pt_BR">
-      <Component Id="Plugins_pt_BR_Microsoft.TeamFoundation.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\pt-BR\Microsoft.TeamFoundation.Common.resources.dll" Id="Plugins_pt_BR_Microsoft.TeamFoundation.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_pt_BR_Microsoft.TeamFoundation.Core.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\pt-BR\Microsoft.TeamFoundation.Core.WebApi.resources.dll" Id="Plugins_pt_BR_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_pt_BR_Microsoft.VisualStudio.Services.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\pt-BR\Microsoft.VisualStudio.Services.Common.resources.dll" Id="Plugins_pt_BR_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_pt_BR_Microsoft.VisualStudio.Services.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\pt-BR\Microsoft.VisualStudio.Services.WebApi.resources.dll" Id="Plugins_pt_BR_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="pt_BR">
-      <Component Id="pt_BR_Microsoft.VisualStudio.Composition.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\pt-BR\Microsoft.VisualStudio.Composition.resources.dll" Id="pt_BR_Microsoft.VisualStudio.Composition.resources.dll" />
-      </Component>
-      <Component Id="pt_BR_Microsoft.VisualStudio.Threading.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\pt-BR\Microsoft.VisualStudio.Threading.resources.dll" Id="pt_BR_Microsoft.VisualStudio.Threading.resources.dll" />
-      </Component>
-      <Component Id="pt_BR_Microsoft.VisualStudio.Validation.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\pt-BR\Microsoft.VisualStudio.Validation.resources.dll" Id="pt_BR_Microsoft.VisualStudio.Validation.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="Plugins_ru">
-      <Component Id="Plugins_ru_Microsoft.TeamFoundation.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ru\Microsoft.TeamFoundation.Common.resources.dll" Id="Plugins_ru_Microsoft.TeamFoundation.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_ru_Microsoft.TeamFoundation.Core.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ru\Microsoft.TeamFoundation.Core.WebApi.resources.dll" Id="Plugins_ru_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_ru_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ru\Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Id="Plugins_ru_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_ru_Microsoft.VisualStudio.Services.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ru\Microsoft.VisualStudio.Services.Common.resources.dll" Id="Plugins_ru_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_ru_Microsoft.VisualStudio.Services.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\ru\Microsoft.VisualStudio.Services.WebApi.resources.dll" Id="Plugins_ru_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="ru">
-      <Component Id="ru_Microsoft.VisualStudio.Composition.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\ru\Microsoft.VisualStudio.Composition.resources.dll" Id="ru_Microsoft.VisualStudio.Composition.resources.dll" />
-      </Component>
-      <Component Id="ru_Microsoft.VisualStudio.Threading.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\ru\Microsoft.VisualStudio.Threading.resources.dll" Id="ru_Microsoft.VisualStudio.Threading.resources.dll" />
-      </Component>
-      <Component Id="ru_Microsoft.VisualStudio.Validation.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\ru\Microsoft.VisualStudio.Validation.resources.dll" Id="ru_Microsoft.VisualStudio.Validation.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="Plugins_tr">
-      <Component Id="Plugins_tr_Microsoft.TeamFoundation.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\tr\Microsoft.TeamFoundation.Common.resources.dll" Id="Plugins_tr_Microsoft.TeamFoundation.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_tr_Microsoft.TeamFoundation.Core.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\tr\Microsoft.TeamFoundation.Core.WebApi.resources.dll" Id="Plugins_tr_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_tr_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\tr\Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Id="Plugins_tr_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_tr_Microsoft.VisualStudio.Services.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\tr\Microsoft.VisualStudio.Services.Common.resources.dll" Id="Plugins_tr_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_tr_Microsoft.VisualStudio.Services.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\tr\Microsoft.VisualStudio.Services.WebApi.resources.dll" Id="Plugins_tr_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="tr">
-      <Component Id="tr_Microsoft.VisualStudio.Composition.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\tr\Microsoft.VisualStudio.Composition.resources.dll" Id="tr_Microsoft.VisualStudio.Composition.resources.dll" />
-      </Component>
-      <Component Id="tr_Microsoft.VisualStudio.Threading.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\tr\Microsoft.VisualStudio.Threading.resources.dll" Id="tr_Microsoft.VisualStudio.Threading.resources.dll" />
-      </Component>
-      <Component Id="tr_Microsoft.VisualStudio.Validation.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\tr\Microsoft.VisualStudio.Validation.resources.dll" Id="tr_Microsoft.VisualStudio.Validation.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="Plugins_zh_Hans">
-      <Component Id="Plugins_zh_Hans_Microsoft.TeamFoundation.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\zh-Hans\Microsoft.TeamFoundation.Common.resources.dll" Id="Plugins_zh_Hans_Microsoft.TeamFoundation.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_zh_Hans_Microsoft.TeamFoundation.Core.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\zh-Hans\Microsoft.TeamFoundation.Core.WebApi.resources.dll" Id="Plugins_zh_Hans_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_zh_Hans_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\zh-Hans\Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Id="Plugins_zh_Hans_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_zh_Hans_Microsoft.VisualStudio.Services.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\zh-Hans\Microsoft.VisualStudio.Services.Common.resources.dll" Id="Plugins_zh_Hans_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_zh_Hans_Microsoft.VisualStudio.Services.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\zh-Hans\Microsoft.VisualStudio.Services.WebApi.resources.dll" Id="Plugins_zh_Hans_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="zh_Hans">
-      <Component Id="zh_Hans_Microsoft.VisualStudio.Composition.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\zh-Hans\Microsoft.VisualStudio.Composition.resources.dll" Id="zh_Hans_Microsoft.VisualStudio.Composition.resources.dll" />
-      </Component>
-      <Component Id="zh_Hans_Microsoft.VisualStudio.Threading.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\zh-Hans\Microsoft.VisualStudio.Threading.resources.dll" Id="zh_Hans_Microsoft.VisualStudio.Threading.resources.dll" />
-      </Component>
-      <Component Id="zh_Hans_Microsoft.VisualStudio.Validation.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\zh-Hans\Microsoft.VisualStudio.Validation.resources.dll" Id="zh_Hans_Microsoft.VisualStudio.Validation.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="Plugins_zh_Hant">
-      <Component Id="Plugins_zh_Hant_Microsoft.TeamFoundation.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\zh-Hant\Microsoft.TeamFoundation.Common.resources.dll" Id="Plugins_zh_Hant_Microsoft.TeamFoundation.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_zh_Hant_Microsoft.TeamFoundation.Core.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\zh-Hant\Microsoft.TeamFoundation.Core.WebApi.resources.dll" Id="Plugins_zh_Hant_Microsoft.TeamFoundation.Core.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_zh_Hant_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\zh-Hant\Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" Id="Plugins_zh_Hant_Microsoft.TeamFoundation.Dashboards.WebApi.resources.dll" />
-      </Component>
-      <Component Id="Plugins_zh_Hant_Microsoft.VisualStudio.Services.Common.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\zh-Hant\Microsoft.VisualStudio.Services.Common.resources.dll" Id="Plugins_zh_Hant_Microsoft.VisualStudio.Services.Common.resources.dll" />
-      </Component>
-      <Component Id="Plugins_zh_Hant_Microsoft.VisualStudio.Services.WebApi.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Plugins\zh-Hant\Microsoft.VisualStudio.Services.WebApi.resources.dll" Id="Plugins_zh_Hant_Microsoft.VisualStudio.Services.WebApi.resources.dll" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="zh_Hant">
-      <Component Id="zh_Hant_Microsoft.VisualStudio.Composition.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\zh-Hant\Microsoft.VisualStudio.Composition.resources.dll" Id="zh_Hant_Microsoft.VisualStudio.Composition.resources.dll" />
-      </Component>
-      <Component Id="zh_Hant_Microsoft.VisualStudio.Threading.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\zh-Hant\Microsoft.VisualStudio.Threading.resources.dll" Id="zh_Hant_Microsoft.VisualStudio.Threading.resources.dll" />
-      </Component>
-      <Component Id="zh_Hant_Microsoft.VisualStudio.Validation.resources.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\zh-Hant\Microsoft.VisualStudio.Validation.resources.dll" Id="zh_Hant_Microsoft.VisualStudio.Validation.resources.dll" />
-      </Component>
-    </DirectoryRef>
+    <ComponentGroup Id="Component.PluginResources" />
     <DirectoryRef Id="ProgramMenuFolder">
       <Component Id="GitExtensions.newstartmenu" Guid="*">
         <Shortcut Id="GitExtensions.newstartmenu" Name="$(var.ProductName)" Description="$(var.ProductName)" Icon="gitextensions.ico" Target="[INSTALLDIR]GitExtensions.exe" WorkingDirectory="INSTALLDIR" />
@@ -1539,33 +653,67 @@
         <RemoveFolder Id="GitExtensions.desktop" On="uninstall" />
       </Component>
     </DirectoryRef>
+
     <Feature Id="GitExtensions" Title="Git Extensions" Level="1" Display="expand">
-      <ComponentRef Id="gitextensions.ico" />
-      <ComponentRef Id="gitex.cmd" />
-      <ComponentRef Id="set_telemetry" />
-      <ComponentRef Id="GitExtensions.exe" />
-      <ComponentRef Id="GitExtensions.exe.config" />
-      <ComponentRef Id="GitCommands.dll" />
-      <ComponentRef Id="GitExtUtils.dll" />
+      <!-- Application build artifacts -->
+      <ComponentGroupRef Id="Component.ConEmuFiles" />
+      <ComponentGroupRef Id="Component.Themes" />
+      <ComponentGroupRef Id="Component.Translation" />
       <ComponentRef Id="AdysTech.CredentialManager.dll" />
-      <ComponentRef Id="GitUI.dll" />
-      <ComponentRef Id="ConEmu.WinForms.dll" />
       <ComponentRef Id="AppInsights.WindowsDesktop.dll" />
+      <ComponentRef Id="Ben.Demystifier.dll" />
+      <ComponentRef Id="BugReporter.dll" />
+      <ComponentRef Id="BugReporter.exe" />
+      <ComponentRef Id="BugReporter.runtimeconfig.json" />
+      <ComponentRef Id="ConEmuWinForms.dll" />
+      <!--
+      <ComponentRef Id="EasyHook.dll" />
+      <ComponentRef Id="EasyHook32.dll" />
+      <ComponentRef Id="EasyHook64.dll" />
+      -->
+      <ComponentRef Id="EnvDTE.dll" />
+      <ComponentRef Id="ExCSS.dll" />
+      <ComponentRef Id="Git.hub.dll" />
+      <ComponentRef Id="GitCommands.dll" />
+      <ComponentRef Id="GitExtensions.deps.json" />
+      <ComponentRef Id="GitExtensions.dll" />
+      <ComponentRef Id="GitExtensions.dll.config" />
+      <ComponentRef Id="GitExtensions.exe" />
+      <ComponentRef Id="GitExtensions.runtimeconfig.json" />
+      <ComponentRef Id="GitExtUtils.dll" />
+      <ComponentRef Id="GitUI.dll" />
+      <ComponentRef Id="GitUIPluginInterfaces.dll" />
+      <ComponentRef Id="ICSharpCode.TextEditor.dll" />
+      <ComponentRef Id="Microsoft.AI.DependencyCollector.dll" />
       <ComponentRef Id="Microsoft.ApplicationInsights.dll" />
+      <ComponentRef Id="Microsoft.Bcl.AsyncInterfaces.dll" />
+      <ComponentRef Id="Microsoft.Toolkit.HighPerformance.dll" />
+      <ComponentRef Id="Microsoft.VisualStudio.Composition.dll" />
+      <ComponentRef Id="Microsoft.VisualStudio.Composition.NetFxAttributes.dll" />
+      <ComponentRef Id="Microsoft.VisualStudio.Threading.dll" />
+      <ComponentRef Id="Microsoft.VisualStudio.Validation.dll" />
       <ComponentRef Id="Microsoft.WindowsAPICodePack.dll" />
       <ComponentRef Id="Microsoft.WindowsAPICodePack.Shell.dll" />
+      <ComponentRef Id="Newtonsoft.Json.dll" />
+      <ComponentRef Id="ResourceManager.dll" />
+      <ComponentRef Id="RestSharp.dll" />
+      <ComponentRef Id="SmartFormat.dll" />
+      <ComponentRef Id="SpellChecker.dll" />
+      <ComponentRef Id="stdole.dll" />
+      <ComponentRef Id="System.ComponentModel.Composition.dll" />
+      <ComponentRef Id="System.Composition.AttributedModel.dll" />
+      <ComponentRef Id="System.Composition.Convention.dll" />
+      <ComponentRef Id="System.Composition.Hosting.dll" />
+      <ComponentRef Id="System.Composition.Runtime.dll" />
+      <ComponentRef Id="System.Composition.TypedParts.dll" />
       <ComponentRef Id="System.IO.Abstractions.dll" />
       <ComponentRef Id="System.Reactive.dll" />
       <ComponentRef Id="System.Reactive.Interfaces.dll" />
       <ComponentRef Id="System.Reactive.Linq.dll" />
-      <ComponentRef Id="System.ValueTuple.dll" />
-      <ComponentRef Id="SmartFormat.dll" />
-      <ComponentRef Id="Ben.Demystifier.dll" />
-      <ComponentRef Id="NetSpell.SpellChecker.dll" />
-      <ComponentRef Id="Newtonsoft.Json.dll" />
-      <ComponentRef Id="ResourceManager.dll" />
-      <ComponentRef Id="GitUIPluginInterfaces.dll" />
-      <ComponentRef Id="ExCSS.dll" />
+      <!-- end application build artifacts -->
+      <ComponentRef Id="gitextensions.ico" />
+      <ComponentRef Id="gitex.cmd" />
+      <ComponentRef Id="set_telemetry" />
       <ComponentRef Id="checksettings.reg" />
       <ComponentRef Id="InstallDir.reg" />
       <ComponentRef Id="gitssh_openssh.reg" />
@@ -1577,39 +725,14 @@
       <ComponentRef Id="pageant.reg" />
       <ComponentRef Id="puttygen.exe" />
       <ComponentRef Id="puttygen.reg" />
-      <ComponentGroupRef Id="Component.ConEmuFiles" />
-      <ComponentGroupRef Id="Component.NetStandard" />
-      <ComponentGroupRef Id="Component.Resources" />
       <ComponentRef Id="GitExtSshAskPass.exe" />
       <ComponentRef Id="GitExtensions.newstartmenu" />
       <ComponentRef Id="GitExtensions.startmenu" />
-      <ComponentRef Id="English.gif" />
-      <ComponentRef Id="English.xlf" />
-      <ComponentRef Id="English.Plugins.xlf" />
-      <ComponentRef Id="Git.hub.dll" />
-      <ComponentRef Id="RestSharp.dll" />
-      <ComponentRef Id="Microsoft.VisualStudio.Composition.dll" />
-      <ComponentRef Id="Microsoft.VisualStudio.Threading.dll" />
-      <ComponentRef Id="Microsoft.VisualStudio.Validation.dll" />
-      <ComponentRef Id="System.Runtime.InteropServices.RuntimeInformation.dll" />
-      <ComponentRef Id="EasyHook.dll" />
-      <ComponentRef Id="EasyHook32.dll" />
-      <ComponentRef Id="EasyHook64.dll" />
-      <ComponentRef Id="Themes.README.md" />
-      <ComponentRef Id="Themes.invariant.css" />
-      <ComponentRef Id="Themes.dark.css" />
-      <ComponentRef Id="Themes.darksilver.css" />
-      <ComponentRef Id="Themes.bright.css" />
-      <!-- Remove unused dll, installed in versions <= 2.31 -->
-      <ComponentRef Id="GithubSharp.Core.dll" />
-      <!-- Remove unused dll, installed in versions <= 2.31 -->
-      <ComponentRef Id="Github.dll" />
-      <!-- Remove unused dll, installed in versions < 4.0 -->
-      <ComponentRef Id="Gerrit.dll" />
-      <!-- PluginManager -->
+      <!-- Plugin Manager build artifacts -->
       <ComponentRef Id="GitExtensions.PluginManager.dll" />
       <ComponentRef Id="PackageManager" />
       <ComponentRef Id="PackageManager.UI.exe" />
+      <!-- End Plugin Manager build artifacts -->
       <Feature Id="Plugins" Title="Plugins" Level="1">
         <ComponentGroupRef Id="Component.PluginResources" />
         <Feature Id="AutoCompileSubmodules" Title="Auto compile submodules" Level="1">
@@ -1635,7 +758,6 @@
         </Feature>
         <Feature Id="Gource" Title="Gource visualization" Level="1">
           <ComponentRef Id="Gource.dll" />
-          <ComponentRef Id="ICSharpCode.SharpZipLib.dll" />
         </Feature>
         <Feature Id="Impact" Title="Impact Graph" Level="1">
           <ComponentRef Id="GitImpact.dll" />
@@ -1661,18 +783,6 @@
         <Feature Id="JenkinsIntegration" Title="Jenkins integration" Level="1">
           <ComponentRef Id="JenkinsIntegration.dll" />
         </Feature>
-        <Feature Id="TfsIntegration" Title="Tfs integration" Level="1">
-          <ComponentRef Id="TfsIntegration.dll" />
-          <ComponentRef Id="TfsInterop.Vs2012.dll" />
-          <!-- ComponentRef Id="TfsInterop.Vs2013.dll" /-->
-          <ComponentRef Id="TfsInterop.Vs2015.dll" />
-          <ComponentRef Id="Microsoft.TeamFoundation.Build2.WebApi.dll" />
-          <ComponentRef Id="Microsoft.TeamFoundation.Common.dll" />
-          <ComponentRef Id="Microsoft.TeamFoundation.Core.WebApi.dll" />
-          <ComponentRef Id="Microsoft.VisualStudio.Services.Common.dll" />
-          <ComponentRef Id="Microsoft.VisualStudio.Services.WebApi.dll" />
-          <ComponentRef Id="System.Net.Http.Formatting.dll" />
-        </Feature>
         <Feature Id="AzureDevOpsIntegration" Title="Azure DevOps and TFS &gt;= 2015 integration" Level="1">
           <ComponentRef Id="AzureDevOpsIntegration.dll" />
         </Feature>
@@ -1681,7 +791,6 @@
           <ComponentRef Id="Atlassian.Jira.dll" />
           <ComponentRef Id="RestSharp.dll" />
           <ComponentRef Id="NString.dll" />
-          <ComponentRef Id="System.Collections.Immutable.dll" />
         </Feature>
       </Feature>
       <Feature Id="GitExtensions.desktop" Title="Desktop shortcut" Level="1">

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.6.0.{build}
+version: 4.0.0.{build}
 
 branches:
   except:

--- a/scripts/native.proj
+++ b/scripts/native.proj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="vswhere" Version="2.8.4" IsImplicitlyDefined="true" GeneratePathProperty="true" />
+    <PackageReference Include="vswhere" IsImplicitlyDefined="true" GeneratePathProperty="true" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
@@ -28,6 +28,9 @@
     </Exec>
 
     <PropertyGroup>
+      <_ArtifactsLogDir>$([MSBuild]::NormalizePath('$(ArtifactsLogDir)', '..', '..', 'log'))</_ArtifactsLogDir>
+      <_OutputPath>$([System.IO.Path]::GetFullPath('$(ArtifactsBinDir)\'))</_OutputPath>
+
       <_MSBuildCurrentPath>$([MSBuild]::NormalizePath('$(_VSInstallPath)', 'MSBuild', 'Current', 'Bin'))</_MSBuildCurrentPath>
 
       <_GitExtSshAskPassPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'GitExtSshAskPass', 'GitExtSshAskPass.sln'))</_GitExtSshAskPassPath>
@@ -39,7 +42,7 @@
 
     <!-- Build GitExtSshAskPass project, x86 -->
     <Exec
-        Command="msbuild.exe $(_GitExtSshAskPassPath) $(_ProjectArgs32)"
+        Command="msbuild.exe $(_GitExtSshAskPassPath) $(_ProjectArgs32_) /p:OutDir=$(_OutputPath)GitExtSshAskPass\ /bl:$(_ArtifactsLogDir)\GitExtSshAskPass.binlog"
         WorkingDirectory="$(_MSBuildCurrentPath)"
         EchoOff="true"
         ConsoleToMsBuild="true"
@@ -47,7 +50,7 @@
     </Exec>
     <!-- Build GitExtensionsShellEx project, x86 -->
     <Exec
-        Command="msbuild.exe $(_GitExtensionsShellExPath) $(_ProjectArgs32)"
+        Command="msbuild.exe $(_GitExtensionsShellExPath) $(_ProjectArgs32) /p:OutDir=$(_OutputPath)GitExtensionsShellEx\ /bl:$(_ArtifactsLogDir)\GitExtensionsShellEx32.binlog"
         WorkingDirectory="$(_MSBuildCurrentPath)"
         EchoOff="true"
         ConsoleToMsBuild="true"
@@ -55,7 +58,7 @@
     </Exec>
     <!-- Build GitExtensionsShellEx project, x64 -->
     <Exec
-        Command="msbuild.exe $(_GitExtensionsShellExPath) $(_ProjectArgs64)"
+        Command="msbuild.exe $(_GitExtensionsShellExPath) $(_ProjectArgs64) /p:OutDir=$(_OutputPath)GitExtensionsShellEx\ /bl:$(_ArtifactsLogDir)\GitExtensionsShellEx64.binlog"
         WorkingDirectory="$(_MSBuildCurrentPath)"
         EchoOff="true"
         ConsoleToMsBuild="true"


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

⚠️ DO NOT SQUASH

## Proposed changes

- Resurrecting https://github.com/gitextensions/gitextensions/pull/9458 proposed by @GintasS.
- Update publish location for native artifacts
- Remove unnecessary files from the published components (e.g. xml, pdbs, etc.)
- A major clean up of the MSI definition, including
    * remove all .NET Framework and .NET Standard related references
    * remove all localised resources
    * rebuild the component list from the published files
- Update the installer to require full uninstall before install
- Rework how the setup project is built reusing the older version of MSBuild and .NET Framework v3.5
- Bump the version to 4.0.0

## Testing

* Building and inspecting the content of the generated zip and msi
* Comparing the content of the generated zip and msi against the published counterparts
* Manual testing locally generated builds for blocked upgrade from pre-4.x versions
    ![image](https://user-images.githubusercontent.com/4403806/140645145-e0335635-3e68-45bd-8da8-6ebdae22d07c.png)
* Manual testing locally generated builds for successful upgrades from 4.x_+ versions


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
