### PR TITLE
Share gitRefs when reloading after changing sort criterias

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.BranchTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.BranchTree.cs
@@ -60,12 +60,12 @@ namespace GitUI.BranchTreePanel
             }
 
             /// <inheritdoc/>
-            protected internal override void Refresh()
+            protected internal override void Refresh(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
             {
                 // Break the local cache to ensure the data is requeried to reflect the required sort order.
                 _loadedBranches = null;
 
-                base.Refresh();
+                base.Refresh(getRefs);
             }
 
             private Nodes FillBranchTree(IReadOnlyList<IGitRef> branches, CancellationToken token)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -10,6 +10,7 @@ using GitUI.BranchTreePanel.ContextMenu;
 using GitUI.BranchTreePanel.Interfaces;
 using GitUI.CommandsDialogs;
 using GitUI.UserControls.RevisionGrid;
+using GitUIPluginInterfaces;
 using ResourceManager;
 
 namespace GitUI.BranchTreePanel
@@ -254,18 +255,8 @@ namespace GitUI.BranchTreePanel
             AddContextMenuItems(menuBranch, _menuBranchCopyContextMenuItems);
             AddContextMenuItems(menuRemote, _menuRemoteCopyContextMenuItems);
 
-            _sortOrderContextMenuItem = new GitRefsSortOrderContextMenuItem(() =>
-            {
-                _branchesTree.Refresh();
-                _remotesTree.Refresh();
-                _tagTree.Refresh();
-            });
-            _sortByContextMenuItem = new GitRefsSortByContextMenuItem(() =>
-            {
-                _branchesTree.Refresh();
-                _remotesTree.Refresh();
-                _tagTree.Refresh();
-            });
+            _sortOrderContextMenuItem = new GitRefsSortOrderContextMenuItem(() => Refresh(new FilteredGitRefsProvider(UICommands.GitModule).GetRefs));
+            _sortByContextMenuItem = new GitRefsSortByContextMenuItem(() => Refresh(new FilteredGitRefsProvider(UICommands.GitModule).GetRefs));
 
             _localBranchMenuItems = new LocalBranchMenuItems<LocalBranchNode>(this);
             AddContextMenuItems(menuBranch, _localBranchMenuItems.Select(s => s.Item), insertAfter: _menuBranchCopyContextMenuItems[1]);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.Tags.cs
@@ -109,12 +109,12 @@ namespace GitUI.BranchTreePanel
             }
 
             /// <inheritdoc/>
-            protected internal override void Refresh()
+            protected internal override void Refresh(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
             {
                 // Break the local cache to ensure the data is requeried to reflect the required sort order.
                 _loadedTags = null;
 
-                base.Refresh();
+                base.Refresh(getRefs);
             }
 
             protected override async Task<Nodes> LoadNodesAsync(CancellationToken token, Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Nodes.cs
@@ -224,7 +224,7 @@ namespace GitUI.BranchTreePanel
             /// <summary>
             /// Requests to refresh the data tree and to apply filtering, if necessary.
             /// </summary>
-            protected internal virtual void Refresh()
+            protected internal virtual void Refresh(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
             {
                 // NOTE: descendants may need to break their local caches to ensure the latest data is loaded.
 
@@ -232,7 +232,7 @@ namespace GitUI.BranchTreePanel
                 {
                     IsFiltering.Value = _isCurrentlyFiltering;
 
-                    await ReloadNodesAsync(LoadNodesAsync, new FilteredGitRefsProvider(Module).GetRefs);
+                    await ReloadNodesAsync(LoadNodesAsync, getRefs);
                 });
             }
 
@@ -242,7 +242,7 @@ namespace GitUI.BranchTreePanel
             /// <param name="isFiltering">
             ///  <see langword="true"/>, if the data is being filtered; otherwise <see langword="false"/>.
             /// </param>
-            internal void ToggleFilterMode(bool isFiltering)
+            internal void Refresh(bool isFiltering, Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
             {
                 // If we're not currently filtering and no need to filter now -> exit.
                 // Else we need to iterate over the list and rebind the tree - whilst there
@@ -262,7 +262,7 @@ namespace GitUI.BranchTreePanel
                 {
                     IsFiltering.Value = true;
 
-                    await ReloadNodesAsync(LoadNodesAsync, new FilteredGitRefsProvider(Module).GetRefs);
+                    await ReloadNodesAsync(LoadNodesAsync, getRefs);
                 });
             }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.RemoteBranchTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.RemoteBranchTree.cs
@@ -59,12 +59,12 @@ namespace GitUI.BranchTreePanel
             }
 
             /// <inheritdoc/>
-            protected internal override void Refresh()
+            protected internal override void Refresh(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
             {
                 // Break the local cache to ensure the data is requeried to reflect the required sort order.
                 _loadedBranches = null;
 
-                base.Refresh();
+                base.Refresh(getRefs);
             }
 
             private async Task<Nodes> FillBranchTreeAsync(IReadOnlyList<IGitRef> branches, CancellationToken token)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -251,11 +251,19 @@ namespace GitUI.BranchTreePanel
         /// <param name="isFiltering">
         ///  <see langword="true"/>, if the data is being filtered; otherwise <see langword="false"/>.
         /// </param>
-        public void ToggleFilterMode(bool isFiltering)
+        /// <param name="getRefs">Function to get refs.</param>
+        public void Refresh(bool isFiltering, Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
         {
-            _branchesTree.ToggleFilterMode(isFiltering);
-            _remotesTree.ToggleFilterMode(isFiltering);
-            _tagTree.ToggleFilterMode(isFiltering);
+            _branchesTree.Refresh(isFiltering, getRefs);
+            _remotesTree.Refresh(isFiltering, getRefs);
+            _tagTree.Refresh(isFiltering, getRefs);
+        }
+
+        public void Refresh(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
+        {
+            _branchesTree.Refresh(getRefs);
+            _remotesTree.Refresh(getRefs);
+            _tagTree.Refresh(getRefs);
         }
 
         public void SelectionChanged(IReadOnlyList<GitRevision> selectedRevisions)

--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -62,7 +62,7 @@ namespace GitUI.CommandsDialogs
                 //      b) filter on specific branch
                 bool isFiltering = !AppSettings.ShowReflogReferences
                                 && (AppSettings.ShowCurrentBranchOnly || AppSettings.BranchFilterEnabled);
-                repoObjectsTree.ToggleFilterMode(isFiltering);
+                repoObjectsTree.Refresh(isFiltering, e.GetRefs);
             };
             RevisionGrid.SelectionChanged += (sender, e) =>
             {

--- a/Plugins/GitUIPluginInterfaces/FilteredGitRefsProvider.cs
+++ b/Plugins/GitUIPluginInterfaces/FilteredGitRefsProvider.cs
@@ -10,20 +10,25 @@ namespace GitUIPluginInterfaces
     {
         public FilteredGitRefsProvider(IGitModule module)
         {
-            _refs = new(() => module.GetRefs(RefsFilter.NoFilter));
+            _getRefs = new(() => module.GetRefs(RefsFilter.NoFilter));
         }
 
-        private readonly Lazy<IReadOnlyList<IGitRef>> _refs;
+        public FilteredGitRefsProvider(Lazy<IReadOnlyList<IGitRef>> getRefs)
+        {
+            _getRefs = getRefs;
+        }
+
+        private readonly Lazy<IReadOnlyList<IGitRef>> _getRefs;
 
         /// <inherit/>
         public IReadOnlyList<IGitRef> GetRefs(RefsFilter filter)
         {
             if (filter == RefsFilter.NoFilter)
             {
-                return _refs.Value;
+                return _getRefs.Value;
             }
 
-            return _refs.Value.Where(r =>
+            return _getRefs.Value.Where(r =>
                 ((filter & RefsFilter.Tags) != 0 && r.IsTag)
                 || ((filter & RefsFilter.Remotes) != 0 && r.IsRemote)
                 || ((filter & RefsFilter.Heads) != 0 && r.IsHead)).ToList();

--- a/Plugins/GitUIPluginInterfaces/GitUIEventArgs.cs
+++ b/Plugins/GitUIPluginInterfaces/GitUIEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows.Forms;
 
@@ -6,14 +7,22 @@ namespace GitUIPluginInterfaces
 {
     public class GitUIEventArgs : CancelEventArgs
     {
-        private readonly IFilteredGitRefsProvider _refs;
+        private readonly IFilteredGitRefsProvider _getRefs;
+
+        public GitUIEventArgs(IWin32Window? ownerForm, IGitUICommands gitUICommands, Lazy<IReadOnlyList<IGitRef>> getRefs)
+            : base(cancel: false)
+        {
+            OwnerForm = ownerForm;
+            GitUICommands = gitUICommands;
+            _getRefs = new FilteredGitRefsProvider(getRefs);
+        }
 
         public GitUIEventArgs(IWin32Window? ownerForm, IGitUICommands gitUICommands)
             : base(cancel: false)
         {
             OwnerForm = ownerForm;
             GitUICommands = gitUICommands;
-            _refs = new FilteredGitRefsProvider(GitModule);
+            _getRefs = new FilteredGitRefsProvider(GitModule);
         }
 
         public IGitUICommands GitUICommands { get; }
@@ -22,6 +31,6 @@ namespace GitUIPluginInterfaces
 
         public IGitModule GitModule => GitUICommands.GitModule;
 
-        public IReadOnlyList<IGitRef> GetRefs(RefsFilter filter) => _refs.GetRefs(filter);
+        public IReadOnlyList<IGitRef> GetRefs(RefsFilter filter) => _getRefs.GetRefs(filter);
     }
 }


### PR DESCRIPTION
Part of #9888 (that is follow up to #9864)

Leaves the "double side panel init" to later.
#9884 is already approved but have a refresh issue that I do not know how to solve in a good way and therefore separate most of the changes.

## Proposed changes

* Changing filters required 3 separate getRefs() calls (so it could be slower than refreshing the complete grid).
* Share getRefs() after loading the grid when filters are applied (normally, this is not needed though if the structure is not rebuilt).

Getting refs can take >10s in large repos and should only not be done 3 times when only one is needed.
Future: This could possibly be cached too, requiring an "external" refresh to reread the cache.

## Screenshots <!-- Remove this section if PR does not change UI -->

For changing sort criteria

### Before

![image](https://user-images.githubusercontent.com/6248932/156943876-b5fdbe2d-eae1-4708-a4d9-55aef685f959.png)

### After

![resort-2](https://user-images.githubusercontent.com/6248932/156943910-ee28be3b-5cf1-43be-91e7-4c58a32afea2.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
