### PR TITLE
RevisionGridControl: prevent exception when switching repository

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -579,6 +579,12 @@ namespace GitUI
             {
                 _gridView.Select();
 
+                // Prevent exception when changing of reporsitory because the grid still contains no rows.
+                if (index >= _gridView.Rows.Count)
+                {
+                    return;
+                }
+
                 bool shallSelect;
                 bool wasSelected = _gridView.Rows[index].Selected;
                 if (toggleSelection)


### PR DESCRIPTION
Fixes nothing, just improve UX in DEBUG inside Visual Studio

## Proposed changes

- Behavior is not changed, the exception is already try/catched
- This check just prevent the exception to be raised which is really boring when debugging the application

## Test methodology <!-- How did you ensure quality? -->

- In debug in VS, switch the opened repository

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build e61325736ad63a00a31f3193bd91a9e946f2b810
- Git 2.28.0.windows.1 (recommended: 2.33.0 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.11
- DPI 192dpi (200% scaling)


## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).
