### PR TITLE
RevGrid: Lazy handling for current branch

### DIFF
--- a/GitCommands/AppTitleGenerator.cs
+++ b/GitCommands/AppTitleGenerator.cs
@@ -47,7 +47,10 @@ namespace GitCommands
                 return AppSettings.ApplicationName;
             }
 
-            branchName = branchName?.Trim('(', ')') ?? defaultBranchName;
+            if (string.IsNullOrWhiteSpace(branchName))
+            {
+                branchName = defaultBranchName;
+            }
 
             // Pathname normally have quotes already
             pathName = GetFileName(pathName);

--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -26,7 +26,7 @@ namespace GitUI.CommandsDialogs
             RevisionGrid.MenuCommands.MenuChanged += (sender, e) => _formBrowseMenus.OnMenuCommandsPropertyChanged();
             RevisionGrid.FilterChanged += (sender, e) =>
             {
-                Text = _appTitleGenerator.Generate(Module.WorkingDir, Module.IsValidGitWorkingDir(), Module.GetSelectedBranch(), TranslatedStrings.NoBranch, e.PathFilter);
+                Text = _appTitleGenerator.Generate(Module.WorkingDir, Module.IsValidGitWorkingDir(), RevisionGrid.CurrentBranch.Value, TranslatedStrings.NoBranch, e.PathFilter);
 
                 // PathFilter is a free text field and may contain wildcards, quoting is optional.
                 // This is will adjust the string at least for paths added from context menus.

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -827,7 +827,11 @@ namespace GitUI.CommandsDialogs
                 bool isDashboard = _dashboard?.Visible ?? false;
                 bool validBrowseDir = !isDashboard && Module.IsValidGitWorkingDir();
 
-                branchSelect.Text = validBrowseDir ? Module.GetSelectedBranch() : "";
+                branchSelect.Text = validBrowseDir
+                    ? !string.IsNullOrWhiteSpace(RevisionGrid.CurrentBranch.Value)
+                        ? RevisionGrid.CurrentBranch.Value
+                        : DetachedHeadParser.DetachedBranch
+                    : "";
                 toolStripButtonLevelUp.Enabled = hasWorkingDir && !bareRepository;
                 CommitInfoTabControl.Visible = validBrowseDir;
                 fileExplorerToolStripMenuItem.Enabled = validBrowseDir;
@@ -909,7 +913,7 @@ namespace GitUI.CommandsDialogs
 
                     _formBrowseMenus.InsertRevisionGridMainMenuItems(repositoryToolStripMenuItem);
 
-                    toolStripButtonPush.DisplayAheadBehindInformation(branchSelect.Text);
+                    toolStripButtonPush.DisplayAheadBehindInformation(RevisionGrid.CurrentBranch.Value);
 
                     ActiveControl = RevisionGrid;
                 }
@@ -1499,7 +1503,7 @@ namespace GitUI.CommandsDialogs
                 string? to = null;
                 string? from = null;
 
-                string currentBranch = Module.GetSelectedBranch();
+                string currentBranch = RevisionGrid.CurrentBranch.Value;
                 var currentCheckout = RevisionGrid.CurrentCheckout;
 
                 if (revisions[0].ObjectId == currentCheckout)

--- a/GitUI/CommandsDialogs/ToolStripPushButton.cs
+++ b/GitUI/CommandsDialogs/ToolStripPushButton.cs
@@ -30,6 +30,11 @@ namespace GitUI.CommandsDialogs
         {
             ResetToDefaultState();
 
+            if (string.IsNullOrWhiteSpace(branchName) || !AppSettings.ShowAheadBehindData)
+            {
+                return;
+            }
+
             var aheadBehindData = _aheadBehindDataProvider?.GetData(branchName);
             if (aheadBehindData is null || aheadBehindData.Count < 1 || !aheadBehindData.ContainsKey(branchName))
             {
@@ -37,13 +42,8 @@ namespace GitUI.CommandsDialogs
             }
 
             var data = aheadBehindData[branchName];
-
-            if (AppSettings.ShowAheadBehindData)
-            {
-                Text = data.ToDisplay();
-                DisplayStyle = ToolStripItemDisplayStyle.ImageAndText;
-            }
-
+            Text = data.ToDisplay();
+            DisplayStyle = ToolStripItemDisplayStyle.ImageAndText;
             ToolTipText = GetToolTipText(data);
 
             if (!string.IsNullOrEmpty(data.BehindCount))

--- a/UnitTests/GitCommands.Tests/AppTitleGeneratorTests.cs
+++ b/UnitTests/GitCommands.Tests/AppTitleGeneratorTests.cs
@@ -58,10 +58,10 @@ namespace GitCommandsTests
         }
 
         [Test]
-        public void Generate_should_include_supplied_branch_without_braces()
+        public void Generate_should_include_supplied_branch()
         {
             string branchName = "feature/my_(test)_branch";
-            string title = _appTitleGenerator.Generate("a", true, branchName: "(" + branchName + ")", defaultBranchName: _defaultBranchName);
+            string title = _appTitleGenerator.Generate("a", true, branchName: branchName, defaultBranchName: _defaultBranchName);
             title.Should().StartWith($"{MockRepositoryDescriptionProvider.ShortName} ({branchName}) - {AppSettings.ApplicationName}");
         }
 
@@ -70,7 +70,7 @@ namespace GitCommandsTests
         {
             string branchName = "feature/my_(test)_branch";
             string pathName = "folder/folder/file";
-            string title = _appTitleGenerator.Generate("a", true, branchName: "(" + branchName + ")", pathName: pathName);
+            string title = _appTitleGenerator.Generate("a", true, branchName: branchName, pathName: pathName);
             title.Should().StartWith($@"""file"" {MockRepositoryDescriptionProvider.ShortName} ({branchName}) - {AppSettings.ApplicationName}");
         }
 


### PR DESCRIPTION
Followup to #9864

## Proposed changes

Avoid Git calls where no branch is checked out and in submodules
This is similar to how HEAD is cached in CurrentCheckout.

For repos where a Git branch is checked out, this is handled by reading files, so some IO is needed.
This adds some ms here and there, nothing critical (but affecting performance a lot more than most programming constructs).

For submodules where normally no branch is checked out, this requires Git commands, both when loading revisions and opening menues etc.

## Screenshots <!-- Remove this section if PR does not change UI -->

No UI changed, just some commands (only startup shown).

### Before

![image](https://user-images.githubusercontent.com/6248932/156902282-3d8306e6-274c-4adf-b47e-8a00b501a415.png)

### After

![image](https://user-images.githubusercontent.com/6248932/156902973-a453e5ee-eb5b-4d42-af76-ebcfdcae0182.png)

## Test methodology <!-- How did you ensure quality? -->

manual
Removed an incorrect test and adopted another.
(A branch name like `(test)` is actually legal and should be displayed as `((test))` in the title.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
