### PR TITLE
Pull rebase: Fix detection of merge commits

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1177,7 +1177,8 @@ namespace GitCommands
             };
 
             // Could fail if pulling interactively from remote where the specified branch does not exist
-            return _gitExecutable.Execute(args, throwOnErrorExit: false).StandardOutput.LazySplit('\n').Any();
+            string mergeCommitsOutput = _gitExecutable.Execute(args, throwOnErrorExit: false).StandardOutput;
+            return !string.IsNullOrWhiteSpace(mergeCommitsOutput);
         }
 
         public ConfigFile GetSubmoduleConfigFile()


### PR DESCRIPTION
When the string is empty (i.e. no merge commits),
`LazySplit('\n').Any()` return `true`.

Replace by a check that the string contains something (i.e. a merge commit has been found)
preventing creation of potentially a lot of unnecessary substrings.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

This popup is always displayed even if there is no merge commits to rebase:
![image](https://user-images.githubusercontent.com/460196/151570905-93c75b8f-da94-4814-83bc-8d0ab1467f49.png)

### After

The popup is displayed only when a merge commit will be rebased.

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build a61328ace4b35d936dbdf2e9127293452f835172
- Git 2.34.0.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 5.0.13
- DPI 192dpi (200% scaling)

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
