### PR TITLE
FormCommit: Reset commit options after push

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1379,9 +1379,6 @@ namespace GitUI.CommandsDialogs
                         return;
                     }
 
-                    Amend.Checked = false;
-                    noVerifyToolStripMenuItem.Checked = false;
-
                     ScriptManager.RunEventScripts(this, ScriptEvent.AfterCommit);
 
                     // Message.Text has been used and stored
@@ -1399,6 +1396,8 @@ namespace GitUI.CommandsDialogs
                     finally
                     {
                         Message.Text = string.Empty;
+                        Amend.Checked = false;
+                        noVerifyToolStripMenuItem.Checked = false;
                     }
 
                     if (pushCompleted && Module.SuperprojectModule is not null &&


### PR DESCRIPTION
Fixes #9914
as follow-up to #8541 which fixed #8327 

## Proposed changes

Reset checked state of `Amend` and `noVerifyToolStripMenuItem` after closing the (modal) Push dialog
(i.e. no need to disable the checkbox while pushing)  

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/36601201/159998855-b8916ffd-dc44-4b3f-852a-fdcea4c8cb30.png)

### After

![image](https://user-images.githubusercontent.com/36601201/159999204-fb3e84a3-1381-472c-89c8-44addcc5ad9e.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build ffacb5d73f973e18e8e585dc21235c10db9291d3
- Git 2.35.1.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 5.0.12
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).