### PR TITLE
BranchFilter text was added backwards

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
@@ -99,7 +99,7 @@ namespace GitUI.CommandsDialogs
 
             void InitFilters()
             {
-                // ToolStripFilters.UpdateBranchFilterItems() is init in UICommands_PostRepositoryChanged
+                // ToolStripFilters.RefreshRevisionFunction() is init in UICommands_PostRepositoryChanged
 
                 if (!string.IsNullOrWhiteSpace(revFilter))
                 {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -609,7 +609,7 @@ namespace GitUI.CommandsDialogs
             RevisionGrid.PerformRefreshRevisions(getRefs, forceRefresh: true);
 
             InternalInitialize();
-            ToolStripFilters.UpdateBranchFilterItems(getRefs);
+            ToolStripFilters.RefreshRevisionFunction(getRefs);
             UpdateSubmodulesStructure();
 
             RefreshGitStatusMonitor();

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -179,6 +179,7 @@ namespace GitUI.UserControls
             this.tscboBranchFilter.Tag = "ToolBar_group:Branch filter";
             this.tscboBranchFilter.Click += new System.EventHandler(this.tscboBranchFilter_Click);
             this.tscboBranchFilter.DropDown += new System.EventHandler(this.tscboBranchFilter_DropDown);
+            this.tscboBranchFilter.GotFocus += tscboBranchFilter_GotFocus;
             this.tscboBranchFilter.KeyUp += new System.Windows.Forms.KeyEventHandler(this.tscboBranchFilter_KeyUp);
             this.tscboBranchFilter.TextChanged += new System.EventHandler(this.tscboBranchFilter_TextChanged);
             this.tscboBranchFilter.TextUpdate += new System.EventHandler(this.tscboBranchFilter_TextUpdate);


### PR DESCRIPTION
Fixes #9872

## Proposed changes

Clearing the dropdown items changed the focus and moved the focus in the textbox to the first position, so next key was added first.

Dropdown was not opened on focus, which made the filter unusable unless you opened the dropdown first (se below).

Cache the function for getting the references with lazy result, to speed up the dropdown.

Still some weird behavior:
* If you focus away/back the first match in the dropdown is selected also if the dropdown is not shown (same in 3.5)
* When moving focus away then back to the control all is selected. In 3.5 allt ext was always selected, you had to start typing from scratch. With 4.0 you can click again, but first position in the box is always selected, you have to move with arrows.

This PR is not perfect but it is similar to the 3.5 behavior and I have no WinForms knowledge and I would like to keep it at this.

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
