### PR TITLE
[WIP] FileStatusList: Add diff group with changes to default branch of default remote

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2202,7 +2202,7 @@ namespace GitCommands
         public IReadOnlyList<string> GetRemoteNames()
         {
             return _gitExecutable
-                .Execute("remote")
+                .Execute("remote", cache: GitCommandCache)
                 .StandardOutput
                 .LazySplit('\n', StringSplitOptions.RemoveEmptyEntries)
                 .ToList();
@@ -3723,10 +3723,14 @@ namespace GitCommands
         }
 
         public ObjectId? GetMergeBase(ObjectId a, ObjectId b)
+            => GetMergeBase(a, b.ToString());
+
+        public ObjectId? GetMergeBase(ObjectId? objectIdA, string b)
         {
+            string a = objectIdA is null ? "HEAD" : objectIdA.ToString();
             if (a == b)
             {
-                return a;
+                return objectIdA;
             }
 
             GitArgumentBuilder args = new("merge-base")

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2202,7 +2202,7 @@ namespace GitCommands
         public IReadOnlyList<string> GetRemoteNames()
         {
             return _gitExecutable
-                .Execute("remote", cache: GitCommandCache)
+                .Execute("remote", cache: null) //// GitCommandCache is not cleared when switching repos
                 .StandardOutput
                 .LazySplit('\n', StringSplitOptions.RemoveEmptyEntries)
                 .ToList();

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -944,7 +944,7 @@ namespace GitUI
                     group = new ListViewGroup(name)
                     {
                         // Collapse some groups for diffs with common BASE
-                        CollapsedState = i.Statuses.Count <= 7 || GitItemStatusesWithDescription.Count < 3 || i == GitItemStatusesWithDescription[0]
+                        CollapsedState = i == GitItemStatusesWithDescription[0] || (i == GitItemStatusesWithDescription[1] && !i.Summary.Contains("BASE"))
                             ? ListViewGroupCollapsedState.Expanded
                             : ListViewGroupCollapsedState.Collapsed,
                         Tag = i.FirstRev


### PR DESCRIPTION
## Proposed changes

- Add FileStatusList diff-group with changes to the default branch of the default remote (if a single revision is selected)
- Collapse all additional diff-groups

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/153966817-7fcf363a-8ff6-4cdc-9bdf-d83b03153829.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/153966425-cb8accb6-fede-419b-ba5d-3fe00e342a7d.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 001f4151c260fb92df818d35bca63138d8dbbdec
- Git 2.35.1.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 5.0.12
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).