### PR TITLE
Do not throw when cancelling current token

### DIFF
--- a/GitExtUtils/GitUI/CancellationTokenSequence.cs
+++ b/GitExtUtils/GitUI/CancellationTokenSequence.cs
@@ -102,7 +102,14 @@ namespace GitUI
             // Calling Next() will cancel the current operation. Ignoring the return value means
             // an unnecessary CancellationTokenSource is allocated, but it will not be leaked or
             // otherwise interfere with the sequence.
-            Next();
+            try
+            {
+                Next();
+            }
+            catch (OperationCanceledException)
+            {
+                // No action
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #10018

## Proposed changes

Catch OperationCanceledException when canceling tokens.

General change, not just in GitStatusMonitor (that may see this more easily due to the lock used).

## Test methodology <!-- How did you ensure quality? -->

Review

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
