### PR TITLE
Replace hard-coded `Ctrl+O` shortcuts with `Hotkey`s

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -832,7 +832,6 @@ namespace GitUI.CommandsDialogs
             // 
             this.openToolStripMenuItem.Image = global::GitUI.Properties.Images.RepoOpen;
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
             this.openToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
             this.openToolStripMenuItem.Text = "&Open...";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.OpenToolStripMenuItemClick);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -984,6 +984,7 @@ namespace GitUI.CommandsDialogs
         private void SetShortcutKeyDisplayStringsFromHotkeySettings()
         {
             // Add shortcuts to the menu items
+            openToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.OpenRepo).ToShortcutKeyDisplayString();
             gitBashToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.GitBash).ToShortcutKeyDisplayString();
             commitToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.Commit).ToShortcutKeyDisplayString();
             stashChangesToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.Stash).ToShortcutKeyDisplayString();
@@ -2056,6 +2057,7 @@ namespace GitUI.CommandsDialogs
             FocusPrevTab = 32,
 
             // START menu
+            OpenRepo = 45,
 
             // DASHBOARD menu
 
@@ -2202,6 +2204,7 @@ namespace GitUI.CommandsDialogs
                 case Command.FocusNextTab: FocusNextTab(); break;
                 case Command.FocusPrevTab: FocusNextTab(forward: false); break;
                 case Command.FocusFilter: ToolStripFilters.SetFocus(); break;
+                case Command.OpenRepo: openToolStripMenuItem.PerformClick(); break;
                 case Command.Commit: UICommands.StartCommitDialog(this); break;
                 case Command.AddNotes: AddNotes(); break;
                 case Command.FindFileInSelectedCommit: FindFileInSelectedCommit(); break;

--- a/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
@@ -305,7 +305,6 @@ namespace GitUI.CommandsDialogs
             // 
             this.diffOpenWorkingDirectoryFileWithToolStripMenuItem.Image = global::GitUI.Properties.Images.EditFile;
             this.diffOpenWorkingDirectoryFileWithToolStripMenuItem.Name = "diffOpenWorkingDirectoryFileWithToolStripMenuItem";
-            this.diffOpenWorkingDirectoryFileWithToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
             this.diffOpenWorkingDirectoryFileWithToolStripMenuItem.Size = new System.Drawing.Size(296, 22);
             this.diffOpenWorkingDirectoryFileWithToolStripMenuItem.Text = "&Open working directory file with...";
             this.diffOpenWorkingDirectoryFileWithToolStripMenuItem.Click += new System.EventHandler(this.diffOpenWorkingDirectoryFileWithToolStripMenuItem_Click);

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -136,6 +136,7 @@ namespace GitUI.CommandsDialogs
             FilterFileInGrid = 13,
             SelectFirstGroupChanges = 14,
             FindFile = 15,
+            OpenWorkingDirectoryFileWith = 16,
         }
 
         public CommandStatus ExecuteCommand(Command cmd)
@@ -160,6 +161,7 @@ namespace GitUI.CommandsDialogs
                 case Command.OpenWithDifftool: OpenFilesWithDiffTool(RevisionDiffKind.DiffAB); break;
                 case Command.OpenWithDifftoolFirstToLocal: OpenFilesWithDiffTool(RevisionDiffKind.DiffALocal); break;
                 case Command.OpenWithDifftoolSelectedToLocal: OpenFilesWithDiffTool(RevisionDiffKind.DiffBLocal); break;
+                case Command.OpenWorkingDirectoryFileWith: diffOpenWorkingDirectoryFileWithToolStripMenuItem.PerformClick(); break;
                 case Command.EditFile: diffEditWorkingDirectoryFileToolStripMenuItem.PerformClick(); break;
                 case Command.OpenAsTempFile: diffOpenRevisionFileToolStripMenuItem.PerformClick(); break;
                 case Command.OpenAsTempFileWith: diffOpenRevisionFileWithToolStripMenuItem.PerformClick(); break;
@@ -197,6 +199,7 @@ namespace GitUI.CommandsDialogs
             firstToSelectedToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenWithDifftool);
             firstToLocalToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenWithDifftoolFirstToLocal);
             selectedToLocalToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenWithDifftoolSelectedToLocal);
+            diffOpenWorkingDirectoryFileWithToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenWorkingDirectoryFileWith);
             diffEditWorkingDirectoryFileToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.EditFile);
             diffOpenRevisionFileToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenAsTempFile);
             diffOpenRevisionFileWithToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenAsTempFileWith);

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
@@ -256,7 +256,6 @@
             // 
             this.openWithToolStripMenuItem.Image = global::GitUI.Properties.Images.EditFile;
             this.openWithToolStripMenuItem.Name = "openWithToolStripMenuItem";
-            this.openWithToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
             this.openWithToolStripMenuItem.Size = new System.Drawing.Size(325, 22);
             this.openWithToolStripMenuItem.Text = "Open working directory file with...";
             this.openWithToolStripMenuItem.Click += new System.EventHandler(this.openWithToolStripMenuItem_Click);

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -258,6 +258,7 @@ See the changes in the commit form.");
             EditFile = 5,
             FilterFileInGrid = 6,
             FindFile = 7,
+            OpenWorkingDirectoryFileWith = 8,
         }
 
         public CommandStatus ExecuteCommand(Command cmd)
@@ -274,6 +275,7 @@ See the changes in the commit form.");
                 case Command.OpenWithDifftool: openWithDifftoolToolStripMenuItem.PerformClick(); break;
                 case Command.OpenAsTempFile: openFileToolStripMenuItem.PerformClick(); break;
                 case Command.OpenAsTempFileWith: openFileWithToolStripMenuItem.PerformClick(); break;
+                case Command.OpenWorkingDirectoryFileWith: openWithToolStripMenuItem.PerformClick(); break;
                 case Command.EditFile: editCheckedOutFileToolStripMenuItem.PerformClick(); break;
                 case Command.FilterFileInGrid: filterFileInGridToolStripMenuItem.PerformClick(); break;
                 case Command.FindFile: findToolStripMenuItem.PerformClick(); break;
@@ -299,6 +301,7 @@ See the changes in the commit form.");
             openWithDifftoolToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenWithDifftool);
             openFileToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenAsTempFile);
             openFileWithToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenAsTempFileWith);
+            openWithToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.OpenWorkingDirectoryFileWith);
             editCheckedOutFileToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.EditFile);
             filterFileInGridToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.FilterFileInGrid);
             findToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.FindFile);

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -288,6 +288,7 @@ namespace GitUI.Hotkey
                     Hk(FormBrowse.Command.OpenAsTempFile, OpenAsTempFileHotkey),
                     Hk(FormBrowse.Command.OpenAsTempFileWith, OpenAsTempFileWithHotkey),
                     Hk(FormBrowse.Command.OpenCommitsWithDifftool, Keys.None),
+                    Hk(FormBrowse.Command.OpenRepo, Keys.Control | Keys.O),
                     Hk(FormBrowse.Command.OpenSettings, Keys.Control | Keys.Oemcomma),
                     Hk(FormBrowse.Command.OpenWithDifftool, OpenWithDifftoolHotkey),
                     Hk(FormBrowse.Command.OpenWithDifftoolFirstToLocal, OpenWithDifftoolFirstToLocalHotkey),
@@ -389,6 +390,7 @@ namespace GitUI.Hotkey
                     Hk(RevisionDiffControl.Command.OpenWithDifftool, OpenWithDifftoolHotkey),
                     Hk(RevisionDiffControl.Command.OpenWithDifftoolFirstToLocal, OpenWithDifftoolFirstToLocalHotkey),
                     Hk(RevisionDiffControl.Command.OpenWithDifftoolSelectedToLocal, OpenWithDifftoolSelectedToLocalHotkey),
+                    Hk(RevisionDiffControl.Command.OpenWorkingDirectoryFileWith, Keys.Control | Keys.O),
                     Hk(RevisionDiffControl.Command.ResetSelectedFiles, Keys.R),
                     Hk(RevisionDiffControl.Command.SelectFirstGroupChanges, Keys.Control | Keys.A),
                     Hk(RevisionDiffControl.Command.ShowFileTree, Keys.T),
@@ -404,6 +406,7 @@ namespace GitUI.Hotkey
                     Hk(RevisionFileTreeControl.Command.OpenAsTempFile, OpenAsTempFileHotkey),
                     Hk(RevisionFileTreeControl.Command.OpenAsTempFileWith, OpenAsTempFileWithHotkey),
                     Hk(RevisionFileTreeControl.Command.OpenWithDifftool, OpenWithDifftoolHotkey),
+                    Hk(RevisionFileTreeControl.Command.OpenWorkingDirectoryFileWith, Keys.Control | Keys.O),
                     Hk(RevisionFileTreeControl.Command.ShowHistory, ShowHistoryHotkey)),
                 new HotkeySettings(
                     FormStash.HotkeySettingsName,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10004

## Proposed changes

- Replace hard-coded `Ctrl+O` shortcuts with configurable `Hotkey`s

## Screenshots <!-- Remove this section if PR does not change UI -->

### After

![image](https://user-images.githubusercontent.com/36601201/172056607-f7ff29ee-6f9d-4ee3-bb13-1d77a609a3cf.png)

![image](https://user-images.githubusercontent.com/36601201/172056632-a401dc19-fb29-4725-9cda-54d60b8bedef.png)

![image](https://user-images.githubusercontent.com/36601201/172056651-4227cc12-372c-4015-b700-762d7a84f13f.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).