### PR TITLE
Eliminate static methods in RevisionReader

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -315,8 +315,8 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                             int centerX = g.RenderingOrigin.X + (int)((currentRow.GetCurrentRevisionLane() + 0.5) * LaneWidth);
                             Rectangle nodeRect = new(centerX - (NodeDimension / 2), centerY - (NodeDimension / 2), NodeDimension, NodeDimension);
 
-                            bool square = currentRow.Revision.HasRef;
-                            bool hasOutline = currentRow.Revision.IsCheckedOut;
+                            bool square = currentRow.Revision.GitRevision.Refs.Count > 0;
+                            bool hasOutline = currentRow.Revision.GitRevision.ObjectId == _revisionGraph.HeadId;
 
                             Brush brush = GetBrushForLaneInfo(currentRowRevisionLaneInfo, currentRow.Revision.IsRelative);
                             if (square)

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -24,16 +24,12 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             Score = guessScore;
         }
 
-        public void ApplyFlags(RevisionNodeFlags types)
+        public void ApplyFlags(bool isCheckedOut)
         {
-            IsRelative |= (types & RevisionNodeFlags.CheckedOut) != 0;
-            HasRef = (types & RevisionNodeFlags.HasRef) != 0;
-            IsCheckedOut = (types & RevisionNodeFlags.CheckedOut) != 0;
+            IsRelative |= isCheckedOut;
         }
 
         public bool IsRelative { get; set; }
-        public bool HasRef { get; set; }
-        public bool IsCheckedOut { get; set; }
 
         /// <summary>
         /// The score is used to order the revisions in topo-order. The initial score will be assigned when a revision is loaded

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -20,15 +20,6 @@ using GitUIPluginInterfaces;
 
 namespace GitUI.UserControls.RevisionGrid
 {
-    [Flags]
-    public enum RevisionNodeFlags
-    {
-        None = 0,
-        CheckedOut = 1,
-        HasRef = 2,
-        OnlyFirstParent = 4
-    }
-
     public sealed partial class RevisionDataGridView : DataGridView
     {
         private const int BackgroundThreadUpdatePeriod = 25;
@@ -321,11 +312,10 @@ namespace GitUI.UserControls.RevisionGrid
         /// Update visible rows if needed.
         /// </summary>
         /// <param name="revision">The revision to add.</param>
-        /// <param name="types">The graph node flags.</param>
         /// <param name="insertWithMatch">Insert the (artificial) revision with the first match in headParents or first if no match found (or headParents is null).</param>
         /// <param name="insertRange">Number of scores "reserved" in the list when inserting.</param>
         /// <param name="parents">Parent ids for the revision to find (and insert before).</param>
-        public void Add(GitRevision revision, RevisionNodeFlags types = RevisionNodeFlags.None, bool insertWithMatch = false, int insertRange = 0, IEnumerable<ObjectId>? parents = null)
+        public void Add(GitRevision revision, bool insertWithMatch = false, int insertRange = 0, IEnumerable<ObjectId>? parents = null)
         {
             // Where to insert the revision, null is last
             int? insertScore = null;
@@ -358,7 +348,7 @@ namespace GitUI.UserControls.RevisionGrid
                 }
             }
 
-            _revisionGraph.Add(revision, types, insertScore, insertRange);
+            _revisionGraph.Add(revision, insertScore, insertRange);
             if (ToBeSelectedObjectIds.Contains(revision.ObjectId))
             {
                 ++_loadedToBeSelectedRevisionsCount;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -981,8 +981,9 @@ namespace GitUI
                 ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
                     await TaskScheduler.Default;
+                    RevisionReader reader = new(capturedModule);
                     string pathFilter = BuildPathFilter(_filterInfo.PathFilter);
-                    ArgumentBuilder args = RevisionReader.BuildArguments(_filterInfo.CommitsLimit,
+                    ArgumentBuilder args = reader.BuildArguments(_filterInfo.CommitsLimit,
                         _filterInfo.RefFilterOptions,
                         _filterInfo.IsShowFilteredBranchesChecked ? _filterInfo.BranchFilter : string.Empty,
                         _filterInfo.GetRevisionFilter(),
@@ -990,8 +991,7 @@ namespace GitUI
                         out bool parentsAreRewritten);
                     ParentsAreRewritten = parentsAreRewritten;
 
-                    await new RevisionReader().ExecuteAsync(
-                        capturedModule,
+                    await reader.GetLogAsync(
                         observeRevisions,
                         args,
                         cancellationToken);

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphMultiThreadingTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphMultiThreadingTests.cs
@@ -34,9 +34,10 @@ namespace GitUITests.UserControls.RevisionGrid
             _revisionGraph = new RevisionGraph();
 
             GitRevision revision = new(ObjectId.Random());
+            _revisionGraph.HeadId = revision.ObjectId;
 
             // Mark the first revision as the current checkout
-            _revisionGraph.Add(revision, RevisionNodeFlags.CheckedOut);
+            _revisionGraph.Add(revision);
         }
 
         [Test, Timeout(10 /*min*/ * 60 /*s*/ * 1000 /*ms*/)]
@@ -84,7 +85,7 @@ namespace GitUITests.UserControls.RevisionGrid
                     revision.ParentIds = new ObjectId[] { randomRevision1.ObjectId, randomRevision2.ObjectId };
                 }
 
-                _revisionGraph.Add(revision, RevisionNodeFlags.None);
+                _revisionGraph.Add(revision);
 
                 randomRevisions.Add(revision);
             }

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
@@ -19,7 +19,12 @@ namespace GitUITests.UserControls.RevisionGrid
             foreach (var revision in Revisions)
             {
                 // Mark the first revision as the current checkout
-                _revisionGraph.Add(revision, _revisionGraph.Count == 0 ? RevisionNodeFlags.CheckedOut : RevisionNodeFlags.None);
+                if (_revisionGraph.Count == 0)
+                {
+                    _revisionGraph.HeadId = revision.ObjectId;
+                }
+
+                _revisionGraph.Add(revision);
             }
         }
 
@@ -82,12 +87,12 @@ namespace GitUITests.UserControls.RevisionGrid
             commit1.ParentIds = new ObjectId[] { commit2.ObjectId };
             commit2.ParentIds = new ObjectId[] { _revisionGraph.GetNodeForRow(4).Objectid };
 
-            _revisionGraph.Add(commit2, RevisionNodeFlags.None); // This commit is now dangling
+            _revisionGraph.Add(commit2); // This commit is now dangling
 
             _revisionGraph.CacheTo(_revisionGraph.Count, _revisionGraph.Count);
             Assert.IsTrue(_revisionGraph.GetTestAccessor().ValidateTopoOrder());
 
-            _revisionGraph.Add(commit1, RevisionNodeFlags.None); // Add the connecting commit
+            _revisionGraph.Add(commit1); // Add the connecting commit
 
             _revisionGraph.CacheTo(_revisionGraph.Count, _revisionGraph.Count);
             Assert.IsTrue(_revisionGraph.GetTestAccessor().ValidateTopoOrder());
@@ -95,7 +100,7 @@ namespace GitUITests.UserControls.RevisionGrid
             // Add a new head
             GitRevision newHead = new(ObjectId.Random());
             newHead.ParentIds = new ObjectId[] { _revisionGraph.GetNodeForRow(0).Objectid };
-            _revisionGraph.Add(newHead, RevisionNodeFlags.None); // Add commit that has the current top node as parent.
+            _revisionGraph.Add(newHead); // Add commit that has the current top node as parent.
 
             _revisionGraph.CacheTo(_revisionGraph.Count, _revisionGraph.Count); // Call to cache fix the order
             Assert.IsTrue(_revisionGraph.GetTestAccessor().ValidateTopoOrder());
@@ -129,9 +134,9 @@ namespace GitUITests.UserControls.RevisionGrid
             GitRevision commit3 = new(ObjectId.Random());
             commit1.ParentIds = new ObjectId[] { commit3.ObjectId };
 
-            _revisionGraph.Add(commit1, RevisionNodeFlags.None);
-            _revisionGraph.Add(commit2, RevisionNodeFlags.None);
-            _revisionGraph.Add(commit3, RevisionNodeFlags.None);
+            _revisionGraph.Add(commit1);
+            _revisionGraph.Add(commit2);
+            _revisionGraph.Add(commit3);
 
             _revisionGraph.CacheTo(_revisionGraph.Count, _revisionGraph.Count);
 


### PR DESCRIPTION
Preparation for #5371 
The end result is pushed to feature/i5371-stash-in-grid
For all stashes (not just the latest)
Not required for 4.0 but should be considered

![image](https://user-images.githubusercontent.com/6248932/182970362-f7e69aae-fa08-4a17-acc1-bea9806799c9.png)

## Proposed changes

- Eliminate static methods in RevisionReader
Prepare RevisionReader for added functionality.
Avoid passing class instance variable with every call.
Parsing revisions may be improved by a milli second in best case.

- Remove RevisionNodeFlags from data grid

Simplify (and a minor optimization) the code when loading revisions.
RevisionNodeFlags has information that is already available in the
GitRevisions, no need to pass that info again.

Set HasNotes after revisions are loaded, that is not required when
displaying a revision.

## Test methodology <!-- How did you ensure quality? -->

Tests are updated

## Merge strategy

- Rebase merge (PR submitter must change the commit message for the last commit).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
