### PR TITLE
Refresh regardless of formProcess results

### DIFF
--- a/GitUI/HelperDialogs/FormProcess.cs
+++ b/GitUI/HelperDialogs/FormProcess.cs
@@ -68,6 +68,9 @@ namespace GitUI.HelperDialogs
         {
         }
 
+        // Note that "DialogResult FormProcess.ShowDialog(owner)" may exit when the process (command) finishes,
+        // so that result is other than OK or Cancel.
+
         public static bool ShowDialog(IWin32Window? owner, ArgumentString arguments, string workingDirectory, string? input, bool useDialogSettings, string? process = null)
         {
             Debug.Assert(owner is not null, "Progress window must be owned by another window! This is a bug, please correct and send a pull request with a fix.");

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2788,10 +2788,8 @@ namespace GitUI
 
             using FormProcess formProcess = new(UICommands, arguments: rebaseCmd, Module.WorkingDir, input: null, useDialogSettings: true);
             formProcess.ProcessEnvVariables.Add("GIT_SEQUENCE_EDITOR", string.Format("sed -i -re '0,/pick/s//{0}/'", command));
-            if (formProcess.ShowDialog(ParentForm) != DialogResult.Cancel)
-            {
-                PerformRefreshRevisions();
-            }
+            formProcess.ShowDialog(ParentForm);
+            PerformRefreshRevisions();
         }
 
         #region Drag/drop patch files on revision grid


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9987

## Proposed changes

Refresh also if formProcess returns Cancel, which it supposedly do if autoclosing

No other similar occurrence for FormProcess (or FormRemoteProcess) was seen in a quick review.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy


I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
