### PR TITLE
range-diff: Handle artificial commits

### DIFF
--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -71,7 +71,7 @@ namespace GitUI
                     ? $"{firstId}...{item.SecondRevision.ObjectId}"
                     : $"{item.BaseA}..{firstId} {item.BaseB}..{item.SecondRevision.ObjectId}";
 
-                await fileViewer.ViewTextAsync("range-diff.sh", $"git range-diff {range}");
+                await fileViewer.ViewTextAsync("git-range-diff.sh", $"git range-diff {range}");
 
                 string output = await fileViewer.Module.GetRangeDiffAsync(
                         firstId,

--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -216,8 +216,8 @@ namespace GitUI
                 secondRev: fileStatusDescs[0].SecondRev,
                 summary: fileStatusDescs[0].Summary,
                 statuses: allAToB,
-                baseA: fileStatusDescs[0].BaseA,
-                baseB: fileStatusDescs[0].BaseB);
+                baseA: baseA,
+                baseB: baseB);
 
             return fileStatusDescs;
 


### PR DESCRIPTION
Regression from #9720/2119320c3401b59c8883f52b06a230a756fb4b18

## Proposed changes

Handle artificial commits in range-diff as HEAD
This was done in FileStatusDiffCalculator.cs before #9720

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
