### PR TITLE
Allow move toolstrips (take 2)

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -2174,7 +2174,7 @@ namespace GitCommands
 
         private static bool? _isDesignMode;
 
-        private static bool IsDesignMode
+        public static bool IsDesignMode
         {
             get
             {

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -238,7 +238,6 @@ namespace GitUI.CommandsDialogs
             this.ToolStripMain.ClickThrough = true;
             this.ToolStripMain.Dock = System.Windows.Forms.DockStyle.None;
             this.ToolStripMain.DrawBorder = false;
-            this.ToolStripMain.GripEnabled = false;
             this.ToolStripMain.GripMargin = new System.Windows.Forms.Padding(0);
             this.ToolStripMain.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.ToolStripMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -1696,7 +1695,6 @@ namespace GitUI.CommandsDialogs
             this.ToolStripScripts.ClickThrough = true;
             this.ToolStripScripts.Dock = System.Windows.Forms.DockStyle.None;
             this.ToolStripScripts.DrawBorder = false;
-            this.ToolStripScripts.GripEnabled = false;
             this.ToolStripScripts.GripMargin = new System.Windows.Forms.Padding(0);
             this.ToolStripScripts.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.ToolStripScripts.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;

--- a/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
@@ -265,6 +265,29 @@ namespace GitUI.CommandsDialogs
             }
         }
 
+        private void ResetToolbarsLayout()
+        {
+            ToolStrip[] toolStrips = _managedToolStrips;
+
+            toolPanel.TopToolStripPanel.Controls.Clear();
+
+            for (int i = 0; i < toolStrips.Length; i++)
+            {
+                ToolStrip toolStrip = toolStrips[i];
+                if (i == 0)
+                {
+                    toolStrip.Location = new();
+                }
+                else
+                {
+                    Rectangle previousBounds = toolStrips[i - 1].Bounds;
+                    toolStrip.Location = new(previousBounds.X + previousBounds.Width + 1, 0);
+                }
+
+                toolPanel.TopToolStripPanel.Controls.Add(toolStrip);
+            }
+        }
+
         private void RestoreToolbarsLayout()
         {
             Padding originalPadding = toolPanel.TopToolStripPanel.Padding;
@@ -276,31 +299,12 @@ namespace GitUI.CommandsDialogs
                 toolPanel.TopToolStripPanel.Controls.Clear();
 
                 // Reset padding to zero before restoring. Refer to https://github.com/gitextensions/gitextensions/issues/8680#issuecomment-922801438
-                toolPanel.TopToolStripPanel.Padding = new Padding(0, 0, 0, 0);
+                toolPanel.TopToolStripPanel.Padding = new(0);
 
                 IToolStripSettingsManager manager = ManagedExtensibility.GetExport<IToolStripSettingsManager>().Value;
                 manager.Load(
                     ownerForm: this,
-                    invalidSettingsHandler: toolStrips =>
-                    {
-                        // In event there is no settings for the strips (e.g., we're loading for the 1st time, or the user has cleared the settings)
-                        // we need to add the strips manually
-                        for (int i = 0; i < toolStrips.Length; i++)
-                        {
-                            ToolStrip toolStrip = toolStrips[i];
-                            if (i == 0)
-                            {
-                                toolStrip.Location = new();
-                            }
-                            else
-                            {
-                                Rectangle previousBounds = toolStrips[i - 1].Bounds;
-                                toolStrip.Location = new(previousBounds.X + previousBounds.Width + 1, 0);
-                            }
-
-                            toolPanel.TopToolStripPanel.Controls.Add(toolStrip);
-                        }
-                    },
+                    invalidSettingsHandler: () => ResetToolbarsLayout(),
                     _managedToolStrips);
             }
             finally

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -284,6 +284,7 @@ namespace GitUI.CommandsDialogs
             InitCountArtificial(out _gitStatusMonitor);
 
             _formBrowseMenus = new FormBrowseMenus(mainMenuStrip);
+            _formBrowseMenus.ResetToolStrips += (s, e) => ResetToolbarsLayout();
 
             RevisionGrid.SuspendRefreshRevisions();
 
@@ -454,7 +455,7 @@ namespace GitUI.CommandsDialogs
 
             base.OnLoad(e);
 
-            _formBrowseMenus.CreateToolbarsMenus(ToolStripMain, ToolStripFilters, ToolStripScripts);
+            _formBrowseMenus.CreateToolbarsMenus(_managedToolStrips);
 
             // The toolbars layouts must be restored *after* WindowPositionManager is called.
             RestoreToolbarsLayout();
@@ -919,7 +920,7 @@ namespace GitUI.CommandsDialogs
                 UICommands.RaisePostBrowseInitialize(this);
             }
 
-            toolPanel.TopToolStripPanel.ResumeLayout();
+            toolPanel.TopToolStripPanel.ResumeLayout(performLayout: false);
             toolPanel.ResumeLayout();
 
             return;
@@ -2361,30 +2362,27 @@ namespace GitUI.CommandsDialogs
             // Some commands like delete branch could be available for artificial as no default is used,
             // but hide for consistency
             branchToolStripMenuItem.Enabled =
-            deleteBranchToolStripMenuItem.Enabled =
-            mergeBranchToolStripMenuItem.Enabled =
-            rebaseToolStripMenuItem.Enabled =
-            checkoutBranchToolStripMenuItem.Enabled =
-            cherryPickToolStripMenuItem.Enabled =
-            checkoutToolStripMenuItem.Enabled =
-            bisectToolStripMenuItem.Enabled =
-                singleNormalCommit && !Module.IsBareRepository();
+                deleteBranchToolStripMenuItem.Enabled =
+                mergeBranchToolStripMenuItem.Enabled =
+                rebaseToolStripMenuItem.Enabled =
+                checkoutBranchToolStripMenuItem.Enabled =
+                cherryPickToolStripMenuItem.Enabled =
+                checkoutToolStripMenuItem.Enabled =
+                bisectToolStripMenuItem.Enabled = singleNormalCommit && !Module.IsBareRepository();
 
             tagToolStripMenuItem.Enabled =
-            deleteTagToolStripMenuItem.Enabled =
-            archiveToolStripMenuItem.Enabled =
-                singleNormalCommit;
+                deleteTagToolStripMenuItem.Enabled =
+                archiveToolStripMenuItem.Enabled = singleNormalCommit;
 
             // Not operating on selected revision
             commitToolStripMenuItem.Enabled =
-            undoLastCommitToolStripMenuItem.Enabled =
-            runMergetoolToolStripMenuItem.Enabled =
-            stashToolStripMenuItem.Enabled =
-            resetToolStripMenuItem.Enabled =
-            cleanupToolStripMenuItem.Enabled =
-            toolStripMenuItemReflog.Enabled =
-            applyPatchToolStripMenuItem.Enabled =
-                !Module.IsBareRepository();
+                undoLastCommitToolStripMenuItem.Enabled =
+                runMergetoolToolStripMenuItem.Enabled =
+                stashToolStripMenuItem.Enabled =
+                resetToolStripMenuItem.Enabled =
+                cleanupToolStripMenuItem.Enabled =
+                toolStripMenuItemReflog.Enabled =
+                applyPatchToolStripMenuItem.Enabled = !Module.IsBareRepository();
         }
 
         private void PullToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -454,10 +454,10 @@ namespace GitUI.CommandsDialogs
 
             base.OnLoad(e);
 
+            _formBrowseMenus.CreateToolbarsMenus(ToolStripMain, ToolStripFilters, ToolStripScripts);
+
             // The toolbars layouts must be restored *after* WindowPositionManager is called.
             RestoreToolbarsLayout();
-
-            _formBrowseMenus.CreateToolbarsMenus(ToolStripMain, ToolStripFilters, ToolStripScripts);
 
             _formBrowseDiagnosticsReporter.Report();
 

--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -31,6 +31,11 @@ namespace GitUI
         /// will be restored upon being re-opened.</param>
         protected GitExtensionsForm(bool enablePositionRestore)
         {
+            if (IsDesignMode)
+            {
+                return;
+            }
+
             var needsPositionSave = enablePositionRestore;
             _needsPositionRestore = enablePositionRestore;
 

--- a/GitUI/Theming/AppColorExtension.cs
+++ b/GitUI/Theming/AppColorExtension.cs
@@ -1,11 +1,19 @@
 ﻿using System.Drawing;
+using GitCommands;
 using GitExtUtils.GitUI.Theming;
 
 namespace GitUI.Theming
 {
     public static class AppColorExtension
     {
-        public static Color GetThemeColor(this AppColor name) =>
-            ThemeModule.Settings.Theme.GetColor(name);
+        public static Color GetThemeColor(this AppColor name)
+        {
+            if (AppSettings.IsDesignMode)
+            {
+                return Color.Transparent;
+            }
+
+            return ThemeModule.Settings.Theme.GetColor(name);
+        }
     }
 }

--- a/GitUI/ToolStripExSettings.cs
+++ b/GitUI/ToolStripExSettings.cs
@@ -1,0 +1,58 @@
+﻿#nullable enable
+
+using System.Configuration;
+using System.Drawing;
+
+namespace GitUI
+{
+    // Inspired by https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSettings.cs
+
+    /// <summary>
+    ///  A settings class used by the ToolStripManager to save toolstrip settings.
+    /// </summary>
+    internal partial class ToolStripExSettings : ApplicationSettingsBase
+    {
+        internal ToolStripExSettings(string settingsKey)
+            : base(settingsKey)
+        {
+        }
+
+        // Indicates whether the settings was persisted, and not a "default" settigns object when there's no settings in user.config.
+        [UserScopedSetting]
+        [DefaultSettingValue("true")]
+        public bool IsDefault
+        {
+            get => (bool)this[nameof(IsDefault)];
+            set => this[nameof(IsDefault)] = value;
+        }
+
+        [UserScopedSetting]
+        [DefaultSettingValue("0,0")]
+        public Point Location
+        {
+            get => (Point)this[nameof(Location)];
+            set => this[nameof(Location)] = value;
+        }
+
+        [UserScopedSetting]
+        public string? ToolStripPanelName
+        {
+            get => this[nameof(ToolStripPanelName)] as string;
+            set => this[nameof(ToolStripPanelName)] = value;
+        }
+
+        [UserScopedSetting]
+        [DefaultSettingValue("true")]
+        public bool Visible
+        {
+            get => (bool)this[nameof(Visible)];
+            set => this[nameof(Visible)] = value;
+        }
+
+        public override void Save()
+        {
+            IsDefault = false;
+            base.Save();
+        }
+    }
+}

--- a/GitUI/ToolStripExSettings.cs
+++ b/GitUI/ToolStripExSettings.cs
@@ -17,6 +17,14 @@ namespace GitUI
         {
         }
 
+        [UserScopedSetting]
+        [DefaultSettingValue("false")]
+        public bool DockedToNeighbour
+        {
+            get => (bool)this[nameof(DockedToNeighbour)];
+            set => this[nameof(DockedToNeighbour)] = value;
+        }
+
         // Indicates whether the settings was persisted, and not a "default" settigns object when there's no settings in user.config.
         [UserScopedSetting]
         [DefaultSettingValue("true")]

--- a/GitUI/ToolStripExSettingsManager.cs
+++ b/GitUI/ToolStripExSettingsManager.cs
@@ -1,0 +1,241 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.Windows.Forms;
+using GitExtUtils.GitUI;
+
+namespace GitUI
+{
+    // Inspired by https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSettingsManager.cs
+
+    public interface IToolStripSettingsManager
+    {
+        void Load(Form ownerForm, params ToolStrip[]? toolStrips);
+        void Save(Form ownerForm, params ToolStrip[]? toolStrips);
+    }
+
+    [Export(typeof(IToolStripSettingsManager))]
+    internal partial class ToolStripExSettingsManager : IToolStripSettingsManager
+    {
+        private void ApplySettings(Form ownerForm, Dictionary<ToolStrip, ToolStripExSettings> toolStripSettingsToApply)
+        {
+            if (toolStripSettingsToApply.Count == 0)
+            {
+                return;
+            }
+
+            // Build up a hash of where we want the ToolStrips to go
+            Dictionary<string, List<ToolStrip>> toolStripPanelDestinations = new();
+
+            foreach (var toolStripSettings in toolStripSettingsToApply)
+            {
+                string? destinationPanel = !string.IsNullOrEmpty(toolStripSettings.Value.ToolStripPanelName) ? toolStripSettings.Value.ToolStripPanelName : null;
+                if (destinationPanel is null)
+                {
+                    // Not in a panel.
+
+                    if (!toolStripSettings.Value.IsDefault)
+                    {
+                        // NOTE: any toolstrip that we want to track the location of must be placed in a ToolStripPanel.
+                        // Whilst the original ToolStripSettingsManager supports tracking of toolstrips outside panels, we don't.
+                        // Please rework the UI as necessary.
+
+                        Debug.Assert(false, $"ToolStrip '{toolStripSettings.Key.Name}' must be parented to a panel.");
+                    }
+
+                    return;
+                }
+                else
+                {
+                    // This toolStrip is in a ToolStripPanel. We will process it below.
+                    if (!toolStripPanelDestinations.ContainsKey(destinationPanel))
+                    {
+                        toolStripPanelDestinations[destinationPanel] = new();
+                    }
+
+                    toolStripPanelDestinations[destinationPanel].Add(toolStripSettings.Key);
+                }
+            }
+
+            // Build up a list of the toolstrippanels to party on.
+            List<ToolStripPanel> toolStripPanels = new();
+            FindControls(true, ownerForm.Controls, toolStripPanels);
+            foreach (ToolStripPanel toolStripPanel in toolStripPanels)
+            {
+                // Set all the controls to visible false.
+                foreach (Control c in toolStripPanel.Controls)
+                {
+                    c.Visible = false;
+                }
+
+                string toolStripPanelName = GetToolStripPanelKey(toolStripPanel, defaultValue: toolStripPanel.Name);
+
+                // Get the associated toolstrips for this panel
+                if (toolStripPanelDestinations.ContainsKey(toolStripPanelName))
+                {
+                    List<ToolStrip> toolStrips = toolStripPanelDestinations[toolStripPanelName];
+                    if (toolStrips is null)
+                    {
+                        continue;
+                    }
+
+                    toolStripPanel.BeginInit();
+
+                    // We need to sort the toolstrips, so that we add with the bottom-most/right-most strips first. This ensures
+                    // correct order of strips.
+                    //
+                    // NOTE: since we currently only support the horizontal orientation, hence we use YXComparer.
+                    // In the future, if we decide to support vertical strips orientation, we'll need to use a XYComparer.
+                    // Refer to https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.ToolStripPanelControlCollection.XYComparer.cs
+                    toolStrips.Sort(new YXComparer());
+
+                    foreach (var toolStrip in toolStrips)
+                    {
+                        var settings = toolStripSettingsToApply[toolStrip];
+
+                        toolStrip.Visible = settings.Visible;
+
+                        // The location is scaled to the current dpi
+                        toolStripPanel.Join(toolStrip, DpiUtil.Scale(settings.Location));
+                    }
+
+                    toolStripPanel.EndInit();
+                }
+            }
+        }
+
+        private void FindControls<T>(bool searchAllChildren, Control.ControlCollection controlsToLookIn, List<T> foundControls)
+            where T : Control
+        {
+            // Perform breadth first search - as it's likely people will want controls belonging
+            // to the same parent close to each other.
+            for (int i = 0; i < controlsToLookIn.Count; i++)
+            {
+                if (controlsToLookIn[i] is null)
+                {
+                    continue;
+                }
+
+                if (controlsToLookIn[i] is T control)
+                {
+                    foundControls.Add(control);
+                }
+            }
+
+            // Optional recursive search for controls in child collections.
+            if (searchAllChildren)
+            {
+                for (int i = 0; i < controlsToLookIn.Count; i++)
+                {
+                    if (controlsToLookIn[i] is null || controlsToLookIn[i] is Form)
+                    {
+                        continue;
+                    }
+
+                    if ((controlsToLookIn[i].Controls is not null) && controlsToLookIn[i].Controls.Count > 0)
+                    {
+                        // If it has a valid child collection, append those results to our collection.
+                        FindControls(searchAllChildren, controlsToLookIn[i].Controls, foundControls);
+                    }
+                }
+            }
+        }
+
+        private string GetSettingsKey(Form ownerForm, string toolStripName)
+            => $"{ownerForm.Name}.{toolStripName}";
+
+        private string GetToolStripPanelKey(ToolStripPanel toolStripPanel, string defaultValue)
+        {
+            // Handle the ToolStripPanels inside a ToolStripContainer
+            if (toolStripPanel.Parent is ToolStripContainer toolStripContainer && !string.IsNullOrEmpty(toolStripContainer.Name))
+            {
+                return $"{toolStripContainer.Name}.{toolStripPanel.Dock}";
+            }
+
+            return defaultValue;
+        }
+
+        private string GetToolStripPanelName(ToolStrip toolStrip)
+        {
+            if (toolStrip.Parent is not ToolStripPanel parentPanel)
+            {
+                return string.Empty;
+            }
+
+            if (!string.IsNullOrEmpty(parentPanel.Name))
+            {
+                return parentPanel.Name;
+            }
+
+            string name = GetToolStripPanelKey(parentPanel, defaultValue: string.Empty);
+            Debug.Assert(!string.IsNullOrEmpty(name), "ToolStrip was parented to a panel, but we couldn't figure out its name.");
+
+            return name;
+        }
+
+        public void Load(Form ownerForm, params ToolStrip[]? toolStrips)
+        {
+            if (toolStrips is null || toolStrips.Length == 0)
+            {
+                throw new ArgumentException($"At least one ToolStrip is required.", nameof(toolStrips));
+            }
+
+            var settings = new Dictionary<ToolStrip, ToolStripExSettings>(toolStrips.Length);
+            foreach (ToolStrip toolStrip in toolStrips)
+            {
+                settings[toolStrip] = new(GetSettingsKey(ownerForm, toolStrip.Name));
+            }
+
+            ApplySettings(ownerForm, settings);
+        }
+
+        public void Save(Form ownerForm, params ToolStrip[]? toolStrips)
+        {
+            if (toolStrips is null || toolStrips.Length == 0)
+            {
+                throw new ArgumentException($"At least one ToolStrip is required.", nameof(toolStrips));
+            }
+
+            foreach (ToolStrip toolStrip in toolStrips)
+            {
+                ToolStripExSettings toolStripSettings = new(GetSettingsKey(ownerForm, toolStrip.Name));
+
+                toolStripSettings.ToolStripPanelName = GetToolStripPanelName(toolStrip);
+                toolStripSettings.Visible = toolStrip.Visible;
+
+                // Store the location at 96dpi
+                toolStripSettings.Location = DpiUtil.Scale(toolStrip.Location, 96);
+
+                toolStripSettings.Save();
+            }
+        }
+
+        // Copied from https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.ToolStripPanelControlCollection.YXComparer.cs
+        // Sort by Y, then X.
+        private class YXComparer : IComparer<Control>
+        {
+            public int Compare(Control? first, Control? second)
+            {
+                if (first!.Bounds.Y < second!.Bounds.Y)
+                {
+                    return -1;
+                }
+
+                if (first.Bounds.Y == second.Bounds.Y)
+                {
+                    if (first.Bounds.X < second.Bounds.X)
+                    {
+                        return -1;
+                    }
+
+                    return 1;
+                }
+
+                return 1;
+            }
+        }
+    }
+}

--- a/GitUI/ToolStripExSettingsManager.cs
+++ b/GitUI/ToolStripExSettingsManager.cs
@@ -14,7 +14,7 @@ namespace GitUI
 
     public interface IToolStripSettingsManager
     {
-        void Load(Form ownerForm, Action<ToolStrip[]> invalidSettingsHandler, params ToolStrip[]? toolStrips);
+        void Load(Form ownerForm, Action invalidSettingsHandler, params ToolStrip[]? toolStrips);
         void Save(Form ownerForm, params ToolStrip[]? toolStrips);
     }
 
@@ -168,7 +168,7 @@ namespace GitUI
             return name;
         }
 
-        public void Load(Form ownerForm, Action<ToolStrip[]> invalidSettingsHandler, params ToolStrip[]? toolStrips)
+        public void Load(Form ownerForm, Action invalidSettingsHandler, params ToolStrip[]? toolStrips)
         {
             if (toolStrips is null || toolStrips.Length == 0)
             {
@@ -191,7 +191,7 @@ namespace GitUI
             }
             else
             {
-                invalidSettingsHandler(toolStrips);
+                invalidSettingsHandler();
             }
 
             return;
@@ -234,6 +234,7 @@ namespace GitUI
                 toolStripSettings.Visible = toolStrip.Visible;
 
                 // This is O(n^2), but we don't have many strips to iterate over.
+                toolStripSettings.DockedToNeighbour = false;
                 foreach (ToolStrip strip in toolStrips)
                 {
                     if (strip.Bounds.Contains(toolStrip.Location.X - 2, toolStrip.Location.Y + 2))

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -98,6 +98,8 @@ the last selected commit.");
         private readonly TranslationString _resetSelectedLinesConfirmation = new("Are you sure you want to reset the changes to the selected lines?");
         private readonly TranslationString _resetChangesCaption = new("Reset changes");
 
+        private readonly TranslationString _resetToolbarsCaption = new("Reset");
+
         private readonly TranslationString _rotInactive = new("[ Inactive ]");
 
         private readonly TranslationString _argumentsText = new("Arguments");
@@ -228,6 +230,8 @@ the last selected commit.");
         public static string ResetSelectedLines => _instance.Value._resetSelectedLines.Text;
         public static string ResetSelectedLinesConfirmation => _instance.Value._resetSelectedLinesConfirmation.Text;
         public static string ResetChangesCaption => _instance.Value._resetChangesCaption.Text;
+
+        public static string ResetToolbarsCaption => _instance.Value._resetToolbarsCaption.Text;
 
         public static string Inactive => _instance.Value._rotInactive.Text;
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -10843,6 +10843,10 @@ Remote: {1}</source>
         <source>Are you sure you want to reset the changes to the selected lines?</source>
         <target />
       </trans-unit>
+      <trans-unit id="_resetToolbarsCaption.Text">
+        <source>Reset</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_rotInactive.Text">
         <source>[ Inactive ]</source>
         <target />

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -231,7 +231,6 @@ namespace GitUI.UserControls
             // 
             this.Dock = System.Windows.Forms.DockStyle.None;
             this.GripMargin = new System.Windows.Forms.Padding(0);
-            this.GripEnabled = false;
             this.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tsbtnAdvancedFilter,

--- a/GitUI/UserControls/ToolStripEx.cs
+++ b/GitUI/UserControls/ToolStripEx.cs
@@ -10,14 +10,9 @@ namespace GitUI
     /// </summary>
     public class ToolStripEx : ToolStrip, IToolStripEx
     {
-        private readonly ToolStripButton _gripButton;
-
         public ToolStripEx()
         {
             Renderer = new ToolStripExSystemRenderer();
-
-            PropertyInfo propGrip = GetType().GetProperty("Grip", BindingFlags.Instance | BindingFlags.NonPublic);
-            _gripButton = propGrip.GetValue(this) as ToolStripButton;
         }
 
         /// <summary>
@@ -35,17 +30,6 @@ namespace GitUI
         [Category("Appearance")]
         [DefaultValue(true)]
         public bool DrawBorder { get; set; } = true;
-
-        /// <summary>
-        ///  Gets or sets whether the ToolStrip grip button is enabled.
-        /// </summary>
-        [Category("Appearance")]
-        [DefaultValue(true)]
-        public bool GripEnabled
-        {
-            get => _gripButton.Enabled;
-            set => _gripButton.Enabled = value;
-        }
 
         protected override void WndProc(ref Message m)
         {


### PR DESCRIPTION
Reintroduce ability to move toolstrips (as proposed in #8572).

This implementation is heavily influenced by the original implementation [`ToolStripSettingsManager`](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSettingsManager.cs) in Windows Forms, however we only track visibility and location of each individual toolstrip. We're also only saving specified toolstrips as opposed to saving all known toolstrips (which in various situations results in terminal failures to restore toolstrips information).

There are two key changes:

1. Restore toolstrip locations after the form's geometry has been restored.    This ensures the toolstrips can be placed at the same coords as they    were saved.
2. Hosting ToolStripPanel's padding must be set to 0 before toolstrips'    locations can be restored/saved. This mitigates https://github.com/dotnet/winforms/issues/4449

Fixes #8680
Reverts #8719



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->

## Test methodology <!-- How did you ensure quality? -->

- 
- 
- 

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
