### PR TITLE
Add Blame Settings page

### DIFF
--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -154,6 +154,7 @@ namespace GitUI.CommandsDialogs
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<FormBrowseRepoSettingsPage>(this), detailedSettingsPage, Images.BranchFolder);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<CommitDialogSettingsPage>(this), detailedSettingsPage, Images.CommitSummary);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<DiffViewerSettingsPage>(this), detailedSettingsPage, Images.Diff);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<BlameViewerSettingsPage>(this), detailedSettingsPage, Images.Blame);
 
             var sshSettingsPage = SettingsPageBase.Create<SshSettingsPage>(this);
             settingsTreeView.AddSettingsPage(sshSettingsPage, gitExtPageRef, Images.Key);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.Designer.cs
@@ -1,0 +1,236 @@
+﻿namespace GitUI.CommandsDialogs.SettingsDialog.Pages
+{
+    partial class BlameViewerSettingsPage
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components is not null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.groupBoxBlameSettings = new System.Windows.Forms.GroupBox();
+            this.tableLayoutPanelBlameSettings = new System.Windows.Forms.TableLayoutPanel();
+            this.cbIgnoreWhitespace = new System.Windows.Forms.CheckBox();
+            this.cbDetectMoveAndCopyInThisFile = new System.Windows.Forms.CheckBox();
+            this.cbDetectMoveAndCopyInAllFiles = new System.Windows.Forms.CheckBox();
+            this.groupBoxDisplayResult = new System.Windows.Forms.GroupBox();
+            this.tableLayoutPanelDisplayResult = new System.Windows.Forms.TableLayoutPanel();
+            this.cbDisplayAuthorFirst = new System.Windows.Forms.CheckBox();
+            this.cbShowAuthor = new System.Windows.Forms.CheckBox();
+            this.cbShowAuthorDate = new System.Windows.Forms.CheckBox();
+            this.cbShowAuthorTime = new System.Windows.Forms.CheckBox();
+            this.cbShowLineNumbers = new System.Windows.Forms.CheckBox();
+            this.cbShowOriginalFilePath = new System.Windows.Forms.CheckBox();
+            this.cbShowAuthorAvatar = new System.Windows.Forms.CheckBox();
+            this.groupBoxBlameSettings.SuspendLayout();
+            this.tableLayoutPanelBlameSettings.SuspendLayout();
+            this.groupBoxDisplayResult.SuspendLayout();
+            this.tableLayoutPanelDisplayResult.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // groupBoxBlameSettings
+            // 
+            this.groupBoxBlameSettings.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBoxBlameSettings.AutoSize = true;
+            this.groupBoxBlameSettings.Controls.Add(this.tableLayoutPanelBlameSettings);
+            this.groupBoxBlameSettings.Location = new System.Drawing.Point(11, 11);
+            this.groupBoxBlameSettings.Name = "groupBoxBlameSettings";
+            this.groupBoxBlameSettings.Size = new System.Drawing.Size(319, 106);
+            this.groupBoxBlameSettings.TabIndex = 0;
+            this.groupBoxBlameSettings.TabStop = false;
+            this.groupBoxBlameSettings.Text = "Blame settings";
+            // 
+            // tableLayoutPanelBlameSettings
+            // 
+            this.tableLayoutPanelBlameSettings.AutoSize = true;
+            this.tableLayoutPanelBlameSettings.ColumnCount = 1;
+            this.tableLayoutPanelBlameSettings.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanelBlameSettings.Controls.Add(this.cbIgnoreWhitespace, 0, 0);
+            this.tableLayoutPanelBlameSettings.Controls.Add(this.cbDetectMoveAndCopyInThisFile, 1, 0);
+            this.tableLayoutPanelBlameSettings.Controls.Add(this.cbDetectMoveAndCopyInAllFiles, 2, 0);
+            this.tableLayoutPanelBlameSettings.Dock = System.Windows.Forms.DockStyle.Top;
+            this.tableLayoutPanelBlameSettings.Location = new System.Drawing.Point(3, 19);
+            this.tableLayoutPanelBlameSettings.Name = "tableLayoutPanelBlameSettings";
+            this.tableLayoutPanelBlameSettings.RowCount = 3;
+            this.tableLayoutPanelBlameSettings.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelBlameSettings.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelBlameSettings.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelBlameSettings.Size = new System.Drawing.Size(313, 84);
+            this.tableLayoutPanelBlameSettings.TabIndex = 0;
+            // 
+            // cbIgnoreWhitespace
+            // 
+            this.cbIgnoreWhitespace.Location = new System.Drawing.Point(3, 3);
+            this.cbIgnoreWhitespace.Name = "cbIgnoreWhitespace";
+            this.cbIgnoreWhitespace.Size = new System.Drawing.Size(247, 22);
+            this.cbIgnoreWhitespace.TabIndex = 0;
+            this.cbIgnoreWhitespace.Text = "Ignore whitespace";
+            // 
+            // cbDetectMoveAndCopyInThisFile
+            // 
+            this.cbDetectMoveAndCopyInThisFile.Location = new System.Drawing.Point(3, 31);
+            this.cbDetectMoveAndCopyInThisFile.Name = "cbDetectMoveAndCopyInThisFile";
+            this.cbDetectMoveAndCopyInThisFile.Size = new System.Drawing.Size(247, 22);
+            this.cbDetectMoveAndCopyInThisFile.TabIndex = 1;
+            this.cbDetectMoveAndCopyInThisFile.Text = "Detect move and copy in this file";
+            // 
+            // cbDetectMoveAndCopyInAllFiles
+            // 
+            this.cbDetectMoveAndCopyInAllFiles.Location = new System.Drawing.Point(3, 59);
+            this.cbDetectMoveAndCopyInAllFiles.Name = "cbDetectMoveAndCopyInAllFiles";
+            this.cbDetectMoveAndCopyInAllFiles.Size = new System.Drawing.Size(247, 22);
+            this.cbDetectMoveAndCopyInAllFiles.TabIndex = 2;
+            this.cbDetectMoveAndCopyInAllFiles.Text = "Detect move and copy in all files";
+            // 
+            // groupBoxDisplayResult
+            // 
+            this.groupBoxDisplayResult.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBoxDisplayResult.AutoSize = true;
+            this.groupBoxDisplayResult.Controls.Add(this.tableLayoutPanelDisplayResult);
+            this.groupBoxDisplayResult.Location = new System.Drawing.Point(11, 123);
+            this.groupBoxDisplayResult.Name = "groupBoxDisplayResult";
+            this.groupBoxDisplayResult.Size = new System.Drawing.Size(319, 218);
+            this.groupBoxDisplayResult.TabIndex = 1;
+            this.groupBoxDisplayResult.TabStop = false;
+            this.groupBoxDisplayResult.Text = "Display result settings";
+            // 
+            // tableLayoutPanelDisplayResult
+            // 
+            this.tableLayoutPanelDisplayResult.AutoSize = true;
+            this.tableLayoutPanelDisplayResult.ColumnCount = 1;
+            this.tableLayoutPanelDisplayResult.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanelDisplayResult.Controls.Add(this.cbDisplayAuthorFirst, 0, 0);
+            this.tableLayoutPanelDisplayResult.Controls.Add(this.cbShowAuthor, 1, 0);
+            this.tableLayoutPanelDisplayResult.Controls.Add(this.cbShowAuthorDate, 2, 0);
+            this.tableLayoutPanelDisplayResult.Controls.Add(this.cbShowAuthorTime, 3, 0);
+            this.tableLayoutPanelDisplayResult.Controls.Add(this.cbShowLineNumbers, 4, 0);
+            this.tableLayoutPanelDisplayResult.Controls.Add(this.cbShowOriginalFilePath, 5, 0);
+            this.tableLayoutPanelDisplayResult.Controls.Add(this.cbShowAuthorAvatar, 6, 0);
+            this.tableLayoutPanelDisplayResult.Dock = System.Windows.Forms.DockStyle.Top;
+            this.tableLayoutPanelDisplayResult.Location = new System.Drawing.Point(3, 19);
+            this.tableLayoutPanelDisplayResult.Name = "tableLayoutPanelDisplayResult";
+            this.tableLayoutPanelDisplayResult.RowCount = 7;
+            this.tableLayoutPanelDisplayResult.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelDisplayResult.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelDisplayResult.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelDisplayResult.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelDisplayResult.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelDisplayResult.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelDisplayResult.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanelDisplayResult.Size = new System.Drawing.Size(313, 196);
+            this.tableLayoutPanelDisplayResult.TabIndex = 0;
+            // 
+            // cbDisplayAuthorFirst
+            // 
+            this.cbDisplayAuthorFirst.Location = new System.Drawing.Point(3, 3);
+            this.cbDisplayAuthorFirst.Name = "cbDisplayAuthorFirst";
+            this.cbDisplayAuthorFirst.Size = new System.Drawing.Size(247, 22);
+            this.cbDisplayAuthorFirst.TabIndex = 0;
+            this.cbDisplayAuthorFirst.Text = "Display author first";
+            // 
+            // cbShowAuthor
+            // 
+            this.cbShowAuthor.Location = new System.Drawing.Point(3, 31);
+            this.cbShowAuthor.Name = "cbShowAuthor";
+            this.cbShowAuthor.Size = new System.Drawing.Size(247, 22);
+            this.cbShowAuthor.TabIndex = 1;
+            this.cbShowAuthor.Text = "Show author";
+            // 
+            // cbShowAuthorDate
+            // 
+            this.cbShowAuthorDate.Location = new System.Drawing.Point(3, 59);
+            this.cbShowAuthorDate.Name = "cbShowAuthorDate";
+            this.cbShowAuthorDate.Size = new System.Drawing.Size(247, 22);
+            this.cbShowAuthorDate.TabIndex = 2;
+            this.cbShowAuthorDate.Text = "Show author date";
+            // 
+            // cbShowAuthorTime
+            // 
+            this.cbShowAuthorTime.Location = new System.Drawing.Point(3, 87);
+            this.cbShowAuthorTime.Name = "cbShowAuthorTime";
+            this.cbShowAuthorTime.Size = new System.Drawing.Size(247, 22);
+            this.cbShowAuthorTime.TabIndex = 3;
+            this.cbShowAuthorTime.Text = "Show author time";
+            // 
+            // cbShowLineNumbers
+            // 
+            this.cbShowLineNumbers.Location = new System.Drawing.Point(3, 115);
+            this.cbShowLineNumbers.Name = "cbShowLineNumbers";
+            this.cbShowLineNumbers.Size = new System.Drawing.Size(247, 22);
+            this.cbShowLineNumbers.TabIndex = 4;
+            this.cbShowLineNumbers.Text = "Show line numbers";
+            // 
+            // cbShowOriginalFilePath
+            // 
+            this.cbShowOriginalFilePath.Location = new System.Drawing.Point(3, 143);
+            this.cbShowOriginalFilePath.Name = "cbShowOriginalFilePath";
+            this.cbShowOriginalFilePath.Size = new System.Drawing.Size(247, 22);
+            this.cbShowOriginalFilePath.TabIndex = 5;
+            this.cbShowOriginalFilePath.Text = "Show original file path";
+            // 
+            // cbShowAuthorAvatar
+            // 
+            this.cbShowAuthorAvatar.Location = new System.Drawing.Point(3, 171);
+            this.cbShowAuthorAvatar.Name = "cbShowAuthorAvatar";
+            this.cbShowAuthorAvatar.Size = new System.Drawing.Size(247, 22);
+            this.cbShowAuthorAvatar.TabIndex = 6;
+            this.cbShowAuthorAvatar.Text = "Show author avatar";
+            // 
+            // BlameViewerSettingsPage
+            // 
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
+            this.Controls.Add(this.groupBoxDisplayResult);
+            this.Controls.Add(this.groupBoxBlameSettings);
+            this.Name = "BlameViewerSettingsPage";
+            this.Size = new System.Drawing.Size(341, 351);
+            this.groupBoxBlameSettings.ResumeLayout(false);
+            this.groupBoxBlameSettings.PerformLayout();
+            this.tableLayoutPanelBlameSettings.ResumeLayout(false);
+            this.groupBoxDisplayResult.ResumeLayout(false);
+            this.groupBoxDisplayResult.PerformLayout();
+            this.tableLayoutPanelDisplayResult.ResumeLayout(false);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.GroupBox groupBoxBlameSettings;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelBlameSettings;
+        private System.Windows.Forms.CheckBox cbIgnoreWhitespace;
+        private System.Windows.Forms.CheckBox cbDetectMoveAndCopyInThisFile;
+        private System.Windows.Forms.CheckBox cbDetectMoveAndCopyInAllFiles;
+        private System.Windows.Forms.GroupBox groupBoxDisplayResult;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanelDisplayResult;
+        private System.Windows.Forms.CheckBox cbDisplayAuthorFirst;
+        private System.Windows.Forms.CheckBox cbShowAuthorDate;
+        private System.Windows.Forms.CheckBox cbShowAuthorTime;
+        private System.Windows.Forms.CheckBox cbShowLineNumbers;
+        private System.Windows.Forms.CheckBox cbShowAuthor;
+        private System.Windows.Forms.CheckBox cbShowOriginalFilePath;
+        private System.Windows.Forms.CheckBox cbShowAuthorAvatar;
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.cs
@@ -1,0 +1,49 @@
+﻿using GitCommands;
+
+namespace GitUI.CommandsDialogs.SettingsDialog.Pages
+{
+    public partial class BlameViewerSettingsPage : SettingsPageWithHeader
+    {
+        public BlameViewerSettingsPage()
+        {
+            InitializeComponent();
+            Text = "Blame Viewer";
+            InitializeComplete();
+        }
+
+        protected override void SettingsToPage()
+        {
+            cbIgnoreWhitespace.Checked = AppSettings.IgnoreWhitespaceOnBlame;
+            cbDetectMoveAndCopyInAllFiles.Checked = AppSettings.DetectCopyInAllOnBlame;
+            cbDetectMoveAndCopyInThisFile.Checked = AppSettings.DetectCopyInFileOnBlame;
+
+            cbDisplayAuthorFirst.Checked = AppSettings.BlameDisplayAuthorFirst;
+            cbShowAuthor.Checked = AppSettings.BlameShowAuthor;
+            cbShowAuthorDate.Checked = AppSettings.BlameShowAuthorDate;
+            cbShowAuthorTime.Checked = AppSettings.BlameShowAuthorTime;
+            cbShowLineNumbers.Checked = AppSettings.BlameShowLineNumbers;
+            cbShowOriginalFilePath.Checked = AppSettings.BlameShowOriginalFilePath;
+            cbShowAuthorAvatar.Checked = AppSettings.BlameShowAuthorAvatar;
+        }
+
+        protected override void PageToSettings()
+        {
+            AppSettings.IgnoreWhitespaceOnBlame = cbIgnoreWhitespace.Checked;
+            AppSettings.DetectCopyInAllOnBlame = cbDetectMoveAndCopyInAllFiles.Checked;
+            AppSettings.DetectCopyInFileOnBlame = cbDetectMoveAndCopyInThisFile.Checked;
+
+            AppSettings.BlameDisplayAuthorFirst = cbDisplayAuthorFirst.Checked;
+            AppSettings.BlameShowAuthor = cbShowAuthor.Checked;
+            AppSettings.BlameShowAuthorDate = cbShowAuthorDate.Checked;
+            AppSettings.BlameShowAuthorTime = cbShowAuthorTime.Checked;
+            AppSettings.BlameShowLineNumbers = cbShowLineNumbers.Checked;
+            AppSettings.BlameShowOriginalFilePath = cbShowOriginalFilePath.Checked;
+            AppSettings.BlameShowAuthorAvatar = cbShowAuthorAvatar.Checked;
+        }
+
+        public static SettingsPageReference GetPageReference()
+        {
+            return new SettingsPageReferenceByType(typeof(BlameViewerSettingsPage));
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.resx
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.resx
@@ -1,0 +1,60 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -541,6 +541,62 @@ Click this info icon for more details.</source>
       </trans-unit>
     </body>
   </file>
+  <file datatype="plaintext" original="BlameViewerSettingsPage" source-language="en">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Blame Viewer</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="cbDetectMoveAndCopyInAllFiles.Text">
+        <source>Detect move and copy in all files</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="cbDetectMoveAndCopyInThisFile.Text">
+        <source>Detect move and copy in this file</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="cbDisplayAuthorFirst.Text">
+        <source>Display author first</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="cbIgnoreWhitespace.Text">
+        <source>Ignore whitespace</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="cbShowAuthor.Text">
+        <source>Show author</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="cbShowAuthorAvatar.Text">
+        <source>Show author avatar</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="cbShowAuthorDate.Text">
+        <source>Show author date</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="cbShowAuthorTime.Text">
+        <source>Show author time</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="cbShowLineNumbers.Text">
+        <source>Show line numbers</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="cbShowOriginalFilePath.Text">
+        <source>Show original file path</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="groupBoxBlameSettings.Text">
+        <source>Blame settings</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="groupBoxDisplayResult.Text">
+        <source>Display result settings</source>
+        <target />
+      </trans-unit>
+    </body>
+  </file>
   <file datatype="plaintext" original="BranchComboBox" source-language="en">
     <body>
       <trans-unit id="_branchCheckoutError.Text">


### PR DESCRIPTION
Part of #9796

## Proposed changes

Blame settings is currently only in FileHistory. They are a little hidden there, hard to find them.
With master Blame is also in Browse so they need to be accessible.

Another option would have been to add them to the FileViewer context menu.
They would have to be added last in the menu to avoid messing with the FileViewer modes and the logic would have to be added to the blame control too.
Also if that is considered, it is expected to have this in Settings.

Designer opened, tab order tested

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Unchanged

![image](https://user-images.githubusercontent.com/6248932/148473091-f72b3f27-44c6-42a6-b67a-9ca3bc1cfb24.png)

### After

![image](https://user-images.githubusercontent.com/6248932/148473390-7e112412-d1e5-417a-a2ff-936a27647f0e.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
