### PR TITLE
Reset pathfilter by disabling checkbox

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -400,7 +400,10 @@ namespace GitUI
         public void SetAndApplyPathFilter(string filter)
         {
             _filterInfo.ByPathFilter = !string.IsNullOrWhiteSpace(filter);
-            _filterInfo.PathFilter = filter;
+            if (_filterInfo.ByPathFilter)
+            {
+                _filterInfo.PathFilter = filter;
+            }
 
             PerformRefreshRevisions();
         }


### PR DESCRIPTION
## Proposed changes

Behave similar to Reset all by disabling the checkbox when the filter is empty.
This makes it simpler to toggle the filter.

## Screenshots <!-- Remove this section if PR does not change UI -->

### After

![image](https://user-images.githubusercontent.com/6248932/166340892-0cde2c81-39ad-49a8-be27-59e09cdd486b.png)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
