### PR TITLE
CommitInfo: Workaround for `Show all tags`

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -107,12 +107,12 @@ namespace GitExtensions
             }
 
             ManagedExtensibility.Initialise(new[]
-            {
-                typeof(GitUI.GitExtensionsForm).Assembly,
-                typeof(GitCommands.GitModule).Assembly,
-                typeof(ResourceManager.GitPluginBase).Assembly
-            },
-            AppSettings.UserPluginsPath);
+                {
+                    typeof(GitUI.GitExtensionsForm).Assembly,
+                    typeof(GitCommands.GitModule).Assembly,
+                    typeof(ResourceManager.GitPluginBase).Assembly
+                },
+                AppSettings.UserPluginsPath);
 
             AppSettings.LoadSettings();
 

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -107,11 +107,12 @@ namespace GitExtensions
             }
 
             ManagedExtensibility.Initialise(new[]
-                {
-                    typeof(GitUI.GitExtensionsForm).Assembly,
-                    typeof(GitCommands.GitModule).Assembly
-                },
-                AppSettings.UserPluginsPath);
+            {
+                typeof(GitUI.GitExtensionsForm).Assembly,
+                typeof(GitCommands.GitModule).Assembly,
+                typeof(ResourceManager.GitPluginBase).Assembly
+            },
+            AppSettings.UserPluginsPath);
 
             AppSettings.LoadSettings();
 

--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -91,7 +91,7 @@ namespace GitUI.CommitInfo
             this.rtbxCommitMessage.Size = new System.Drawing.Size(440, 20);
             this.rtbxCommitMessage.TabIndex = 1;
             this.rtbxCommitMessage.Text = "";
-            this.rtbxCommitMessage.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfoLinkClicked);
+            this.rtbxCommitMessage.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfo_LinkClicked);
             this.rtbxCommitMessage.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextBox_KeyDown);
             this.rtbxCommitMessage.MouseDown += new System.Windows.Forms.MouseEventHandler(this._RevisionHeader_MouseDown);
             // 
@@ -213,7 +213,7 @@ namespace GitUI.CommitInfo
             this.RevisionInfo.Size = new System.Drawing.Size(448, 98);
             this.RevisionInfo.TabIndex = 2;
             this.RevisionInfo.Text = "";
-            this.RevisionInfo.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfoLinkClicked);
+            this.RevisionInfo.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfo_LinkClicked);
             this.RevisionInfo.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextBox_KeyDown);
             this.RevisionInfo.MouseDown += new System.Windows.Forms.MouseEventHandler(this._RevisionHeader_MouseDown);
             // 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -217,7 +217,6 @@ namespace GitUI.CommitInfo
 
         private void ShowAll(string? what)
         {
-            // ignore argument 'what' because links cannot be distinguished if having same label (since .NET core)
             switch (what)
             {
                 case "branches":

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -55,7 +55,7 @@ namespace GitUI.CommitInfo
         private static readonly TranslationString _plusCommits = new("commits");
         private static readonly TranslationString _repoFailure = new("Repository failure");
 
-        private readonly ILinkFactory _linkFactory = new LinkFactory();
+        private readonly ILinkFactory _linkFactory;
         private readonly ICommitDataManager _commitDataManager;
         private readonly ICommitDataBodyRenderer _commitDataBodyRenderer;
         private readonly IExternalLinksStorage _externalLinksStorage;
@@ -106,6 +106,8 @@ namespace GitUI.CommitInfo
             };
 
             _commitDataManager = new CommitDataManager(() => Module);
+
+            _linkFactory = ManagedExtensibility.GetExport<ILinkFactory>().Value;
 
             _commitDataBodyRenderer = new CommitDataBodyRenderer(() => Module, _linkFactory);
             _externalLinksStorage = new ExternalLinksStorage();
@@ -184,7 +186,7 @@ namespace GitUI.CommitInfo
             set => SetRevisionWithChildren(value, null);
         }
 
-        private void RevisionInfoLinkClicked(object sender, LinkClickedEventArgs e)
+        private void RevisionInfo_LinkClicked(object sender, LinkClickedEventArgs e)
         {
             try
             {
@@ -884,7 +886,11 @@ namespace GitUI.CommitInfo
                 _commitInfo = commitInfo;
             }
 
+            public RichTextBox RevisionInfo => _commitInfo.RevisionInfo;
+
             public IDictionary<string, int> GetSortedTags() => _commitInfo.GetSortedTags();
+
+            public void RevisionInfo_LinkClicked(object sender, LinkClickedEventArgs e) => _commitInfo.RevisionInfo_LinkClicked(sender, e);
         }
     }
 }

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -188,7 +188,8 @@ namespace GitUI.CommitInfo
         {
             try
             {
-                _linkFactory.ExecuteLink(e.LinkText, commandEventArgs => CommandClickedEvent?.Invoke(sender, commandEventArgs), ShowAll);
+                string? linkUri = RevisionInfo.GetLink(e.LinkStart);
+                _linkFactory.ExecuteLink(linkUri, commandEventArgs => CommandClickedEvent?.Invoke(sender, commandEventArgs), ShowAll);
             }
             catch (Exception ex)
             {
@@ -218,9 +219,10 @@ namespace GitUI.CommitInfo
             switch (what)
             {
                 case "branches":
-                case "tags":
                     _showAllBranches = true;
                     _branchInfo = null; // forces update
+                    break;
+                case "tags":
                     _showAllTags = true;
                     _tagInfo = null; // forces update
                     break;

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -301,7 +301,6 @@ namespace GitUI.CommitInfo
             _branches = null;
             _tags = null;
             _annotatedTagsMessages = null;
-            _linkFactory.Clear();
 
             UpdateCommitMessage();
 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -214,13 +214,13 @@ namespace GitUI.CommitInfo
 
         private void ShowAll(string? what)
         {
+            // ignore argument 'what' because links cannot be distinguished if having same label (since .NET core)
             switch (what)
             {
                 case "branches":
+                case "tags":
                     _showAllBranches = true;
                     _branchInfo = null; // forces update
-                    break;
-                case "tags":
                     _showAllTags = true;
                     _tagInfo = null; // forces update
                     break;

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -121,7 +121,8 @@ namespace GitUI.CommitInfo
         {
             try
             {
-                _linkFactory.ExecuteLink(e.LinkText, commandEventArgs => CommandClicked?.Invoke(sender, commandEventArgs));
+                string? linkUri = rtbRevisionHeader.GetLink(e.LinkStart);
+                _linkFactory.ExecuteLink(linkUri, commandEventArgs => CommandClicked?.Invoke(sender, commandEventArgs));
             }
             catch (Exception ex)
             {

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -1539,7 +1539,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                             {
                                 string head = rtfText.Substring(0, idx);
                                 string tail = rtfText.Substring(idx);
-                                RtbSetSelectedRtf(rtb, head + @"\v " + LinkSeparator + cs.hyperlink + @"\v0" + tail);
+                                RtbSetSelectedRtf(rtb, $@"{head}\v {LinkSeparator}{cs.hyperlink}\v0{tail}");
                                 length = rtb.TextLength - cs.hyperlinkStart;
                             }
                         }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.Remotes.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.Remotes.cs
@@ -68,6 +68,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             _remotesManager = new ConfigFileRemoteSettingsManager(() => _referenceRepository.Module);
 
             var composition = TestComposition.Empty
+                .AddParts(typeof(MockLinkFactory))
                 .AddParts(typeof(MockWindowsJumpListManager))
                 .AddParts(typeof(MockRepositoryDescriptionProvider))
                 .AddParts(typeof(MockAppTitleGenerator));

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.ReorderNodes.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.ReorderNodes.cs
@@ -76,6 +76,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             _commands = new GitUICommands(_repo1.Module);
 
             var composition = TestComposition.Empty
+                .AddParts(typeof(MockLinkFactory))
                 .AddParts(typeof(MockWindowsJumpListManager))
                 .AddParts(typeof(MockRepositoryDescriptionProvider))
                 .AddParts(typeof(MockAppTitleGenerator));

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.Submodules.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.Submodules.cs
@@ -82,6 +82,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             _commands = new GitUICommands(_repo1Module);
 
             var composition = TestComposition.Empty
+                .AddParts(typeof(MockLinkFactory))
                 .AddParts(typeof(MockWindowsJumpListManager))
                 .AddParts(typeof(MockRepositoryDescriptionProvider))
                 .AddParts(typeof(MockAppTitleGenerator));

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.cs
@@ -81,6 +81,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             _referenceRepository.CreateCommit("head commit");
 
             var composition = TestComposition.Empty
+                .AddParts(typeof(MockLinkFactory))
                 .AddParts(typeof(MockWindowsJumpListManager))
                 .AddParts(typeof(MockRepositoryDescriptionProvider))
                 .AddParts(typeof(MockAppTitleGenerator));

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -62,6 +62,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             _commands = new GitUICommands(_referenceRepository.Module);
 
             var composition = TestComposition.Empty
+                .AddParts(typeof(MockLinkFactory))
                 .AddParts(typeof(MockWindowsJumpListManager))
                 .AddParts(typeof(MockRepositoryDescriptionProvider))
                 .AddParts(typeof(MockAppTitleGenerator));

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/Mocks/MockAppTitleGenerator.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/Mocks/MockAppTitleGenerator.cs
@@ -1,6 +1,5 @@
 ﻿using System.Composition;
 using GitCommands;
-using GitCommands.UserRepositoryHistory;
 using Microsoft.VisualStudio.Composition;
 
 namespace GitExtensions.UITests.CommandsDialogs

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/Mocks/MockLinkFactory.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/Mocks/MockLinkFactory.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Composition;
+using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Composition;
+using ResourceManager;
+
+namespace GitExtensions.UITests.CommandsDialogs
+{
+    [Shared, PartNotDiscoverable]
+    [Export(typeof(ILinkFactory))]
+    internal class MockLinkFactory : ILinkFactory
+    {
+        private readonly ILinkFactory _linkFactory = new LinkFactory();
+
+        public string? LastExecutedLinkUri { get; private set; }
+
+        public string CreateBranchLink(string noPrefixBranch)
+            => _linkFactory.CreateBranchLink(noPrefixBranch);
+
+        public string CreateCommitLink(ObjectId objectId, string? linkText = null, bool preserveGuidInLinkText = false)
+            => _linkFactory.CreateCommitLink(objectId, linkText, preserveGuidInLinkText);
+
+        public string CreateLink(string? caption, string uri)
+            => _linkFactory.CreateLink(caption, uri);
+
+        public string CreateShowAllLink(string what)
+            => _linkFactory.CreateShowAllLink(what);
+
+        public string CreateTagLink(string tag)
+            => _linkFactory.CreateTagLink(tag);
+
+        public void ExecuteLink(string? linkUri, Action<CommandEventArgs>? handleInternalLink = null, Action<string?>? showAll = null)
+        {
+            LastExecutedLinkUri = linkUri;
+
+            _linkFactory.ExecuteLink(linkUri, handleInternalLink, showAll);
+        }
+    }
+}

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SplitterPersistenceTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SplitterPersistenceTests.cs
@@ -35,6 +35,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             AppSettings.ShowAuthorAvatarColumn = false;
 
             _composition = TestComposition.Empty
+                .AddParts(typeof(MockLinkFactory))
                 .AddParts(typeof(MockWindowsJumpListManager))
                 .AddParts(typeof(MockRepositoryDescriptionProvider))
                 .AddParts(typeof(MockAppTitleGenerator));

--- a/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
@@ -4,12 +4,15 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using CommonTestUtils;
+using CommonTestUtils.MEF;
 using FluentAssertions;
 using GitCommands;
 using GitExtensions.UITests;
+using GitExtensions.UITests.CommandsDialogs;
 using GitUI;
 using GitUI.CommandsDialogs;
 using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Composition;
 using NUnit.Framework;
 
 namespace GitUITests.GitUICommandsTests
@@ -44,6 +47,14 @@ namespace GitUITests.GitUICommandsTests
             }
 
             _commands = new GitUICommands(_referenceRepository.Module);
+
+            var composition = TestComposition.Empty
+                .AddParts(typeof(MockLinkFactory))
+                .AddParts(typeof(MockWindowsJumpListManager))
+                .AddParts(typeof(MockRepositoryDescriptionProvider))
+                .AddParts(typeof(MockAppTitleGenerator));
+            ExportProvider mefExportProvider = composition.ExportProviderFactory.CreateExportProvider();
+            ManagedExtensibility.SetTestExportProvider(mefExportProvider);
         }
 
         [OneTimeSetUp]

--- a/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_handle_ShowAll_branches_correctly.approved.txt
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_handle_ShowAll_branches_correctly.approved.txt
@@ -1,36 +1,31 @@
-﻿{\rtf1\ansi\ansicpg1251\deff0\nouicompat\deflang1049{\fonttbl{\f0\fnil\fcharset204 Segoe UI;}}
-{\colortbl ;\red0\green0\blue255;}
-{\*\generator Riched20 10.0.22000}\viewkind4\uc1 
-\pard\f0\fs18 Contained in branches:\par
+﻿Contained in branches:
+branch01|||gitext://gotobranch/branch01
+branch02|||gitext://gotobranch/branch02
+branch03|||gitext://gotobranch/branch03
+branch04|||gitext://gotobranch/branch04
+branch05|||gitext://gotobranch/branch05
+branch06|||gitext://gotobranch/branch06
+branch07|||gitext://gotobranch/branch07
+branch08|||gitext://gotobranch/branch08
+branch09|||gitext://gotobranch/branch09
+branch10|||gitext://gotobranch/branch10
+branch11|||gitext://gotobranch/branch11
+branch12|||gitext://gotobranch/branch12
+branch13|||gitext://gotobranch/branch13
+branch14|||gitext://gotobranch/branch14
+branch15|||gitext://gotobranch/branch15
+Contained in tags:
+v1.0|||gitext://gototag/v1.0
+v1.1|||gitext://gototag/v1.1
+v1.2|||gitext://gototag/v1.2
+v1.3|||gitext://gototag/v1.3
+v1.4|||gitext://gototag/v1.4
+v1.5|||gitext://gototag/v1.5
+v1.6|||gitext://gototag/v1.6
+v1.7|||gitext://gototag/v1.7
+v1.8|||gitext://gototag/v1.8
+v1.9|||gitext://gototag/v1.9
+[ Show all ]|||gitext://showall/tags
 
-\pard branch01\v |||gitext://gotobranch/branch01\v0\par
-branch02\v |||gitext://gotobranch/branch02\v0\par
-branch03\v |||gitext://gotobranch/branch03\v0\par
-branch04\v |||gitext://gotobranch/branch04\v0\par
-branch05\v |||gitext://gotobranch/branch05\v0\par
-branch06\v |||gitext://gotobranch/branch06\v0\par
-branch07\v |||gitext://gotobranch/branch07\v0\par
-branch08\v |||gitext://gotobranch/branch08\v0\par
-branch09\v |||gitext://gotobranch/branch09\v0\par
-branch10\v |||gitext://gotobranch/branch10\v0\par
-branch11\v |||gitext://gotobranch/branch11\v0\par
-branch12\v |||gitext://gotobranch/branch12\v0\par
-branch13\v |||gitext://gotobranch/branch13\v0\par
-branch14\v |||gitext://gotobranch/branch14\v0\par
-branch15\v |||gitext://gotobranch/branch15\v0\par
-Contained in tags:\par
-v1.0\v |||gitext://gototag/v1.0\v0\par
-v1.1\v |||gitext://gototag/v1.1\v0\par
-v1.2\v |||gitext://gototag/v1.2\v0\par
-v1.3\v |||gitext://gototag/v1.3\v0\par
-v1.4\v |||gitext://gototag/v1.4\v0\par
-v1.5\v |||gitext://gototag/v1.5\v0\par
-v1.6\v |||gitext://gototag/v1.6\v0\par
-v1.7\v |||gitext://gototag/v1.7\v0\par
-v1.8\v |||gitext://gototag/v1.8\v0\par
-v1.9\v |||gitext://gototag/v1.9\v0\par
-[ Show all ]\v |||gitext://showall/tags\v0\par
-\par
-\par
-Derives from no tag\par
-}
+
+Derives from no tag

--- a/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_handle_ShowAll_branches_correctly.approved.txt
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_handle_ShowAll_branches_correctly.approved.txt
@@ -1,0 +1,36 @@
+﻿{\rtf1\ansi\ansicpg1251\deff0\nouicompat\deflang1049{\fonttbl{\f0\fnil\fcharset204 Segoe UI;}}
+{\colortbl ;\red0\green0\blue255;}
+{\*\generator Riched20 10.0.22000}\viewkind4\uc1 
+\pard\f0\fs18 Contained in branches:\par
+
+\pard branch01\v |||gitext://gotobranch/branch01\v0\par
+branch02\v |||gitext://gotobranch/branch02\v0\par
+branch03\v |||gitext://gotobranch/branch03\v0\par
+branch04\v |||gitext://gotobranch/branch04\v0\par
+branch05\v |||gitext://gotobranch/branch05\v0\par
+branch06\v |||gitext://gotobranch/branch06\v0\par
+branch07\v |||gitext://gotobranch/branch07\v0\par
+branch08\v |||gitext://gotobranch/branch08\v0\par
+branch09\v |||gitext://gotobranch/branch09\v0\par
+branch10\v |||gitext://gotobranch/branch10\v0\par
+branch11\v |||gitext://gotobranch/branch11\v0\par
+branch12\v |||gitext://gotobranch/branch12\v0\par
+branch13\v |||gitext://gotobranch/branch13\v0\par
+branch14\v |||gitext://gotobranch/branch14\v0\par
+branch15\v |||gitext://gotobranch/branch15\v0\par
+Contained in tags:\par
+v1.0\v |||gitext://gototag/v1.0\v0\par
+v1.1\v |||gitext://gototag/v1.1\v0\par
+v1.2\v |||gitext://gototag/v1.2\v0\par
+v1.3\v |||gitext://gototag/v1.3\v0\par
+v1.4\v |||gitext://gototag/v1.4\v0\par
+v1.5\v |||gitext://gototag/v1.5\v0\par
+v1.6\v |||gitext://gototag/v1.6\v0\par
+v1.7\v |||gitext://gototag/v1.7\v0\par
+v1.8\v |||gitext://gototag/v1.8\v0\par
+v1.9\v |||gitext://gototag/v1.9\v0\par
+[ Show all ]\v |||gitext://showall/tags\v0\par
+\par
+\par
+Derives from no tag\par
+}

--- a/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_handle_ShowAll_tags_correctly.approved.txt
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_handle_ShowAll_tags_correctly.approved.txt
@@ -1,0 +1,36 @@
+﻿{\rtf1\ansi\ansicpg1251\deff0\nouicompat\deflang1049{\fonttbl{\f0\fnil\fcharset204 Segoe UI;}}
+{\colortbl ;\red0\green0\blue255;}
+{\*\generator Riched20 10.0.22000}\viewkind4\uc1 
+\pard\f0\fs18 Contained in branches:\par
+
+\pard branch01\v |||gitext://gotobranch/branch01\v0\par
+branch02\v |||gitext://gotobranch/branch02\v0\par
+branch03\v |||gitext://gotobranch/branch03\v0\par
+branch04\v |||gitext://gotobranch/branch04\v0\par
+branch05\v |||gitext://gotobranch/branch05\v0\par
+branch06\v |||gitext://gotobranch/branch06\v0\par
+branch07\v |||gitext://gotobranch/branch07\v0\par
+branch08\v |||gitext://gotobranch/branch08\v0\par
+branch09\v |||gitext://gotobranch/branch09\v0\par
+branch10\v |||gitext://gotobranch/branch10\v0\par
+[ Show all ]\v |||gitext://showall/branches\v0\par
+\par
+Contained in tags:\par
+v1.0\v |||gitext://gototag/v1.0\v0\par
+v1.1\v |||gitext://gototag/v1.1\v0\par
+v1.2\v |||gitext://gototag/v1.2\v0\par
+v1.3\v |||gitext://gototag/v1.3\v0\par
+v1.4\v |||gitext://gototag/v1.4\v0\par
+v1.5\v |||gitext://gototag/v1.5\v0\par
+v1.6\v |||gitext://gototag/v1.6\v0\par
+v1.7\v |||gitext://gototag/v1.7\v0\par
+v1.8\v |||gitext://gototag/v1.8\v0\par
+v1.9\v |||gitext://gototag/v1.9\v0\par
+v1.10\v |||gitext://gototag/v1.10\v0\par
+v1.11\v |||gitext://gototag/v1.11\v0\par
+v1.12\v |||gitext://gototag/v1.12\v0\par
+v1.13\v |||gitext://gototag/v1.13\v0\par
+v1.14\v |||gitext://gototag/v1.14\v0\par
+\par
+Derives from no tag\par
+}

--- a/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_handle_ShowAll_tags_correctly.approved.txt
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_handle_ShowAll_tags_correctly.approved.txt
@@ -1,36 +1,31 @@
-﻿{\rtf1\ansi\ansicpg1251\deff0\nouicompat\deflang1049{\fonttbl{\f0\fnil\fcharset204 Segoe UI;}}
-{\colortbl ;\red0\green0\blue255;}
-{\*\generator Riched20 10.0.22000}\viewkind4\uc1 
-\pard\f0\fs18 Contained in branches:\par
+﻿Contained in branches:
+branch01|||gitext://gotobranch/branch01
+branch02|||gitext://gotobranch/branch02
+branch03|||gitext://gotobranch/branch03
+branch04|||gitext://gotobranch/branch04
+branch05|||gitext://gotobranch/branch05
+branch06|||gitext://gotobranch/branch06
+branch07|||gitext://gotobranch/branch07
+branch08|||gitext://gotobranch/branch08
+branch09|||gitext://gotobranch/branch09
+branch10|||gitext://gotobranch/branch10
+[ Show all ]|||gitext://showall/branches
 
-\pard branch01\v |||gitext://gotobranch/branch01\v0\par
-branch02\v |||gitext://gotobranch/branch02\v0\par
-branch03\v |||gitext://gotobranch/branch03\v0\par
-branch04\v |||gitext://gotobranch/branch04\v0\par
-branch05\v |||gitext://gotobranch/branch05\v0\par
-branch06\v |||gitext://gotobranch/branch06\v0\par
-branch07\v |||gitext://gotobranch/branch07\v0\par
-branch08\v |||gitext://gotobranch/branch08\v0\par
-branch09\v |||gitext://gotobranch/branch09\v0\par
-branch10\v |||gitext://gotobranch/branch10\v0\par
-[ Show all ]\v |||gitext://showall/branches\v0\par
-\par
-Contained in tags:\par
-v1.0\v |||gitext://gototag/v1.0\v0\par
-v1.1\v |||gitext://gototag/v1.1\v0\par
-v1.2\v |||gitext://gototag/v1.2\v0\par
-v1.3\v |||gitext://gototag/v1.3\v0\par
-v1.4\v |||gitext://gototag/v1.4\v0\par
-v1.5\v |||gitext://gototag/v1.5\v0\par
-v1.6\v |||gitext://gototag/v1.6\v0\par
-v1.7\v |||gitext://gototag/v1.7\v0\par
-v1.8\v |||gitext://gototag/v1.8\v0\par
-v1.9\v |||gitext://gototag/v1.9\v0\par
-v1.10\v |||gitext://gototag/v1.10\v0\par
-v1.11\v |||gitext://gototag/v1.11\v0\par
-v1.12\v |||gitext://gototag/v1.12\v0\par
-v1.13\v |||gitext://gototag/v1.13\v0\par
-v1.14\v |||gitext://gototag/v1.14\v0\par
-\par
-Derives from no tag\par
-}
+Contained in tags:
+v1.0|||gitext://gototag/v1.0
+v1.1|||gitext://gototag/v1.1
+v1.2|||gitext://gototag/v1.2
+v1.3|||gitext://gototag/v1.3
+v1.4|||gitext://gototag/v1.4
+v1.5|||gitext://gototag/v1.5
+v1.6|||gitext://gototag/v1.6
+v1.7|||gitext://gototag/v1.7
+v1.8|||gitext://gototag/v1.8
+v1.9|||gitext://gototag/v1.9
+v1.10|||gitext://gototag/v1.10
+v1.11|||gitext://gototag/v1.11
+v1.12|||gitext://gototag/v1.12
+v1.13|||gitext://gototag/v1.13
+v1.14|||gitext://gototag/v1.14
+
+Derives from no tag

--- a/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_render_links_correctly.approved.txt
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_render_links_correctly.approved.txt
@@ -1,0 +1,33 @@
+﻿{\rtf1\ansi\ansicpg1251\deff0\nouicompat\deflang1049{\fonttbl{\f0\fnil\fcharset204 Segoe UI;}}
+{\colortbl ;\red0\green0\blue255;}
+{\*\generator Riched20 10.0.22000}\viewkind4\uc1 
+\pard\f0\fs18 Contained in branches:\par
+
+\pard branch01\v |||gitext://gotobranch/branch01\v0\par
+branch02\v |||gitext://gotobranch/branch02\v0\par
+branch03\v |||gitext://gotobranch/branch03\v0\par
+branch04\v |||gitext://gotobranch/branch04\v0\par
+branch05\v |||gitext://gotobranch/branch05\v0\par
+branch06\v |||gitext://gotobranch/branch06\v0\par
+branch07\v |||gitext://gotobranch/branch07\v0\par
+branch08\v |||gitext://gotobranch/branch08\v0\par
+branch09\v |||gitext://gotobranch/branch09\v0\par
+branch10\v |||gitext://gotobranch/branch10\v0\par
+[ Show all ]\v |||gitext://showall/branches\v0\par
+\par
+Contained in tags:\par
+v1.0\v |||gitext://gototag/v1.0\v0\par
+v1.1\v |||gitext://gototag/v1.1\v0\par
+v1.2\v |||gitext://gototag/v1.2\v0\par
+v1.3\v |||gitext://gototag/v1.3\v0\par
+v1.4\v |||gitext://gototag/v1.4\v0\par
+v1.5\v |||gitext://gototag/v1.5\v0\par
+v1.6\v |||gitext://gototag/v1.6\v0\par
+v1.7\v |||gitext://gototag/v1.7\v0\par
+v1.8\v |||gitext://gototag/v1.8\v0\par
+v1.9\v |||gitext://gototag/v1.9\v0\par
+[ Show all ]\v |||gitext://showall/tags\v0\par
+\par
+\par
+Derives from no tag\par
+}

--- a/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_render_links_correctly.approved.txt
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_render_links_correctly.approved.txt
@@ -1,33 +1,28 @@
-﻿{\rtf1\ansi\ansicpg1251\deff0\nouicompat\deflang1049{\fonttbl{\f0\fnil\fcharset204 Segoe UI;}}
-{\colortbl ;\red0\green0\blue255;}
-{\*\generator Riched20 10.0.22000}\viewkind4\uc1 
-\pard\f0\fs18 Contained in branches:\par
+﻿Contained in branches:
+branch01|||gitext://gotobranch/branch01
+branch02|||gitext://gotobranch/branch02
+branch03|||gitext://gotobranch/branch03
+branch04|||gitext://gotobranch/branch04
+branch05|||gitext://gotobranch/branch05
+branch06|||gitext://gotobranch/branch06
+branch07|||gitext://gotobranch/branch07
+branch08|||gitext://gotobranch/branch08
+branch09|||gitext://gotobranch/branch09
+branch10|||gitext://gotobranch/branch10
+[ Show all ]|||gitext://showall/branches
 
-\pard branch01\v |||gitext://gotobranch/branch01\v0\par
-branch02\v |||gitext://gotobranch/branch02\v0\par
-branch03\v |||gitext://gotobranch/branch03\v0\par
-branch04\v |||gitext://gotobranch/branch04\v0\par
-branch05\v |||gitext://gotobranch/branch05\v0\par
-branch06\v |||gitext://gotobranch/branch06\v0\par
-branch07\v |||gitext://gotobranch/branch07\v0\par
-branch08\v |||gitext://gotobranch/branch08\v0\par
-branch09\v |||gitext://gotobranch/branch09\v0\par
-branch10\v |||gitext://gotobranch/branch10\v0\par
-[ Show all ]\v |||gitext://showall/branches\v0\par
-\par
-Contained in tags:\par
-v1.0\v |||gitext://gototag/v1.0\v0\par
-v1.1\v |||gitext://gototag/v1.1\v0\par
-v1.2\v |||gitext://gototag/v1.2\v0\par
-v1.3\v |||gitext://gototag/v1.3\v0\par
-v1.4\v |||gitext://gototag/v1.4\v0\par
-v1.5\v |||gitext://gototag/v1.5\v0\par
-v1.6\v |||gitext://gototag/v1.6\v0\par
-v1.7\v |||gitext://gototag/v1.7\v0\par
-v1.8\v |||gitext://gototag/v1.8\v0\par
-v1.9\v |||gitext://gototag/v1.9\v0\par
-[ Show all ]\v |||gitext://showall/tags\v0\par
-\par
-\par
-Derives from no tag\par
-}
+Contained in tags:
+v1.0|||gitext://gototag/v1.0
+v1.1|||gitext://gototag/v1.1
+v1.2|||gitext://gototag/v1.2
+v1.3|||gitext://gototag/v1.3
+v1.4|||gitext://gototag/v1.4
+v1.5|||gitext://gototag/v1.5
+v1.6|||gitext://gototag/v1.6
+v1.7|||gitext://gototag/v1.7
+v1.8|||gitext://gototag/v1.8
+v1.9|||gitext://gototag/v1.9
+[ Show all ]|||gitext://showall/tags
+
+
+Derives from no tag

--- a/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.cs
@@ -201,7 +201,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
                 // Wait for pending operations so the Control is loaded completely before testing it
                 await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
 
-                Approvals.Verify(commitInfo.GetTestAccessor().RevisionInfo.Rtf);
+                Approvals.Verify(commitInfo.GetTestAccessor().RevisionInfo.Text);
             });
         }
 
@@ -289,7 +289,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
                 commitInfo.GetTestAccessor().RevisionInfo_LinkClicked(commitInfo, new("not important", linkStart: 423, linkLength: 0));
                 mockLinkFactory.LastExecutedLinkUri.Should().Be("gitext://showall/branches");
 
-                Approvals.Verify(commitInfo.GetTestAccessor().RevisionInfo.Rtf);
+                Approvals.Verify(commitInfo.GetTestAccessor().RevisionInfo.Text);
             });
         }
 
@@ -333,7 +333,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
                 commitInfo.GetTestAccessor().RevisionInfo_LinkClicked(commitInfo, new("not important", linkStart: 774, linkLength: 0));
                 mockLinkFactory.LastExecutedLinkUri.Should().Be("gitext://showall/tags");
 
-                Approvals.Verify(commitInfo.GetTestAccessor().RevisionInfo.Rtf);
+                Approvals.Verify(commitInfo.GetTestAccessor().RevisionInfo.Text);
             });
         }
 

--- a/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.cs
@@ -1,14 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using ApprovalTests;
 using CommonTestUtils;
+using CommonTestUtils.MEF;
 using FluentAssertions;
 using GitCommands;
 using GitCommands.Git;
+using GitExtensions.UITests.CommandsDialogs;
 using GitUI;
+using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Composition;
 using NSubstitute;
 using NUnit.Framework;
+using ResourceManager;
 
 namespace GitExtensions.UITests.UserControls.CommitInfo
 {
@@ -35,6 +44,11 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
             GitCommandRunner cmdRunner = new(_gitExecutable, () => GitModule.SystemEncoding);
             typeof(GitModule).GetField("_gitCommandRunner", BindingFlags.Instance | BindingFlags.NonPublic)
                 .SetValue(_commands.Module, cmdRunner);
+
+            var composition = TestComposition.Empty
+                .AddParts(typeof(MockLinkFactory));
+            ExportProvider mefExportProvider = composition.ExportProviderFactory.CreateExportProvider();
+            ManagedExtensibility.SetTestExportProvider(mefExportProvider);
         }
 
         [OneTimeTearDown]
@@ -52,6 +66,8 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
                     "refs/heads/master\nwarning: message");
 
                 ((Action)(() => commitInfo.GetTestAccessor().GetSortedTags())).Should().Throw<RefsWarningException>();
+
+                return Task.CompletedTask;
             });
         }
 
@@ -74,6 +90,8 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
 
                 refs.Count.Should().Be(3);
                 refs.Should().BeEquivalentTo(expected);
+
+                return Task.CompletedTask;
             });
         }
 
@@ -97,6 +115,8 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
 
                 refs.Count.Should().Be(4);
                 refs.Should().BeEquivalentTo(expected);
+
+                return Task.CompletedTask;
             });
         }
 
@@ -121,6 +141,8 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
 
                 refs.Count.Should().Be(5);
                 refs.Should().BeEquivalentTo(expected);
+
+                return Task.CompletedTask;
             });
         }
 
@@ -144,10 +166,178 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
 
                 refs.Count.Should().Be(4);
                 refs.Should().BeEquivalentTo(expected);
+
+                return Task.CompletedTask;
             });
         }
 
-        private void RunCommitInfoTest(Action<GitUI.CommitInfo.CommitInfo> runTest)
+        [Test]
+        public void ReloadCommitInfo_should_render_links_correctly()
+        {
+            string hash = "a48da1aba59a65b2a7f0df7e3512817caf16819f";
+
+            // Generate branches: branch01...branch15
+            _gitExecutable.StageOutput($"branch --contains {hash}", string.Join('\n', Enumerable.Range(1, 15).Select(i => $"branch{i:00}")));
+
+            // Generate tags: v1.0...v1.15
+            _gitExecutable.StageOutput($"tag --contains {hash}", string.Join('\n', Enumerable.Range(0, 15).Select(i => $"v1.{i}")));
+
+            _gitExecutable.StageOutput($"describe --tags --first-parent --abbrev=40 {hash}", "");
+
+            var realCommitObjectId = ObjectId.Parse(hash);
+            GitRevision revision = new(realCommitObjectId)
+            {
+                Author = "John Doe",
+                AuthorUnixTime = DateTimeUtils.ToUnixTime(DateTime.Parse("2010-03-24 13:37:12")),
+                AuthorEmail = "j.doe@some.email.dotcom",
+                Subject = "fix: bugs",
+                Body = "fix: bugs\r\n\r\nall bugs fixed"
+            };
+
+            RunCommitInfoTest(async (commitInfo) =>
+            {
+                commitInfo.SetRevisionWithChildren(revision, children: null);
+
+                // Wait for pending operations so the Control is loaded completely before testing it
+                await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
+
+                Approvals.Verify(commitInfo.GetTestAccessor().RevisionInfo.Rtf);
+            });
+        }
+
+        // Link start numbers are obtained manually.
+        [TestCase("branch05", 183, "gitext://gotobranch/branch05")]
+        [TestCase("v1.9", 745, "gitext://gototag/v1.9")]
+        public void ReloadCommitInfo_should_extract_links_correctly(string refText, int linkStart, string expectedUri)
+        {
+            string hash = "a48da1aba59a65b2a7f0df7e3512817caf16819f";
+
+            // Generate branches: branch01...branch15
+            _gitExecutable.StageOutput($"branch --contains {hash}", string.Join('\n', Enumerable.Range(1, 15).Select(i => $"branch{i:00}")));
+
+            // Generate tags: v1.0...v1.15
+            _gitExecutable.StageOutput($"tag --contains {hash}", string.Join('\n', Enumerable.Range(0, 15).Select(i => $"v1.{i}")));
+
+            _gitExecutable.StageOutput($"describe --tags --first-parent --abbrev=40 {hash}", "");
+
+            var realCommitObjectId = ObjectId.Parse(hash);
+            GitRevision revision = new(realCommitObjectId)
+            {
+                Author = "John Doe",
+                AuthorUnixTime = DateTimeUtils.ToUnixTime(DateTime.Parse("2010-03-24 13:37:12")),
+                AuthorEmail = "j.doe@some.email.dotcom",
+                Subject = "fix: bugs",
+                Body = "fix: bugs\r\n\r\nall bugs fixed"
+            };
+
+            RunCommitInfoTest(async (commitInfo) =>
+            {
+                if (ManagedExtensibility.GetExport<ILinkFactory>().Value is not MockLinkFactory mockLinkFactory)
+                {
+                    Assert.Fail($"Unexpected {typeof(ILinkFactory)} implementation.");
+                    return;
+                }
+
+                commitInfo.SetRevisionWithChildren(revision, children: null);
+
+                // Wait for pending operations so the Control is loaded completely before testing it
+                await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
+
+                // simulate a click on refText link
+                commitInfo.GetTestAccessor().RevisionInfo_LinkClicked(commitInfo, new(refText, linkStart, linkLength: refText.Length));
+                mockLinkFactory.LastExecutedLinkUri.Should().Be(expectedUri);
+            });
+        }
+
+        [Test]
+        public void ReloadCommitInfo_should_handle_ShowAll_branches_correctly()
+        {
+            string hash = "a48da1aba59a65b2a7f0df7e3512817caf16819f";
+
+            // Generate branches: branch01...branch15
+            _gitExecutable.StageOutput($"branch --contains {hash}", string.Join('\n', Enumerable.Range(1, 15).Select(i => $"branch{i:00}")));
+
+            // Generate tags: v1.0...v1.15
+            _gitExecutable.StageOutput($"tag --contains {hash}", string.Join('\n', Enumerable.Range(0, 15).Select(i => $"v1.{i}")));
+
+            _gitExecutable.StageOutput($"describe --tags --first-parent --abbrev=40 {hash}", "");
+
+            var realCommitObjectId = ObjectId.Parse(hash);
+            GitRevision revision = new(realCommitObjectId)
+            {
+                Author = "John Doe",
+                AuthorUnixTime = DateTimeUtils.ToUnixTime(DateTime.Parse("2010-03-24 13:37:12")),
+                AuthorEmail = "j.doe@some.email.dotcom",
+                Subject = "fix: bugs",
+                Body = "fix: bugs\r\n\r\nall bugs fixed"
+            };
+
+            RunCommitInfoTest(async (commitInfo) =>
+            {
+                if (ManagedExtensibility.GetExport<ILinkFactory>().Value is not MockLinkFactory mockLinkFactory)
+                {
+                    Assert.Fail($"Unexpected {typeof(ILinkFactory)} implementation.");
+                    return;
+                }
+
+                commitInfo.SetRevisionWithChildren(revision, children: null);
+
+                // Wait for pending operations so the Control is loaded completely before testing it
+                await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
+
+                // simulate a click on refText link
+                commitInfo.GetTestAccessor().RevisionInfo_LinkClicked(commitInfo, new("not important", linkStart: 423, linkLength: 0));
+                mockLinkFactory.LastExecutedLinkUri.Should().Be("gitext://showall/branches");
+
+                Approvals.Verify(commitInfo.GetTestAccessor().RevisionInfo.Rtf);
+            });
+        }
+
+        [Test]
+        public void ReloadCommitInfo_should_handle_ShowAll_tags_correctly()
+        {
+            string hash = "a48da1aba59a65b2a7f0df7e3512817caf16819f";
+
+            // Generate branches: branch01...branch15
+            _gitExecutable.StageOutput($"branch --contains {hash}", string.Join('\n', Enumerable.Range(1, 15).Select(i => $"branch{i:00}")));
+
+            // Generate tags: v1.0...v1.15
+            _gitExecutable.StageOutput($"tag --contains {hash}", string.Join('\n', Enumerable.Range(0, 15).Select(i => $"v1.{i}")));
+
+            _gitExecutable.StageOutput($"describe --tags --first-parent --abbrev=40 {hash}", "");
+
+            var realCommitObjectId = ObjectId.Parse(hash);
+            GitRevision revision = new(realCommitObjectId)
+            {
+                Author = "John Doe",
+                AuthorUnixTime = DateTimeUtils.ToUnixTime(DateTime.Parse("2010-03-24 13:37:12")),
+                AuthorEmail = "j.doe@some.email.dotcom",
+                Subject = "fix: bugs",
+                Body = "fix: bugs\r\n\r\nall bugs fixed"
+            };
+
+            RunCommitInfoTest(async (commitInfo) =>
+            {
+                if (ManagedExtensibility.GetExport<ILinkFactory>().Value is not MockLinkFactory mockLinkFactory)
+                {
+                    Assert.Fail($"Unexpected {typeof(ILinkFactory)} implementation.");
+                    return;
+                }
+
+                commitInfo.SetRevisionWithChildren(revision, children: null);
+
+                // Wait for pending operations so the Control is loaded completely before testing it
+                await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
+
+                // simulate a click on refText link
+                commitInfo.GetTestAccessor().RevisionInfo_LinkClicked(commitInfo, new("not important", linkStart: 774, linkLength: 0));
+                mockLinkFactory.LastExecutedLinkUri.Should().Be("gitext://showall/tags");
+
+                Approvals.Verify(commitInfo.GetTestAccessor().RevisionInfo.Rtf);
+            });
+        }
+
+        private void RunCommitInfoTest(Func<GitUI.CommitInfo.CommitInfo, Task> runTestAsync)
         {
             UITest.RunControl(
                 createControl: form =>
@@ -158,10 +348,14 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
                     // the following assignment of CommitInfo.UICommandsSource will already call this command
                     _gitExecutable.StageOutput(@"for-each-ref --sort=""-taggerdate"" --format=""%(refname)"" refs/tags/", "");
 
+                    form.Size = new(600, 480);
+
                     return new GitUI.CommitInfo.CommitInfo
                     {
+                        Dock = DockStyle.Fill,
                         Parent = form,
-                        UICommandsSource = uiCommandsSource
+                        ShowBranchesAsLinks = true,
+                        UICommandsSource = uiCommandsSource,
                     };
                 },
                 runTestAsync: async commitInfo =>
@@ -169,7 +363,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
                     // Wait for pending operations so the Control is loaded completely before testing it
                     await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
 
-                    runTest(commitInfo);
+                    await runTestAsync(commitInfo);
                 });
         }
     }

--- a/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
@@ -4,11 +4,14 @@ using System.IO;
 using System.Threading;
 using System.Windows.Forms;
 using CommonTestUtils;
+using CommonTestUtils.MEF;
 using FluentAssertions;
 using GitCommands;
+using GitExtensions.UITests.CommandsDialogs;
 using GitUI;
 using GitUI.CommandsDialogs;
 using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Composition;
 using NUnit.Framework;
 
 namespace GitExtensions.UITests.UserControls.RevisionGrid
@@ -53,6 +56,14 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
             _commands = new GitUICommands(_referenceRepository.Module);
 
             AppSettings.RevisionGraphShowArtificialCommits = true;
+
+            var composition = TestComposition.Empty
+                .AddParts(typeof(MockLinkFactory))
+                .AddParts(typeof(MockWindowsJumpListManager))
+                .AddParts(typeof(MockRepositoryDescriptionProvider))
+                .AddParts(typeof(MockAppTitleGenerator));
+            ExportProvider mefExportProvider = composition.ExportProviderFactory.CreateExportProvider();
+            ManagedExtensibility.SetTestExportProvider(mefExportProvider);
         }
 
         [TearDown]

--- a/ResourceManager/LinkFactory.cs
+++ b/ResourceManager/LinkFactory.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Concurrent;
+using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
@@ -22,6 +22,7 @@ namespace ResourceManager
         void ExecuteLink(string? linkUri, Action<CommandEventArgs>? handleInternalLink = null, Action<string?>? showAll = null);
     }
 
+    [Export(typeof(ILinkFactory))]
     public sealed class LinkFactory : ILinkFactory
     {
         private const string InternalScheme = "gitext";

--- a/TranslationApp/Program.cs
+++ b/TranslationApp/Program.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Windows.Forms;
 using BugReporter;
 using GitUI;
+using GitUIPluginInterfaces;
 using Microsoft.VisualStudio.Threading;
 using ResourceManager;
 
@@ -28,6 +29,13 @@ namespace TranslationApp
             using (BugReportForm dummy = new())
             {
             }
+
+            ManagedExtensibility.Initialise(new[]
+            {
+                typeof(GitUI.GitExtensionsForm).Assembly,
+                typeof(GitCommands.GitModule).Assembly,
+                typeof(ResourceManager.GitPluginBase).Assembly
+            });
 
             // Required for translation
             PluginRegistry.Initialize();

--- a/UnitTests/GitUI.Tests/TranslationTest.cs
+++ b/UnitTests/GitUI.Tests/TranslationTest.cs
@@ -2,7 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using CommonTestUtils.MEF;
 using GitUI;
+using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Composition;
 using NUnit.Framework;
 using ResourceManager;
 using ResourceManager.Xliff;
@@ -15,6 +18,11 @@ namespace GitUITests
         [SetUp]
         public void SetUp()
         {
+            var composition = TestComposition.Empty
+               .AddParts(typeof(LinkFactory));
+            ExportProvider mefExportProvider = composition.ExportProviderFactory.CreateExportProvider();
+            ManagedExtensibility.SetTestExportProvider(mefExportProvider);
+
             GitModuleForm.IsUnitTestActive = true;
         }
 

--- a/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
@@ -6,13 +6,16 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CommonTestUtils;
+using CommonTestUtils.MEF;
 using FluentAssertions;
 using GitCommands;
 using GitUI;
 using GitUI.Blame;
 using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Composition;
 using NSubstitute;
 using NUnit.Framework;
+using ResourceManager;
 
 namespace GitUITests.UserControls
 {
@@ -33,6 +36,11 @@ namespace GitUITests.UserControls
         [SetUp]
         public void SetUp()
         {
+            var composition = TestComposition.Empty
+                .AddParts(typeof(LinkFactory));
+            ExportProvider mefExportProvider = composition.ExportProviderFactory.CreateExportProvider();
+            ManagedExtensibility.SetTestExportProvider(mefExportProvider);
+
             GitBlameCommit blameCommit1 = new(
                 ObjectId.Random(),
                 "author1",

--- a/UnitTests/ResourceManager.Tests/LinkFactoryTests.cs
+++ b/UnitTests/ResourceManager.Tests/LinkFactoryTests.cs
@@ -5,7 +5,7 @@ using ResourceManager;
 namespace ResourceManagerTests
 {
     [TestFixture]
-    internal class LinkFactoryFixture
+    internal class LinkFactoryTests
     {
         [TestCase(null)]
         [TestCase("")]
@@ -14,7 +14,7 @@ namespace ResourceManagerTests
         public void ParseInvalidLink(string link)
         {
             LinkFactory linkFactory = new();
-            Assert.False(linkFactory.ParseLink(link, out var actualUri));
+            Assert.False(linkFactory.GetTestAccessor().TryParseLink(link, out var actualUri));
             Assert.That(actualUri, Is.Null);
         }
 
@@ -24,7 +24,7 @@ namespace ResourceManagerTests
             LinkFactory linkFactory = new();
             linkFactory.CreateBranchLink("master");
             string expected = "gitext://gotobranch/master";
-            Assert.True(linkFactory.ParseLink("master#gitext://gotobranch/master", out var actualUri));
+            Assert.True(linkFactory.GetTestAccessor().TryParseLink("master#gitext://gotobranch/master", out var actualUri));
             Assert.That(actualUri.AbsoluteUri, Is.EqualTo(expected));
         }
 
@@ -34,7 +34,7 @@ namespace ResourceManagerTests
             LinkFactory linkFactory = new();
             linkFactory.CreateBranchLink("PR#23");
             string expected = "gitext://gotobranch/PR#23";
-            Assert.True(linkFactory.ParseLink("PR#23#gitext://gotobranch/PR#23", out var actualUri));
+            Assert.True(linkFactory.GetTestAccessor().TryParseLink("PR#23#gitext://gotobranch/PR#23", out var actualUri));
             Assert.That(actualUri.AbsoluteUri, Is.EqualTo(expected));
         }
 
@@ -43,7 +43,7 @@ namespace ResourceManagerTests
             LinkFactory linkFactory = new();
             linkFactory.CreateLink(caption, uri);
             string expected = uri;
-            Assert.True(linkFactory.ParseLink(caption + "#" + uri, out var actualUri));
+            Assert.True(linkFactory.GetTestAccessor().TryParseLink(caption + "#" + uri, out var actualUri));
             Assert.That(actualUri.AbsoluteUri, Is.EqualTo(expected));
         }
 
@@ -65,7 +65,7 @@ namespace ResourceManagerTests
             LinkFactory linkFactory = new();
 
             string expected = "https://github.com/gitextensions/gitextensions/pull/3471#end";
-            Assert.True(linkFactory.ParseLink("https://github.com/gitextensions/gitextensions/pull/3471#end", out var actualUri));
+            Assert.True(linkFactory.GetTestAccessor().TryParseLink("https://github.com/gitextensions/gitextensions/pull/3471#end", out var actualUri));
             Assert.That(actualUri.AbsoluteUri, Is.EqualTo(expected));
         }
 
@@ -79,7 +79,7 @@ namespace ResourceManagerTests
         public void ParseInternalScheme_Null()
         {
             LinkFactory linkFactory = new();
-            Assert.False(linkFactory.ParseInternalScheme(null, out var actualCommandEventArgs));
+            Assert.False(linkFactory.GetTestAccessor().ParseInternalScheme(null, out var actualCommandEventArgs));
             Assert.That(actualCommandEventArgs, Is.Null);
         }
 
@@ -91,7 +91,7 @@ namespace ResourceManagerTests
         {
             LinkFactory linkFactory = new();
             Uri uri = new(link);
-            Assert.False(linkFactory.ParseInternalScheme(uri, out var actualCommandEventArgs));
+            Assert.False(linkFactory.GetTestAccessor().ParseInternalScheme(uri, out var actualCommandEventArgs));
             Assert.That(actualCommandEventArgs, Is.Null);
         }
 
@@ -107,7 +107,7 @@ namespace ResourceManagerTests
         {
             LinkFactory linkFactory = new();
             Uri uri = new(link);
-            Assert.True(linkFactory.ParseInternalScheme(uri, out var actualCommandEventArgs));
+            Assert.True(linkFactory.GetTestAccessor().ParseInternalScheme(uri, out var actualCommandEventArgs));
             Assert.That(actualCommandEventArgs.Command, Is.EqualTo(expectedCommand));
             Assert.That(actualCommandEventArgs.Data, Is.EqualTo(expectedData));
         }


### PR DESCRIPTION
Fixes #9934

## Proposed changes

- Show both all branches and all tags regardless of which `[ Show all ]` link is clicked 

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/162070398-5dcb37bf-2197-432f-97d9-d936c23e8800.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/162070750-97cb06d9-5b7d-4de5-ae7c-fdd60cd8b532.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build b855fa621dd5ab924621b61a52f5633f39ab0230
- Git 2.35.1.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.3
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).