### PR TITLE
Adjust Debug.Assert for tests

### DIFF
--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using GitCommands.Utils;
 using GitExtUtils;
 using GitUIPluginInterfaces;
 
@@ -200,7 +201,7 @@ namespace GitCommands.Git.Commands
         /// <returns>The Git command to execute.</returns>
         public static ArgumentString PushLocalCmd(string gitRef, ObjectId targetId, string repoDir, bool force = false)
         {
-            Debug.Assert(repoDir.IndexOf(PathUtil.NativeDirectorySeparatorChar) >= 0,
+            Debug.Assert(!EnvUtils.RunningOnWindows() || repoDir.IndexOf(PathUtil.NativeDirectorySeparatorChar) < 0,
                 $"'PushLocalCmd' must be called with 'repoDir' in Posix format");
 
             return new GitArgumentBuilder("push")
@@ -230,9 +231,9 @@ namespace GitCommands.Git.Commands
         /// </param>
         public static ArgumentString CloneCmd(string fromPath, string toPath, bool central = false, bool initSubmodules = false, string? branch = "", int? depth = null, bool? isSingleBranch = null)
         {
-            Debug.Assert(fromPath.IndexOf(PathUtil.NativeDirectorySeparatorChar) >= 0,
+            Debug.Assert(!EnvUtils.RunningOnWindows() || fromPath.IndexOf(PathUtil.NativeDirectorySeparatorChar) < 0,
                $"'CloneCmd' must be called with 'fromPath' in Posix format");
-            Debug.Assert(toPath.IndexOf(PathUtil.NativeDirectorySeparatorChar) >= 0,
+            Debug.Assert(!EnvUtils.RunningOnWindows() || toPath.IndexOf(PathUtil.NativeDirectorySeparatorChar) < 0,
                $"'CloneCmd' must be called with 'toPath' in Posix format");
 
             return new GitArgumentBuilder("clone")


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Regression in #9702

## Proposed changes

Tests fail with Debug.Assert

Note: Other tests fail locally due to other changes in master.

```
Message: 
System.TypeInitializationException : The type initializer for 'GitUI.Theming.ThemeModule' threw an exception.
  ----> Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException : Method Debug.Fail failed with 'C:\dev\gc\gitextensions_4\artifacts\Debug\bin\tests\IntegrationTests\UI.IntegrationTests\net5.0-windows\testhost.exe must point to GitExtensions.exe
', and was translated to Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException to avoid terminating the process hosting the test.

  Stack Trace: 
ThemeModule.get_IsDarkTheme() line 17
GitExtensionsForm.ctor(Boolean enablePositionRestore) line 43
GitModuleForm.ctor(GitUICommands commands, Boolean enablePositionRestore) line 64
GitModuleForm.ctor(GitUICommands commands) line 80
FormBrowse.ctor(GitUICommands commands, BrowseArguments args) line 252
GitUICommands.StartBrowseDialog(IWin32Window owner, BrowseArguments args) line 1131
FormBrowse_LeftPanel_RemotesTests.<RunFormTest>b__20_0() line 218
UITest.RunForm[T](Action showForm, Func`2 runTestAsync) line 80
FormBrowse_LeftPanel_RemotesTests.RunFormTest(Func`2 testDriverAsync) line 217
FormBrowse_LeftPanel_RemotesTests.RunRepoObjectsTreeTest(Action`1 testDriver) line 207
<40 more frames...>
ParallelWorkItemDispatcher.Dispatch(WorkItem work, ParallelExecutionStrategy strategy)
ParallelWorkItemDispatcher.Dispatch(WorkItem work)
CompositeWorkItem.RunChildren()
CompositeWorkItem.PerformWork()
WorkItem.RunOnCurrentThread()
WorkItem.Execute()
TestWorker.TestWorkerThreadProc()
ThreadHelper.ThreadStart_Context(Object state)
ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
ThreadHelper.ThreadStart()

```

## Test methodology <!-- How did you ensure quality? -->

Tests run

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
