### PR TITLE
Blame: Start on line also when control already exists

### DIFF
--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -98,25 +98,28 @@ namespace GitUI.Blame
 
         public void LoadBlame(GitRevision revision, IReadOnlyList<ObjectId>? children, string? fileName, RevisionGridControl? revGrid, Control? controlToMask, Encoding encoding, int? initialLine = null, bool force = false, CancellationToken cancellationToken = default)
         {
-            var objectId = revision.ObjectId;
+            ObjectId objectId = revision.ObjectId;
 
             // refresh only when something changed
             if (!force && objectId == _blameId && fileName == _fileName && revGrid == _revGrid && encoding == _encoding)
             {
+                if (initialLine is not null)
+                {
+                    BlameFile.GoToLine(initialLine.Value);
+                }
+
                 return;
             }
-
-            controlToMask?.Mask();
-
-            var scrollPos = BlameFile.VScrollPosition;
-
-            var line = _clickedBlameLine is not null && _clickedBlameLine.Commit.ObjectId == objectId
-                ? _clickedBlameLine.OriginLineNumber
-                : initialLine ?? 0;
 
             _revGrid = revGrid;
             _fileName = fileName;
             _encoding = encoding;
+
+            controlToMask?.Mask();
+            int scrollPos = BlameFile.VScrollPosition;
+            int line = _clickedBlameLine is not null && _clickedBlameLine.Commit.ObjectId == objectId
+                ? _clickedBlameLine.OriginLineNumber
+                : initialLine ?? 0;
 
             _blameLoader.LoadAsync(() => _blame = Module.Blame(fileName, objectId.ToString(), encoding),
                 () => ProcessBlame(fileName, revision, children, controlToMask, line, scrollPos, cancellationToken));


### PR DESCRIPTION
This is the core change in #9805 
To add tests to this, a lot more has to be changed and this change is useful to functional testing other upcoming GoToLine changes,
so it was broken out to a separate PR.

#9805 is kept to handle the tests.

## Proposed changes

Blame can start presenting on a line. This is is available in
RevDiff and RevFileTree since #9424.
(Even if the code enabling this has existed for long time,
it was just used for a special case.)

The "goto line" was only used if the control had to be init,
not if e.g. toggling to Diff and selecting an new diff line
and then Blame again.

## Screenshots <!-- Remove this section if PR does not change UI -->

See #9805 

## Test methodology <!-- How did you ensure quality? -->

Manual - tests in #9805

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
