### PR TITLE
FormResolveConflicts: Clearer label and confirmation messages for Reset button

### DIFF
--- a/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
@@ -468,7 +468,7 @@ namespace GitUI.CommandsDialogs
             this.Reset.Name = "Reset";
             this.Reset.Size = new System.Drawing.Size(140, 25);
             this.Reset.TabIndex = 6;
-            this.Reset.Text = "Reset to &previous commit";
+            this.Reset.Text = "&Reset";
             this.Reset.UseVisualStyleBackColor = true;
             this.Reset.Click += new System.EventHandler(this.Reset_Click);
             // 

--- a/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
@@ -468,7 +468,7 @@ namespace GitUI.CommandsDialogs
             this.Reset.Name = "Reset";
             this.Reset.Size = new System.Drawing.Size(140, 25);
             this.Reset.TabIndex = 6;
-            this.Reset.Text = "Abort";
+            this.Reset.Text = "Reset to &previous commit";
             this.Reset.UseVisualStyleBackColor = true;
             this.Reset.Click += new System.EventHandler(this.Reset_Click);
             // 

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -93,7 +93,7 @@ namespace GitUI.CommandsDialogs
                 "All changes since the last commit will be deleted." + Environment.NewLine +
                 Environment.NewLine + "Do you want to reset the changes?");
 
-        private readonly TranslationString _resetCaption = new("Reset changes");
+        private readonly TranslationString _resetCaption = new("Reset");
 
         private readonly TranslationString _areYouSureYouWantDeleteFiles =
             new("Are you sure you want to DELETE all changes?" + Environment.NewLine +

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -71,11 +71,9 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _openMergeToolItemText = new("Open in");
         private readonly TranslationString _button1Text = new("Open in");
 
-        private readonly TranslationString _resetItemRebaseText = new("Abort rebase");
         private readonly TranslationString _contextChooseLocalRebaseText = new("Choose local (theirs)");
         private readonly TranslationString _contextChooseRemoteRebaseText = new("Choose remote (ours)");
 
-        private readonly TranslationString _resetItemMergeText = new("Abort merge");
         private readonly TranslationString _contextChooseLocalMergeText = new("Choose local (ours)");
         private readonly TranslationString _contextChooseRemoteMergeText = new("Choose remote (theirs)");
 
@@ -91,11 +89,11 @@ namespace GitUI.CommandsDialogs
             new("All files (*.*)");
 
         private readonly TranslationString _abortCurrentOperation =
-            new("You can abort the current operation by resetting changes." + Environment.NewLine +
+            new("You can abort the current conflict resolution by resetting hard." + Environment.NewLine +
                 "All changes since the last commit will be deleted." + Environment.NewLine +
-                Environment.NewLine + "Do you want to reset changes?");
+                Environment.NewLine + "Do you want to reset the changes?");
 
-        private readonly TranslationString _abortCurrentOperationCaption = new("Abort");
+        private readonly TranslationString _resetCaption = new("Reset changes");
 
         private readonly TranslationString _areYouSureYouWantDeleteFiles =
             new("Are you sure you want to DELETE all changes?" + Environment.NewLine +
@@ -254,13 +252,11 @@ namespace GitUI.CommandsDialogs
 
                 if (Module.InTheMiddleOfRebase())
                 {
-                    Reset.Text = _resetItemRebaseText.Text;
                     ContextChooseLocal.Text = _contextChooseLocalRebaseText.Text;
                     ContextChooseRemote.Text = _contextChooseRemoteRebaseText.Text;
                 }
                 else
                 {
-                    Reset.Text = _resetItemMergeText.Text;
                     ContextChooseLocal.Text = _contextChooseLocalMergeText.Text;
                     ContextChooseRemote.Text = _contextChooseRemoteMergeText.Text;
                 }
@@ -695,7 +691,7 @@ namespace GitUI.CommandsDialogs
 
         private bool ShowAbortMessage()
         {
-            if (MessageBox.Show(_abortCurrentOperation.Text, _abortCurrentOperationCaption.Text,
+            if (MessageBox.Show(_abortCurrentOperation.Text, _resetCaption.Text,
                 MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
             {
                 if (AppSettings.DontConfirmSecondAbortConfirmation ||

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7074,7 +7074,7 @@ Forcing a branch to reset if it has not been merged might leave some commits unr
         <target />
       </trans-unit>
       <trans-unit id="Reset.Text">
-        <source>Reset to &amp;previous commit</source>
+        <source>&amp;Reset</source>
         <target />
       </trans-unit>
       <trans-unit id="_abortCurrentOperation.Text">
@@ -7311,7 +7311,7 @@ Please go to settings and configure the mergetool!</source>
         <target />
       </trans-unit>
       <trans-unit id="_resetCaption.Text">
-        <source>Reset changes</source>
+        <source>Reset</source>
         <target />
       </trans-unit>
       <trans-unit id="_solveMergeConflictApplyToAllCheckBoxText.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7074,18 +7074,14 @@ Forcing a branch to reset if it has not been merged might leave some commits unr
         <target />
       </trans-unit>
       <trans-unit id="Reset.Text">
-        <source>Abort</source>
+        <source>Reset to &amp;previous commit</source>
         <target />
       </trans-unit>
       <trans-unit id="_abortCurrentOperation.Text">
-        <source>You can abort the current operation by resetting changes.
+        <source>You can abort the current conflict resolution by resetting hard.
 All changes since the last commit will be deleted.
 
-Do you want to reset changes?</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_abortCurrentOperationCaption.Text">
-        <source>Abort</source>
+Do you want to reset the changes?</source>
         <target />
       </trans-unit>
       <trans-unit id="_allConflictsResolved.Text">
@@ -7314,12 +7310,8 @@ Please go to settings and configure the mergetool!</source>
         <source>ours</source>
         <target />
       </trans-unit>
-      <trans-unit id="_resetItemMergeText.Text">
-        <source>Abort merge</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_resetItemRebaseText.Text">
-        <source>Abort rebase</source>
+      <trans-unit id="_resetCaption.Text">
+        <source>Reset changes</source>
         <target />
       </trans-unit>
       <trans-unit id="_solveMergeConflictApplyToAllCheckBoxText.Text">


### PR DESCRIPTION
Replaces #9907, which would be too intrusive and does not work for cherry-picks

## Proposed changes

- FormResolveConflicts: Just clearer label and confirmation messages for `Reset` button
  (The command `git reset --hard` will still be used.)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/36601201/159139764-fa6879b4-6c69-4005-9a50-fd06399e1939.png)

### After

![image](https://user-images.githubusercontent.com/36601201/170123528-0798cc5f-4126-4480-8ff6-fd425b3e8ec8.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build ec324afbbc5dec66a66e58937f98cf2e2130af69
- Git 2.35.1.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.3
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).