### PR TITLE
Decrease CustomDiffMergeToolProvider start delay

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -216,8 +216,7 @@ namespace GitUI.CommandsDialogs
                 new(diffToolRemoteLocalStripMenuItem, diffToolRemoteLocalStripMenuItem_Click),
             };
 
-            const int ToolDelay = 10000;
-            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true, ToolDelay, cancellationToken: _customDiffToolsSequence.Next());
+            new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true, cancellationToken: _customDiffToolsSequence.Next());
         }
 
         private void LoadFileHistory()

--- a/GitUI/CustomDiffMergeToolProvider.cs
+++ b/GitUI/CustomDiffMergeToolProvider.cs
@@ -15,7 +15,7 @@ namespace GitUI
         /// Time to wait before loading custom diff tools in FormBrowse
         /// Avoid loading while git-log and git-diff run.
         /// </summary>
-        private const int FormBrowseToolDelay = 15000;
+        private const int FormBrowseToolDelay = 8000;
 
         /// <summary>
         /// Clear the existing caches.


### PR DESCRIPTION
## Proposed changes

Related to the listing of all diff and mergetools in #8700.

The loading of tools takes considerable time (10 s or so) and a delay was added to not interfere with diffs etc after startup.
That time was set to 15s (for difftools, mergetools has 0.5s after first time opening ResolveConflicts),
which is much longer than needed.
The command (including Git) is also fully async cancelable in master.

The time to load a the linux repo has decreased from about 8s to about 4s for me,
so it should be OK to decrease the load time from 15s to 8s.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
