### PR TITLE
async conflicted state

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -472,7 +472,7 @@ namespace GitUI.CommandsDialogs
                         new WindowsThumbnailToolbarButton(toolStripButtonPull.Text, toolStripButtonPull.Image, PullToolStripMenuItemClick)));
             }
 
-            this.InvokeAsync(OnActivate).FileAndForget();
+            OnActivateAsync().FileAndForget();
             base.OnActivated(e);
         }
 
@@ -895,7 +895,7 @@ namespace GitUI.CommandsDialogs
 
                 RefreshWorkingDirComboText();
 
-                OnActivate();
+                ThreadHelper.JoinableTaskFactory.RunAsync(OnActivateAsync);
 
                 LoadUserMenu();
 
@@ -1006,13 +1006,13 @@ namespace GitUI.CommandsDialogs
             // TODO: add more
         }
 
-        private void OnActivate()
+        private async Task OnActivateAsync()
         {
             // check if we are in the middle of bisect
-            notificationBarBisectInProgress.RefreshBisect();
+            await notificationBarBisectInProgress.RefreshBisectAsync();
 
             // check if we are in the middle of an action (merge/rebase/etc.)
-            notificationBarGitActionInProgress.RefreshGitAction();
+            await notificationBarGitActionInProgress.RefreshGitActionAsync();
         }
 
         private void UpdateStashCount()

--- a/UnitTests/GitUI.Tests/UserControls/InteractiveGitActionControlTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/InteractiveGitActionControlTests.cs
@@ -1,4 +1,5 @@
-﻿using GitUI.UserControls;
+﻿using GitUI;
+using GitUI.UserControls;
 using NUnit.Framework;
 
 namespace GitUITests.UserControls
@@ -25,7 +26,7 @@ namespace GitUITests.UserControls
         [TestCase(InteractiveGitActionControl.GitAction.None, true)]
         public void SetState(InteractiveGitActionControl.GitAction action, bool conflicts)
         {
-            _accessor.SetGitAction(action, conflicts);
+            ThreadHelper.JoinableTaskFactory.Run(async () => await _accessor.SetGitActionAsync(action, conflicts));
 
             Assert.AreEqual(action, _accessor.Action);
             Assert.AreEqual(conflicts, _accessor.HasConflicts);


### PR DESCRIPTION
At least improves #9223
(cannot reproduce after this change).

## Proposed changes

FormBrowse()->OnActivate() is called in several situations, see #9223.
The Git call and IO calls are performed on the main thread, which should not be done.
(I cannot explain how this improves #9223.)

## Test methodology <!-- How did you ensure quality? -->

Manual:
Advanced-Edit latest commit, Continue (without changes)

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
