### PR TITLE
LeftPanel was initiated twice at startup

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -153,7 +153,7 @@ namespace GitCommands
         }
 
         /// <inherit/>
-        public string WorkingDir { get; }
+        public string WorkingDir { get; init; }
 
         /// <summary>
         /// GitVersion for the default GitExecutable.
@@ -359,6 +359,13 @@ namespace GitCommands
         {
             get
             {
+                if (string.IsNullOrEmpty(WorkingDir))
+                {
+                    // No directory for this module, so the common directory must be empty too
+                    // (should not be retrieved from the GE start directory)
+                    return "";
+                }
+
                 // Get a cache of the common dir
                 // Lock needed as the command is called rapidly when creating the module
                 if (_gitCommonDirectory is not null)

--- a/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
+++ b/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
@@ -80,11 +80,6 @@ namespace GitCommands.Remotes
         /// Retrieves enabled remote names.
         /// </summary>
         IReadOnlyList<string> GetEnabledRemoteNames();
-
-        /// <summary>
-        /// Retrieves enabled remote names of remotes without branches (i.e. that require a fetch).
-        /// </summary>
-        IReadOnlyList<string> GetEnabledRemoteNamesWithoutBranches();
     }
 
     public class ConfigFileRemoteSettingsManager : IConfigFileRemoteSettingsManager
@@ -196,20 +191,6 @@ namespace GitCommands.Remotes
         public IReadOnlyList<string> GetEnabledRemoteNames()
         {
             return GetModule().GetRemoteNames();
-        }
-
-        /// <summary>
-        /// Retrieves enabled remote names of remotes without branches (i.e. that require a fetch).
-        /// </summary>
-        public IReadOnlyList<string> GetEnabledRemoteNamesWithoutBranches()
-        {
-            HashSet<string> remotesWithBranches = GetModule().GetRefs(RefsFilter.Remotes)
-                .Select(branch => branch.Name.SubstringUntil('/'))
-                .ToHashSet();
-
-            HashSet<string> allRemotes = GetEnabledRemoteNames().ToHashSet();
-
-            return allRemotes.Except(remotesWithBranches).ToList();
         }
 
         /// <summary>

--- a/GitUI/BranchTreePanel/RepoObjectsTree.BranchTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.BranchTree.cs
@@ -32,10 +32,9 @@ namespace GitUI.BranchTreePanel
 
             protected override bool SupportsFiltering => true;
 
-            protected override Task OnAttachedAsync()
+            protected override void OnAttached()
             {
                 IsFiltering.Value = false;
-                return ReloadNodesAsync(LoadNodesAsync);
             }
 
             protected override Task PostRepositoryChangedAsync()

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -212,17 +212,6 @@ namespace GitUI.BranchTreePanel
                 SubmoduleStatusProvider.Default.StatusUpdated += Provider_StatusUpdated;
             }
 
-            protected override Task OnAttachedAsync()
-            {
-                var e = _currentSubmoduleInfo;
-                if (e is not null)
-                {
-                    OnStatusUpdated(e);
-                }
-
-                return Task.CompletedTask;
-            }
-
             protected override Task<Nodes> LoadNodesAsync(CancellationToken token)
             {
                 return Task.FromResult(new Nodes(null));

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -96,10 +96,9 @@ namespace GitUI.BranchTreePanel
 
             protected override bool SupportsFiltering => true;
 
-            protected override Task OnAttachedAsync()
+            protected override void OnAttached()
             {
                 IsFiltering.Value = false;
-                return ReloadNodesAsync(LoadNodesAsync);
             }
 
             protected override Task PostRepositoryChangedAsync()

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -200,15 +200,14 @@ namespace GitUI.BranchTreePanel
             protected bool IsAttached { get; private set; }
             protected virtual bool SupportsFiltering { get; } = false;
 
-            public Task AttachedAsync()
+            public void Attached()
             {
                 IsAttached = true;
-                return OnAttachedAsync();
+                OnAttached();
             }
 
-            protected virtual Task OnAttachedAsync()
+            protected virtual void OnAttached()
             {
-                return Task.CompletedTask;
             }
 
             public void Detached()

--- a/GitUI/BranchTreePanel/RepoObjectsTree.RemoteBranchTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.RemoteBranchTree.cs
@@ -32,10 +32,9 @@ namespace GitUI.BranchTreePanel
 
             protected override bool SupportsFiltering => true;
 
-            protected override Task OnAttachedAsync()
+            protected override void OnAttached()
             {
                 IsFiltering.Value = false;
-                return ReloadNodesAsync(LoadNodesAsync);
             }
 
             protected override Task PostRepositoryChangedAsync()

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -399,11 +399,8 @@ namespace GitUI.BranchTreePanel
             treeMain.Font = AppSettings.Font;
             _rootNodes.Add(tree);
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-            {
-                await tree.AttachedAsync();
-            }).FileAndForget();
-        }
+            tree.Attached();
+         }
 
         private void RemoveTree(Tree tree)
         {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -262,7 +262,8 @@ namespace GitUI.BranchTreePanel
         {
             // If we arrived here through the chain of events after selecting a node in the tree,
             // and the selected revision is the one we have selected - do nothing.
-            if (selectedRevisions.Count == 1 && selectedRevisions[0].ObjectId == GetSelectedNodeObjectId(treeMain.SelectedNode))
+            if ((selectedRevisions.Count == 0 && treeMain.SelectedNode is null)
+                || (selectedRevisions.Count == 1 && selectedRevisions[0].ObjectId == GetSelectedNodeObjectId(treeMain.SelectedNode)))
             {
                 return;
             }
@@ -270,7 +271,11 @@ namespace GitUI.BranchTreePanel
             var cancellationToken = _selectionCancellationTokenSequence.Next();
 
             GitRevision selectedRevision = selectedRevisions.FirstOrDefault();
-            string selectedGuid = selectedRevision?.IsArtificial ?? true ? "HEAD" : selectedRevision.Guid;
+            string? selectedGuid = selectedRevision is null
+                ? null
+                : selectedRevision.IsArtificial
+                    ? "HEAD"
+                    : selectedRevision.Guid;
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
+++ b/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
@@ -52,7 +52,7 @@ namespace GitUI.CommandsDialogs
 
             try
             {
-                var buildResultPageEnabled = IsBuildResultPageEnabled();
+                var buildResultPageEnabled = revision is not null && IsBuildResultPageEnabled();
                 var buildInfoIsAvailable = !string.IsNullOrEmpty(revision?.BuildStatus?.Url);
 
                 if (buildResultPageEnabled && buildInfoIsAvailable)

--- a/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
@@ -99,7 +99,7 @@ namespace GitUI.CommandsDialogs
 
             void InitFilters()
             {
-                ToolStripFilters.UpdateBranchFilterItems();
+                // ToolStripFilters.UpdateBranchFilterItems() is init in UICommands_PostRepositoryChanged
 
                 if (!string.IsNullOrWhiteSpace(revFilter))
                 {

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -72,14 +72,8 @@ namespace GitCommandsTests
         [Test]
         public void ParseGitBlame()
         {
-            GitBlame result;
-
-            using (_executable.StageOutput("rev-parse --git-common-dir", ".git"))
-            {
-                var path = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData/README.blame");
-
-                result = _gitModule.ParseGitBlame(File.ReadAllText(path), Encoding.UTF8);
-            }
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData/README.blame");
+            GitBlame result = _gitModule.ParseGitBlame(File.ReadAllText(path), Encoding.UTF8);
 
             Assert.AreEqual(80, result.Lines.Count);
 

--- a/UnitTests/GitCommands.Tests/Remote/ConfigFileRemoteSettingsManagerTests.cs
+++ b/UnitTests/GitCommands.Tests/Remote/ConfigFileRemoteSettingsManagerTests.cs
@@ -389,30 +389,6 @@ namespace GitCommandsTests.Remote
         }
 
         [Test]
-        public void GetEnabledRemotesNameWithoutBranches_returns_enabled_remotes_without_branches_only()
-        {
-            string enabledRemoteNameWithBranches = "enabledRemote1";
-            string enabledRemoteNameNoBranches = "enabledRemote2";
-            string disabledRemoteName = "disabledRemote";
-
-            _module.GetRemoteNames().Returns(x => new[] { enabledRemoteNameWithBranches, enabledRemoteNameNoBranches });
-
-            var refs = new[]
-            {
-                CreateSubstituteRef("02e10a13e06e7562f7c3c516abb2a0e1a0c0dd90", $"refs/remotes/{enabledRemoteNameWithBranches}/develop", $"{enabledRemoteNameWithBranches}"),
-            };
-
-            _module.GetRefs(RefsFilter.NoFilter).ReturnsForAnyArgs(refs);
-
-            List<IConfigSection> sections = new() { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true) };
-            _configFile.GetConfigSections().Returns(x => sections);
-
-            var enabledRemotesNoBranches = _remotesManager.GetEnabledRemoteNamesWithoutBranches();
-            Assert.AreEqual(1, enabledRemotesNoBranches.Count);
-            Assert.AreEqual(enabledRemoteNameNoBranches, enabledRemotesNoBranches[0]);
-        }
-
-        [Test]
         public void EnabledRemoteExists_returns_true_for_enabled_remotes_only()
         {
             string enabledRemoteName = "enabledRemote";


### PR DESCRIPTION
Regression in master

Based on #9729 (may be separated).
Ready for review (first commit is not to be considered) even if draft.

## Proposed changes

The structuring of FormBrowse in master has changed so the left panel is initiated both at creation and at  PostRepositoryChanged.
This could add a couple of seconds to the startup. (Especially at work with virus programs.)

Also eliminate a few Git calls when starting to Dashboard.
(More confusing than a problem.)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/142078733-c7a1eb73-a117-42a4-86ee-ea685cf36cb7.png)

### After

![image](https://user-images.githubusercontent.com/6248932/142078906-d48de7d8-8ba9-4c1a-acc1-9ca2cda7a3f6.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

- Rebase merge (PR submitter must change the commit message for the last commit).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
