### PR TITLE
RevDiff: Setting to show Blame in FileTree

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -482,6 +482,7 @@ namespace GitCommands
         public static ISetting<string> ConEmuStyle => Setting.Create(DetailedSettingsPath, nameof(ConEmuStyle), "<Solarized Light>");
         public static ISetting<string> ConEmuTerminal => Setting.Create(DetailedSettingsPath, nameof(ConEmuTerminal), "bash");
         public static ISetting<bool> UseBrowseForFileHistory => Setting.Create(DetailedSettingsPath, nameof(UseBrowseForFileHistory), true);
+        public static ISetting<bool> UseDiffViewerForBlame => Setting.Create(DetailedSettingsPath, nameof(UseDiffViewerForBlame), false);
         public static ISetting<bool> ShowGpgInformation => Setting.Create(DetailedSettingsPath, nameof(ShowGpgInformation), true);
 
         public static CommitInfoPosition CommitInfoPosition

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -637,7 +637,7 @@ namespace GitUI.CommandsDialogs
             {
                 int? line = DiffText.Visible ? DiffText.CurrentFileLine : null;
                 blameToolStripMenuItem.Checked = !blameToolStripMenuItem.Checked;
-                BlameSelectedFileDiff();
+                BlameSelectedFileDiff(line);
                 return;
             }
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -635,6 +635,7 @@ namespace GitUI.CommandsDialogs
 
             if (AppSettings.UseDiffViewerForBlame.Value)
             {
+                int? line = DiffText.Visible ? DiffText.CurrentFileLine : null;
                 blameToolStripMenuItem.Checked = !blameToolStripMenuItem.Checked;
                 BlameSelectedFileDiff();
                 return;

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -78,7 +78,12 @@ See the changes in the commit form.");
             _refreshGitStatus = refreshGitStatus;
         }
 
-        public void ExpandToFile(string filePath)
+        /// <summary>
+        /// Expand the tree for the path and show the contents
+        /// </summary>
+        /// <param name="filePath">The path to the file</param>
+        /// <param name="requestBlame">Request that Blame is shown in the FileTree</param>
+        public void ExpandToFile(string filePath, bool requestBlame = false)
         {
             if (string.IsNullOrWhiteSpace(filePath))
             {
@@ -128,6 +133,11 @@ See the changes in the commit form.");
                 if (isIncompleteMatch)
                 {
                     MessageBox.Show(_nodeNotFoundNextAvailableParentSelected.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+
+                if (requestBlame && !AppSettings.RevisionFileTreeShowBlame)
+                {
+                    blameToolStripMenuItem1.Checked = AppSettings.RevisionFileTreeShowBlame = true;
                 }
 
                 tvGitTree.SelectedNode = foundNode;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
@@ -33,6 +33,7 @@
             this.cboTerminal = new System.Windows.Forms.ComboBox();
             this.label2 = new System.Windows.Forms.Label();
             this.chkUseBrowseForFileHistory = new System.Windows.Forms.CheckBox();
+            this.chkUseDiffViewerForBlame = new System.Windows.Forms.CheckBox();
             this.gbGeneral = new System.Windows.Forms.GroupBox();
             this.gbTabs = new System.Windows.Forms.GroupBox();
             this.gbGeneral.SuspendLayout();
@@ -88,6 +89,16 @@
             this.chkUseBrowseForFileHistory.Text = "Show file history in the main window";
             this.chkUseBrowseForFileHistory.UseVisualStyleBackColor = true;
             // 
+            // chkUseDiffViewerForBlame
+            // 
+            this.chkUseDiffViewerForBlame.AutoSize = true;
+            this.chkUseDiffViewerForBlame.Location = new System.Drawing.Point(9, 71);
+            this.chkUseDiffViewerForBlame.Name = "chkUseDiffViewerForBlame";
+            this.chkUseDiffViewerForBlame.Size = new System.Drawing.Size(162, 19);
+            this.chkUseDiffViewerForBlame.TabIndex = 5;
+            this.chkUseDiffViewerForBlame.Text = "Show blame in diff viewer";
+            this.chkUseDiffViewerForBlame.UseVisualStyleBackColor = true;
+            // 
             // gbGeneral
             // 
             this.gbGeneral.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
@@ -95,9 +106,10 @@
             this.gbGeneral.Controls.Add(this.cboTerminal);
             this.gbGeneral.Controls.Add(this.label2);
             this.gbGeneral.Controls.Add(this.chkUseBrowseForFileHistory);
+            this.gbGeneral.Controls.Add(this.chkUseDiffViewerForBlame);
             this.gbGeneral.Location = new System.Drawing.Point(11, 11);
             this.gbGeneral.Name = "gbGeneral";
-            this.gbGeneral.Size = new System.Drawing.Size(435, 81);
+            this.gbGeneral.Size = new System.Drawing.Size(435, 104);
             this.gbGeneral.TabIndex = 1;
             this.gbGeneral.TabStop = false;
             this.gbGeneral.Text = "General";
@@ -108,7 +120,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.gbTabs.Controls.Add(this.chkShowGpgInformation);
             this.gbTabs.Controls.Add(this.chkChowConsoleTab);
-            this.gbTabs.Location = new System.Drawing.Point(11, 98);
+            this.gbTabs.Location = new System.Drawing.Point(11, 121);
             this.gbTabs.Name = "gbTabs";
             this.gbTabs.Size = new System.Drawing.Size(435, 82);
             this.gbTabs.TabIndex = 5;
@@ -123,7 +135,7 @@
             this.Controls.Add(this.gbGeneral);
             this.Name = "FormBrowseRepoSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
-            this.Size = new System.Drawing.Size(457, 192);
+            this.Size = new System.Drawing.Size(457, 215);
             this.gbGeneral.ResumeLayout(false);
             this.gbGeneral.PerformLayout();
             this.gbTabs.ResumeLayout(false);
@@ -139,6 +151,7 @@
         private System.Windows.Forms.ComboBox cboTerminal;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.CheckBox chkUseBrowseForFileHistory;
+        private System.Windows.Forms.CheckBox chkUseDiffViewerForBlame;
         private System.Windows.Forms.GroupBox gbGeneral;
         private System.Windows.Forms.GroupBox gbTabs;
     }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
@@ -26,6 +26,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             AppSettings.ShowConEmuTab.Value = chkChowConsoleTab.Checked;
             AppSettings.UseBrowseForFileHistory.Value = chkUseBrowseForFileHistory.Checked;
+            AppSettings.UseDiffViewerForBlame.Value = chkUseDiffViewerForBlame.Checked;
             AppSettings.ShowGpgInformation.Value = chkShowGpgInformation.Checked;
 
             AppSettings.ConEmuTerminal.Value = ((IShellDescriptor)cboTerminal.SelectedItem).Name.ToLowerInvariant();
@@ -36,6 +37,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             chkChowConsoleTab.Checked = AppSettings.ShowConEmuTab.Value;
             chkUseBrowseForFileHistory.Checked = AppSettings.UseBrowseForFileHistory.Value;
+            chkUseDiffViewerForBlame.Checked = AppSettings.UseDiffViewerForBlame.Value;
             chkShowGpgInformation.Checked = AppSettings.ShowGpgInformation.Value;
 
             foreach (IShellDescriptor shell in _shellProvider.GetShells())

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3351,6 +3351,10 @@ Do you want to continue?</source>
         <source>Show file history in the main window</source>
         <target />
       </trans-unit>
+      <trans-unit id="chkUseDiffViewerForBlame.Text">
+        <source>Show blame in diff viewer</source>
+        <target />
+      </trans-unit>
       <trans-unit id="gbGeneral.Text">
         <source>General</source>
         <target />


### PR DESCRIPTION
Part of #9796 

This addresses what is maybe the core problem in #9796: Blame in RevDiff
This was added in #9424 and was intended for quick checks. The use
corresponding to FileHistory was intended to be used in FileTree.

(Some other changes planned for Blame in general and specifically for Blame in RevDiff for other concerns.)

## Proposed changes

Blame in RevDiff has certain limitations as revisions for a file may
not exist in the grid and the file to blame may not exist in all
revisions.

Add a setting to explicitly enable blame in RevGrid.

## Screenshots <!-- Remove this section if PR does not change UI -->


### Before

Blame 'B' in RevDiff by default opened in RevDiff itself

![image](https://user-images.githubusercontent.com/6248932/150658222-4372dfcb-2c41-42b6-ac14-1189c030b973.png)

### After

Default is only FileTree

![image](https://user-images.githubusercontent.com/6248932/150658107-b28844ed-4789-46d9-93dc-5c4fc1db4b3a.png)

Blame 'B' in RevDiff by default opens FileTree
Basically the same as selecting filetree in the context menu 'T' but Blame is opened if show file contents was selected ('B' in FileTree).

![image](https://user-images.githubusercontent.com/6248932/150658148-6fe0e6f4-88a8-40c0-99e2-269ddd8c25d5.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
