### PR TITLE
Add mnemonics to filter toolbar

### DIFF
--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3168,7 +3168,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="toolStripLabel1.Text">
-        <source>Branches:</source>
+        <source>&amp;Branches:</source>
         <target />
       </trans-unit>
       <trans-unit id="toolStripLabel1.ToolTipText">
@@ -3212,7 +3212,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="tslblRevisionFilter.Text">
-        <source>Filter:</source>
+        <source>&amp;Filter:</source>
         <target />
       </trans-unit>
       <trans-unit id="tslblRevisionFilter.ToolTipText">
@@ -3292,7 +3292,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="tsmiShowReflogs.Text">
-        <source>Reflogs</source>
+        <source>R&amp;eflogs</source>
         <target />
       </trans-unit>
       <trans-unit id="tsmiShowReflogs.ToolTipText">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3291,10 +3291,6 @@ Do you want to continue?</source>
         <source>Show first parents</source>
         <target />
       </trans-unit>
-      <trans-unit id="tsmiShowReflogs.Text">
-        <source>R&amp;eflogs</source>
-        <target />
-      </trans-unit>
       <trans-unit id="tsmiShowReflogs.ToolTipText">
         <source>Show reflogs</source>
         <target />

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -72,7 +72,7 @@ namespace GitUI.UserControls
             this.toolStripLabel1.Name = "toolStripLabel1";
             this.toolStripLabel1.Size = new System.Drawing.Size(58, 22);
             this.toolStripLabel1.Tag = "ToolBar_group:Branch filter";
-            this.toolStripLabel1.Text = "Branches:";
+            this.toolStripLabel1.Text = "&Branches:";
             this.toolStripLabel1.ToolTipText = "Branch filter";
             // 
             // tsbtnAdvancedFilter
@@ -129,7 +129,7 @@ namespace GitUI.UserControls
             this.tsmiShowReflogs.Image = global::GitUI.Properties.Images.Book;
             this.tsmiShowReflogs.Name = "tsmiShowReflogs";
             this.tsmiShowReflogs.Size = new System.Drawing.Size(23, 22);
-            this.tsmiShowReflogs.Text = "Reflogs";
+            this.tsmiShowReflogs.Text = "R&eflogs";
             this.tsmiShowReflogs.ToolTipText = "Show reflogs";
             this.tsmiShowReflogs.Click += new System.EventHandler(this.tsmiShowReflogs_Click);
             // 
@@ -190,7 +190,7 @@ namespace GitUI.UserControls
             this.tslblRevisionFilter.Name = "tslblRevisionFilter";
             this.tslblRevisionFilter.Size = new System.Drawing.Size(36, 22);
             this.tslblRevisionFilter.Tag = "ToolBar_group:Text filter";
-            this.tslblRevisionFilter.Text = "Filter:";
+            this.tslblRevisionFilter.Text = "&Filter:";
             this.tslblRevisionFilter.ToolTipText = "Text filter";
             // 
             // tstxtRevisionFilter

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -129,7 +129,6 @@ namespace GitUI.UserControls
             this.tsmiShowReflogs.Image = global::GitUI.Properties.Images.Book;
             this.tsmiShowReflogs.Name = "tsmiShowReflogs";
             this.tsmiShowReflogs.Size = new System.Drawing.Size(23, 22);
-            this.tsmiShowReflogs.Text = "R&eflogs";
             this.tsmiShowReflogs.ToolTipText = "Show reflogs";
             this.tsmiShowReflogs.Click += new System.EventHandler(this.tsmiShowReflogs_Click);
             // 


### PR DESCRIPTION
## Proposed changes

- add mnemonics to labels of `ToolStripFilters`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/36601201/144765174-263cea65-f6c6-4a63-8a4f-a62769c5e10c.png)

### After

![image](https://user-images.githubusercontent.com/36601201/150018527-d6503fd8-06fe-462f-956c-825a8d4c8661.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 7c33b6fab9bee4328eb970efa6d50653f5297e74
- Git 2.31.1.windows.1 (recommended: 2.33.0 or later)
- Microsoft Windows NT 10.0.19043.0
- .NET 5.0.12
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).