### PR TITLE
Set branch name in repo menu async

### DIFF
--- a/UnitTests/GitUI.Tests/CommandsDialogs/FormBrowseControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/FormBrowseControllerTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows.Forms;
+﻿using System.Threading;
+using System.Windows.Forms;
+using CommonTestUtils;
 using FluentAssertions;
 using GitCommands.Gpg;
 using GitCommands.UserRepositoryHistory;
@@ -9,6 +11,7 @@ using NUnit.Framework;
 
 namespace GitUITests.CommandsDialogs
 {
+    [Apartment(ApartmentState.STA)]
     [TestFixture]
     public sealed class FormBrowseControllerTests
     {
@@ -73,6 +76,9 @@ namespace GitUITests.CommandsDialogs
             Repository repository = new(path);
 
             _controller.AddRecentRepositories(containerMenu, repository, caption, (s, e) => { });
+
+            // await adding branch name in ShortcutKeyDisplayString, done async
+            ThreadHelper.JoinableTaskContext.Factory.Run(() => ThreadHelper.JoinPendingOperationsAsync(default));
 
             ToolStripMenuItem item = (ToolStripMenuItem)containerMenu.DropDownItems[0];
             item.ShortcutKeyDisplayString.Should().Be(branch);


### PR DESCRIPTION
Follow up to #7883

## Proposed changes

Evaluate the branch names for favorite/recent repo branch names async
(as IO is required) instead of delaying the opening of the menu.

For me (50 recent + 15 favorites, all on SSD but about five in WSL) there was a delay of 3.5s to open the menu (first time, file caching improved subsequent opening).
With this change, I still do not see that the branch name is added after the menu is opened.
The same for the dashboard.

Note: All "branch retrieval jobs" are now done in parallel instead of serial as it was before, so there is a higher CPU load spike now.
This may flood the threadpool and may need throttling. https://devblogs.microsoft.com/premier-developer/limiting-concurrency-for-faster-and-more-responsive-apps/
For the user it is still much better than before when all was running on the UI thread...

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
