### PR TITLE
Register codepage provider to support more encoding

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -47,6 +47,7 @@ namespace GitCommands
 
         static AppSettings()
         {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
             ApplicationDataPath = new Lazy<string?>(() =>
             {
                 if (IsPortable())

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Configuration;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Utils;
@@ -41,6 +42,8 @@ namespace GitExtensions
             // the call to GetInformation() from BugReporter.ShowNBug() will fail.
             // There's no perf hit calling Initialise() multiple times.
             UserEnvironmentInformation.Initialise(ThisAssembly.Git.Sha, ThisAssembly.Git.IsDirty);
+
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
             AppSettings.SetDocumentationBaseUrl(ThisAssembly.Git.Branch);
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -612,7 +612,6 @@ namespace GitUI.CommandsDialogs
             UpdateSubmodulesStructure();
 
             RefreshGitStatusMonitor();
-            revisionDiff.RefreshArtificial();
             UpdateStashCount();
         }
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1872,6 +1872,10 @@ the last selected commit.</source>
         <source>Filter files using a regular expression...</source>
         <target />
       </trans-unit>
+      <trans-unit id="LoadingFiles.Text">
+        <source>Loading data...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="NoFiles.Text">
         <source>No changes</source>
         <target />

--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -32,6 +32,7 @@
             this.FileStatusListView = new GitUI.UserControls.NativeListView();
             this.columnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.NoFiles = new System.Windows.Forms.Label();
+            this.LoadingFiles = new System.Windows.Forms.Label();
             this.FilterComboBox = new System.Windows.Forms.ComboBox();
             this.FilterWatermarkLabel = new System.Windows.Forms.Label();
             this.FilterToolTip = new System.Windows.Forms.ToolTip(this.components);
@@ -84,6 +85,17 @@
             this.NoFiles.Name = "NoFiles";
             this.NoFiles.Size = new System.Drawing.Size(65, 13);
             this.NoFiles.TabIndex = 5;
+            // 
+            // LoadingFiles
+            // 
+            this.LoadingFiles.AutoSize = true;
+            this.LoadingFiles.BackColor = System.Drawing.SystemColors.Window;
+            this.LoadingFiles.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.LoadingFiles.Location = new System.Drawing.Point(4, 21);
+            this.LoadingFiles.Margin = new System.Windows.Forms.Padding(0);
+            this.LoadingFiles.Name = "LoadingFiles";
+            this.LoadingFiles.Size = new System.Drawing.Size(65, 13);
+            this.LoadingFiles.TabIndex = 5;
             // 
             // FilterComboBox
             // 
@@ -149,6 +161,7 @@
             this.Controls.Add(this.DeleteFilterButton);
             this.Controls.Add(this.FilterWatermarkLabel);
             this.Controls.Add(this.NoFiles);
+            this.Controls.Add(this.LoadingFiles);
             this.Controls.Add(this.FileStatusListView);
             this.Controls.Add(this.lblSplitter);
             this.Controls.Add(this.FilterComboBox);
@@ -164,6 +177,7 @@
 
         private GitUI.UserControls.NativeListView FileStatusListView;
         private System.Windows.Forms.Label NoFiles;
+        private System.Windows.Forms.Label LoadingFiles;
         private System.Windows.Forms.ColumnHeader columnHeader;
         private System.Windows.Forms.ComboBox FilterComboBox;
         private System.Windows.Forms.Label FilterWatermarkLabel;

--- a/contributors.txt
+++ b/contributors.txt
@@ -173,3 +173,4 @@ YYYY/MM/DD, github id, Full name, email
 2021/12/06, Tyrrrz, Alexey Golub, tyrrrz(at)gmail.com
 2021/12/29, blazejszuca, Błażej Szuca, blazej.szuca+gitextensions(at)gmail.com
 2022/03/23, axunonb, Norbert Bietsch, nb[@)axuno.net
+2022/04/05, lanzhiquan, Zhiquan Lan, lanzhiquan@foxmail.com


### PR DESCRIPTION
Fixes #8717

## Proposed changes

Register codepage provider to support more encoding

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="453" alt="0" src="https://user-images.githubusercontent.com/11311878/161583213-c6c02b78-b81e-4810-98a4-e7f357567c0c.png">


### After

<img width="456" alt="1" src="https://user-images.githubusercontent.com/11311878/161583284-a48647f4-19dc-4464-815e-10e14cc4ab20.png">


## Test methodology <!-- How did you ensure quality? -->

- 
- 
- 

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are cl
<img width="453" alt="0" src="https://user-images.githubusercontent.com/11311878/161583095-8bf389c6-837d-4556-ac8c-ebcf41a6be2d.png">
arified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
