### PR TITLE
Support User local paths for VsCode merge tools

### DIFF
--- a/GitCommands/DiffMergeTools/VsCode.cs
+++ b/GitCommands/DiffMergeTools/VsCode.cs
@@ -1,14 +1,18 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace GitCommands.DiffMergeTools
 {
     internal class VsCode : DiffMergeTool
     {
+        private static readonly string[] Folders = GetFolders();
+
         /// <inheritdoc />
         public override string DiffCommand => "--wait --diff \"$LOCAL\" \"$REMOTE\"";
 
         /// <inheritdoc />
-        public override string ExeFileName => "code.exe";
+        public override string ExeFileName => "Code.exe";
 
         /// <inheritdoc />
         public override string MergeCommand => "--wait \"$MERGED\"";
@@ -17,9 +21,16 @@ namespace GitCommands.DiffMergeTools
         public override string Name => "vscode";
 
         /// <inheritdoc />
-        public override IEnumerable<string> SearchPaths => new[]
+        public override IEnumerable<string> SearchPaths => Folders;
+
+        private static string[] GetFolders()
         {
-            @"Microsoft VS Code\"
-        };
+            string folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            return new[]
+            {
+                Path.Combine(folder, @"Programs\Microsoft VS Code"),
+                @"Microsoft VS Code\",
+            };
+        }
     }
 }

--- a/GitCommands/DiffMergeTools/VsCode.cs
+++ b/GitCommands/DiffMergeTools/VsCode.cs
@@ -15,7 +15,7 @@ namespace GitCommands.DiffMergeTools
         public override string ExeFileName => "Code.exe";
 
         /// <inheritdoc />
-        public override string MergeCommand => "--wait \"$MERGED\"";
+        public override string MergeCommand => "--wait --merge \"$REMOTE\" \"$LOCAL\" \"$BASE\" \"$MERGED\"";
 
         /// <inheritdoc />
         public override string Name => "vscode";


### PR DESCRIPTION
Fixes #10133

## Proposed changes

Add AppData\\Local\\Programs\\/Microsoft\ VS\ Code to install paths for VS Code, the default installation path.
Solution is similar as for SemanticMerge.
One alternative would be to ad "bin" to the paths and change executable to code.cmd

This is not solving the problem reported in #10133, "code" is still not working. "code.cmd" would work though.
However, it handles the user experience adding vscode.

Should be included in 4.0 too.

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
