### PR TITLE
Enable fetching moved tags

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1530,7 +1530,7 @@ namespace GitCommands
                 { fetchTags == true, "--tags" },
                 { fetchTags == false, "--no-tags" },
                 { isUnshallow, "--unshallow" },
-                { pruneRemoteBranches || pruneRemoteBranchesAndTags, "--prune" },
+                { pruneRemoteBranches || pruneRemoteBranchesAndTags, "--prune --force" },
                 { pruneRemoteBranchesAndTags, "--prune-tags" },
             };
         }

--- a/GitUI/CommandsDialogs/FormPull.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPull.Designer.cs
@@ -145,7 +145,7 @@
             this.Prune.TabIndex = 26;
             this.Prune.Text = "&Prune remote branches";
             this.Tooltip.SetToolTip(this.Prune, "Removes remote tracking branches that no longer exist on the remote (e.g. if some" +
-        "one else deleted them).\r\n\r\nActual command line (if checked): --prune\r\n");
+        "one else deleted them).\r\n\r\nActual command line (if checked): --prune --force\r\n");
             this.Prune.CheckedChanged += new System.EventHandler(this.Prune_CheckedChanged);
             // 
             // PruneTags

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -146,14 +146,14 @@ namespace GitCommandsTests
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune",
+                    "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --force",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", pruneRemoteBranches: true).Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --prune-tags",
+                    "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --force --prune-tags",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", pruneRemoteBranches: true, pruneRemoteBranchesAndTags: true).Arguments);
             }
         }


### PR DESCRIPTION
Enables #7094

## Proposed changes

Enable fetching moved tags
in combination with once (manually) run `git config remote.<name>.tagOpt --tags`
by adding "--force" to "--prune" in `GetFetchArgs`.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

`"C:\Program Files\Git\bin\git.exe" fetch --progress "--all" --prune`

### After

`"C:\Program Files\Git\bin\git.exe" fetch --progress "--all" --prune --force`

## Test methodology <!-- How did you ensure quality? -->

- adapt existing unit test
- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build f7398a736a4ece01221601580ae586229317b53f
- Git 2.35.1.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 5.0.12
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).