### PR TITLE
RevisionGrid: Option for git log with --topo-order

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -131,7 +131,8 @@ namespace GitCommands
                     new ArgumentBuilder
                     {
                         { refFilterOptions.HasFlag(RefFilterOptions.Reflogs), "--reflog" },
-                        { AppSettings.SortByAuthorDate, "--author-date-order" },
+                        { AppSettings.RevisionSortOrder == RevisionSortOrder.AuthorDate, "--author-date-order" },
+                        { AppSettings.RevisionSortOrder == RevisionSortOrder.Topology, "--topo-order" },
                         {
                             refFilterOptions.HasFlag(RefFilterOptions.All),
                             "--all",

--- a/GitCommands/Settings/AppSettings.CommitInfoPosition.cs
+++ b/GitCommands/Settings/AppSettings.CommitInfoPosition.cs
@@ -1,0 +1,10 @@
+﻿namespace GitCommands
+{
+    public enum CommitInfoPosition
+    {
+        // DO NOT RENAME THESE -- doing so will break user preferences
+        BelowList = 0,
+        LeftwardFromList = 1,
+        RightwardFromList = 2
+    }
+}

--- a/GitCommands/Settings/AppSettings.LocalChangesAction.cs
+++ b/GitCommands/Settings/AppSettings.LocalChangesAction.cs
@@ -1,0 +1,11 @@
+﻿namespace GitCommands
+{
+    public enum LocalChangesAction
+    {
+        // DO NOT RENAME THESE -- doing so will break user preferences
+        DontChange,
+        Merge,
+        Reset,
+        Stash
+    }
+}

--- a/GitCommands/Settings/AppSettings.RevisionSortOrder.cs
+++ b/GitCommands/Settings/AppSettings.RevisionSortOrder.cs
@@ -1,0 +1,10 @@
+﻿namespace GitCommands
+{
+    public enum RevisionSortOrder
+    {
+        // DO NOT RENAME THESE -- doing so will break user preferences
+        GitDefault,
+        AuthorDate,
+        Topology
+    }
+}

--- a/GitCommands/Settings/AppSettings.ShorteningRecentRepoPathStrategy.cs
+++ b/GitCommands/Settings/AppSettings.ShorteningRecentRepoPathStrategy.cs
@@ -1,0 +1,10 @@
+﻿namespace GitCommands
+{
+    public enum ShorteningRecentRepoPathStrategy
+    {
+        // DO NOT RENAME THESE -- doing so will break user preferences
+        None,
+        MostSignDir,
+        MiddleDots
+    }
+}

--- a/GitCommands/Settings/AppSettings.TruncatePathMethod.cs
+++ b/GitCommands/Settings/AppSettings.TruncatePathMethod.cs
@@ -1,0 +1,11 @@
+﻿namespace GitCommands
+{
+    public enum TruncatePathMethod
+    {
+        // DO NOT RENAME THESE -- doing so will break user preferences
+        None,
+        Compact,
+        TrimStart,
+        FileNameOnly
+    }
+}

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -19,6 +19,14 @@ using Microsoft.Win32;
 
 namespace GitCommands
 {
+    public enum CommitInfoPosition
+    {
+        // DO NOT RENAME THESE -- doing so will break user preferences
+        BelowList = 0,
+        LeftwardFromList = 1,
+        RightwardFromList = 2
+    }
+
     public enum LocalChangesAction
     {
         // DO NOT RENAME THESE -- doing so will break user preferences
@@ -28,13 +36,12 @@ namespace GitCommands
         Stash
     }
 
-    public enum TruncatePathMethod
+    public enum RevisionSortOrder
     {
         // DO NOT RENAME THESE -- doing so will break user preferences
-        None,
-        Compact,
-        TrimStart,
-        FileNameOnly
+        GitDefault,
+        AuthorDate,
+        Topology
     }
 
     public enum ShorteningRecentRepoPathStrategy
@@ -45,11 +52,13 @@ namespace GitCommands
         MiddleDots
     }
 
-    public enum CommitInfoPosition
+    public enum TruncatePathMethod
     {
-        BelowList = 0,
-        LeftwardFromList = 1,
-        RightwardFromList = 2
+        // DO NOT RENAME THESE -- doing so will break user preferences
+        None,
+        Compact,
+        TrimStart,
+        FileNameOnly
     }
 
     public static class AppSettings
@@ -524,10 +533,10 @@ namespace GitCommands
             set => SetBool("showgitstatusforartificialcommits", value);
         }
 
-        public static bool SortByAuthorDate
+        public static RevisionSortOrder RevisionSortOrder
         {
-            get => GetBool("sortbyauthordate", false);
-            set => SetBool("sortbyauthordate", value);
+            get => GetEnum("RevisionSortOrder", RevisionSortOrder.GitDefault);
+            set => SetEnum("RevisionSortOrder", value);
         }
 
         public static bool CommitInfoShowContainedInBranches => CommitInfoShowContainedInBranchesLocal ||

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -19,48 +19,6 @@ using Microsoft.Win32;
 
 namespace GitCommands
 {
-    public enum CommitInfoPosition
-    {
-        // DO NOT RENAME THESE -- doing so will break user preferences
-        BelowList = 0,
-        LeftwardFromList = 1,
-        RightwardFromList = 2
-    }
-
-    public enum LocalChangesAction
-    {
-        // DO NOT RENAME THESE -- doing so will break user preferences
-        DontChange,
-        Merge,
-        Reset,
-        Stash
-    }
-
-    public enum RevisionSortOrder
-    {
-        // DO NOT RENAME THESE -- doing so will break user preferences
-        GitDefault,
-        AuthorDate,
-        Topology
-    }
-
-    public enum ShorteningRecentRepoPathStrategy
-    {
-        // DO NOT RENAME THESE -- doing so will break user preferences
-        None,
-        MostSignDir,
-        MiddleDots
-    }
-
-    public enum TruncatePathMethod
-    {
-        // DO NOT RENAME THESE -- doing so will break user preferences
-        None,
-        Compact,
-        TrimStart,
-        FileNameOnly
-    }
-
     public static class AppSettings
     {
         // semi-constants

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
@@ -31,7 +31,6 @@
             System.Windows.Forms.TableLayoutPanel tlpnlMain;
             this.gbGeneral = new System.Windows.Forms.GroupBox();
             this.tlpnlGeneral = new System.Windows.Forms.TableLayoutPanel();
-            this.chkSortByAuthorDate = new GitUI.UserControls.Settings.SettingsCheckBox();
             this.chkShowRelativeDate = new System.Windows.Forms.CheckBox();
             this.truncatePathMethod = new System.Windows.Forms.ComboBox();
             this.truncateLongFilenames = new System.Windows.Forms.Label();
@@ -59,13 +58,16 @@
             this.lblNoImageService = new System.Windows.Forms.Label();
             this.lblCustomAvatarTemplate = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_DaysToCacheImages = new System.Windows.Forms.NumericUpDown();
+            this.RevisionSortOrderHelp = new System.Windows.Forms.PictureBox();
             this.pictureAvatarHelp = new System.Windows.Forms.PictureBox();
             this.avatarProviderHelp = new System.Windows.Forms.PictureBox();
             this.fixedWidthFontDialog = new System.Windows.Forms.FontDialog();
             this.applicationDialog = new System.Windows.Forms.FontDialog();
             this.commitFontDialog = new System.Windows.Forms.FontDialog();
+            this.lblRevisionsSortBy = new System.Windows.Forms.Label();
             this.lblBranchesSortBy = new System.Windows.Forms.Label();
             this.lblBranchesOrder = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_cmbRevisionsSortBy = new System.Windows.Forms.ComboBox();
             this._NO_TRANSLATE_cmbBranchesSortBy = new System.Windows.Forms.ComboBox();
             this._NO_TRANSLATE_cmbBranchesOrder = new System.Windows.Forms.ComboBox();
             tlpnlMain = new System.Windows.Forms.TableLayoutPanel();
@@ -77,6 +79,7 @@
             this.gbAuthorImages.SuspendLayout();
             this.tlpnlAuthor.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_DaysToCacheImages)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RevisionSortOrderHelp)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureAvatarHelp)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.avatarProviderHelp)).BeginInit();
             this.SuspendLayout();
@@ -109,7 +112,7 @@
             this.gbGeneral.Location = new System.Drawing.Point(3, 3);
             this.gbGeneral.Name = "gbGeneral";
             this.gbGeneral.Padding = new System.Windows.Forms.Padding(8);
-            this.gbGeneral.Size = new System.Drawing.Size(1559, 225);
+            this.gbGeneral.Size = new System.Drawing.Size(1559, 227);
             this.gbGeneral.TabIndex = 0;
             this.gbGeneral.TabStop = false;
             this.gbGeneral.Text = "General";
@@ -124,13 +127,15 @@
             this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tlpnlGeneral.Controls.Add(this._NO_TRANSLATE_cmbBranchesOrder, 0, 6);
             this.tlpnlGeneral.Controls.Add(this._NO_TRANSLATE_cmbBranchesSortBy, 0, 5);
+            this.tlpnlGeneral.Controls.Add(this._NO_TRANSLATE_cmbRevisionsSortBy, 0, 4);
+            this.tlpnlGeneral.Controls.Add(this.RevisionSortOrderHelp, 1, 4);
             this.tlpnlGeneral.Controls.Add(this.lblBranchesOrder, 0, 6);
             this.tlpnlGeneral.Controls.Add(this.lblBranchesSortBy, 0, 5);
+            this.tlpnlGeneral.Controls.Add(this.lblRevisionsSortBy, 0, 4);
             this.tlpnlGeneral.Controls.Add(this.chkShowRelativeDate, 0, 0);
             this.tlpnlGeneral.Controls.Add(this.chkShowRepoCurrentBranch, 0, 1);
             this.tlpnlGeneral.Controls.Add(this.chkShowCurrentBranchInVisualStudio, 0, 2);
             this.tlpnlGeneral.Controls.Add(this.chkEnableAutoScale, 0, 3);
-            this.tlpnlGeneral.Controls.Add(this.chkSortByAuthorDate, 0, 4);
             this.tlpnlGeneral.Controls.Add(this.truncateLongFilenames, 0, 7);
             this.tlpnlGeneral.Controls.Add(this.truncatePathMethod, 1, 7);
             this.tlpnlGeneral.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -195,17 +200,6 @@
             this.chkEnableAutoScale.TabIndex = 2;
             this.chkEnableAutoScale.Text = "Auto scale user interface when high DPI is used";
             this.chkEnableAutoScale.UseVisualStyleBackColor = true;
-            // 
-            // chkSortByAuthorDate
-            // 
-            this.chkSortByAuthorDate.AutoSize = true;
-            this.chkSortByAuthorDate.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.chkSortByAuthorDate.Checked = false;
-            this.chkSortByAuthorDate.Location = new System.Drawing.Point(3, 95);
-            this.chkSortByAuthorDate.Name = "chkSortByAuthorDate";
-            this.chkSortByAuthorDate.Size = new System.Drawing.Size(118, 17);
-            this.chkSortByAuthorDate.TabIndex = 3;
-            this.chkSortByAuthorDate.Text = "Sort by author date";
             // 
             // truncateLongFilenames
             // 
@@ -507,6 +501,17 @@
             this._NO_TRANSLATE_DaysToCacheImages.TabIndex = 2;
             this._NO_TRANSLATE_DaysToCacheImages.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
+            // RevisionSortOrderHelp
+            // 
+            this.RevisionSortOrderHelp.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.RevisionSortOrderHelp.Image = global::GitUI.Properties.Resources.information;
+            this.RevisionSortOrderHelp.Location = new System.Drawing.Point(353, 104);
+            this.RevisionSortOrderHelp.Margin = new System.Windows.Forms.Padding(3, 5, 3, 3);
+            this.RevisionSortOrderHelp.Name = "RevisionSortOrderHelp";
+            this.RevisionSortOrderHelp.Size = new System.Drawing.Size(16, 16);
+            this.RevisionSortOrderHelp.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
+            this.RevisionSortOrderHelp.TabStop = false;
+            // 
             // customAvatarHelp
             // 
             this.avatarProviderHelp.Cursor = System.Windows.Forms.Cursors.Hand;
@@ -548,6 +553,17 @@
             this.commitFontDialog.AllowVerticalFonts = false;
             this.commitFontDialog.Color = System.Drawing.SystemColors.ControlText;
             // 
+            // lblRevisionsSortBy
+            // 
+            this.lblRevisionsSortBy.AutoSize = true;
+            this.lblRevisionsSortBy.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblRevisionsSortBy.Location = new System.Drawing.Point(3, 115);
+            this.lblRevisionsSortBy.Name = "lblRevisionsSortBy";
+            this.lblRevisionsSortBy.Size = new System.Drawing.Size(120, 27);
+            this.lblRevisionsSortBy.TabIndex = 3;
+            this.lblRevisionsSortBy.Text = "Sort revisions by";
+            this.lblRevisionsSortBy.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
             // lblBranchesSortBy
             // 
             this.lblBranchesSortBy.AutoSize = true;
@@ -569,6 +585,20 @@
             this.lblBranchesOrder.TabIndex = 7;
             this.lblBranchesOrder.Text = "Order branches";
             this.lblBranchesOrder.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // _NO_TRANSLATE_cmbRevisionsSortBy
+            // 
+            this._NO_TRANSLATE_cmbRevisionsSortBy.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_cmbRevisionsSortBy.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this._NO_TRANSLATE_cmbRevisionsSortBy.FormattingEnabled = true;
+            this._NO_TRANSLATE_cmbRevisionsSortBy.Items.AddRange(new object[] {
+            "Git Default",
+            "Author Date",
+            "Topo (Ancestor)"});
+            this._NO_TRANSLATE_cmbRevisionsSortBy.Location = new System.Drawing.Point(129, 118);
+            this._NO_TRANSLATE_cmbRevisionsSortBy.Name = "_NO_TRANSLATE_cmbRevisionsSortBy";
+            this._NO_TRANSLATE_cmbRevisionsSortBy.Size = new System.Drawing.Size(322, 21);
+            this._NO_TRANSLATE_cmbRevisionsSortBy.TabIndex = 3;
             // 
             // _NO_TRANSLATE_cmbBranchesSortBy
             // 
@@ -624,6 +654,7 @@
             this.tlpnlAuthor.ResumeLayout(false);
             this.tlpnlAuthor.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_DaysToCacheImages)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.RevisionSortOrderHelp)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureAvatarHelp)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.avatarProviderHelp)).EndInit();
             this.ResumeLayout(false);
@@ -662,13 +693,15 @@
         private System.Windows.Forms.TableLayoutPanel tlpnlGeneral;
         private System.Windows.Forms.TableLayoutPanel tlpnlAuthor;
         private System.Windows.Forms.CheckBox ShowAuthorAvatarInCommitGraph;
+        private System.Windows.Forms.PictureBox RevisionSortOrderHelp;
         private System.Windows.Forms.PictureBox pictureAvatarHelp;
         private System.Windows.Forms.PictureBox avatarProviderHelp;
         private System.Windows.Forms.Label lblAvatarProvider;
         private System.Windows.Forms.ComboBox AvatarProvider;
-        private GitUI.UserControls.Settings.SettingsCheckBox chkSortByAuthorDate;
-        private System.Windows.Forms.Label lblBranchesOrder;
+        private System.Windows.Forms.Label lblRevisionsSortBy;
         private System.Windows.Forms.Label lblBranchesSortBy;
+        private System.Windows.Forms.Label lblBranchesOrder;
+        private System.Windows.Forms.ComboBox _NO_TRANSLATE_cmbRevisionsSortBy;
         private System.Windows.Forms.ComboBox _NO_TRANSLATE_cmbBranchesSortBy;
         private System.Windows.Forms.ComboBox _NO_TRANSLATE_cmbBranchesOrder;
     }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -21,7 +21,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private readonly TranslationString _noDictFile = new("None");
         private readonly TranslationString _noDictFilesFound = new("No dictionary files found in: {0}");
         private readonly TranslationString _noImageServiceTooltip = new($"A default image, if the provider has no image for the email address.\r\n\r\nClick this info icon for more details.");
-        private readonly TranslationString _authorDateSortWarningTooltip = new("Sorting by author date may delay rendering of the revision graph.");
+        private readonly TranslationString _revisionSortWarningTooltip = new("Sorting revisions may delay rendering of the revision graph.");
         private readonly TranslationString _avatarProviderTooltip = new($"The avatar provider defines the source for user-defined avatar images.\r\nThe \"Default\" provider uses GitHub and Gravatar,\r\nthe \"Custom\" provider allows you to set custom provider URLs and\r\n\"None\" disables user-defined avatars.\r\n\r\nClick this info icon for more details.");
 
         public AppearanceSettingsPage()
@@ -30,6 +30,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Text = "Appearance";
             InitializeComplete();
 
+            FillComboBoxWithEnumValues<RevisionSortOrder>(_NO_TRANSLATE_cmbRevisionsSortBy);
             FillComboBoxWithEnumValues<GitRefsSortOrder>(_NO_TRANSLATE_cmbBranchesOrder);
             FillComboBoxWithEnumValues<GitRefsSortBy>(_NO_TRANSLATE_cmbBranchesSortBy);
             FillComboBoxWithEnumValues<AvatarProvider>(AvatarProvider);
@@ -50,9 +51,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             base.OnRuntimeLoad();
 
             ToolTip.SetToolTip(_NO_TRANSLATE_NoImageService, _noImageServiceTooltip.Text);
+            ToolTip.SetToolTip(RevisionSortOrderHelp, _revisionSortWarningTooltip.Text);
             ToolTip.SetToolTip(pictureAvatarHelp, _noImageServiceTooltip.Text);
             ToolTip.SetToolTip(avatarProviderHelp, _avatarProviderTooltip.Text);
-            chkSortByAuthorDate.ToolTipText = _authorDateSortWarningTooltip.Text;
+            RevisionSortOrderHelp.Size = DpiUtil.Scale(RevisionSortOrderHelp.Size);
             pictureAvatarHelp.Size = DpiUtil.Scale(pictureAvatarHelp.Size);
             avatarProviderHelp.Size = DpiUtil.Scale(avatarProviderHelp.Size);
 
@@ -83,7 +85,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             _NO_TRANSLATE_DaysToCacheImages.Value = AppSettings.AvatarImageCacheDays;
             ShowAuthorAvatarInCommitInfo.Checked = AppSettings.ShowAuthorAvatarInCommitInfo;
             ShowAuthorAvatarInCommitGraph.Checked = AppSettings.ShowAuthorAvatarColumn;
-            chkSortByAuthorDate.Checked = AppSettings.SortByAuthorDate;
+            _NO_TRANSLATE_cmbRevisionsSortBy.SelectedIndex = (int)AppSettings.RevisionSortOrder;
             AvatarProvider.SelectedValue = AppSettings.AvatarProvider;
             _NO_TRANSLATE_NoImageService.SelectedValue = AppSettings.AvatarFallbackType;
             txtCustomAvatarTemplate.Text = AppSettings.CustomAvatarTemplate;
@@ -149,7 +151,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.ShowAuthorAvatarInCommitInfo = ShowAuthorAvatarInCommitInfo.Checked;
             AppSettings.AvatarImageCacheDays = (int)_NO_TRANSLATE_DaysToCacheImages.Value;
             AppSettings.CustomAvatarTemplate = txtCustomAvatarTemplate.Text;
-            AppSettings.SortByAuthorDate = chkSortByAuthorDate.Checked;
+            AppSettings.RevisionSortOrder = (RevisionSortOrder)_NO_TRANSLATE_cmbRevisionsSortBy.SelectedIndex;
             AppSettings.RefsSortOrder = (GitRefsSortOrder)_NO_TRANSLATE_cmbBranchesOrder.SelectedIndex;
             AppSettings.RefsSortBy = (GitRefsSortBy)_NO_TRANSLATE_cmbBranchesSortBy.SelectedIndex;
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -145,10 +145,6 @@ This action will be performed without warning while checking out branch.</source
         <source>Show author's avatar in the commit info view</source>
         <target />
       </trans-unit>
-      <trans-unit id="_authorDateSortWarningTooltip.Text">
-        <source>Sorting by author date may delay rendering of the revision graph.</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_avatarProviderTooltip.Text">
         <source>The avatar provider defines the source for user-defined avatar images.
 The "Default" provider uses GitHub and Gravatar,
@@ -172,6 +168,10 @@ Click this info icon for more details.</source>
 Click this info icon for more details.</source>
         <target />
       </trans-unit>
+      <trans-unit id="_revisionSortWarningTooltip.Text">
+        <source>Sorting revisions may delay rendering of the revision graph.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="chkEnableAutoScale.Text">
         <source>Auto scale user interface when high DPI is used</source>
         <target />
@@ -186,10 +186,6 @@ Click this info icon for more details.</source>
       </trans-unit>
       <trans-unit id="chkShowRepoCurrentBranch.Text">
         <source>Show current branch names in the dashboard and the recent repositories dropdown menu</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="chkSortByAuthorDate.Text">
-        <source>Sort by author date</source>
         <target />
       </trans-unit>
       <trans-unit id="downloadDictionary.Text">
@@ -238,6 +234,10 @@ Click this info icon for more details.</source>
       </trans-unit>
       <trans-unit id="lblNoImageService.Text">
         <source>Fallback generated avatar style</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="lblRevisionsSortBy.Text">
+        <source>Sort revisions by</source>
         <target />
       </trans-unit>
       <trans-unit id="lblSpellingDictionary.Text">
@@ -9689,7 +9689,7 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="ShowArtificialCommits.Text">
-        <source>Show artificial c&amp;ommits</source>
+        <source>Show artificial commits</source>
         <target />
       </trans-unit>
       <trans-unit id="ShowCurrentBranchOnly.Text">
@@ -9730,6 +9730,10 @@ See the changes in the commit form.</source>
       </trans-unit>
       <trans-unit id="ToggleHighlightSelectedBranch.Text">
         <source>Highlight selected branch (until refresh)</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="TopoOrder.Text">
+        <source>Arrange commits by t&amp;opo order (ancestor order)</source>
         <target />
       </trans-unit>
       <trans-unit id="_quickSearchQuickHelp.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9733,7 +9733,7 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="TopoOrder.Text">
-        <source>Arrange commits by t&amp;opo order (ancestor order)</source>
+        <source>Arrange c&amp;ommits by topo order (ancestor order)</source>
         <target />
       </trans-unit>
       <trans-unit id="_quickSearchQuickHelp.Text">

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2114,7 +2114,13 @@ namespace GitUI
 
         internal void ToggleAuthorDateSort()
         {
-            AppSettings.SortByAuthorDate = !AppSettings.SortByAuthorDate;
+            AppSettings.RevisionSortOrder = AppSettings.RevisionSortOrder != RevisionSortOrder.AuthorDate ? RevisionSortOrder.AuthorDate : RevisionSortOrder.GitDefault;
+            PerformRefreshRevisions();
+        }
+
+        internal void ToggleTopoOrder()
+        {
+            AppSettings.RevisionSortOrder = AppSettings.RevisionSortOrder != RevisionSortOrder.Topology ? RevisionSortOrder.Topology : RevisionSortOrder.GitDefault;
             PerformRefreshRevisions();
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -435,7 +435,7 @@ namespace GitUI.UserControls.RevisionGrid
                 new MenuCommand
                 {
                     Name = "TopoOrder",
-                    Text = "Arrange commits by t&opo order (ancestor order)",
+                    Text = "Arrange c&ommits by topo order (ancestor order)",
                     ExecuteAction = () => _revisionGrid.ToggleTopoOrder(),
                     IsCheckedFunc = () => AppSettings.RevisionSortOrder == RevisionSortOrder.Topology
                 },

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -262,7 +262,7 @@ namespace GitUI.UserControls.RevisionGrid
                 new MenuCommand
                 {
                     Name = "ShowArtificialCommits",
-                    Text = "Show artificial c&ommits",
+                    Text = "Show artificial commits",
                     ExecuteAction = () => _revisionGrid.ToggleShowArtificialCommits(),
                     IsCheckedFunc = () => AppSettings.RevisionGraphShowArtificialCommits
                 },
@@ -363,20 +363,6 @@ namespace GitUI.UserControls.RevisionGrid
 
                 new MenuCommand
                 {
-                    Name = "drawNonrelativesGrayToolStripMenuItem",
-                    Text = "Draw non relatives gra&y",
-                    ExecuteAction = () => _revisionGrid.ToggleDrawNonRelativesGray(),
-                    IsCheckedFunc = () => AppSettings.RevisionGraphDrawNonRelativesGray
-                },
-                new MenuCommand
-                {
-                    Name = "AuthorDateSort",
-                    Text = "&Sort commits by author date",
-                    ExecuteAction = () => _revisionGrid.ToggleAuthorDateSort(),
-                    IsCheckedFunc = () => AppSettings.SortByAuthorDate
-                },
-                new MenuCommand
-                {
                     Name = "showAuthorDateToolStripMenuItem",
                     Text = "Sho&w author date",
                     ExecuteAction = () => _revisionGrid.ToggleShowAuthorDate(),
@@ -424,6 +410,13 @@ namespace GitUI.UserControls.RevisionGrid
 
                 new MenuCommand
                 {
+                    Name = "drawNonrelativesGrayToolStripMenuItem",
+                    Text = "Draw non relatives gra&y",
+                    ExecuteAction = () => _revisionGrid.ToggleDrawNonRelativesGray(),
+                    IsCheckedFunc = () => AppSettings.RevisionGraphDrawNonRelativesGray
+                },
+                new MenuCommand
+                {
                     Name = "ToggleHighlightSelectedBranch",
                     Text = "Highlight selected branch (until refresh)",
                     ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ToggleHighlightSelectedBranch),
@@ -432,6 +425,20 @@ namespace GitUI.UserControls.RevisionGrid
 
                 MenuCommand.CreateSeparator(),
 
+                new MenuCommand
+                {
+                    Name = "AuthorDateSort",
+                    Text = "&Sort commits by author date",
+                    ExecuteAction = () => _revisionGrid.ToggleAuthorDateSort(),
+                    IsCheckedFunc = () => AppSettings.RevisionSortOrder == RevisionSortOrder.AuthorDate
+                },
+                new MenuCommand
+                {
+                    Name = "TopoOrder",
+                    Text = "Arrange commits by t&opo order (ancestor order)",
+                    ExecuteAction = () => _revisionGrid.ToggleTopoOrder(),
+                    IsCheckedFunc = () => AppSettings.RevisionSortOrder == RevisionSortOrder.Topology
+                },
                 new MenuCommand
                 {
                     Name = "showFirstParent",

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -187,7 +187,7 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.TruncatePathMethod)], TruncatePathMethod.None, false, false);
                 yield return (properties[nameof(AppSettings.ShowGitStatusInBrowseToolbar)], true, false, false);
                 yield return (properties[nameof(AppSettings.ShowGitStatusForArtificialCommits)], true, false, false);
-                yield return (properties[nameof(AppSettings.SortByAuthorDate)], false, false, false);
+                yield return (properties[nameof(AppSettings.RevisionSortOrder)], RevisionSortOrder.GitDefault, false, false);
                 yield return (properties[nameof(AppSettings.CommitInfoShowContainedInBranchesLocal)], true, false, false);
                 yield return (properties[nameof(AppSettings.CheckForUncommittedChangesInCheckoutBranch)], true, false, false);
                 yield return (properties[nameof(AppSettings.AlwaysShowCheckoutBranchDlg)], false, false, false);


### PR DESCRIPTION
Fixes #9758

## Proposed changes

- Explicitly specify the argument `--topo-order` to `git log` if not sorting by author date

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![commit date order](https://user-images.githubusercontent.com/36601201/144314211-981b2e7b-b6a5-4138-ae7f-3073e68281b0.png)

### After

![topo order](https://user-images.githubusercontent.com/36601201/144314414-dcd694ce-63aa-4713-9c18-1f56bc63dea6.png)

## Test methodology <!-- How did you ensure quality? -->

- 👀

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 624068b81beb2475fa94987dc1e0c50ab60a1618
- Git 2.31.1.windows.1 (recommended: 2.33.0 or later)
- Microsoft Windows NT 10.0.19043.0
- .NET 5.0.12
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).