### PR TITLE
Reword/Edit: Rebase on actual parent

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -775,7 +775,7 @@ namespace GitUI
         /// Get the GitRevision with the actual parents as they may be rewritten in filtered grids.
         /// </summary>
         /// <param name="revision">The revision, likely from the grid.</param>
-        /// <returns>The input GitRevision if no changes and a clone with actual parents if parents are rewritte.</returns>
+        /// <returns>The input GitRevision if no changes and a clone with actual parents if parents are rewritten.</returns>
         public GitRevision GetActualRevision(GitRevision revision)
         {
             // Index commits must have HEAD as parent already
@@ -2779,7 +2779,7 @@ namespace GitUI
             }
 
             string rebaseCmd = GitCommandHelpers.RebaseCmd(
-                LatestSelectedRevision.FirstParentId?.ToString(), interactive: true, preserveMerges: false,
+                GetActualRevision(LatestSelectedRevision)?.FirstParentId?.ToString(), interactive: true, preserveMerges: false,
                 autosquash: false, autoStash: true, ignoreDate: false, committerDateIsAuthorDate: false, supportRebaseMerges: Module.GitVersion.SupportRebaseMerges);
 
             using FormProcess formProcess = new(UICommands, arguments: rebaseCmd, Module.WorkingDir, input: null, useDialogSettings: true);


### PR DESCRIPTION
Fixes #10147

## Proposed changes

If the grid is filtered, get the actual parent id as the grid may
be rewritten.
Affects to reword/edit rebase and blame.

For blame, also adjust the rules to show the "blame previous" menu item.

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
