### PR TITLE
Open new instance if double click on current submodule

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -101,8 +101,8 @@ namespace GitUI.BranchTreePanel
             bool isSingleSubmoduleSelected = hasSingleSelection && selectedNode is SubmoduleNode;
             var submoduleNode = selectedNode as SubmoduleNode;
             bool isBareRepository = Module.IsBareRepository();
-            EnableMenuItems(isSingleSubmoduleSelected && submoduleNode.CanOpen, mnubtnOpenSubmodule, mnubtnOpenGESubmodule);
-            mnubtnUpdateSubmodule.Enable(isSingleSubmoduleSelected);
+            mnubtnOpenSubmodule.Enable(isSingleSubmoduleSelected && !submoduleNode.IsCurrent);
+            EnableMenuItems(isSingleSubmoduleSelected, mnubtnOpenGESubmodule, mnubtnUpdateSubmodule);
             EnableMenuItems(isSingleSubmoduleSelected && !isBareRepository && submoduleNode.IsCurrent, mnubtnManageSubmodules, mnubtnSynchronizeSubmodules);
             EnableMenuItems(isSingleSubmoduleSelected && !isBareRepository, mnubtnResetSubmodule, mnubtnStashSubmodule, mnubtnCommitSubmodule);
         }
@@ -155,10 +155,10 @@ namespace GitUI.BranchTreePanel
             RegisterClick<RemoteRepoNode>(mnubtnDisableRemote, remote => remote.Disable());
 
             // SubmoduleNode
-            RegisterClick<SubmoduleNode>(mnubtnManageSubmodules, _ => _submoduleTree.ManageSubmodules(this));
-            RegisterClick<SubmoduleNode>(mnubtnSynchronizeSubmodules, _ => _submoduleTree.SynchronizeSubmodules(this));
             RegisterClick<SubmoduleNode>(mnubtnOpenSubmodule, node => _submoduleTree.OpenSubmodule(this, node));
             RegisterClick<SubmoduleNode>(mnubtnOpenGESubmodule, node => _submoduleTree.OpenSubmoduleInGitExtensions(this, node));
+            RegisterClick<SubmoduleNode>(mnubtnManageSubmodules, _ => _submoduleTree.ManageSubmodules(this));
+            RegisterClick<SubmoduleNode>(mnubtnSynchronizeSubmodules, _ => _submoduleTree.SynchronizeSubmodules(this));
             RegisterClick<SubmoduleNode>(mnubtnUpdateSubmodule, node => _submoduleTree.UpdateSubmodule(this, node));
             RegisterClick<SubmoduleNode>(mnubtnResetSubmodule, node => _submoduleTree.ResetSubmodule(this, node));
             RegisterClick<SubmoduleNode>(mnubtnStashSubmodule, node => _submoduleTree.StashSubmodule(this, node));

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -71,9 +71,9 @@ namespace GitUI.BranchTreePanel
             this.mnuBtnPruneAllBranchesFromARemote = new System.Windows.Forms.ToolStripMenuItem();
             this.mnuBtnOpenRemoteUrlInBrowser = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
-            this.mnubtnManageSubmodules = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnOpenSubmodule = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnOpenGESubmodule = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnManageSubmodules = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnUpdateSubmodule = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnSynchronizeSubmodules = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnResetSubmodule = new System.Windows.Forms.ToolStripMenuItem();
@@ -146,9 +146,9 @@ namespace GitUI.BranchTreePanel
             this.mnuBtnPruneAllBranchesFromARemote,
             this.mnuBtnOpenRemoteUrlInBrowser,
             this.toolStripSeparator5,
-            this.mnubtnManageSubmodules,
             this.mnubtnOpenSubmodule,
             this.mnubtnOpenGESubmodule,
+            this.mnubtnManageSubmodules,
             this.mnubtnUpdateSubmodule,
             this.mnubtnSynchronizeSubmodules,
             this.mnubtnResetSubmodule,
@@ -278,14 +278,6 @@ namespace GitUI.BranchTreePanel
             this.toolStripSeparator5.Name = "toolStripSeparator5";
             this.toolStripSeparator5.Size = new System.Drawing.Size(263, 6);
             // 
-            // mnubtnManageSubmodules
-            // 
-            this.mnubtnManageSubmodules.Image = global::GitUI.Properties.Images.SubmodulesManage;
-            this.mnubtnManageSubmodules.Name = "mnubtnManageSubmodules";
-            this.mnubtnManageSubmodules.Size = new System.Drawing.Size(266, 26);
-            this.mnubtnManageSubmodules.Text = "&Manage...";
-            this.mnubtnManageSubmodules.ToolTipText = "Manage submodules";
-            // 
             // mnubtnOpenSubmodule
             // 
             this.mnubtnOpenSubmodule.Image = global::GitUI.Properties.Images.FolderOpen;
@@ -301,6 +293,14 @@ namespace GitUI.BranchTreePanel
             this.mnubtnOpenGESubmodule.Size = new System.Drawing.Size(266, 26);
             this.mnubtnOpenGESubmodule.Text = "O&pen";
             this.mnubtnOpenGESubmodule.ToolTipText = "Open selected submodule in a new instance";
+            // 
+            // mnubtnManageSubmodules
+            // 
+            this.mnubtnManageSubmodules.Image = global::GitUI.Properties.Images.SubmodulesManage;
+            this.mnubtnManageSubmodules.Name = "mnubtnManageSubmodules";
+            this.mnubtnManageSubmodules.Size = new System.Drawing.Size(266, 26);
+            this.mnubtnManageSubmodules.Text = "&Manage...";
+            this.mnubtnManageSubmodules.ToolTipText = "Manage submodules";
             // 
             // mnubtnUpdateSubmodule
             // 

--- a/GitUI/BranchTreePanel/SubmoduleNode.cs
+++ b/GitUI/BranchTreePanel/SubmoduleNode.cs
@@ -49,8 +49,6 @@ namespace GitUI.BranchTreePanel
             ApplyStatus();
         }
 
-        public bool CanOpen => !IsCurrent;
-
         protected override string DisplayText()
         {
             return SubmoduleName + BranchText + Info.Detailed?.AddedAndRemovedText;
@@ -101,7 +99,14 @@ namespace GitUI.BranchTreePanel
 
         internal override void OnDoubleClick()
         {
-            Open();
+            if (!IsCurrent)
+            {
+                Open();
+            }
+            else
+            {
+                LaunchGitExtensions();
+            }
         }
 
         protected override void ApplyStyle()

--- a/GitUI/BranchTreePanel/SubmoduleNode.cs
+++ b/GitUI/BranchTreePanel/SubmoduleNode.cs
@@ -99,13 +99,14 @@ namespace GitUI.BranchTreePanel
 
         internal override void OnDoubleClick()
         {
-            if (!IsCurrent)
+            if (IsCurrent)
             {
-                Open();
+                // For the current module the module is already open, so launch a new instance
+                LaunchGitExtensions();
             }
             else
             {
-                LaunchGitExtensions();
+                Open();
             }
         }
 


### PR DESCRIPTION
https://github.com/gitextensions/gitextensions/pull/10118#issuecomment-1211078704

## Proposed changes

Add menu item to open the current submodule (including the
superproject module) instead of reopening the module
(this option was not added to the menu).

Add the menu item to open the new instance too, first in the menu.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/184008757-8f94d30c-d346-442f-a48c-2f490319092c.png)

![image](https://user-images.githubusercontent.com/6248932/184008886-c80602e6-f234-4ed7-8e19-124e124d9c83.png)

### After

![image](https://user-images.githubusercontent.com/6248932/184008972-b8594da3-7e49-4510-bf05-1de2702b6bbb.png)

![image](https://user-images.githubusercontent.com/6248932/184009054-43b55a1e-f5bc-4b28-90b9-b11b08f32e5b.png)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
