### PR TITLE
VS Code build support

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+            "ms-vscode.cpptools",
+            "ms-dotnettools.csharp",
+            "pmiossec.vscode-gitextensions",
+            "VisualStudioExptTeam.vscodeintellicode"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,10 +5,26 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "PowerShell: Interactive Session",
-            "type": "PowerShell",
+            "name": "Debug",
+            "type": "coreclr",
             "request": "launch",
-            "cwd": ""
-        }
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/artifacts/Debug/bin/GitExtensions/net6.0-windows/GitExtensions.exe",
+            "args": ["browse", "${workspaceFolder}"],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "internalConsole"
+        },
+        {
+            "name": "Debug - Dashboard",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/artifacts/Debug/bin/GitExtensions/net6.0-windows/GitExtensions.exe",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "internalConsole"
+        },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,83 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "build-vc",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                ".\\scripts\\native.proj"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+            }
+        },
+        {
+            "label": "test",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "test"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build"
+            },
+            "dependsOn": ["build", "build-vc"]
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/GitExtensions.sln"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "translate",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "/p:RunTranslationApp=true"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Proposed changes

Add basic VS Code support to build, test and run GE.
Also recommending plugins.
I personally would like a .code-workspace file too, but current settings can be stored in the folder and there are no folder external dependencies, so this works.

Not much use myself, but the current configuration is broken, this is something to improve on.
VS Code is used more and more, even if a Windows only app as GE is better supported in Visual Studio, this may help occasional users.

Also for 4.0, if users try to build/debug the release.

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
