### PR TITLE
FileHistory: Launch commandline in FormBrowse

### DIFF
--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1416,7 +1416,7 @@ namespace GitUI
                     return RunBlameCommand(args);
                 case "branch":
                     return StartCreateBranchDialog();
-                case "browse":      // [path] [-filter]
+                case "browse":      // [path] [--pathFilter=filname] [-filter] [-commit=selected[,first]]
                     return RunBrowseCommand(args);
                 case "checkout":
                 case "checkoutbranch":
@@ -1725,8 +1725,22 @@ namespace GitUI
                 filterByRevision = true;
             }
 
-            ShowModelessForm(owner: null, requiresValidWorkingDir: true, preEvent: null, postEvent: null,
+            // Similar to StartFileHistoryDialog(), tests works better with this setup
+            if (AppSettings.UseBrowseForFileHistory.Value)
+            {
+                ShowModelessForm(owner: null, requiresValidWorkingDir: true, preEvent: null, postEvent: null,
+                                () => new FormBrowse(commands: this, new BrowseArguments
+                                {
+                                    RevFilter = filterByRevision ? revision?.ObjectId.ToString() : null,
+                                    PathFilter = fileHistoryFileName,
+                                    SelectedId = revision?.ObjectId
+                                }));
+            }
+            else
+            {
+                ShowModelessForm(owner: null, requiresValidWorkingDir: true, preEvent: null, postEvent: null,
                 () => new FormFileHistory(commands: this, fileHistoryFileName, revision, filterByRevision, showBlame));
+            }
 
             return true;
         }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1725,21 +1725,21 @@ namespace GitUI
                 filterByRevision = true;
             }
 
-            // Similar to StartFileHistoryDialog(), tests works better with this setup
+            // Similar to StartFileHistoryDialog()
             if (AppSettings.UseBrowseForFileHistory.Value)
             {
                 ShowModelessForm(owner: null, requiresValidWorkingDir: true, preEvent: null, postEvent: null,
-                                () => new FormBrowse(commands: this, new BrowseArguments
-                                {
-                                    RevFilter = filterByRevision ? revision?.ObjectId.ToString() : null,
-                                    PathFilter = fileHistoryFileName,
-                                    SelectedId = revision?.ObjectId
-                                }));
+                                 () => new FormBrowse(commands: this, new BrowseArguments
+                                 {
+                                     RevFilter = filterByRevision ? revision?.ObjectId.ToString() : null,
+                                     PathFilter = fileHistoryFileName,
+                                     SelectedId = revision?.ObjectId
+                                 }));
             }
             else
             {
                 ShowModelessForm(owner: null, requiresValidWorkingDir: true, preEvent: null, postEvent: null,
-                () => new FormFileHistory(commands: this, fileHistoryFileName, revision, filterByRevision, showBlame));
+                                 () => new FormFileHistory(commands: this, fileHistoryFileName, revision, filterByRevision, showBlame));
             }
 
             return true;

--- a/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
@@ -39,6 +39,7 @@ namespace GitUITests.GitUICommandsTests
 
                 AppSettings.UseConsoleEmulatorForCommands = false;
                 AppSettings.CloseProcessDialog = true;
+                AppSettings.UseBrowseForFileHistory.Value = false;
             }
             else
             {


### PR DESCRIPTION
#9445 uses the FormBrowse for displaying file history
(by default, configurable with AppSettings.UseBrowseForFileHistory).
FormFileHistory is deprecated.

However, command line invocation of filehistory still used FormFileHistory,
not using the setting. This is needed for all 'external' use like
Explorer and Visual Studio.

## Screenshots <!-- Remove this section if PR does not change UI -->

FormBrowse with path filter is opened instead of FormFileHistory

## Test methodology <!-- How did you ensure quality? -->

Tests are adopted to run with FormFileHistory, same as today.
There are other tests already for FormBrowse.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
