### PR TITLE
FormDiff: Set HEAD for diff calculator

### DIFF
--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -68,9 +68,10 @@ namespace GitUI.CommandsDialogs
             _baseRevision = new GitRevision(baseId);
             _headRevision = new GitRevision(headId);
 
-            ObjectId? baseMergeId = baseId.IsArtificial ? Module.GetCurrentCheckout() : baseId;
-            ObjectId? headMergeId = headId.IsArtificial ? Module.GetCurrentCheckout() : headId;
-            if (baseMergeId is null || headMergeId is null)
+            Lazy<ObjectId?> head = new(() => Module.GetCurrentCheckout());
+            ObjectId? baseMergeId = baseId.IsArtificial ? head.Value : baseId;
+            ObjectId? headMergeId = headId.IsArtificial ? head.Value : headId;
+            if (baseMergeId is null || headMergeId is null || baseMergeId == headMergeId)
             {
                 _mergeBase = null;
             }
@@ -144,7 +145,7 @@ namespace GitUI.CommandsDialogs
                 revisions = new[] { _headRevision, _baseRevision };
             }
 
-            DiffFiles.SetDiffs(revisions, Module.GetCurrentCheckout());
+            DiffFiles.SetDiffs(revisions);
 
             // Bug in git-for-windows: Comparing working directory to any branch, fails, due to -R
             // I.e., git difftool --gui --no-prompt --dir-diff -R HEAD fails, but

--- a/GitUI/CommandsDialogs/FormLog.cs
+++ b/GitUI/CommandsDialogs/FormLog.cs
@@ -60,7 +60,7 @@ namespace GitUI.CommandsDialogs
         {
             using (WaitCursorScope.Enter())
             {
-                DiffFiles.SetDiffs(RevisionGrid.GetSelectedRevisions(), RevisionGrid.CurrentCheckout);
+                DiffFiles.SetDiffs(RevisionGrid.GetSelectedRevisions());
             }
         }
 

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -52,7 +52,7 @@ namespace GitUI.UserControls
 
             if (revision is not null)
             {
-                DiffFiles.SetDiffs(new[] { revision }, Module.GetCurrentCheckout());
+                DiffFiles.SetDiffs(new[] { revision });
                 if (fileToSelect is not null)
                 {
                     var itemToSelect = DiffFiles.AllItems.FirstOrDefault(i => i.Item.Name == fileToSelect);

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -52,7 +52,7 @@ namespace GitUI.UserControls
 
             if (revision is not null)
             {
-                DiffFiles.SetDiffs(new[] { revision }, headId: null);
+                DiffFiles.SetDiffs(new[] { revision }, Module.GetCurrentCheckout());
                 if (fileToSelect is not null)
                 {
                     var itemToSelect = DiffFiles.AllItems.FirstOrDefault(i => i.Item.Name == fileToSelect);

--- a/GitUI/UserControls/FileStatusDiffCalculator.FileStatusDiffCalculatorInfo.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.FileStatusDiffCalculatorInfo.cs
@@ -10,6 +10,7 @@ namespace GitUI
         {
             public IReadOnlyList<GitRevision> Revisions { get; set; }
             public ObjectId? HeadId { get; set; }
+            public bool AllowMultiDiff { get; set; }
         }
     }
 }

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -697,10 +697,10 @@ namespace GitUI
             _nextIndexToSelect = -1;
         }
 
-        public void SetDiffs(IReadOnlyList<GitRevision> revisions, ObjectId? headId)
+        public void SetDiffs(IReadOnlyList<GitRevision> revisions)
         {
             _enableDisablingShowDiffForAllParents = true;
-            GitItemStatusesWithDescription = _diffCalculator.SetDiffs(revisions, headId, cancellationToken: default);
+            GitItemStatusesWithDescription = _diffCalculator.SetDiffs(revisions, headId: null, allowMultiDiff: false, cancellationToken: default);
         }
 
         public async Task SetDiffsAsync(IReadOnlyList<GitRevision> revisions, ObjectId? headId, CancellationToken cancellationToken)
@@ -711,7 +711,7 @@ namespace GitUI
 
             await TaskScheduler.Default;
             cancellationToken.ThrowIfCancellationRequested();
-            IReadOnlyList<FileStatusWithDescription> gitItemStatusesWithDescription = _diffCalculator.SetDiffs(revisions, headId, cancellationToken);
+            IReadOnlyList<FileStatusWithDescription> gitItemStatusesWithDescription = _diffCalculator.SetDiffs(revisions, headId, allowMultiDiff: true, cancellationToken);
 
             await this.SwitchToMainThreadAsync(cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
## Proposed changes

FormDiff: Set HEAD for diff calculator, causing a popup 
The core problem is that HEAD is set incorrectly, could be artificial.

![image](https://user-images.githubusercontent.com/6248932/176555548-81caaa7f-f8fb-4156-a3ca-c1c1176a4814.png)

Set merge base also when artificial commits are selected

Regression in master.

## Test methodology <!-- How did you ensure quality? -->

manual 

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
