### PR TITLE
Support colorblind variation of default theme

### DIFF
--- a/GitExtUtils/GitUI/Theming/AppColorDefaults.cs
+++ b/GitExtUtils/GitUI/Theming/AppColorDefaults.cs
@@ -24,11 +24,45 @@ namespace GitExtUtils.GitUI.Theming
                 { AppColor.DiffAddedExtra, Color.FromArgb(135, 255, 135) }
             };
 
-        public static Color GetBy(AppColor name)
+        private static readonly Dictionary<string, Dictionary<AppColor, Color>> Variations = new()
         {
-            return Values.TryGetValue(name, out var result)
-                ? result
-                : FallbackColor;
+            {
+                "colorblind", new()
+                {
+                   { AppColor.Graph, Color.FromArgb(0x06, 0x00, 0xa8) },
+                   { AppColor.RemoteBranch, Color.FromArgb(0x06, 0x00, 0xa8) },
+                   { AppColor.DiffRemoved, Color.FromArgb(0x94, 0xcb, 0xff) },
+                   { AppColor.DiffRemovedExtra, Color.FromArgb(0x4d, 0xa6, 0xff) },
+                }
+            }
+        };
+
+        public static Color GetBy(AppColor name, string[]? variations = null)
+        {
+            if (!Values.TryGetValue(name, out var result))
+            {
+                result = FallbackColor;
+            }
+
+            if (variations == null)
+            {
+                return result;
+            }
+
+            foreach (string variation in variations)
+            {
+                if (!Variations.TryGetValue(variation, out var colorOverrides))
+                {
+                    continue;
+                }
+
+                if (colorOverrides.TryGetValue(name, out var colorOverride))
+                {
+                    result = colorOverride;
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/GitExtUtils/GitUI/Theming/Theme.cs
+++ b/GitExtUtils/GitUI/Theming/Theme.cs
@@ -105,9 +105,9 @@ namespace GitExtUtils.GitUI.Theming
             return result;
         }
 
-        private static Theme CreateDefaultTheme()
+        public static Theme CreateDefaultTheme(string[]? variations = null)
         {
-            var appColors = AppColorNames.ToDictionary(name => name, AppColorDefaults.GetBy);
+            var appColors = AppColorNames.ToDictionary(name => name, name => AppColorDefaults.GetBy(name, variations));
             var sysColors = SysColorNames.ToDictionary(name => name, GetFixedColor);
             return new Theme(appColors, sysColors, ThemeId.Default);
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.cs
@@ -86,12 +86,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             set => lblRestartNeeded.Visible = value;
         }
 
-        public bool IsChoosingThemeVariationsEnabled
-        {
-            get => chkColorblind.Enabled;
-            set => chkColorblind.Enabled = value;
-        }
-
         public bool IsChoosingVisualStyleEnabled
         {
             get => chkUseSystemVisualStyle.Enabled;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPageController.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPageController.cs
@@ -90,9 +90,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             if (counter == 0)
             {
                 _page.LabelRestartIsNeededVisible = SettingsAreModified;
-                _page.IsChoosingThemeVariationsEnabled =
-                    _page.IsChoosingVisualStyleEnabled =
-                        _page.SelectedThemeId != ThemeId.Default;
+                _page.IsChoosingVisualStyleEnabled =
+                    _page.SelectedThemeId != ThemeId.Default;
             }
 
             if (_page.SelectedThemeId != ThemeId.Default)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/IColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/IColorsSettingsPage.cs
@@ -14,8 +14,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         bool LabelRestartIsNeededVisible { get; set; }
 
-        bool IsChoosingThemeVariationsEnabled { get; set; }
-
         bool IsChoosingVisualStyleEnabled { get; set; }
 
         void ShowThemeLoadingErrorMessage(ThemeId themeId, string[] variations, Exception ex);

--- a/GitUI/Themes/bright.css
+++ b/GitUI/Themes/bright.css
@@ -6,7 +6,7 @@
 .Graph                       { color: #8a0000; } /* hsl(0,   100%, 27%) */
 .Graph.colorblind            { color: #0600a8; } /* hsl(242, 100%, 33%) */
 .RemoteBranch                { color: #8a0000; } /* hsl(0,   100%, 27%) */
-.Branch.colorblind           { color: #0600a8; } /* hsl(242, 100%, 33%) */
+.RemoteBranch.colorblind     { color: #0600a8; } /* hsl(242, 100%, 33%) */
 .DiffRemoved                 { color: #ffc7c7; } /* hsl(0,   100%, 89%) */
 .DiffRemoved.colorblind      { color: #94cbff; } /* hsl(209, 100%, 79%) */
 .DiffRemovedExtra            { color: #ffa3a3; } /* hsl(0,   100%, 82%) */

--- a/GitUI/Themes/dark.css
+++ b/GitUI/Themes/dark.css
@@ -39,8 +39,8 @@
 .Tag                         { color: #408080; }
 .Graph                       { color: #882d00; }
 .Branch                      { color: #00d76b; }
-.Branch.colorblind           { color: #0080ff; } /* hsl(210, 100%, 50%) */
 .RemoteBranch                { color: #ff8080; } /* hsl(0,   100%, 75%) */
+.RemoteBranch.colorblind     { color: #0080ff; } /* hsl(210, 100%, 50%) */
 .DiffSection                 { color: #4f4f4f; }
 .DiffRemoved                 { color: #4b0606; } /* hsl(0,   85%,  16%) */
 .DiffRemoved.colorblind      { color: #080646; } /* hsl(242, 84%,  15%) */

--- a/GitUI/Themes/darksilver.css
+++ b/GitUI/Themes/darksilver.css
@@ -38,13 +38,14 @@
 .HighlightAllOccurences  { color: #606020; }
 .Tag                     { color: #408080; }
 .Graph                   { color: #882d00; }
-.RemoteBranch            { color: #ff8080; } /* hsl(0,   100%, 75%) */
+.Branch                  { color: #00d76b; }
 .DiffSection             { color: #4f4f4f; }
 .DiffAdded               { color: #054e2a; }
 .DiffAddedExtra          { color: #058545; }
 
-.Branch                      { color: #00d76b; }
-.Branch.colorblind           { color: #0080ff; } /* hsl(210, 100%, 50%) */
+
+.RemoteBranch                { color: #ff8080; } /* hsl(0,   100%, 75%) */
+.RemoteBranch.colorblind     { color: #0080ff; } /* hsl(210, 100%, 50%) */
 .DiffRemoved                 { color: #5a0707; } /* hsl(0,   86%,  19%) */
 .DiffRemoved.colorblind      { color: #090755; } /* hsl(242, 85%,  18%) */
 .DiffRemovedExtra            { color: #7f0505; } /* hsl(0,   92%,  26%) */

--- a/GitUI/Themes/darksilver.css
+++ b/GitUI/Themes/darksilver.css
@@ -33,20 +33,18 @@
 .MenuHighlight           { color: #7fabfd; }
 
 /* Application colors */
-.OtherTag                { color: #cccccc; }
-.AuthoredHighlight       { color: #373832; }
-.HighlightAllOccurences  { color: #606020; }
-.Tag                     { color: #408080; }
-.Graph                   { color: #882d00; }
-.Branch                  { color: #00d76b; }
-.DiffSection             { color: #4f4f4f; }
-.DiffAdded               { color: #054e2a; }
-.DiffAddedExtra          { color: #058545; }
-
-
+.OtherTag                    { color: #cccccc; }
+.AuthoredHighlight           { color: #373832; }
+.HighlightAllOccurences      { color: #606020; }
+.Tag                         { color: #408080; }
+.Graph                       { color: #882d00; }
+.Branch                      { color: #00d76b; }
 .RemoteBranch                { color: #ff8080; } /* hsl(0,   100%, 75%) */
 .RemoteBranch.colorblind     { color: #0080ff; } /* hsl(210, 100%, 50%) */
+.DiffSection                 { color: #4f4f4f; }
 .DiffRemoved                 { color: #5a0707; } /* hsl(0,   86%,  19%) */
 .DiffRemoved.colorblind      { color: #090755; } /* hsl(242, 85%,  18%) */
 .DiffRemovedExtra            { color: #7f0505; } /* hsl(0,   92%,  26%) */
 .DiffRemovedExtra.colorblind { color: #0b0698; } /* hsl(242, 92%,  31%) */
+.DiffAdded                   { color: #054e2a; }
+.DiffAddedExtra              { color: #058545; }

--- a/GitUI/Theming/ThemeModule.cs
+++ b/GitUI/Theming/ThemeModule.cs
@@ -58,9 +58,10 @@ namespace GitUI.Theming
             }
 
             ThemeId themeId = AppSettings.ThemeId;
+            string[] variations = AppSettings.ThemeVariations;
             if (string.IsNullOrEmpty(themeId.Name))
             {
-                return CreateFallbackSettings(invariantTheme);
+                return CreateFallbackSettings(invariantTheme, variations);
             }
 
             Theme theme;
@@ -71,7 +72,7 @@ namespace GitUI.Theming
             catch (ThemeException ex)
             {
                 MessageBoxes.ShowError(null, $"Failed to load {(themeId.IsBuiltin ? "preinstalled" : "user-defined")} theme {themeId.Name}: {ex}");
-                return CreateFallbackSettings(invariantTheme);
+                return CreateFallbackSettings(invariantTheme, variations);
             }
 
             if (!AppSettings.UseSystemVisualStyle && !_suppressWin32HooksForTests)
@@ -85,7 +86,7 @@ namespace GitUI.Theming
                 catch (Exception ex)
                 {
                     MessageBoxes.ShowError(null, $"Failed to install Win32 theming hooks: {ex}");
-                    return CreateFallbackSettings(invariantTheme);
+                    return CreateFallbackSettings(invariantTheme, variations);
                 }
             }
 
@@ -150,8 +151,8 @@ namespace GitUI.Theming
             }
         }
 
-        private static ThemeSettings CreateFallbackSettings(Theme invariantTheme) =>
-            new(Theme.Default, invariantTheme, ThemeVariations.None, useSystemVisualStyle: true);
+        private static ThemeSettings CreateFallbackSettings(Theme invariantTheme, string[] variations) =>
+            new(Theme.CreateDefaultTheme(variations), invariantTheme, variations, useSystemVisualStyle: true);
 
         internal static class TestAccessor
         {

--- a/UnitTests/GitUI.Tests/CommandsDialogs/SettingsDialog/Pages/ColorsPageSettingsPageControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/SettingsDialog/Pages/ColorsPageSettingsPageControllerTests.cs
@@ -44,24 +44,12 @@ namespace GitUITests.CommandsDialogs.SettingsDialog.Pages
         }
 
         [Test]
-        public void When_current_theme_is_default_choosing_theme_variation_should_be_enabled()
-        {
-            AppSettings.ThemeId = ThemeId.Default;
-            ThemeModule.TestAccessor.ReloadThemeSettings(_context.ThemeRepository);
-
-            _context.Controller.ShowThemeSettings();
-
-            _context.Page.IsChoosingThemeVariationsEnabled.Should().BeTrue();
-        }
-
-        [Test]
-        public void When_current_theme_is_non_default_choosing_visual_style_or_theme_variation_should_be_enabled()
+        public void When_current_theme_is_non_default_choosing_visual_style_should_be_enabled()
         {
             AppSettings.ThemeId = new ThemeId("non_default", isBuiltin: true);
             ThemeModule.TestAccessor.ReloadThemeSettings(_context.ThemeRepository);
-            _context.Controller.ShowThemeSettings();
 
-            _context.Page.IsChoosingThemeVariationsEnabled.Should().BeTrue();
+            _context.Controller.ShowThemeSettings();
             _context.Page.IsChoosingVisualStyleEnabled.Should().BeTrue();
         }
 
@@ -178,7 +166,6 @@ namespace GitUITests.CommandsDialogs.SettingsDialog.Pages
             public string[] SelectedThemeVariations { get; set; }
             public bool UseSystemVisualStyle { get; set; }
             public bool LabelRestartIsNeededVisible { get; set; }
-            public bool IsChoosingThemeVariationsEnabled { get; set; }
             public bool IsChoosingVisualStyleEnabled { get; set; }
 
             public void ShowThemeLoadingErrorMessage(ThemeId themeId, string[] variations, Exception ex) =>

--- a/UnitTests/GitUI.Tests/CommandsDialogs/SettingsDialog/Pages/ColorsPageSettingsPageControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/SettingsDialog/Pages/ColorsPageSettingsPageControllerTests.cs
@@ -34,15 +34,24 @@ namespace GitUITests.CommandsDialogs.SettingsDialog.Pages
         }
 
         [Test]
-        public void When_current_theme_is_default_choosing_visual_style_or_theme_variation_should_be_disabled()
+        public void When_current_theme_is_default_choosing_visual_style_should_be_disabled()
+        {
+            AppSettings.ThemeId = ThemeId.Default;
+            ThemeModule.TestAccessor.ReloadThemeSettings(_context.ThemeRepository);
+
+            _context.Controller.ShowThemeSettings();
+            _context.Page.IsChoosingVisualStyleEnabled.Should().BeFalse();
+        }
+
+        [Test]
+        public void When_current_theme_is_default_choosing_theme_variation_should_be_enabled()
         {
             AppSettings.ThemeId = ThemeId.Default;
             ThemeModule.TestAccessor.ReloadThemeSettings(_context.ThemeRepository);
 
             _context.Controller.ShowThemeSettings();
 
-            _context.Page.IsChoosingThemeVariationsEnabled.Should().BeFalse();
-            _context.Page.IsChoosingVisualStyleEnabled.Should().BeFalse();
+            _context.Page.IsChoosingThemeVariationsEnabled.Should().BeTrue();
         }
 
         [Test]


### PR DESCRIPTION
## Proposed changes

Default theme uses hardoded color values. Add hardcoded color values for colorblind variation as well.

## Screenshots

![image](https://user-images.githubusercontent.com/12046452/148318712-0596dcc6-0cd6-44eb-8b12-646946b143e0.png)

## Test methodology

Tested manually
ColorSettingsPage logic to not disable colorblind checkbox is covered by unit test

## Test environment(s) <!-- Remove any that don't apply -->

Windows 10

## Merge strategy

- Rebase merge (PR submitter must change the commit message for the last commit).

----
:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).