### PR TITLE
Handle detached HEAD for orphan branches

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1092,7 +1092,7 @@ namespace GitCommands
 
         /// <summary>
         /// Gets the commit ID of the currently checked out commit.
-        /// If the repo is bare, has no commits or is corrupt, <c>null</c> is returned.
+        /// If the repo is bare, has no commits, detached head or is corrupt, <c>null</c> is returned.
         /// </summary>
         public ObjectId? GetCurrentCheckout()
         {
@@ -3618,16 +3618,16 @@ namespace GitCommands
                 { !string.IsNullOrEmpty(authorPattern), string.Concat("--author=\"", authorPattern, "\"") }
             };
 
-            var messages = _gitExecutable.GetOutput(
-                args,
-                outputEncoding: LosslessEncoding).Split(Delimiters.Null, StringSplitOptions.RemoveEmptyEntries);
-
-            if (messages.Length == 0)
+            ExecutionResult result = _gitExecutable.Execute(args, outputEncoding: LosslessEncoding, throwOnErrorExit: false);
+            if (!result.ExitedSuccessfully)
             {
                 return new[] { string.Empty };
             }
 
-            return messages.Select(ReEncodeCommitMessage);
+            string[] messages = result.StandardOutput.Split(Delimiters.Null, StringSplitOptions.RemoveEmptyEntries);
+            return messages.Length == 0
+                ? new[] { string.Empty }
+                : messages.Select(ReEncodeCommitMessage);
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -253,20 +253,27 @@ namespace GitUI.CommandsDialogs
             {
                 // FileStatusList has no interface for both worktree<-index, index<-HEAD at the same time
                 // Must be handled when displaying
-                var headId = Module.RevParse("HEAD");
-                Validates.NotNull(headId);
-                GitRevision headRev = new(headId);
-                GitRevision indexRev = new(ObjectId.IndexId)
-                {
-                    ParentIds = new[] { headId }
-                };
+                ObjectId? headId = Module.RevParse("HEAD");
                 GitRevision workTreeRev = new(ObjectId.WorkTreeId)
                 {
                     ParentIds = new[] { ObjectId.IndexId }
                 };
-                var indexItems = gitItemStatuses.Where(item => item.Staged == StagedStatus.Index).ToList();
-                var workTreeItems = gitItemStatuses.Where(item => item.Staged != StagedStatus.Index).ToList();
-                Stashed.SetStashDiffs(headRev, indexRev, ResourceManager.TranslatedStrings.Index, indexItems, workTreeRev, ResourceManager.TranslatedStrings.Workspace, workTreeItems);
+                if (headId is null)
+                {
+                    // Likely a detached head
+                    Stashed.SetDiffs(null, workTreeRev, gitItemStatuses);
+                }
+                else
+                {
+                    GitRevision headRev = new(headId);
+                    GitRevision indexRev = new(ObjectId.IndexId)
+                    {
+                        ParentIds = new[] { headId }
+                    };
+                    var indexItems = gitItemStatuses.Where(item => item.Staged == StagedStatus.Index).ToList();
+                    var workTreeItems = gitItemStatuses.Where(item => item.Staged != StagedStatus.Index).ToList();
+                    Stashed.SetStashDiffs(headRev, indexRev, ResourceManager.TranslatedStrings.Index, indexItems, workTreeRev, ResourceManager.TranslatedStrings.Workspace, workTreeItems);
+                }
             }
             else
             {

--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -51,14 +51,17 @@ namespace GitUI
 
                 if (actualRev.ParentIds is null || actualRev.ParentIds.Count == 0)
                 {
-                    Validates.NotNull(selectedRev.TreeGuid);
-
-                    // No parent for the initial commit
                     fileStatusDescs.Add(new FileStatusWithDescription(
                         firstRev: null,
                         secondRev: selectedRev,
                         summary: GetDescriptionForRevision(selectedRev.ObjectId),
-                        statuses: module.GetTreeFiles(selectedRev.TreeGuid, full: true)));
+                        statuses: selectedRev.TreeGuid is null
+
+                            // likely index commit without HEAD
+                            ? module.GetDiffFilesWithSubmodulesStatus(null, selectedRev.ObjectId, null)
+
+                            // No parent for the initial commit
+                            : module.GetTreeFiles(selectedRev.TreeGuid, full: true)));
                 }
                 else
                 {

--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -66,7 +66,7 @@ namespace GitUI
                 else
                 {
                     // Get the parents for the selected revision
-                    var multipleParents = AppSettings.ShowDiffForAllParents ? actualRev.ParentIds.Count : 1;
+                    var multipleParents = actualRev.ParentIds is null ? 0 : AppSettings.ShowDiffForAllParents ? actualRev.ParentIds.Count : 1;
                     fileStatusDescs.AddRange(actualRev
                         .ParentIds
                         .Take(multipleParents)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1227,7 +1227,7 @@ namespace GitUI
                     CommitUnixTime = 0,
                     CommitterEmail = userEmail,
                     Subject = ResourceManager.TranslatedStrings.Index,
-                    ParentIds = new[] { CurrentCheckout },
+                    ParentIds = CurrentCheckout is null ? null : new[] { CurrentCheckout },
                     HasNotes = true
                 };
 
@@ -2490,7 +2490,8 @@ namespace GitUI
             // => Fill with HEAD to if less than two normal revisions (it is OK to compare HEAD HEAD)
             var revisions = GetSelectedRevisions().Select(i => i.ObjectId).Where(i => !i.IsArtificial).ToList();
             bool hasArtificial = GetSelectedRevisions().Any(i => i.IsArtificial);
-            if (revisions.Count == 0 && !hasArtificial)
+            ObjectId? headId = Module.RevParse("HEAD");
+            if (headId is null || (revisions.Count == 0 && !hasArtificial))
             {
                 return;
             }
@@ -2498,8 +2499,8 @@ namespace GitUI
             GitArgumentBuilder args = new("merge-base")
             {
                 { revisions.Count > 2 || (revisions.Count == 2 && hasArtificial), "--octopus" },
-                { revisions.Count < 1, "HEAD" },
-                { revisions.Count < 2, "HEAD" },
+                { revisions.Count < 1, headId.ToString() },
+                { revisions.Count < 2, headId.ToString() },
                 revisions
             };
 


### PR DESCRIPTION
Fixes #9913
Fixes #9910
Create Stash
Goto Common ancestor

## Proposed changes

HEAD is not set for orphan branches or initial commits.

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
