### PR TITLE
Show reword commit dialog only once

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2786,14 +2786,11 @@ namespace GitUI
                 LatestSelectedRevision.FirstParentId?.ToString(), interactive: true, preserveMerges: false,
                 autosquash: false, autoStash: true, ignoreDate: false, committerDateIsAuthorDate: false, supportRebaseMerges: Module.GitVersion.SupportRebaseMerges);
 
-            using (FormProcess formProcess = new(UICommands, arguments: rebaseCmd, Module.WorkingDir, input: null, useDialogSettings: true))
+            using FormProcess formProcess = new(UICommands, arguments: rebaseCmd, Module.WorkingDir, input: null, useDialogSettings: true);
+            formProcess.ProcessEnvVariables.Add("GIT_SEQUENCE_EDITOR", string.Format("sed -i -re '0,/pick/s//{0}/'", command));
+            if (formProcess.ShowDialog(ParentForm) != DialogResult.Cancel)
             {
-                formProcess.ProcessEnvVariables.Add("GIT_SEQUENCE_EDITOR", string.Format("sed -i -re '0,/pick/s//{0}/'", command));
-                formProcess.ShowDialog(ParentForm);
-                if (formProcess.ShowDialog(ParentForm) != DialogResult.Cancel)
-                {
-                    PerformRefreshRevisions();
-                }
+                PerformRefreshRevisions();
             }
         }
 


### PR DESCRIPTION
Part of #9987

## Proposed changes

Reword/Edit commit dialog was displayed twice with identical contents.

Regression from 03eadac015d6bbe08118fbafe898d32bf2337cce

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
