### PR TITLE
Fix #8918: Mergetool and difftool commands are now populated if paths…

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
@@ -170,7 +170,6 @@
             this.txtDiffToolPath.Location = new System.Drawing.Point(129, 200);
             this.txtDiffToolPath.Name = "txtDiffToolPath";
             this.txtDiffToolPath.Size = new System.Drawing.Size(902, 20);
-            this.txtDiffToolPath.TabIndex = 17;
             this.txtDiffToolPath.TextChanged += new System.EventHandler(this.txtDiffToolPath_TextChanged);
             this.txtDiffToolPath.LostFocus += new System.EventHandler(this.txtDiffMergeToolPath_LostFocus);
             // 
@@ -290,7 +289,6 @@
             this.txtMergeToolPath.Location = new System.Drawing.Point(129, 111);
             this.txtMergeToolPath.Name = "txtMergeToolPath";
             this.txtMergeToolPath.Size = new System.Drawing.Size(902, 20);
-            this.txtMergeToolPath.TabIndex = 9;
             this.txtMergeToolPath.TextChanged += new System.EventHandler(this.txtMergeToolPath_TextChanged);
             this.txtMergeToolPath.LostFocus += new System.EventHandler(this.txtDiffMergeToolPath_LostFocus);
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
@@ -170,8 +170,8 @@
             this.txtDiffToolPath.Location = new System.Drawing.Point(129, 200);
             this.txtDiffToolPath.Name = "txtDiffToolPath";
             this.txtDiffToolPath.Size = new System.Drawing.Size(902, 20);
-            this.txtDiffToolPath.TextChanged += new System.EventHandler(this.txtDiffToolPath_TextChanged);
             this.txtDiffToolPath.LostFocus += new System.EventHandler(this.txtDiffMergeToolPath_LostFocus);
+            this.txtDiffToolPath.TextChanged += new System.EventHandler(this.txtDiffToolPath_TextChanged);
             // 
             // _NO_TRANSLATE_cboDiffTool
             // 
@@ -289,8 +289,8 @@
             this.txtMergeToolPath.Location = new System.Drawing.Point(129, 111);
             this.txtMergeToolPath.Name = "txtMergeToolPath";
             this.txtMergeToolPath.Size = new System.Drawing.Size(902, 20);
-            this.txtMergeToolPath.TextChanged += new System.EventHandler(this.txtMergeToolPath_TextChanged);
             this.txtMergeToolPath.LostFocus += new System.EventHandler(this.txtDiffMergeToolPath_LostFocus);
+            this.txtMergeToolPath.TextChanged += new System.EventHandler(this.txtMergeToolPath_TextChanged);
             // 
             // lblMergeTool
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
@@ -170,6 +170,8 @@
             this.txtDiffToolPath.Location = new System.Drawing.Point(129, 200);
             this.txtDiffToolPath.Name = "txtDiffToolPath";
             this.txtDiffToolPath.Size = new System.Drawing.Size(902, 20);
+            this.txtDiffToolPath.TabIndex = 17;
+            this.txtDiffToolPath.TextChanged += new System.EventHandler(this.txtDiffToolPath_TextChanged);
             this.txtDiffToolPath.LostFocus += new System.EventHandler(this.txtDiffMergeToolPath_LostFocus);
             // 
             // _NO_TRANSLATE_cboDiffTool
@@ -288,6 +290,8 @@
             this.txtMergeToolPath.Location = new System.Drawing.Point(129, 111);
             this.txtMergeToolPath.Name = "txtMergeToolPath";
             this.txtMergeToolPath.Size = new System.Drawing.Size(902, 20);
+            this.txtMergeToolPath.TabIndex = 9;
+            this.txtMergeToolPath.TextChanged += new System.EventHandler(this.txtMergeToolPath_TextChanged);
             this.txtMergeToolPath.LostFocus += new System.EventHandler(this.txtDiffMergeToolPath_LostFocus);
             // 
             // lblMergeTool

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -250,6 +250,32 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
         }
 
+        private void txtMergeToolPath_TextChanged(object sender, EventArgs e)
+        {
+            if (txtMergeToolPath.Focused && sender == txtMergeToolPath)
+            {
+                // we only want to suggest command for known tool types
+                var toolName = _NO_TRANSLATE_cboMergeTool.Text;
+                if (!string.IsNullOrWhiteSpace(toolName))
+                {
+                    SuggestMergeToolCommand();
+                }
+            }
+        }
+
+        private void txtDiffToolPath_TextChanged(object sender, EventArgs e)
+        {
+            if (txtDiffToolPath.Focused && sender == txtDiffToolPath)
+            {
+                // we only want to suggest command for known tool types
+                var toolName = _NO_TRANSLATE_cboDiffTool.Text;
+                if (!string.IsNullOrWhiteSpace(toolName))
+                {
+                    SuggestDiffToolCommand();
+                }
+            }
+        }
+
         private void btnMergeToolBrowse_Click(object sender, EventArgs e)
         {
             txtMergeToolPath.Text = BrowseDiffMergeTool(_NO_TRANSLATE_cboMergeTool.Text, txtMergeToolPath.Text, DiffMergeToolType.Merge).ToPosixPath();
@@ -330,22 +356,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             {
                 Global_FilesEncoding.Items.Clear();
                 CommonLogic.FillEncodings(Global_FilesEncoding);
-            }
-        }
-
-        private void txtMergeToolPath_TextChanged(object sender, EventArgs e)
-        {
-            if (txtMergeToolPath.Focused && sender == txtMergeToolPath)
-            {
-                SuggestMergeToolCommand();
-            }
-        }
-
-        private void txtDiffToolPath_TextChanged(object sender, EventArgs e)
-        {
-            if (txtDiffToolPath.Focused && sender == txtDiffToolPath)
-            {
-                SuggestDiffToolCommand();
             }
         }
     }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -254,9 +254,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             if (txtMergeToolPath.Focused && sender == txtMergeToolPath)
             {
-                // we only want to suggest command for known tool types
+                // we only want to suggest command for known built-in tool types
                 var toolName = _NO_TRANSLATE_cboMergeTool.Text;
-                if (!string.IsNullOrWhiteSpace(toolName))
+                if (!string.IsNullOrWhiteSpace(toolName) && RegisteredDiffMergeTools.All(DiffMergeToolType.Merge).Contains(toolName))
                 {
                     SuggestMergeToolCommand();
                 }
@@ -267,9 +267,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             if (txtDiffToolPath.Focused && sender == txtDiffToolPath)
             {
-                // we only want to suggest command for known tool types
+                // we only want to suggest command for known built-in tool types
                 var toolName = _NO_TRANSLATE_cboDiffTool.Text;
-                if (!string.IsNullOrWhiteSpace(toolName))
+                if (!string.IsNullOrWhiteSpace(toolName) && RegisteredDiffMergeTools.All(DiffMergeToolType.Diff).Contains(toolName))
                 {
                     SuggestDiffToolCommand();
                 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -252,27 +252,31 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void txtMergeToolPath_TextChanged(object sender, EventArgs e)
         {
-            if (txtMergeToolPath.Focused && sender == txtMergeToolPath)
+            if (!txtMergeToolPath.Focused || sender != txtMergeToolPath)
             {
-                // we only want to suggest command for known built-in tool types
-                var toolName = _NO_TRANSLATE_cboMergeTool.Text;
-                if (!string.IsNullOrWhiteSpace(toolName) && RegisteredDiffMergeTools.All(DiffMergeToolType.Merge).Contains(toolName))
-                {
-                    SuggestMergeToolCommand();
-                }
+                return;
+            }
+
+            // we only want to suggest command for known built-in tool types
+            var toolName = _NO_TRANSLATE_cboMergeTool.Text;
+            if (!string.IsNullOrWhiteSpace(toolName) && RegisteredDiffMergeTools.All(DiffMergeToolType.Merge).Contains(toolName))
+            {
+                SuggestMergeToolCommand();
             }
         }
 
         private void txtDiffToolPath_TextChanged(object sender, EventArgs e)
         {
-            if (txtDiffToolPath.Focused && sender == txtDiffToolPath)
+            if (!txtDiffToolPath.Focused || sender != txtDiffToolPath)
             {
-                // we only want to suggest command for known built-in tool types
-                var toolName = _NO_TRANSLATE_cboDiffTool.Text;
-                if (!string.IsNullOrWhiteSpace(toolName) && RegisteredDiffMergeTools.All(DiffMergeToolType.Diff).Contains(toolName))
-                {
-                    SuggestDiffToolCommand();
-                }
+                return;
+            }
+
+            // we only want to suggest command for known built-in tool types
+            var toolName = _NO_TRANSLATE_cboDiffTool.Text;
+            if (!string.IsNullOrWhiteSpace(toolName) && RegisteredDiffMergeTools.All(DiffMergeToolType.Diff).Contains(toolName))
+            {
+                SuggestDiffToolCommand();
             }
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -332,5 +332,21 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 CommonLogic.FillEncodings(Global_FilesEncoding);
             }
         }
+
+        private void txtMergeToolPath_TextChanged(object sender, EventArgs e)
+        {
+            if (txtMergeToolPath.Focused && sender == txtMergeToolPath)
+            {
+                SuggestMergeToolCommand();
+            }
+        }
+
+        private void txtDiffToolPath_TextChanged(object sender, EventArgs e)
+        {
+            if (txtDiffToolPath.Focused && sender == txtDiffToolPath)
+            {
+                SuggestDiffToolCommand();
+            }
+        }
     }
 }


### PR DESCRIPTION
… are manually configured.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8918

## Proposed changes

- In configuration section of git tools: Mergetool and difftool commands are populated if paths to the tools are changed manually without need of pressing "suggest" button.

## Test methodology <!-- How did you ensure quality? -->

- manual tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
