### PR TITLE
FileHistory mode at browse startup

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.BrowseArguments.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.BrowseArguments.cs
@@ -25,6 +25,11 @@ namespace GitUI.CommandsDialogs
             ///  Gets the first selected commit id (as in a diff).
             /// </summary>
             public ObjectId? FirstId { get; init; }
+
+            /// <summary>
+            /// If to start in "FileHistory mode" with blame view
+            /// </summary>
+            public bool IsFileBlameHistory { get; init; }
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.Linq;
+using GitCommands;
 using GitUI.Properties;
 using GitUIPluginInterfaces;
 
@@ -8,7 +9,7 @@ namespace GitUI.CommandsDialogs
     {
         // This file is dedicated to init logic for FormBrowse revisiong grid control
 
-        private void InitRevisionGrid(ObjectId? selectedId, ObjectId? firstId)
+        private void InitRevisionGrid(ObjectId? selectedId, ObjectId? firstId, bool isBlame)
         {
             RevisionGrid.IndexWatcher.Changed += (_, args) =>
             {
@@ -40,6 +41,13 @@ namespace GitUI.CommandsDialogs
             };
             RevisionGrid.RevisionGraphLoaded += (sender, e) =>
             {
+                // The FileTree tab should be shown at first start, in "filehistory" mode
+                if (isBlame)
+                {
+                    CommitInfoTabControl.SelectedTab = TreeTabPage;
+                    isBlame = false;
+                }
+
                 if (sender is null || MainSplitContainer.Panel1Collapsed)
                 {
                     // - the event is either not originated from the revision grid, or

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1585,7 +1585,8 @@ namespace GitUI
                     new BrowseArguments
                     {
                         RevFilter = GetParameterOrEmptyStringAsDefault(args, "-filter"),
-                        PathFilter = GetParameterOrEmptyStringAsDefault(args, PathFilterArg)
+                        PathFilter = GetParameterOrEmptyStringAsDefault(args, PathFilterArg),
+                        IsFileBlameHistory = args.Any(arg => arg.StartsWith(PathFilterArg))
                     });
             }
 
@@ -1597,7 +1598,8 @@ namespace GitUI
                         RevFilter = GetParameterOrEmptyStringAsDefault(args, "-filter"),
                         PathFilter = GetParameterOrEmptyStringAsDefault(args, PathFilterArg),
                         SelectedId = selectedId,
-                        FirstId = firstId
+                        FirstId = firstId,
+                        IsFileBlameHistory = args.Any(arg => arg.StartsWith(PathFilterArg))
                     });
             }
 
@@ -1751,7 +1753,8 @@ namespace GitUI
                                  {
                                      RevFilter = filterByRevision ? revision?.ObjectId.ToString() : null,
                                      PathFilter = fileHistoryFileName,
-                                     SelectedId = revision?.ObjectId
+                                     SelectedId = revision?.ObjectId,
+                                     IsFileBlameHistory = true
                                  }));
             }
             else


### PR DESCRIPTION
Final (?) part of #9796 

## Proposed changes

When starting up with command line arguments "filehistory" or
"blamehistory" (for instance from VS or explorer),
hide the side panel and start in FileTree tab to
provide an experience similar to old FileHistory.

The forced side panel state is not persisted to settings at shutdown.

If argument is "blamehistory" the Blame viewer is explicitly enabled
(similar to blame from DifTab), for "filehistory" the last used form
is used.

## Screenshots <!-- Remove this section if PR does not change UI -->

When starting with command line arguments "filehistory appveyor.yml"

### Before

![image](https://user-images.githubusercontent.com/6248932/153090698-2d28eb3d-ab1a-4e80-8b20-d1054849491a.png)

### After

![image](https://user-images.githubusercontent.com/6248932/153090665-27f2daef-d0dd-4136-be1d-6087b7fa9e61.png)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
