### PR TITLE
Fix search not launching/working when changing filter selection

### DIFF
--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3271,10 +3271,6 @@ Do you want to continue?</source>
         <source>&amp;Favorite repositories</source>
         <target />
       </trans-unit>
-      <trans-unit id="tsmiHash.Text">
-        <source>&amp;Hash</source>
-        <target />
-      </trans-unit>
       <trans-unit id="tsmiRecentRepositories.Text">
         <source>&amp;Recent repositories</source>
         <target />

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -42,27 +42,27 @@ namespace GitUI.UserControls
             // tsmiCommitFilter
             // 
             this.tsmiCommitFilter.Checked = true;
+            this.tsmiCommitFilter.CheckOnClick = true;
             this.tsmiCommitFilter.Name = "tsmiCommitFilter";
             this.tsmiCommitFilter.Text = "Commit &message";
-            this.tsmiCommitFilter.Click += RevisionFilterItem_Click;
             // 
             // tsmiCommitter
             // 
+            this.tsmiCommitterFilter.CheckOnClick = true;
             this.tsmiCommitterFilter.Name = "tsmiCommitter";
             this.tsmiCommitterFilter.Text = "&Committer";
-            this.tsmiCommitterFilter.Click += RevisionFilterItem_Click;
             // 
             // tsmiAuthor
             // 
+            this.tsmiAuthorFilter.CheckOnClick = true;
             this.tsmiAuthorFilter.Name = "tsmiAuthor";
             this.tsmiAuthorFilter.Text = "&Author";
-            this.tsmiAuthorFilter.Click += RevisionFilterItem_Click;
             // 
             // tsmiDiffContains
             // 
+            this.tsmiDiffContainsFilter.CheckOnClick = true;
             this.tsmiDiffContainsFilter.Name = "tsmiDiffContains";
             this.tsmiDiffContainsFilter.Text = "&Diff contains (SLOW)";
-            this.tsmiDiffContainsFilter.Click += RevisionFilterItem_Click;
             // 
             // toolStripLabel1
             // 

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -18,7 +18,6 @@ namespace GitUI.UserControls
             this.tsmiCommitFilter = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiCommitterFilter = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiAuthorFilter = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsmiHash = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiDiffContainsFilter = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripLabel1 = new System.Windows.Forms.ToolStripLabel();
             this.tsbtnAdvancedFilter = new System.Windows.Forms.ToolStripSplitButton();
@@ -43,33 +42,27 @@ namespace GitUI.UserControls
             // tsmiCommitFilter
             // 
             this.tsmiCommitFilter.Checked = true;
-            this.tsmiCommitFilter.CheckOnClick = true;
             this.tsmiCommitFilter.Name = "tsmiCommitFilter";
             this.tsmiCommitFilter.Text = "Commit &message";
+            this.tsmiCommitFilter.Click += RevisionFilterItem_Click;
             // 
             // tsmiCommitter
             // 
-            this.tsmiCommitterFilter.CheckOnClick = true;
             this.tsmiCommitterFilter.Name = "tsmiCommitter";
             this.tsmiCommitterFilter.Text = "&Committer";
+            this.tsmiCommitterFilter.Click += RevisionFilterItem_Click;
             // 
             // tsmiAuthor
             // 
-            this.tsmiAuthorFilter.CheckOnClick = true;
             this.tsmiAuthorFilter.Name = "tsmiAuthor";
             this.tsmiAuthorFilter.Text = "&Author";
-            // 
-            // tsmiHash
-            // 
-            this.tsmiHash.CheckOnClick = true;
-            this.tsmiHash.Name = "tsmiHash";
-            this.tsmiHash.Text = "&Hash";
+            this.tsmiAuthorFilter.Click += RevisionFilterItem_Click;
             // 
             // tsmiDiffContains
             // 
-            this.tsmiDiffContainsFilter.CheckOnClick = true;
             this.tsmiDiffContainsFilter.Name = "tsmiDiffContains";
             this.tsmiDiffContainsFilter.Text = "&Diff contains (SLOW)";
+            this.tsmiDiffContainsFilter.Click += RevisionFilterItem_Click;
             // 
             // toolStripLabel1
             // 
@@ -298,7 +291,6 @@ namespace GitUI.UserControls
         private ToolStripMenuItem tsmiCommitterFilter;
         private ToolStripMenuItem tsmiAuthorFilter;
         private ToolStripMenuItem tsmiDiffContainsFilter;
-        private ToolStripMenuItem tsmiHash;
         private ToolStripButton tsmiShowReflogs;
         private ToolStripButton tsmiShowFirstParent;
         private ToolStripTextBox tstxtRevisionFilter;

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -391,14 +391,6 @@ namespace GitUI.UserControls
             UpdateBranchFilterItems();
         }
 
-        private void RevisionFilterItem_Click(object sender, System.EventArgs e)
-        {
-            foreach (ToolStripMenuItem item in tsddbtnRevisionFilter.DropDownItems)
-            {
-                item.Checked = sender == item;
-            }
-        }
-
         private void tsmiDisablePathFilters_Click(object sender, EventArgs e) => RevisionGridFilter.SetAndApplyPathFilter("");
 
         private void tsmiDisableAllFilters_Click(object sender, EventArgs e) => RevisionGridFilter.ResetAllFiltersAndRefresh();

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -391,6 +391,14 @@ namespace GitUI.UserControls
             UpdateBranchFilterItems();
         }
 
+        private void RevisionFilterItem_Click(object sender, System.EventArgs e)
+        {
+            foreach (ToolStripMenuItem item in tsddbtnRevisionFilter.DropDownItems)
+            {
+                item.Checked = sender == item;
+            }
+        }
+
         private void tsmiDisablePathFilters_Click(object sender, EventArgs e) => RevisionGridFilter.SetAndApplyPathFilter("");
 
         private void tsmiDisableAllFilters_Click(object sender, EventArgs e) => RevisionGridFilter.ResetAllFiltersAndRefresh();
@@ -428,7 +436,6 @@ namespace GitUI.UserControls
             public ToolStripMenuItem tsmiCommitterFilter => _control.tsmiCommitterFilter;
             public ToolStripMenuItem tsmiAuthorFilter => _control.tsmiAuthorFilter;
             public ToolStripMenuItem tsmiDiffContainsFilter => _control.tsmiDiffContainsFilter;
-            public ToolStripMenuItem tsmiHash => _control.tsmiHash;
             public ToolStripButton tsmiShowFirstParent => _control.tsmiShowFirstParent;
             public ToolStripButton tsmiShowReflogs => _control.tsmiShowReflogs;
             public ToolStripTextBox tstxtRevisionFilter => _control.tstxtRevisionFilter;

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -223,6 +223,7 @@ namespace GitUI.UserControls.RevisionGrid
                    ByAuthor ||
                    ByCommitter ||
                    ByMessage ||
+                   ByDiffContent ||
                    ByPathFilter ||
                    ByBranchFilter ||
                    ShowSimplifyByDecoration;
@@ -311,6 +312,7 @@ namespace GitUI.UserControls.RevisionGrid
             ByAuthor = false;
             ByCommitter = false;
             ByMessage = false;
+            ByDiffContent = false;
             ByPathFilter = false;
             ByBranchFilter = false;
             ShowSimplifyByDecoration = false;

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -240,55 +240,68 @@ namespace GitUI.UserControls.RevisionGrid
                 Debug.Fail("Not supported");
             }
 
+            bool searchParametersChanged = filter.FilterByAuthor != ByAuthor
+                                          || filter.FilterByCommitter != ByCommitter
+                                          || filter.FilterByCommit != ByMessage
+                                          || filter.FilterByDiffContent != ByDiffContent;
+
             if (filter.FilterByAuthor)
             {
-                if (ByAuthor && string.Equals(Author, filter.Text, StringComparison.CurrentCulture))
+                if (!string.Equals(Author, filter.Text, StringComparison.CurrentCulture))
                 {
-                    return false;
+                    ByAuthor = !string.IsNullOrWhiteSpace(filter.Text);
+                    Author = filter.Text;
+                    searchParametersChanged = true;
                 }
-
-                ByAuthor = !string.IsNullOrWhiteSpace(filter.Text);
-                Author = filter.Text;
-                return true;
+            }
+            else
+            {
+                ByAuthor = false;
             }
 
             if (filter.FilterByCommitter)
             {
-                if (ByCommitter && string.Equals(Committer, filter.Text, StringComparison.CurrentCulture))
+                if (!string.Equals(Committer, filter.Text, StringComparison.CurrentCulture))
                 {
-                    return false;
+                    ByCommitter = !string.IsNullOrWhiteSpace(filter.Text);
+                    Committer = filter.Text;
+                    searchParametersChanged = true;
                 }
-
-                ByCommitter = !string.IsNullOrWhiteSpace(filter.Text);
-                Committer = filter.Text;
-                return true;
+            }
+            else
+            {
+                ByCommitter = false;
             }
 
             if (filter.FilterByCommit)
             {
-                if (ByMessage && string.Equals(Message, filter.Text, StringComparison.CurrentCulture))
+                if (!string.Equals(Message, filter.Text, StringComparison.CurrentCulture))
                 {
-                    return false;
+                    ByMessage = !string.IsNullOrWhiteSpace(filter.Text);
+                    Message = filter.Text;
+                    searchParametersChanged = true;
                 }
-
-                ByMessage = !string.IsNullOrWhiteSpace(filter.Text);
-                Message = filter.Text;
-                return true;
+            }
+            else
+            {
+                ByMessage = false;
             }
 
             if (filter.FilterByDiffContent)
             {
-                if (ByDiffContent && string.Equals(DiffContent, filter.Text, StringComparison.CurrentCulture))
+                if (!string.Equals(DiffContent, filter.Text, StringComparison.CurrentCulture))
                 {
-                    return false;
+                    ByDiffContent = !string.IsNullOrWhiteSpace(filter.Text);
+                    DiffContent = filter.Text;
+                    searchParametersChanged = true;
                 }
-
-                ByDiffContent = !string.IsNullOrWhiteSpace(filter.Text);
-                DiffContent = filter.Text;
-                return true;
+            }
+            else
+            {
+                ByDiffContent = false;
             }
 
-            return false;
+            return searchParametersChanged;
         }
 
         public void ResetAllFilters()

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
@@ -741,5 +741,104 @@ namespace GitUITests.UserControls
             filterInfo.GetSummary().Should().Be(expectedSummary);
             filterInfo.GetRevisionFilter().ToString().Should().Be(expectedArgs);
         }
+
+        [Test]
+        public void FilterInfo_Apply_ByCommitMessage()
+        {
+            FilterInfo filterInfo = new();
+            var filterLaunched = filterInfo.Apply(new RevisionFilter("message", byCommit: true, byCommitter: false, byAuthor: false, byDiffContent: false));
+
+            filterLaunched.Should().BeTrue();
+            filterInfo.ByMessage.Should().BeTrue();
+            filterInfo.Message.Should().Be("message");
+
+            filterInfo.ByAuthor.Should().BeFalse();
+            filterInfo.ByCommitter.Should().BeFalse();
+            filterInfo.ByDiffContent.Should().BeFalse();
+        }
+
+        [Test]
+        public void FilterInfo_Apply_ByCommitter()
+        {
+            FilterInfo filterInfo = new();
+            var filterLaunched = filterInfo.Apply(new RevisionFilter("committer", byCommit: false, byCommitter: true, byAuthor: false, byDiffContent: false));
+
+            filterLaunched.Should().BeTrue();
+            filterInfo.ByCommitter.Should().BeTrue();
+            filterInfo.Committer.Should().Be("committer");
+
+            filterInfo.ByMessage.Should().BeFalse();
+            filterInfo.ByAuthor.Should().BeFalse();
+            filterInfo.ByDiffContent.Should().BeFalse();
+        }
+
+        [Test]
+        public void FilterInfo_Apply_ByAuthor()
+        {
+            FilterInfo filterInfo = new();
+            var filterLaunched = filterInfo.Apply(new RevisionFilter("author", byCommit: false, byCommitter: false, byAuthor: true, byDiffContent: false));
+
+            filterLaunched.Should().BeTrue();
+            filterInfo.ByAuthor.Should().BeTrue();
+            filterInfo.Author.Should().Be("author");
+
+            filterInfo.ByMessage.Should().BeFalse();
+            filterInfo.ByCommitter.Should().BeFalse();
+            filterInfo.ByDiffContent.Should().BeFalse();
+        }
+
+        [Test]
+        public void FilterInfo_Apply_ByDiffContent()
+        {
+            FilterInfo filterInfo = new();
+            var filterLaunched = filterInfo.Apply(new RevisionFilter("diff", byCommit: false, byCommitter: false, byAuthor: false, byDiffContent: true));
+
+            filterLaunched.Should().BeTrue();
+            filterInfo.ByDiffContent.Should().BeTrue();
+            filterInfo.DiffContent.Should().Be("diff");
+
+            filterInfo.ByMessage.Should().BeFalse();
+            filterInfo.ByAuthor.Should().BeFalse();
+            filterInfo.ByCommitter.Should().BeFalse();
+        }
+
+        [Test]
+        public void FilterInfo_Apply_ByMessage_Then_By_DiffContent()
+        {
+            // FilterInfo keep a state, so simulating actions of user where filter is changed 2 times
+            // to ensure that the filtering will be triggered i.e. returned value is always `true`
+
+            FilterInfo filterInfo = new();
+            var filterLaunched = filterInfo.Apply(new RevisionFilter("a_content", byCommit: true, byCommitter: false, byAuthor: false, byDiffContent: false));
+
+            filterLaunched.Should().BeTrue();
+            filterInfo.ByMessage.Should().BeTrue();
+            filterInfo.Message.Should().Be("a_content");
+
+            filterInfo.ByAuthor.Should().BeFalse();
+            filterInfo.ByCommitter.Should().BeFalse();
+            filterInfo.ByDiffContent.Should().BeFalse();
+
+            filterLaunched = filterInfo.Apply(new RevisionFilter("a_content", byCommit: true, byCommitter: false, byAuthor: false, byDiffContent: true));
+
+            filterLaunched.Should().BeTrue();
+            filterInfo.ByMessage.Should().BeTrue();
+            filterInfo.Message.Should().Be("a_content");
+            filterInfo.ByDiffContent.Should().BeTrue();
+            filterInfo.DiffContent.Should().Be("a_content");
+
+            filterInfo.ByAuthor.Should().BeFalse();
+            filterInfo.ByCommitter.Should().BeFalse();
+
+            filterLaunched = filterInfo.Apply(new RevisionFilter("a_content", byCommit: false, byCommitter: false, byAuthor: false, byDiffContent: true));
+
+            filterLaunched.Should().BeTrue();
+            filterInfo.ByDiffContent.Should().BeTrue();
+            filterInfo.DiffContent.Should().Be("a_content");
+
+            filterInfo.ByMessage.Should().BeFalse();
+            filterInfo.ByAuthor.Should().BeFalse();
+            filterInfo.ByCommitter.Should().BeFalse();
+        }
     }
 }


### PR DESCRIPTION
Fixes this use case:

1. Searching for a string (by default searching in commit message)
2. Selecting "Diff contains" and unselecting "Commit message"
3. Launch a search but search/filtering is not launched :(

Note: I think this fix should also back-ported to v4


## Proposed changes

- Fix filtering when playing with type of filtering

![image](https://user-images.githubusercontent.com/460196/182702093-18f0d0d8-3e97-4f10-83b8-e45aeea6b6d7.png)


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

No filter launched (so empty revision grid)
![image](https://user-images.githubusercontent.com/460196/182701205-bfc4fcd2-c857-415d-b105-9c0e907f8e60.png)

### After

The filtering is launched (so get results)
![image](https://user-images.githubusercontent.com/460196/182701445-25592f09-7184-4ca6-85b5-bb7e22627031.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual
- Unit tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build df80a9de42f264168585fa79e0f07645de433013
- Git 2.35.1.windows.2 (recommended: 2.37.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.6
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
