### PR TITLE
Route hotkeys to all visible controls

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2137,7 +2137,7 @@ namespace GitUI.CommandsDialogs
         protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
         {
             return !IsDesignMode && HotkeysEnabled
-                && (base.ProcessCmdKey(ref msg, keyData) // upstream
+                && (base.ProcessCmdKey(ref msg, keyData) // generic handling of this form's hotkeys (upstream)
                     || (!GitExtensionsControl.IsTextEditKey(keyData) // downstream (without keys for quick search)
                         && (RevisionGridControl.ProcessHotkey(keyData)
                             || (CommitInfoTabControl.SelectedTab == DiffTabPage && revisionDiff.ProcessHotkey(keyData))

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2134,6 +2134,16 @@ namespace GitUI.CommandsDialogs
             UICommands.RepoChangedNotifier.Notify();
         }
 
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            return !IsDesignMode && HotkeysEnabled
+                && (base.ProcessCmdKey(ref msg, keyData) // upstream
+                    || (!GitExtensionsControl.IsTextEditKey(keyData) // downstream (without keys for quick search)
+                        && (RevisionGridControl.ProcessHotkey(keyData)
+                            || (CommitInfoTabControl.SelectedTab == DiffTabPage && revisionDiff.ProcessHotkey(keyData))
+                            || (CommitInfoTabControl.SelectedTab == TreeTabPage && fileTree.ProcessHotkey(keyData)))));
+        }
+
         protected override CommandStatus ExecuteCommand(int cmd)
         {
             switch ((Command)cmd)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -618,9 +618,12 @@ namespace GitUI.CommandsDialogs
             if (keyData == Keys.F5)
             {
                 RescanChanges();
+                return true;
             }
 
-            return base.ProcessCmdKey(ref msg, keyData);
+            return base.ProcessCmdKey(ref msg, keyData) // upstream
+                || (!IsDesignMode && HotkeysEnabled && !GitExtensionsControl.IsTextEditKey(keyData, multiLine: true) // downstream
+                    && SelectedDiff.ProcessHotkey(keyData));
         }
 
         public void LoadCustomDifftools()

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -621,7 +621,7 @@ namespace GitUI.CommandsDialogs
                 return true;
             }
 
-            return base.ProcessCmdKey(ref msg, keyData) // upstream
+            return base.ProcessCmdKey(ref msg, keyData) // generic handling of this form's hotkeys (upstream)
                 || (!IsDesignMode && HotkeysEnabled && !GitExtensionsControl.IsTextEditKey(keyData, multiLine: true) // downstream
                     && SelectedDiff.ProcessHotkey(keyData));
         }

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -1196,7 +1196,7 @@ namespace GitUI.CommandsDialogs
 
         public override bool ProcessHotkey(Keys keyData)
         {
-            return base.ProcessHotkey(keyData)
+            return base.ProcessHotkey(keyData) // generic handling of this controls's hotkeys (upstream)
                 || (!GitExtensionsControl.IsTextEditKey(keyData) // downstream (without keys for quick search and filter)
                     && ((DiffFiles.Visible && DiffFiles.ProcessHotkey(keyData))
                         || (DiffText.Visible && DiffText.ProcessHotkey(keyData))

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -1194,6 +1194,15 @@ namespace GitUI.CommandsDialogs
             }
         }
 
+        public override bool ProcessHotkey(Keys keyData)
+        {
+            return base.ProcessHotkey(keyData)
+                || (!GitExtensionsControl.IsTextEditKey(keyData) // downstream (without keys for quick search and filter)
+                    && ((DiffFiles.Visible && DiffFiles.ProcessHotkey(keyData))
+                        || (DiffText.Visible && DiffText.ProcessHotkey(keyData))
+                        || (BlameControl.Visible && BlameControl.ProcessHotkey(keyData))));
+        }
+
         /// <summary>
         /// Hotkey handler.
         /// </summary>

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -260,6 +260,14 @@ See the changes in the commit form.");
             return true;
         }
 
+        public override bool ProcessHotkey(Keys keyData)
+        {
+            return base.ProcessHotkey(keyData)
+                || (!GitExtensionsControl.IsTextEditKey(keyData) // downstream (without keys for quick search)
+                    && ((FileText.Visible && FileText.ProcessHotkey(keyData))
+                        || (BlameControl.Visible && BlameControl.ProcessHotkey(keyData))));
+        }
+
         public void ReloadHotkeys()
         {
             Hotkeys = HotkeySettingsManager.LoadHotkeys(HotkeySettingsName);

--- a/ResourceManager/GitExtensionsControl.cs
+++ b/ResourceManager/GitExtensionsControl.cs
@@ -74,6 +74,18 @@ namespace ResourceManager
 
         #region Hotkeys
 
+        /// <summary>Checks if a hotkey wants to handle the key and execute it.</summary>
+        public virtual bool ProcessHotkey(Keys keyData)
+        {
+            if (!HotkeysEnabled)
+            {
+                return false;
+            }
+
+            HotkeyCommand? hotkey = Hotkeys?.FirstOrDefault(hotkey => hotkey?.KeyData == keyData);
+            return hotkey is not null && ExecuteCommand(hotkey.CommandCode).Executed;
+        }
+
         /// <summary>Gets or sets a value that specifies if the hotkeys are used</summary>
         protected bool HotkeysEnabled { get; set; }
 
@@ -83,18 +95,7 @@ namespace ResourceManager
         /// <summary>Checks if a hotkey wants to handle the key before letting the message propagate.</summary>
         protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
         {
-            if (HotkeysEnabled && Hotkeys is not null)
-            {
-                foreach (var hotkey in Hotkeys)
-                {
-                    if (hotkey is not null && hotkey.KeyData == keyData)
-                    {
-                        return ExecuteCommand(hotkey.CommandCode).Executed;
-                    }
-                }
-            }
-
-            return base.ProcessCmdKey(ref msg, keyData);
+            return ProcessHotkey(keyData) || base.ProcessCmdKey(ref msg, keyData);
         }
 
         protected Keys GetShortcutKeys(int commandCode)

--- a/ResourceManager/GitExtensionsControl.cs
+++ b/ResourceManager/GitExtensionsControl.cs
@@ -74,7 +74,12 @@ namespace ResourceManager
 
         #region Hotkeys
 
-        /// <summary>Checks if a hotkey wants to handle the key and execute it.</summary>
+        /// <summary>
+        /// Checks if a hotkey wants to handle the key and execute that hotkey
+        /// (without propagating an unhandled key to the base class function <cref>ProcessCmdKey</cref>).
+        /// Can be overridden in order to execute a hotkey of other (visible) subcontrols
+        /// if this focused/queried control does not have such an (active) hotkey itself.
+        /// </summary>
         public virtual bool ProcessHotkey(Keys keyData)
         {
             if (!HotkeysEnabled)

--- a/ResourceManager/GitExtensionsControl.cs
+++ b/ResourceManager/GitExtensionsControl.cs
@@ -75,10 +75,10 @@ namespace ResourceManager
         #region Hotkeys
 
         /// <summary>
-        /// Checks if a hotkey wants to handle the key and execute that hotkey
-        /// (without propagating an unhandled key to the base class function <cref>ProcessCmdKey</cref>).
-        /// Can be overridden in order to execute a hotkey of other (visible) subcontrols
-        /// if this focused/queried control does not have such an (active) hotkey itself.
+        /// Checks if the control wants to handle the key and execute that hotkey
+        /// (without propagating an unhandled key to the base class function as in <cref>ProcessCmdKey</cref>).
+        /// Can be overridden in order to execute a hotkey for a (visible) subcontrol
+        /// (if this focused/queried control does not have such an (active) hotkey itself).
         /// </summary>
         public virtual bool ProcessHotkey(Keys keyData)
         {

--- a/ResourceManager/GitExtensionsFormBase.cs
+++ b/ResourceManager/GitExtensionsFormBase.cs
@@ -54,14 +54,12 @@ namespace ResourceManager
         /// <summary>Overridden: Checks if a hotkey wants to handle the key before letting the message propagate</summary>
         protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
         {
-            if (!IsDesignMode && HotkeysEnabled && Hotkeys is not null)
+            if (!IsDesignMode && HotkeysEnabled)
             {
-                foreach (var hotkey in Hotkeys)
+                HotkeyCommand? hotkey = Hotkeys?.FirstOrDefault(hotkey => hotkey?.KeyData == keyData);
+                if (hotkey is not null && ExecuteCommand(hotkey.CommandCode).Executed)
                 {
-                    if (hotkey is not null && hotkey.KeyData == keyData)
-                    {
-                        return ExecuteCommand(hotkey.CommandCode).Executed;
-                    }
+                    return true;
                 }
             }
 


### PR DESCRIPTION
## Proposed changes

- Route hotkeys to the other visible controls in FormBrowse and FormCommit if not handled by the focused control 

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 9916393dc46aaeb1c5a5006d046768b301bd5721
- Git 2.31.1.windows.1 (recommended: 2.33.0 or later)
- Microsoft Windows NT 10.0.19044.0
- .NET 5.0.12
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).