### PR TITLE
Improve the clarity of tooltips for Rebase UI date options

### DIFF
--- a/GitUI/CommandsDialogs/FormRebase.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRebase.Designer.cs
@@ -285,7 +285,7 @@ namespace GitUI.CommandsDialogs
             this.chkIgnoreDate.Size = new System.Drawing.Size(86, 19);
             this.chkIgnoreDate.TabIndex = 16;
             this.chkIgnoreDate.Text = "Ignore &date";
-            this.toolTip1.SetToolTip(this.chkIgnoreDate, "Changes the author dates of the commits in this branch\r\ninto the commit dates.");
+            this.toolTip1.SetToolTip(this.chkIgnoreDate, "Sets the author date to the current date (same as\r\ncommit date), ignoring the original author date.");
             this.chkIgnoreDate.UseVisualStyleBackColor = true;
             this.chkIgnoreDate.CheckedChanged += new System.EventHandler(this.chkIgnoreDate_CheckedChanged);
             // 
@@ -298,8 +298,7 @@ namespace GitUI.CommandsDialogs
             this.chkCommitterDateIsAuthorDate.Size = new System.Drawing.Size(185, 19);
             this.chkCommitterDateIsAuthorDate.TabIndex = 17;
             this.chkCommitterDateIsAuthorDate.Text = "Co&mmitter date is author date";
-            this.toolTip1.SetToolTip(this.chkCommitterDateIsAuthorDate, "Changes the committer dates of the commits in this branch\r\ninto the author dates." +
-        "");
+            this.toolTip1.SetToolTip(this.chkCommitterDateIsAuthorDate, "Sets the commit date to the original author date\r\n(instead of the current date).");
             this.chkCommitterDateIsAuthorDate.UseVisualStyleBackColor = true;
             this.chkCommitterDateIsAuthorDate.CheckedChanged += new System.EventHandler(this.chkCommitterDateIsAuthorDate_CheckedChanged);
             // 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7708 (latest comments about the tooltip clarity)

## Proposed changes

- Improve the clarity of tooltips for Rebase UI date options:
  - Ignore date
  - Committer date is author date
- Also, shorten the width of the tooltip by breaking text somewhere in the middle.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/6047296/180402040-173af849-220a-4850-b147-0d995dc667ae.png)
![image](https://user-images.githubusercontent.com/6047296/180402066-e8b97288-54c7-4f56-b24a-fad452521c67.png)

### After

![image](https://user-images.githubusercontent.com/6047296/180405869-a712143b-85ee-478b-a54c-b67b10f674fc.png) ~13% narrower
![image](https://user-images.githubusercontent.com/6047296/180405915-b76c10fd-1d4f-493b-bdcd-d50f1eab9abc.png) ~19% narrower

## Test methodology

- Open the Rebase UI using Commands > Rebase...
- Hover on the two mentioned check boxes (date options).
- Observe the tooltips.

## Test environment(s)

- Git Extensions 4.1.0.14867
- Build 2c3150d01d9c76bd13c72a742c26ceafcbf9eb64 (Dirty)
- Git 2.33.0.windows.1 (recommended: 2.35.0 or later)
- Microsoft Windows NT 10.0.19043.0
- .NET 6.0.6
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).

CC: @gerhardol for your review please.