### PR TITLE
Display assigned hotkeys in View menu on startup

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -204,7 +204,8 @@ namespace GitUI
             copyToClipboardToolStripMenuItem.SetRevisionFunc(() => GetSelectedRevisions());
 
             MenuCommands = new RevisionGridMenuCommands(this);
-            MenuCommands.CreateOrUpdateMenuCommands();
+            ReloadHotkeys();
+            HotkeysEnabled = true;
 
             // fill View context menu from MenuCommands
             FillMenuFromMenuCommands(MenuCommands.ViewMenuCommands, viewToolStripMenuItem);
@@ -214,9 +215,6 @@ namespace GitUI
 
             // Apply checkboxes changes also to FormBrowse main menu
             MenuCommands.TriggerMenuChanged();
-
-            Hotkeys = HotkeySettingsManager.LoadHotkeys(HotkeySettingsName);
-            HotkeysEnabled = true;
 
             _gridView.ShowCellToolTips = false;
             _gridView.AuthorHighlighting = _authorHighlighting;


### PR DESCRIPTION
Fixes the bug of #9822

## Proposed changes

RevisionGridControl: (Re)load `Hotkeys` before `CreateOrUpdateMenuCommands`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before /  After

![image](https://user-images.githubusercontent.com/36601201/158894012-d3dd48d6-9193-4688-af84-dd75e47940cc.png)   ![image](https://user-images.githubusercontent.com/36601201/158893613-0771bffe-800f-4b51-8dc8-b106a4f34dc1.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 1f4e1c088eb31e8f5a42f02167f062318011187c
- Git 2.35.1.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 5.0.12
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).