### PR TITLE
RevGrid: Save currently selected before clearing the grid

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -851,6 +851,8 @@ namespace GitUI
         /// </summary>
         public bool CanRefresh => !_isRefreshingRevisions && _updatingFilters == 0;
 
+        #region PerformRefreshRevisions
+
         /// <summary>
         ///  Queries git for the new set of revisions and refreshes the grid.
         /// </summary>
@@ -1316,7 +1318,103 @@ namespace GitUI
 
                 return spi;
             }
+
+#pragma warning disable CS1587 // XML comment is not placed on a valid language element
+            /// <summary>
+            /// Select initial revision(s) in the grid.
+            /// The SelectedId is the last selected commit in the grid (with related CommitInfo in Browse).
+            /// The FirstId is first selected, the first commit in a diff.
+            /// </summary>
+            void SelectInitialRevision(ObjectId? currentCheckout, IReadOnlyList<ObjectId>? toBeSelectedObjectIds)
+#pragma warning restore CS1587 // XML comment is not placed on a valid language element
+            {
+                if (toBeSelectedObjectIds is null || toBeSelectedObjectIds.Count == 0)
+                {
+                    if (SelectedId is not null)
+                    {
+                        if (FirstId is not null)
+                        {
+                            toBeSelectedObjectIds = new ObjectId[] { FirstId, SelectedId };
+                            FirstId = null;
+                        }
+                        else
+                        {
+                            toBeSelectedObjectIds = new ObjectId[] { SelectedId };
+                        }
+
+                        SelectedId = null;
+                    }
+                    else
+                    {
+                        toBeSelectedObjectIds = currentCheckout is null ? Array.Empty<ObjectId>() : new ObjectId[] { currentCheckout };
+                    }
+                }
+
+                _gridView.ToBeSelectedObjectIds = toBeSelectedObjectIds;
+            }
+
+            void CheckAndRepairInitialRevision()
+            {
+                // Check if there is any commit that couldn't be selected.
+                if (!_gridView.ToBeSelectedObjectIds.Any())
+                {
+                    return;
+                }
+
+                // Search for the commitid that was not selected in the grid. If not found, select the first parent.
+                int index = SearchRevision(_gridView.ToBeSelectedObjectIds.First());
+                if (index >= 0)
+                {
+                    SetSelectedIndex(index);
+                }
+
+                return;
+
+                int SearchRevision(ObjectId objectId)
+                {
+                    // Attempt to look up an item by its ID
+                    if (_gridView.TryGetRevisionIndex(objectId) is int exactIndex)
+                    {
+                        return exactIndex;
+                    }
+
+                    if (objectId is not null && !objectId.IsArtificial)
+                    {
+                        // Not found, so search for its parents
+                        foreach (var parentId in TryGetParents(objectId))
+                        {
+                            if (_gridView.TryGetRevisionIndex(parentId) is int parentIndex)
+                            {
+                                return parentIndex;
+                            }
+                        }
+                    }
+
+                    // Not found...
+                    return -1;
+                }
+            }
+
+            IEnumerable<ObjectId> TryGetParents(ObjectId objectId)
+            {
+                GitArgumentBuilder args = new("rev-list")
+                {
+                    { _filterInfo.HasCommitsLimit, $"--max-count={_filterInfo.CommitsLimit}" },
+                    objectId
+                };
+
+                ExecutionResult result = Module.GitExecutable.Execute(args, throwOnErrorExit: false);
+                foreach (var line in result.StandardOutput.LazySplit('\n'))
+                {
+                    if (ObjectId.TryParse(line, out var parentId))
+                    {
+                        yield return parentId;
+                    }
+                }
+            }
         }
+
+        #endregion
 
         /// <summary>
         /// The parents for commits are replaced with the parent in the graph (as all commits may not be included)
@@ -1327,98 +1425,6 @@ namespace GitUI
         internal bool FilterIsApplied(bool inclBranchFilter)
         {
             return _filterInfo.HasFilter || (inclBranchFilter && _filterInfo.IsShowFilteredBranchesChecked && !string.IsNullOrEmpty(_filterInfo.BranchFilter));
-        }
-
-        /// <summary>
-        /// Select initial revision(s) in the grid.
-        /// The SelectedId is the last selected commit in the grid (with related CommitInfo in Browse).
-        /// The FirstId is first selected, the first commit in a diff.
-        /// </summary>
-        private void SelectInitialRevision(ObjectId? currentCheckout, IReadOnlyList<ObjectId>? toBeSelectedObjectIds)
-        {
-            if (toBeSelectedObjectIds is null || toBeSelectedObjectIds.Count == 0)
-            {
-                if (SelectedId is not null)
-                {
-                    if (FirstId is not null)
-                    {
-                        toBeSelectedObjectIds = new ObjectId[] { FirstId, SelectedId };
-                        FirstId = null;
-                    }
-                    else
-                    {
-                        toBeSelectedObjectIds = new ObjectId[] { SelectedId };
-                    }
-
-                    SelectedId = null;
-                }
-                else
-                {
-                    toBeSelectedObjectIds = currentCheckout is null ? Array.Empty<ObjectId>() : new ObjectId[] { currentCheckout };
-                }
-            }
-
-            _gridView.ToBeSelectedObjectIds = toBeSelectedObjectIds;
-        }
-
-        private void CheckAndRepairInitialRevision()
-        {
-            // Check if there is any commit that couldn't be selected.
-            if (!_gridView.ToBeSelectedObjectIds.Any())
-            {
-                return;
-            }
-
-            // Search for the commitid that was not selected in the grid. If not found, select the first parent.
-            int index = SearchRevision(_gridView.ToBeSelectedObjectIds.First());
-            if (index >= 0)
-            {
-                SetSelectedIndex(index);
-            }
-
-            return;
-
-            int SearchRevision(ObjectId objectId)
-            {
-                // Attempt to look up an item by its ID
-                if (_gridView.TryGetRevisionIndex(objectId) is int exactIndex)
-                {
-                    return exactIndex;
-                }
-
-                if (objectId is not null && !objectId.IsArtificial)
-                {
-                    // Not found, so search for its parents
-                    foreach (var parentId in TryGetParents(objectId))
-                    {
-                        if (_gridView.TryGetRevisionIndex(parentId) is int parentIndex)
-                        {
-                            return parentIndex;
-                        }
-                    }
-                }
-
-                // Not found...
-                return -1;
-            }
-        }
-
-        private IEnumerable<ObjectId> TryGetParents(ObjectId objectId)
-        {
-            GitArgumentBuilder args = new("rev-list")
-            {
-                { _filterInfo.HasCommitsLimit, $"--max-count={_filterInfo.CommitsLimit}" },
-                objectId
-            };
-
-            ExecutionResult result = Module.GitExecutable.Execute(args, throwOnErrorExit: false);
-            foreach (var line in result.StandardOutput.LazySplit('\n'))
-            {
-                if (ObjectId.TryParse(line, out var parentId))
-                {
-                    yield return parentId;
-                }
-            }
         }
 
         #region Graph event handlers


### PR DESCRIPTION
Fixes #9884
Introduced in #9864 

## Proposed changes

The restructure in #9864 cleared the current selected revisions in the grid before they were read and HEAD was therefore always selected after a refresh.

As #9864 simplified the internals for the refresh, the handling could br simplified further, removing global variables.

This may also fix the problem with incorrect commit seleced after refresh that occurred occasionally (no refrerences right now.

Sidenote: PerformRefreshRevisions could be moved to a separate module, the metod is now 500 lines (this PR moves further methods as they are only used by PerformRefreshRevisions ).
Not now, there are further changes coming.

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
