### PR TITLE
Exclude boundary commits with --grep

### DIFF
--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3256,7 +3256,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="tsmiCommitFilter.Text">
-        <source>Commit &amp;message and hash</source>
+        <source>Commit &amp;message</source>
         <target />
       </trans-unit>
       <trans-unit id="tsmiCommitterFilter.Text">

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -45,7 +45,7 @@ namespace GitUI.UserControls
             this.tsmiCommitFilter.Checked = true;
             this.tsmiCommitFilter.CheckOnClick = true;
             this.tsmiCommitFilter.Name = "tsmiCommitFilter";
-            this.tsmiCommitFilter.Text = "Commit &message and hash";
+            this.tsmiCommitFilter.Text = "Commit &message";
             // 
             // tsmiCommitter
             // 

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -114,19 +114,26 @@ namespace GitUI.UserControls.RevisionGrid
             get
             {
                 RefFilterOptions refFilterOptions;
-                if (!ByBranchFilter)
+                if (!string.IsNullOrWhiteSpace(Message))
                 {
+                    refFilterOptions = RefFilterOptions.None;
+                }
+                else if (!ByBranchFilter)
+                {
+                    // Include parents to matches
                     refFilterOptions = RefFilterOptions.All | RefFilterOptions.Boundary;
                 }
                 else if (ShowCurrentBranchOnly)
                 {
                     refFilterOptions = RefFilterOptions.None;
                 }
+                else if (BranchFilter.Length > 0)
+                {
+                    refFilterOptions = RefFilterOptions.Branches;
+                }
                 else
                 {
-                    refFilterOptions = BranchFilter.Length > 0
-                        ? RefFilterOptions.Branches
-                        : RefFilterOptions.All | RefFilterOptions.Boundary;
+                    refFilterOptions = RefFilterOptions.All | RefFilterOptions.Boundary;
                 }
 
                 const RefFilterOptions gitNotesOptions = RefFilterOptions.All | RefFilterOptions.Boundary;

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -80,7 +80,6 @@ namespace GitUI.UserControls.RevisionGrid
 
         public int CommitsLimitDefault => AppSettings.MaxRevisionGraphCommits;
 
-        [System.Diagnostics.DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public int CommitsLimit
         {
             get => ByCommitsLimit && _commitsLimit >= 0 ? _commitsLimit : CommitsLimitDefault;

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -80,6 +80,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         public int CommitsLimitDefault => AppSettings.MaxRevisionGraphCommits;
 
+        [System.Diagnostics.DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public int CommitsLimit
         {
             get => ByCommitsLimit && _commitsLimit >= 0 ? _commitsLimit : CommitsLimitDefault;

--- a/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
@@ -80,6 +80,7 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
 
             RunSetAndApplyBranchFilterTest(
                 initialFilter: "",
+                grepMessage: "",
                 revisionGridControl =>
                 {
                     Assert.False(AppSettings.BranchFilterEnabled);
@@ -94,6 +95,7 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
 
             RunSetAndApplyBranchFilterTest(
                 initialFilter: "Branch1",
+                grepMessage: "",
                 revisionGridControl =>
                 {
                     Assert.True(AppSettings.BranchFilterEnabled);
@@ -105,6 +107,21 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
 
                     revisionGridControl.CurrentFilter.RefFilterOptions.Should().Be(RefFilterOptions.Branches);
                 });
+
+            RunSetAndApplyBranchFilterTest(
+                initialFilter: "",
+                grepMessage: "Commit1",
+                revisionGridControl =>
+                {
+                    Assert.False(AppSettings.BranchFilterEnabled);
+                    Assert.False(AppSettings.ShowCurrentBranchOnly);
+
+                    Assert.True(revisionGridControl.CurrentFilter.IsShowAllBranchesChecked);
+                    Assert.False(revisionGridControl.CurrentFilter.IsShowCurrentBranchOnlyChecked);
+                    Assert.False(revisionGridControl.CurrentFilter.IsShowFilteredBranchesChecked);
+
+                    revisionGridControl.CurrentFilter.RefFilterOptions.Should().Be(RefFilterOptions.None);
+                });
         }
 
         [Test]
@@ -114,7 +131,8 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
             AppSettings.ShowCurrentBranchOnly = false;
 
             RunSetAndApplyBranchFilterTest(
-                "",
+                initialFilter: "",
+                grepMessage: "",
                 revisionGridControl =>
                 {
                     WaitForRevisionsToBeLoaded(revisionGridControl);
@@ -144,7 +162,8 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
             AppSettings.ShowCurrentBranchOnly = false;
 
             RunSetAndApplyBranchFilterTest(
-                "Branch1",
+                initialFilter: "Branch1",
+                grepMessage: "",
                 revisionGridControl =>
                 {
                     WaitForRevisionsToBeLoaded(revisionGridControl);
@@ -307,7 +326,7 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                 });
         }
 
-        private void RunSetAndApplyBranchFilterTest(string initialFilter, Action<RevisionGridControl> runTest)
+        private void RunSetAndApplyBranchFilterTest(string initialFilter, string grepMessage, Action<RevisionGridControl> runTest)
         {
             // Disable artificial commits as they appear to destabilise these tests
             AppSettings.RevisionGraphShowArtificialCommits = false;
@@ -323,6 +342,8 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
 
                     formBrowse.RevisionGridControl.SetSelectedRevision(ObjectId.Parse(_headCommit)).Should().BeTrue();
 
+                    formBrowse.RevisionGridControl.CurrentFilter.ByMessage = !string.IsNullOrWhiteSpace(grepMessage);
+                    formBrowse.RevisionGridControl.CurrentFilter.Message = grepMessage;
                     formBrowse.RevisionGridControl.SetAndApplyBranchFilter(initialFilter);
 
                     // wait for the revisions to be loaded


### PR DESCRIPTION
Fixes #10074

## Proposed changes

git-log --boundary and --all is included in many revision listings. (The options are currently used together.)
This basically means that the parent to matches is included. This may be desired in some situations, but not with `--grep`.

It is not obvious that --boundary and --grep should be used where they are used now.
Similarly, -all may still be used with --grep. (I do not see how that is used at all though.)
The options can be tuned and expanded in general...

Also fixed the label for search.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/180081144-75175f37-307f-41de-8d68-8848cf280493.png)

![image](https://user-images.githubusercontent.com/6248932/180083947-77537e58-6922-4230-91ca-33a6f9a9cade.png)

### After

![image](https://user-images.githubusercontent.com/6248932/180081238-aeacc9cf-b588-4766-8be9-9e2e33f27eb0.png)

![image](https://user-images.githubusercontent.com/6248932/180084147-e6dde402-f1d4-4470-9ca4-7a84e8afe590.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
