### PR TITLE
Do not start NBug if mergetool exits with other than 0

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -923,7 +923,7 @@ namespace GitCommands
                 fileName.ToPosixPath().QuoteNE()
             };
 
-            using IProcess process = (isWindowsGit ? _gitWindowsExecutable : _gitExecutable).Start(args, createWindow: true);
+            using IProcess process = (isWindowsGit ? _gitWindowsExecutable : _gitExecutable).Start(args, createWindow: true, throwOnErrorExit: false);
             process.WaitForExit();
         }
 

--- a/Plugins/GitUIPluginInterfaces/IExecutable.cs
+++ b/Plugins/GitUIPluginInterfaces/IExecutable.cs
@@ -23,8 +23,7 @@ namespace GitUIPluginInterfaces
         /// <param name="outputEncoding">The <see cref="Encoding"/> to use when interpreting standard output and standard
         /// error, or <c>null</c> if <paramref name="redirectOutput"/> is <c>false</c>.</param>
         /// <param name="useShellExecute">The value for the flag <c>ProcessStartInfo.UseShellExecute</c>.</param>
-        /// <param name="throwOnErrorExit">A flag configuring whether to throw an exception if the exit code is not 0
-        /// or if the output to StandardError is not empty.</param>
+        /// <param name="throwOnErrorExit">A flag configuring whether to throw an exception if the exit code is not 0.</param>
         /// <returns>The started process.</returns>
         [MustUseReturnValue]
         IProcess Start(ArgumentString arguments = default,


### PR DESCRIPTION
## Proposed changes

Exit code is other than 0 if user aborts a merge.
#9056 is a step in the right direction, this is another situation where other exit codes than 0 are OK though.
Regression in master, to be included in 4.0

Occurs in FormResolve with _Start mergetool_

![image](https://user-images.githubusercontent.com/6248932/183311766-e2c63755-8361-4422-8e35-f1049bca3760.png)

![image](https://user-images.githubusercontent.com/6248932/183311669-6390f9e1-4744-43e6-9d23-5534cc9ad433.png)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
