### PR TITLE
RevisionFilter: Indicate filters with button state and tooltip

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -32,7 +32,7 @@ namespace GitUI.CommandsDialogs
                 string? path = e.PathFilter;
                 if (path is not null && path.Length > 1 && path[0] == '"' && path[path.Length - 1] == '"')
                 {
-                    path = path[1..(path.Length - 2)];
+                    path = path[1..(path.Length - 1)];
                 }
 
                 revisionDiff.FallbackFollowedFile = path;

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -619,6 +619,7 @@ namespace GitUI.CommandsDialogs
 
             // Visibility of FileTree is not known, assume (CommitInfoTabControl.Contains(TreeTabPage);)
             diffShowInFileTreeToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuShowInFileTree(selectionInfo);
+            diffFilterFileInGridToolStripMenuItem.Enabled = _revisionDiffController.ShouldShowMenuFileHistory(selectionInfo);
             fileHistoryDiffToolstripMenuItem.Enabled = _revisionDiffController.ShouldShowMenuFileHistory(selectionInfo);
             blameToolStripMenuItem.Enabled = _revisionDiffController.ShouldShowMenuBlame(selectionInfo);
         }

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -297,6 +297,7 @@ namespace GitUI.Hotkey
                     Hk(RevisionGridControl.Command.CompareToCurrentBranch, Keys.None),
                     Hk(RevisionGridControl.Command.CompareToWorkingDirectory, Keys.Control | Keys.D),
                     Hk(RevisionGridControl.Command.CreateFixupCommit, Keys.Control | Keys.X),
+                    Hk(RevisionGridControl.Command.DisableRevisionFilter, Keys.Control | Keys.Shift | Keys.F),
                     Hk(RevisionGridControl.Command.GoToChild, Keys.Control | Keys.N),
                     Hk(RevisionGridControl.Command.GoToCommit, Keys.Control | Keys.Shift | Keys.G),
                     Hk(RevisionGridControl.Command.GoToParent, Keys.Control | Keys.P),

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -114,6 +114,16 @@ namespace GitUI
 
         private readonly TranslationString _noChanges = new("No changes");
 
+        // FormRevisionFilter
+        private readonly TranslationString _since = new("Since");
+        private readonly TranslationString _until = new("Until");
+        private readonly TranslationString _author = new("Author");
+        private readonly TranslationString _committer = new("Committer");
+        private readonly TranslationString _message = new("Message");
+        private readonly TranslationString _limit = new("Limit");
+        private readonly TranslationString _ignoreCase = new("Ignore case");
+        private readonly TranslationString _pathFilter = new("Path filter");
+
         // public only because of FormTranslate
         public TranslatedStrings()
         {
@@ -231,6 +241,15 @@ namespace GitUI
         public static string OpenInVisualStudioFailureCaption => _instance.Value._openInVisualStudioFailureCaption.Text;
         public static string RemoteInError => _instance.Value._remoteInError.Text;
         public static string NoChanges => _instance.Value._noChanges.Text;
+
+        public static string Since = _instance.Value._since.Text;
+        public static string Until = _instance.Value._until.Text;
+        public static string Author = _instance.Value._author.Text;
+        public static string Committer = _instance.Value._committer.Text;
+        public static string Message = _instance.Value._message.Text;
+        public static string Limit = _instance.Value._limit.Text;
+        public static string IgnoreCase = _instance.Value._ignoreCase.Text;
+        public static string PathFilter = _instance.Value._pathFilter.Text;
 
         #region Scripts
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7375,42 +7375,6 @@ Do you want to use this custom merge script?</source>
         <source>Simplify by decoration</source>
         <target />
       </trans-unit>
-      <trans-unit id="label1.Text">
-        <source>Since</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="label2.Text">
-        <source>Until</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="label3.Text">
-        <source>Author</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="label4.Text">
-        <source>Committer</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="label5.Text">
-        <source>Message</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="label6.Text">
-        <source>Ignore case</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="label7.Text">
-        <source>Limit</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="label8.Text">
-        <source>Path filter</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="label9.Text">
-        <source>Branches</source>
-        <target />
-      </trans-unit>
     </body>
   </file>
   <file datatype="plaintext" original="FormSelectMultipleBranches" source-language="en">
@@ -10457,6 +10421,10 @@ Please verify the server url.</source>
         <source>Arguments</source>
         <target />
       </trans-unit>
+      <trans-unit id="_author.Text">
+        <source>Author</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_authorDateText.Text">
         <source>{0:Author date|Author dates}</source>
         <target />
@@ -10550,6 +10518,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_committed.Text">
         <source>committed</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_committer.Text">
+        <source>Committer</source>
         <target />
       </trans-unit>
       <trans-unit id="_committerText.Text">
@@ -10676,6 +10648,10 @@ Select this commit to populate the full message.</source>
         <source>{0} {1:hour|hours} ago</source>
         <target />
       </trans-unit>
+      <trans-unit id="_ignoreCase.Text">
+        <source>Ignore case</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_indexText.Text">
         <source>Commit index</source>
         <target />
@@ -10686,6 +10662,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_invisibleCommitText.Text">
         <source>'{0}' is not currently visible</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_limit.Text">
+        <source>Limit</source>
         <target />
       </trans-unit>
       <trans-unit id="_loadingDataText.Text">
@@ -10706,6 +10686,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_markBisectAsGood.Text">
         <source>Marked as good in bisect</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_message.Text">
+        <source>Message</source>
         <target />
       </trans-unit>
       <trans-unit id="_messageText.Text">
@@ -10770,6 +10754,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_parentsText.Text">
         <source>{0:Parent|Parents}</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_pathFilter.Text">
+        <source>Path filter</source>
         <target />
       </trans-unit>
       <trans-unit id="_remote.Text">
@@ -10867,6 +10855,10 @@ Remote: {1}</source>
 - For more than four selected commits, show the difference from the first to the last selected commit.</source>
         <target />
       </trans-unit>
+      <trans-unit id="_since.Text">
+        <source>Since</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_sortBy.Text">
         <source>&amp;Sort by...</source>
         <target />
@@ -10910,6 +10902,10 @@ Yes, I allow telemetry!</source>
       </trans-unit>
       <trans-unit id="_unstageSelectedLines.Text">
         <source>Unstage selected line(s)</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_until.Text">
+        <source>Until</source>
         <target />
       </trans-unit>
       <trans-unit id="_viewPullRequest.Text">

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -296,6 +296,9 @@ namespace GitUI.UserControls
             tsmiShowFirstParent.Checked = e.ShowFirstParent;
             tsmiShowReflogs.Checked = e.ShowReflogReferences;
             InitBranchSelectionFilter(e);
+            tsbtnAdvancedFilter.Checked = e.HasFilter;
+            tsbtnAdvancedFilter.AutoToolTip = e.HasFilter;
+            tsbtnAdvancedFilter.ToolTipText = e.FilterSummary;
         }
 
         private static void ToolStripSplitButtonDropDownClosed(object sender, EventArgs e)

--- a/GitUI/UserControls/RevisionGrid/FilterChangedEventArgs.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterChangedEventArgs.cs
@@ -12,7 +12,9 @@ namespace GitUI
             ShowFilteredBranches = filter.IsShowFilteredBranchesChecked;
             ShowFirstParent = filter.ShowFirstParent;
             ShowReflogReferences = filter.ShowReflogReferences;
+            HasFilter = filter.HasFilter;
             PathFilter = filter.PathFilter;
+            FilterSummary = filter.GetSummary();
         }
 
         public bool ShowAllBranches { get; }
@@ -20,10 +22,16 @@ namespace GitUI
         public bool ShowFilteredBranches { get; }
         public bool ShowFirstParent { get; }
         public bool ShowReflogReferences { get; }
+        public bool HasFilter { get; }
 
         /// <summary>
         ///  Gets the currently applied Path filter.
         /// </summary>
         public string PathFilter { get; }
+
+        /// <summary>
+        ///  Gets a summary of the current filter.
+        /// </summary>
+        public string FilterSummary { get; }
     }
 }

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Text;
 using GitCommands;
 using GitExtUtils;
 
@@ -337,6 +338,55 @@ namespace GitUI.UserControls.RevisionGrid
             }
 
             return filter;
+        }
+
+        public string GetSummary()
+        {
+            StringBuilder filter = new();
+
+            if (ByPathFilter)
+            {
+                filter.AppendLine($"{TranslatedStrings.PathFilter}: {PathFilter}");
+            }
+
+            if (ByBranchFilter)
+            {
+                filter.AppendLine($"{TranslatedStrings.Branches}: {BranchFilter}");
+            }
+
+            if (ByAuthor && !string.IsNullOrWhiteSpace(Author))
+            {
+                filter.AppendLine($"{TranslatedStrings.Author}: {Author}");
+            }
+
+            if (ByCommitter && !string.IsNullOrWhiteSpace(Committer))
+            {
+                filter.AppendLine($"{TranslatedStrings.Committer}: {Committer}");
+            }
+
+            if (ByMessage && !string.IsNullOrEmpty(Message))
+            {
+                filter.AppendLine($"{TranslatedStrings.Message}: {Message}");
+            }
+
+            if (ByDiffContent && !string.IsNullOrEmpty(DiffContent))
+            {
+                filter.AppendLine($"{TranslatedStrings.Message}: {DiffContent}");
+            }
+
+            if (ByDateFrom)
+            {
+                filter.AppendLine($"{TranslatedStrings.Since}: {DateFrom}");
+            }
+
+            if (ByDateTo)
+            {
+                filter.AppendLine($"{TranslatedStrings.Until}: {DateTo}");
+            }
+
+            // Ignore IgnoreCase, CurrentBranchOnlyCheck, SimplifyByDecorationCheck
+
+            return filter.ToString();
         }
 
         private T GetValue<T>(bool condition, T valueTrue, T valueFalse)

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
@@ -33,15 +33,15 @@
             this.Message = new System.Windows.Forms.TextBox();
             this.Author = new System.Windows.Forms.TextBox();
             this.Since = new System.Windows.Forms.DateTimePicker();
-            this.label1 = new System.Windows.Forms.Label();
-            this.label2 = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_lblSince = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_lblUntil = new System.Windows.Forms.Label();
             this.Until = new System.Windows.Forms.DateTimePicker();
-            this.label3 = new System.Windows.Forms.Label();
-            this.label4 = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_lblAuthor = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_lblCommitter = new System.Windows.Forms.Label();
             this.Committer = new System.Windows.Forms.TextBox();
-            this.label5 = new System.Windows.Forms.Label();
-            this.label7 = new System.Windows.Forms.Label();
-            this.label6 = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_lblMessage = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_lblLimit = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_lblIgnoreCase = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.SinceCheck = new System.Windows.Forms.CheckBox();
             this.CheckUntil = new System.Windows.Forms.CheckBox();
@@ -50,10 +50,10 @@
             this.MessageCheck = new System.Windows.Forms.CheckBox();
             this.IgnoreCase = new System.Windows.Forms.CheckBox();
             this.CommitsLimitCheck = new System.Windows.Forms.CheckBox();
-            this.label8 = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_lblPathFilter = new System.Windows.Forms.Label();
             this.PathFilterCheck = new System.Windows.Forms.CheckBox();
             this.PathFilter = new System.Windows.Forms.TextBox();
-            this.label9 = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_lblBranches = new System.Windows.Forms.Label();
             this.BranchFilterCheck = new System.Windows.Forms.CheckBox();
             this.BranchFilter = new System.Windows.Forms.TextBox();
             this.CurrentBranchOnlyCheck = new System.Windows.Forms.CheckBox();
@@ -117,25 +117,25 @@
             this.Since.Name = "Since";
             this.Since.Size = new System.Drawing.Size(200, 23);
             // 
-            // label1
+            // _NO_TRANSLATE_lblSince
             // 
-            this.label1.AutoSize = true;
-            this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label1.Location = new System.Drawing.Point(3, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(67, 29);
-            this.label1.Text = "Since";
-            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this._NO_TRANSLATE_lblSince.AutoSize = true;
+            this._NO_TRANSLATE_lblSince.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_lblSince.Location = new System.Drawing.Point(3, 0);
+            this._NO_TRANSLATE_lblSince.Name = "_NO_TRANSLATE_lblSince";
+            this._NO_TRANSLATE_lblSince.Size = new System.Drawing.Size(67, 29);
+            this._NO_TRANSLATE_lblSince.Text = "Since";
+            this._NO_TRANSLATE_lblSince.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // label2
+            // _NO_TRANSLATE_lblUntil
             // 
-            this.label2.AutoSize = true;
-            this.label2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label2.Location = new System.Drawing.Point(3, 29);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(67, 29);
-            this.label2.Text = "Until";
-            this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this._NO_TRANSLATE_lblUntil.AutoSize = true;
+            this._NO_TRANSLATE_lblUntil.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_lblUntil.Location = new System.Drawing.Point(3, 29);
+            this._NO_TRANSLATE_lblUntil.Name = "_NO_TRANSLATE_lblUntil";
+            this._NO_TRANSLATE_lblUntil.Size = new System.Drawing.Size(67, 29);
+            this._NO_TRANSLATE_lblUntil.Text = "Until";
+            this._NO_TRANSLATE_lblUntil.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // Until
             // 
@@ -144,25 +144,25 @@
             this.Until.Name = "Until";
             this.Until.Size = new System.Drawing.Size(200, 23);
             // 
-            // label3
+            // _NO_TRANSLATE_lblAuthor
             // 
-            this.label3.AutoSize = true;
-            this.label3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label3.Location = new System.Drawing.Point(3, 58);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(67, 29);
-            this.label3.Text = "Author";
-            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this._NO_TRANSLATE_lblAuthor.AutoSize = true;
+            this._NO_TRANSLATE_lblAuthor.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_lblAuthor.Location = new System.Drawing.Point(3, 58);
+            this._NO_TRANSLATE_lblAuthor.Name = "_NO_TRANSLATE_lblAuthor";
+            this._NO_TRANSLATE_lblAuthor.Size = new System.Drawing.Size(67, 29);
+            this._NO_TRANSLATE_lblAuthor.Text = "Author";
+            this._NO_TRANSLATE_lblAuthor.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // label4
+            // _NO_TRANSLATE_lblCommitter
             // 
-            this.label4.AutoSize = true;
-            this.label4.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label4.Location = new System.Drawing.Point(3, 87);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(67, 29);
-            this.label4.Text = "Committer";
-            this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this._NO_TRANSLATE_lblCommitter.AutoSize = true;
+            this._NO_TRANSLATE_lblCommitter.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_lblCommitter.Location = new System.Drawing.Point(3, 87);
+            this._NO_TRANSLATE_lblCommitter.Name = "_NO_TRANSLATE_lblCommitter";
+            this._NO_TRANSLATE_lblCommitter.Size = new System.Drawing.Size(67, 29);
+            this._NO_TRANSLATE_lblCommitter.Text = "Committer";
+            this._NO_TRANSLATE_lblCommitter.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // Committer
             // 
@@ -171,35 +171,35 @@
             this.Committer.Name = "Committer";
             this.Committer.Size = new System.Drawing.Size(285, 23);
             // 
-            // label5
+            // _NO_TRANSLATE_lblMessage
             // 
-            this.label5.AutoSize = true;
-            this.label5.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label5.Location = new System.Drawing.Point(3, 116);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(67, 29);
-            this.label5.Text = "Message";
-            this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this._NO_TRANSLATE_lblMessage.AutoSize = true;
+            this._NO_TRANSLATE_lblMessage.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_lblMessage.Location = new System.Drawing.Point(3, 116);
+            this._NO_TRANSLATE_lblMessage.Name = "_NO_TRANSLATE_lblMessage";
+            this._NO_TRANSLATE_lblMessage.Size = new System.Drawing.Size(67, 29);
+            this._NO_TRANSLATE_lblMessage.Text = "Message";
+            this._NO_TRANSLATE_lblMessage.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // label7
+            // _NO_TRANSLATE_lblLimit
             // 
-            this.label7.AutoSize = true;
-            this.label7.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label7.Location = new System.Drawing.Point(3, 165);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(67, 29);
-            this.label7.Text = "Limit";
-            this.label7.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this._NO_TRANSLATE_lblLimit.AutoSize = true;
+            this._NO_TRANSLATE_lblLimit.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_lblLimit.Location = new System.Drawing.Point(3, 165);
+            this._NO_TRANSLATE_lblLimit.Name = "_NO_TRANSLATE_lblLimit";
+            this._NO_TRANSLATE_lblLimit.Size = new System.Drawing.Size(67, 29);
+            this._NO_TRANSLATE_lblLimit.Text = "Limit";
+            this._NO_TRANSLATE_lblLimit.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // label6
+            // _NO_TRANSLATE_lblIgnoreCase
             // 
-            this.label6.AutoSize = true;
-            this.label6.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label6.Location = new System.Drawing.Point(3, 145);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(67, 20);
-            this.label6.Text = "Ignore case";
-            this.label6.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this._NO_TRANSLATE_lblIgnoreCase.AutoSize = true;
+            this._NO_TRANSLATE_lblIgnoreCase.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_lblIgnoreCase.Location = new System.Drawing.Point(3, 145);
+            this._NO_TRANSLATE_lblIgnoreCase.Name = "_NO_TRANSLATE_lblIgnoreCase";
+            this._NO_TRANSLATE_lblIgnoreCase.Size = new System.Drawing.Size(67, 20);
+            this._NO_TRANSLATE_lblIgnoreCase.Text = "Ignore case";
+            this._NO_TRANSLATE_lblIgnoreCase.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // tableLayoutPanel1
             // 
@@ -207,30 +207,30 @@
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_lblSince, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.SinceCheck, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.Since, 2, 0);
-            this.tableLayoutPanel1.Controls.Add(this.label2, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_lblUntil, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.CheckUntil, 1, 1);
             this.tableLayoutPanel1.Controls.Add(this.Until, 2, 1);
-            this.tableLayoutPanel1.Controls.Add(this.label3, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_lblAuthor, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.AuthorCheck, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.Author, 2, 2);
-            this.tableLayoutPanel1.Controls.Add(this.label4, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_lblCommitter, 0, 3);
             this.tableLayoutPanel1.Controls.Add(this.CommitterCheck, 1, 3);
             this.tableLayoutPanel1.Controls.Add(this.Committer, 2, 3);
-            this.tableLayoutPanel1.Controls.Add(this.label5, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_lblMessage, 0, 4);
             this.tableLayoutPanel1.Controls.Add(this.MessageCheck, 1, 4);
             this.tableLayoutPanel1.Controls.Add(this.Message, 2, 4);
-            this.tableLayoutPanel1.Controls.Add(this.label6, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_lblIgnoreCase, 0, 5);
             this.tableLayoutPanel1.Controls.Add(this.IgnoreCase, 1, 5);
-            this.tableLayoutPanel1.Controls.Add(this.label7, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_lblLimit, 0, 6);
             this.tableLayoutPanel1.Controls.Add(this.CommitsLimitCheck, 1, 6);
             this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_CommitsLimit, 2, 6);
-            this.tableLayoutPanel1.Controls.Add(this.label8, 0, 7);
+            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_lblPathFilter, 0, 7);
             this.tableLayoutPanel1.Controls.Add(this.PathFilterCheck, 1, 7);
             this.tableLayoutPanel1.Controls.Add(this.PathFilter, 2, 7);
-            this.tableLayoutPanel1.Controls.Add(this.label9, 0, 8);
+            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_lblBranches, 0, 8);
             this.tableLayoutPanel1.Controls.Add(this.BranchFilterCheck, 1, 8);
             this.tableLayoutPanel1.Controls.Add(this.BranchFilter, 2, 8);
             this.tableLayoutPanel1.Controls.Add(this.CurrentBranchOnlyCheck, 2, 9);
@@ -325,15 +325,15 @@
             this.CommitsLimitCheck.UseVisualStyleBackColor = true;
             this.CommitsLimitCheck.CheckedChanged += new System.EventHandler(this.option_CheckedChanged);
             // 
-            // label8
+            // _NO_TRANSLATE_lblPathFilter
             // 
-            this.label8.AutoSize = true;
-            this.label8.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label8.Location = new System.Drawing.Point(3, 194);
-            this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(67, 29);
-            this.label8.Text = "Path filter";
-            this.label8.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this._NO_TRANSLATE_lblPathFilter.AutoSize = true;
+            this._NO_TRANSLATE_lblPathFilter.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_lblPathFilter.Location = new System.Drawing.Point(3, 194);
+            this._NO_TRANSLATE_lblPathFilter.Name = "_NO_TRANSLATE_lblPathFilter";
+            this._NO_TRANSLATE_lblPathFilter.Size = new System.Drawing.Size(67, 29);
+            this._NO_TRANSLATE_lblPathFilter.Text = "Path filter";
+            this._NO_TRANSLATE_lblPathFilter.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // PathFilterCheck
             // 
@@ -352,15 +352,15 @@
             this.PathFilter.Name = "PathFilter";
             this.PathFilter.Size = new System.Drawing.Size(285, 23);
             // 
-            // label9
+            // _NO_TRANSLATE_lblBranches
             // 
-            this.label9.AutoSize = true;
-            this.label9.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label9.Location = new System.Drawing.Point(3, 223);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(67, 29);
-            this.label9.Text = "Branches";
-            this.label9.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this._NO_TRANSLATE_lblBranches.AutoSize = true;
+            this._NO_TRANSLATE_lblBranches.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_lblBranches.Location = new System.Drawing.Point(3, 223);
+            this._NO_TRANSLATE_lblBranches.Name = "_NO_TRANSLATE_lblBranches";
+            this._NO_TRANSLATE_lblBranches.Size = new System.Drawing.Size(67, 29);
+            this._NO_TRANSLATE_lblBranches.Text = "Branches";
+            this._NO_TRANSLATE_lblBranches.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // BranchFilterCheck
             // 
@@ -428,15 +428,15 @@
         private System.Windows.Forms.TextBox Message;
         private System.Windows.Forms.TextBox Author;
         private System.Windows.Forms.DateTimePicker Since;
-        private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label _NO_TRANSLATE_lblSince;
+        private System.Windows.Forms.Label _NO_TRANSLATE_lblUntil;
         private System.Windows.Forms.DateTimePicker Until;
-        private System.Windows.Forms.Label label3;
-        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Label _NO_TRANSLATE_lblAuthor;
+        private System.Windows.Forms.Label _NO_TRANSLATE_lblCommitter;
         private System.Windows.Forms.TextBox Committer;
-        private System.Windows.Forms.Label label5;
-        private System.Windows.Forms.Label label7;
-        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Label _NO_TRANSLATE_lblMessage;
+        private System.Windows.Forms.Label _NO_TRANSLATE_lblLimit;
+        private System.Windows.Forms.Label _NO_TRANSLATE_lblIgnoreCase;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.CheckBox CommitsLimitCheck;
         private System.Windows.Forms.CheckBox IgnoreCase;
@@ -445,10 +445,10 @@
         private System.Windows.Forms.CheckBox AuthorCheck;
         private System.Windows.Forms.CheckBox CheckUntil;
         private System.Windows.Forms.CheckBox SinceCheck;
-        private System.Windows.Forms.Label label8;
+        private System.Windows.Forms.Label _NO_TRANSLATE_lblPathFilter;
         private System.Windows.Forms.CheckBox PathFilterCheck;
         private System.Windows.Forms.TextBox PathFilter;
-        private System.Windows.Forms.Label label9;
+        private System.Windows.Forms.Label _NO_TRANSLATE_lblBranches;
         private System.Windows.Forms.TextBox BranchFilter;
         private System.Windows.Forms.CheckBox CurrentBranchOnlyCheck;
         private System.Windows.Forms.CheckBox BranchFilterCheck;

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -19,6 +19,15 @@ namespace GitUI.UserControls.RevisionGrid
         {
             InitializeComponent();
             InitializeComplete();
+            _NO_TRANSLATE_lblSince.Text = TranslatedStrings.Since;
+            _NO_TRANSLATE_lblUntil.Text = TranslatedStrings.Until;
+            _NO_TRANSLATE_lblAuthor.Text = TranslatedStrings.Author;
+            _NO_TRANSLATE_lblCommitter.Text = TranslatedStrings.Committer;
+            _NO_TRANSLATE_lblMessage.Text = TranslatedStrings.Message;
+            _NO_TRANSLATE_lblIgnoreCase.Text = TranslatedStrings.IgnoreCase;
+            _NO_TRANSLATE_lblLimit.Text = TranslatedStrings.Limit;
+            _NO_TRANSLATE_lblPathFilter.Text = TranslatedStrings.PathFilter;
+            _NO_TRANSLATE_lblBranches.Text = TranslatedStrings.Branches;
 
             _filterInfo = filterInfo;
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Command.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Command.cs
@@ -40,6 +40,7 @@
             ToggleBetweenArtificialAndHeadCommits = 33,
             ShowReflogReferences = 34,
             ShowLatestStash = 35,
+            DisableRevisionFilter = 36,
         }
     }
 }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -382,6 +382,12 @@ namespace GitUI
             _filterInfo.DisableFilters();
         }
 
+        public void DisableRevisionFilter()
+        {
+            _filterInfo.DisableFilters();
+            ForceRefreshRevisions();
+        }
+
         public void SetAndApplyPathFilter(string filter)
         {
             _filterInfo.ByPathFilter = !string.IsNullOrWhiteSpace(filter);
@@ -2715,6 +2721,7 @@ namespace GitUI
             {
                 case Command.ToggleRevisionGraph: ToggleRevisionGraphColumn(); break;
                 case Command.RevisionFilter: ShowRevisionFilterDialog(); break;
+                case Command.DisableRevisionFilter: DisableRevisionFilter(); break;
                 case Command.ToggleAuthorDateCommitDate: ToggleShowAuthorDate(); break;
                 case Command.ToggleShowRelativeDate: ToggleShowRelativeDate(EventArgs.Empty); break;
                 case Command.ToggleDrawNonRelativesGray: ToggleDrawNonRelativesGray(); break;

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
@@ -713,6 +713,33 @@ namespace GitUITests.UserControls
             filterInfo.ByBranchFilter.Should().BeFalse();
         }
 
-        // TODO: GetRevisionFilter
+        [TestCase("committer1", "author2", "message3", "pathFilter4", "branchFilter5",
+            "Path filter: pathFilter4\r\nBranches: branchFilter5\r\nAuthor: committer1\r\nCommitter: author2\r\nMessage: message3\r\nSince: 10/1/2021 1:30:34 AM\r\nUntil: 11/1/2021 1:30:34 AM\r\n",
+            @"--author=""committer1"" --committer=""author2"" --grep=""message3"" --regexp-ignore-case --since=""2021-10-01 01:30:34"" --until=""2021-11-01 01:30:34""")]
+        public void FilterInfo_GetRevisionFilter(string author, string committer, string message, string pathFilter, string branchFilter, string expectedSummary, string expectedArgs)
+        {
+            DateTime dateFrom = new(2021, 10, 1, 1, 30, 34, DateTimeKind.Local);
+            DateTime dateTo = new(2021, 11, 1, 1, 30, 34, DateTimeKind.Local);
+            FilterInfo filterInfo = new()
+            {
+                DateFrom = dateFrom,
+                ByDateFrom = dateFrom != DateTime.MinValue,
+                DateTo = dateTo,
+                ByDateTo = dateTo != DateTime.MinValue,
+                Author = author,
+                ByAuthor = !string.IsNullOrEmpty(author),
+                Committer = committer,
+                ByCommitter = !string.IsNullOrEmpty(committer),
+                Message = message,
+                ByMessage = !string.IsNullOrEmpty(message),
+                PathFilter = pathFilter,
+                ByPathFilter = !string.IsNullOrEmpty(pathFilter),
+                BranchFilter = branchFilter,
+                ByBranchFilter = !string.IsNullOrEmpty(branchFilter)
+            };
+
+            filterInfo.GetSummary().Should().Be(expectedSummary);
+            filterInfo.GetRevisionFilter().ToString().Should().Be(expectedArgs);
+        }
     }
 }


### PR DESCRIPTION
A follow up to #7598

## Proposed changes

#### RevisionFilter: Indicate filters with button state and tooltip

Visualize if there are filters available in the advanced filter.
Add tooltip with the current filter

#### RevDiff: Disable FilterInGrid if no selection
Exception occurred

#### RevisionFilter: Hotkey to disable filters

Ctrl-shift-F to disable the current filters (similar to what is done when switching repos)

Edi: Removed one commit that was moved to #9729 

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/141660697-88f3b5ac-a42f-416f-971c-6a136176a9f6.png)

![image](https://user-images.githubusercontent.com/6248932/141660930-76cc68c3-6cad-465e-af69-34ba357cd02e.png)

### After

![image](https://user-images.githubusercontent.com/6248932/141660772-efc27280-2d47-4c93-8a36-ec099caf508a.png)

![image](https://user-images.githubusercontent.com/6248932/141660780-dddf9d7b-29a6-4d81-a0ad-0790d65c0c43.png)

![image](https://user-images.githubusercontent.com/6248932/141660813-bf6ecbdb-b4d8-47fe-9c41-c6322267d352.png)


## Test methodology <!-- How did you ensure quality? -->

Manual

Adding TODO similar for GetRevisionFilter for FilterSummary
This is related to some other changes that should go into 4.0, so that should be done later.

## Merge strategy

- Rebase merge (PR submitter must change the commit message for the last commit).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
