### PR TITLE
RefreshGrid: async reading refs and logs in parallel

### DIFF
--- a/GitCommands/Git/GitRefName.cs
+++ b/GitCommands/Git/GitRefName.cs
@@ -33,6 +33,9 @@ namespace GitCommands
         /// <summary>"refs/stash".</summary>
         public static string RefsStashPrefix { get; } = "refs/stash";
 
+        /// <summary>"refs/notes/commits".</summary>
+        public static string RefsNotesPrefix { get; } = "refs/notes/commits";
+
         /// <summary>"^{}".</summary>
         public static string TagDereferenceSuffix { get; } = "^{}";
 

--- a/GitUI/CommandsDialogs/FormBrowse.InitCommitDetails.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitCommitDetails.cs
@@ -36,7 +36,9 @@ namespace GitUI.CommandsDialogs
 
             if (!AppSettings.ShowGpgInformation.Value)
             {
+                CommitInfoTabControl.SelectedIndexChanged -= CommitInfoTabControl_SelectedIndexChanged;
                 CommitInfoTabControl.RemoveIfExists(GpgInfoTabPage);
+                CommitInfoTabControl.SelectedIndexChanged += CommitInfoTabControl_SelectedIndexChanged;
             }
 
             FillBuildReport(revision: null); // Ensure correct page visibility

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -568,9 +568,12 @@ namespace GitUI.CommandsDialogs
 
         private void UICommands_PostRepositoryChanged(object sender, GitUIEventArgs e)
         {
+            // Note that this called in most FormBrowse context to "be sure"
+            // that the repo has not been updated externally.
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await this.SwitchToMainThreadAsync();
+
                 RefreshRevisions(e.GetRefs);
             }).FileAndForget();
 
@@ -1014,8 +1017,8 @@ namespace GitUI.CommandsDialogs
                 ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     // Add a delay to not interfere with GUI updates when switching repository
-                    await Task.Delay(500);
                     await TaskScheduler.Default;
+                    await Task.Delay(500);
 
                     var result = Module.GetStashes(noLocks: true).Count;
 
@@ -2972,7 +2975,9 @@ namespace GitUI.CommandsDialogs
             var commitInfoPosition = AppSettings.CommitInfoPosition;
             if (commitInfoPosition == CommitInfoPosition.BelowList)
             {
+                CommitInfoTabControl.SelectedIndexChanged -= CommitInfoTabControl_SelectedIndexChanged;
                 CommitInfoTabControl.InsertIfNotExists(0, CommitInfoTabPage);
+                CommitInfoTabControl.SelectedIndexChanged += CommitInfoTabControl_SelectedIndexChanged;
                 CommitInfoTabControl.SelectedTab = CommitInfoTabPage;
 
                 RevisionsSplitContainer.FixedPanel = FixedPanel.Panel2;
@@ -2984,7 +2989,9 @@ namespace GitUI.CommandsDialogs
             {
                 // enough to fit CommitInfoHeader in most cases, when the width is (avatar + commit hash)
                 int width = DpiUtil.Scale(490) + SystemInformation.VerticalScrollBarWidth;
+                CommitInfoTabControl.SelectedIndexChanged -= CommitInfoTabControl_SelectedIndexChanged;
                 CommitInfoTabControl.RemoveIfExists(CommitInfoTabPage);
+                CommitInfoTabControl.SelectedIndexChanged += CommitInfoTabControl_SelectedIndexChanged;
 
                 if (commitInfoPosition == CommitInfoPosition.RightwardFromList)
                 {

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9820,10 +9820,6 @@ See the changes in the commit form.</source>
         <source>Base commit for compare is not selected.</source>
         <target />
       </trans-unit>
-      <trans-unit id="_cannotHighlightSelectedBranch.Text">
-        <source>Cannot highlight selected branch when revision graph is loading.</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_dontShowAgain.Text">
         <source>Don't show me this message again.</source>
         <target />
@@ -9836,7 +9832,7 @@ See the changes in the commit form.</source>
         <source>Filter text '{0}' not valid for "Diff contains" filter.</source>
         <target />
       </trans-unit>
-      <trans-unit id="_loadingControlAsync.Text">
+      <trans-unit id="_loadingControlText.Text">
         <source>Loading</source>
         <target />
       </trans-unit>

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
@@ -32,7 +32,7 @@ namespace GitCommandsTests
         [TestCase(1, true)]
         public void BuildArguments_should_add_maxcount_if_requested(int maxCount, bool expected)
         {
-            var args = _revisionReader.GetTestAccessor().BuildArgumentsBuildArguments(maxCount, RefFilterOptions.All, "", "", "");
+            var args = RevisionReader.BuildArguments(maxCount, RefFilterOptions.All, "", "", "", out bool parentsAreRewritten);
 
             if (expected)
             {
@@ -42,14 +42,17 @@ namespace GitCommandsTests
             {
                 args.ToString().Should().NotContain(" --max-count=");
             }
+
+            parentsAreRewritten.Should().BeFalse();
         }
 
         [Test]
         public void BuildArguments_should_be_NUL_terminated()
         {
-            var args = _revisionReader.GetTestAccessor().BuildArgumentsBuildArguments(-1, RefFilterOptions.All, "", "", "");
+            var args = RevisionReader.BuildArguments(-1, RefFilterOptions.All, "", "", "", out bool parentsAreRewritten);
 
             args.ToString().Should().Contain(" log -z ");
+            parentsAreRewritten.Should().BeFalse();
         }
 
         [TestCase(RefFilterOptions.FirstParent, false)]
@@ -58,7 +61,7 @@ namespace GitCommandsTests
         [TestCase(RefFilterOptions.All | RefFilterOptions.Reflogs, true)]
         public void BuildArguments_should_add_reflog_if_requested(RefFilterOptions refFilterOptions, bool expected)
         {
-            var args = _revisionReader.GetTestAccessor().BuildArgumentsBuildArguments(-1, refFilterOptions, "", "", "");
+            var args = RevisionReader.BuildArguments(-1, refFilterOptions, "", "", "", out bool parentsAreRewritten);
 
             if (expected)
             {
@@ -68,6 +71,8 @@ namespace GitCommandsTests
             {
                 args.ToString().Should().NotContain(" --reflog ");
             }
+
+            parentsAreRewritten.Should().BeFalse();
         }
 
         /* first 'parent first' */
@@ -92,7 +97,7 @@ namespace GitCommandsTests
         [TestCase(RefFilterOptions.Tags, " --tags ", null)]
         public void BuildArguments_check_parameters(RefFilterOptions refFilterOptions, string expectedToContain, string notExpectedToContain)
         {
-            var args = _revisionReader.GetTestAccessor().BuildArgumentsBuildArguments(-1, refFilterOptions, "my_*", "my_revision", "my_path");
+            var args = RevisionReader.BuildArguments(-1, refFilterOptions, "my_*", "my_revision", "my_path", out bool parentsAreRewritten);
 
             if (expectedToContain is not null)
             {
@@ -103,6 +108,8 @@ namespace GitCommandsTests
             {
                 args.ToString().Should().NotContain(notExpectedToContain);
             }
+
+            parentsAreRewritten.Should().BeTrue();
         }
 
         [Test]


### PR DESCRIPTION
Co-authored by RussKie
This replaces #9853
(changes pushed to #9853 too).

## Proposed changes

Improve the responsiveness in the loading phase and decrease
the revision loading time.

Revision info is read in two parallel steps:

1. Read current commit, refs, prepare grid etc.
2. Read all revisions with git-log.

Both these operations can take a long time and is done async.
Before part 1. was read synchrounously and blocked the interface
(git-log was async).
As the information is needed by step 2. when commits are added to the grid,
the information from step 1. is therefore protected with Lazy accessosors
and a semaphore.

RevisionReader (git-log) was previously also updating other information,
but is now a pure revision reader.

Other:

* The text label informing that loading of revisions still occur was
not displayed.

* NavigationHistory was normally always reset also if the grid was refreshed.
(With a potential race condition to keep existing history also if a new repo was opened).

* Clear side panel and the commit info panel at the beginning of the refresh.

* Avoid a Git call to get current head

* Optimizations for git-notes, assuming no notes exists.

## Screenshots 

Showing the difference for linux, limited number of refs so there are repos that benefits more
(after run in the debugger)

3.0 for loading refs is to load ahead/behind for the sidepanel, done in the background

The time differs from run to run, this is showing something I feel is representative.
The biggest difference will be seen in repos with many refs anyway.

The "sync" phase in the VS repo would be 10 s:
https://github.com/gitextensions/gitextensions/pull/9853#issuecomment-1030990082

### Before

170 ms in the sync phase (33 ms to load current HEAD)
Another 30 ms before logs are loaded
3.1 s to load revisions

3.3 s to load all

![image](https://user-images.githubusercontent.com/6248932/153774012-aee70db3-31fc-4b48-b2e9-4bee1e988bb2.png)

### After

![image](https://user-images.githubusercontent.com/6248932/153772934-b14c2fc3-56b5-436c-bc74-f05688b3263f.png)

(most of 196 ms after ls-files is time between activating and 
A few ms blocking the UI thread,
110 ms (a few more) in the spinner phase before loading refs, in this case the first rev is shown displayed just after that.
3.3s to load completely - git-log is more or less running from start to end

In this case the total loading time is actually a few ms more, but the git-log

![image](https://user-images.githubusercontent.com/6248932/153774396-c4e4f1c6-2f5c-48b8-9774-a3d280f28ad1.png)

![image](https://user-images.githubusercontent.com/6248932/153773051-b07c2280-3395-43f2-860f-2288cab62293.png)

## Test methodology <!-- How did you ensure quality? -->

Tests slightly updated, but mostly manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
