### PR TITLE
Fix test View_reflects_applied_branch_filter

### DIFF
--- a/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
@@ -96,9 +96,6 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                 });
         }
 
-#if !DEBUG
-        [Ignore("This test is unstable in AppVeyor")]
-#endif
         [Test]
         public void View_reflects_applied_branch_filter()
         {
@@ -109,6 +106,8 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                 "",
                 revisionGridControl =>
                 {
+                    WaitForRevisionsToBeLoaded(revisionGridControl);
+
                     var ta = revisionGridControl.GetTestAccessor();
                     Assert.False(revisionGridControl.CurrentFilter.IsShowFilteredBranchesChecked);
                     ta.VisibleRevisionCount.Should().Be(4);


### PR DESCRIPTION
## Proposed changes

Local (DEBUG) tests failed with .NET6
AppVeyor tests can be reenable.

Repeated the tests in AppVeyor

## Test methodology <!-- How did you ensure quality? -->

Repeated AppVeyor tests in loops

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
