### PR TITLE
Offload refs and revision loading to background thread

### DIFF
--- a/GitCommands/Git/GitRefName.cs
+++ b/GitCommands/Git/GitRefName.cs
@@ -33,6 +33,9 @@ namespace GitCommands
         /// <summary>"refs/stash".</summary>
         public static string RefsStashPrefix { get; } = "refs/stash";
 
+        /// <summary>"refs/notes/commits".</summary>
+        public static string RefsNotesPrefix { get; } = "refs/notes/commits";
+
         /// <summary>"^{}".</summary>
         public static string TagDereferenceSuffix { get; } = "^{}";
 

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -73,14 +73,10 @@ namespace GitCommands
             string pathFilter,
             CancellationToken token)
         {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-            var revisionCount = 0;
-
             await TaskScheduler.Default;
-
             token.ThrowIfCancellationRequested();
 
+            var revisionCount = 0;
             var arguments = BuildArguments(maxCount, refFilterOptions, branchFilter, revisionFilter, pathFilter);
 
 #if DEBUG

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -244,6 +244,20 @@ namespace GitUI.BranchTreePanel
             _ = UICommandsSource;
         }
 
+        public void Reset()
+        {
+            treeMain.BeginUpdate();
+            treeMain.SuspendLayout();
+
+            foreach (Tree rootNode in _rootNodes)
+            {
+                rootNode.TreeViewNode.Nodes.Clear();
+            }
+
+            treeMain.PerformLayout();
+            treeMain.EndUpdate();
+        }
+
         /// <summary>
         /// Toggles filtering mode on or off to the git refs present in the left panel depending on the app's global filtering rules .
         /// These rules include: show all branches / show current branch / show filtered branches, etc.

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -210,7 +210,6 @@ namespace GitUI.CommandsDialogs
 
         #endregion
 
-        private readonly CancellationTokenSequence _refreshRevsionsSequence = new();
         private readonly SplitterManager _splitterManager = new(new AppSettingsPath("FormBrowse"));
         private readonly GitStatusMonitor _gitStatusMonitor;
         private readonly FormBrowseMenus _formBrowseMenus;
@@ -564,7 +563,7 @@ namespace GitUI.CommandsDialogs
                 RevisionInfo.SetRevisionWithChildren(revision: null, children: Array.Empty<ObjectId>());
 
                 // Reload the revisions
-                RefreshRevisions(e.GetRefs, _refreshRevsionsSequence.Next());
+                RefreshRevisions(e.GetRefs);
             }).FileAndForget();
 
             ToolStripFilters.UpdateBranchFilterItems(e.GetRefs);
@@ -574,7 +573,7 @@ namespace GitUI.CommandsDialogs
             revisionDiff.UICommands_PostRepositoryChanged(sender, e);
         }
 
-        private void RefreshRevisions(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs, CancellationToken cancellationToken)
+        private void RefreshRevisions(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
         {
             if (RevisionGrid.IsDisposed || IsDisposed || Disposing)
             {
@@ -730,7 +729,7 @@ namespace GitUI.CommandsDialogs
                         if (plugin.Execute(new GitUIEventArgs(this, UICommands)))
                         {
                             _gitStatusMonitor.InvalidateGitWorkingDirectoryStatus();
-                            RefreshRevisions(new FilteredGitRefsProvider(UICommands.GitModule).GetRefs, cancellationToken: default);
+                            RefreshRevisions(new FilteredGitRefsProvider(UICommands.GitModule).GetRefs);
                         }
                     };
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -594,7 +594,7 @@ namespace GitUI.CommandsDialogs
             }
 
             Debug.Assert(RevisionGrid.CanRefresh, "Already loading revisions when running RefreshRevisions(). This could cause the commits in the grid to be loaded several times.");
-            RevisionGrid.PerformRefreshRevisions(getRefs, cancellationToken);
+            RevisionGrid.PerformRefreshRevisions(getRefs);
 
             InternalInitialize();
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9820,7 +9820,7 @@ See the changes in the commit form.</source>
         <source>Filter text '{0}' not valid for "Diff contains" filter.</source>
         <target />
       </trans-unit>
-      <trans-unit id="_loadingControlAsync.Text">
+      <trans-unit id="_loadingControlText.Text">
         <source>Loading</source>
         <target />
       </trans-unit>

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
@@ -32,7 +32,7 @@ namespace GitCommandsTests
         [TestCase(1, true)]
         public void BuildArguments_should_add_maxcount_if_requested(int maxCount, bool expected)
         {
-            var args = _revisionReader.GetTestAccessor().BuildArgumentsBuildArguments(maxCount, RefFilterOptions.All, "", "", "");
+            var args = RevisionReader.BuildArguments(maxCount, RefFilterOptions.All, "", "", "", out bool parentsAreRewritten);
 
             if (expected)
             {
@@ -42,14 +42,17 @@ namespace GitCommandsTests
             {
                 args.ToString().Should().NotContain(" --max-count=");
             }
+
+            parentsAreRewritten.Should().BeFalse();
         }
 
         [Test]
         public void BuildArguments_should_be_NUL_terminated()
         {
-            var args = _revisionReader.GetTestAccessor().BuildArgumentsBuildArguments(-1, RefFilterOptions.All, "", "", "");
+            var args = RevisionReader.BuildArguments(-1, RefFilterOptions.All, "", "", "", out bool parentsAreRewritten);
 
             args.ToString().Should().Contain(" log -z ");
+            parentsAreRewritten.Should().BeFalse();
         }
 
         [TestCase(RefFilterOptions.FirstParent, false)]
@@ -58,7 +61,7 @@ namespace GitCommandsTests
         [TestCase(RefFilterOptions.All | RefFilterOptions.Reflogs, true)]
         public void BuildArguments_should_add_reflog_if_requested(RefFilterOptions refFilterOptions, bool expected)
         {
-            var args = _revisionReader.GetTestAccessor().BuildArgumentsBuildArguments(-1, refFilterOptions, "", "", "");
+            var args = RevisionReader.BuildArguments(-1, refFilterOptions, "", "", "", out bool parentsAreRewritten);
 
             if (expected)
             {
@@ -68,6 +71,8 @@ namespace GitCommandsTests
             {
                 args.ToString().Should().NotContain(" --reflog ");
             }
+
+            parentsAreRewritten.Should().BeFalse();
         }
 
         /* first 'parent first' */
@@ -92,7 +97,7 @@ namespace GitCommandsTests
         [TestCase(RefFilterOptions.Tags, " --tags ", null)]
         public void BuildArguments_check_parameters(RefFilterOptions refFilterOptions, string expectedToContain, string notExpectedToContain)
         {
-            var args = _revisionReader.GetTestAccessor().BuildArgumentsBuildArguments(-1, refFilterOptions, "my_*", "my_revision", "my_path");
+            var args = RevisionReader.BuildArguments(-1, refFilterOptions, "my_*", "my_revision", "my_path", out bool parentsAreRewritten);
 
             if (expectedToContain is not null)
             {
@@ -103,6 +108,8 @@ namespace GitCommandsTests
             {
                 args.ToString().Should().NotContain(notExpectedToContain);
             }
+
+            parentsAreRewritten.Should().BeTrue();
         }
 
         [Test]


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

- This is a tactical fix aim at increasing the responsiveness of the app during the refresh by moving Module.GetRefs call and revisionReader.Execute calls to a background thread.
This makes the app responsive even while loading huge repos like VS, which has >100K commits and takes more than 10s to parse revisions info, and has close to 180K tags, which also take more than 10s to parse.
NB: It also takes another 10+s to load that many tags into the left panel, and this issue is not being addressed in the context of this change.
A more holistic fix would likely involve rework of Module.GetRefs implementation.

- Also pass a cancellation token to allow cancel the load operation.

- Lastly show the spinner while revisions are being loaded, and clear both the left panel and the commit info panel at the beginning of the refresh.


## Screenshots <!-- Remove this section if PR does not change UI -->

ℹ️  I have disabled tags, because those have a significant effect and add about 25 extra seconds to the load.

### Before

- Git Extensions 4.0.0.13119
- Build b26006c674076a56b1c55a50918f4a65bfd5fb7a (Dirty)
- Git 2.33.0.windows.1
- Microsoft Windows NT 10.0.22000.0
- .NET 5.0.13
- DPI 96dpi (no scaling)

https://user-images.githubusercontent.com/4403806/152541597-ec82ab45-e2c7-4bbb-a9ca-874ee4fabeb0.mp4


<!-- TODO -->

### After

https://user-images.githubusercontent.com/4403806/152540529-e11d17a8-3226-4286-a0a1-e36035b74192.mp4

You can still see moment of unresponsiveness but by far and large this is a significant improvement.
⚠️ And this was run with VS debugger attached. 
<!-- TODO -->

## Test methodology <!-- How did you ensure quality? -->

- manually

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
