### PR TITLE
Show Stash in rev grid

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -42,26 +42,107 @@ namespace GitCommands
         private readonly Encoding _logOutputEncoding;
         private readonly long _sixMonths;
 
-        public RevisionReader(GitModule module)
-            : this(module, module.LogOutputEncoding, new DateTimeOffset(DateTime.Now.ToUniversalTime() - TimeSpan.FromDays(30 * 6)).ToUnixTimeSeconds())
+        // reflog selector to identify stashes
+        private readonly bool _hasReflogSelector;
+
+        private string LogFormat => _hasReflogSelector ? FullFormat.Replace("%B", "%gD%n%B") : FullFormat;
+
+        public RevisionReader(GitModule module, bool hasReflogSelector)
+            : this(module, hasReflogSelector, module.LogOutputEncoding, new DateTimeOffset(DateTime.Now.ToUniversalTime() - TimeSpan.FromDays(30 * 6)).ToUnixTimeSeconds())
         {
         }
 
-        internal RevisionReader(GitModule module, Encoding logOutputEncoding, long sixMonths)
+        private RevisionReader(GitModule module, bool hasReflogSelector, Encoding logOutputEncoding, long sixMonths)
         {
             _module = module;
+            _hasReflogSelector = hasReflogSelector;
             _logOutputEncoding = logOutputEncoding;
             _sixMonths = sixMonths;
         }
 
-        public async Task GetLogAsync(
+        /// <summary>
+        /// Get the git-stash GitRevisions.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation cancellationToken.</param>
+        /// <returns>List with GitRevisions.</returns>
+        public IReadOnlyCollection<GitRevision> GetStashes(CancellationToken cancellationToken)
+        {
+            Debug.Assert(_hasReflogSelector, "_hasReflogSelector must be set to get the reflog selectors (to identify stashes)");
+
+            GitArgumentBuilder arguments = new("stash")
+            {
+                "list",
+                "-z",
+                $"--pretty=format:\"{LogFormat}\""
+            };
+
+            return GetRevisionsFromArguments(arguments, cancellationToken);
+        }
+
+        /// <summary>
+        /// Get the GitRevisions for the listed files, excluding commits without changes.
+        /// </summary>
+        /// <param name="untracked">commit list.</param>
+        /// <param name="cancellationToken">Cancellation cancellationToken.</param>
+        /// <returns>List with GitRevisions.</returns>
+        public IReadOnlyCollection<GitRevision> GetRevisionsFromList(IList<ObjectId> untracked, CancellationToken cancellationToken)
+        {
+            if (untracked.Count == 0)
+            {
+                return Array.Empty<GitRevision>();
+            }
+
+            GitArgumentBuilder arguments = new("log")
+            {
+                "-z",
+                $"--pretty=format:\"{LogFormat}\"",
+                "--dirstat=files",
+                string.Join(" ", untracked),
+                ".",
+            };
+
+            return GetRevisionsFromArguments(arguments, cancellationToken);
+        }
+
+        /// <summary>
+        /// Get the GitRevisions for Git argument.
+        /// </summary>
+        /// <param name="arguments">Git command arguments.</param>
+        /// <param name="cancellationToken">Cancellation cancellationToken.</param>
+        /// <returns>List with GitRevisions.</returns>
+        private IReadOnlyCollection<GitRevision> GetRevisionsFromArguments(GitArgumentBuilder arguments, CancellationToken cancellationToken)
+        {
+            List<GitRevision> stashes = new();
+
+            using (IProcess process = _module.GitCommandRunner.RunDetached(arguments, redirectOutput: true, outputEncoding: GitModule.LosslessEncoding))
+            {
+                byte[] buffer = new byte[4096];
+
+                foreach (ArraySegment<byte> chunk in process.StandardOutput.BaseStream.ReadNullTerminatedChunks(ref buffer))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (TryParseRevision(chunk, out GitRevision? revision))
+                    {
+                        stashes.Add(revision);
+                    }
+                }
+            }
+
+            return stashes;
+        }
+
+        /// <summary>
+        /// Get the git-log revisions for the revision grid.
+        /// </summary>
+        /// <param name="subject">Observer to update the revision grid when the revisions are available.</param>
+        /// <param name="arguments">git-log arguments.</param>
+        /// <param name="cancellationToken">Cancellation cancellationToken.</param>
+        public void GetLog(
             IObserver<GitRevision> subject,
             ArgumentBuilder arguments,
-            CancellationToken token)
+            CancellationToken cancellationToken)
         {
-            await TaskScheduler.Default;
-            token.ThrowIfCancellationRequested();
-
 #if DEBUG
             int revisionCount = 0;
             var sw = Stopwatch.StartNew();
@@ -72,13 +153,13 @@ namespace GitCommands
 #if DEBUG
                 Debug.WriteLine($"git {arguments}");
 #endif
-                token.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
                 var buffer = new byte[4096];
 
                 foreach (var chunk in process.StandardOutput.BaseStream.ReadNullTerminatedChunks(ref buffer))
                 {
-                    token.ThrowIfCancellationRequested();
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     if (TryParseRevision(chunk, out GitRevision? revision))
                     {
@@ -95,7 +176,7 @@ namespace GitCommands
 #endif
             }
 
-            if (!token.IsCancellationRequested)
+            if (!cancellationToken.IsCancellationRequested)
             {
                 subject.OnCompleted();
             }
@@ -114,7 +195,7 @@ namespace GitCommands
             {
                 { maxCount > 0, $"--max-count={maxCount}" },
                 "-z",
-                $"--pretty=format:\"{FullFormat}\"",
+                $"--pretty=format:\"{LogFormat}\"",
                 { AppSettings.RevisionSortOrder == RevisionSortOrder.AuthorDate, "--author-date-order" },
                 { AppSettings.RevisionSortOrder == RevisionSortOrder.Topology, "--topo-order" },
                 { refFilterOptions.HasFlag(RefFilterOptions.Boundary), "--boundary" },
@@ -298,6 +379,7 @@ namespace GitCommands
             var authorEmail = reader.ReadLine();
             var committer = reader.ReadLine();
             var committerEmail = reader.ReadLine();
+            var reflogSelector = _hasReflogSelector ? reader.ReadLine() : null;
 
             bool skipBody = _sixMonths > authorUnixTime;
             (string? subject, string? body, bool hasMultiLineMessage) = reader.PeekSubjectBody(skipBody);
@@ -328,7 +410,8 @@ namespace GitCommands
                 Subject = subject,
                 Body = body,
                 HasMultiLineMessage = hasMultiLineMessage,
-                HasNotes = false
+                HasNotes = false,
+                ReflogSelector = reflogSelector,
             };
 
             return true;
@@ -416,6 +499,11 @@ namespace GitCommands
             internal TestAccessor(RevisionReader revisionReader)
             {
                 _revisionReader = revisionReader;
+            }
+
+            internal static RevisionReader RevisionReader(GitModule module, bool hasReflogSelector, Encoding logOutputEncoding, long sixMonths)
+            {
+                return new RevisionReader(module, hasReflogSelector, logOutputEncoding, sixMonths);
             }
 
             internal bool TryParseRevision(ArraySegment<byte> chunk, [NotNullWhen(returnValue: true)] out GitRevision? revision) =>

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1085,10 +1085,16 @@ namespace GitCommands
             set => SetBool("showReflogReferences", value);
         }
 
-        public static bool ShowLatestStash
+        public static bool ShowStashes
         {
-            get => GetBool("showLatestStash", true);
-            set => SetBool("showLatestStash", value);
+            get => GetBool("showStashes", true);
+            set => SetBool("showStashes", value);
+        }
+
+        // Set manually in settings file
+        public static int MaxStashesWithUntrackedFiles
+        {
+            get => GetInt("maxStashesWithUntrackedFiles", 10);
         }
 
         public static bool ShowSuperprojectTags

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -17,9 +17,6 @@ namespace GitUI.CommandsDialogs
     {
         private readonly TranslationString _currentWorkingDirChanges = new("Current working directory changes");
         private readonly TranslationString _noStashes = new("There are no stashes.");
-        private readonly TranslationString _stashDropConfirmTitle = new("Drop Stash Confirmation");
-        private readonly TranslationString _cannotBeUndone = new("This action cannot be undone.");
-        private readonly TranslationString _areYouSure = new("Are you sure you want to drop the stash? This action cannot be undone.");
 
         private readonly CancellationTokenSequence _viewChangesSequence = new();
         private readonly AsyncLoader _asyncLoader = new();
@@ -338,9 +335,9 @@ namespace GitUI.CommandsDialogs
                 {
                     TaskDialogPage page = new()
                     {
-                        Text = _areYouSure.Text,
-                        Caption = _stashDropConfirmTitle.Text,
-                        Heading = _cannotBeUndone.Text,
+                        Text = TranslatedStrings.AreYouSure,
+                        Caption = TranslatedStrings.StashDropConfirmTitle,
+                        Heading = TranslatedStrings.CannotBeUndone,
                         Buttons = { TaskDialogButton.Yes, TaskDialogButton.No },
                         Icon = TaskDialogIcon.Information,
                         Verification = new TaskDialogVerificationCheckBox

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -215,11 +215,11 @@ namespace GitUI
             return DoActionOnRepo(owner, Action);
         }
 
-        public bool StashPop(IWin32Window? owner)
+        public bool StashPop(IWin32Window? owner, string stashName = "")
         {
             bool Action()
             {
-                FormProcess.ShowDialog(owner, arguments: "stash pop", Module.WorkingDir, input: null, useDialogSettings: true);
+                FormProcess.ShowDialog(owner, arguments: $"stash pop {stashName.QuoteNE()}", Module.WorkingDir, input: null, useDialogSettings: true);
                 MergeConflictHandler.HandleMergeConflicts(this, owner, false, false);
 
                 // git-stash may have changed commits also if aborted, the grid must be refreshed

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -130,6 +130,10 @@ the last selected commit.");
         private readonly TranslationString _showCurrentBranchOnly = new("Show current branch only");
         private readonly TranslationString _simplifyByDecoration = new("Simplify by decoration");
 
+        private readonly TranslationString _stashDropConfirmTitle = new("Drop Stash Confirmation");
+        private readonly TranslationString _cannotBeUndone = new("This action cannot be undone.");
+        private readonly TranslationString _areYouSure = new("Are you sure you want to drop the stash? This action cannot be undone.");
+
         // public only because of FormTranslate
         public TranslatedStrings()
         {
@@ -279,5 +283,9 @@ the last selected commit.");
         public static string ScriptText => _instance.Value._scriptText.Text;
 
         #endregion
+
+        public static string StashDropConfirmTitle => _instance.Value._stashDropConfirmTitle.Text;
+        public static string CannotBeUndone => _instance.Value._cannotBeUndone.Text;
+        public static string AreYouSure => _instance.Value._areYouSure.Text;
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7532,24 +7532,12 @@ Therefore the Cancel button does NOT revert any changes made.</source>
         <source>Select a stash</source>
         <target />
       </trans-unit>
-      <trans-unit id="_areYouSure.Text">
-        <source>Are you sure you want to drop the stash? This action cannot be undone.</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_cannotBeUndone.Text">
-        <source>This action cannot be undone.</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_currentWorkingDirChanges.Text">
         <source>Current working directory changes</source>
         <target />
       </trans-unit>
       <trans-unit id="_noStashes.Text">
         <source>There are no stashes.</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_stashDropConfirmTitle.Text">
-        <source>Drop Stash Confirmation</source>
         <target />
       </trans-unit>
       <trans-unit id="cherryPickFileChangesToolStripMenuItem.Text">
@@ -9691,16 +9679,16 @@ See the changes in the commit form.</source>
         <source>Show &amp;filtered branches</source>
         <target />
       </trans-unit>
-      <trans-unit id="ShowLatestStash.Text">
-        <source>Show &amp;latest stash</source>
-        <target />
-      </trans-unit>
       <trans-unit id="ShowReflogReferences.Text">
         <source>Show &amp;reflog references</source>
         <target />
       </trans-unit>
       <trans-unit id="ShowRemoteBranches.Text">
         <source>Show remote &amp;branches</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="ShowStashes.Text">
+        <source>Show stashes</source>
         <target />
       </trans-unit>
       <trans-unit id="ShowSuperprojectBranches.Text">
@@ -9855,6 +9843,10 @@ See the changes in the commit form.</source>
         <source>Loading</source>
         <target />
       </trans-unit>
+      <trans-unit id="applyStashToolStripMenuItem.Text">
+        <source>Appl&amp;y stash</source>
+        <target />
+      </trans-unit>
       <trans-unit id="archiveRevisionToolStripMenuItem.Text">
         <source>Arch&amp;ive this commit...</source>
         <target />
@@ -9919,6 +9911,10 @@ See the changes in the commit form.</source>
         <source>De&amp;lete tag...</source>
         <target />
       </trans-unit>
+      <trans-unit id="dropStashToolStripMenuItem.Text">
+        <source>&amp;Drop stash...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="editCommitToolStripMenuItem.Text">
         <source>&amp;Edit commit</source>
         <target />
@@ -9961,6 +9957,10 @@ See the changes in the commit form.</source>
       </trans-unit>
       <trans-unit id="openPullRequestPageStripMenuItem.Text">
         <source>Vie&amp;w pull request in a browser</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="popStashToolStripMenuItem.Text">
+        <source>Pop &amp;stash</source>
         <target />
       </trans-unit>
       <trans-unit id="rebaseInteractivelyToolStripMenuItem.Text">
@@ -10501,6 +10501,10 @@ Please verify the server url.</source>
   </file>
   <file datatype="plaintext" original="TranslatedStrings" source-language="en">
     <body>
+      <trans-unit id="_areYouSure.Text">
+        <source>Are you sure you want to drop the stash? This action cannot be undone.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_argumentsText.Text">
         <source>Arguments</source>
         <target />
@@ -10574,6 +10578,10 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_cancelText.Text">
         <source>Cancel</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_cannotBeUndone.Text">
+        <source>This action cannot be undone.</source>
         <target />
       </trans-unit>
       <trans-unit id="_childrenText.Text">
@@ -10970,6 +10978,10 @@ the last selected commit.</source>
       </trans-unit>
       <trans-unit id="_stageSelectedLines.Text">
         <source>Stage selected line(s)</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_stashDropConfirmTitle.Text">
+        <source>Drop Stash Confirmation</source>
         <target />
       </trans-unit>
       <trans-unit id="_submodulesText.Text">

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -85,6 +85,21 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
             DrawSuperprojectRefs(e, superprojectRefs, style, messageBounds, ref offset);
 
+            if (revision.IsStash)
+            {
+                RevisionGridRefRenderer.DrawRef(
+                    e.State.HasFlag(DataGridViewElementStates.Selected),
+                    style.NormalFont,
+                    ref offset,
+                    revision.ReflogSelector.Substring(5),
+                    AppColor.OtherTag.GetThemeColor(),
+                    RefArrowType.None,
+                    messageBounds,
+                    e.Graphics,
+                    dashedLine: false,
+                    fill: AppSettings.FillRefLabels);
+            }
+
             if (revision.IsArtificial)
             {
                 DrawArtificialRevision(e, revision, style, messageBounds, ref offset);

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -148,7 +148,7 @@ namespace GitUI.UserControls.RevisionGrid
                 // "other refs" include Gerrit refs like refs/for/ and refs/changes/
                 if (refFilterOptions.HasFlag(RefFilterOptions.All))
                 {
-                    if (!AppSettings.ShowLatestStash)
+                    if (!AppSettings.ShowStashes)
                     {
                         refFilterOptions |= RefFilterOptions.NoStash;
                     }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Command.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Command.cs
@@ -39,7 +39,7 @@
             OpenCommitsWithDifftool = 32,
             ToggleBetweenArtificialAndHeadCommits = 33,
             ShowReflogReferences = 34,
-            ShowLatestStash = 35,
+            ShowStashes = 35,
             ResetRevisionFilter = 36,
             ResetRevisionPathFilter = 37,
             SelectNextForkPointAsDiffBase = 38,

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -29,6 +29,10 @@ namespace GitUI
             this.stopBisectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.bisectSeparator = new System.Windows.Forms.ToolStripSeparator();
             this.copyToClipboardToolStripMenuItem = new GitUI.UserControls.RevisionGrid.CopyContextMenuItem();
+            this.stashStripSeparator = new System.Windows.Forms.ToolStripSeparator();
+            this.applyStashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.popStashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.dropStashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
             this.checkoutBranchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mergeBranchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -121,6 +125,10 @@ namespace GitUI
             this.bisectSeparator,
             this.copyToClipboardToolStripMenuItem,
             this.toolStripSeparator8,
+            this.applyStashToolStripMenuItem,
+            this.popStashToolStripMenuItem,
+            this.dropStashToolStripMenuItem,
+            this.stashStripSeparator,
             this.checkoutBranchToolStripMenuItem,
             this.mergeBranchToolStripMenuItem,
             this.rebaseOnToolStripMenuItem,
@@ -193,6 +201,35 @@ namespace GitUI
             // 
             this.toolStripSeparator8.Name = "toolStripSeparator8";
             this.toolStripSeparator8.Size = new System.Drawing.Size(261, 6);
+            // 
+            // applyStashToolStripMenuItem
+            // 
+            this.applyStashToolStripMenuItem.Image = global::GitUI.Properties.Images.Stash;
+            this.applyStashToolStripMenuItem.Name = "applyStashToolStripMenuItem";
+            this.applyStashToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
+            this.applyStashToolStripMenuItem.Text = "Appl&y stash";
+            this.applyStashToolStripMenuItem.Click += new System.EventHandler(this.ApplyStashToolStripMenuItemClick);
+            // 
+            // popStashToolStripMenuItem
+            // 
+            this.popStashToolStripMenuItem.Image = global::GitUI.Properties.Images.Stash;
+            this.popStashToolStripMenuItem.Name = "popStashToolStripMenuItem";
+            this.popStashToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
+            this.popStashToolStripMenuItem.Text = "Pop &stash";
+            this.popStashToolStripMenuItem.Click += new System.EventHandler(this.PopStashToolStripMenuItemClick);
+            // 
+            // dropStashToolStripMenuItem
+            // 
+            this.dropStashToolStripMenuItem.Image = global::GitUI.Properties.Images.Stash;
+            this.dropStashToolStripMenuItem.Name = "dropStashToolStripMenuItem";
+            this.dropStashToolStripMenuItem.Size = new System.Drawing.Size(264, 24);
+            this.dropStashToolStripMenuItem.Text = "&Drop stash...";
+            this.dropStashToolStripMenuItem.Click += new System.EventHandler(this.DropStashToolStripMenuItemClick);
+            // 
+            // stashStripSeparator
+            // 
+            this.stashStripSeparator.Name = "stashStripSeparator";
+            this.stashStripSeparator.Size = new System.Drawing.Size(220, 6);
             // 
             // checkoutBranchToolStripMenuItem
             // 
@@ -547,6 +584,9 @@ namespace GitUI
         private System.Windows.Forms.ToolStripMenuItem deleteBranchToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem checkoutRevisionToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem archiveRevisionToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem applyStashToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem popStashToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem dropStashToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem checkoutBranchToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem mergeBranchToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem cherryPickCommitToolStripMenuItem;
@@ -593,5 +633,6 @@ namespace GitUI
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator10;
         private System.Windows.Forms.ToolStripSeparator compareStripSeparator;
+        private System.Windows.Forms.ToolStripSeparator stashStripSeparator;
     }
 }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -186,11 +186,12 @@ namespace GitUI.UserControls.RevisionGrid
             /*
                 VIEW menu
                 ═════════════
-                        KQZ
+                        KLQZ
                     !   Highlight selected branch (until refresh)
                     !   Set advanced filter
                     !   Show commit message body
                     !   Show first parents
+                    !   Show stashes
                     -   Show SHA-1 column
                     A   Show all branches
                     B   Show remote branches
@@ -202,7 +203,6 @@ namespace GitUI.UserControls.RevisionGrid
                     H   Show author avatar column
                     I   Show build status icon
                     J   Show superproject remote branches
-                    L   Show latest stash
                     M   Show merge commits
                     N   Show git notes
                     O   Show artificial commits
@@ -276,11 +276,11 @@ namespace GitUI.UserControls.RevisionGrid
                 },
                 new MenuCommand
                 {
-                    Name = "ShowLatestStash",
-                    Text = "Show &latest stash",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowLatestStash),
-                    ExecuteAction = () => _revisionGrid.ToggleShowLatestStash(),
-                    IsCheckedFunc = () => AppSettings.ShowLatestStash
+                    Name = "ShowStashes",
+                    Text = "Show stashes",
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowStashes),
+                    ExecuteAction = () => _revisionGrid.ToggleShowStashes(),
+                    IsCheckedFunc = () => AppSettings.ShowStashes
                 },
 
                 MenuCommand.CreateSeparator(),

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -189,7 +189,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         }
 
         [Test]
-        public void ShowLatestStash_starting_disabled_should_filter_as_expected()
+        public void ShowStashes_starting_disabled_should_filter_as_expected()
         {
             using ReferenceRepository referenceRepository = new();
             GitUICommands commands = new(referenceRepository.Module);
@@ -200,34 +200,34 @@ namespace GitExtensions.UITests.CommandsDialogs
             referenceRepository.Stash("Stash2");
             referenceRepository.CreateCommit("Commit3");
 
-            bool showLatestStash = AppSettings.ShowLatestStash;
+            bool showStashes = AppSettings.ShowStashes;
             bool revisionGraphShowArtificialCommits = AppSettings.RevisionGraphShowArtificialCommits;
 
-            AppSettings.ShowLatestStash = false;
+            AppSettings.ShowStashes = false;
             AppSettings.RevisionGraphShowArtificialCommits = false;
             RunFormTest(
                 form =>
                 {
                     try
                     {
-                        // 1. Check with ShowLatestStash disabled
-                        Console.WriteLine("Scenario 1: set 'Show latest stash' to false");
+                        // 1. Check with ShowStashes disabled
+                        Console.WriteLine("Scenario 1: set 'Show stashes' to false");
                         WaitForRevisionsToBeLoaded(form);
                         // Assert
-                        AppSettings.ShowLatestStash.Should().BeFalse();
+                        AppSettings.ShowStashes.Should().BeFalse();
                         form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(4);
 
-                        // 2. Change ShowLatestStash to enabled
-                        Console.WriteLine("Scenario 1: change 'Show latest stash' to enabled");
-                        form.GetTestAccessor().RevisionGrid.ToggleShowLatestStash();
+                        // 2. Change ShowStashes to enabled
+                        Console.WriteLine("Scenario 1: change 'Show stashes' to enabled");
+                        form.GetTestAccessor().RevisionGrid.ToggleShowStashes();
                         WaitForRevisionsToBeLoaded(form);
                         // Assert
-                        AppSettings.ShowLatestStash.Should().BeTrue();
-                        form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(6);
+                        AppSettings.ShowStashes.Should().BeTrue();
+                        form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(7);
                     }
                     finally
                     {
-                        AppSettings.ShowLatestStash = showLatestStash;
+                        AppSettings.ShowStashes = showStashes;
                         AppSettings.RevisionGraphShowArtificialCommits = revisionGraphShowArtificialCommits;
                     }
                 },
@@ -235,7 +235,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         }
 
         [Test]
-        public void ShowLatestStash_starting_enabled_should_filter_as_expected()
+        public void ShowStashes_starting_enabled_should_filter_as_expected()
         {
             using ReferenceRepository referenceRepository = new();
             GitUICommands commands = new(referenceRepository.Module);
@@ -246,29 +246,29 @@ namespace GitExtensions.UITests.CommandsDialogs
             referenceRepository.Stash("Stash2");
             referenceRepository.CreateCommit("Commit3");
 
-            bool showLatestStash = AppSettings.ShowLatestStash;
+            bool showStashes = AppSettings.ShowStashes;
             bool revisionGraphShowArtificialCommits = AppSettings.RevisionGraphShowArtificialCommits;
 
-            AppSettings.ShowLatestStash = true;
+            AppSettings.ShowStashes = true;
             AppSettings.RevisionGraphShowArtificialCommits = false;
             RunFormTest(
                 form =>
                 {
                     try
                     {
-                        // 2. Check with ShowLatestStash enabled
-                        Console.WriteLine("Scenario 2: set 'Show latest stash' to true");
+                        // 1. Check with ShowStashes enabled
+                        Console.WriteLine("Scenario 2: set 'Show stash' to true");
                         WaitForRevisionsToBeLoaded(form);
                         // Assert
-                        AppSettings.ShowLatestStash.Should().BeTrue();
-                        form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(6);
+                        AppSettings.ShowStashes.Should().BeTrue();
+                        form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(7);
 
-                        // 2. Change ShowLatestStash to disabled
-                        Console.WriteLine("Scenario 2: change 'Show latest stash' to disabled");
-                        form.GetTestAccessor().RevisionGrid.ToggleShowLatestStash();
+                        // 2. Change ShowStashes to disabled
+                        Console.WriteLine("Scenario 2: change 'Show stash' to disabled");
+                        form.GetTestAccessor().RevisionGrid.ToggleShowStashes();
                         WaitForRevisionsToBeLoaded(form);
                         // Assert
-                        AppSettings.ShowLatestStash.Should().BeFalse();
+                        AppSettings.ShowStashes.Should().BeFalse();
 #if DEBUG
                         // https://github.com/gitextensions/gitextensions/issues/10170
                         // This test occasionaly fails with 3 visible revisions
@@ -277,7 +277,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                     }
                     finally
                     {
-                        AppSettings.ShowLatestStash = showLatestStash;
+                        AppSettings.ShowStashes = showStashes;
                         AppSettings.RevisionGraphShowArtificialCommits = revisionGraphShowArtificialCommits;
                     }
                 },

--- a/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
@@ -78,7 +78,6 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
             AppSettings.BranchFilterEnabled = false;
             AppSettings.ShowCurrentBranchOnly = false;
             AppSettings.ShowGitNotes = true;
-            AppSettings.ShowLatestStash = true;
 
             RunSetAndApplyBranchFilterTest(
                 initialFilter: "",
@@ -132,7 +131,6 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
             AppSettings.BranchFilterEnabled = false;
             AppSettings.ShowCurrentBranchOnly = false;
             AppSettings.ShowGitNotes = true;
-            AppSettings.ShowLatestStash = true;
 
             RunSetAndApplyBranchFilterTest(
                 initialFilter: "",
@@ -174,7 +172,6 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
             AppSettings.BranchFilterEnabled = false;
             AppSettings.ShowCurrentBranchOnly = false;
             AppSettings.ShowGitNotes = true;
-            AppSettings.ShowLatestStash = true;
 
             RunSetAndApplyBranchFilterTest(
                 initialFilter: "Branch1",

--- a/Plugins/GitUIPluginInterfaces/GitRevision.cs
+++ b/Plugins/GitUIPluginInterfaces/GitRevision.cs
@@ -108,6 +108,16 @@ namespace GitUIPluginInterfaces
         /// </summary>
         public bool IsArtificial => ObjectId.IsArtificial;
 
+        /// <summary>
+        /// Indicates whether the commit is a main stash commit.
+        /// </summary>
+        public bool IsStash => ReflogSelector is not null;
+
+        /// <summary>
+        /// The reflog selector, contains the stash name like "stash{0}"
+        /// </summary>
+        public string? ReflogSelector { get; set; }
+
         public bool HasParent => ParentIds?.Count > 0;
 
         public ObjectId? FirstParentId => ParentIds?.FirstOrDefault();

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test.ForScenario.empty_commit.approved.json
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test.ForScenario.empty_commit.approved.json
@@ -26,6 +26,8 @@
     "HasMultiLineMessage": false,
     "HasNotes": false,
     "IsArtificial": false,
+    "IsStash": false,
+    "ReflogSelector": null,
     "HasParent": true,
     "FirstParentId": {
         "IsArtificial": false

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test.ForScenario.multi_pathfilter.approved.json
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test.ForScenario.multi_pathfilter.approved.json
@@ -26,6 +26,8 @@
     "HasMultiLineMessage": true,
     "HasNotes": false,
     "IsArtificial": false,
+    "IsStash": false,
+    "ReflogSelector": null,
     "HasParent": true,
     "FirstParentId": {
         "IsArtificial": false

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test.ForScenario.no_subject.approved.json
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test.ForScenario.no_subject.approved.json
@@ -32,6 +32,8 @@
     "HasMultiLineMessage": false,
     "HasNotes": false,
     "IsArtificial": false,
+    "IsStash": false,
+    "ReflogSelector": null,
     "HasParent": true,
     "FirstParentId": {
         "IsArtificial": false

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test.ForScenario.normal.approved.json
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test.ForScenario.normal.approved.json
@@ -32,6 +32,8 @@
     "HasMultiLineMessage": true,
     "HasNotes": false,
     "IsArtificial": false,
+    "IsStash": false,
+    "ReflogSelector": null,
     "HasParent": true,
     "FirstParentId": {
         "IsArtificial": false

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test.ForScenario.reflogselector.approved.json
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test.ForScenario.reflogselector.approved.json
@@ -7,6 +7,12 @@
     "ParentIds": [
         {
             "IsArtificial": false
+        },
+        {
+            "IsArtificial": false
+        },
+        {
+            "IsArtificial": false
         }
     ],
     "TreeGuid": {
@@ -22,12 +28,12 @@
     "CommitDate": "2021-06-23T20:19:46Z",
     "BuildStatus": null,
     "Subject": "wip tests",
-    "Body": "wip tests",
-    "HasMultiLineMessage": false,
+    "Body": "wip tests\n\nsecond line\nthird line before multiple whitespace",
+    "HasMultiLineMessage": true,
     "HasNotes": false,
     "IsArtificial": false,
-    "IsStash": false,
-    "ReflogSelector": null,
+    "IsStash": true,
+    "ReflogSelector": "stash{0}",
     "HasParent": true,
     "FirstParentId": {
         "IsArtificial": false

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test.ForScenario.subject_no_body.approved.json
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test.ForScenario.subject_no_body.approved.json
@@ -26,6 +26,8 @@
     "HasMultiLineMessage": true,
     "HasNotes": false,
     "IsArtificial": false,
+    "IsStash": false,
+    "ReflogSelector": null,
     "HasParent": true,
     "FirstParentId": {
         "IsArtificial": false

--- a/UnitTests/GitCommands.Tests/TestData/RevisionReader/reflogselector.bin
+++ b/UnitTests/GitCommands.Tests/TestData/RevisionReader/reflogselector.bin
@@ -1,0 +1,15 @@
+0c350e248500e4e893e6d17dcc61591cc1cd64e71bcb98ebe109b0a9a569b6c827d55f97730cdb247b89abaf240ec4e057a2304659cbde7b1e7bb68e 7b89abaf240ec4e057a2304659cbde7b1e7bb68e 7b89abaf240ec4e057a2304659cbde7b1e7bb68e
+1624479586
+1624479586
+Gerhard Olsson
+gerhardol@users.noreply.github.com
+Gerhard Olsson
+gerhardol@users.noreply.github.com
+stash{0}
+wip tests
+
+second line
+third line before multiple whitespace
+		
+
+

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
@@ -20,7 +20,6 @@ namespace GitUITests.UserControls
         public void SetUp()
         {
             AppSettings.ShowGitNotes = false;
-            AppSettings.ShowLatestStash = true;
         }
 
         [Test]


### PR DESCRIPTION
Resolves #5371 (and #5785
Fixes #9873

## Proposed changes

Show stash commits in the revision grid, with menu options to pop and drop stashes.

A stash is implemented in Git with 3 internal commit.
Some more explanations in GitUI\UserControls\RevisionGrid\RevisionGridControl.cs:988
The implementations I have seen do not expose the third commit with untracked files.
The PR includes this "untracked" commit (empty "untracked" are filtered) for the first 10 stashes (see Performance below for details).
This setting is read from the settings but no setter is exposed, mostly because there is no natural place to show it (maybe in View is the best, but other similar settings are in General, that is considered full).

The implementation by default only show the stashes where the parents are shown in the grid.
So for instance if you stash and then rebase then the stash is not shown (but see below).
Unless reflogs are shown, only stashes that are related to commits visible in the grid is shown.
(Another difference with reflog is that stashes are presented in Git order, the "inserted" stashes are always shown related to the main commit).

The label for stash commits is partly for this reason set to the reflog selector like "stash@{0}" (required to pop/drop stashes) (another reason is to not get lost too easy when looking at commits, especially when many stashes are created for the same commit).
(For instance GitKraken shows these commits.)
FormStash can still be used to see these, they could also be added to the side panel (similar to SourceTree) (but the contents would not be shown). See #5460.
(Sublime merge shows both in grid and sidepanel)

GE currently always show the latest stash, this was expected by mstv in the initial version.
The latest stash is therefore always shown if stashes are shown.
This commit will always include the index and untracked commits.
See https://github.com/gitextensions/gitextensions/pull/10138#issuecomment-1236200583 for a discussion about how that could be changed.

There is no new menu operation to create a stash, use stash button or Ctrl-Alt-Up to create a stash.
Create a stash operate on both Index and WorkTree commits, so there is no natural way to connect this to a revision (but _partial_ commit should be possible to create in RevDiff).
FormStash was improved in #9303 too.

### Performance

Loading revisions in 4.0 is heavily optimized, some performance measurements to ensure there is no regression.
(I have tried to make sure the addition has minimal impact on performance).

My GE repo has 19400 commits and 542 stashes, testing on Win10 with Zen2600, 16GB, SSD.
I consider 542 stashes to be an upper limit to what is reasonable to test with.

If stashes are not displayed, basically one null variable is, adding less than 1 ms to process all revisions. So usecases not showing stashes are not affected.
Enabled but no existing stashes has a few more checks, affects loading with about 9 ms.

Times are approximate, some variation (+/- 30 ms), but relative consistent differences.
Time will be affected by number of cores etc
Refreshing refs is done in three partly parallel steps:

1. Getting refs and checkout
Total step 175 ms (git-for-each-ref 125 ms)

2. Getting Stash commit (10 stash checked for untracked)
Total step 175 ms (git-stash-list 95 ms, git-log <untracked-id> 70 ms)
If this time is higher than step 1 the load time is increasing.
Note that the second Git command for untracked is not needed if reflog is shown.

3. Getting revisions
Total git-log time 600 ms but first revision is delivered and could be processed for display after 140 ms (this is when the spinner is replaced with "Loading" in upper right corner) (as refs are slower, revgrid will be updated 35 ms after this)
(if sorting in the grid is enabled, revisions will be shown with at least a 100 ms delay)
Processing time to find if stashes should be added is about 9 ms.
The GUI update is done in about the time that git-log runs.
The "Loading" label is then removed, but some additional CPU may be needed for selecting a new revision (if filtering changed).

Stashes slow down showing revisions in the grid with about 9 ms plus possible additional time due to parallel processing overhead (but I have not seen any faster ref handling with stash disabled).
This is assuming that the 10 "untracked" takes the same time as getting refs, which in my case is 10, which I also believe is an OK value of untracked to show.
0 untracked limits step 2 with 60 ms (but revisions are not shown earlier), 50 untracked adds 30 ms and all 542 adds 400 ms.

Brief tests with Linux repo in wsl limited to 100000 commits shown with one local branch and 10 stashes.
With so few refs, refs are handled in 150 ms and stash-list in 170 and listing untracked will add 100 ms and 50 ms (processing adding to grid) out of total 4.1 s. So hardly noticeable.

## Screenshots <!-- Remove this section if PR does not change UI -->

With reflogs shown, the change is that labels and menu operations are enabled for all commits.

### Before

Latest stash shown

![image](https://user-images.githubusercontent.com/6248932/183312947-b2455131-227b-497b-bfa2-0d64f81a3e59.png)

### After

If parent commit is not shown, stash is not shown (first is shown though, not updated example)

![image](https://user-images.githubusercontent.com/6248932/183313063-0eab1103-cd6a-4dcd-bd1f-15f1677afa20.png)

Other commits are shown, "untracked" commit only if it is not empty

![image](https://user-images.githubusercontent.com/6248932/183313149-76b55c74-7377-4a37-b4ee-d2b0eae52539.png)

Menu

![image](https://user-images.githubusercontent.com/6248932/189742955-ded2242a-3c92-4fd8-9e08-f157a4d22d97.png)

## Test methodology <!-- How did you ensure quality? -->

A few tests added, some modified.

## Test environment(s) <!-- Remove any that don't apply -->

Git 2.37.1
No other version tested, nothing seen in the Git doc about any compatibility.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
