### PR TITLE
Update .NET Runtime Bootstrapper

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -61,11 +61,7 @@ namespace GitCommands
         public static readonly string ApplicationId = ApplicationName.Replace(" ", "");
         public static readonly string SettingsFileName = ApplicationId + ".settings";
         public static readonly string UserPluginsDirectoryName = "UserPlugins";
-
-        // Under DotnetRuntimeBootstrapper this points to C:\Program Files\dotnet\dotnet.exe
-        // whereas we need our executable
-        private static string _applicationExecutablePath = Assembly.GetEntryAssembly().Location.Replace(".dll", ".exe");
-
+        private static string _applicationExecutablePath = Application.ExecutablePath;
         private static string? _documentationBaseUrl;
 
         public static Lazy<string?> ApplicationDataPath { get; private set; }

--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -20,13 +20,11 @@
     <Nullable>annotations</Nullable>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(Configuration)' == 'Release'">
+  <ItemGroup>
     <PackageReference Include="DotnetRuntimeBootstrapper">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="GitInfo">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Packages.props
+++ b/Packages.props
@@ -7,7 +7,7 @@
     <PackageReference Update="AppInsights.WindowsDesktop" Version="2.17.10" />
     <PackageReference Update="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Update="ConEmu.Core" Version="21.7.18" />
-    <PackageReference Update="DotnetRuntimeBootstrapper" Version="1.1.2" />
+    <PackageReference Update="DotnetRuntimeBootstrapper" Version="2.0.2" />
     <PackageReference Update="EnvDTE" Version="16.10.31320.204" />
     <PackageReference Update="ExCSS" Version="4.1.0" />
     <PackageReference Update="GitInfo" Version="2.1.2" />

--- a/contributors.txt
+++ b/contributors.txt
@@ -170,3 +170,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/10/22, calebnhay, Caleb N. Hay, caleb(at)calebnhay(dot)com
 2021/10/28, matthiaslischka, Matthias Lischka, matthias.lischka(at)gmx.at
 2021/11/13, h0lg, Holger Schmidt, leroyz.mailaccount(at)gmx.net
+2021/12/06, Tyrrrz, Alexey Golub, tyrrrz(at)gmail.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9766

## Proposed changes

- Update DotnetRuntimeBootstrapper to latest version
- Revert the workaround for getting application path (it should now resolve correctly)
- Remove condition on package reference (bootstrapper is now only generated on publish, not on build)

## Test methodology <!-- How did you ensure quality? -->

- I tested it manually :)

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.31.1.windows.1
- Windows 10.0.19043.1348

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
