### PR TITLE
make ToolStripEx use ToolStripExSystemRenderer by default as before #9608

### DIFF
--- a/GitExtUtils/GitUI/Theming/ThemeFix.cs
+++ b/GitExtUtils/GitUI/Theming/ThemeFix.cs
@@ -74,15 +74,14 @@ namespace GitExtUtils.GitUI.Theming
 
         private static void SetupToolStrip(ToolStrip strip)
         {
-            strip.EnableTheming(enable: true);
-
+            strip.UseExtendedThemeAwareRenderer();
             strip.Items.OfType<ToolStripLabel>()
                 .ForEach(SetupToolStripLabel);
         }
 
         private static void SetupContextMenu(ContextMenuStrip strip)
         {
-            strip.EnableTheming(enable: true);
+            strip.UseExtendedThemeAwareRenderer();
         }
 
         private static void SetupToolStripLabel(ToolStripLabel label)

--- a/GitExtUtils/GitUI/ToolStripExProfessionalRenderer.cs
+++ b/GitExtUtils/GitUI/ToolStripExProfessionalRenderer.cs
@@ -2,8 +2,13 @@
 
 namespace GitUI
 {
-    internal sealed class ToolStripExRenderer : ToolStripSystemRenderer
+    internal class ToolStripExProfessionalRenderer : ToolStripProfessionalRenderer
     {
+        public ToolStripExProfessionalRenderer()
+        {
+            RoundedEdges = false;
+        }
+
         protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
         {
             if (e.ToolStrip.GetMenuItemBackgroundFilter()?.ShouldRenderMenuItemBackground(e) != false)

--- a/GitExtUtils/GitUI/ToolStripExSystemRenderer.cs
+++ b/GitExtUtils/GitUI/ToolStripExSystemRenderer.cs
@@ -1,0 +1,24 @@
+﻿using System.Windows.Forms;
+
+namespace GitUI
+{
+    public sealed class ToolStripExSystemRenderer : ToolStripSystemRenderer
+    {
+        protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
+        {
+            if (e.ToolStrip.GetMenuItemBackgroundFilter()?.ShouldRenderMenuItemBackground(e) != false)
+            {
+                base.OnRenderMenuItemBackground(e);
+            }
+        }
+
+        protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
+        {
+            if (e.ToolStrip is not IToolStripEx { DrawBorder: false })
+            {
+                // render border
+                base.OnRenderToolStripBorder(e);
+            }
+        }
+    }
+}

--- a/GitExtUtils/GitUI/ToolStripExThemeAwareRenderer.cs
+++ b/GitExtUtils/GitUI/ToolStripExThemeAwareRenderer.cs
@@ -5,7 +5,7 @@ using GitExtUtils.GitUI.Theming;
 
 namespace GitUI
 {
-    internal sealed class ToolStripExThemeAwareRenderer : ToolStripProfessionalRenderer
+    internal sealed class ToolStripExThemeAwareRenderer : ToolStripExProfessionalRenderer
     {
         private static readonly ConditionalWeakTable<Bitmap, Bitmap> AdaptedImagesCache = new();
 
@@ -25,23 +25,6 @@ namespace GitUI
 
             base.OnRenderItemCheck(new ToolStripItemImageRenderEventArgs(
                 e.Graphics, e.Item, adapted, e.ImageRectangle));
-        }
-
-        protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
-        {
-            if (e.ToolStrip.GetMenuItemBackgroundFilter()?.ShouldRenderMenuItemBackground(e) != false)
-            {
-                base.OnRenderMenuItemBackground(e);
-            }
-        }
-
-        protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
-        {
-            if (e.ToolStrip is not IToolStripEx { DrawBorder: false })
-            {
-                // render border
-                base.OnRenderToolStripBorder(e);
-            }
         }
     }
 }

--- a/GitUI/UserControls/ToolStripEx.cs
+++ b/GitUI/UserControls/ToolStripEx.cs
@@ -14,7 +14,7 @@ namespace GitUI
 
         public ToolStripEx()
         {
-            this.UseCustomRenderer();
+            Renderer = new ToolStripExSystemRenderer();
 
             PropertyInfo propGrip = GetType().GetProperty("Grip", BindingFlags.Instance | BindingFlags.NonPublic);
             _gripButton = propGrip.GetValue(this) as ToolStripButton;

--- a/ResourceManager/GitExtensionsFormBase.cs
+++ b/ResourceManager/GitExtensionsFormBase.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
+using GitExtUtils.GitUI.Theming;
 using GitUI;
 using ResourceManager.Properties;
 
@@ -34,6 +35,10 @@ namespace ResourceManager
 
             ShowInTaskbar = Application.OpenForms.Count <= 0;
             Icon = Resources.GitExtensionsLogoIcon;
+
+#if !SUPPORT_THEME_HOOKS
+            Load += (s, e) => ((Form)s!).FixVisualStyle();
+#endif
         }
 
         protected bool IsDesignMode => _initialiser.IsDesignMode;


### PR DESCRIPTION
Achieve the goal of #9608 without unintentionally making `ToolStripEx` use `ProfessionalRenderer` instead of `SystemRenderer`

In particular, this makes `FormBrowse` toolbars selected buttons be highlighted properly, as before.

after #9608
![image](https://user-images.githubusercontent.com/8553578/142762748-754abcae-1b94-472f-91df-10208fe8d96b.gif)

before #9608 and after this PR
![image](https://user-images.githubusercontent.com/12046452/148162965-7be197aa-4c16-4113-a92e-e40718dd1a4f.png)

