### PR TITLE
PathFilter: Set FallbackFollowedFile at every filter update

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -26,6 +26,17 @@ namespace GitUI.CommandsDialogs
             RevisionGrid.FilterChanged += (sender, e) =>
             {
                 Text = _appTitleGenerator.Generate(Module.WorkingDir, Module.IsValidGitWorkingDir(), Module.GetSelectedBranch(), TranslatedStrings.NoBranch, e.PathFilter);
+
+                // PathFilter is a free text field and may contain wildcards, quoting is optional.
+                // This is will adjust the string at least for paths added from context menus.
+                string? path = e.PathFilter;
+                if (path is not null && path.Length > 1 && path[0] == '"' && path[path.Length - 1] == '"')
+                {
+                    path = path[1..(path.Length - 2)];
+                }
+
+                revisionDiff.FallbackFollowedFile = path;
+                fileTree.FallbackFollowedFile = path;
             };
             RevisionGrid.RevisionGraphLoaded += (sender, e) =>
             {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -625,8 +625,6 @@ namespace GitUI.CommandsDialogs
 
         public void SetPathFilter(string pathFilter)
         {
-            revisionDiff.FallbackFollowedFile = pathFilter;
-            fileTree.FallbackFollowedFile = pathFilter;
             RevisionGrid.SetAndApplyPathFilter(pathFilter.QuoteNE());
         }
 
@@ -1800,7 +1798,6 @@ namespace GitUI.CommandsDialogs
 
                     // If we're applying custom branch or revision filters - reset them
                     RevisionGrid.DisableFilters();
-                    SetPathFilter(pathFilter: null);
                     ToolStripFilters.ClearFilters();
                     AppSettings.BranchFilterEnabled = AppSettings.BranchFilterEnabled && AppSettings.ShowCurrentBranchOnly;
                 }


### PR DESCRIPTION
Separated from #9729 (and #9728) as #9729 may require some more time.

## Proposed changes

* Adjust the paths for FallbackFollowedFile by removing quotes.
As before, user specific entries with wildcards and multiple files cannot
be handled.

* Update FallbackFollowedFile in RevDiff and FileHistory also when changed
in the UI filter (not just from the tab menus).

* Do not update filters by nullifying the pathfilters when switching repos.
This triggers additional FilterChanged events.
As a bonus, the pathfilter info is available (disabled) in the filter.
Could be useful if switching to a new worktree or when switching back to the
old repo.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
