### PR TITLE
More xml-related fixes

### DIFF
--- a/GitCommands/ExternalLinks/ExternalLinksStorage.cs
+++ b/GitCommands/ExternalLinks/ExternalLinksStorage.cs
@@ -54,11 +54,18 @@ namespace GitCommands.ExternalLinks
                         definition.RemoveEmptyFormats();
                     }
 
-                    StringWriter sw = new();
                     XmlSerializer serializer = new(typeof(List<ExternalLinkDefinition>));
                     XmlSerializerNamespaces ns = new();
                     ns.Add(string.Empty, string.Empty);
-                    serializer.Serialize(sw, definitions.OrderBy(x => x.Name).ToList(), ns);
+
+                    XmlWriterSettings xmlWriterSettings = new()
+                    {
+                        Indent = true
+                    };
+                    using StringWriter sw = new();
+                    using XmlWriter xmlWriter = XmlWriter.Create(sw, xmlWriterSettings);
+
+                    serializer.Serialize(xmlWriter, definitions.OrderBy(x => x.Name).ToList(), ns);
                     xml = sw.ToString();
                 }
 

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
+using System.Xml;
 using System.Xml.Serialization;
 using GitCommands;
 using GitUI.BranchTreePanel;
@@ -99,10 +99,15 @@ namespace GitUI.Hotkey
             {
                 UpdateUsedKeys(settings);
 
-                StringBuilder str = new();
-                using StringWriter writer = new(str);
-                Serializer.Serialize(writer, settings);
-                AppSettings.SerializedHotkeys = str.ToString();
+                XmlWriterSettings xmlWriterSettings = new()
+                {
+                    Indent = true
+                };
+                using StringWriter sw = new();
+                using XmlWriter xmlWriter = XmlWriter.Create(sw, xmlWriterSettings);
+
+                Serializer.Serialize(xmlWriter, settings);
+                AppSettings.SerializedHotkeys = sw.ToString();
             }
             catch
             {

--- a/GitUI/Script/ScriptManager.cs
+++ b/GitUI/Script/ScriptManager.cs
@@ -204,5 +204,10 @@ namespace GitUI.Script
         {
             return GetScripts().Select(s => s.HotkeyCommandIdentifier).Max() + 1;
         }
+
+        internal struct TestAccessor
+        {
+            public static void Reset() => _scripts = null;
+        }
     }
 }

--- a/GitUI/Script/ScriptManager.cs
+++ b/GitUI/Script/ScriptManager.cs
@@ -71,8 +71,14 @@ namespace GitUI.Script
         {
             try
             {
-                StringWriter sw = new();
-                _serializer.Serialize(sw, _scripts);
+                XmlWriterSettings xmlWriterSettings = new()
+                {
+                    Indent = true
+                };
+                using StringWriter sw = new();
+                using XmlWriter xmlWriter = XmlWriter.Create(sw, xmlWriterSettings);
+
+                _serializer.Serialize(xmlWriter, _scripts);
                 return sw.ToString();
             }
             catch

--- a/IntegrationTests/UI.IntegrationTests/Script/ScriptManagerTests.Can_save_settings.approved.txt
+++ b/IntegrationTests/UI.IntegrationTests/Script/ScriptManagerTests.Can_save_settings.approved.txt
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-16"?>
+<ArrayOfScriptInfo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <ScriptInfo>
+    <Enabled>true</Enabled>
+    <Name>name</Name>
+    <Command>cmd</Command>
+    <Arguments>args</Arguments>
+    <AddToRevisionGridContextMenu>false</AddToRevisionGridContextMenu>
+    <OnEvent>None</OnEvent>
+    <AskConfirmation>false</AskConfirmation>
+    <RunInBackground>false</RunInBackground>
+    <IsPowerShell>false</IsPowerShell>
+    <HotkeyCommandIdentifier>0</HotkeyCommandIdentifier>
+    <Icon>bug</Icon>
+  </ScriptInfo>
+</ArrayOfScriptInfo>

--- a/IntegrationTests/UI.IntegrationTests/Script/ScriptManagerTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/Script/ScriptManagerTests.cs
@@ -1,0 +1,40 @@
+﻿using ApprovalTests;
+using GitCommands;
+using GitUI.Script;
+using NUnit.Framework;
+
+namespace GitExtensions.UITests.Script
+{
+    [TestFixture]
+    public class ScriptManagerTests
+    {
+        [Test]
+        public void Can_save_settings()
+        {
+            string originalScripts = AppSettings.OwnScripts;
+
+            try
+            {
+                AppSettings.OwnScripts = "<ArrayOfScriptInfo />";
+
+                var scripts = ScriptManager.GetScripts();
+
+                scripts.Add(new ScriptInfo()
+                {
+                    Name = "name",
+                    Command = "cmd",
+                    Arguments = "args"
+                });
+
+                string? xml = ScriptManager.SerializeIntoXml();
+
+                // Verify as a string, as the xml verifier ignores line breaks.
+                Approvals.Verify(xml);
+            }
+            finally
+            {
+                AppSettings.OwnScripts = originalScripts;
+            }
+        }
+    }
+}

--- a/IntegrationTests/UI.IntegrationTests/Script/ScriptManagerTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/Script/ScriptManagerTests.cs
@@ -34,6 +34,7 @@ namespace GitExtensions.UITests.Script
             finally
             {
                 AppSettings.OwnScripts = originalScripts;
+                ScriptManager.TestAccessor.Reset();
             }
         }
     }

--- a/IntegrationTests/UI.IntegrationTests/Script/ScriptRunnerTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/Script/ScriptRunnerTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;

--- a/UnitTests/GitCommands.Tests/ExternalLinks/ExternalLinksStorageIntegrationTests.Can_save_settings.approved.xml
+++ b/UnitTests/GitCommands.Tests/ExternalLinks/ExternalLinksStorageIntegrationTests.Can_save_settings.approved.xml
@@ -1,0 +1,25 @@
+﻿<dictionary>
+  <item>
+    <key>
+      <string>RevisionLinkDefs</string>
+    </key>
+    <value>
+      <string>&lt;?xml version="1.0" encoding="utf-16"?&gt;
+&lt;ArrayOfGitExtLinkDef&gt;
+  &lt;GitExtLinkDef&gt;
+    &lt;Enabled&gt;true&lt;/Enabled&gt;
+    &lt;LinkFormats /&gt;
+    &lt;Name&gt;&amp;lt;new&amp;gt;&lt;/Name&gt;
+    &lt;RemoteSearchInParts&gt;
+      &lt;RemotePart&gt;URL&lt;/RemotePart&gt;
+    &lt;/RemoteSearchInParts&gt;
+    &lt;SearchInParts&gt;
+      &lt;RevisionPart&gt;Message&lt;/RevisionPart&gt;
+    &lt;/SearchInParts&gt;
+    &lt;UseRemotesPattern&gt;upstream|origin&lt;/UseRemotesPattern&gt;
+    &lt;UseOnlyFirstRemote&gt;true&lt;/UseOnlyFirstRemote&gt;
+  &lt;/GitExtLinkDef&gt;
+&lt;/ArrayOfGitExtLinkDef&gt;</string>
+    </value>
+  </item>
+</dictionary>

--- a/UnitTests/GitUI.Tests/Hotkey/HotkeySettingsManagerTests.Can_save_settings.approved.txt
+++ b/UnitTests/GitUI.Tests/Hotkey/HotkeySettingsManagerTests.Can_save_settings.approved.txt
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-16"?>
+<ArrayOfHotkeySettings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <HotkeySettings Name="settings1">
+    <Commands>
+      <HotkeyCommand CommandCode="1" Name="C1" KeyData="A" />
+      <HotkeyCommand CommandCode="2" Name="C2" KeyData="B" />
+    </Commands>
+  </HotkeySettings>
+  <HotkeySettings Name="settings2">
+    <Commands>
+      <HotkeyCommand CommandCode="1" Name="C1" KeyData="A" />
+      <HotkeyCommand CommandCode="2" Name="C2" KeyData="B" />
+    </Commands>
+  </HotkeySettings>
+</ArrayOfHotkeySettings>

--- a/UnitTests/GitUI.Tests/Hotkey/HotkeySettingsManagerTests.cs
+++ b/UnitTests/GitUI.Tests/Hotkey/HotkeySettingsManagerTests.cs
@@ -1,6 +1,8 @@
 ﻿using System.Linq;
 using System.Windows.Forms;
+using ApprovalTests;
 using FluentAssertions;
+using GitCommands;
 using GitUI.Hotkey;
 using NUnit.Framework;
 using ResourceManager;
@@ -8,7 +10,7 @@ using ResourceManager;
 namespace GitUITests.Hotkey
 {
     [TestFixture]
-    public class HotkeySettingsManagerFixture
+    public class HotkeySettingsManagerTests
     {
         [Test]
         public void MergeEqualSettings()
@@ -33,6 +35,7 @@ namespace GitUITests.Hotkey
             defaultHotkeySettingsArray.SequenceEqual(loadedHotkeySettingsArray).Should().BeFalse();
         }
 
+        [Test]
         public void SequenceEqualOnEqualSettings()
         {
             var defaultHotkeySettingsArray = CreateHotkeySettings(2);
@@ -41,6 +44,7 @@ namespace GitUITests.Hotkey
             defaultHotkeySettingsArray.SequenceEqual(loadedHotkeySettingsArray).Should().BeTrue();
         }
 
+        [Test]
         public void MergeLoadedSettings()
         {
             // arrange
@@ -54,6 +58,7 @@ namespace GitUITests.Hotkey
             defaultHotkeySettingsArray.SequenceEqual(loadedHotkeySettingsArray).Should().BeTrue();
         }
 
+        [Test]
         public void MergeLoadedDiffSizeSettings()
         {
             // arrange
@@ -67,6 +72,24 @@ namespace GitUITests.Hotkey
             expected[1].Commands[1].KeyData = loadedHotkeySettingsArray[1].Commands[1].KeyData;
 
             defaultHotkeySettingsArray.SequenceEqual(expected).Should().BeTrue();
+        }
+
+        [Test]
+        public void Can_save_settings()
+        {
+            string originalHotkeys = AppSettings.SerializedHotkeys;
+
+            try
+            {
+                HotkeySettingsManager.SaveSettings(CreateHotkeySettings(2));
+
+                // Verify as a string, as the xml verifier ignores line breaks.
+                Approvals.Verify(AppSettings.SerializedHotkeys);
+            }
+            finally
+            {
+                AppSettings.SerializedHotkeys = originalHotkeys;
+            }
         }
 
         private static HotkeySettings[] CreateHotkeySettings(int count)


### PR DESCRIPTION
Workarounds for a regression in .NET 6, see: https://github.com/dotnet/runtime/issues/64885


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
![Screenshot 2022-04-18 000211](https://user-images.githubusercontent.com/4403806/163782473-941fad65-44f2-4c20-bc01-14a8e69b54e6.png)
![Screenshot 2022-04-18 182333](https://user-images.githubusercontent.com/4403806/163782525-2996bcd7-f04f-49d1-91b4-b10dafe31ec3.png)

### After

<!-- TODO -->
![Screenshot 2022-04-18 182515](https://user-images.githubusercontent.com/4403806/163782533-8b341787-d918-4f21-8aa8-69e85405f78f.png)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
