### PR TITLE
Increase contrast between graph colors

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
@@ -8,12 +8,11 @@ namespace GitUI.UserControls.RevisionGrid.Graph
     {
         internal static readonly IReadOnlyList<Color> PresetGraphColors = new[]
         {
-            Color.FromArgb(230, 36, 107), // red-pink
+            Color.FromArgb(240, 100, 160), // red-pink
             Color.FromArgb(120, 180, 230), // light blue
             Color.FromArgb(36, 194, 33), // green
-            Color.FromArgb(142, 108, 193), // light violet
-            Color.FromArgb(221, 76, 60), // red
-            Color.FromArgb(60, 120, 220), // dark blue
+            Color.FromArgb(160, 120, 240), // light violet
+            Color.FromArgb(221, 50, 40), // red
             Color.FromArgb(26, 198, 166), // cyan-green
             Color.FromArgb(231, 176, 15) // orange
         };


### PR DESCRIPTION
## Proposed changes

- Increase contrast between graph colors for red-pink, light-violet, red
- Remove the dark-blue graph color which is too near to the selection color

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before / After

![grafik](https://user-images.githubusercontent.com/36601201/161402440-89ee6639-8154-46d3-bab2-7aee95879396.png)   ![grafik](https://user-images.githubusercontent.com/36601201/161402612-abdb0d32-b5dd-4434-b857-96a89211a58e.png)

![grafik](https://user-images.githubusercontent.com/36601201/161402528-27362b04-7f53-44e5-8f39-b6c0142a7905.png)   ![grafik](https://user-images.githubusercontent.com/36601201/161402670-86616d62-4d7c-4e86-8668-75473c4aec4b.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build c593255d9e15227fe7ddeba5e4a9fc246ad09efe
- Git 2.35.1.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 5.0.12
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).