### PR TITLE
Settings could not be read from \\wsl$

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -329,6 +329,7 @@ namespace GitCommands
         /// See https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---git-pathltpathgt.
         /// </summary>
         /// <param name="relativePath">A path relative to the .git directory.</param>
+        /// <returns>An absolute path in Windows format.</returns>
         public string ResolveGitInternalPath(string relativePath)
         {
             GitArgumentBuilder args = new("rev-parse")
@@ -336,16 +337,14 @@ namespace GitCommands
                 "--git-path",
                 relativePath.Quote()
             };
-            var gitPath = _gitExecutable.GetOutput(args);
+            string gitPath = _gitExecutable.GetOutput(args).Trim();
 
-            var systemPath = GetWindowsPath(gitPath).Trim();
-
-            if (systemPath.StartsWith(".git\\"))
+            if (gitPath.StartsWith(".git/"))
             {
-                systemPath = Path.Combine(GetGitDirectory(), systemPath.Substring(".git\\".Length));
+                gitPath = Path.Combine(GetGitDirectory(), gitPath[".git/".Length..]);
             }
 
-            return systemPath;
+            return GetWindowsPath(gitPath);
         }
 
         private string? _gitCommonDirectory;

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -12,6 +12,8 @@ namespace GitCommands
     {
         private static readonly IEnvironmentAbstraction EnvironmentAbstraction = new EnvironmentAbstraction();
         private static readonly IEnvironmentPathsProvider EnvironmentPathsProvider = new EnvironmentPathsProvider(EnvironmentAbstraction);
+
+        // Windows build 21354 supports wsl.localhost too, not supported for WSL Git
         private const string WslPrefix = @"\\wsl$\";
 
         public static readonly char PosixDirectorySeparatorChar = '/';
@@ -232,7 +234,7 @@ namespace GitCommands
         /// <returns>The path in Windows format with native file separators.</returns>
         public static string GetWindowsPath(string? path, string? wslDistro)
         {
-            if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(wslDistro))
+            if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(wslDistro) || path.StartsWith($"{WslPrefix}"))
             {
                 return path?.ToNativePath() ?? "";
             }

--- a/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
+++ b/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
@@ -329,7 +329,18 @@ namespace GitCommands.Remotes
                 }
             }
 
+            // If URL is in a Windows path, it may need to be converted to WSL Git path
+            if (!Uri.IsWellFormedUriString(remoteUrl, UriKind.RelativeOrAbsolute))
+            {
+                remoteUrl = module.GetGitExecPath(remoteUrl);
+            }
+
             UpdateSettings(module, remoteName, remoteDisabled, SettingKeyString.RemoteUrl, remoteUrl);
+            if (!Uri.IsWellFormedUriString(remotePushUrl, UriKind.RelativeOrAbsolute))
+            {
+                remotePushUrl = module.GetGitExecPath(remotePushUrl);
+            }
+
             UpdateSettings(module, remoteName, remoteDisabled, SettingKeyString.RemotePushUrl, remotePushUrl);
             UpdateSettings(module, remoteName, remoteDisabled, SettingKeyString.RemotePuttySshKey, remotePuttySshKey);
 

--- a/GitCommands/Settings/GitExtSettingsCache.cs
+++ b/GitCommands/Settings/GitExtSettingsCache.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Text;
 using System.Xml;
 
@@ -55,7 +56,9 @@ namespace GitCommands.Settings
                 CheckCharacters = false
             };
 
-            using var xr = XmlReader.Create(fileName, readerSettings);
+            // StreamReader required for \\wsl$\ that is an illegal URI
+            using StreamReader sr = new(fileName);
+            using XmlReader xr = XmlReader.Create(sr, readerSettings);
             try
             {
                 _encodedNameMap.ReadXml(xr);

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -534,9 +534,10 @@ namespace GitUI.CommandsDialogs
                     if (!form.ProcessArguments.Contains(" -f ") && !form.ProcessArguments.Contains(" --force"))
                     {
                         // Note that WSL may add other arguments prior to the actual command so "push" may not be first.
-                        Debug.Assert(form.ProcessArguments.Contains("push "), "Arguments should start with 'push' command");
+                        int pos = form.ProcessArguments.IndexOf("push ");
+                        Debug.Assert(pos >= 0, "Arguments should start with 'push' command");
 
-                        form.ProcessArguments = form.ProcessArguments.Insert("push".Length, " --force-with-lease");
+                        form.ProcessArguments = form.ProcessArguments.Insert(pos + "push ".Length, "--force-with-lease ");
                     }
 
                     form.Retry();


### PR DESCRIPTION
A few follow up from #9702 

## Proposed changes

A few a follow up related to WSL Git.

* Settings could not be read from \\wsl$

The URI is invalid, why the path has to be read with a StreamReader.
This caused various issues like remotes could not be disabled

This is not related to WSL Git, it also occurs if Windows Git is used.
This is one reason why insiders Windows builds also supports `wsl.localhost`
(\\wsl$ paths will be required to utilize wsl git. This is a feature but must be documented.)

This problem was primarily seen when deactivating remotes, an exception occurred (as a settings file were not refreshed).

* WSL: Remotes for filepaths could not be saved

Paths must be manipulated to match Git executable.

* WSL: Git internal paths were incorrectly resolved

Affected Remote mostly

* WSL: force-push was inserted incorrectly

The `--force-with-lease` offered if a push is refused assumed that the command started with "push".
The option is "inserted" in the command string.
WSL Git has the distribution first, why the insert point differs.

Note: The output from `git push` is not always available for WSL Git (for instance at home).
At work it works though.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

- Rebase merge (PR submitter must change the commit message for the last commit).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
