### PR TITLE
Show tags by default in side panel

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1861,7 +1861,7 @@ namespace GitCommands
 
         public static bool RepoObjectsTreeShowTags
         {
-            get => GetBool("RepoObjectsTree.ShowTags", false);
+            get => GetBool("RepoObjectsTree.ShowTags", true);
             set => SetBool("RepoObjectsTree.ShowTags", value);
         }
 

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -329,7 +329,7 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.DiffListSorting)], DiffListSortType.FilePath, false, false);
                 yield return (properties[nameof(AppSettings.RepoObjectsTreeShowBranches)], true, false, false);
                 yield return (properties[nameof(AppSettings.RepoObjectsTreeShowRemotes)], true, false, false);
-                yield return (properties[nameof(AppSettings.RepoObjectsTreeShowTags)], false, false, false);
+                yield return (properties[nameof(AppSettings.RepoObjectsTreeShowTags)], true, false, false);
                 yield return (properties[nameof(AppSettings.RepoObjectsTreeShowSubmodules)], true, false, false);
                 yield return (properties[nameof(AppSettings.RepoObjectsTreeBranchesIndex)], 0, false, false);
                 yield return (properties[nameof(AppSettings.RepoObjectsTreeRemotesIndex)], 1, false, false);


### PR DESCRIPTION
## Proposed changes

At new installations:
Tags in sidepanel seem to be hard to find - even if the settings now have changed to buttons
( a bad move, removed useful area for something never changed)
https://github.com/gitextensions/gitextensions/issues/5460#issuecomment-423133032

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/181999746-a8e82708-dd6b-4a69-a3fb-f0547744e1c7.png)

### After

![image](https://user-images.githubusercontent.com/6248932/181999866-1f528307-ac4a-475e-8622-bf7d861328f7.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
