### PR TITLE
ShowSimplifyByDecoration: Not dependent on branch filter

### DIFF
--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -123,6 +123,7 @@ the last selected commit.");
         private readonly TranslationString _limit = new("Limit");
         private readonly TranslationString _ignoreCase = new("Ignore case");
         private readonly TranslationString _pathFilter = new("Path filter");
+        private readonly TranslationString _simplifyByDecoration = new("Simplify by decoration");
 
         // public only because of FormTranslate
         public TranslatedStrings()
@@ -249,6 +250,7 @@ the last selected commit.");
         public static string Limit = _instance.Value._limit.Text;
         public static string IgnoreCase = _instance.Value._ignoreCase.Text;
         public static string PathFilter = _instance.Value._pathFilter.Text;
+        public static string SimplifyByDecoration = _instance.Value._simplifyByDecoration.Text;
 
         #region Scripts
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7420,10 +7420,6 @@ Do you want to use this custom merge script?</source>
         <source>OK</source>
         <target />
       </trans-unit>
-      <trans-unit id="SimplifyByDecorationCheck.Text">
-        <source>Simplify by decoration</source>
-        <target />
-      </trans-unit>
     </body>
   </file>
   <file datatype="plaintext" original="FormSelectMultipleBranches" source-language="en">
@@ -10903,6 +10899,10 @@ See documentation for more details about icons and range diffs.
 all the first selected with the last selected commit.
 - For more than four selected commits, show the difference from the first to
 the last selected commit.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_simplifyByDecoration.Text">
+        <source>Simplify by decoration</source>
         <target />
       </trans-unit>
       <trans-unit id="_since.Text">

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -198,6 +198,7 @@ namespace GitUI.UserControls.RevisionGrid
                     // If reflogs are shown, then we can't apply any filters
                     ByBranchFilter = false;
                     ShowCurrentBranchOnly = false;
+                    ShowSimplifyByDecoration = false;
                 }
             }
         }
@@ -216,7 +217,8 @@ namespace GitUI.UserControls.RevisionGrid
                    ByCommitter ||
                    ByMessage ||
                    ByPathFilter ||
-                   ByBranchFilter;
+                   ByBranchFilter ||
+                   ShowSimplifyByDecoration;
         }
 
         /// <summary>
@@ -291,6 +293,7 @@ namespace GitUI.UserControls.RevisionGrid
             ByMessage = false;
             ByPathFilter = false;
             ByBranchFilter = false;
+            ShowSimplifyByDecoration = false;
         }
 
         public ArgumentString GetRevisionFilter()
@@ -384,7 +387,12 @@ namespace GitUI.UserControls.RevisionGrid
                 filter.AppendLine($"{TranslatedStrings.Until}: {DateTo}");
             }
 
-            // Ignore IgnoreCase, CurrentBranchOnlyCheck, SimplifyByDecorationCheck
+            if (ShowSimplifyByDecoration)
+            {
+                filter.AppendLine($"{TranslatedStrings.SimplifyByDecoration}");
+            }
+
+            // Ignore IgnoreCase, CurrentBranchOnlyCheck
 
             return filter.ToString();
         }

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
@@ -58,6 +58,7 @@
             this.BranchFilter = new System.Windows.Forms.TextBox();
             this.CurrentBranchOnlyCheck = new System.Windows.Forms.CheckBox();
             this.SimplifyByDecorationCheck = new System.Windows.Forms.CheckBox();
+            this._NO_TRANSLATE_lblSimplifyByDecoration = new System.Windows.Forms.Label();
             this.MainPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this._NO_TRANSLATE_CommitsLimit)).BeginInit();
             this.tableLayoutPanel1.SuspendLayout();
@@ -234,7 +235,8 @@
             this.tableLayoutPanel1.Controls.Add(this.BranchFilterCheck, 1, 8);
             this.tableLayoutPanel1.Controls.Add(this.BranchFilter, 2, 8);
             this.tableLayoutPanel1.Controls.Add(this.CurrentBranchOnlyCheck, 2, 9);
-            this.tableLayoutPanel1.Controls.Add(this.SimplifyByDecorationCheck, 2, 10);
+            this.tableLayoutPanel1.Controls.Add(this.SimplifyByDecorationCheck, 1, 10);
+            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_lblSimplifyByDecoration, 2, 10);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(12, 12);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
@@ -394,12 +396,21 @@
             // 
             this.SimplifyByDecorationCheck.AutoSize = true;
             this.SimplifyByDecorationCheck.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.SimplifyByDecorationCheck.Location = new System.Drawing.Point(96, 280);
+            this.SimplifyByDecorationCheck.Location = new System.Drawing.Point(76, 280);
             this.SimplifyByDecorationCheck.Name = "SimplifyByDecorationCheck";
             this.SimplifyByDecorationCheck.Size = new System.Drawing.Size(285, 19);
-            this.SimplifyByDecorationCheck.Text = "Simplify by decoration";
             this.SimplifyByDecorationCheck.UseVisualStyleBackColor = true;
             this.SimplifyByDecorationCheck.CheckedChanged += new System.EventHandler(this.option_CheckedChanged);
+            // 
+            // _NO_TRANSLATE_lblSimplifyByDecoration
+            // 
+            this._NO_TRANSLATE_lblSimplifyByDecoration.AutoSize = true;
+            this._NO_TRANSLATE_lblSimplifyByDecoration.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_lblSimplifyByDecoration.Location = new System.Drawing.Point(96, 280);
+            this._NO_TRANSLATE_lblSimplifyByDecoration.Name = "_NO_TRANSLATE_lblSimplifyByDecoration";
+            this._NO_TRANSLATE_lblSimplifyByDecoration.Size = new System.Drawing.Size(67, 29);
+            this._NO_TRANSLATE_lblSimplifyByDecoration.Text = "Simplify by decoration";
+            this._NO_TRANSLATE_lblSimplifyByDecoration.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // FormRevisionFilter
             // 
@@ -453,5 +464,6 @@
         private System.Windows.Forms.CheckBox CurrentBranchOnlyCheck;
         private System.Windows.Forms.CheckBox BranchFilterCheck;
         private System.Windows.Forms.CheckBox SimplifyByDecorationCheck;
+        private System.Windows.Forms.Label _NO_TRANSLATE_lblSimplifyByDecoration;
     }
 }

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -28,6 +28,7 @@ namespace GitUI.UserControls.RevisionGrid
             _NO_TRANSLATE_lblLimit.Text = TranslatedStrings.Limit;
             _NO_TRANSLATE_lblPathFilter.Text = TranslatedStrings.PathFilter;
             _NO_TRANSLATE_lblBranches.Text = TranslatedStrings.Branches;
+            _NO_TRANSLATE_lblSimplifyByDecoration.Text = TranslatedStrings.SimplifyByDecoration;
 
             _filterInfo = filterInfo;
 
@@ -89,9 +90,7 @@ namespace GitUI.UserControls.RevisionGrid
             PathFilter.Enabled = PathFilterCheck.Checked;
 
             CurrentBranchOnlyCheck.Enabled = BranchFilterCheck.Checked;
-            SimplifyByDecorationCheck.Enabled = BranchFilterCheck.Checked;
-            BranchFilter.Enabled = BranchFilterCheck.Checked &&
-                                   !CurrentBranchOnlyCheck.Checked;
+            BranchFilter.Enabled = BranchFilterCheck.Checked && !CurrentBranchOnlyCheck.Checked;
         }
 
         private void OkClick(object sender, EventArgs e)
@@ -114,7 +113,7 @@ namespace GitUI.UserControls.RevisionGrid
             _filterInfo.ByBranchFilter = BranchFilterCheck.Checked;
             _filterInfo.BranchFilter = BranchFilter.Text;
             _filterInfo.ShowCurrentBranchOnly = BranchFilterCheck.Checked && CurrentBranchOnlyCheck.Checked;
-            _filterInfo.ShowSimplifyByDecoration = BranchFilterCheck.Checked && SimplifyByDecorationCheck.Checked;
+            _filterInfo.ShowSimplifyByDecoration = SimplifyByDecorationCheck.Checked;
         }
     }
 }


### PR DESCRIPTION
Fixes #4642
Fixes #9548
Fixes #7354

(This is really initiated by looking at documentation, issues are found later.)

## Proposed changes

ShowSimplifyByDecoration has been incorrectly set as dependent of
Branches filter (at least since 2.51). This is an independent revision filter.

https://git-scm.com/docs/git-log#Documentation/git-log.txt---simplify-by-decoration

This PR disconnects the option from Branches.

The implementation can probaly be done better, this is just better than what is.

Enabling the option shows the commits with branches/tags only

![image](https://user-images.githubusercontent.com/6248932/148660690-9eb9a207-4678-4bd0-b759-b01d931b2886.png)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/148660714-d7f67091-19d7-47a8-9199-56e07aa39586.png)

### After

![image](https://user-images.githubusercontent.com/6248932/148660725-a270a9e2-dea8-4945-8887-58ba568e76f5.png)

Tooltip when active

![image](https://user-images.githubusercontent.com/6248932/148660758-59d4dbdd-4de0-4915-b489-d882a09d649b.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
