### PR TITLE
Remove unused `TreeGuid`

### DIFF
--- a/GitCommands/CommitData.cs
+++ b/GitCommands/CommitData.cs
@@ -8,7 +8,6 @@ namespace GitCommands
     {
         public CommitData(
             ObjectId objectId,
-            ObjectId? treeGuid,
             IReadOnlyList<ObjectId>? parentIds,
             string author,
             DateTime authorDate,
@@ -17,7 +16,6 @@ namespace GitCommands
             string body)
         {
             ObjectId = objectId;
-            TreeGuid = treeGuid;
             ParentIds = parentIds;
             Author = author;
             AuthorDate = authorDate.ToDateTimeOffset();
@@ -27,7 +25,6 @@ namespace GitCommands
         }
 
         public ObjectId ObjectId { get; }
-        public ObjectId? TreeGuid { get; } // TODO nothing seems to be using this value
         public IReadOnlyList<ObjectId>? ParentIds { get; }
         public string Author { get; }
         public DateTimeOffset AuthorDate { get; }

--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -40,8 +40,8 @@ namespace GitCommands
 
     public sealed class CommitDataManager : ICommitDataManager
     {
-        private const string CommitDataFormat = "%H%n%T%n%P%n%aN <%aE>%n%at%n%cN <%cE>%n%ct%n%e%n%B";
-        private const string CommitDataWithNotesFormat = "%H%n%T%n%P%n%aN <%aE>%n%at%n%cN <%cE>%n%ct%n%e%n%B%nNotes:%n%-N";
+        private const string CommitDataFormat = "%H%n%n%P%n%aN <%aE>%n%at%n%cN <%cE>%n%ct%n%e%n%B";
+        private const string CommitDataWithNotesFormat = "%H%n%n%P%n%aN <%aE>%n%at%n%cN <%cE>%n%ct%n%e%n%B%nNotes:%n%-N";
         private const string BodyAndNotesFormat = "%B%nNotes:%n%-N";
         private const string NotesFormat = "%-N";
 
@@ -107,9 +107,9 @@ namespace GitCommands
 
             var module = GetModule();
 
-            // $ git log --pretty="format:%H%n%T%n%P%n%aN <%aE>%n%at%n%cN <%cE>%n%ct%n%e%n%B%nNotes:%n%-N" -1
+            // $ git log --pretty="format:%H%n%n%P%n%aN <%aE>%n%at%n%cN <%cE>%n%ct%n%e%n%B%nNotes:%n%-N" -1
             // 4bc1049fc3b9191dbd390e1ae6885aedd1a4e34b
-            // a59c21f0b2e6f43ae89b76a216f9f6124fc359f8
+            // (comment: used to contain %T, kept newline)
             // 8e3873685d89f8cb543657d1b9e66e516cae7e1d dfd353d3b02d24a0d98855f6a1848c51d9ba4d6b
             // RussKie <RussKie@users.noreply.github.com>
             // 1521115435
@@ -134,7 +134,7 @@ namespace GitCommands
 
             var guid = ObjectId.Parse(lines[0]);
 
-            // lines[1] contains the optional treeGuid
+            // lines[1] is empty (contained the optional treeGuid)
 
             // TODO: we can use this to add more relationship info like gitk does if wanted
             var parentIds = lines[2].LazySplit(' ').Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => ObjectId.Parse(id)).ToList();

--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -134,8 +134,7 @@ namespace GitCommands
 
             var guid = ObjectId.Parse(lines[0]);
 
-            // TODO: we can use this to add more relationship info like gitk does if wanted
-            var treeGuid = ObjectId.Parse(lines[1]);
+            // lines[1] contains the optional treeGuid
 
             // TODO: we can use this to add more relationship info like gitk does if wanted
             var parentIds = lines[2].LazySplit(' ').Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => ObjectId.Parse(id)).ToList();
@@ -151,7 +150,7 @@ namespace GitCommands
             Validates.NotNull(author);
             Validates.NotNull(committer);
 
-            return new CommitData(guid, treeGuid, parentIds, author, authorDate, committer, commitDate, body);
+            return new CommitData(guid, parentIds, author, authorDate, committer, commitDate, body);
         }
 
         /// <inheritdoc />
@@ -167,7 +166,7 @@ namespace GitCommands
                 throw new ArgumentException($"Cannot have a null {nameof(GitRevision.ObjectId)}.", nameof(revision));
             }
 
-            return new CommitData(revision.ObjectId, revision.TreeGuid, revision.ParentIds,
+            return new CommitData(revision.ObjectId, revision.ParentIds,
                 string.Format("{0} <{1}>", revision.Author, revision.AuthorEmail), revision.AuthorDate,
                 string.Format("{0} <{1}>", revision.Committer, revision.CommitterEmail), revision.CommitDate,
                 revision.Body ?? revision.Subject)

--- a/UnitTests/GitCommands.Tests/CommitDataManagerTest.cs
+++ b/UnitTests/GitCommands.Tests/CommitDataManagerTest.cs
@@ -34,7 +34,7 @@ namespace GitCommandsTests
                        "\tP4@547123";
 
             var rawData = "37da2014bc5128ca084543423e410d81df838845\n" +
-                          "a13ae23be4d207c7af2818fd7cc2caa2d0a63e47\n" +
+                          "optional treeGuid is not parsed: a13ae23be4d207c7af2818fd7cc2caa2d0a63e47\n" +
                           "ad1ccc2ecc00865d61e74b703a260d17b4db1216 a8d564d3bb8c65e88e40239937cb48dda57f01b8 1711f4a6522f86c3e4e404a66a78f4586d25d89d\n" +
                           "John Doe (Acme Inc) <John.Doe@test.com>\n" +
                           "1508676972\n" +
@@ -49,7 +49,6 @@ namespace GitCommandsTests
             data.Committer.Should().Be("John Doe <John.Doe@test.com>");
             data.ObjectId.Should().Be(ObjectId.Parse("37da2014bc5128ca084543423e410d81df838845"));
             data.ParentIds.Should().BeEquivalentTo(ObjectId.Parse("ad1ccc2ecc00865d61e74b703a260d17b4db1216"), ObjectId.Parse("a8d564d3bb8c65e88e40239937cb48dda57f01b8"), ObjectId.Parse("1711f4a6522f86c3e4e404a66a78f4586d25d89d"));
-            data.TreeGuid.Should().Be(ObjectId.Parse("a13ae23be4d207c7af2818fd7cc2caa2d0a63e47"));
 
             data.AuthorDate.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture).Should().Be("2017-10-22T12:56:12");
             data.CommitDate.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture).Should().Be("2017-10-22T12:56:12");

--- a/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataBodyRendererTests.cs
+++ b/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataBodyRendererTests.cs
@@ -49,7 +49,7 @@ namespace ResourceManagerTests.CommitDataRenders
                 return true;
             });
 
-            CommitData data = new(ObjectId.Random(), ObjectId.Random(),
+            CommitData data = new(ObjectId.Random(),
                 Array.Empty<ObjectId>(),
                 "John Doe (Acme Inc) <John.Doe@test.com>", DateTime.UtcNow,
                 "John Doe <John.Doe@test.com>", DateTime.UtcNow,
@@ -63,7 +63,7 @@ namespace ResourceManagerTests.CommitDataRenders
         [Test]
         public void Render_should_render_body_without_links()
         {
-            CommitData data = new(ObjectId.Random(), ObjectId.Random(),
+            CommitData data = new(ObjectId.Random(),
                 Array.Empty<ObjectId>(),
                 "John Doe (Acme Inc) <John.Doe@test.com>", DateTime.UtcNow,
                 "John Doe <John.Doe@test.com>", DateTime.UtcNow,

--- a/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererIntegrationTests.cs
+++ b/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererIntegrationTests.cs
@@ -21,14 +21,13 @@ namespace ResourceManagerTests.CommitDataRenders
         public void Setup()
         {
             var commitGuid = ObjectId.Random();
-            var treeGuid = ObjectId.Random();
             var parentId1 = ObjectId.Random();
             var parentId2 = ObjectId.Random();
             var authorTime = DateTime.UtcNow.AddDays(-3);
             var commitTime = DateTime.UtcNow.AddDays(-2);
 
             _data = new CommitData(
-                commitGuid, treeGuid,
+                commitGuid,
                 new[] { parentId1, parentId2 },
                 "John Doe (Acme Inc) <John.Doe@test.com>", authorTime,
                 "Jane Doe <Jane.Doe@test.com>", commitTime,

--- a/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererTests.cs
+++ b/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererTests.cs
@@ -91,7 +91,6 @@ namespace ResourceManagerTests.CommitDataRenders
             var commitDate = authorDate;
             CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
-                ObjectId.Random(),
                 Array.Empty<ObjectId>(),
                 author, authorDate,
                 committer, commitDate, "");
@@ -119,7 +118,6 @@ namespace ResourceManagerTests.CommitDataRenders
             var commitDate = authorDate;
             CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
-                ObjectId.Random(),
                 Array.Empty<ObjectId>(),
                 author, authorDate,
                 committer, commitDate, "");
@@ -148,7 +146,6 @@ namespace ResourceManagerTests.CommitDataRenders
             var commitDate = DateTime.Parse("2017-10-23T06:17:11+05");
             CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
-                ObjectId.Random(),
                 Array.Empty<ObjectId>(),
                 author, authorDate,
                 committer, commitDate, "");
@@ -177,7 +174,6 @@ namespace ResourceManagerTests.CommitDataRenders
             var commitDate = authorDate;
             CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
-                ObjectId.Random(),
                 Array.Empty<ObjectId>(),
                 author, authorDate,
                 committer, commitDate, "");
@@ -209,7 +205,6 @@ namespace ResourceManagerTests.CommitDataRenders
             var commitDate = authorDate;
             CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
-                ObjectId.Random(),
                 _parentHashes,
                 author, authorDate,
                 committer, commitDate, "");
@@ -239,7 +234,6 @@ namespace ResourceManagerTests.CommitDataRenders
             var commitDate = authorDate;
             CommitData data = new(
                 ObjectId.Parse(artificialGuid),
-                ObjectId.Random(),
                 _parentHashes,
                 author, authorDate,
                 committer, commitDate, "");
@@ -273,7 +267,6 @@ namespace ResourceManagerTests.CommitDataRenders
             var commitDate = authorDate;
             CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
-                ObjectId.Random(),
                 Array.Empty<ObjectId>(),
                 author, authorDate,
                 committer, commitDate, "");
@@ -301,7 +294,6 @@ namespace ResourceManagerTests.CommitDataRenders
             var commitDate = authorDate;
             CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
-                ObjectId.Random(),
                 Array.Empty<ObjectId>(),
                 author, authorDate,
                 committer, commitDate, "");
@@ -330,7 +322,6 @@ namespace ResourceManagerTests.CommitDataRenders
             var commitDate = DateTime.Parse("2017-10-23T06:17:11+05");
             CommitData data = new(
                 ObjectId.Parse("7fa3109989e0523aeacb178995a2a3aa6c302a2c"),
-                ObjectId.Random(),
                 Array.Empty<ObjectId>(),
                 author, authorDate,
                 committer, commitDate, "");


### PR DESCRIPTION
Fixes #9378
I hope

## Proposed changes

Remove the unused `CommitDataManager.TreeGuid` and do not attempt to parse this *optional* value.

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- adapted testcases

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build a9241924a70caa8d687e8be477587f68f8718455
- Git 2.35.1.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.3
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).