### PR TITLE
FileViewer: Display error text rather than popup

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -535,7 +535,11 @@ namespace GitUI.Editor
 
             file.TreeGuid ??= Module.GetFileBlobHash(file.Name, objectId);
 
-            Validates.NotNull(file.TreeGuid);
+            if (file.TreeGuid is null)
+            {
+                return ViewTextAsync(file.Name, $"Cannot get treeId from Git for {file.Name} for commit {objectId}.");
+            }
+
             var sha = file.TreeGuid.ToString();
             var isSubmodule = file.IsSubmodule;
 


### PR DESCRIPTION
Fixes #9944 

## Proposed changes

If TreeGuid cannot be retrieved with git-ls-files

Current popup has no info about filename or revision (Git Command Log must be manually checked).

## Test methodology <!-- How did you ensure quality? -->

Code review

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
