### PR TITLE
Ensure commit message textbox is visible

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -140,9 +140,11 @@ namespace GitUI.CommitInfo
 
             commitInfoHeader.SetContextMenuStrip(commitInfoContextMenuStrip);
 
-            // at this point rtbxCommitMessage.Bounds = {X = 8 Y = 8 Width = 440 Height = 0}
-            // and with Height=0 we won't be receiving any ContentsResizedEvents
-            rtbxCommitMessage.Height = 1;
+            // This issue surfaces at 150% scale factor.
+            // At this point rtbxCommitMessage.Bounds = {X = 8 Y = 8 Width = 440 Height = 0}
+            // and with Height=0 we won't be receiving any ContentsResizedEvents.
+            // To workaround the zero-height - force the min size.
+            rtbxCommitMessage.MinimumSize = new(1, 1);
         }
 
         /// <summary>


### PR DESCRIPTION
At 150% scale factor the RTB containing commit messages gets randomly set to 0-height. This in turn disables all resize notifications, and commit messages become invisible.
Force the RTB to have min size (1, 1) to prevent 0-height.



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="435" alt="image" src="https://user-images.githubusercontent.com/4403806/163707563-26235826-b0b0-4066-9d23-33e4295940d1.png">


### After

<img width="435" alt="image" src="https://user-images.githubusercontent.com/4403806/163707494-b3d6b2a5-e145-46db-b8c8-ef996206e884.png">


## Test methodology <!-- How did you ensure quality? -->

- Manual at various scale factors.

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
