### PR TITLE
Mitigeate anchor bug in WinForms

### DIFF
--- a/GitUI/CommandsDialogs/FormCreateBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.Designer.cs
@@ -158,8 +158,6 @@
             // 
             // tableLayoutPanel1
             // 
-            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.AutoSize = true;
             this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.tableLayoutPanel1.ColumnCount = 2;

--- a/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -533,9 +533,6 @@
             // 
             // PushOptionsPanel
             // 
-            this.PushOptionsPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.PushOptionsPanel.Controls.Add(this.flowLayoutPanel1);
             this.PushOptionsPanel.Controls.Add(this.ReplaceTrackingReference);
             this.PushOptionsPanel.Controls.Add(this.ForcePushOptionPanel);

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -104,6 +104,24 @@ namespace GitUI.CommandsDialogs
         {
             InitializeComponent();
 
+            // Workaround for WinForms bug https://github.com/dotnet/winforms/issues/5774 when DPI scaling != 100%
+            // Revert the commit introducing this change when it will be fixed in .net
+            if (DpiUtil.IsNonStandard)
+            {
+                // ComboBoxes have a big blank height that:
+                // 1. make that the "to" label appears too low when value is set to 'DockStyle.Fill'
+                labelTo.Dock = DockStyle.Top;
+
+                // 2. overflow the below controls
+                var newY = ShowOptions.Location.Y + DpiUtil.Scale(38) - 15; // Add some vertical margin for something working from scale 125% to 350%
+                ShowOptions.Location = new Point(6, newY);
+                PushOptionsPanel.Location = new Point(8, newY);
+            }
+            else
+            {
+                PushOptionsPanel.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            }
+
             Push.Text = TranslatedStrings.ButtonPush;
 
             NewColumn.Width = DpiUtil.Scale(97);

--- a/GitUI/UserControls/BranchComboBox.Designer.cs
+++ b/GitUI/UserControls/BranchComboBox.Designer.cs
@@ -34,9 +34,6 @@
             // 
             // branches
             // 
-            this.branches.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.branches.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.Suggest;
             this.branches.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.branches.FormattingEnabled = true;

--- a/GitUI/UserControls/BranchComboBox.cs
+++ b/GitUI/UserControls/BranchComboBox.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
 using GitExtUtils;
+using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
 using Microsoft;
@@ -18,6 +19,11 @@ namespace GitUI
         public BranchComboBox()
         {
             InitializeComponent();
+
+            // Workaround for WinForms bug https://github.com/dotnet/winforms/issues/5774 when DPI scaling != 100%
+            // Revert the commit introducing this change when it will be fixed in .net
+            branches.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+
             InitializeComplete();
 
             branches.DisplayMember = nameof(IGitRef.Name);


### PR DESCRIPTION
See https://github.com/dotnet/winforms/issues/5774

while keeping original behavior when scaling is 100% in FormPush
(because in FormCreateBranch it's not possible)

Workaround for #9402 and #9491 until a fix is deployed in .net
and this commit could be reverted...

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

See #9402 and #9491

FYI, some margin has been added to display "Options" lower otherwise a blank zone (that seems to be caused by the ComboBox) hide the options. It's maybe another regression in WinForms not linked to anchoring regression.
See the problem when margin is not added:

![image](https://user-images.githubusercontent.com/460196/148135662-9eb82ce8-fe1e-4b56-9a42-9839ce0130be.png)


### After

Form Push:
![image](https://user-images.githubusercontent.com/460196/148134864-cbe53af2-b216-4e5d-906a-7b2ba27f9718.png)

![image](https://user-images.githubusercontent.com/460196/148134891-8d746d56-0796-4a9a-9d76-10011042e770.png)

Form Create branch:

![image](https://user-images.githubusercontent.com/460196/148134938-c8734402-adab-48fc-bfa1-1f931bd15bf5.png)

Delete Branches control:

![image](https://user-images.githubusercontent.com/460196/148275238-140a110b-5af1-4c2e-9e63-9b1b8d3c4c77.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual (and painfully) with different scallings

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 8ed5513451f76e200d008de595a17aa910d88158
- Git 2.34.0.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.13
- DPI 192dpi (200% scaling)

## Merge strategy

- Squash merge  or Rebase merge 


