### PR TITLE
fix: Cannot cherry-pick new file from stash

### DIFF
--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -465,7 +465,7 @@ namespace GitUI.CommandsDialogs
 
         private void ContextMenuStripStashedFiles_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            cherryPickFileChangesToolStripMenuItem.Enabled = Stashed.SelectedItems.Count() == 1;
+            cherryPickFileChangesToolStripMenuItem.Enabled = Stashed.SelectedItems.Count() == 1 && View.SupportLinePatching;
         }
     }
 }

--- a/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -99,14 +99,7 @@ namespace GitUI.CommandsDialogs
 
         public bool ShouldShowMenuCherryPick(ContextMenuSelectionInfo selectionInfo)
         {
-            return selectionInfo.SelectedGitItemCount == 1
-                && !selectionInfo.IsAnySubmodule
-                && !selectionInfo.IsDisplayOnlyDiff
-                && !selectionInfo.IsBareRepository
-                && selectionInfo.AllFilesExist
-                && selectionInfo.SupportPatches
-                && !(selectionInfo.IsAnyItemWorkTree || selectionInfo.IsAnyItemIndex)
-                && !(selectionInfo.SelectedRevision?.IsArtificial ?? false);
+            return selectionInfo.SupportPatches;
         }
 
         // Stage/unstage must limit the selected items, IsStaged is not reflecting Staged status

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1539,24 +1539,43 @@ namespace GitUI.Editor
             }
 
             byte[]? patch;
-            if (reverse)
+
+            Validates.NotNull(_viewItem);
+            if (_viewItem.Item.IsNew)
             {
-                patch = PatchManager.GetResetWorkTreeLinesAsPatch(
+                var treeGuid = reverse ? _viewItem.Item.TreeGuid?.ToString() : null;
+                patch = PatchManager.GetSelectedLinesAsNewPatch(
                     Module,
+                    _viewItem.Item.Name,
                     GetText(),
                     selectionStart,
                     selectionLength,
-                    Encoding);
+                    Encoding,
+                    reset: reverse,
+                    FilePreamble,
+                    treeGuid);
             }
             else
             {
-                patch = PatchManager.GetSelectedLinesAsPatch(
-                    GetText(),
-                    selectionStart,
-                    selectionLength,
-                    false,
-                    Encoding,
-                    false);
+                if (reverse)
+                {
+                    patch = PatchManager.GetResetWorkTreeLinesAsPatch(
+                        Module,
+                        GetText(),
+                        selectionStart,
+                        selectionLength,
+                        Encoding);
+                }
+                else
+                {
+                    patch = PatchManager.GetSelectedLinesAsPatch(
+                        GetText(),
+                        selectionStart,
+                        selectionLength,
+                        false,
+                        Encoding,
+                        false);
+                }
             }
 
             if (patch is null || patch.Length == 0)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -985,14 +985,22 @@ namespace GitUI.Editor
                 && (fileName.EndsWith(".diff", StringComparison.OrdinalIgnoreCase)
                     || fileName.EndsWith(".patch", StringComparison.OrdinalIgnoreCase)))
             {
+                // Override the set view mode
                 _viewMode = ViewMode.FixedDiff;
             }
 
-            SupportLinePatching = ((IsDiffView(_viewMode) && (text?.Contains("@@") ?? false)
+            SupportLinePatching =
+
+                // Diffs, currently requires that the file to update exists
+                ((IsDiffView(_viewMode) && (text?.Contains("@@") ?? false)
                         && File.Exists(_fullPathResolver.Resolve(fileName)))
+
+                // New files, patches only applies for artificial or if the file does not exist
                     || ((item?.Item.IsNew ?? false)
                         && ((item.Item.Staged is StagedStatus.WorkTree or StagedStatus.Index)
                             || !File.Exists(_fullPathResolver.Resolve(fileName)))))
+
+                // No patching allowed if no worktree
                 && !Module.IsBareRepository();
 
             SetVisibilityDiffContextMenu(_viewMode);

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
@@ -131,7 +131,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void BrowseDiff_MainMenus_NoSelection()
         {
-            var selectionInfo = CreateContextMenuSelectionInfo(selectedGitItemCount: 0, allFilesExist: false, isAnyTracked: false);
+            var selectionInfo = CreateContextMenuSelectionInfo(selectedGitItemCount: 0, allFilesExist: false, isAnyTracked: false, supportPatches: false);
             _controller.ShouldShowMenuSaveAs(selectionInfo).Should().BeFalse();
             _controller.ShouldShowMenuCherryPick(selectionInfo).Should().BeFalse();
             _controller.ShouldShowMenuStage(selectionInfo).Should().BeFalse();
@@ -174,7 +174,6 @@ namespace GitUITests.CommandsDialogs
             GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(selectedRevision: rev, selectedGitItemCount: t);
             _controller.ShouldShowMenuSaveAs(selectionInfo).Should().Be(t != 0);
-            _controller.ShouldShowMenuCherryPick(selectionInfo).Should().Be(t != 0);
             _controller.ShouldShowMenuStage(selectionInfo).Should().BeFalse();
             _controller.ShouldShowMenuUnstage(selectionInfo).Should().BeFalse();
             _controller.ShouldShowSubmoduleMenus(selectionInfo).Should().BeFalse();
@@ -267,7 +266,6 @@ namespace GitUITests.CommandsDialogs
             GitRevision rev = new(ObjectId.Random());
             var selectionInfo = CreateContextMenuSelectionInfo(rev, isDisplayOnlyDiff: t);
             _controller.ShouldShowMenuSaveAs(selectionInfo).Should().Be(!t);
-            _controller.ShouldShowMenuCherryPick(selectionInfo).Should().Be(!t);
             _controller.ShouldShowMenuOpenRevision(selectionInfo).Should().Be(!t);
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

Fix bug when cherry-picking from stash a new file. Currently when action is performed nothing happens. 

That happens because we cannot internally resolve diff chunks in a new file.

## Test methodology <!-- How did you ensure quality? -->

Manual testing

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
