### PR TITLE
git-fetch --jobs==0 if no configuration

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1522,9 +1522,14 @@ namespace GitCommands
                 }
             }
 
+            bool remoteJobs = string.IsNullOrWhiteSpace(EffectiveConfigFile.GetValue("fetch.parallel"));
+            bool submoduleJobs = string.IsNullOrWhiteSpace(EffectiveConfigFile.GetValue("submodule.fetchJobs"));
+
             // TODO return ArgumentBuilder and add special case ArgumentBuilder.Add(ArgumentBuilder childBuilder)
             return new ArgumentBuilder
             {
+                { remoteJobs && string.IsNullOrWhiteSpace(branchArguments), "--multiple" },
+                { remoteJobs && submoduleJobs, "--jobs=0" },
                 remote.ToPosixPath()?.Trim().Quote(),
                 branchArguments,
                 { fetchTags == true, "--tags" },

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1522,14 +1522,13 @@ namespace GitCommands
                 }
             }
 
-            bool remoteJobs = string.IsNullOrWhiteSpace(EffectiveConfigFile.GetValue("fetch.parallel"));
-            bool submoduleJobs = string.IsNullOrWhiteSpace(EffectiveConfigFile.GetValue("submodule.fetchJobs"));
+            bool jobsConfig = string.IsNullOrWhiteSpace(EffectiveConfigFile.GetValue("fetch.parallel"))
+                && string.IsNullOrWhiteSpace(EffectiveConfigFile.GetValue("submodule.fetchJobs"));
 
             // TODO return ArgumentBuilder and add special case ArgumentBuilder.Add(ArgumentBuilder childBuilder)
             return new ArgumentBuilder
             {
-                { remoteJobs && string.IsNullOrWhiteSpace(branchArguments), "--multiple" },
-                { remoteJobs && submoduleJobs, "--jobs=0" },
+                { jobsConfig, "--jobs=0" },
                 remote.ToPosixPath()?.Trim().Quote(),
                 branchArguments,
                 { fetchTags == true, "--tags" },

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -118,42 +118,42 @@ namespace GitCommandsTests
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags",
+                    "fetch --progress --jobs=0 \"remote\" +remotebranch:refs/heads/localbranch --no-tags",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch").Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --tags",
+                    "fetch --progress --jobs=0 \"remote\" +remotebranch:refs/heads/localbranch --tags",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", true).Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch",
+                    "fetch --progress --jobs=0 \"remote\" +remotebranch:refs/heads/localbranch",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", null).Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --unshallow",
+                    "fetch --progress --jobs=0 \"remote\" +remotebranch:refs/heads/localbranch --no-tags --unshallow",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", isUnshallow: true).Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --force",
+                    "fetch --progress --jobs=0 \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --force",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", pruneRemoteBranches: true).Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --force --prune-tags",
+                    "fetch --progress --jobs=0 \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --force --prune-tags",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", pruneRemoteBranches: true, pruneRemoteBranchesAndTags: true).Arguments);
             }
         }


### PR DESCRIPTION
Fixes #9937

## Proposed changes

Override the Git default of one parallel job.

If the user has set fetch.parallel or submodule.fetchJobs the
the user config value is set (or git default if just one is set).

Config check adds 4ms the first check for me and <1ms the second (when the value is cached).

## Test methodology <!-- How did you ensure quality? -->

Manual
I guess this could be tested, someone is welcome to contribute.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
