### PR TITLE
Browse: Clarify RefreshRevisions() handling

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -78,7 +78,7 @@ namespace GitUI.CommandsDialogs
             DiffText.ScrollToTop();
         }
 
-        public void UICommands_PostRepositoryChanged(object sender, GitUIEventArgs e)
+        public void RepositoryChanged()
         {
             _rememberFileContextMenuController.RememberedDiffFileItem = null;
         }


### PR DESCRIPTION
Follow up to #9864, related to #9888

## Proposed changes

If a new repo is opened in FormBrowse the call chain is
SetGitModule() -> UICommands_PostRepositoryChanged() -> RefreshRevisions()
Most other refreshes in Browse uses RepoChangedNotifier.Notify(),
which is confusing when reading the code.

As the sidepanel is init from RepoChangedNotifier.Notify(),
the use of Notify() cannot be changed now.
This commit just separates the changes to RefreshRevisions().

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
