### PR TITLE
Do not call DoDragDrop when mouse is up

### DIFF
--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -67,6 +67,7 @@
             this.FileStatusListView.DoubleClick += new System.EventHandler(this.FileStatusListView_DoubleClick);
             this.FileStatusListView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FileStatusListView_KeyDown);
             this.FileStatusListView.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FileStatusListView_MouseDown);
+            this.FileStatusListView.MouseUp += new System.Windows.Forms.MouseEventHandler(this.FileStatusListView_MouseUp);
             this.FileStatusListView.MouseMove += new System.Windows.Forms.MouseEventHandler(this.FileStatusListView_MouseMove);
             this.FileStatusListView.Scroll += new System.Windows.Forms.ScrollEventHandler(this.FileStatusListView_Scroll);
             // 

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1562,7 +1562,7 @@ namespace GitUI
 
         private void FileStatusListView_MouseUp(object sender, MouseEventArgs e)
         {
-            // Stop DRAG when mouse up
+            // Release the drag capture
             if (e.Button == MouseButtons.Left)
             {
                 _dragBoxFromMouseDown = Rectangle.Empty;

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1560,6 +1560,15 @@ namespace GitUI
             }
         }
 
+        private void FileStatusListView_MouseUp(object sender, MouseEventArgs e)
+        {
+            // Stop DRAG when mouse up
+            if (e.Button == MouseButtons.Left)
+            {
+                _dragBoxFromMouseDown = Rectangle.Empty;
+            }
+        }
+
         private void FileStatusListView_MouseMove(object sender, MouseEventArgs e)
         {
             ListView? listView = sender as ListView;

--- a/contributors.txt
+++ b/contributors.txt
@@ -177,3 +177,4 @@ YYYY/MM/DD, github id, Full name, email
 2022/05/12, TheShadoWCo, Maximov Valery, maximovvaelry@gmail.com
 2022/05/19, zvirja, Oleksandr Povar, zvirja1[.@)gmail.com
 2022/05/20, Rhumborl, Philip Cole, pccole[at)gmail.com
+2022/08/23, huangsunyang, SunYang Huang, huangsunyang(at)126.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- In FileStatusList, DoDragDrop is called even when mouse (left button) is up, which is unnecessary
- Besides, in some windows versions, IME has a [bug](https://support.microsoft.com/en-us/topic/kb4564002-you-might-have-issues-on-windows-10-version-20h2-and-windows-10-version-2004-when-using-some-microsoft-imes-63696506-47d2-9997-0b72-41a68e328692) that DoDragDrop call will hang up. And Git Extensions is always calling DoDragDrop, thus increases the possibilily of this bug

<!-- TODO -->

## Test methodology <!-- How did you ensure quality? -->

- In FileStatusList, shift/ctrl click function remains same
- In FileStatusList, drag drop function remains same

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
