### PR TITLE
Share GitRef() at startup

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.BranchTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.BranchTree.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands.Git;
+using GitUI.CommandsDialogs;
 using GitUI.UserControls.RevisionGrid;
 using GitUIPluginInterfaces;
 using Microsoft;
@@ -37,20 +39,20 @@ namespace GitUI.BranchTreePanel
                 IsFiltering.Value = false;
             }
 
-            protected override Task PostRepositoryChangedAsync()
+            protected override Task PostRepositoryChangedAsync(GitUIEventArgs e)
             {
                 IsFiltering.Value = false;
-                return ReloadNodesAsync(LoadNodesAsync);
+                return ReloadNodesAsync(LoadNodesAsync, e.GetRefs);
             }
 
-            protected override async Task<Nodes> LoadNodesAsync(CancellationToken token)
+            protected override async Task<Nodes> LoadNodesAsync(CancellationToken token, Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
             {
                 await TaskScheduler.Default;
                 token.ThrowIfCancellationRequested();
 
                 if (!IsFiltering.Value || _loadedBranches is null)
                 {
-                    _loadedBranches = Module.GetRefs(RefsFilter.Heads);
+                    _loadedBranches = getRefs(RefsFilter.Heads);
                     token.ThrowIfCancellationRequested();
                 }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Submodules.cs
@@ -212,7 +212,7 @@ namespace GitUI.BranchTreePanel
                 SubmoduleStatusProvider.Default.StatusUpdated += Provider_StatusUpdated;
             }
 
-            protected override Task<Nodes> LoadNodesAsync(CancellationToken token)
+            protected override Task<Nodes> LoadNodesAsync(CancellationToken token, Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
             {
                 return Task.FromResult(new Nodes(null));
             }
@@ -275,12 +275,13 @@ namespace GitUI.BranchTreePanel
 
                     if (_currentNodes is null)
                     {
-                        await ReloadNodesAsync(token =>
+                        // Module.GetRefs() is not used for Submodules
+                        await ReloadNodesAsync((token, _) =>
                         {
                             cts = CancellationTokenSource.CreateLinkedTokenSource(e.Token, token);
                             loadNodesTask = LoadNodesAsync(e.Info, cts.Token);
                             return loadNodesTask;
-                        }).ConfigureAwait(false);
+                        }, null).ConfigureAwait(false);
                     }
 
                     if (cts is not null && loadNodesTask is not null)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -101,10 +102,10 @@ namespace GitUI.BranchTreePanel
                 IsFiltering.Value = false;
             }
 
-            protected override Task PostRepositoryChangedAsync()
+            protected override Task PostRepositoryChangedAsync(GitUIEventArgs e)
             {
                 IsFiltering.Value = false;
-                return ReloadNodesAsync(LoadNodesAsync);
+                return ReloadNodesAsync(LoadNodesAsync, e.GetRefs);
             }
 
             /// <inheritdoc/>
@@ -116,14 +117,14 @@ namespace GitUI.BranchTreePanel
                 base.Refresh();
             }
 
-            protected override async Task<Nodes> LoadNodesAsync(CancellationToken token)
+            protected override async Task<Nodes> LoadNodesAsync(CancellationToken token, Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
             {
                 await TaskScheduler.Default;
                 token.ThrowIfCancellationRequested();
 
                 if (!IsFiltering.Value || _loadedTags is null)
                 {
-                    _loadedTags = Module.GetRefs(RefsFilter.Tags);
+                    _loadedTags = getRefs(RefsFilter.Tags);
                     token.ThrowIfCancellationRequested();
                 }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.RemoteBranchTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.RemoteBranchTree.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Remotes;
+using GitUI.CommandsDialogs;
 using GitUI.UserControls.RevisionGrid;
 using GitUIPluginInterfaces;
 using Microsoft;
@@ -37,20 +38,20 @@ namespace GitUI.BranchTreePanel
                 IsFiltering.Value = false;
             }
 
-            protected override Task PostRepositoryChangedAsync()
+            protected override Task PostRepositoryChangedAsync(GitUIEventArgs e)
             {
                 IsFiltering.Value = false;
-                return ReloadNodesAsync(LoadNodesAsync);
+                return ReloadNodesAsync(LoadNodesAsync, e.GetRefs);
             }
 
-            protected override async Task<Nodes> LoadNodesAsync(CancellationToken token)
+            protected override async Task<Nodes> LoadNodesAsync(CancellationToken token, Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
             {
                 await TaskScheduler.Default;
                 token.ThrowIfCancellationRequested();
 
                 if (!IsFiltering.Value || _loadedBranches is null)
                 {
-                    _loadedBranches = Module.GetRefs(RefsFilter.Remotes).ToList();
+                    _loadedBranches = getRefs(RefsFilter.Remotes);
                     token.ThrowIfCancellationRequested();
                 }
 

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -268,7 +269,7 @@ namespace GitUI.UserControls
             ApplyRevisionFilter();
         }
 
-        public void UpdateBranchFilterItems()
+        public void UpdateBranchFilterItems(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs = null)
         {
             tscboBranchFilter.Items.Clear();
 
@@ -284,7 +285,9 @@ namespace GitUI.UserControls
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await TaskScheduler.Default;
-                string[] branches = module.GetRefs(branchesFilter).Select(branch => branch.Name).ToArray();
+                IReadOnlyList<IGitRef> refs = (getRefs ?? module.GetRefs)(branchesFilter);
+
+                string[] branches = refs.Select(branch => branch.Name).ToArray();
 
                 await this.SwitchToMainThreadAsync();
                 BindBranches(branches);

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -840,7 +840,7 @@ namespace GitUI
         ///  Queries git for the new set of revisions and refreshes the grid.
         /// </summary>
         /// <exception cref="AggregateException"></exception>
-        public void PerformRefreshRevisions()
+        public void PerformRefreshRevisions(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs = null)
         {
             ThreadHelper.AssertOnUIThread();
 
@@ -902,7 +902,7 @@ namespace GitUI
                 _revisionReader ??= new RevisionReader();
 
                 // Find all ambiguous refs (including stash, notes etc)
-                var refs = Module.GetRefs(RefsFilter.NoFilter);
+                IReadOnlyList<IGitRef> refs = (getRefs ?? Module.GetRefs)(RefsFilter.NoFilter);
                 _ambiguousRefs = GitRef.GetAmbiguousRefNames(refs);
 
                 _gridView.SuspendLayout();

--- a/Plugins/GitUIPluginInterfaces/FilteredGitRefsProvider.cs
+++ b/Plugins/GitUIPluginInterfaces/FilteredGitRefsProvider.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GitExtUtils;
+
+namespace GitUIPluginInterfaces
+{
+    /// <inherit/>
+    public sealed class FilteredGitRefsProvider : IFilteredGitRefsProvider
+    {
+        public FilteredGitRefsProvider(IGitModule module)
+        {
+            _refs = new(() => module.GetRefs(RefsFilter.NoFilter));
+        }
+
+        private readonly Lazy<IReadOnlyList<IGitRef>> _refs;
+
+        /// <inherit/>
+        public IReadOnlyList<IGitRef> GetRefs(RefsFilter filter)
+        {
+            if (filter == RefsFilter.NoFilter)
+            {
+                return _refs.Value;
+            }
+
+            return _refs.Value.Where(r =>
+                ((filter & RefsFilter.Tags) != 0 && r.IsTag)
+                || ((filter & RefsFilter.Remotes) != 0 && r.IsRemote)
+                || ((filter & RefsFilter.Heads) != 0 && r.IsHead)).ToList();
+        }
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/GitUIEventArgs.cs
+++ b/Plugins/GitUIPluginInterfaces/GitUIEventArgs.cs
@@ -1,15 +1,19 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace GitUIPluginInterfaces
 {
     public class GitUIEventArgs : CancelEventArgs
     {
+        private readonly IFilteredGitRefsProvider _refs;
+
         public GitUIEventArgs(IWin32Window? ownerForm, IGitUICommands gitUICommands)
             : base(cancel: false)
         {
             OwnerForm = ownerForm;
             GitUICommands = gitUICommands;
+            _refs = new FilteredGitRefsProvider(GitModule);
         }
 
         public IGitUICommands GitUICommands { get; }
@@ -17,5 +21,7 @@ namespace GitUIPluginInterfaces
         public IWin32Window? OwnerForm { get; }
 
         public IGitModule GitModule => GitUICommands.GitModule;
+
+        public IReadOnlyList<IGitRef> GetRefs(RefsFilter filter) => _refs.GetRefs(filter);
     }
 }

--- a/Plugins/GitUIPluginInterfaces/IFilteredGitRefsProvider.cs
+++ b/Plugins/GitUIPluginInterfaces/IFilteredGitRefsProvider.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace GitUIPluginInterfaces
+{
+    /// <summary>
+    /// A lazy provider for GitRefs() that can be shared for instance when a repository is changed.
+    /// </summary>
+    public interface IFilteredGitRefsProvider
+    {
+        /// <summary>
+        /// Returns the IGitRefs matching the filter.
+        /// </summary>
+        /// <param name="filter">The filter</param>
+        /// <returns>The filtered GitRefs</returns>
+        IReadOnlyList<IGitRef> GetRefs(RefsFilter filter);
+    }
+}

--- a/UnitTests/GitCommands.Tests/Git/FilteredGitRefsProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/FilteredGitRefsProviderTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using FluentAssertions;
+using GitExtUtils;
+using GitUIPluginInterfaces;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Git
+{
+    public sealed class FilteredGitRefsProviderTests
+    {
+        private IGitModule _module;
+
+        [SetUp]
+        public void Setup()
+        {
+            _module = Substitute.For<IGitModule>();
+        }
+
+        private IGitRef CreateSubstituteRef(string guid, string completeName, string remote)
+        {
+            var isRemote = !string.IsNullOrEmpty(remote);
+            var name = (isRemote ? remote + "/" : "") + completeName.LazySplit('/').LastOrDefault();
+            var isTag = completeName.StartsWith("refs/tags/", StringComparison.InvariantCultureIgnoreCase);
+            var isHead = completeName.StartsWith("refs/heads/", StringComparison.InvariantCultureIgnoreCase);
+            var gitRef = Substitute.For<IGitRef>();
+            gitRef.Module.Returns(_module);
+            gitRef.Guid.Returns(guid);
+            gitRef.CompleteName.Returns(completeName);
+            gitRef.Name.Returns(name);
+            gitRef.Remote.Returns(remote);
+            gitRef.IsRemote.Returns(isRemote);
+            gitRef.IsTag.Returns(isTag);
+            gitRef.IsHead.Returns(isHead);
+            return gitRef;
+        }
+
+        [Test]
+        public void FilteredGitRefsProviderTest()
+        {
+            var refs = new[]
+            {
+                CreateSubstituteRef("f6323b8e80f96dff017dd14bdb28a576556adab4", "refs/heads/develop", ""),
+                CreateSubstituteRef("02e10a13e06e7562f7c3c516abb2a0e1a0c0dd90", "refs/remotes/origin/develop", "origin"),
+                CreateSubstituteRef("f6323b8e80f96dff017dd14bdb28a576556adab5", "refs/heads/local", ""),
+            };
+
+            _module.GetRefs(RefsFilter.NoFilter).ReturnsForAnyArgs(refs);
+
+            FilteredGitRefsProvider filteredRefs = new(_module);
+
+            filteredRefs.GetRefs(RefsFilter.NoFilter).Count.Should().Be(3);
+            filteredRefs.GetRefs(RefsFilter.Remotes).Count.Should().Be(1);
+            filteredRefs.GetRefs(RefsFilter.Heads).Count.Should().Be(2);
+            filteredRefs.GetRefs(RefsFilter.Tags).Count.Should().Be(0);
+            filteredRefs.GetRefs(RefsFilter.Remotes | RefsFilter.Heads).Count.Should().Be(3);
+        }
+    }
+}


### PR DESCRIPTION
requires #9734

## Proposed changes

In master, GitRefs() run 13+2 times during the startup when 1+2 would be sufficient. While some of these are due to a change in master handled in #9729, there are 9+1 in 3.5 (sidepanel many of them).
At work each of these may require several hundred ms. Even if they to some extent can run in parallel, the startuptime may increase with several seconds.

After #9734 most GitRef() calls are done from PostRepositoryChanged and the call can be shared.

## Screenshots <!-- Remove this section if PR does not change UI -->

Timing is when running in the debugger, much different from normal operation (except Git command running  time).

### Before

From #9734 (see that PR for current master).

![image](https://user-images.githubusercontent.com/6248932/142078906-d48de7d8-8ba9-4c1a-acc1-9ca2cda7a3f6.png)

### After

This contains a few commands running after the commands seen above.
![image](https://user-images.githubusercontent.com/6248932/142080791-238cbad2-ae40-4dff-b955-d249ecae5832.png)

## Test methodology <!-- How did you ensure quality? -->

Test is added

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
