### PR TITLE
FileSystemWatcher is not working for \\wsl$

### DIFF
--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -121,7 +121,7 @@ namespace GitCommands
                 throw new ArgumentException(nameof(path));
             }
 
-            return IsWslPath(path) ? ResolveWsl(path, relativePath) : ResolveRelativePath(path, relativePath);
+            return IsWslPrefixPath(path) ? ResolveWsl(path, relativePath) : ResolveRelativePath(path, relativePath);
         }
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace GitCommands
         /// </summary>
         internal static string ResolveWsl(string path, string relativePath = "")
         {
-            if (string.IsNullOrWhiteSpace(path) || !IsWslPath(path))
+            if (string.IsNullOrWhiteSpace(path) || !IsWslPrefixPath(path))
             {
                 throw new ArgumentException(nameof(path));
             }
@@ -160,7 +160,24 @@ namespace GitCommands
             return tempPath.LocalPath;
         }
 
-        internal static bool IsWslPath(string path)
+        /// <summary>
+        /// Check if the path is any known path for WSL that may require special handling
+        /// </summary>
+        /// <param name="path">Path to check</param>
+        /// <returns>true if a path is a known WSL path</returns>
+        public static bool IsWslPath(string path)
+        {
+            return !string.IsNullOrWhiteSpace(path)
+                && (IsWslPrefixPath(path)
+                    || path.ToLower().StartsWith(@"\\wsl.localhost\"));
+        }
+
+        /// <summary>
+        /// Check if the path is has handled specially for WSL
+        /// </summary>
+        /// <param name="path">Path to check</param>
+        /// <returns>true if the path is a WSL path with internal handling</returns>
+        private static bool IsWslPrefixPath(string path)
         {
             return path.ToLower().StartsWith(WslPrefix);
         }
@@ -177,7 +194,7 @@ namespace GitCommands
 
             static int GetWslDistroLength(string? path)
             {
-                if (string.IsNullOrWhiteSpace(path) || !IsWslPath(path))
+                if (string.IsNullOrWhiteSpace(path) || !IsWslPrefixPath(path))
                 {
                     return -1;
                 }
@@ -481,6 +498,11 @@ namespace GitCommands
             }
 
             return true;
+        }
+
+        internal readonly struct TestAccessor
+        {
+            public static bool IsWslPrefixPath(string path) => PathUtil.IsWslPrefixPath(path);
         }
     }
 }

--- a/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
+++ b/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
@@ -330,13 +330,13 @@ namespace GitCommands.Remotes
             }
 
             // If URL is in a Windows path, it may need to be converted to WSL Git path
-            if (!Uri.IsWellFormedUriString(remoteUrl, UriKind.RelativeOrAbsolute))
+            if (remoteUrl is not null && !Uri.IsWellFormedUriString(remoteUrl, UriKind.RelativeOrAbsolute))
             {
                 remoteUrl = module.GetGitExecPath(remoteUrl);
             }
 
             UpdateSettings(module, remoteName, remoteDisabled, SettingKeyString.RemoteUrl, remoteUrl);
-            if (!Uri.IsWellFormedUriString(remotePushUrl, UriKind.RelativeOrAbsolute))
+            if (remotePushUrl is not null && !Uri.IsWellFormedUriString(remotePushUrl, UriKind.RelativeOrAbsolute))
             {
                 remotePushUrl = module.GetGitExecPath(remotePushUrl);
             }

--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -36,6 +36,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         /// </summary>
         private const int PeriodicUpdateInterval = 5 * 60 * 1000;
 
+        /// <summary>
+        /// Periodic update in WSL, where FileSystemWatcher may not report changes
+        /// https://github.com/microsoft/WSL/issues/4581
+        /// </summary>
+        private const int PeriodicUpdateIntervalWSL = 60 * 1000;
+
         private readonly FileSystemWatcher _workTreeWatcher = new();
         private readonly FileSystemWatcher _gitDirWatcher = new();
         private readonly System.Windows.Forms.Timer _timerRefresh;
@@ -425,8 +431,9 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 cancelToken = _statusSequence.Next();
                 noLocks = !_isFirstPostRepoChanged;
 
-                // Schedule update every 5 min, even if we don't know that anything changed
-                _nextUpdateTime = commandStartTime + PeriodicUpdateInterval;
+                // Schedule periodic update, even if we don't know that anything changed
+                _nextUpdateTime = commandStartTime
+                    + (PathUtil.IsWslPath(_workTreeWatcher.Path) ? PeriodicUpdateIntervalWSL : PeriodicUpdateInterval);
                 _nextEarliestTime = commandStartTime + MinUpdateInterval;
                 _isFirstPostRepoChanged = false;
                 _commandIsRunning = true;

--- a/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
@@ -223,18 +223,15 @@ namespace GitCommandsTests.Helpers
             Assert.Throws(expectedException, () => PathUtil.ResolveWsl(input));
         }
 
-        [TestCase(@"\\Wsl$\Ubuntu\work\..\GitExtensions\", true)]
-        [TestCase(@"\\wsl$\Ubuntu\work\..\GitExtensions\", true)]
-        [TestCase(@"C:\work\..\GitExtensions\", false)]
-        public void IsWslPath(string path, bool expected)
+        [TestCase(@"\\Wsl$\Ubuntu\work\..\GitExtensions\", true, true)]
+        [TestCase(@"\\wsl$\Ubuntu\work\..\GitExtensions\", true, true)]
+        [TestCase(@"C:\work\..\GitExtensions\", false, false)]
+        [TestCase(@"\\Wsl$/Ubuntu\work\..\GitExtensions\", false, false)]
+        [TestCase(@"\\Wsl.localhost\GitExtensions\", true, false)]
+        public void IsWslPath(string path, bool expected, bool expectedPrefix)
         {
             PathUtil.IsWslPath(path).Should().Be(expected);
-        }
-
-        [TestCase(@"\\Wsl$/Ubuntu\work\..\GitExtensions\", false)]
-        public void IsWslPath_unexpected_usage(string path, bool expected)
-        {
-            PathUtil.IsWslPath(path).Should().Be(expected);
+            PathUtil.TestAccessor.IsWslPrefixPath(path).Should().Be(expectedPrefix);
         }
 
         [TestCase(@"\\Wsl$\Ubuntu\work\..\GitExtensions\", "Ubuntu")]


### PR DESCRIPTION
## Proposed changes

The FileSystemWatcher is not reporting changes for WSL
https://github.com/microsoft/WSL/issues/4581

GitStatusMonitor was not updated as well as deactivating a remote caused a BugReporter popup.
Other issues could be that the settings file were incorrectly overwritten. (That already exist in Windows, maybe worse.)
A few related changes too.

Easiest to review commit by commit

## Test methodology <!-- How did you ensure quality? -->

A few tests updated.

## Merge strategy

- To be decided later.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
