### PR TITLE
Blame: Start on line also when control already exists

### DIFF
--- a/GitCommands/CommitData.cs
+++ b/GitCommands/CommitData.cs
@@ -9,7 +9,7 @@ namespace GitCommands
         public CommitData(
             ObjectId objectId,
             ObjectId? treeGuid,
-            IReadOnlyList<ObjectId> parentIds,
+            IReadOnlyList<ObjectId>? parentIds,
             string author,
             DateTime authorDate,
             string committer,
@@ -28,7 +28,7 @@ namespace GitCommands
 
         public ObjectId ObjectId { get; }
         public ObjectId? TreeGuid { get; } // TODO nothing seems to be using this value
-        public IReadOnlyList<ObjectId> ParentIds { get; }
+        public IReadOnlyList<ObjectId>? ParentIds { get; }
         public string Author { get; }
         public DateTimeOffset AuthorDate { get; }
         public string Committer { get; }

--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -167,11 +167,6 @@ namespace GitCommands
                 throw new ArgumentException($"Cannot have a null {nameof(GitRevision.ObjectId)}.", nameof(revision));
             }
 
-            if (revision.ParentIds is null)
-            {
-                throw new ArgumentException($"Cannot have null {nameof(GitRevision.ParentIds)}.", nameof(revision));
-            }
-
             return new CommitData(revision.ObjectId, revision.TreeGuid, revision.ParentIds,
                 string.Format("{0} <{1}>", revision.Author, revision.AuthorEmail), revision.AuthorDate,
                 string.Format("{0} <{1}>", revision.Committer, revision.CommitterEmail), revision.CommitDate,

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -714,7 +714,7 @@ namespace GitUI.Editor
                 var viewPosition = _currentViewPosition;
                 if (isDiff && _viewer.GetLineText(0) == viewPosition.FirstLine && viewPosition.ActiveLineNum is not null)
                 {
-                    // prefer the RightLineNum that is for the currentl revision
+                    // prefer the RightLineNum that is for the current revision
                     return viewPosition.ActiveLineNum.RightLineNumber != DiffLineInfo.NotApplicableLineNum
                         ? viewPosition.ActiveLineNum.RightLineNumber
                         : viewPosition.ActiveLineNum.LeftLineNumber;

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -713,10 +713,10 @@ namespace GitUI.Editor
                 var viewPosition = _currentViewPosition;
                 if (isDiff && _viewer.GetLineText(0) == viewPosition.FirstLine && viewPosition.ActiveLineNum is not null)
                 {
-                    // prefer the LeftLineNum because the base revision will not change
-                    return viewPosition.ActiveLineNum.LeftLineNumber != DiffLineInfo.NotApplicableLineNum
-                        ? viewPosition.ActiveLineNum.LeftLineNumber
-                        : viewPosition.ActiveLineNum.RightLineNumber;
+                    // prefer the RightLineNum that is for the currentl revision
+                    return viewPosition.ActiveLineNum.RightLineNumber != DiffLineInfo.NotApplicableLineNum
+                        ? viewPosition.ActiveLineNum.RightLineNumber
+                        : viewPosition.ActiveLineNum.LeftLineNumber;
                 }
 
                 // Convert from offset to line number

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -453,6 +453,7 @@ namespace GitUI.Editor
         public void GoToLine(int lineNumber)
         {
             TextEditor.ActiveTextAreaControl.Caret.Position = new TextLocation(0, GetCaretOffset(lineNumber, rightFile: true));
+            TextEditor.ActiveTextAreaControl.CenterViewOn(TextEditor.ActiveTextAreaControl.Caret.Position.Line, treshold: 5);
         }
 
         /// <summary>

--- a/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
+++ b/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
@@ -106,7 +106,7 @@ namespace ResourceManager.CommitDataRenders
             }
 
             var parentIds = commitData.ParentIds;
-            if (parentIds.Count != 0)
+            if (parentIds?.Count > 0)
             {
                 header.AppendLine(_labelFormatter.FormatLabel(TranslatedStrings.GetParents(parentIds.Count), padding) + RenderObjectIds(parentIds, showRevisionsAsLinks));
             }

--- a/UnitTests/CommonTestUtils/ReferenceRepository.cs
+++ b/UnitTests/CommonTestUtils/ReferenceRepository.cs
@@ -23,6 +23,8 @@ namespace CommonTestUtils
 
         public string CommitHash => _commitHash;
 
+        private const string _fileName = "A.txt";
+
         private string Commit(Repository repository, string commitMessage)
         {
             LibGit2Sharp.Signature author = new("GitUITests", "unittests@gitextensions.com", DateTimeOffset.Now);
@@ -39,14 +41,28 @@ namespace CommonTestUtils
             Console.WriteLine($"Created branch: {commitHash}, message: {branchName}");
         }
 
-        public void CreateCommit(string commitMessage, string content = null)
+        public string CreateCommit(string commitMessage, string content = null)
         {
             using LibGit2Sharp.Repository repository = new(_moduleTestHelper.Module.WorkingDir);
-            _moduleTestHelper.CreateRepoFile("A.txt", content ?? commitMessage);
-            repository.Index.Add("A.txt");
+            _moduleTestHelper.CreateRepoFile(_fileName, content ?? commitMessage);
+            repository.Index.Add(_fileName);
 
             _commitHash = Commit(repository, commitMessage);
             Console.WriteLine($"Created commit: {_commitHash}, message: {commitMessage}");
+            return _commitHash;
+        }
+
+        public string CreateCommit(string commitMessage, string content1, string fileName1, string content2, string fileName2)
+        {
+            using LibGit2Sharp.Repository repository = new(_moduleTestHelper.Module.WorkingDir);
+            _moduleTestHelper.CreateRepoFile(fileName1, content1);
+            repository.Index.Add(fileName1);
+            _moduleTestHelper.CreateRepoFile(fileName2, content2);
+            repository.Index.Add(fileName2);
+
+            _commitHash = Commit(repository, commitMessage);
+            Console.WriteLine($"Created commit: {_commitHash}, message: {commitMessage}");
+            return _commitHash;
         }
 
         public string CreateRepoFile(string fileName, string fileContent) => _moduleTestHelper.CreateRepoFile(fileName, fileContent);
@@ -122,8 +138,8 @@ namespace CommonTestUtils
         public void Stash(string stashMessage, string content = null)
         {
             using LibGit2Sharp.Repository repository = new(_moduleTestHelper.Module.WorkingDir);
-            _moduleTestHelper.CreateRepoFile("A.txt", content ?? stashMessage);
-            repository.Index.Add("A.txt");
+            _moduleTestHelper.CreateRepoFile(_fileName, content ?? stashMessage);
+            repository.Index.Add(_fileName);
 
             LibGit2Sharp.Signature author = new("GitUITests", "unittests@gitextensions.com", DateTimeOffset.Now);
             Stash stash = repository.Stashes.Add(author, stashMessage);


### PR DESCRIPTION
(This was seen when preparing #9424, no separate issue exists.)

## Proposed changes

Blame can start presenting on a line. This is is available in
RevDiff and RevFileTree since #9424.
(Even if the code enabling this has existed for long time.)

The "goto line" was only used if the control had to be init,
not if e.g. toggling to Diff and selecting an new diff line
and then Blame again.

Before #9804 This has to be tested in RevFileTree

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Before line 52 would have been displayed also the second time blame was activated

### After

First opening Blame on line 53, then on 152
Note that the "make visible" line is hidden in this screenshot, should be in the middle of the screen. This is standard FileViewer behavior.

![blame-line](https://user-images.githubusercontent.com/6248932/148592152-4211e0e0-5908-40f2-b1b3-8509cd842b58.gif)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
