### PR TITLE
GitVersion: Remove support for obsolete versions

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3610,10 +3610,7 @@ namespace GitCommands
                 return new[] { string.Empty };
             }
 
-            return messages.Select(cm =>
-                {
-                     return ReEncodeCommitMessage(cm);
-                });
+            return messages.Select(ReEncodeCommitMessage);
         }
 
         /// <summary>

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -26,7 +26,7 @@ namespace GitCommands
         /// <summary>
         /// The oldest Git version without known incompatibilities.
         /// </summary>
-        public static readonly GitVersion LastFailVersion = new("2.15.2");
+        public static readonly GitVersion LastVersionWithoutKnownLimitations = new("2.15.2");
 
         private static readonly Dictionary<string, GitVersion> _current = new();
 
@@ -46,8 +46,9 @@ namespace GitCommands
             {
                 string output = new Executable(AppSettings.GitCommand).GetOutput("--version");
                 _current[gitIdentifiable] = new GitVersion(output);
-                if (_current[gitIdentifiable] < LastFailVersion)
+                if (_current[gitIdentifiable] < LastVersionWithoutKnownLimitations)
                 {
+                    // Report the last supported version rather than the last version without known issues
                     MessageBox.Show(null, $"{_current[gitIdentifiable]} is lower than {LastSupportedVersion}. Some commands can fail.", "Unsupported Git version", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }


### PR DESCRIPTION
Late review comments for #9680/11911493064a525045f3defa55a740e5796226dd from @mstv

## Proposed changes

No functionality change, just rename and a comment

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
