### PR TITLE
RevDiff: Move RangeDiff to A->B group

### DIFF
--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -200,8 +200,7 @@ namespace GitUI
                 return fileStatusDescs;
             }
 
-            // Add rangeDiff as a separate group (range is not the same as diff with artificial commits)
-            List<GitItemStatus> statuses = new() { new GitItemStatus(name: TranslatedStrings.DiffRange) { IsRangeDiff = true } };
+            // Add rangeDiff as a FileStatus item (even with artificial commits)
             var first = firstRev.ObjectId == firstRevHead ? firstRev : new GitRevision(firstRevHead);
             var selected = selectedRev.ObjectId == selectedRevHead ? selectedRev : new GitRevision(selectedRevHead);
             var (baseToFirstCount, baseToSecondCount) = module.GetCommitRangeDiffCount(first.ObjectId, selected.ObjectId);
@@ -209,15 +208,16 @@ namespace GitUI
             // first and selected has a common merge base and count must be available
             // Only a printout, so no Validates
             var desc = $"{TranslatedStrings.DiffRange} {baseToFirstCount ?? -1}↓ {baseToSecondCount ?? -1}↑ BASE {GetDescriptionForRevision(baseRevGuid)}";
+            allAToB = allAToB.Append(new GitItemStatus(name: desc) { IsRangeDiff = true }).ToList();
 
-            FileStatusWithDescription rangeDiff = new(
-                firstRev: first,
-                secondRev: selected,
-                summary: desc,
-                statuses: statuses,
-                baseA: baseA,
-                baseB: baseB);
-            fileStatusDescs.Add(rangeDiff);
+            // Replace the A->B group with new statuses
+            fileStatusDescs[0] = new(
+                firstRev: fileStatusDescs[0].FirstRev,
+                secondRev: fileStatusDescs[0].SecondRev,
+                summary: fileStatusDescs[0].Summary,
+                statuses: allAToB,
+                baseA: fileStatusDescs[0].BaseA,
+                baseB: fileStatusDescs[0].BaseB);
 
             return fileStatusDescs;
 


### PR DESCRIPTION
Suggested in #9720, required #9718 too

## Proposed changes

RangeDiff shows the differences between two branches, identifying and comparing commits.
This was previously in a separate group.

This PR discards the second group and moves it into the First(A)->Second(B) goup.
The RangeDiff is always sorted last.

Note: The RangeDiff always happened to be sorted last also without the sort changes, that could be replaced with a comment.
But this could accidentally break. (A test could be added eventually.)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/143660151-3f06bb64-d5fc-4f46-8c39-e41f6909b0db.png)

### After

![image](https://user-images.githubusercontent.com/6248932/143660056-8dee5e32-1545-4485-91a7-5e04e1966ae4.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
