### PR TITLE
Restore WindowState when activating

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1963,7 +1963,12 @@ namespace GitCommands
         public static bool WriteErrorLog
         {
             get => GetBool("WriteErrorLog", false);
-            set => SetBool("WriteErrorLog", value);
+        }
+
+        // Set manually in settings file
+        public static bool WorkaroundRestoreFromMinimize
+        {
+            get => GetBool("WorkaroundRestoreFromMinimize", false);
         }
 
         private static IEnumerable<(string name, string value)> GetSettingsFromRegistry()

--- a/ResourceManager/GitExtensionsFormBase.cs
+++ b/ResourceManager/GitExtensionsFormBase.cs
@@ -97,6 +97,13 @@ namespace ResourceManager
                 if (m.Msg == NativeMethods.WM_ACTIVATEAPP && m.WParam != IntPtr.Zero)
                 {
                     OnApplicationActivated();
+                    if (WindowState == FormWindowState.Minimized && Owner is null && AppSettings.WorkaroundRestoreFromMinimize)
+                    {
+                        // Changed behavior from .NET4 to .NET5, application occasionally requires explicit "restore" in Taskbar.
+                        // See https://github.com/gitextensions/gitextensions/pull/10119.
+                        Trace.WriteLine("WindowState is unexpectedly Minimized in OnApplicationActivated(), restoring.");
+                        WindowState = FormWindowState.Normal;
+                    }
                 }
             }
 
@@ -163,13 +170,6 @@ namespace ResourceManager
         /// </summary>
         protected virtual void OnApplicationActivated()
         {
-            if (WindowState == FormWindowState.Minimized && Owner is null)
-            {
-                // Changed behavior from .NET4 to .NET5, application requires explicit "restore" in Taskbar.
-                // See https://github.com/gitextensions/gitextensions/pull/10119.
-                Trace.WriteLine("WindowState is unexpectedly Minimized in OnApplicationActivated(), restoring.");
-                WindowState = FormWindowState.Normal;
-            }
         }
     }
 }

--- a/ResourceManager/GitExtensionsFormBase.cs
+++ b/ResourceManager/GitExtensionsFormBase.cs
@@ -163,6 +163,13 @@ namespace ResourceManager
         /// </summary>
         protected virtual void OnApplicationActivated()
         {
+            if (WindowState == FormWindowState.Minimized && Owner is null)
+            {
+                // Changed behavior from .NET4 to .NET5, application requires explicit "restore" in Taskbar.
+                // See https://github.com/gitextensions/gitextensions/pull/10119.
+                Trace.WriteLine("WindowState is unexpectedly Minimized in OnApplicationActivated(), restoring.");
+                WindowState = FormWindowState.Normal;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #9752

## Proposed changes

This is a fix, probably not the correct solution, added for review.

Occasionally when restoring GE from minimized, the app fail to stay open.

One drawback with the fix is that rightclick to close on the minature in the taskbar requires that the app is not minimized. OK to select the cross.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
