### PR TITLE
CommitInfo: Fixup revision links in commit message

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.Designer.cs
+++ b/GitUI/CommitInfo/CommitInfo.Designer.cs
@@ -91,7 +91,7 @@ namespace GitUI.CommitInfo
             this.rtbxCommitMessage.Size = new System.Drawing.Size(440, 20);
             this.rtbxCommitMessage.TabIndex = 1;
             this.rtbxCommitMessage.Text = "";
-            this.rtbxCommitMessage.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfo_LinkClicked);
+            this.rtbxCommitMessage.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.LinkClicked);
             this.rtbxCommitMessage.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextBox_KeyDown);
             this.rtbxCommitMessage.MouseDown += new System.Windows.Forms.MouseEventHandler(this._RevisionHeader_MouseDown);
             // 
@@ -213,7 +213,7 @@ namespace GitUI.CommitInfo
             this.RevisionInfo.Size = new System.Drawing.Size(448, 98);
             this.RevisionInfo.TabIndex = 2;
             this.RevisionInfo.Text = "";
-            this.RevisionInfo.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.RevisionInfo_LinkClicked);
+            this.RevisionInfo.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.LinkClicked);
             this.RevisionInfo.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextBox_KeyDown);
             this.RevisionInfo.MouseDown += new System.Windows.Forms.MouseEventHandler(this._RevisionHeader_MouseDown);
             // 

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -186,11 +186,11 @@ namespace GitUI.CommitInfo
             set => SetRevisionWithChildren(value, null);
         }
 
-        private void RevisionInfo_LinkClicked(object sender, LinkClickedEventArgs e)
+        private void LinkClicked(object sender, LinkClickedEventArgs e)
         {
             try
             {
-                string? linkUri = RevisionInfo.GetLink(e.LinkStart);
+                string? linkUri = ((RichTextBox)sender).GetLink(e.LinkStart);
                 _linkFactory.ExecuteLink(linkUri, commandEventArgs => CommandClickedEvent?.Invoke(sender, commandEventArgs), ShowAll);
             }
             catch (Exception ex)
@@ -885,11 +885,13 @@ namespace GitUI.CommitInfo
                 _commitInfo = commitInfo;
             }
 
+            public RichTextBox CommitMessage => _commitInfo.rtbxCommitMessage;
+
             public RichTextBox RevisionInfo => _commitInfo.RevisionInfo;
 
             public IDictionary<string, int> GetSortedTags() => _commitInfo.GetSortedTags();
 
-            public void RevisionInfo_LinkClicked(object sender, LinkClickedEventArgs e) => _commitInfo.RevisionInfo_LinkClicked(sender, e);
+            public void LinkClicked(object sender, LinkClickedEventArgs e) => _commitInfo.LinkClicked(sender, e);
         }
     }
 }


### PR DESCRIPTION
Fixes #10008

## Proposed changes

- Get link from `sender` casted to `RichTextBox`

## Test methodology <!-- How did you ensure quality? -->

- extended unit test

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 66ce8e99f702e9c0a143cccb759b54ee7562a80d
- Git 2.35.2.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.3
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).