### PR TITLE
Blame: open current diff/view line

### DIFF
--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -435,7 +435,7 @@ See the changes in the commit form.");
                     {
                         if (!blameToolStripMenuItem1.Checked)
                         {
-                            return ViewGitItemAsync(gitItem);
+                            return ViewGitItemAsync(gitItem, line);
                         }
 
                         FileText.Visible = false;
@@ -445,14 +445,14 @@ See the changes in the commit form.");
 
                 case GitObjectType.Commit:
                     {
-                        return ViewGitItemAsync(gitItem);
+                        return ViewGitItemAsync(gitItem, line: null);
                     }
 
                 default:
                     return ClearOutputAsync();
             }
 
-            Task ViewGitItemAsync(GitItem gitItem)
+            Task ViewGitItemAsync(GitItem gitItem, int? line)
             {
                 GitItemStatus file = new(name: gitItem.FileName)
                 {
@@ -463,7 +463,7 @@ See the changes in the commit form.");
 
                 BlameControl.Visible = false;
                 FileText.Visible = true;
-                return FileText.ViewGitItemAsync(file, gitItem.ObjectId);
+                return FileText.ViewGitItemAsync(file, gitItem.ObjectId, line: line);
             }
         }
 
@@ -527,8 +527,8 @@ See the changes in the commit form.");
                 return;
             }
 
+            int? line = FileText.Visible ? FileText.CurrentFileLine : BlameControl.CurrentFileLine;
             blameToolStripMenuItem1.Checked = !blameToolStripMenuItem1.Checked;
-            int? line = FileText.Visible ? FileText.CurrentFileLine : null;
 
             ThreadHelper.JoinableTaskFactory.RunAsync(() => ShowGitItemAsync(gitItem, line));
         }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -425,9 +425,10 @@ namespace GitUI.Editor
         /// </summary>
         /// <param name="item">The gitItem to present.</param>
         /// <param name="text">The patch text.</param>
+        /// <param name="line">The line to display.</param>
         /// <param name="openWithDifftool">The action to open the difftool.</param>
-        public Task ViewPatchAsync(FileStatusItem item, string text, Action? openWithDifftool)
-            => ViewPrivateAsync(item, item?.Item?.Name, text, openWithDifftool, ViewMode.Diff);
+        public Task ViewPatchAsync(FileStatusItem item, string text, int? line, Action? openWithDifftool)
+            => ViewPrivateAsync(item, item?.Item?.Name, text, line, openWithDifftool, ViewMode.Diff);
 
         /// <summary>
         /// Present the text as a patch in the file viewer, for GitHub.
@@ -436,7 +437,7 @@ namespace GitUI.Editor
         /// <param name="text">The patch text.</param>
         /// <param name="openWithDifftool">The action to open the difftool.</param>
         public Task ViewFixedPatchAsync(string fileName, string text, Action? openWithDifftool = null)
-            => ViewPrivateAsync(item: null, fileName, text, openWithDifftool, ViewMode.FixedDiff);
+            => ViewPrivateAsync(item: null, fileName, text, line: null, openWithDifftool, ViewMode.FixedDiff);
 
         public void ViewFixedPatch(string? fileName,
             string text,
@@ -447,7 +448,7 @@ namespace GitUI.Editor
         }
 
         public Task ViewRangeDiffAsync(string fileName, string text)
-            => ViewPrivateAsync(item: null, fileName, text, openWithDifftool: null, ViewMode.RangeDiff);
+            => ViewPrivateAsync(item: null, fileName, text, line: null, openWithDifftool: null, ViewMode.RangeDiff);
 
         public void ViewText(string? fileName,
             string text,
@@ -462,11 +463,13 @@ namespace GitUI.Editor
         /// </summary>
         /// <param name="fileName">The fileName to present.</param>
         /// <param name="text">The patch text.</param>
+        /// <param name="line">The line to display.</param>
         /// <param name="openWithDifftool">The action to open the difftool.</param>
         /// <param name="checkGitAttributes">Check Git attributes to check for binary files.</param>
         public Task ViewTextAsync(string? fileName,
             string text,
             FileStatusItem? item = null,
+            int? line = null,
             Action? openWithDifftool = null,
             bool checkGitAttributes = false)
         {
@@ -505,6 +508,10 @@ namespace GitUI.Editor
                     else
                     {
                         internalFileViewer.SetText(text, openWithDifftool);
+                        if (line is not null)
+                        {
+                            GoToLine(line.Value);
+                        }
                     }
 
                     TextLoaded?.Invoke(this, null);
@@ -512,14 +519,14 @@ namespace GitUI.Editor
                 });
         }
 
-        public Task ViewGitItemAsync(FileStatusItem item, Action? openWithDifftool = null)
+        public Task ViewGitItemAsync(FileStatusItem item, int? line, Action? openWithDifftool)
         {
-            return ViewGitItemAsync(item.Item, item.SecondRevision.ObjectId, item, openWithDifftool);
+            return ViewGitItemAsync(item.Item, item.SecondRevision.ObjectId, item, line, openWithDifftool);
         }
 
-        public Task ViewGitItemAsync(GitItemStatus file, ObjectId objectId, Action? openWithDifftool = null)
+        public Task ViewGitItemAsync(GitItemStatus file, ObjectId objectId, int? line = null, Action? openWithDifftool = null)
         {
-            return ViewGitItemAsync(file, objectId, null, openWithDifftool);
+            return ViewGitItemAsync(file, objectId, item: null, line, openWithDifftool);
         }
 
         /// <summary>
@@ -528,14 +535,15 @@ namespace GitUI.Editor
         /// <param name="file">GitItem file, with TreeGuid.</param>
         /// <param name="objectId">Revision to present. Can be null if file.TreeGuid is set.</param>
         /// <param name="item">Metadata for line patching and presentation.</param>
+        /// <param name="line">The line to display.</param>
         /// <param name="openWithDifftool">difftool command</param>
         /// <returns>Task to view the item</returns>
-        private Task ViewGitItemAsync(GitItemStatus file, ObjectId? objectId, FileStatusItem? item, Action? openWithDifftool)
+        private Task ViewGitItemAsync(GitItemStatus file, ObjectId? objectId, FileStatusItem? item, int? line, Action? openWithDifftool)
         {
             if (objectId == ObjectId.WorkTreeId || file.Staged == StagedStatus.WorkTree)
             {
                 // No blob exists for worktree, present contents from file system
-                return ViewFileAsync(file.Name, file.IsSubmodule, item, openWithDifftool);
+                return ViewFileAsync(file.Name, file.IsSubmodule, item, line, openWithDifftool);
             }
 
             file.TreeGuid ??= Module.GetFileBlobHash(file.Name, objectId);
@@ -566,6 +574,7 @@ namespace GitUI.Editor
                 getFileText: GetFileTextIfBlobExists,
                 getSubmoduleText: () => LocalizationHelpers.GetSubmoduleText(Module, file.Name.TrimEnd('/'), sha, cache: true),
                 item: item,
+                line: line,
                 openWithDifftool: openWithDifftool);
 
             string GetFileTextIfBlobExists()
@@ -598,9 +607,10 @@ namespace GitUI.Editor
         /// <param name="fileName">The file/submodule path.</param>
         /// <param name="isSubmodule">If submodule.</param>
         /// <param name="item">Metadata for line patching and presentation.</param>
+        /// <param name="line">The line to display.</param>
         /// <param name="openWithDifftool">Diff action.</param>
         /// <returns>Task.</returns>
-        public Task ViewFileAsync(string fileName, bool isSubmodule = false, FileStatusItem? item = null, Action? openWithDifftool = null)
+        public Task ViewFileAsync(string fileName, bool isSubmodule = false, FileStatusItem? item = null, int? line = null, Action? openWithDifftool = null)
         {
             string? fullPath = _fullPathResolver.Resolve(fileName);
             Validates.NotNull(fullPath);
@@ -636,6 +646,7 @@ namespace GitUI.Editor
                     getFileText: GetFileText,
                     getSubmoduleText: () => LocalizationHelpers.GetSubmoduleText(Module, fileName.TrimEnd('/'), "", cache: false),
                     item: item,
+                    line: line,
                     openWithDifftool));
 
             Image? GetImage()
@@ -750,7 +761,7 @@ namespace GitUI.Editor
             return viewMode is (ViewMode.Diff or ViewMode.FixedDiff or ViewMode.RangeDiff);
         }
 
-        private Task ViewPrivateAsync(FileStatusItem? item, string? fileName, string text, Action? openWithDifftool, ViewMode viewMode = ViewMode.Diff)
+        private Task ViewPrivateAsync(FileStatusItem? item, string? fileName, string text, int? line, Action? openWithDifftool, ViewMode viewMode)
         {
             return ShowOrDeferAsync(
                 text.Length,
@@ -758,6 +769,10 @@ namespace GitUI.Editor
                 {
                     ResetView(viewMode, fileName, item: item, text: text);
                     internalFileViewer.SetText(text, openWithDifftool, isDiff: IsDiffView(_viewMode), isRangeDiff: _viewMode == ViewMode.RangeDiff);
+                    if (line is not null)
+                    {
+                        GoToLine(line.Value);
+                    }
 
                     TextLoaded?.Invoke(this, null);
                     return Task.CompletedTask;
@@ -1037,7 +1052,7 @@ namespace GitUI.Editor
             }
         }
 
-        private Task ViewItemAsync(string fileName, bool isSubmodule, Func<Image?> getImage, Func<string> getFileText, Func<string> getSubmoduleText, FileStatusItem? item, Action? openWithDifftool)
+        private Task ViewItemAsync(string fileName, bool isSubmodule, Func<Image?> getImage, Func<string> getFileText, Func<string> getSubmoduleText, FileStatusItem? item, int? line, Action? openWithDifftool)
         {
             FilePreamble = null;
 
@@ -1047,7 +1062,7 @@ namespace GitUI.Editor
                     getSubmoduleText,
                     text =>
                     {
-                        ThreadHelper.JoinableTaskFactory.Run(() => ViewTextAsync(fileName, text, item, openWithDifftool));
+                        ThreadHelper.JoinableTaskFactory.Run(() => ViewTextAsync(fileName, text, item, line: null, openWithDifftool));
                     });
             }
             else if (FileHelper.IsImage(fileName))
@@ -1091,7 +1106,7 @@ namespace GitUI.Editor
                 return _async.LoadAsync(
                     getFileText,
                     text => ThreadHelper.JoinableTaskFactory.Run(
-                        () => ViewTextAsync(fileName, text, item, openWithDifftool, checkGitAttributes: true)));
+                        () => ViewTextAsync(fileName, text, item, line, openWithDifftool, checkGitAttributes: true)));
             }
         }
 
@@ -2028,7 +2043,7 @@ namespace GitUI.Editor
                     new GitItemStatus(name: fileName ?? ""));
                 var fileViewer = _fileViewer;
                 ThreadHelper.JoinableTaskFactory.Run(
-                    () => fileViewer.ViewPatchAsync(f, text, openWithDifftool));
+                    () => fileViewer.ViewPatchAsync(f, text, line: null, openWithDifftool));
             }
         }
     }

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -17,6 +17,7 @@ namespace GitUI
         /// </summary>
         /// <param name="fileViewer">Current FileViewer.</param>
         /// <param name="item">The FileStatusItem to present changes for.</param>
+        /// <param name="line">The line to display.</param>
         /// <param name="defaultText">default text if no diff is possible.</param>
         /// <param name="openWithDiffTool">The difftool command to open with.</param>
         /// <param name="additionalCommandInfo">If the diff is range-diff, this contains the current path filter.</param>
@@ -24,6 +25,7 @@ namespace GitUI
         public static async Task ViewChangesAsync(this FileViewer fileViewer,
             FileStatusItem? item,
             CancellationToken cancellationToken,
+            int? line = null,
             string defaultText = "",
             Action? openWithDiffTool = null,
             string additionalCommandInfo = null)
@@ -54,7 +56,7 @@ namespace GitUI
             if (item.Item.IsNew || firstId is null || (!item.Item.IsDeleted && FileHelper.IsImage(item.Item.Name)))
             {
                 // View blob guid from revision, or file for worktree
-                await fileViewer.ViewGitItemAsync(item, openWithDiffTool);
+                await fileViewer.ViewGitItemAsync(item, line, openWithDiffTool);
                 return;
             }
 
@@ -97,7 +99,7 @@ namespace GitUI
             }
             else
             {
-                await fileViewer.ViewPatchAsync(item, text: selectedPatch, openWithDifftool: openWithDiffTool);
+                await fileViewer.ViewPatchAsync(item, text: selectedPatch, line: line, openWithDifftool: openWithDiffTool);
             }
 
             return;

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -85,6 +85,8 @@ namespace GitUI.Blame
             BlameAuthor.ShowLineNumbers = AppSettings.BlameShowLineNumbers;
         }
 
+        public int CurrentFileLine => BlameFile.CurrentFileLine;
+
         public void HideCommitInfo()
         {
             splitContainer1.Panel1Collapsed = true;


### PR DESCRIPTION
Related to #9842 

## Proposed changes

Open the current line in the Blame viewer when switching to
RevDiff diff viewer and FileTree content instead of the
line active before the diff.

This is not important, but can be confusing as diff/view to blame selects the line in blame.

This increases the complexity some in FileViewer though, why this is not an obvious function.
(Can set this as draft or WIP, but it is ready to review.)

## Screenshots <!-- Remove this section if PR does not change UI -->

Also diff -> Tree, RevTree blame-view

### Before

![blame-to-diff-old](https://user-images.githubusercontent.com/6248932/160933060-2988d489-a808-4311-b25e-8326ee1a3d5a.gif)


### After

![blame-to-diff-new](https://user-images.githubusercontent.com/6248932/160933076-b93010d2-d981-4d37-877a-2199905775c3.gif)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
