### PR TITLE
Upgrade pkg SmartFormat to v3.0.0

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -21,7 +21,7 @@
     <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Update="NString" Version="2.1.1" />
     <PackageReference Update="RestSharp" Version="106.12.0" />
-    <PackageReference Update="SmartFormat.NET" Version="2.7.0" />
+    <PackageReference Update="SmartFormat" Version="3.0.0" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.321" />
     <PackageReference Update="System.Collections.Immutable" Version="5.0.0" /> <!-- Required? -->
     <PackageReference Update="System.IO.Abstractions" Version="13.2.43" />

--- a/ResourceManager/ResourceManager.csproj
+++ b/ResourceManager/ResourceManager.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" />
-    <PackageReference Include="SmartFormat.NET" />
+    <PackageReference Include="SmartFormat" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ResourceManager/TranslatedStrings.cs
+++ b/ResourceManager/TranslatedStrings.cs
@@ -51,9 +51,11 @@ Yes, I allow telemetry!");
         // public only because of FormTranslate
         public TranslatedStrings()
         {
-            // Our original implementations were create against SmartFormat.NET pre-dating v2.0.0.
-            // In v2.5.0 the default error action was changed to ThrowError. See https://github.com/axuno/SmartFormat/issues/192.
-            Smart.Default.Settings.FormatErrorAction = ErrorAction.Ignore;
+            // Our original implementations were created against SmartFormat.NET pre-dating v2.0.0.
+            // Since v2.5.0 the default error action was changed to ThrowError. See https://github.com/axuno/SmartFormat/issues/192.
+            // This applies for the Formatter AND the Parser
+            Smart.Default.Settings.Formatter.ErrorAction = FormatErrorAction.Ignore;
+            Smart.Default.Settings.Parser.ErrorAction = ParseErrorAction.Ignore;
 
             Translator.Translate(this, AppSettings.CurrentTranslation);
         }

--- a/contributors.txt
+++ b/contributors.txt
@@ -172,3 +172,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/11/13, h0lg, Holger Schmidt, leroyz.mailaccount(at)gmx.net
 2021/12/06, Tyrrrz, Alexey Golub, tyrrrz(at)gmail.com
 2021/12/29, blazejszuca, Błażej Szuca, blazej.szuca+gitextensions(at)gmail.com
+2022/03/23, axunonb, Norbert Bietsch, nb[@)axuno.net


### PR DESCRIPTION
Refers to https://github.com/gitextensions/gitextensions/discussions/9909#discussioncomment-2410663

## Proposed changes

- Upgrade package `SmartFormat` to v3.0.0, using the `Core` instead of the `Full` package, getting rid of unnecessary dependencies
- Brings higher performance in speed and memory footprint ([more details](https://github.com/axuno/SmartFormat/wiki/Why-Migrate))
- Fix: To achieve the same error behavior as in pre v2.5.0, formatter exceptions **and** parser exceptions must be set to "ignore". The latter was missing when migrating to v2.5.0

## Test methodology <!-- How did you ensure quality? -->

- Existing unit tests succeed with the updated package
- Manual, testing for English, French and German translations display okay (random samples)

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.33.0.windows.2
- Windows 11 Pro

## Merge strategy

- I agree that the maintainer squash merge this PR
----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
