### PR TITLE
Init sidepanel only when loading

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.BranchTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.BranchTree.cs
@@ -34,17 +34,6 @@ namespace GitUI.BranchTreePanel
 
             protected override bool SupportsFiltering => true;
 
-            protected override void OnAttached()
-            {
-                IsFiltering.Value = false;
-            }
-
-            protected override Task PostRepositoryChangedAsync(GitUIEventArgs e)
-            {
-                IsFiltering.Value = false;
-                return ReloadNodesAsync(LoadNodesAsync, e.GetRefs);
-            }
-
             protected override async Task<Nodes> LoadNodesAsync(CancellationToken token, Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
             {
                 await TaskScheduler.Default;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -97,17 +97,6 @@ namespace GitUI.BranchTreePanel
 
             protected override bool SupportsFiltering => true;
 
-            protected override void OnAttached()
-            {
-                IsFiltering.Value = false;
-            }
-
-            protected override Task PostRepositoryChangedAsync(GitUIEventArgs e)
-            {
-                IsFiltering.Value = false;
-                return ReloadNodesAsync(LoadNodesAsync, e.GetRefs);
-            }
-
             /// <inheritdoc/>
             protected internal override void Refresh(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
             {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.RemoteBranchTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.RemoteBranchTree.cs
@@ -33,17 +33,6 @@ namespace GitUI.BranchTreePanel
 
             protected override bool SupportsFiltering => true;
 
-            protected override void OnAttached()
-            {
-                IsFiltering.Value = false;
-            }
-
-            protected override Task PostRepositoryChangedAsync(GitUIEventArgs e)
-            {
-                IsFiltering.Value = false;
-                return ReloadNodesAsync(LoadNodesAsync, e.GetRefs);
-            }
-
             protected override async Task<Nodes> LoadNodesAsync(CancellationToken token, Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
             {
                 await TaskScheduler.Default;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -253,11 +253,12 @@ namespace GitUI.BranchTreePanel
         ///  <see langword="true"/>, if the data is being filtered; otherwise <see langword="false"/>.
         /// </param>
         /// <param name="getRefs">Function to get refs.</param>
-        public void Refresh(bool isFiltering, Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
+        /// <param name="forceRefresh">Refresh may be required as references may have been changed.</param>
+        public void Refresh(bool isFiltering, bool forceRefresh, Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
         {
-            _branchesTree.Refresh(isFiltering, getRefs);
-            _remotesTree.Refresh(isFiltering, getRefs);
-            _tagTree.Refresh(isFiltering, getRefs);
+            _branchesTree.Refresh(isFiltering, forceRefresh, getRefs);
+            _remotesTree.Refresh(isFiltering, forceRefresh, getRefs);
+            _tagTree.Refresh(isFiltering, forceRefresh, getRefs);
         }
 
         public void Refresh(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)

--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -39,7 +39,7 @@ namespace GitUI.CommandsDialogs
                 revisionDiff.FallbackFollowedFile = path;
                 fileTree.FallbackFollowedFile = path;
             };
-            RevisionGrid.RevisionGraphLoaded += (sender, e) =>
+            RevisionGrid.GridLoading += (sender, e) =>
             {
                 // The FileTree tab should be shown at first start, in "filehistory" mode
                 if (isBlame)
@@ -62,7 +62,7 @@ namespace GitUI.CommandsDialogs
                 //      b) filter on specific branch
                 bool isFiltering = !AppSettings.ShowReflogReferences
                                 && (AppSettings.ShowCurrentBranchOnly || AppSettings.BranchFilterEnabled);
-                repoObjectsTree.Refresh(isFiltering, e.GetRefs);
+                repoObjectsTree.Refresh(isFiltering, e.ForceRefresh, e.GetRefs);
             };
             RevisionGrid.SelectionChanged += (sender, e) =>
             {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -597,7 +597,7 @@ namespace GitUI.CommandsDialogs
             }
 
             Debug.Assert(RevisionGrid.CanRefresh, "Already loading revisions when running RefreshRevisions(). This could cause the commits in the grid to be loaded several times.");
-            RevisionGrid.PerformRefreshRevisions(getRefs);
+            RevisionGrid.PerformRefreshRevisions(getRefs, forceRefresh: true);
 
             InternalInitialize();
             ToolStripFilters.UpdateBranchFilterItems(getRefs);

--- a/GitUI/UserControls/RevisionGrid/GridLoadEventArgs.cs
+++ b/GitUI/UserControls/RevisionGrid/GridLoadEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using GitUIPluginInterfaces;
+
+namespace GitUI.UserControls.RevisionGrid
+{
+    public class GridLoadEventArgs : GitUIEventArgs
+    {
+        public GridLoadEventArgs(IWin32Window? ownerForm, IGitUICommands gitUICommands, Lazy<IReadOnlyList<IGitRef>> getRefs, bool forceRefresh)
+            : base(ownerForm, gitUICommands, getRefs)
+        {
+            ForceRefresh = forceRefresh;
+        }
+
+        public bool ForceRefresh { get; init; }
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/GitUIEventArgs.cs
+++ b/Plugins/GitUIPluginInterfaces/GitUIEventArgs.cs
@@ -9,20 +9,19 @@ namespace GitUIPluginInterfaces
     {
         private readonly IFilteredGitRefsProvider _getRefs;
 
-        public GitUIEventArgs(IWin32Window? ownerForm, IGitUICommands gitUICommands, Lazy<IReadOnlyList<IGitRef>> getRefs)
+        public GitUIEventArgs(IWin32Window? ownerForm, IGitUICommands gitUICommands, Lazy<IReadOnlyList<IGitRef>> getRefs = null)
             : base(cancel: false)
         {
             OwnerForm = ownerForm;
             GitUICommands = gitUICommands;
-            _getRefs = new FilteredGitRefsProvider(getRefs);
-        }
-
-        public GitUIEventArgs(IWin32Window? ownerForm, IGitUICommands gitUICommands)
-            : base(cancel: false)
-        {
-            OwnerForm = ownerForm;
-            GitUICommands = gitUICommands;
-            _getRefs = new FilteredGitRefsProvider(GitModule);
+            if (getRefs is null)
+            {
+                _getRefs = new FilteredGitRefsProvider(GitModule);
+            }
+            else
+            {
+                _getRefs = new FilteredGitRefsProvider(getRefs);
+            }
         }
 
         public IGitUICommands GitUICommands { get; }


### PR DESCRIPTION
Follow up to #9864 

## Proposed changes

* Previously, the side panel was initiated from Browse (UICommands_PostRepositoryChanged is almost always invoked by Browse changes regardless or not if the repo is changed),
then again after loading the grid if a filter was applied or changed.
(normally the loaded branches etc were reused, so no additional Git call just making this confusing and some additional loading).
The second part is needed if the change was initiated from RevGrid itself (normally when changing filters etc).

The side panel init is now only started when loading the grid.
Update is forced if the repo changes (set for instance for F5 refreshes).

Some parts separated to #9896 and #9897

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

Rebase merge 

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
