### PR TITLE
Process events before PerformRefreshRevisions

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -568,6 +568,9 @@ namespace GitUI.CommandsDialogs
 
         private void UICommands_PostRepositoryChanged(object sender, GitUIEventArgs e)
         {
+            // Process events e.g. from closing FormProcess, particularly after rebase / conflict resolution actions
+            Application.DoEvents();
+
             // Note that this called in most FormBrowse context to "be sure"
             // that the repo has not been updated externally.
             RefreshRevisions(e.GetRefs);
@@ -596,14 +599,15 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
+            InternalInitialize();
+            RefreshGitStatusMonitor();
+
             Debug.Assert(RevisionGrid.CanRefresh, "Already loading revisions when running RefreshRevisions(). This could cause the commits in the grid to be loaded several times.");
             RevisionGrid.PerformRefreshRevisions(getRefs);
 
-            InternalInitialize();
             ToolStripFilters.UpdateBranchFilterItems(getRefs);
             UpdateSubmodulesStructure();
 
-            RefreshGitStatusMonitor();
             revisionDiff.RefreshArtificial();
             UpdateStashCount();
         }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -568,9 +568,6 @@ namespace GitUI.CommandsDialogs
 
         private void UICommands_PostRepositoryChanged(object sender, GitUIEventArgs e)
         {
-            // Process events e.g. from closing FormProcess, particularly after rebase / conflict resolution actions
-            Application.DoEvents();
-
             // Note that this called in most FormBrowse context to "be sure"
             // that the repo has not been updated externally.
             RefreshRevisions(e.GetRefs);
@@ -599,15 +596,17 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            InternalInitialize();
-            RefreshGitStatusMonitor();
+            // Process events e.g. from closing FormProcess, particularly after rebase / conflict resolution actions
+            Application.DoEvents();
 
             Debug.Assert(RevisionGrid.CanRefresh, "Already loading revisions when running RefreshRevisions(). This could cause the commits in the grid to be loaded several times.");
             RevisionGrid.PerformRefreshRevisions(getRefs);
 
+            InternalInitialize();
             ToolStripFilters.UpdateBranchFilterItems(getRefs);
             UpdateSubmodulesStructure();
 
+            RefreshGitStatusMonitor();
             revisionDiff.RefreshArtificial();
             UpdateStashCount();
         }

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -52,7 +52,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         {
             _loadingCompleted = false;
             _maxScore = 0;
-            _nodeByObjectId = new ConcurrentDictionary<ObjectId, RevisionGraphRevision>();
+            _nodeByObjectId.Clear();
             _nodes = ImmutableList<RevisionGraphRevision>.Empty;
             _orderedNodesCache = null;
             _orderedRowCache = null;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1279,9 +1279,9 @@ namespace GitUI
                 {
                     await this.SwitchToMainThreadAsync();
 
+                    _isRefreshingRevisions = false;
                     _gridView.LoadingCompleted();
                     SetPage(_gridView, getUnfilteredRefs);
-                    _isRefreshingRevisions = false;
                     CheckAndRepairInitialRevision();
                     HighlightRevisionsByAuthor(GetSelectedRevisions());
 


### PR DESCRIPTION
Fixes #9223
Fixes #9792

## Proposed changes

- before calling `RevisionGrid.PerformRefreshRevisions`:
  - process events e.g. from closing FormProcess, particularly after rebase / conflict resolution actions
- reset `RevisionGridControl._isRefreshingRevisions` before calling `LoadingCompleted` and `SetPage`
- minor tuning of `RevisionGraph.Clear`: clear Dictionary instead of creating a new one

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

no graph or empty RevisionGrid after rebase / merge / conflict resolution operations

### After

RevisionGrid is updated without need for manual refresh

## Test methodology <!-- How did you ensure quality? -->

- manual, e.g.
  - start rebase with conflicts
  - close dialog
  - abort 

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 10d51fd4222272d8cb5997b50ad386b7c02f0284
- Git 2.35.1.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 5.0.12
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).