### PR TITLE
Do not report Git error for a command seemingly executed in the background

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -513,14 +513,16 @@ namespace GitCommands
             return _gitExecutable.RunCommand(arguments, createWindow: createWindow);
         }
 
-        public bool InTheMiddleOfConflictedMerge()
+        public bool InTheMiddleOfConflictedMerge(bool background = false)
         {
             GitArgumentBuilder args = new("ls-files")
             {
                 "-z",
                 "--unmerged"
             };
-            var result = _gitExecutable.Execute(args);
+
+            // Do not report errors for commands called in the background
+            ExecutionResult result = _gitExecutable.Execute(args, throwOnErrorExit: !background);
             return result.ExitedSuccessfully && !string.IsNullOrEmpty(result.StandardOutput);
         }
 

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -513,7 +513,7 @@ namespace GitCommands
             return _gitExecutable.RunCommand(arguments, createWindow: createWindow);
         }
 
-        public bool InTheMiddleOfConflictedMerge(bool background = false)
+        public bool InTheMiddleOfConflictedMerge(bool throwOnErrorExit = true)
         {
             GitArgumentBuilder args = new("ls-files")
             {
@@ -522,7 +522,7 @@ namespace GitCommands
             };
 
             // Do not report errors for commands called in the background
-            ExecutionResult result = _gitExecutable.Execute(args, throwOnErrorExit: !background);
+            ExecutionResult result = _gitExecutable.Execute(args, throwOnErrorExit: throwOnErrorExit);
             return result.ExitedSuccessfully && !string.IsNullOrEmpty(result.StandardOutput);
         }
 

--- a/GitUI/UserControls/InteractiveGitActionControl.cs
+++ b/GitUI/UserControls/InteractiveGitActionControl.cs
@@ -73,12 +73,13 @@ namespace GitUI.UserControls
             bool hasConflicts;
             try
             {
-                hasConflicts = Module.InTheMiddleOfConflictedMerge();
+                // This command can be executed seemingly in the background (selecting Browse),
+                // do not notify the user (this can occur if Git is upgraded)
+                // The command also occasionally fails when "reactivating" WSL Git.
+                hasConflicts = Module.InTheMiddleOfConflictedMerge(true);
             }
             catch (Win32Exception)
             {
-                // This command can be executed seemingly in the background (selecting Browse),
-                // do not notify the user (this can occur if Git is upgraded)
                 hasConflicts = false;
             }
 

--- a/GitUI/UserControls/InteractiveGitActionControl.cs
+++ b/GitUI/UserControls/InteractiveGitActionControl.cs
@@ -76,7 +76,7 @@ namespace GitUI.UserControls
                 // This command can be executed seemingly in the background (selecting Browse),
                 // do not notify the user (this can occur if Git is upgraded)
                 // The command also occasionally fails when "reactivating" WSL Git.
-                hasConflicts = Module.InTheMiddleOfConflictedMerge(true);
+                hasConflicts = Module.InTheMiddleOfConflictedMerge(throwOnErrorExit: false);
             }
             catch (Win32Exception)
             {


### PR DESCRIPTION
## Proposed changes

git-ls-files is executed every time GE is reactivated, to determine if "InTheMiddleOfAMerge is to be displayed.
If this fails, there is nothing wrong with GE (and really not Git), no interest to throw a popup for the user.

This is especially annoying with WSL. If the Linux VM is busy will WSL occasionally time out and you get the popup regularily.
After this command, the risk for timeouts is lower, the user will get notification when actually performing actions.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
