### PR TITLE
Allow running TranslationApp in Debug

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1826,15 +1826,18 @@ namespace GitCommands
         public static string GetGitExtensionsFullPath()
         {
 #if DEBUG
-#pragma warning disable SA1515 // Single-line comment should be preceded by blank line
             bool isExpectedExe =
+
                 // The app's entry point is GitExtensions.exe
                 _applicationExecutablePath.EndsWith("GitExtensions.exe", StringComparison.InvariantCultureIgnoreCase) ||
+
                 // Tests are run by testhost.exe
-                _applicationExecutablePath.EndsWith("testhost.exe", StringComparison.InvariantCultureIgnoreCase);
+                _applicationExecutablePath.EndsWith("testhost.exe", StringComparison.InvariantCultureIgnoreCase) ||
+
+                // Translations
+                _applicationExecutablePath.EndsWith("TranslationApp.exe", StringComparison.InvariantCultureIgnoreCase);
 
             Debug.Assert(isExpectedExe, $"{_applicationExecutablePath} must point to GitExtensions.exe");
-#pragma warning restore SA1515 // Single-line comment should be preceded by blank line
 #endif
 
             return _applicationExecutablePath;


### PR DESCRIPTION
Follow up to #9747

## Proposed changes

Allow that the translation app is run in debug, not asserting.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
