### PR TITLE
Updated tooltip for ShowDiffForAllParents

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
@@ -85,7 +85,7 @@
             this.chkUseBrowseForFileHistory.Name = "chkUseBrowseForFileHistory";
             this.chkUseBrowseForFileHistory.Size = new System.Drawing.Size(212, 17);
             this.chkUseBrowseForFileHistory.TabIndex = 4;
-            this.chkUseBrowseForFileHistory.Text = "Use Browse For FileHistory";
+            this.chkUseBrowseForFileHistory.Text = "Show file history in the main window";
             this.chkUseBrowseForFileHistory.UseVisualStyleBackColor = true;
             // 
             // gbGeneral

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -84,12 +84,13 @@ namespace GitUI
 
 - For a single selected commit, show the difference with its parent commit.
 - For a single selected merge commit, show the difference with all parents.
-- For two selected commits with a common ancestor (BASE):
-   - Show the difference between the commits.
-   - The difference of unique files from BASE to each of the selected commits.
-   - The difference of common files (identical changes) from BASE to the commits.
-- For multiple selected commits (up to four), show the difference for all the first selected with the last selected commit.
-- For more than four selected commits, show the difference from the first to the last selected commit.");
+- For two selected commits with a common ancestor (BASE), show the difference
+between the commits as well as the difference from BASE to the selected commits.
+See documentation for more details about icons and range diffs.
+- For multiple selected commits (up to four), show the difference for
+all the first selected with the last selected commit.
+- For more than four selected commits, show the difference from the first to
+the last selected commit.");
 
         private readonly TranslationString _stageSelectedLines = new("Stage selected line(s)");
         private readonly TranslationString _unstageSelectedLines = new("Unstage selected line(s)");

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1723,12 +1723,13 @@ The primary difftool can still be selected by clicking the main menu entry.</sou
 
 - For a single selected commit, show the difference with its parent commit.
 - For a single selected merge commit, show the difference with all parents.
-- For two selected commits with a common ancestor (BASE):
-   - Show the difference between the commits.
-   - The difference of unique files from BASE to each of the selected commits.
-   - The difference of common files (identical changes) from BASE to the commits.
-- For multiple selected commits (up to four), show the difference for all the first selected with the last selected commit.
-- For more than four selected commits, show the difference from the first to the last selected commit.</source>
+- For two selected commits with a common ancestor (BASE), show the difference
+between the commits as well as the difference from BASE to the selected commits.
+See documentation for more details about icons and range diffs.
+- For multiple selected commits (up to four), show the difference for
+all the first selected with the last selected commit.
+- For more than four selected commits, show the difference from the first to
+the last selected commit.</source>
         <target />
       </trans-unit>
       <trans-unit id="label1.Text">
@@ -3291,7 +3292,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="chkUseBrowseForFileHistory.Text">
-        <source>Use Browse For FileHistory</source>
+        <source>Show file history in the main window</source>
         <target />
       </trans-unit>
       <trans-unit id="gbGeneral.Text">
@@ -10839,12 +10840,13 @@ Remote: {1}</source>
 
 - For a single selected commit, show the difference with its parent commit.
 - For a single selected merge commit, show the difference with all parents.
-- For two selected commits with a common ancestor (BASE):
-   - Show the difference between the commits.
-   - The difference of unique files from BASE to each of the selected commits.
-   - The difference of common files (identical changes) from BASE to the commits.
-- For multiple selected commits (up to four), show the difference for all the first selected with the last selected commit.
-- For more than four selected commits, show the difference from the first to the last selected commit.</source>
+- For two selected commits with a common ancestor (BASE), show the difference
+between the commits as well as the difference from BASE to the selected commits.
+See documentation for more details about icons and range diffs.
+- For multiple selected commits (up to four), show the difference for
+all the first selected with the last selected commit.
+- For more than four selected commits, show the difference from the first to
+the last selected commit.</source>
         <target />
       </trans-unit>
       <trans-unit id="_since.Text">


### PR DESCRIPTION
Follow up to #9720 

## Proposed changes

The diffs shown in Diff Tab when multi-selecting commits is slightly updated in master, missed in #9720 

Also, a lot of strings used with TranslatedStrings were translated twice.
No simple way what I see to hardcode this in TranslationApp, so changing this by renaming controls.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/147892739-5524f9d2-57f3-4848-894e-75ce667031ff.png)

### After

![image](https://user-images.githubusercontent.com/6248932/147892759-9016a4de-054b-42fe-8037-f1ac7e5c81f1.png)

## Test methodology <!-- How did you ensure quality? -->

Compiling

## Merge strategy

- Rebase merge (PR submitter must change the commit message for the last commit).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
