### PR TITLE
RevisionGrid: Use Hotkeys for navigation

### DIFF
--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -300,6 +300,8 @@ namespace GitUI.Hotkey
                     Hk(RevisionGridControl.Command.GoToChild, Keys.Control | Keys.N),
                     Hk(RevisionGridControl.Command.GoToCommit, Keys.Control | Keys.Shift | Keys.G),
                     Hk(RevisionGridControl.Command.GoToParent, Keys.Control | Keys.P),
+                    Hk(RevisionGridControl.Command.NavigateBackward, Keys.Alt | Keys.Left),
+                    Hk(RevisionGridControl.Command.NavigateForward, Keys.Alt | Keys.Right),
                     Hk(RevisionGridControl.Command.NextQuickSearch, Keys.Alt | Keys.Down),
                     Hk(RevisionGridControl.Command.OpenCommitsWithDifftool, Keys.None),
                     Hk(RevisionGridControl.Command.PrevQuickSearch, Keys.Alt | Keys.Up),

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1412,16 +1412,16 @@ namespace GitUI
             switch (e.KeyCode)
             {
                 case Keys.BrowserBack:
-                case Keys.Left when e.Modifiers.HasFlag(Keys.Alt):
                     {
                         NavigateBackward();
+                        e.Handled = true;
                         break;
                     }
 
                 case Keys.BrowserForward:
-                case Keys.Right when e.Modifiers.HasFlag(Keys.Alt):
                     {
                         NavigateForward();
+                        e.Handled = true;
                         break;
                     }
             }
@@ -1450,6 +1450,7 @@ namespace GitUI
                             new GitRefListsForRevision(selectedRevision).GetRenameableLocalBranches(),
                             gitRef => UICommands.StartRenameDialog(ParentForm, gitRef.Name),
                             FormQuickGitRefSelector.Action.Rename);
+                        e.Handled = true;
                         break;
                     }
 
@@ -1473,6 +1474,7 @@ namespace GitUI
                                 }
                             },
                             FormQuickGitRefSelector.Action.Delete);
+                        e.Handled = true;
                         break;
                     }
             }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -146,7 +146,7 @@ namespace GitUI.UserControls.RevisionGrid
                     Name = "NavigateBackward",
                     Text = "Navigate &backward",
                     Image = Images.NavigateBackward,
-                    ShortcutKeyDisplayString = (Keys.Alt | Keys.Left).ToShortcutKeyDisplayString(),
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.NavigateBackward),
                     ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGridControl.Command.NavigateBackward)
                 },
                 new MenuCommand
@@ -154,7 +154,7 @@ namespace GitUI.UserControls.RevisionGrid
                     Name = "NavigateForward",
                     Text = "Navigate &forward",
                     Image = Images.NavigateForward,
-                    ShortcutKeyDisplayString = (Keys.Alt | Keys.Right).ToShortcutKeyDisplayString(),
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.NavigateForward),
                     ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGridControl.Command.NavigateForward)
                 },
                 MenuCommand.CreateSeparator(),


### PR DESCRIPTION
Fixes #9845

## Proposed changes

- Register the already implemented `Command`s `NavigateBackward` and `NavigateForward` in the `HotkeySettingsManager`
  (The hardcoded keys did not have an effect anymore since 930e22a8b8
  because they were caught by the regarding `Hotkey`s of `FileViewer`.)
- `RevisionGridControl.OnGridViewKeyDown`:
  Remove the hard-coded `Alt+Left` & `Alt+Right` and set `e.Handled = true` for the remaining keys

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/36601201/151880508-3fc92a76-9965-4b20-9a11-f4257f13085c.png)

### After

![image](https://user-images.githubusercontent.com/36601201/151880741-bcfdfe5b-1bc0-4f63-8de2-9187f9278105.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build e91a0a9921e5eabe497838838c3e7b22313f77f4
- Git 2.35.1.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 5.0.12
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).