### PR TITLE
Adjust color for build in progress indication

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
@@ -22,6 +22,9 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         private readonly RevisionDataGridView _gridView;
         private readonly Func<GitModule> _module;
 
+        // Increase contrast to selected rows
+        private readonly Color _lightBlue = Color.FromArgb(130, 180, 240);
+
         public BuildStatusColumnProvider(RevisionGridControl grid, RevisionDataGridView gridView, Func<GitModule> module)
             : base("Build Status")
         {
@@ -128,7 +131,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                         customColor = isSelected ? Color.Red : Color.DarkRed;
                         break;
                     case BuildInfo.BuildStatus.InProgress:
-                        customColor = isSelected ? Color.LightBlue : Color.Blue;
+                        customColor = isSelected ? _lightBlue : Color.Blue;
                         break;
                     case BuildInfo.BuildStatus.Unstable:
                         customColor = Color.OrangeRed;
@@ -156,7 +159,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                         color = Color.Red;
                         break;
                     case BuildInfo.BuildStatus.InProgress:
-                        color = Color.DodgerBlue;
+                        color = _lightBlue;
                         break;
                     case BuildInfo.BuildStatus.Unstable:
                         color = Color.DarkOrange;


### PR DESCRIPTION
https://github.com/gitextensions/gitextensions/pull/9932#issuecomment-1086822200

## Proposed changes

Tune build-server-in-progress color
Slightly lighter blue than light-blue branch color.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/161449922-1ed28464-904d-44b3-8b4b-49de894a775a.png)

![image](https://user-images.githubusercontent.com/6248932/161449933-88e7d67e-4d37-4ad8-8cab-321e5d2d3fff.png)

### After

![image](https://user-images.githubusercontent.com/6248932/161449972-03c4f5f0-f93f-4257-8d99-b5d2b9b4af53.png)

![image](https://user-images.githubusercontent.com/6248932/161449992-f6639b23-0f02-4d7a-8420-066a17571da9.png)

## Test methodology <!-- How did you ensure quality? -->

Visual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
