### PR TITLE
`CommitInfo`: Ensure empty line between sections

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -537,7 +537,7 @@ namespace GitUI.CommitInfo
                         if (!string.IsNullOrEmpty(precedingTag))
                         {
                             string tagString = ShowBranchesAsLinks ? _linkFactory.CreateTagLink(precedingTag) : WebUtility.HtmlEncode(precedingTag);
-                            gitDescribeInfo.Append(Environment.NewLine + WebUtility.HtmlEncode(_derivesFromTag.Text) + " " + tagString);
+                            gitDescribeInfo.Append(WebUtility.HtmlEncode(_derivesFromTag.Text) + " " + tagString);
                             if (!string.IsNullOrEmpty(commitCount))
                             {
                                 gitDescribeInfo.Append(" + " + commitCount + " " + WebUtility.HtmlEncode(_plusCommits.Text));
@@ -545,7 +545,7 @@ namespace GitUI.CommitInfo
                         }
                         else
                         {
-                            gitDescribeInfo.Append(Environment.NewLine + WebUtility.HtmlEncode(_derivesFromNoTag.Text));
+                            gitDescribeInfo.Append(WebUtility.HtmlEncode(_derivesFromNoTag.Text));
                         }
 
                         return gitDescribeInfo.ToString();
@@ -589,7 +589,7 @@ namespace GitUI.CommitInfo
                 _branchInfo = _refsFormatter.FormatBranches(_branches, ShowBranchesAsLinks, limit: !_showAllBranches);
             }
 
-            string body = string.Join(Environment.NewLine,
+            string body = string.Join(Environment.NewLine + Environment.NewLine,
                 new[] { _annotatedTagsInfo, _linksInfo, _branchInfo, _tagInfo, _gitDescribeInfo }
                     .Where(_ => !string.IsNullOrEmpty(_)));
 
@@ -610,7 +610,7 @@ namespace GitUI.CommitInfo
                     }
                 }
 
-                return result.ToString();
+                return result.ToString().TrimEnd();
             }
         }
 

--- a/GitUI/CommitInfo/RefsFormatter.cs
+++ b/GitUI/CommitInfo/RefsFormatter.cs
@@ -136,7 +136,7 @@ namespace GitUI.CommitInfo
             if (truncated)
             {
                 sb.AppendLine()
-                  .AppendLine(_linkFactory.CreateShowAllLink(refsType));
+                  .Append(_linkFactory.CreateShowAllLink(refsType));
             }
 
             return sb.ToString();

--- a/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_handle_ShowAll_branches_correctly.approved.txt
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_handle_ShowAll_branches_correctly.approved.txt
@@ -14,6 +14,7 @@ branch12|||gitext://gotobranch/branch12
 branch13|||gitext://gotobranch/branch13
 branch14|||gitext://gotobranch/branch14
 branch15|||gitext://gotobranch/branch15
+
 Contained in tags:
 v1.0|||gitext://gototag/v1.0
 v1.1|||gitext://gototag/v1.1
@@ -26,6 +27,5 @@ v1.7|||gitext://gototag/v1.7
 v1.8|||gitext://gototag/v1.8
 v1.9|||gitext://gototag/v1.9
 [ Show all ]|||gitext://showall/tags
-
 
 Derives from no tag

--- a/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_render_links_correctly.approved.txt
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.ReloadCommitInfo_should_render_links_correctly.approved.txt
@@ -24,5 +24,4 @@ v1.8|||gitext://gototag/v1.8
 v1.9|||gitext://gototag/v1.9
 [ Show all ]|||gitext://showall/tags
 
-
 Derives from no tag

--- a/UnitTests/GitUI.Tests/UserControls/CommitInfo/RefsFormatterTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/CommitInfo/RefsFormatterTests.cs
@@ -97,7 +97,7 @@ namespace GitUITests.UserControls.CommitInfo
 
         private string GetShowAllLink(string type)
         {
-            return $"{Environment.NewLine}<a href='gitext://showall/{type}'>[ {TranslatedStrings.ShowAll} ]</a>{Environment.NewLine}";
+            return $"{Environment.NewLine}<a href='gitext://showall/{type}'>[ {TranslatedStrings.ShowAll} ]</a>";
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

- `CommitInfo`: Ensure that there is exactly one empty line between the sections

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/36601201/172047490-774e11e6-4047-4009-bb83-e48a7f309d93.png)

### After

![image](https://user-images.githubusercontent.com/36601201/172047497-eef1be49-a1f1-4cea-bc6b-da3c26539a1c.png)

## Test methodology <!-- How did you ensure quality? -->

- bugfixed the test, too

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 1589528398e44bc05a6e552908b1d5d637cb9563
- Git 2.35.2.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.3
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).