### PR TITLE
Load app colors from CSS themes

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -11,6 +11,7 @@ using GitUI.CommandsDialogs.SettingsDialog;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;
 using GitUI.Infrastructure.Telemetry;
 using GitUI.NBugReports;
+using GitUI.Theming;
 using GitUIPluginInterfaces;
 using Microsoft.VisualStudio.Threading;
 
@@ -42,8 +43,8 @@ namespace GitExtensions
 
             AppSettings.SetDocumentationBaseUrl(ThisAssembly.Git.Branch);
 
-#if SUPPORT_THEMES
             ThemeModule.Load();
+#if SUPPORT_THEME_HOOKS
             Application.ApplicationExit += (s, e) => ThemeModule.Unload();
 
             SystemEvents.UserPreferenceChanged += (s, e) =>

--- a/GitUI/Theming/LocalHook.cs
+++ b/GitUI/Theming/LocalHook.cs
@@ -91,7 +91,7 @@ namespace EasyHook
 
             m_IsExclusive = false;
 
-#if SUPPORT_THEMES
+#if SUPPORT_THEME_HOOKS
             if (m_Handle == IntPtr.Zero)
                NativeAPI.LhSetGlobalInclusiveACL(m_ACL, m_ACL.Length);
             else
@@ -126,7 +126,7 @@ namespace EasyHook
 
             m_IsExclusive = true;
 
-#if SUPPORT_THEMES
+#if SUPPORT_THEME_HOOKS
             if (m_Handle == IntPtr.Zero)
                NativeAPI.LhSetGlobalExclusiveACL(m_ACL, m_ACL.Length);
             else
@@ -231,7 +231,7 @@ namespace EasyHook
                 }
 
                 IntPtr address = IntPtr.Zero;
-#if SUPPORT_THEMES
+#if SUPPORT_THEME_HOOKS
                 NativeAPI.LhGetHookBypassAddress(m_Handle, out address);
 #endif
                 return address;
@@ -302,7 +302,7 @@ namespace EasyHook
                 throw new ObjectDisposedException(typeof(LocalHook).FullName);
             }
 
-#if SUPPORT_THEMES
+#if SUPPORT_THEME_HOOKS
             NativeAPI.LhIsThreadIntercepted(m_Handle, InThreadID, out Result);
 #endif
 
@@ -338,7 +338,7 @@ namespace EasyHook
                     return;
                 }
 
-#if SUPPORT_THEMES
+#if SUPPORT_THEME_HOOKS
                 NativeAPI.LhUninstallHook(m_Handle);
 #endif
 
@@ -414,7 +414,7 @@ namespace EasyHook
 
             try
             {
-#if SUPPORT_THEMES
+#if SUPPORT_THEME_HOOKS
                 NativeAPI.LhInstallHook(
                    InTargetProc,
                    Marshal.GetFunctionPointerForDelegate(Result.m_HookProc),
@@ -462,7 +462,7 @@ namespace EasyHook
             String InModule,
             String InSymbolName)
         {
-#if SUPPORT_THEMES
+#if SUPPORT_THEME_HOOKS
             IntPtr Module = NativeAPI.GetModuleHandle(InModule);
 
             if (Module == IntPtr.Zero)
@@ -487,7 +487,7 @@ namespace EasyHook
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
-#if SUPPORT_THEMES
+#if SUPPORT_THEME_HOOKS
             NativeAPI.LhWaitForPendingRemovals();
 #endif
         }

--- a/GitUI/Theming/ThemeModule.cs
+++ b/GitUI/Theming/ThemeModule.cs
@@ -78,7 +78,7 @@ namespace GitUI.Theming
             {
                 try
                 {
-#if SUPPORT_THEMES
+#if SUPPORT_THEME_HOOKS
                     InstallHooks(theme);
 #endif
                 }
@@ -94,7 +94,7 @@ namespace GitUI.Theming
 
         private static void ResetGdiCaches()
         {
-#if SUPPORT_THEMES
+#if SUPPORT_THEME_HOOKS
             var systemDrawingAssembly = typeof(Color).Assembly;
 
             var colorTableField =

--- a/Packages.props
+++ b/Packages.props
@@ -9,7 +9,7 @@
     <PackageReference Update="ConEmu.Core" Version="21.7.18" />
     <PackageReference Update="DotnetRuntimeBootstrapper" Version="2.0.2" />
     <PackageReference Update="EnvDTE" Version="16.10.31320.204" />
-    <PackageReference Update="ExCSS" Version="4.1.0" />
+    <PackageReference Update="ExCSS" Version="4.1.3" />
     <PackageReference Update="GitInfo" Version="2.1.2" />
     <PackageReference Update="JetBrains.Annotations" Version="2021.2.0" />
     <PackageReference Update="LibGit2Sharp" Version="0.26.2" />

--- a/UnitTests/GitUI.Tests/Theming/ThemeLoaderTests.cs
+++ b/UnitTests/GitUI.Tests/Theming/ThemeLoaderTests.cs
@@ -39,8 +39,6 @@ namespace GitUITests.Theming
         private const string MockAppThemesDirectory = "c:\\gitextensions\\themes";
         private const string MockUserThemesDirectory = "c:\\appdata\\gitextensions\\themes";
 
-#if SUPPORT_THEMES
-
         [Test]
         public void Should_load_any_themable_system_color(
             [ValueSource(nameof(ThemableSystemColorNames))] KnownColor colorName,
@@ -134,6 +132,7 @@ namespace GitUITests.Theming
                 .Which.Message.Should().Contain("InvalidColorName");
         }
 
+        [Ignore("ExCSS version >= 3 do not report parsing errors.")]
         [Test]
         public void Should_throw_When_css_syntax_error()
         {
@@ -194,7 +193,6 @@ namespace GitUITests.Theming
             var theme = loader.LoadTheme(themePath, new ThemeId("theme", isBuiltin: true), allowedClasses: ThemeVariations.None);
             theme.GetColor(colorName).ToArgb().Should().Be(colorOverride.ToArgb());
         }
-#endif
 
         [Test]
         public void Should_throw_When_cyclic_css_imports()
@@ -266,7 +264,7 @@ namespace GitUITests.Theming
             string.Join(
                 Environment.NewLine,
                 colorByName.Select(
-                    pair => $".{pair.Key}: {{ color: {ThemePersistence.TestAccessor.FormatColor(pair.Value)}; }}"));
+                    pair => $".{pair.Key} {{ color: {ThemePersistence.TestAccessor.FormatColor(pair.Value)}; }}"));
 
         private static Theme LoadTheme(ThemeLoader loader, params string[] variations) =>
             loader.LoadTheme(


### PR DESCRIPTION
Fixes #9782

## Proposed changes

Restore the possibility to change application colors from .css files.
While the theme handling is unfortunately disabled after .NET5, the possibility to set colors like branches was available before theming and is expected by users.

@NikolayXHD suggested that ExCSS is removed and replaced with regex parsing, to get rid of a dependency and get parse errors (that must be ignored with ExCSS >= 3).
This is not done due to simplicity, easier to fix this than to reimplement.  (If the implementation is limited to allow only single line comments, one command per line etc, it would be simpler and maybe feasible.)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/147742823-53ca1af2-510e-449b-a82e-803c604bb3f5.png)

### After

Weird mix of switch local-remote colors and colorblind
![image](https://user-images.githubusercontent.com/6248932/147742946-14abf7f1-e256-4184-90ac-be3c9e72b353.png)

## Test methodology <!-- How did you ensure quality? -->

Renabled and adapted tests

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
