### PR TITLE
RevDiff: Count number of changed files per group

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -931,9 +931,15 @@ namespace GitUI
                 ListViewGroup? group = null;
                 if (i.FirstRev is not null)
                 {
-                    group = new ListViewGroup(i.Summary)
+                    string name = i.Statuses.Count == 1 && i.Statuses[0].IsRangeDiff
+                        ? i.Summary
+                        : $"({i.Statuses.Count}) {i.Summary}";
+                    group = new ListViewGroup(name)
                     {
-                        CollapsedState = ListViewGroupCollapsedState.Expanded,
+                        // Collapse some groups for diffs with common BASE
+                        CollapsedState = i.Statuses.Count <= 7 || GitItemStatusesWithDescription.Count < 3 || i == GitItemStatusesWithDescription[0]
+                            ? ListViewGroupCollapsedState.Expanded
+                            : ListViewGroupCollapsedState.Collapsed,
                         Tag = i.FirstRev
                     };
 


### PR DESCRIPTION
Discussed in #9703

## Proposed changes

For FileStatusList, can have one or more groups

- Show number of changes in a group first in the group name. Change for all group headers, except RangeDiff.

- Collapse groups RevDiff groups if they do not fulfill the following:
  - All other than comparing branches with a common BASE (the only that has more than two groups, currently five)
  - First group
  - 5 or less files

@mstv wanted the last part to expand groups if they occupy less than 80%, but I want to keep it simple.
 
## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/141376169-1b063dc0-e612-4fe1-a222-ed51801de221.png)

### After

![image](https://user-images.githubusercontent.com/6248932/141376030-8c9d2bd3-8075-46d7-b6ce-fa4b0ba0b245.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
