### PR TITLE
Show CurrentCommitId for super project for submodules

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -232,22 +232,27 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             Rectangle messageBounds,
             ref int offset)
         {
+            if (spi.CurrentCommit == revision.ObjectId)
+            {
+                DrawSuperProjectRef("", ref offset, isSelected: true);
+            }
+
             if (spi.ConflictBase == revision.ObjectId)
             {
-                DrawSuperProjectRef("Base", ref offset);
+                DrawSuperProjectRef("Base", ref offset, isSelected: false);
             }
 
             if (spi.ConflictLocal == revision.ObjectId)
             {
-                DrawSuperProjectRef("Local", ref offset);
+                DrawSuperProjectRef("Local", ref offset, isSelected: false);
             }
 
             if (spi.ConflictRemote == revision.ObjectId)
             {
-                DrawSuperProjectRef("Remote", ref offset);
+                DrawSuperProjectRef("Remote", ref offset, isSelected: false);
             }
 
-            void DrawSuperProjectRef(string label, ref int currentOffset)
+            void DrawSuperProjectRef(string label, ref int currentOffset, bool isSelected)
             {
                 RevisionGridRefRenderer.DrawRef(
                     e.State.HasFlag(DataGridViewElementStates.Selected),
@@ -255,9 +260,10 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                     ref currentOffset,
                     label,
                     Color.OrangeRed,
-                    RefArrowType.NotFilled,
+                    isSelected ? RefArrowType.Filled : RefArrowType.NotFilled,
                     messageBounds,
-                    e.Graphics);
+                    e.Graphics,
+                    dashedLine: true);
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1306,7 +1306,7 @@ namespace GitUI
                 }
                 else
                 {
-                    spi.CurrentBranch = commit;
+                    spi.CurrentCommit = commit;
                 }
 
                 var refs = await gitModule.SuperprojectModule.GetSubmoduleItemsForEachRefAsync(gitModule.SubmodulePath, noLocks: noLocks);

--- a/GitUI/UserControls/RevisionGrid/RevisionGridRefRenderer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridRefRenderer.cs
@@ -18,13 +18,15 @@ namespace GitUI
 
         public static void DrawRef(bool isRowSelected, Font font, ref int offset, string name, Color headColor, RefArrowType arrowType, in Rectangle bounds, Graphics graphics, bool dashedLine = false)
         {
-            var paddingLeftRight = DpiUtil.Scale(4);
+            var paddingLeftRight = !string.IsNullOrEmpty(name) ? DpiUtil.Scale(4) : DpiUtil.Scale(1);
             var paddingTopBottom = DpiUtil.Scale(2);
             var marginRight = DpiUtil.Scale(7);
 
             var textColor = ColorHelper.Lerp(headColor, Color.Black, 0.25F);
 
-            var textSize = TextRenderer.MeasureText(graphics, name, font, Size.Empty, TextFormatFlags.NoPadding);
+            Size textSize = !string.IsNullOrEmpty(name)
+                ? TextRenderer.MeasureText(graphics, name, font, Size.Empty, TextFormatFlags.NoPadding)
+                : new(0, TextRenderer.MeasureText(graphics, " ", font, Size.Empty, TextFormatFlags.NoPadding).Height);
 
             var arrowWidth = arrowType == RefArrowType.None ? 0 : bounds.Height / 2;
 

--- a/GitUI/UserControls/RevisionGrid/SuperProjectInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/SuperProjectInfo.cs
@@ -5,8 +5,7 @@ namespace GitUI
 {
     internal sealed class SuperProjectInfo
     {
-        // TODO nothing reads this property
-        public ObjectId? CurrentBranch { get; set; }
+        public ObjectId? CurrentCommit { get; set; }
         public ObjectId? ConflictBase { get; set; }
         public ObjectId? ConflictRemote { get; set; }
         public ObjectId? ConflictLocal { get; set; }


### PR DESCRIPTION
## Proposed changes

Seen in #9864 

For submodules, show the commit in the supermodule (index).
So if the submodule is not updated, the marker will differ.

Related to #8703 that selects the commit in superproject head when opening a submodule.

The color is not themable, also used when the submodule is in conflict.
This could be done in the grid too
(but then GetSuperprojectCheckoutAsync() will have to be split to not delay submodules too much).

The alternative to this PR is to delete the unused property.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

(No extra arrow)

### After

![image](https://user-images.githubusercontent.com/6248932/155903223-3c184d74-93a9-4952-ab6f-396ec6ad1737.png)

## Test methodology <!-- How did you ensure quality? -->

Manual.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
