### PR TITLE
RevGrid: Optimize onlyFirstParent handling

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -881,6 +881,7 @@ namespace GitUI
             bool firstRevisionReceived = false;
             bool headIsHandled = false;
             bool hasAnyNotes = false;
+            bool onlyFirstParent = false;
 
             // getRefs (refreshing from Browse) is Lazy already, but not from RevGrid (updating filters etc)
             Lazy<IReadOnlyList<IGitRef>> getUnfilteredRefs = new(() => (getRefs ?? capturedModule.GetRefs)(RefsFilter.NoFilter));
@@ -956,6 +957,7 @@ namespace GitUI
 
                     // optimize for no notes at all
                     hasAnyNotes = AppSettings.ShowGitNotes && getUnfilteredRefs.Value.Any(i => i.CompleteName == GitRefName.RefsNotesPrefix);
+                    onlyFirstParent = _filterInfo.RefFilterOptions.HasFlag(RefFilterOptions.FirstParent);
 
                     // Allow add revisions to the grid
                     semaphoreUpdateGrid.Release();
@@ -1167,7 +1169,7 @@ namespace GitUI
                     flags |= RevisionNodeFlags.HasRef;
                 }
 
-                if (_filterInfo.RefFilterOptions.HasFlag(RefFilterOptions.FirstParent))
+                if (onlyFirstParent)
                 {
                     flags |= RevisionNodeFlags.OnlyFirstParent;
                 }


### PR DESCRIPTION
## Proposed changes

Further optimizations loading revisions, while adding revisions to the grid (while 'Loading' is shown).

Measuring with StopWatch in a Release builds, this measures <1 ms vs 30-60 ms.

Note: `_gridView.Add(revision, flags);` requires 250 ms for me which is actually less than I expected.
There may still be optimizations there, but I doubt it will be much. (Maybe the GUI updates can be improved more.)
The refs datastructure could maybe be improved too, but that is only about 10 ms, so not much gain.

Further loading improvements should be possible with caching of commands affected by worktree/index changes, which is tricky.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
