### PR TITLE
"rebase/merge --abort" instead of "reset --hard"

### DIFF
--- a/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
@@ -58,7 +58,7 @@ namespace GitUI.CommandsDialogs
             this.startMergetool = new System.Windows.Forms.Button();
             this.openMergeToolBtn = new System.Windows.Forms.Button();
             this.Rescan = new System.Windows.Forms.Button();
-            this.Reset = new System.Windows.Forms.Button();
+            this.Abort = new System.Windows.Forms.Button();
             this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.tableLayoutPanel5 = new System.Windows.Forms.TableLayoutPanel();
@@ -464,13 +464,13 @@ namespace GitUI.CommandsDialogs
             // 
             // Reset
             // 
-            this.Reset.Location = new System.Drawing.Point(3, 96);
-            this.Reset.Name = "Reset";
-            this.Reset.Size = new System.Drawing.Size(140, 25);
-            this.Reset.TabIndex = 6;
-            this.Reset.Text = "Abort";
-            this.Reset.UseVisualStyleBackColor = true;
-            this.Reset.Click += new System.EventHandler(this.Reset_Click);
+            this.Abort.Location = new System.Drawing.Point(3, 96);
+            this.Abort.Name = "Reset";
+            this.Abort.Size = new System.Drawing.Size(140, 25);
+            this.Abort.TabIndex = 6;
+            this.Abort.Text = "Abort";
+            this.Abort.UseVisualStyleBackColor = true;
+            this.Abort.Click += new System.EventHandler(this.Abort_Click);
             // 
             // tableLayoutPanel4
             // 
@@ -497,7 +497,7 @@ namespace GitUI.CommandsDialogs
             this.flowLayoutPanel1.Controls.Add(this.openMergeToolBtn);
             this.flowLayoutPanel1.Controls.Add(this.startMergetool);
             this.flowLayoutPanel1.Controls.Add(this.Rescan);
-            this.flowLayoutPanel1.Controls.Add(this.Reset);
+            this.flowLayoutPanel1.Controls.Add(this.Abort);
             this.flowLayoutPanel1.Controls.Add(this.progressBar);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
@@ -610,7 +610,7 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.DataGridView ConflictedFiles;
         private System.Windows.Forms.Button openMergeToolBtn;
         private System.Windows.Forms.Button Rescan;
-        private System.Windows.Forms.Button Reset;
+        private System.Windows.Forms.Button Abort;
         private System.Windows.Forms.Button startMergetool;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
         private System.Windows.Forms.Button merge;

--- a/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
@@ -465,7 +465,7 @@ namespace GitUI.CommandsDialogs
             // Reset
             // 
             this.Abort.Location = new System.Drawing.Point(3, 96);
-            this.Abort.Name = "Reset";
+            this.Abort.Name = "Abort";
             this.Abort.Size = new System.Drawing.Size(140, 25);
             this.Abort.TabIndex = 6;
             this.Abort.Text = "Abort";

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -255,13 +255,13 @@ namespace GitUI.CommandsDialogs
 
                 if (Module.InTheMiddleOfRebase())
                 {
-                    Reset.Text = _resetItemRebaseText.Text;
+                    Abort.Text = _resetItemRebaseText.Text;
                     ContextChooseLocal.Text = _contextChooseLocalRebaseText.Text;
                     ContextChooseRemote.Text = _contextChooseRemoteRebaseText.Text;
                 }
                 else
                 {
-                    Reset.Text = _resetItemMergeText.Text;
+                    Abort.Text = _resetItemMergeText.Text;
                     ContextChooseLocal.Text = _contextChooseLocalMergeText.Text;
                     ContextChooseRemote.Text = _contextChooseRemoteMergeText.Text;
                 }
@@ -710,7 +710,7 @@ namespace GitUI.CommandsDialogs
             return false;
         }
 
-        private void Reset_Click(object sender, EventArgs e)
+        private void Abort_Click(object sender, EventArgs e)
         {
             using (WaitCursorScope.Enter())
             {

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -7,6 +7,7 @@ using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.Git;
+using GitCommands.Git.Commands;
 using GitCommands.Utils;
 using GitExtUtils;
 using GitUI.HelperDialogs;
@@ -91,9 +92,9 @@ namespace GitUI.CommandsDialogs
             new("All files (*.*)");
 
         private readonly TranslationString _abortCurrentOperation =
-            new("You can abort the current operation by resetting changes." + Environment.NewLine +
-                "All changes since the last commit will be deleted." + Environment.NewLine +
-                Environment.NewLine + "Do you want to reset changes?");
+            new("You can abort the current operation." + Environment.NewLine +
+                "All changes - particularly conflict resolutions - will be deleted." + Environment.NewLine +
+                Environment.NewLine + "Do you want to reset the changes?");
 
         private readonly TranslationString _abortCurrentOperationCaption = new("Abort");
 
@@ -715,7 +716,10 @@ namespace GitUI.CommandsDialogs
             {
                 if (ShowAbortMessage())
                 {
-                    Module.Reset(ResetMode.Hard);
+                    ArgumentString arguments = Module.InTheMiddleOfRebase()
+                        ? GitCommandHelpers.AbortRebaseCmd()
+                        : GitCommandHelpers.AbortMergeCmd();
+                    FormProcess.ShowDialog(this, arguments, Module.WorkingDir, input: null, useDialogSettings: true);
                     Close();
                 }
             }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7013,6 +7013,10 @@ Forcing a branch to reset if it has not been merged might leave some commits unr
         <source>Resolve merge conflicts</source>
         <target />
       </trans-unit>
+      <trans-unit id="Abort.Text">
+        <source>Abort</source>
+        <target />
+      </trans-unit>
       <trans-unit id="ContextChooseBase.Text">
         <source>Choose base</source>
         <target />
@@ -7063,10 +7067,6 @@ Forcing a branch to reset if it has not been merged might leave some commits unr
       </trans-unit>
       <trans-unit id="Rescan.Text">
         <source>Rescan merge conflicts</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="Reset.Text">
-        <source>Abort</source>
         <target />
       </trans-unit>
       <trans-unit id="_abortCurrentOperation.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7070,10 +7070,10 @@ Forcing a branch to reset if it has not been merged might leave some commits unr
         <target />
       </trans-unit>
       <trans-unit id="_abortCurrentOperation.Text">
-        <source>You can abort the current operation by resetting changes.
-All changes since the last commit will be deleted.
+        <source>You can abort the current operation.
+All changes - particularly conflict resolutions - will be deleted.
 
-Do you want to reset changes?</source>
+Do you want to reset the changes?</source>
         <target />
       </trans-unit>
       <trans-unit id="_abortCurrentOperationCaption.Text">


### PR DESCRIPTION
Fixes #9575

## Proposed changes

- "rebase/merge --abort" instead "reset --hard"

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/36601201/159139764-fa6879b4-6c69-4005-9a50-fd06399e1939.png)

![image](https://user-images.githubusercontent.com/36601201/159140015-69863484-2b98-4a8d-a57c-00abacd562c1.png)

### After

![image](https://user-images.githubusercontent.com/36601201/159139820-ffc4358f-1702-49dd-8d05-482c04dc09aa.png)

![image](https://user-images.githubusercontent.com/36601201/159139913-46ef8690-54b9-45d8-9cb8-b27d21d56b51.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 1e409ce21c9c668b009cfb7f7f2fd4374ac28ac1
- Git 2.35.1.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 5.0.12
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).