### PR TITLE
Do not assert for head when creating branches

### DIFF
--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -360,8 +360,6 @@ namespace GitUI.CommandsDialogs
 
             var originalId = Module.GetCurrentCheckout();
 
-            Debug.Assert(originalId is not null, "originalId is not null");
-
             bool success = ScriptManager.RunEventScripts(this, ScriptEvent.BeforeCheckout);
             if (!success)
             {


### PR DESCRIPTION
## Proposed changes

HEAD may be null before creating branches for instance when creating
orphan branches without committing.

Assert added in 2018.

## Test methodology <!-- How did you ensure quality? -->

Manual.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
