### PR TITLE
RevDiff: async SetDiff

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -612,7 +612,6 @@ namespace GitUI.CommandsDialogs
             UpdateSubmodulesStructure();
 
             RefreshGitStatusMonitor();
-            revisionDiff.RefreshArtificial();
             UpdateStashCount();
         }
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1872,6 +1872,10 @@ the last selected commit.</source>
         <source>Filter files using a regular expression...</source>
         <target />
       </trans-unit>
+      <trans-unit id="LoadingFiles.Text">
+        <source>Loading data...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="NoFiles.Text">
         <source>No changes</source>
         <target />

--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -32,6 +32,7 @@
             this.FileStatusListView = new GitUI.UserControls.NativeListView();
             this.columnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.NoFiles = new System.Windows.Forms.Label();
+            this.LoadingFiles = new System.Windows.Forms.Label();
             this.FilterComboBox = new System.Windows.Forms.ComboBox();
             this.FilterWatermarkLabel = new System.Windows.Forms.Label();
             this.FilterToolTip = new System.Windows.Forms.ToolTip(this.components);
@@ -84,6 +85,17 @@
             this.NoFiles.Name = "NoFiles";
             this.NoFiles.Size = new System.Drawing.Size(65, 13);
             this.NoFiles.TabIndex = 5;
+            // 
+            // LoadingFiles
+            // 
+            this.LoadingFiles.AutoSize = true;
+            this.LoadingFiles.BackColor = System.Drawing.SystemColors.Window;
+            this.LoadingFiles.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.LoadingFiles.Location = new System.Drawing.Point(4, 21);
+            this.LoadingFiles.Margin = new System.Windows.Forms.Padding(0);
+            this.LoadingFiles.Name = "LoadingFiles";
+            this.LoadingFiles.Size = new System.Drawing.Size(65, 13);
+            this.LoadingFiles.TabIndex = 5;
             // 
             // FilterComboBox
             // 
@@ -149,6 +161,7 @@
             this.Controls.Add(this.DeleteFilterButton);
             this.Controls.Add(this.FilterWatermarkLabel);
             this.Controls.Add(this.NoFiles);
+            this.Controls.Add(this.LoadingFiles);
             this.Controls.Add(this.FileStatusListView);
             this.Controls.Add(this.lblSplitter);
             this.Controls.Add(this.FilterComboBox);
@@ -164,6 +177,7 @@
 
         private GitUI.UserControls.NativeListView FileStatusListView;
         private System.Windows.Forms.Label NoFiles;
+        private System.Windows.Forms.Label LoadingFiles;
         private System.Windows.Forms.ColumnHeader columnHeader;
         private System.Windows.Forms.ComboBox FilterComboBox;
         private System.Windows.Forms.Label FilterWatermarkLabel;


### PR DESCRIPTION
Fixes #9899

With this I see no more major async needs in the refreshRevision sequence,
(InternalInitialize() calls CheckForUpdates but that is only done occasionally during start.)

## Proposed changes

* Change git-diff file difference calculation to be asynchronous and
display a message indicating that the files are loading (instead of
showing the old diff).

This is also used in FormCommit etc, not much changes there as there is not much you can do until the diff is loaded anyway.

Using the same cancellationToken as is used for showing file contents.

* Browse RefreshRevisions(): Skip RefreshArtificial()

This is redundant as the revision is restored after loading the grid is done.
Duplicate update is normally avoided as revisions are not yet set when
RefreshArtificial() was called.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The diff before revision is changed, not responding if another revision is selected.

### After

Note: modified to show in the filelist after mstv suggestions, to avoid overlay issues and flickering.

![image](https://user-images.githubusercontent.com/6248932/160296695-3e20ce2b-a223-4506-97ef-9466f8e2f9bd.png)
<!--
![image](https://user-images.githubusercontent.com/6248932/159176425-057f62ba-2dc0-4c8b-a4b9-0e4d0ffebfd9.png)
-->

## Test methodology <!-- How did you ensure quality? -->

Manual
Inserting Thread.Sleep(); in FileStatusList.SetDiffs()

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
