### PR TITLE
Select remote branch on Alt+Click in side panel

### DIFF
--- a/GitUI/BranchTreePanel/BaseBranchNode.cs
+++ b/GitUI/BranchTreePanel/BaseBranchNode.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using GitCommands;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Properties;
 
@@ -30,6 +31,8 @@ namespace GitUI.BranchTreePanel
         }
 
         protected string? AheadBehind { get; set; }
+
+        protected string? RelatedBranch { get; set; }
 
         /// <summary>
         /// Short name of the branch/branch path. <example>"issue1344"</example>.
@@ -64,9 +67,10 @@ namespace GitUI.BranchTreePanel
                 && (ReferenceEquals(other, this) || string.Equals(FullPath, other.FullPath));
         }
 
-        public void UpdateAheadBehind(string aheadBehindData)
+        public void UpdateAheadBehind(string aheadBehindData, string relatedBranch)
         {
             AheadBehind = aheadBehindData;
+            RelatedBranch = relatedBranch;
         }
 
         public bool Rebase()
@@ -114,7 +118,9 @@ namespace GitUI.BranchTreePanel
         {
             TreeViewNode.TreeView?.BeginInvoke(new Action(() =>
             {
-                UICommands.BrowseGoToRef(FullPath, showNoRevisionMsg: true, toggleSelection: RepoObjectsTree.ModifierKeys.HasFlag(Keys.Control));
+                string branch = RelatedBranch is null || !RepoObjectsTree.ModifierKeys.HasFlag(Keys.Alt)
+                    ? FullPath : RelatedBranch.Substring(startIndex: GitRefName.RefsRemotesPrefix.Length);
+                UICommands.BrowseGoToRef(branch, showNoRevisionMsg: true, toggleSelection: RepoObjectsTree.ModifierKeys.HasFlag(Keys.Control));
                 TreeViewNode.TreeView?.Focus();
             }));
         }

--- a/GitUI/BranchTreePanel/BranchTree.cs
+++ b/GitUI/BranchTreePanel/BranchTree.cs
@@ -100,9 +100,9 @@ namespace GitUI.BranchTreePanel
                 bool isVisible = !IsFiltering.Value || _refsSource.Contains(branch.ObjectId);
                 LocalBranchNode localBranchNode = new(this, branch.ObjectId, branch.Name, branch.Name == currentBranch, isVisible);
 
-                if (aheadBehindData is not null && aheadBehindData.ContainsKey(localBranchNode.FullPath))
+                if (aheadBehindData is not null && aheadBehindData.TryGetValue(localBranchNode.FullPath, out AheadBehindData aheadBehind))
                 {
-                    localBranchNode.UpdateAheadBehind(aheadBehindData[localBranchNode.FullPath].ToDisplay());
+                    localBranchNode.UpdateAheadBehind(aheadBehind.ToDisplay(), aheadBehind.RemoteRef);
                 }
 
                 var parent = localBranchNode.CreateRootNode(pathToNode, (tree, parentPath) => new BranchPathNode(tree, parentPath));


### PR DESCRIPTION
Fixes #9194

## Proposed changes

When Alt+Click on local branches in the sidepanel, select the tracked remote branch.
Simplify finding remote tracked branches (to for instance find differences).

For branches with no tracked remote the local is selected as before.

Note Ctrl+Alt+Click is not handled now. Should that toggle the remote branch status?
(commit message is not correct right now)

Discussed in #9194.
Cherry-picked from @mstv private branch, with a minor adjustment

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The local branch was always selected.

### After

One normal click selecting the same branch, one alt-click to select the remote branch revision.

![i9194-alt-click](https://user-images.githubusercontent.com/6248932/180665442-c9b1f3b5-8ab6-4c89-80e4-5867d9076ab7.gif)


## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
