### PR TITLE
Sidepanel: Keep revisions opening a new instance

### DIFF
--- a/GitUI/BranchTreePanel/SubmoduleNode.cs
+++ b/GitUI/BranchTreePanel/SubmoduleNode.cs
@@ -87,21 +87,23 @@ namespace GitUI.BranchTreePanel
                 return;
             }
 
+            ObjectId? selected;
             ObjectId? first;
-            ObjectId? second;
-            if (!IsCurrent)
+            if (IsCurrent)
             {
-                first = ObjectId.WorkTreeId;
-                second = Info?.Detailed?.RawStatus?.OldCommit;
+                // Get the current (most likely) selections from the grid
+                IReadOnlyList<GitRevision>? revs = UICommands.GetSelectedRevisions() ?? new List<GitRevision>();
+                selected = revs.Count > 0 ? revs[0].ObjectId : null;
+                first = revs.Count > 1 ? revs[revs.Count - 1].ObjectId : null;
             }
             else
             {
-                IReadOnlyList<GitRevision> revs = UICommands.GetSelectedRevisions();
-                first = revs.Count > 0 ? revs[0].ObjectId : null;
-                second = revs.Count > 1 ? revs[revs.Count - 1].ObjectId : null;
+                // Try select a "diff" from the expected commit to worktree for a submodule
+                selected = ObjectId.WorkTreeId;
+                first = Info?.Detailed?.RawStatus?.OldCommit;
             }
 
-            GitUICommands.LaunchBrowse(workingDir: Info.Path.EnsureTrailingPathSeparator(), first, second);
+            GitUICommands.LaunchBrowse(workingDir: Info.Path.EnsureTrailingPathSeparator(), selected, first);
         }
 
         internal override void OnSelected()

--- a/GitUI/BranchTreePanel/SubmoduleNode.cs
+++ b/GitUI/BranchTreePanel/SubmoduleNode.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git;
 using GitCommands.Submodules;
@@ -86,7 +87,21 @@ namespace GitUI.BranchTreePanel
                 return;
             }
 
-            GitUICommands.LaunchBrowse(workingDir: Info.Path.EnsureTrailingPathSeparator(), ObjectId.WorkTreeId, Info?.Detailed?.RawStatus?.OldCommit);
+            ObjectId? first;
+            ObjectId? second;
+            if (!IsCurrent)
+            {
+                first = ObjectId.WorkTreeId;
+                second = Info?.Detailed?.RawStatus?.OldCommit;
+            }
+            else
+            {
+                IReadOnlyList<GitRevision> revs = UICommands.GetSelectedRevisions();
+                first = revs.Count > 0 ? revs[0].ObjectId : null;
+                second = revs.Count > 1 ? revs[revs.Count - 1].ObjectId : null;
+            }
+
+            GitUICommands.LaunchBrowse(workingDir: Info.Path.EnsureTrailingPathSeparator(), first, second);
         }
 
         internal override void OnSelected()

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -650,6 +650,11 @@ namespace GitUI.CommandsDialogs
             }
         }
 
+        public IReadOnlyList<GitRevision> GetSelectedRevisions()
+        {
+            return RevisionGrid.GetSelectedRevisions();
+        }
+
         #endregion
 
         public void SetPathFilter(string pathFilter)

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1905,6 +1905,11 @@ namespace GitUI
             BrowseRepo?.SetWorkingDir(path, selectedId, firstId);
         }
 
+        public IReadOnlyList<GitRevision> GetSelectedRevisions()
+        {
+            return BrowseRepo?.GetSelectedRevisions();
+        }
+
         public IGitRemoteCommand CreateRemoteCommand()
         {
             return new GitRemoteCommand(this);

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1905,7 +1905,7 @@ namespace GitUI
             BrowseRepo?.SetWorkingDir(path, selectedId, firstId);
         }
 
-        public IReadOnlyList<GitRevision> GetSelectedRevisions()
+        public IReadOnlyList<GitRevision>? GetSelectedRevisions()
         {
             return BrowseRepo?.GetSelectedRevisions();
         }

--- a/Plugins/GitUIPluginInterfaces/IBrowseRepo.cs
+++ b/Plugins/GitUIPluginInterfaces/IBrowseRepo.cs
@@ -1,8 +1,11 @@
-﻿namespace GitUIPluginInterfaces
+﻿using System.Collections.Generic;
+
+namespace GitUIPluginInterfaces
 {
     public interface IBrowseRepo
     {
         void GoToRef(string refName, bool showNoRevisionMsg, bool toggleSelection = false);
         void SetWorkingDir(string? path, ObjectId? selectedId = null, ObjectId? firstId = null);
+        IReadOnlyList<GitRevision> GetSelectedRevisions();
     }
 }


### PR DESCRIPTION
Requires #10145 to be used, but can be reviewed independent of that PR.

## Proposed changes

When launching a new GE instance from the sidepanel, set
first/last selected revisions in the grid as first/second in
the new instance.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Always selecting HEAD 

![image](https://user-images.githubusercontent.com/6248932/184014961-12a2995f-eaaa-4c5c-bd00-fe1d458be81c.png)

### After

Keeping selections
![image](https://user-images.githubusercontent.com/6248932/184015059-2d0a80a7-f68f-4608-a71c-baaaf86f0897.png)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
