### PR TITLE
Correct ownership of Push taskdialog

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -527,6 +527,8 @@ namespace GitUI.CommandsDialogs
             if (match.Success && !Module.IsBareRepository())
             {
                 IWin32Window owner = form.Owner;
+                Debug.Assert(owner is not null, "Progress window must be owned by another window! This is a bug, please correct and send a pull request with a fix.");
+
                 (var onRejectedPullAction, var forcePush) = AskForAutoPullOnPushRejectedAction(owner, match.Groups["currBranch"].Success);
 
                 if (forcePush)
@@ -643,7 +645,8 @@ namespace GitUI.CommandsDialogs
 
                 page.Buttons.Add(btnPushForce);
 
-                TaskDialogButton result = TaskDialog.ShowDialog(Handle, page);
+                Debug.Assert(owner is not null, "The dialog must be owned by another window! This is a bug, please correct and send a pull request with a fix.");
+                TaskDialogButton result = TaskDialog.ShowDialog(owner, page);
                 if (result == TaskDialogButton.Cancel)
                 {
                     onRejectedPullAction = AppSettings.PullAction.None;

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -526,10 +526,13 @@ namespace GitUI.CommandsDialogs
             Match match = isRejected.Match(form.GetOutputString());
             if (match.Success && !Module.IsBareRepository())
             {
-                IWin32Window owner = form.Owner;
-                Debug.Assert(owner is not null, "Progress window must be owned by another window! This is a bug, please correct and send a pull request with a fix.");
+                Debug.Assert(form.Visible, "The progress dialog must be visible.");
 
-                (var onRejectedPullAction, var forcePush) = AskForAutoPullOnPushRejectedAction(owner, match.Groups["currBranch"].Success);
+                // form is ProgressDialog, and form.Owner is FormPush that spawned the ProgressDialog, so essentially owner == this.
+                IWin32Window owner = form.Owner;
+                Debug.Assert(owner == this, "The progress window must belong to this dialog! This is a bug, please correct and send a pull request with a fix.");
+
+                (AppSettings.PullAction onRejectedPullAction, var forcePush) = AskForAutoPullOnPushRejectedAction(match.Groups["currBranch"].Success);
 
                 if (forcePush)
                 {
@@ -592,7 +595,7 @@ namespace GitUI.CommandsDialogs
             return false;
         }
 
-        private (AppSettings.PullAction pullAction, bool forcePush) AskForAutoPullOnPushRejectedAction(IWin32Window owner, bool allOptions)
+        private (AppSettings.PullAction pullAction, bool forcePush) AskForAutoPullOnPushRejectedAction(bool allOptions)
         {
             bool forcePush = false;
             AppSettings.PullAction? onRejectedPullAction = AppSettings.AutoPullOnPushRejectedAction;
@@ -645,8 +648,7 @@ namespace GitUI.CommandsDialogs
 
                 page.Buttons.Add(btnPushForce);
 
-                Debug.Assert(owner is not null, "The dialog must be owned by another window! This is a bug, please correct and send a pull request with a fix.");
-                TaskDialogButton result = TaskDialog.ShowDialog(owner, page);
+                TaskDialogButton result = TaskDialog.ShowDialog(this, page);
                 if (result == TaskDialogButton.Cancel)
                 {
                     onRejectedPullAction = AppSettings.PullAction.None;


### PR DESCRIPTION
The dialog is spawned when attempting to push a branch that would result in a rewrite of the remote HEAD.
![image](https://user-images.githubusercontent.com/4403806/160601025-5c4040ac-25e2-46d8-bf40-47dfaf509c71.png)
