### PR TITLE
CommitInfo: Clear RevisionInfo if no real revision

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -313,6 +313,10 @@ namespace GitUI.CommitInfo
             {
                 StartAsyncDataLoad(Module.EffectiveSettings);
             }
+            else
+            {
+                RevisionInfo.Clear();
+            }
 
             return;
 


### PR DESCRIPTION
## Proposed changes

- For artificial commits, clear the lower panel of the `CommitInfo`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/161403287-dd4935f4-1a45-4620-9141-792d13267a60.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/161403302-81df7ce4-6494-4422-9337-43918a0c4500.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build b841ac9fbb29918b75ffbf3c3826ca5bb2c5d502
- Git 2.35.1.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 5.0.12
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).