### PR TITLE
Add git stash --staged

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -158,7 +158,7 @@ namespace GitCommands
         /// <summary>
         /// GitVersion for the default GitExecutable.
         /// </summary>
-        public GitVersion GitVersion => GitVersion.CurrentVersion(_wslDistro);
+        public GitVersion GitVersion => GitVersion.CurrentVersion(GitExecutable, _wslDistro);
 
         /// <inherit/>
         public IExecutable GitExecutable => _gitExecutable;

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 using GitExtUtils;
+using GitUIPluginInterfaces;
 
 namespace GitCommands
 {
@@ -41,11 +42,16 @@ namespace GitCommands
         /// </summary>
         /// <param name="gitIdentifiable">The unique identification of the Git executable</param>
         /// <returns>The GitVersion</returns>
-        public static GitVersion CurrentVersion(string gitIdentifiable = "")
+        public static GitVersion CurrentVersion(IExecutable gitExec = null, string gitIdentifiable = "")
         {
             if (!_current.ContainsKey(gitIdentifiable) || _current[gitIdentifiable] is null || _current[gitIdentifiable].IsUnknown)
             {
-                string output = new Executable(AppSettings.GitCommand).GetOutput("--version");
+                if (gitExec is null)
+                {
+                    gitExec = new Executable(AppSettings.GitCommand);
+                }
+
+                string output = gitExec.GetOutput("--version");
                 _current[gitIdentifiable] = new GitVersion(output);
                 if (_current[gitIdentifiable] < LastVersionWithoutKnownLimitations)
                 {

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -46,11 +46,7 @@ namespace GitCommands
         {
             if (!_current.ContainsKey(gitIdentifiable) || _current[gitIdentifiable] is null || _current[gitIdentifiable].IsUnknown)
             {
-                if (gitExec is null)
-                {
-                    gitExec = new Executable(AppSettings.GitCommand);
-                }
-
+                gitExec ??= new Executable(AppSettings.GitCommand);
                 string output = gitExec.GetOutput("--version");
                 _current[gitIdentifiable] = new GitVersion(output);
                 if (_current[gitIdentifiable] < LastVersionWithoutKnownLimitations)

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -10,12 +10,13 @@ namespace GitCommands
     {
         private static readonly GitVersion v2_19_0 = new("2.19.0");
         private static readonly GitVersion v2_20_0 = new("2.20.0");
+        private static readonly GitVersion v2_35_0 = new("2.35.0");
 
         /// <summary>
         /// The recommonded Git version (normally latest official before a GE release).
         /// This and later versions are green in the settings check.
         /// </summary>
-        public static readonly GitVersion LastRecommendedVersion = new("2.33.0");
+        public static readonly GitVersion LastRecommendedVersion = new("2.35.0");
 
         /// <summary>
         /// The oldest version with reasonable reliable support in GE.
@@ -119,6 +120,7 @@ namespace GitCommands
         public bool SupportRebaseMerges => this >= v2_19_0;
         public bool SupportGuiMergeTool => this >= v2_20_0;
         public bool SupportRangeDiffTool => this >= v2_19_0;
+        public bool SupportStashStaged => this >= v2_35_0;
 
         public bool IsUnknown => _a == 0 && _b == 0 && _c == 0 && _d == 0;
 

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -39,6 +39,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripSplitStash = new System.Windows.Forms.ToolStripSplitButton();
             this.stashChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.stashStagedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.stashPopToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
             this.manageStashesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -389,6 +390,7 @@ namespace GitUI.CommandsDialogs
             // 
             this.toolStripSplitStash.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.stashChangesToolStripMenuItem,
+            this.stashStagedToolStripMenuItem,
             this.stashPopToolStripMenuItem,
             this.toolStripSeparator9,
             this.manageStashesToolStripMenuItem,
@@ -408,6 +410,14 @@ namespace GitUI.CommandsDialogs
             this.stashChangesToolStripMenuItem.Text = "&Stash";
             this.stashChangesToolStripMenuItem.ToolTipText = "Stash changes";
             this.stashChangesToolStripMenuItem.Click += new System.EventHandler(this.StashChangesToolStripMenuItemClick);
+            // 
+            // stashStagedToolStripMenuItem
+            // 
+            this.stashStagedToolStripMenuItem.Name = "stashStagedToolStripMenuItem";
+            this.stashStagedToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
+            this.stashStagedToolStripMenuItem.Text = "S&tash staged";
+            this.stashStagedToolStripMenuItem.ToolTipText = "Stash staged changes";
+            this.stashStagedToolStripMenuItem.Click += new System.EventHandler(this.StashStagedToolStripMenuItemClick);
             // 
             // stashPopToolStripMenuItem
             // 
@@ -1792,6 +1802,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripPushButton toolStripButtonPush;
         private ToolStripSplitButton toolStripSplitStash;
         private ToolStripMenuItem stashChangesToolStripMenuItem;
+        private ToolStripMenuItem stashStagedToolStripMenuItem;
         private ToolStripMenuItem stashPopToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator9;
         private ToolStripMenuItem manageStashesToolStripMenuItem;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -266,7 +266,7 @@ namespace GitUI.CommandsDialogs
             MainSplitContainer.Visible = false;
             MainSplitContainer.SplitterDistance = DpiUtil.Scale(260);
 
-            stashStagedToolStripMenuItem.Visible = GitVersion.Current.SupportStashStaged;
+            stashStagedToolStripMenuItem.Visible = Module.GitVersion.SupportStashStaged;
 
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -266,6 +266,8 @@ namespace GitUI.CommandsDialogs
             MainSplitContainer.Visible = false;
             MainSplitContainer.SplitterDistance = DpiUtil.Scale(260);
 
+            stashStagedToolStripMenuItem.Visible = GitVersion.Current.SupportStashStaged;
+
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await TaskScheduler.Default;
@@ -1589,6 +1591,12 @@ namespace GitUI.CommandsDialogs
         private void StashChangesToolStripMenuItemClick(object sender, EventArgs e)
         {
             UICommands.StashSave(this, AppSettings.IncludeUntrackedFilesInManualStash);
+            UpdateStashCount();
+        }
+
+        private void StashStagedToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            UICommands.StashStaged(this);
             UpdateStashCount();
         }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -266,8 +266,6 @@ namespace GitUI.CommandsDialogs
             MainSplitContainer.Visible = false;
             MainSplitContainer.SplitterDistance = DpiUtil.Scale(260);
 
-            stashStagedToolStripMenuItem.Visible = Module.GitVersion.SupportStashStaged;
-
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await TaskScheduler.Default;
@@ -871,6 +869,7 @@ namespace GitUI.CommandsDialogs
                 }
 
                 stashChangesToolStripMenuItem.Enabled = !bareRepository;
+                stashStagedToolStripMenuItem.Visible = Module.GitVersion.SupportStashStaged;
                 gitGUIToolStripMenuItem.Enabled = !bareRepository;
 
                 SetShortcutKeyDisplayStringsFromHotkeySettings();

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -123,6 +123,7 @@ namespace GitUI.CommandsDialogs
             this.CommitAndPush = new System.Windows.Forms.Button();
             this.Amend = new System.Windows.Forms.CheckBox();
             this.ResetAuthor = new System.Windows.Forms.CheckBox();
+            this.StashStaged = new System.Windows.Forms.Button();
             this.Reset = new System.Windows.Forms.Button();
             this.ResetUnStaged = new System.Windows.Forms.Button();
             this.toolbarCommit = new GitUI.ToolStripEx();
@@ -1115,6 +1116,7 @@ namespace GitUI.CommandsDialogs
             var resetAuthorPanel = new Panel{ AutoSize = false, Size = this.ResetAuthor.Size, Margin = new Padding(0) };
             resetAuthorPanel.Controls.Add(this.ResetAuthor);
             this.flowCommitButtons.Controls.Add(resetAuthorPanel);
+            this.flowCommitButtons.Controls.Add(this.StashStaged);
             this.flowCommitButtons.Controls.Add(this.Reset);
             this.flowCommitButtons.Controls.Add(this.ResetUnStaged);
             this.flowCommitButtons.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -1178,11 +1180,25 @@ namespace GitUI.CommandsDialogs
             this.ResetAuthor.UseVisualStyleBackColor = true;
             this.ResetAuthor.Visible = false;
             // 
+            // StashStaged
+            // 
+            this.StashStaged.Image = global::GitUI.Properties.Images.Stash;
+            this.StashStaged.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.StashStaged.Location = new System.Drawing.Point(0, 110);
+            this.StashStaged.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
+            this.StashStaged.Name = "StashStaged";
+            this.StashStaged.Size = new System.Drawing.Size(171, 26);
+            this.StashStaged.TabIndex = 14;
+            this.StashStaged.TabStop = false;
+            this.StashStaged.Text = "S&tash staged changes";
+            this.StashStaged.UseVisualStyleBackColor = true;
+            this.StashStaged.Click += new System.EventHandler(this.StashStagedClick);
+            // 
             // Reset
             // 
             this.Reset.Image = global::GitUI.Properties.Images.ResetWorkingDirChanges;
             this.Reset.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.Reset.Location = new System.Drawing.Point(0, 110);
+            this.Reset.Location = new System.Drawing.Point(0, 142);
             this.Reset.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
             this.Reset.Name = "Reset";
             this.Reset.Size = new System.Drawing.Size(171, 26);
@@ -1196,7 +1212,7 @@ namespace GitUI.CommandsDialogs
             // 
             this.ResetUnStaged.Image = global::GitUI.Properties.Images.ResetWorkingDirChanges;
             this.ResetUnStaged.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.ResetUnStaged.Location = new System.Drawing.Point(0, 142);
+            this.ResetUnStaged.Location = new System.Drawing.Point(0, 174);
             this.ResetUnStaged.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
             this.ResetUnStaged.Name = "ResetUnStaged";
             this.ResetUnStaged.Size = new System.Drawing.Size(171, 26);
@@ -1679,10 +1695,11 @@ namespace GitUI.CommandsDialogs
         private FlowLayoutPanel flowCommitButtons;
         private Button Commit;
         private Button CommitAndPush;
-        private Button Reset;
+        private CheckBox StageInSuperproject;
         private CheckBox Amend;
         private CheckBox ResetAuthor;
-        private CheckBox StageInSuperproject;
+        private Button StashStaged;
+        private Button Reset;
         private Button ResetUnStaged;
         private ToolStripMenuItem resetUnstagedChangesToolStripMenuItem;
         private ToolStripMenuItem noVerifyToolStripMenuItem;

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1695,11 +1695,11 @@ namespace GitUI.CommandsDialogs
         private FlowLayoutPanel flowCommitButtons;
         private Button Commit;
         private Button CommitAndPush;
-        private CheckBox StageInSuperproject;
-        private CheckBox Amend;
-        private CheckBox ResetAuthor;
         private Button StashStaged;
         private Button Reset;
+        private CheckBox Amend;
+        private CheckBox ResetAuthor;
+        private CheckBox StageInSuperproject;
         private Button ResetUnStaged;
         private ToolStripMenuItem resetUnstagedChangesToolStripMenuItem;
         private ToolStripMenuItem noVerifyToolStripMenuItem;

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -307,7 +307,7 @@ namespace GitUI.CommandsDialogs
             selectionFilter.Size = DpiUtil.Scale(selectionFilter.Size);
             toolStripStatusBranchIcon.Width = DpiUtil.Scale(toolStripStatusBranchIcon.Width);
 
-            if (!GitVersion.Current.SupportStashStaged)
+            if (!Module.GitVersion.SupportStashStaged)
             {
                 flowCommitButtons.Controls.Remove(StashStaged);
             }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -307,6 +307,11 @@ namespace GitUI.CommandsDialogs
             selectionFilter.Size = DpiUtil.Scale(selectionFilter.Size);
             toolStripStatusBranchIcon.Width = DpiUtil.Scale(toolStripStatusBranchIcon.Width);
 
+            if (!GitVersion.Current.SupportStashStaged)
+            {
+                flowCommitButtons.Controls.Remove(StashStaged);
+            }
+
             SetVisibilityOfSelectionFilter(AppSettings.CommitDialogSelectionFilter);
             Reset.Visible = AppSettings.ShowResetAllChanges;
             ResetUnStaged.Visible = AppSettings.ShowResetWorkTreeChanges;
@@ -2696,6 +2701,12 @@ namespace GitUI.CommandsDialogs
         private void HandleResetButton(bool onlyUnstaged)
         {
             BypassFormActivatedEventHandler(() => UICommands.StartResetChangesDialog(this, Unstaged.AllItems.Select(i => i.Item).ToList(), onlyWorkTree: onlyUnstaged));
+            Initialize();
+        }
+
+        private void StashStagedClick(object sender, EventArgs e)
+        {
+            BypassFormActivatedEventHandler(() => UICommands.StashStaged(owner: this));
             Initialize();
         }
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -202,6 +202,19 @@ namespace GitUI
             return DoActionOnRepo(owner, Action);
         }
 
+        public bool StashStaged(IWin32Window? owner)
+        {
+            bool Action()
+            {
+                FormProcess.ShowDialog(owner, arguments: "stash --staged", Module.WorkingDir, input: null, useDialogSettings: true);
+
+                // git-stash may have changed commits also if aborted, the grid must be refreshed
+                return true;
+            }
+
+            return DoActionOnRepo(owner, Action);
+        }
+
         public bool StashPop(IWin32Window? owner)
         {
             bool Action()

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3127,6 +3127,14 @@ Do you want to continue?</source>
         <source>Apply and drop single stash</source>
         <target />
       </trans-unit>
+      <trans-unit id="stashStagedToolStripMenuItem.Text">
+        <source>S&amp;tash staged</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="stashStagedToolStripMenuItem.ToolTipText">
+        <source>Stash staged changes</source>
+        <target />
+      </trans-unit>
       <trans-unit id="stashToolStripMenuItem.Text">
         <source>Ma&amp;nage stashes...</source>
         <target />
@@ -3838,6 +3846,10 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
       </trans-unit>
       <trans-unit id="StageInSuperproject.Text">
         <source>Stage &amp;in Superproject</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="StashStaged.Text">
+        <source>S&amp;tash staged changes</source>
         <target />
       </trans-unit>
       <trans-unit id="_addSelectionToCommitMessage.Text">


### PR DESCRIPTION
Fixes #9839

## Proposed changes

- Add `git stash --staged` command to FormBrowse and to FormCommit
  if Git version is >= 2.35.0
- Recommend this version of Git

My use case: Occasionally, I want to swap staged and unstaged, e.g. if the previous commit needs to be amended or when something different is to be committed urgently.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/36601201/151887761-4c7bc5b0-a2a2-4de1-81ed-36eade1bce96.png)

![image](https://user-images.githubusercontent.com/36601201/151887813-ad922a08-5164-407c-996d-4310a0a254ea.png)

### After

![image](https://user-images.githubusercontent.com/36601201/151887895-a27426ac-cb30-4a2f-a2e6-437be6be87fb.png)

![image](https://user-images.githubusercontent.com/36601201/151888032-2d7ddfbb-bcbe-4f93-b286-e8c94b77b31e.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 0fe73fac09d500dcd1d28123a2436645c6d983b8
- Git 2.35.1.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 5.0.12
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).