### PR TITLE
Let RTB extension `GetPlainText` ignore links

### DIFF
--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -1068,13 +1068,13 @@ namespace GitUI.Editor.RichTextBoxExtension
             try
             {
                 //--------------------------------
-                // this is an inefficient method to get text format
-                // but RichTextBox doesn't provide another method to
-                // get something like an array of charformat and paraformat
+                // This is an inefficient method to get text format.
+                // But RichTextBox doesn't provide another method to
+                // get something like an array of charformat and paraformat.
                 //--------------------------------
                 for (int i = from; i < to; i++)
                 {
-                    // try to select one visible character (RichTextBox returns a string, can be empty, may contain more than what is visible)
+                    // Try to select one visible character (RichTextBox returns a string, can be empty, may contain more than what is visible)
                     rtb.Select(i, 1);
                     string selectedText = rtb.SelectedText;
 

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -1074,9 +1074,15 @@ namespace GitUI.Editor.RichTextBoxExtension
                 //--------------------------------
                 for (int i = from; i < to; i++)
                 {
-                    // select one character
+                    // (try to) select one character
                     rtb.Select(i, 1);
-                    text.Append(rtb.SelectedText);
+                    string selectedText = rtb.SelectedText;
+
+                    // For every character of a link, the current RichTextBox returns the entire link (but should be the empty string). So, skip the links.
+                    if (!selectedText.StartsWith(LinkSeparator))
+                    {
+                        text.Append(selectedText);
+                    }
                 }
             }
             catch (Exception /*ex*/)

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -1074,7 +1074,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                 //--------------------------------
                 for (int i = from; i < to; i++)
                 {
-                    // (try to) select one character
+                    // try to select one visible character (RichTextBox returns a string, can be empty, may contain more than what is visible)
                     rtb.Select(i, 1);
                     string selectedText = rtb.SelectedText;
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9726

## Proposed changes

- Let `RichTextBoxXhtmlSupportExtension.GetPlainText` ignore links, which are returned multiple times (string length of link?)

## Screenshots <!-- Remove this section if PR does not change UI -->

see issue

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build d71a4f5344ecf5a5f119b4c9e18485de6366eeab
- Git 2.33.1.windows.1
- Microsoft Windows NT 10.0.19043.0
- .NET 5.0.12
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
