### PR TITLE
Allow amend commits to also add --reset-author

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2134,7 +2134,7 @@ namespace GitCommands
             }
         }
 
-        public ArgumentString CommitCmd(bool amend, bool signOff = false, string author = "", bool useExplicitCommitMessage = true, bool noVerify = false, bool gpgSign = false, string gpgKeyId = "", bool allowEmpty = false)
+        public ArgumentString CommitCmd(bool amend, bool signOff = false, string author = "", bool useExplicitCommitMessage = true, bool noVerify = false, bool gpgSign = false, string gpgKeyId = "", bool allowEmpty = false, bool resetAuthor = false)
         {
             return new GitArgumentBuilder("commit")
             {
@@ -2145,7 +2145,8 @@ namespace GitCommands
                 { gpgSign && string.IsNullOrWhiteSpace(gpgKeyId), "-S" },
                 { gpgSign && !string.IsNullOrWhiteSpace(gpgKeyId), $"-S{gpgKeyId}" },
                 { useExplicitCommitMessage, $"-F \"{GetGitExecPath(Path.Combine(GetGitDirectory(), "COMMITMESSAGE"))}\"" },
-                { allowEmpty, "--allow-empty" }
+                { allowEmpty, "--allow-empty" },
+                { resetAuthor && amend, "--reset-author" }
             };
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -122,6 +122,7 @@ namespace GitUI.CommandsDialogs
             this.Commit = new System.Windows.Forms.Button();
             this.CommitAndPush = new System.Windows.Forms.Button();
             this.Amend = new System.Windows.Forms.CheckBox();
+            this.ResetAuthor = new System.Windows.Forms.CheckBox();
             this.Reset = new System.Windows.Forms.Button();
             this.ResetUnStaged = new System.Windows.Forms.Button();
             this.toolbarCommit = new GitUI.ToolStripEx();
@@ -1111,6 +1112,9 @@ namespace GitUI.CommandsDialogs
             this.flowCommitButtons.Controls.Add(this.CommitAndPush);
             this.flowCommitButtons.Controls.Add(this.StageInSuperproject);
             this.flowCommitButtons.Controls.Add(this.Amend);
+            var resetAuthorPanel = new Panel{ AutoSize = false, Size = this.ResetAuthor.Size, Margin = new Padding(0) };
+            resetAuthorPanel.Controls.Add(this.ResetAuthor);
+            this.flowCommitButtons.Controls.Add(resetAuthorPanel);
             this.flowCommitButtons.Controls.Add(this.Reset);
             this.flowCommitButtons.Controls.Add(this.ResetUnStaged);
             this.flowCommitButtons.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -1153,7 +1157,7 @@ namespace GitUI.CommandsDialogs
             // Amend
             // 
             this.Amend.AutoSize = true;
-            this.Amend.Location = new System.Drawing.Point(0, 93);
+            this.Amend.Location = new System.Drawing.Point(0, 64);
             this.Amend.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
             this.Amend.Name = "Amend";
             this.Amend.Size = new System.Drawing.Size(97, 17);
@@ -1162,12 +1166,24 @@ namespace GitUI.CommandsDialogs
             this.Amend.UseVisualStyleBackColor = true;
             this.Amend.CheckedChanged += new System.EventHandler(this.Amend_CheckedChanged);
             // 
+            // ResetAuthor
+            // 
+            this.ResetAuthor.AutoSize = true;
+            this.ResetAuthor.Location = new System.Drawing.Point(0, 0);
+            this.ResetAuthor.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
+            this.ResetAuthor.Name = "ResetAuthor";
+            this.ResetAuthor.Size = new System.Drawing.Size(97, 17);
+            this.ResetAuthor.TabIndex = 0;
+            this.ResetAuthor.Text = "R&eset Author";
+            this.ResetAuthor.UseVisualStyleBackColor = true;
+            this.ResetAuthor.Visible = false;
+            // 
             // Reset
             // 
             this.Reset.Image = global::GitUI.Properties.Images.ResetWorkingDirChanges;
             this.Reset.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.Reset.Location = new System.Drawing.Point(0, 122);
-            this.Reset.Margin = new System.Windows.Forms.Padding(0, 9, 0, 3);
+            this.Reset.Location = new System.Drawing.Point(0, 110);
+            this.Reset.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
             this.Reset.Name = "Reset";
             this.Reset.Size = new System.Drawing.Size(171, 26);
             this.Reset.TabIndex = 11;
@@ -1180,7 +1196,7 @@ namespace GitUI.CommandsDialogs
             // 
             this.ResetUnStaged.Image = global::GitUI.Properties.Images.ResetWorkingDirChanges;
             this.ResetUnStaged.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.ResetUnStaged.Location = new System.Drawing.Point(0, 154);
+            this.ResetUnStaged.Location = new System.Drawing.Point(0, 142);
             this.ResetUnStaged.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
             this.ResetUnStaged.Name = "ResetUnStaged";
             this.ResetUnStaged.Size = new System.Drawing.Size(171, 26);
@@ -1665,6 +1681,7 @@ namespace GitUI.CommandsDialogs
         private Button CommitAndPush;
         private Button Reset;
         private CheckBox Amend;
+        private CheckBox ResetAuthor;
         private CheckBox StageInSuperproject;
         private Button ResetUnStaged;
         private ToolStripMenuItem resetUnstagedChangesToolStripMenuItem;

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1173,7 +1173,7 @@ namespace GitUI.CommandsDialogs
             ExecuteCommitCommand();
         }
 
-        private void CheckForStagedAndCommit(bool amend, bool push)
+        private void CheckForStagedAndCommit(bool amend, bool push, bool resetAuthor)
         {
             BypassFormActivatedEventHandler(() =>
             {
@@ -1359,7 +1359,8 @@ namespace GitUI.CommandsDialogs
                         noVerifyToolStripMenuItem.Checked,
                         gpgSignCommitToolStripComboBox.SelectedIndex > 0,
                         toolStripGpgKeyTextBox.Text,
-                        Staged.IsEmpty);
+                        Staged.IsEmpty,
+                        resetAuthor);
 
                     success = FormProcess.ShowDialog(this, arguments: commitCmd, Module.WorkingDir, input: null, useDialogSettings: true);
 
@@ -2747,7 +2748,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            CheckForStagedAndCommit(Amend.Checked, push: true);
+            CheckForStagedAndCommit(amend: Amend.Checked, push: true, resetAuthor: Amend.Checked && ResetAuthor.Checked);
         }
 
         private void UpdateAuthorInfo()
@@ -2808,7 +2809,7 @@ namespace GitUI.CommandsDialogs
 
         private void ExecuteCommitCommand()
         {
-            CheckForStagedAndCommit(Amend.Checked, push: false);
+            CheckForStagedAndCommit(amend: Amend.Checked, push: false, resetAuthor: Amend.Checked && ResetAuthor.Checked);
         }
 
         private void Message_KeyDown(object sender, KeyEventArgs e)
@@ -3262,6 +3263,13 @@ namespace GitUI.CommandsDialogs
 
         private void Amend_CheckedChanged(object sender, EventArgs e)
         {
+            ResetAuthor.Visible = Amend.Checked;
+
+            if (!Amend.Checked && ResetAuthor.Checked)
+            {
+                ResetAuthor.Checked = false;
+            }
+
             if (string.IsNullOrEmpty(Message.Text) && Amend.Checked)
             {
                 ReplaceMessage(Module.GetPreviousCommitMessages(1).FirstOrDefault()?.Trim());
@@ -3385,6 +3393,10 @@ namespace GitUI.CommandsDialogs
             internal CommandStatus ExecuteCommand(Command command) => _formCommit.ExecuteCommand((int)command);
 
             internal Rectangle Bounds => _formCommit.Bounds;
+
+            internal CheckBox ResetAuthor => _formCommit.ResetAuthor;
+
+            internal CheckBox Amend => _formCommit.Amend;
         }
     }
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3807,6 +3807,10 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         <source>&amp;Reset all changes</source>
         <target />
       </trans-unit>
+      <trans-unit id="ResetAuthor.Text">
+        <source>R&amp;eset Author</source>
+        <target />
+      </trans-unit>
       <trans-unit id="ResetUnStaged.Text">
         <source>Reset u&amp;nstaged changes</source>
         <target />

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -376,6 +376,44 @@ namespace GitExtensions.UITests.CommandsDialogs
         }
 
         [Test]
+        public void ResetAuthor_depends_on_amend()
+        {
+            RunFormTest(form =>
+            {
+                var testForm = form.GetTestAccessor();
+
+                // check initial state
+                Assert.False(testForm.Amend.Checked);
+                Assert.False(testForm.ResetAuthor.Checked);
+                Assert.False(testForm.ResetAuthor.Visible);
+
+                testForm.Amend.Checked = true;
+
+                // check that reset author checkbox becomes visible when amend is checked
+                Assert.True(testForm.Amend.Checked);
+                Assert.True(testForm.ResetAuthor.Visible);
+
+                testForm.ResetAuthor.Checked = true;
+
+                Assert.True(testForm.Amend.Checked);
+
+                testForm.Amend.Checked = false;
+
+                // check that reset author checkbox becomes invisible and unchecked when amend is unchecked
+                Assert.False(testForm.Amend.Checked);
+                Assert.False(testForm.ResetAuthor.Checked);
+                Assert.False(testForm.ResetAuthor.Visible);
+
+                testForm.Amend.Checked = true;
+
+                // check that when amend is checked again reset author is still unchecked
+                Assert.True(testForm.Amend.Checked);
+                Assert.True(testForm.ResetAuthor.Visible);
+                Assert.False(testForm.ResetAuthor.Checked);
+            });
+        }
+
+        [Test]
         public void Dialog_remembers_window_geometry()
         {
             RunGeometryMemoryTest(


### PR DESCRIPTION
## Proposed changes

- Allows to add --reset-author to an amend commit

### Before

Amending commits with --reset-author was not possible (to my knowledge)

### After

Obviously this PR forces --reset-author for each amend commit. I would like to take this as a basis if this should be in the product at all and if yes, how it should be realized in the UI. UI part has not been done or thought about so far.

## Test methodology <!-- How did you ensure quality? -->

- Manual testing :)

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.34.1
- Windows 10 21H1


I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
