### PR TITLE
Blame: No change of control at double click

### DIFF
--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -69,7 +69,6 @@ namespace GitUI.Blame
             BlameFile.IsReadOnly = true;
             BlameFile.VScrollPositionChanged += BlameFile_VScrollPositionChanged;
             BlameFile.SelectedLineChanged += SelectedLineChanged;
-            BlameFile.RequestDiffView += ActiveTextAreaControlDoubleClick;
             BlameFile.MouseMove += BlameFile_MouseMove;
             BlameFile.EscapePressed += () => EscapePressed?.Invoke();
             BlameFile.EnableAutomaticContinuousScroll = false;


### PR DESCRIPTION
https://github.com/gitextensions/gitextensions/issues/9796#issuecomment-1150520616

## Proposed changes

Changes the default behavior, to change the revision the left gutter
must be clicked.
If changing the default behavior change is not acceptable here, there are altaernatives:
* Add a setting to continue allowing this. (default off - where?)
* Add a popup confirming the behavior at first use.

I prefer the simple solution, as is.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
