### PR TITLE
appveyor: avoid warnings about crlf

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ build_script:
     if ($isBuildingPR) {
         git config user.email "gitextensions@github.com"
         git config user.name "Git Extensions"
-        git commit -a -m "restore merge commit"
+        git -c core.autocrlf=false commit -a -m "restore merge commit"
         # ignore warning about line-endings conversion
         $global:LASTEXITCODE = 0
     }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

Avoid the warnings in Appveyor, that confuses users too.

https://ci.appveyor.com/project/gitextensions/gitextensions/builds/41525423#L74

## Test methodology <!-- How did you ensure quality? -->

Appveyor build

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
