### PR TITLE
GitNotes: Reduce overhead when Body exists

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -328,7 +328,7 @@ namespace GitUI.CommitInfo
 
                 if (_revision.Body is null || (AppSettings.ShowGitNotes && !_revision.HasNotes))
                 {
-                    _commitDataManager.UpdateBody(data, out _);
+                    _commitDataManager.UpdateBody(data, appendNotesOnly: _revision.Body is not null, out _);
                     _revision.Body = data.Body;
                     _revision.HasNotes = true;
                 }


### PR DESCRIPTION
Part of #4816 

## Proposed changes

A very minor optimisation to only fetch Notes and not Body when not needed.

There are only a few ms saved from this (so this is still more than most any code efficiency comment about LINQ etc but still hardly noticeable), the primary reason is to see this explicitly in the log and not check again why the Body/Subject is parsed over and over again.

## Screenshots <!-- Remove this section if PR does not change UI -->

First and last Git command is due to diff tab, the other are required when displaying a commit.

### Before

![image](https://user-images.githubusercontent.com/6248932/147882514-30c833af-d043-4115-8c9a-7574d2fb2e14.png)

### After

![image](https://user-images.githubusercontent.com/6248932/147882629-33a2cd7c-3b46-4a52-b309-846789351725.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
