### PR TITLE
left panel: reverted menu icon scale to match item font size

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -130,7 +130,6 @@ namespace GitUI.BranchTreePanel
             // 
             // menuMain
             // 
-            this.menuMain.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menuMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyContextMenuItem,
             this.filterForSelectedRefsMenuItem,
@@ -173,7 +172,7 @@ namespace GitUI.BranchTreePanel
             this.toolStripSeparator1,
             this.runScriptToolStripMenuItem});
             this.menuMain.Name = "menuMain";
-            this.menuMain.Size = new System.Drawing.Size(267, 912);
+            this.menuMain.Size = new System.Drawing.Size(263, 848);
             this.menuMain.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
             this.menuMain.Opened += new System.EventHandler(this.contextMenu_Opened);
             // 
@@ -498,7 +497,6 @@ namespace GitUI.BranchTreePanel
             this.leftPanelToolStrip.ClickThrough = true;
             this.leftPanelToolStrip.DrawBorder = false;
             this.leftPanelToolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-            this.leftPanelToolStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.leftPanelToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tsbCollapseAll,
             this.tsbShowBranches,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9964

## Screenshots (Before / After)

![image](https://user-images.githubusercontent.com/680296/163720346-96a87042-538b-4f2c-9d24-67f8eebfa61d.png) ![image](https://user-images.githubusercontent.com/680296/163720393-1ba4dc09-956f-4ade-99d0-ae3feadab20d.png)

I agree that the maintainer squash merge this PR (if the commit message is clear).

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
