### PR TITLE
Replace AppSettings.UseFastChecks with ShowGitStatusInBrowseToolbar

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1188,12 +1188,6 @@ namespace GitCommands
             set => SetBool("relativedate", value);
         }
 
-        public static bool UseFastChecks
-        {
-            get => GetBool("usefastchecks", false);
-            set => SetBool("usefastchecks", value);
-        }
-
         public static bool ShowGitNotes
         {
             get => GetBool("showgitnotes", false);

--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -16,7 +16,7 @@ namespace GitUI.CommandsDialogs
                 this.InvokeAsync(
                         () =>
                         {
-                            RefreshButton.Image = indexChanged && AppSettings.UseFastChecks && Module.IsValidGitWorkingDir()
+                            RefreshButton.Image = indexChanged && AppSettings.ShowGitStatusInBrowseToolbar && Module.IsValidGitWorkingDir()
                                 ? Images.ReloadRevisionsDirty
                                 : Images.ReloadRevisions;
                         })

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
@@ -41,7 +41,6 @@
             this.chkShowGitStatusForArtificialCommits = new System.Windows.Forms.CheckBox();
             this.chkShowStashCountInBrowseWindow = new System.Windows.Forms.CheckBox();
             this.chkShowSubmoduleStatusInBrowse = new System.Windows.Forms.CheckBox();
-            this.chkUseFastChecks = new System.Windows.Forms.CheckBox();
             this.lblCommitsLimit = new System.Windows.Forms.CheckBox();
             this._NO_TRANSLATE_MaxCommits = new System.Windows.Forms.NumericUpDown();
             this.groupBoxBehaviour = new System.Windows.Forms.GroupBox();
@@ -166,20 +165,18 @@
             this.tlpnlPerformance.ColumnCount = 2;
             this.tlpnlPerformance.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlPerformance.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tlpnlPerformance.Controls.Add(this.chkShowAheadBehindDataInBrowseWindow, 0, 5);
-            this.tlpnlPerformance.Controls.Add(this.chkCheckForUncommittedChangesInCheckoutBranch, 0, 6);
+            this.tlpnlPerformance.Controls.Add(this.chkShowAheadBehindDataInBrowseWindow, 0, 4);
+            this.tlpnlPerformance.Controls.Add(this.chkCheckForUncommittedChangesInCheckoutBranch, 0, 5);
             this.tlpnlPerformance.Controls.Add(this.chkShowGitStatusInToolbar, 0, 0);
             this.tlpnlPerformance.Controls.Add(this.chkShowGitStatusForArtificialCommits, 0, 1);
-            this.tlpnlPerformance.Controls.Add(this.chkShowStashCountInBrowseWindow, 0, 4);
+            this.tlpnlPerformance.Controls.Add(this.chkShowStashCountInBrowseWindow, 0, 3);
             this.tlpnlPerformance.Controls.Add(this.chkShowSubmoduleStatusInBrowse, 0, 2);
-            this.tlpnlPerformance.Controls.Add(this.chkUseFastChecks, 0, 3);
-            this.tlpnlPerformance.Controls.Add(this.lblCommitsLimit, 0, 7);
-            this.tlpnlPerformance.Controls.Add(this._NO_TRANSLATE_MaxCommits, 1, 7);
+            this.tlpnlPerformance.Controls.Add(this.lblCommitsLimit, 0, 6);
+            this.tlpnlPerformance.Controls.Add(this._NO_TRANSLATE_MaxCommits, 1, 6);
             this.tlpnlPerformance.Dock = System.Windows.Forms.DockStyle.Top;
             this.tlpnlPerformance.Location = new System.Drawing.Point(8, 21);
             this.tlpnlPerformance.Name = "tlpnlPerformance";
-            this.tlpnlPerformance.RowCount = 8;
-            this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpnlPerformance.RowCount = 7;
             this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlPerformance.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -261,17 +258,6 @@
             this.chkShowSubmoduleStatusInBrowse.TabIndex = 2;
             this.chkShowSubmoduleStatusInBrowse.Text = "Show submodule status in browse menu";
             this.chkShowSubmoduleStatusInBrowse.UseVisualStyleBackColor = true;
-            // 
-            // chkUseFastChecks
-            // 
-            this.chkUseFastChecks.AutoSize = true;
-            this.chkUseFastChecks.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkUseFastChecks.Location = new System.Drawing.Point(3, 72);
-            this.chkUseFastChecks.Name = "chkUseFastChecks";
-            this.chkUseFastChecks.Size = new System.Drawing.Size(347, 17);
-            this.chkUseFastChecks.TabIndex = 4;
-            this.chkUseFastChecks.Text = "Use FileSystemWatcher to check if index is changed";
-            this.chkUseFastChecks.UseVisualStyleBackColor = true;
             // 
             // lblCommitsLimit
             // 
@@ -587,7 +573,6 @@
         private System.Windows.Forms.CheckBox chkCheckForUncommittedChangesInCheckoutBranch;
         private System.Windows.Forms.CheckBox chkShowGitStatusInToolbar;
         private System.Windows.Forms.CheckBox chkShowGitStatusForArtificialCommits;
-        private System.Windows.Forms.CheckBox chkUseFastChecks;
         private System.Windows.Forms.CheckBox chkShowStashCountInBrowseWindow;
         private System.Windows.Forms.CheckBox chkShowSubmoduleStatusInBrowse;
         private System.Windows.Forms.CheckBox lblCommitsLimit;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
@@ -95,7 +95,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             _NO_TRANSLATE_MaxCommits.Enabled = AppSettings.MaxRevisionGraphCommits != 0;
             chkCloseProcessDialog.Checked = AppSettings.CloseProcessDialog;
             chkShowGitCommandLine.Checked = AppSettings.ShowGitCommandLine;
-            chkUseFastChecks.Checked = AppSettings.UseFastChecks;
             cbDefaultCloneDestination.Text = AppSettings.DefaultCloneDestinationPath;
             cboDefaultPullAction.SelectedValue
                 = AppSettings.DefaultPullAction != AppSettings.PullAction.Default ?
@@ -118,7 +117,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.ShowGitStatusForArtificialCommits = chkShowGitStatusForArtificialCommits.Checked;
             AppSettings.CloseProcessDialog = chkCloseProcessDialog.Checked;
             AppSettings.ShowGitCommandLine = chkShowGitCommandLine.Checked;
-            AppSettings.UseFastChecks = chkUseFastChecks.Checked;
             AppSettings.MaxRevisionGraphCommits = lblCommitsLimit.Checked ? (int)_NO_TRANSLATE_MaxCommits.Value : 0;
             AppSettings.RevisionGridQuickSearchTimeout = (int)RevisionGridQuickSearchTimeout.Value;
             AppSettings.ShowStashCount = chkShowStashCountInBrowseWindow.Checked;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7900,10 +7900,6 @@ Context menu for additional operations</source>
         <source>Update submodules on checkout</source>
         <target />
       </trans-unit>
-      <trans-unit id="chkUseFastChecks.Text">
-        <source>Use FileSystemWatcher to check if index is changed</source>
-        <target />
-      </trans-unit>
       <trans-unit id="chkUseHistogramDiffAlgorithm.Text">
         <source>Use histogram diff algorithm</source>
         <target />

--- a/GitUI/UserControls/RevisionGrid/IndexWatcher.cs
+++ b/GitUI/UserControls/RevisionGrid/IndexWatcher.cs
@@ -53,7 +53,7 @@ namespace GitUI.UserControls.RevisionGrid
             {
                 try
                 {
-                    _enabled = AppSettings.UseFastChecks;
+                    _enabled = AppSettings.ShowGitStatusInBrowseToolbar;
 
                     _gitDirPath = Module.WorkingDirGitDir;
 
@@ -116,7 +116,7 @@ namespace GitUI.UserControls.RevisionGrid
             RefreshWatcher();
         }
 
-        public void Clear()
+        private void Clear()
         {
             IndexChanged = true;
             RefreshWatcher();
@@ -124,7 +124,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         private void RefreshWatcher()
         {
-            if (_gitDirPath != Module.WorkingDirGitDir || _enabled != AppSettings.UseFastChecks)
+            if (_gitDirPath != Module.WorkingDirGitDir || _enabled != AppSettings.ShowGitStatusInBrowseToolbar)
             {
                 SetFileSystemWatcher();
             }
@@ -134,6 +134,7 @@ namespace GitUI.UserControls.RevisionGrid
         {
             _enabled = false;
             GitIndexWatcher.EnableRaisingEvents = false;
+            RefsWatcher.EnableRaisingEvents = false;
             GitIndexWatcher.Changed -= fileSystemWatcher_Changed;
             RefsWatcher.Changed -= fileSystemWatcher_Changed;
             GitIndexWatcher.Dispose();

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -260,7 +260,6 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.ShowAheadBehindData)], true, false, false);
                 yield return (properties[nameof(AppSettings.ShowSubmoduleStatus)], false, false, false);
                 yield return (properties[nameof(AppSettings.RelativeDate)], true, false, false);
-                yield return (properties[nameof(AppSettings.UseFastChecks)], false, false, false);
                 yield return (properties[nameof(AppSettings.ShowGitNotes)], false, false, false);
                 yield return (properties[nameof(AppSettings.ShowAnnotatedTagsMessages)], true, false, false);
                 yield return (properties[nameof(AppSettings.ShowMergeCommits)], true, false, false);


### PR DESCRIPTION
## Proposed changes

Remove the specific setting for the index watcher, use the GitStatusMonitor
settings instead. UseFastChecks hardly adds any overhead, it adds
FileSystemWatcher to index and refs (GitStatusMonitor has a separate
watcher on index).
If the file system is changed, the top-left refresh button becomes red.
(As well as avoiding refreshing the grid in some situations, may not be working though.)

UseFastChecks was visible in Performance settings and expected by
users (and occasionally maintainers) to make a difference.
Sometimes the setting is mixed up with the GitStatusMonitor setting
that can make a difference (as git-status requires a lot of resources,
not FileSystemWatcher).

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/147963890-25d5339b-2932-44b8-b1f6-87086f5210ea.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
