### PR TITLE
Reduce Linq overhead in ArgumentBuilder

### DIFF
--- a/GitExtUtils/ArgumentBuilder.cs
+++ b/GitExtUtils/ArgumentBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 
@@ -69,10 +68,12 @@ namespace GitExtUtils
         /// <param name="args">The arguments to add to this builder.</param>
         public void AddRange(IEnumerable<string> args)
         {
-            args = args.Where(a => !string.IsNullOrEmpty(a));
             foreach (string s in args)
             {
-                Add(s);
+                if (!string.IsNullOrEmpty(s))
+                {
+                    Add(s);
+                }
             }
         }
 


### PR DESCRIPTION
Reduces Linq overhead underneath `.Where(...)` by replacing it with simple `if` statement.

This is a performance optimization. I would also say it is also code readability improvement, but it's matter of taste, I think.