### PR TITLE
Reset theme to default

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1432,16 +1432,30 @@ namespace GitCommands
 
         public static ThemeId ThemeId
         {
+            // Updating key names in v4.0, to force resetting to default
+            // (as dark themes look bad due to SUPPORT_THEME_HOOKS no longer supported)
             get
             {
                 return new ThemeId(
-                    GetString("uitheme", ThemeId.Default.Name),
-                    GetBool("uithemeisbuiltin", ThemeId.Default.IsBuiltin));
+                    GetString("uitheme_v2", ThemeId.Default.Name),
+                    GetBool("uithemeisbuiltin_v2", ThemeId.Default.IsBuiltin));
             }
             set
             {
-                SetString("uitheme", value.Name ?? string.Empty);
-                SetBool("uithemeisbuiltin", value.IsBuiltin);
+                SetString("uitheme_v2", value.Name ?? string.Empty);
+                SetBool("uithemeisbuiltin_v2", value.IsBuiltin);
+            }
+        }
+
+        public static string? ThemeIdName_v1
+        {
+            get
+            {
+                return GetString("uitheme", null);
+            }
+            set
+            {
+                SetString("uitheme", value);
             }
         }
 


### PR DESCRIPTION
Fixes #9812
Really just point 2, but I find this sufficient - I would settle with just changing the name of the setting.

## Proposed changes

Change the settings name key to force resetting the theme
with application colors to default, as dark theme application colors will
not look good without hooks for system colors.

The user is warned once when starting the first time if the
theme is other than the default.

## Screenshots <!-- Remove this section if PR does not change UI -->

### After

First time starting up with a non default theme
![image](https://user-images.githubusercontent.com/6248932/149221388-14f86307-21b2-4dce-9ab2-f6b1f35d12ab.png)

## Test methodology <!-- How did you ensure quality? -->

- Setting non default theme (using 3.5 or master)
- Start with this PR and verify the poup
- Start again, verify no popup

- Set default theme (using 3.5 or master)
- Start, verify no popup

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
