### PR TITLE
BlameControl: cancellation token for git-blame

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3260,7 +3260,7 @@ namespace GitCommands
             return _gitTreeParser.Parse(tree);
         }
 
-        public GitBlame Blame(string? fileName, string from, Encoding encoding, string? lines = null)
+        public GitBlame Blame(string? fileName, string from, Encoding encoding, string? lines = null, CancellationToken cancellationToken = default)
         {
             GitArgumentBuilder args = new("blame")
             {
@@ -3275,7 +3275,13 @@ namespace GitCommands
                 fileName.ToPosixPath().Quote()
             };
 
-            var output = _gitExecutable.GetOutput(args, cache: GitCommandCache, outputEncoding: LosslessEncoding);
+            ExecutionResult result = _gitExecutable.Execute(
+                args,
+                cache: GitCommandCache,
+                outputEncoding: LosslessEncoding,
+                cancellationToken: cancellationToken);
+
+            var output = result.StandardOutput;
 
             try
             {

--- a/GitUI/CommandsDialogs/FormBlame.cs
+++ b/GitUI/CommandsDialogs/FormBlame.cs
@@ -34,7 +34,7 @@ namespace GitUI.CommandsDialogs
 
             FileName = fileName;
 
-            blameControl1.LoadBlame(revision ?? Module.GetRevision(), null, fileName, null, null, Module.FilesEncoding, initialLine);
+            _ = blameControl1.LoadBlameAsync(revision ?? Module.GetRevision(), null, fileName, null, null, Module.FilesEncoding, initialLine);
             blameControl1.ConfigureRepositoryHostPlugin(PluginRegistry.TryGetGitHosterForModule(Module));
         }
 

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -340,7 +340,7 @@ namespace GitUI.CommandsDialogs
 
             if (tabControl1.SelectedTab == BlameTab)
             {
-                Blame.LoadBlame(revision, children, fileName, RevisionGrid, BlameTab, Diff.Encoding, force: force);
+                _ = Blame.LoadBlameAsync(revision, children, fileName, RevisionGrid, BlameTab, Diff.Encoding, force: force, cancellationToken: _viewChangesSequence.Next());
             }
             else if (tabControl1.SelectedTab == ViewTab)
             {

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
@@ -7,19 +7,6 @@
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary> 
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components is not null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         #region Component Designer generated code
 
         /// <summary> 

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -328,6 +328,11 @@ namespace GitUI.Editor
             }
         }
 
+        public void ClearBlameGutter()
+        {
+            internalFileViewer.ShowGutterAvatars = false;
+        }
+
         public void ReloadHotkeys()
         {
             Hotkeys = HotkeySettingsManager.LoadHotkeys(HotkeySettingsName);
@@ -649,9 +654,11 @@ namespace GitUI.Editor
             }
         }
 
+        public Task ClearAsync() => ViewTextAsync("", "");
+
         public void Clear()
         {
-            ThreadHelper.JoinableTaskFactory.Run(() => ViewTextAsync("", ""));
+            ThreadHelper.JoinableTaskFactory.Run(() => ClearAsync());
         }
 
         /// <summary>
@@ -863,24 +870,25 @@ namespace GitUI.Editor
             }
         }
 
-        private Task ShowOrDeferAsync(long contentLength, Func<Task> showFunc)
+        private async Task ShowOrDeferAsync(long contentLength, Func<Task> showFunc)
         {
             const long maxLength = 5 * 1024 * 1024;
 
             if (contentLength > maxLength)
             {
-                Clear();
+                await ClearAsync();
                 Refresh();
                 _NO_TRANSLATE_lblShowPreview.Text = string.Format(_largeFileSizeWarning.Text, contentLength / (1024d * 1024));
                 _NO_TRANSLATE_lblShowPreview.Show();
                 _deferShowFunc = showFunc;
-                return Task.CompletedTask;
+                return;
             }
             else
             {
                 _NO_TRANSLATE_lblShowPreview.Hide();
                 _deferShowFunc = null;
-                return showFunc();
+                await showFunc();
+                return;
             }
         }
 

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -48,7 +48,7 @@ namespace GitUI
                     return;
                 }
 
-                fileViewer.Clear();
+                await fileViewer.ClearAsync();
                 return;
             }
 


### PR DESCRIPTION
## Proposed changes

git-blame may require considerable time, the git executable
must be cancelable.
For instance git-blame of "GitUI/Translation/en_pseudo.xlf" takes about a minute for me.

Clear the blame viewer when processing a new file.
Before the contents of the previous file was not cleared, which was confusing.
(This was not a problem when a separate FileHistory had to be opened for Blame, but is now when Blame can be viewed in FileTree and RevDidd).

Note that cancelling the Git command will not kill the Git process. So clicking around in the file tree can start several long running processes.
Before, they always ran to completion in GitModule, now they are aborted (no exit status and short runtime in command log).
So in some sense cancelling is worse as the command still runs but command cache is not updated if the file is viewed again...
process.Kill() could be used when cancellation is done.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

(You can see that the second time English-plugins.xlf is clicked that it is quickly displayed as git-blame ran to completion before the executable was cancelled).
![blame-view-0](https://user-images.githubusercontent.com/6248932/149413774-3757c983-2131-4be2-97ec-c5c13960d79c.gif)

### After

![blame-view-1](https://user-images.githubusercontent.com/6248932/149413791-1b2d517d-4b4a-4da2-86b6-e53ee4e5ee08.gif)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
