### PR TITLE
AppTitle: File name in path filter first

### DIFF
--- a/GitCommands/AppTitleGenerator.cs
+++ b/GitCommands/AppTitleGenerator.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.ComponentModel.Composition;
+using System.IO;
 using GitCommands.UserRepositoryHistory;
 using GitUIPluginInterfaces;
 
@@ -49,19 +50,34 @@ namespace GitCommands
             branchName = branchName?.Trim('(', ')') ?? defaultBranchName;
 
             // Pathname normally have quotes already
-            pathName = string.IsNullOrWhiteSpace(pathName)
-                ? ""
-                    : pathName.StartsWith(@"""") && pathName.EndsWith(@"""")
-                        ? $"{pathName} "
-                        : $"{pathName.Quote()} ";
+            pathName = GetFileName(pathName);
 
             var description = _descriptionProvider.Get(workingDir);
 
 #if DEBUG
-            return $"{description} ({branchName}) {pathName}- {AppSettings.ApplicationName}{_extraInfo}";
+            return $"{pathName}{description} ({branchName}) - {AppSettings.ApplicationName}{_extraInfo}";
 #else
-            return $"{description} ({branchName}) {pathName}- {AppSettings.ApplicationName}";
+            return $"{pathName}{description} ({branchName}) - {AppSettings.ApplicationName}";
 #endif
+
+            string? GetFileName(string? path)
+            {
+                if (string.IsNullOrWhiteSpace(pathName))
+                {
+                    return null;
+                }
+
+                string filePart = Path.GetFileName(pathName.Trim('"')).QuoteNE();
+                if (string.IsNullOrWhiteSpace(filePart))
+                {
+                    // No file, just quote the pathFilter
+                    filePart = pathName.StartsWith(@"""") && pathName.EndsWith(@"""")
+                        ? pathName
+                        : $"{pathName.Quote()}";
+                }
+
+                return $"{filePart} ";
+            }
         }
 
         public static void Initialise(string sha, string buildBranch)

--- a/UnitTests/GitCommands.Tests/AppTitleGeneratorTests.cs
+++ b/UnitTests/GitCommands.Tests/AppTitleGeneratorTests.cs
@@ -71,7 +71,7 @@ namespace GitCommandsTests
             string branchName = "feature/my_(test)_branch";
             string pathName = "folder/folder/file";
             string title = _appTitleGenerator.Generate("a", true, branchName: "(" + branchName + ")", pathName: pathName);
-            title.Should().StartWith($@"{MockRepositoryDescriptionProvider.ShortName} ({branchName}) ""{pathName}"" - {AppSettings.ApplicationName}");
+            title.Should().StartWith($@"""file"" {MockRepositoryDescriptionProvider.ShortName} ({branchName}) - {AppSettings.ApplicationName}");
         }
 
         [Test]
@@ -79,7 +79,16 @@ namespace GitCommandsTests
         {
             string pathName = @"""folder/folder/file""";
             string title = _appTitleGenerator.Generate("a", true, pathName: pathName, defaultBranchName: _defaultBranchName);
-            title.Should().StartWith($@"{MockRepositoryDescriptionProvider.ShortName} ({_defaultBranchName}) {pathName} - {AppSettings.ApplicationName}");
+            title.Should().StartWith($@"""file"" {MockRepositoryDescriptionProvider.ShortName} ({_defaultBranchName}) - {AppSettings.ApplicationName}");
+        }
+
+        [TestCase(@"""folder/folder/""", @"folder/folder/")]
+        [TestCase(@"folder/folder/", @"folder/folder/")]
+        [TestCase(@"""folder/folder/f*ile extra""", @"f*ile extra")]
+        public void Generate_should_quote_paths_where_filenames_cannot_be_resolved(string pathName, string expectedPath)
+        {
+            string title = _appTitleGenerator.Generate("a", true, pathName: pathName, defaultBranchName: _defaultBranchName);
+            title.Should().StartWith($@"""{expectedPath}"" {MockRepositoryDescriptionProvider.ShortName} ({_defaultBranchName}) - {AppSettings.ApplicationName}");
         }
 
 #if DEBUG


### PR DESCRIPTION
Part of #9796 

## Proposed changes

If a path filter is applied, display the filename path (if not possible use the filter path) first in the app title.
This is to separate path filters similar to how FileHistory is separated but also show the filtered path better.

I am not thrilled by the ⏱ but have no better suggestions myself.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

FileHistory is not default in master but can be enabled

![image](https://user-images.githubusercontent.com/6248932/148613633-cfacbc4c-f45c-4dde-833a-242ba0f07061.png)

![image](https://user-images.githubusercontent.com/6248932/148613562-d72b1168-42ed-4107-bc62-b614bda49a8a.png)

### After

![image](https://user-images.githubusercontent.com/6248932/148613879-b7a5096b-291d-41df-b864-d671a100c0b3.png)

![image](https://user-images.githubusercontent.com/6248932/148613832-1e50758e-debb-4748-8463-b0720e101282.png)

## Test methodology <!-- How did you ensure quality? -->

Updated the app title tests.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
