### PR TITLE
RevGrid: Show popup when a revision is not in the revision grid

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -553,8 +553,11 @@ namespace GitUI.CommandsDialogs
                 Validates.NotNull(e.Data);
                 if (Module.TryResolvePartialCommitId(e.Data, out var objectId))
                 {
-                    RevisionGrid.SetSelectedRevision(objectId);
-                }
+                    if (!RevisionGrid.SetSelectedRevision(objectId))
+                    {
+                        MessageBoxes.RevisionFilteredInGrid(this, objectId);
+                    }
+               }
             }
             else if (e.Command == "gotobranch" || e.Command == "gototag")
             {
@@ -562,7 +565,10 @@ namespace GitUI.CommandsDialogs
                 CommitData? commit = _commitDataManager.GetCommitData(e.Data, out _);
                 if (commit is not null)
                 {
-                    RevisionGrid.SetSelectedRevision(commit.ObjectId);
+                    if (!RevisionGrid.SetSelectedRevision(commit.ObjectId))
+                    {
+                        MessageBoxes.RevisionFilteredInGrid(this, commit.ObjectId);
+                    }
                 }
             }
             else if (e.Command == "navigatebackward")

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -79,9 +79,12 @@ namespace GitUI.HelperDialogs
         private void linkLabelParent_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             var linkLabel = (LinkLabel)sender;
-            var parentId = (ObjectId)linkLabel.Tag;
+            ObjectId parentId = (ObjectId)linkLabel.Tag;
 
-            revisionGrid.SetSelectedRevision(parentId);
+            if (!revisionGrid.SetSelectedRevision(parentId))
+            {
+                MessageBoxes.RevisionFilteredInGrid(this, parentId);
+            }
         }
 
         private void revisionGrid_SelectionChanged(object sender, EventArgs e)

--- a/GitUI/MessageBoxes.cs
+++ b/GitUI/MessageBoxes.cs
@@ -2,15 +2,18 @@
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Config;
+using GitUIPluginInterfaces;
 using ResourceManager;
 
 namespace GitUI
 {
     public class MessageBoxes : Translate
     {
-        private readonly TranslationString _archiveRevisionCaption = new("Archive revision");
+        private readonly TranslationString _cannotFindRevisionFilter = new(@"Revision ""{0}"" is not visible in the revision grid. Remove the revision filter.");
+        private readonly TranslationString _cannotFindRevisionCaption = new("Cannot find revision");
+        private readonly TranslationString _noRevisionFoundError = new("No revision found.");
 
-        private readonly TranslationString _failedToExecuteScript = new("Failed to execute script");
+        private readonly TranslationString _archiveRevisionCaption = new("Archive revision");
 
         private readonly TranslationString _failedToRunShell = new("Failed to run shell");
 
@@ -58,6 +61,12 @@ namespace GitUI
         private static MessageBoxes? instance;
 
         private static MessageBoxes Instance => instance ??= new();
+
+        public static void RevisionFilteredInGrid(IWin32Window? owner, ObjectId objectId)
+            => ShowError(owner, string.Format(Instance._cannotFindRevisionFilter.Text, objectId.ToShortString()), Instance._cannotFindRevisionCaption.Text);
+
+        public static void CannotFindGitRevision(IWin32Window? owner)
+            => ShowError(owner, Instance._noRevisionFoundError.Text, Instance._cannotFindRevisionCaption.Text);
 
         public static void FailedToRunShell(IWin32Window? owner, string shell, Exception ex)
             => ShowError(owner, $"{Instance._failedToRunShell.Text} {shell.Quote()}.{Environment.NewLine}"

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8677,6 +8677,14 @@ help</source>
         <source>Archive revision</source>
         <target />
       </trans-unit>
+      <trans-unit id="_cannotFindRevisionCaption.Text">
+        <source>Cannot find revision</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_cannotFindRevisionFilter.Text">
+        <source>Revision "{0}" is not visible in the revision grid. Remove the revision filter.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_cannotOpenGitExtensionsCaption.Text">
         <source>Cannot open Git Extensions</source>
         <target />
@@ -8687,10 +8695,6 @@ help</source>
       </trans-unit>
       <trans-unit id="_directoryDoesNotExist.Text">
         <source>The directory "{0}" does not exist.</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_failedToExecuteScript.Text">
-        <source>Failed to execute script</source>
         <target />
       </trans-unit>
       <trans-unit id="_failedToRunShell.Text">
@@ -8711,6 +8715,10 @@ help</source>
       </trans-unit>
       <trans-unit id="_middleOfRebaseCaption.Text">
         <source>Rebase</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_noRevisionFoundError.Text">
+        <source>No revision found.</source>
         <target />
       </trans-unit>
       <trans-unit id="_notValidGitDirectory.Text">
@@ -9722,10 +9730,6 @@ See the changes in the commit form.</source>
       </trans-unit>
       <trans-unit id="ToggleHighlightSelectedBranch.Text">
         <source>Highlight selected branch (until refresh)</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_noRevisionFoundError.Text">
-        <source>No revision found.</source>
         <target />
       </trans-unit>
       <trans-unit id="_quickSearchQuickHelp.Text">

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -499,15 +499,18 @@ namespace GitUI.Blame
                 return;
             }
 
-            if (_revGrid is not null)
+            ObjectId selectedId = _lastBlameLine.Commit.ObjectId;
+            if (_revGrid is null)
             {
-                _clickedBlameLine = _lastBlameLine;
-                _revGrid.SetSelectedRevision(_lastBlameLine.Commit.ObjectId);
-            }
-            else
-            {
-                using FormCommitDiff frm = new(UICommands, _lastBlameLine.Commit.ObjectId);
+                using FormCommitDiff frm = new(UICommands, selectedId);
                 frm.ShowDialog(this);
+                return;
+            }
+
+            _clickedBlameLine = _lastBlameLine;
+            if (!_revGrid.SetSelectedRevision(selectedId))
+            {
+                MessageBoxes.RevisionFilteredInGrid(this, selectedId);
             }
         }
 
@@ -624,7 +627,11 @@ namespace GitUI.Blame
         {
             if (_revGrid is not null)
             {
-                _revGrid.SetSelectedRevision(revisionId);
+                if (!_revGrid.SetSelectedRevision(revisionId))
+                {
+                    MessageBoxes.RevisionFilteredInGrid(this, revisionId);
+                }
+
                 return;
             }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -15,7 +15,6 @@ namespace GitUI.UserControls.RevisionGrid
         public event EventHandler? MenuChanged;
 
         private readonly TranslationString _quickSearchQuickHelp = new("Start typing in revision grid to start quick search.");
-        private readonly TranslationString _noRevisionFoundError = new("No revision found.");
 
         private readonly RevisionGridControl _revisionGrid;
 
@@ -501,11 +500,14 @@ namespace GitUI.UserControls.RevisionGrid
 
             if (objectId is not null)
             {
-                _revisionGrid.SetSelectedRevision(objectId);
+                if (!_revisionGrid.SetSelectedRevision(objectId))
+                {
+                    MessageBoxes.RevisionFilteredInGrid(_revisionGrid, objectId);
+                }
             }
             else
             {
-                MessageBox.Show(_revisionGrid, _noRevisionFoundError.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.CannotFindGitRevision(owner: _revisionGrid);
             }
         }
     }

--- a/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
@@ -311,7 +311,7 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                     // wait for the revisions to be loaded
                     await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
 
-                    formBrowse.RevisionGridControl.SetSelectedRevision(ObjectId.Parse(_headCommit));
+                    formBrowse.RevisionGridControl.SetSelectedRevision(ObjectId.Parse(_headCommit)).Should().BeTrue();
 
                     formBrowse.RevisionGridControl.SetAndApplyBranchFilter(initialFilter);
 


### PR DESCRIPTION
Discussed in relation to #9796 

## Proposed changes

If a objectId is expected to be available in the repo (for instance
retrieved with git-rev-parse), but is not included in the grid,
GE will inform the user with a popup instead of just silently ignore.

This is how GE has behaved for a long time, but there were previously less opportunities to 
enter commit sha that were in the repo but not displayed in the grid. 
There are various filters (including path filter) that hides commits and
links are exposed in the side panel and commit info.

All occurrences of `SetSelectedRevision()` are not getting the popup, it is opt-in
even if most occurrences are included. I have tried to verify that there are no popups in 
"automatic" situations and that the ObjectIds are valid Git sha (normally parsed by git-rev-parse or from git-blame etc).

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Navigate - go to commit with input that is not commitish.

![image](https://user-images.githubusercontent.com/6248932/150697909-d6a34ef9-b268-477e-bc7a-e86d49fcf23e.png)

### After

![image](https://user-images.githubusercontent.com/6248932/150697919-bb3b7540-0feb-413d-9807-2c1bad431caf.png)

![image](https://user-images.githubusercontent.com/6248932/150697963-8ccea5d1-ad6e-4970-9db4-6ccc85b92f40.png)

## Test methodology <!-- How did you ensure quality? -->

Manual review and check of situations the pops should occur in

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
