### PR TITLE
Update menu items and toolbar buttons unconditionally

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -604,7 +604,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            Debug.Assert(RevisionGrid.CanRefresh, "Already loading revisions when running RefreshRevisions(). This could cause the commits in the grid to be loaded several times.");
+            Debug.Assert(!RevisionGrid.IsRefreshingRevisions, "Already loading revisions when running RefreshRevisions(). This could cause the commits in the grid to be loaded several times.");
             RevisionGrid.PerformRefreshRevisions(getRefs, forceRefresh: true);
 
             InternalInitialize();

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -512,7 +512,6 @@ namespace GitUI.UserControls.RevisionGrid
 
         public void MarkAsDataLoading()
         {
-            Debug.Assert(IsDataLoadComplete, "The grid is already marked as 'data load in process'.");
             IsDataLoadComplete = false;
         }
 


### PR DESCRIPTION
Fixes #10009

## Proposed changes

- `RevisionGridControl.PerformRefreshRevisions` must not skip the execution when still refreshing due to a former request!
   Cancel the outdated refresh instead.
   Of course, this does not apply if `SuspendRefreshRevisions` has been called before.
- `RevisionDataGridView.MarkAsDataLoading` must not complain after a refresh was canceled, i.e. has not been marked as complete yet.

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 55275b0c648afa4b25c8d649323c5904c88c3b76
- Git 2.35.2.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.3
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).