### PR TITLE
IndexWatcher: Use for refresh icon only

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -874,11 +874,6 @@ namespace GitUI.CommandsDialogs
 
                 SetShortcutKeyDisplayStringsFromHotkeySettings();
 
-                if (hasWorkingDir)
-                {
-                    ShowRevisions();
-                }
-
                 RefreshWorkingDirComboText();
 
                 OnActivate();
@@ -899,7 +894,6 @@ namespace GitUI.CommandsDialogs
                     toolStripButtonPush.DisplayAheadBehindInformation(branchSelect.Text);
 
                     ActiveControl = RevisionGrid;
-                    RevisionGrid.IndexWatcher.Reset();
                 }
                 else
                 {
@@ -952,23 +946,13 @@ namespace GitUI.CommandsDialogs
                     {
                         if (ScriptRunner.RunScript(this, Module, script.Name, UICommands, RevisionGrid).NeedsGridRefresh)
                         {
-                            RevisionGrid.RefreshRevisions();
+                            RevisionGrid.PerformRefreshRevisions();
                         }
                     };
 
                     // add to toolstrip
                     ToolStripScripts.Items.Add(button);
                 }
-            }
-
-            void ShowRevisions()
-            {
-                if (RevisionGrid.IndexWatcher.IndexChanged)
-                {
-                    RefreshSelection();
-                }
-
-                RevisionGrid.IndexWatcher.Reset();
             }
         }
 
@@ -1833,7 +1817,6 @@ namespace GitUI.CommandsDialogs
             {
                 dashboardToolStripMenuItem.Visible = true;
 
-                RevisionGrid.IndexWatcher.Reset();
                 MainSplitContainer.Visible = false;
                 ShowDashboard();
             }

--- a/GitUI/UserControls/RevisionGrid/IndexWatcher.cs
+++ b/GitUI/UserControls/RevisionGrid/IndexWatcher.cs
@@ -30,9 +30,7 @@ namespace GitUI.UserControls.RevisionGrid
             _uICommandsSource.UICommandsChanged += OnUICommandsChanged;
             GitIndexWatcher = new FileSystemWatcher();
             RefsWatcher = new FileSystemWatcher();
-            SetFileSystemWatcher();
 
-            IndexChanged = true;
             GitIndexWatcher.Changed += fileSystemWatcher_Changed;
             RefsWatcher.Changed += fileSystemWatcher_Changed;
         }
@@ -59,6 +57,7 @@ namespace GitUI.UserControls.RevisionGrid
 
                     GitIndexWatcher.Path = _gitDirPath;
                     GitIndexWatcher.Filter = "index";
+                    GitIndexWatcher.NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.LastWrite | NotifyFilters.CreationTime;
                     GitIndexWatcher.IncludeSubdirectories = false;
                     GitIndexWatcher.EnableRaisingEvents = _enabled;
 
@@ -74,7 +73,7 @@ namespace GitUI.UserControls.RevisionGrid
         }
 
         private bool _indexChanged;
-        public bool IndexChanged
+        private bool IndexChanged
         {
             get
             {
@@ -110,16 +109,23 @@ namespace GitUI.UserControls.RevisionGrid
             IndexChanged = true;
         }
 
+        /// <summary>
+        /// Reenable indexwatcher (if disabled), reset icon.
+        /// </summary>
         public void Reset()
         {
-            IndexChanged = false;
             RefreshWatcher();
+            IndexChanged = false;
         }
 
-        private void Clear()
+        /// <summary>
+        /// Disable events, reset icon.
+        /// </summary>
+        public void Clear()
         {
-            IndexChanged = true;
-            RefreshWatcher();
+            GitIndexWatcher.EnableRaisingEvents = false;
+            RefsWatcher.EnableRaisingEvents = false;
+            IndexChanged = false;
         }
 
         private void RefreshWatcher()


### PR DESCRIPTION
Related to #9864 
Possibly fixes #9792 #9223

## Proposed changes

The IndexWatcher controls the icon for the refresh button in Browse.
Before #9791 the setting could be controlled individually,
now the same setting as for GitStatus (commit count).

Previously it also tried to optimize grid refresh operations in a few
situations, skipping when no changes was detected to the index or any refs.
These checks are now removed, always refreshing the grid.

The check for changes seem to miss updates occasionally (and never in
WSL where FileSystemWatcher do not reeport updates).
This seem to be improved by matching on creation of index.lock
in addition to index, but then also reset of worktree files
are tracked as index changes.

Before the file watcher was initiated at creation of the control and
when a new revision was loaded. This requires a sync call to
git-rev-parse --git-common-dir delaying the revision loading
50-100 ms.
This is changed to just clear the icon when loading a revision
(as well as when a new repo is loaded even if that should not be required)
and resetting the file system watcher after all revisions was loaded.

The IndexWatcher was reset several additional times after the grid
was refreshed.

The IndexWatcher.IndexChanged was used to possibly refresh the revisions
that was already refreshed when the revisions were selected in the grid.
(Also, no changes should have occurred this time.)

An example where FileSystemWatcher does not fire.

```
echo >> appveyor.yml ; git add appveyor.yml
```

## Test methodology <!-- How did you ensure quality? -->

Manual.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
