### PR TITLE
AppTitle was set to previous repo branch

### DIFF
--- a/GitExtensions/Properties/launchSettings.json
+++ b/GitExtensions/Properties/launchSettings.json
@@ -3,6 +3,9 @@
     "GitExtensions": {
       "commandName": "Project",
       "commandLineArgs": "browse \"$(MSBuildThisFileDirectory)..\""
+    },
+    "Dashboard": {
+      "commandName": "Project"
     }
   }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -25,7 +25,7 @@ namespace GitUI.CommandsDialogs
             RevisionGrid.MenuCommands.MenuChanged += (sender, e) => _formBrowseMenus.OnMenuCommandsPropertyChanged();
             RevisionGrid.FilterChanged += (sender, e) =>
             {
-                Text = _appTitleGenerator.Generate(Module.WorkingDir, Module.IsValidGitWorkingDir(), branchSelect.Text, TranslatedStrings.NoBranch, e.PathFilter);
+                Text = _appTitleGenerator.Generate(Module.WorkingDir, Module.IsValidGitWorkingDir(), Module.GetSelectedBranch(), TranslatedStrings.NoBranch, e.PathFilter);
             };
             RevisionGrid.RevisionGraphLoaded += (sender, e) =>
             {


### PR DESCRIPTION
This originates in #9553 or similar that reworked the FormBrowse and filter init logic.

## Proposed changes

Except when starting the first time directly to a repo, the title was set to the previous repo as it used info not yet updated.
When starting from Dashboard, the path was empty.
This operation is reading refs/ normally, so not delaying the operation.
(In another PR, there is a an optimization swapping the other way...)

In addition add start to Dashboard a debug profile to simplify testing starting from Dashboard.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/141660503-9ea95f0f-35ca-432e-be02-7e0268e48edd.png)

### After

![image](https://user-images.githubusercontent.com/6248932/141660511-0ab1ced4-3add-4afd-88ef-cfcc2bc42788.png)

![image](https://user-images.githubusercontent.com/6248932/141660523-26d283df-aed3-4bbf-9dd4-999a151ad00c.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

- Rebase merge (PR submitter must change the commit message for the last commit).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
