### PR TITLE
RevisionGrid: Cleanup PerformRefreshRevisions

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -604,7 +604,6 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            Debug.Assert(RevisionGrid.CanRefresh, "Already loading revisions when running RefreshRevisions(). This could cause the commits in the grid to be loaded several times.");
             RevisionGrid.PerformRefreshRevisions(getRefs, forceRefresh: true);
 
             InternalInitialize();

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -502,12 +502,12 @@ namespace GitUI.UserControls.RevisionGrid
             }
 
             return;
+        }
 
-            void MarkAsDataLoadingComplete()
-            {
-                Debug.Assert(!IsDataLoadComplete, "The grid is already marked as 'data load complete'.");
-                IsDataLoadComplete = true;
-            }
+        public void MarkAsDataLoadingComplete()
+        {
+            Debug.Assert(!IsDataLoadComplete, "The grid is already marked as 'data load complete'.");
+            IsDataLoadComplete = true;
         }
 
         public void MarkAsDataLoading()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #

## Proposed changes

- Raise questions about `_isRefreshingRevisions` and `cancellationToken`
- Avoid dangling tasks waiting for `semaphoreCurrentCommit` (might contribute to #9830)
- Exception-safe locking of `semaphoreCurrentCommit`
- Fixup typo in `UpdateSelectedRef` argument
- TODO: It is highly desirable that loading the revisions becomes cancellable.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->

## Test methodology <!-- How did you ensure quality? -->

- 
- 
- 

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build a66f50670d4b724937f49cb7155b0904660d23dd
- Git 2.35.2.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.3
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).