### PR TITLE
Show 'no changes' in grid for artificial

### DIFF
--- a/GitUI/UserControls/RevisionGrid/ArtificialCommitChangeCount.cs
+++ b/GitUI/UserControls/RevisionGrid/ArtificialCommitChangeCount.cs
@@ -9,12 +9,17 @@ namespace GitUI
     public sealed class ArtificialCommitChangeCount
     {
         /// <summary>
+        /// If the count is valid (i.e. not: updating, unknown (i.e. a modal form) or unused).
+        /// </summary>
+        public bool DataValid { get; private set; } = false;
+
+        /// <summary>
         /// Number of changed files.
         /// </summary>
         public IReadOnlyList<GitItemStatus> Changed { get; private set; } = Array.Empty<GitItemStatus>();
 
         /// <summary>
-        ///  Number of new files.
+        /// Number of new files.
         /// </summary>
         public IReadOnlyList<GitItemStatus> New { get; private set; } = Array.Empty<GitItemStatus>();
 
@@ -36,26 +41,31 @@ namespace GitUI
         public IReadOnlyList<GitItemStatus> SubmodulesDirty { get; private set; } = Array.Empty<GitItemStatus>();
 
         /// <summary>
-        /// Any change in any category.
+        /// Any valid change in any category.
         /// </summary>
         public bool HasChanges
-            => (Changed?.Count ?? 0) > 0
+            => DataValid
+               && ((Changed?.Count ?? 0) > 0
                || (New?.Count ?? 0) > 0
                || (Deleted?.Count ?? 0) > 0
                || (SubmodulesChanged?.Count ?? 0) > 0
-               || (SubmodulesDirty?.Count ?? 0) > 0;
+               || (SubmodulesDirty?.Count ?? 0) > 0);
 
         /// <summary>
         /// Update the change count.
         /// </summary>
         /// <param name="items">Git items.</param>
-        public void Update(IReadOnlyList<GitItemStatus> items)
+        public void Update(IReadOnlyList<GitItemStatus>? items)
         {
-            Changed = items.Where(item => !item.IsNew && !item.IsDeleted && !item.IsSubmodule).ToList();
-            New = items.Where(item => item.IsNew && !item.IsSubmodule).ToList();
-            Deleted = items.Where(item => item.IsDeleted && !item.IsSubmodule).ToList();
-            SubmodulesChanged = items.Where(item => item.IsSubmodule && item.IsChanged).ToList();
-            SubmodulesDirty = items.Where(item => item.IsSubmodule && item.IsDirty).ToList();
+            DataValid = items is not null;
+            if (DataValid)
+            {
+                Changed = items.Where(item => !item.IsNew && !item.IsDeleted && !item.IsSubmodule).ToList();
+                New = items.Where(item => item.IsNew && !item.IsSubmodule).ToList();
+                Deleted = items.Where(item => item.IsDeleted && !item.IsSubmodule).ToList();
+                SubmodulesChanged = items.Where(item => item.IsSubmodule && item.IsChanged).ToList();
+                SubmodulesDirty = items.Where(item => item.IsSubmodule && item.IsDirty).ToList();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Part of #9955

## Proposed changes

Add indication similar to that on the Commit button if there is no info (grey) or no changes (green)
instead of no info.

Minor fix for ToggleBetweenArtificialAndHeadCommits that checked for count rather if the commit existed.
(This check has always bothered me, kept it when reverting a change to update the count).

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/163565302-db2c573e-be2b-4c13-99cf-ac50922995f9.png)

### After

![image](https://user-images.githubusercontent.com/6248932/163565464-9dd7488d-225d-4de3-94b2-37d897867933.png)

![image](https://user-images.githubusercontent.com/6248932/163565492-7e64e4c2-b557-4845-9789-eb8dd3f3532a.png)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
