### PR TITLE
Make the Debug build debuggable

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -61,7 +61,11 @@ namespace GitCommands
         public static readonly string ApplicationId = ApplicationName.Replace(" ", "");
         public static readonly string SettingsFileName = ApplicationId + ".settings";
         public static readonly string UserPluginsDirectoryName = "UserPlugins";
-        private static string _applicationExecutablePath = Application.ExecutablePath;
+
+        // Under DotnetRuntimeBootstrapper this points to C:\Program Files\dotnet\dotnet.exe
+        // whereas we need our executable
+        private static string _applicationExecutablePath = Assembly.GetEntryAssembly().Location.Replace(".dll", ".exe");
+
         private static string? _documentationBaseUrl;
 
         public static Lazy<string?> ApplicationDataPath { get; private set; }
@@ -1809,6 +1813,7 @@ namespace GitCommands
 
         public static string GetGitExtensionsFullPath()
         {
+            Debug.Assert(_applicationExecutablePath.EndsWith("GitExtensions.exe"), $"{_applicationExecutablePath} must point to GitExtensions.exe");
             return _applicationExecutablePath;
         }
 

--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -20,11 +20,13 @@
     <Nullable>annotations</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'Release'">
     <PackageReference Include="DotnetRuntimeBootstrapper">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="GitInfo">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

 An addendum to #9704.


## Proposed changes

- The .NET bootstrap created a .NET Framework entry point. This tricks the debugger, and it doesn't see the app as a .NET process, and, thus, unable to hit any breakpoints. 
To mitigate this, only apply the bootstrap to the Release configuration.
- Correct path to our executable under DotnetRuntimeBootstrapper.
Resolves #9743

