### PR TITLE
Ignore nonexisting submodule paths

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2490,10 +2490,19 @@ namespace GitUI.CommandsDialogs
 
         private void SubmoduleToolStripButtonClick(object sender, EventArgs e)
         {
-            if (sender is ToolStripMenuItem menuSender)
+            if (sender is not ToolStripMenuItem menuSender)
             {
-                SetWorkingDir(menuSender.Tag as string);
+                return;
             }
+
+            string path = menuSender.Tag as string;
+            if (!Directory.Exists(path))
+            {
+                MessageBoxes.SubmoduleDirectoryDoesNotExist(this, path);
+                return;
+            }
+
+            SetWorkingDir(path);
         }
 
         private void toolStripButtonLevelUp_DropDownOpening(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -345,7 +345,14 @@ See the changes in the commit form.");
 
         private void SpawnCommitBrowser(GitItem item)
         {
-            GitUICommands.LaunchBrowse(workingDir: _fullPathResolver.Resolve(item.FileName.EnsureTrailingPathSeparator()) ?? "", selectedId: item.ObjectId);
+            string path = _fullPathResolver.Resolve(item.FileName.EnsureTrailingPathSeparator()) ?? "";
+            if (!Directory.Exists(path))
+            {
+                MessageBoxes.SubmoduleDirectoryDoesNotExist(this, path, item.Name);
+                return;
+            }
+
+            GitUICommands.LaunchBrowse(workingDir: path, selectedId: item.ObjectId);
         }
 
         private void tvGitTree_AfterSelect(object sender, TreeViewEventArgs e)

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -369,9 +369,14 @@ namespace GitUI
         /// <param name="workingDir">The working directory for the new process.</param>
         /// <param name="selectedId">The optional commit to be selected.</param>
         /// <param name="firstId">The first commit to be selected, the first commit in a diff.</param>
-        /// <returns>The <see cref="IProcess"/> object for controlling the launched instance.</returns>
-        public static IProcess LaunchBrowse(string workingDir = "", ObjectId? selectedId = null, ObjectId? firstId = null)
+        public static void LaunchBrowse(string workingDir = "", ObjectId? selectedId = null, ObjectId? firstId = null)
         {
+            if (!Directory.Exists(workingDir))
+            {
+                MessageBoxes.GitExtensionsDirectoryDoesNotExist(owner: null, workingDir);
+                return;
+            }
+
             StringBuilder arguments = new("browse");
 
             if (selectedId is null)
@@ -389,7 +394,7 @@ namespace GitUI
                 }
             }
 
-            return Launch(arguments.ToString(), workingDir);
+            Launch(arguments.ToString(), workingDir);
         }
 
         public bool StartCompareRevisionsDialog(IWin32Window? owner = null)

--- a/GitUI/MessageBoxes.cs
+++ b/GitUI/MessageBoxes.cs
@@ -44,6 +44,11 @@ namespace GitUI
         private readonly TranslationString _shellNotFound = new("The selected shell is not installed, or is not on your path.");
         private readonly TranslationString _resetChangesCaption = new("Reset changes");
 
+        private readonly TranslationString _submoduleDirectoryDoesNotExist = new(@"The directory ""{0}"" does not exist for submodule ""{1}"".");
+        private readonly TranslationString _directoryDoesNotExist = new(@"The directory ""{0}"" does not exist.");
+        private readonly TranslationString _cannotOpenSubmoduleCaption = new("Cannot open submodule");
+        private readonly TranslationString _cannotOpenGitExtensionsCaption = new("Cannot open Git Extensions");
+
         // internal for FormTranslate
         internal MessageBoxes()
         {
@@ -80,6 +85,15 @@ namespace GitUI
 
         public static void SelectOnlyOneOrTwoRevisions(IWin32Window? owner)
             => ShowError(owner, Instance._selectOnlyOneOrTwoRevisions.Text, Instance._archiveRevisionCaption.Text);
+
+        public static void SubmoduleDirectoryDoesNotExist(IWin32Window? owner, string directory, string submoduleName)
+            => ShowError(owner, string.Format(Instance._submoduleDirectoryDoesNotExist.Text, directory, submoduleName), Instance._cannotOpenSubmoduleCaption.Text);
+
+        public static void SubmoduleDirectoryDoesNotExist(IWin32Window? owner, string directory)
+            => ShowError(owner, string.Format(Instance._directoryDoesNotExist.Text, directory), Instance._cannotOpenSubmoduleCaption.Text);
+
+        public static void GitExtensionsDirectoryDoesNotExist(IWin32Window? owner, string directory)
+            => ShowError(owner, string.Format(Instance._directoryDoesNotExist.Text, directory), Instance._cannotOpenGitExtensionsCaption.Text);
 
         public static bool CacheHostkey(IWin32Window? owner)
             => Confirm(owner, Instance._serverHostkeyNotCachedText.Text, "SSH");

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8649,6 +8649,18 @@ help</source>
         <source>Archive revision</source>
         <target />
       </trans-unit>
+      <trans-unit id="_cannotOpenGitExtensionsCaption.Text">
+        <source>Cannot open Git Extensions</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_cannotOpenSubmoduleCaption.Text">
+        <source>Cannot open submodule</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_directoryDoesNotExist.Text">
+        <source>The directory "{0}" does not exist.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_failedToExecuteScript.Text">
         <source>Failed to execute script</source>
         <target />
@@ -8709,6 +8721,10 @@ Do you want to trust this host key and then try again?</source>
       </trans-unit>
       <trans-unit id="_shellNotFoundCaption.Text">
         <source>Shell not found</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_submoduleDirectoryDoesNotExist.Text">
+        <source>The directory "{0}" does not exist for submodule "{1}".</source>
         <target />
       </trans-unit>
       <trans-unit id="_theRepositorySubmodules.Text">

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -852,7 +852,14 @@ namespace GitUI
                 : status?.Commit;
             ObjectId? firstId = status?.OldCommit;
 
-            GitUICommands.LaunchBrowse(workingDir: _fullPathResolver.Resolve(submoduleName.EnsureTrailingPathSeparator()) ?? "", selectedId, firstId);
+            string path = _fullPathResolver.Resolve(submoduleName.EnsureTrailingPathSeparator()) ?? "";
+            if (!Directory.Exists(path))
+            {
+                MessageBoxes.SubmoduleDirectoryDoesNotExist(this, path, submoduleName);
+                return;
+            }
+
+            GitUICommands.LaunchBrowse(workingDir: path, selectedId, firstId);
         }
 
         private void SelectItems(Func<ListViewItem, bool> predicate)


### PR DESCRIPTION

Fixes #8366

## Proposed changes

Show MessageBox with submodule information

Replaces #9612, also some other situations handling #9056
This could be done in a nicer way, but this is important to point users in a better direction just not ignoring (as in 3.5) or showing a popup recommending to report an issue on GE (as in master).
For users, the behavior in master seem like a regression.

1. See #9612 - due to null types in master
Note that the popup is shown two times when opening a repo (structure and status) then periodically when status is updated. (So did the Validate error.)
The popup could be limited to be shown for just the first popup when the structure has been updated, but this is an error in the repo setup.

See this (auto closed) PR for how to recreate the issue.

2. Open when submodule path (not yet) exists due to #9056
  - Submodule Open in Sidepanel 
  - Submodule open in RevDiff/RevFileTree
  - Submodule open in Browse submodule toolbar

This is easiest done by deleting or renaming a submodule.
This also occurred when doubleclicking a submodule no longer existing, for instance the GitExtensionsDoc for commits two years ago.
Some occurrences like doubleclicking a deleted submodule in RevDiff was previously just ignored.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

See also #9612 

![image](https://user-images.githubusercontent.com/6248932/149637988-58367556-57ec-44a8-82ea-b6da86324302.png)

### After

![image](https://user-images.githubusercontent.com/6248932/149638059-8b03b064-5a89-4759-a675-da1c5c6a6b30.png)

![image](https://user-images.githubusercontent.com/6248932/149637999-d6e7f5e0-3553-448e-9a6f-2c39c41a6e7d.png)

![image](https://user-images.githubusercontent.com/6248932/149638006-5210aa5a-b43e-4729-ad19-33f1cea70bfb.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
