### PR TITLE
RevisionGrid: Set accessibility values

### DIFF
--- a/GitUI/UserControls/AccessibleDataGridViewTextBoxCell.cs
+++ b/GitUI/UserControls/AccessibleDataGridViewTextBoxCell.cs
@@ -1,0 +1,27 @@
+﻿using System.Windows.Forms;
+
+namespace GitUI.UserControls
+{
+    /// <summary>
+    /// A <cref>DataGridViewTextBoxCell</cref> with <cref>CreateAccessibilityInstance</cref> overridden
+    /// in order to suppress the <cref>Name</cref> "Message Row nnn", which is redundant
+    /// because the row and column numbers are provided in dedicated accessibility properties.
+    /// </summary>
+    public class AccessibleDataGridViewTextBoxCell : DataGridViewTextBoxCell
+    {
+        protected class DataGridViewTextBoxCellUnnamedAccessibleObject : DataGridViewTextBoxCellAccessibleObject
+        {
+            public DataGridViewTextBoxCellUnnamedAccessibleObject(DataGridViewCell? owner) : base(owner)
+            {
+            }
+
+            public override string Name
+                => string.Empty;
+        }
+
+        protected override AccessibleObject CreateAccessibilityInstance()
+        {
+            return new DataGridViewTextBoxCellUnnamedAccessibleObject(this);
+        }
+    }
+}

--- a/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
@@ -60,6 +60,15 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             }
         }
 
+        public override void OnCellFormatting(DataGridViewCellFormattingEventArgs e, GitRevision revision)
+        {
+            // Set the grid cell's accessibility text
+            if (!revision.IsArtificial)
+            {
+                e.Value = revision.ObjectId.ToShortString();
+            }
+        }
+
         public override bool TryGetToolTip(DataGridViewCellMouseEventArgs e, GitRevision revision, [NotNullWhen(returnValue: true)] out string? toolTip)
         {
             if (revision.ObjectId.IsArtificial)

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -95,6 +95,12 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             }
         }
 
+        public override void OnCellFormatting(DataGridViewCellFormattingEventArgs e, GitRevision revision)
+        {
+            // Set the grid cell's accessibility text
+            e.Value = revision.Subject.Trim();
+        }
+
         public override bool TryGetToolTip(DataGridViewCellMouseEventArgs e, GitRevision revision, [NotNullWhen(returnValue: true)] out string? toolTip)
         {
             _toolTipBuilder.Clear();

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -28,6 +28,8 @@ namespace GitUI.UserControls.RevisionGrid
 
     public sealed partial class RevisionDataGridView : DataGridView
     {
+        private static readonly AccessibleDataGridViewTextBoxCell _accessibleDataGridViewTextBoxCell = new();
+
         private readonly SolidBrush _alternatingRowBackgroundBrush;
         private readonly SolidBrush _authoredHighlightBrush;
 
@@ -205,6 +207,7 @@ namespace GitUI.UserControls.RevisionGrid
             _columnProviders.Add(columnProvider);
 
             columnProvider.Column.Tag = columnProvider;
+            columnProvider.Column.CellTemplate = _accessibleDataGridViewTextBoxCell;
 
             Columns.Add(columnProvider.Column);
         }


### PR DESCRIPTION
Fixes #9852

## Proposed changes

- Set missing accessibility `Value` for `RevisionGrid` columns:
  - message
  - commit id
- Set empty string for accessibility property `Name` of all `RevisionGrid` cells
  because it contained redundant information "Message Row nnn"

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/156935017-b5a7dddf-d168-4c7f-a372-b6e38c700775.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/158034124-b9b0b774-d61b-468f-863f-ee9eccded8e7.png)

## Test methodology <!-- How did you ensure quality? -->

- manual: run "...\Windows Kits\10\bin\10.0.19041.0\x86\inspect.exe"  and hover the grid cells

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 687a8e3de13f4171b17e3ddd6d767225c3237840
- Git 2.35.1.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 5.0.12
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).