### PR TITLE
Set RuntimeFrameworkVersion for DotnetRuntimeBootstrapper

### DIFF
--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -18,9 +18,6 @@
 
     <!-- To be removed when NRT annotations are complete -->
     <Nullable>annotations</Nullable>
-
-    <!-- Set version for runtimeconfig.json, used by DotnetRuntimeBootstrapper -->
-    <RuntimeFrameworkVersion>6.0.8</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -18,6 +18,9 @@
 
     <!-- To be removed when NRT annotations are complete -->
     <Nullable>annotations</Nullable>
+
+    <!-- Set version for runtimeconfig.json, used by DotnetRuntimeBootstrapper -->
+    <RuntimeFrameworkVersion>6.0.8</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Packages.props
+++ b/Packages.props
@@ -7,7 +7,7 @@
     <PackageReference Update="AppInsights.WindowsDesktop" Version="2.18.1" />
     <PackageReference Update="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Update="ConEmu.Core" Version="22.4.18" />
-    <PackageReference Update="DotnetRuntimeBootstrapper" Version="2.0.3" />
+    <PackageReference Update="DotnetRuntimeBootstrapper" Version="2.3.1" />
     <PackageReference Update="EnvDTE" Version="17.0.32112.339" />
     <PackageReference Update="ExCSS" Version="4.1.3" />
     <PackageReference Update="GitInfo" Version="2.2.0" />

--- a/scripts/RepoLayout.props
+++ b/scripts/RepoLayout.props
@@ -6,6 +6,8 @@
   -->
 
   <PropertyGroup>
+    <!-- Set version for runtimeconfig.json, used by DotnetRuntimeBootstrapper for minimal version to support -->
+    <RuntimeFrameworkVersion>6.0.7</RuntimeFrameworkVersion>
     <SolutionTargetFramework>net6.0-windows</SolutionTargetFramework>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>


### PR DESCRIPTION
Resolves #10075


See https://github.com/gitextensions/gitextensions/discussions/10131#discussioncomment-3405852
Discussed in https://github.com/Tyrrrz/DotnetRuntimeBootstrapper/discussions/33#discussioncomment-3413110

## Proposed changes

Set version that propagates to runtimeconfig.json that serves as the minimal version that DotnetRuntimeBootstrapper checks.
By default, the version is set to 6.0.0 in
artifacts/Debug/bin/GitExtensions/net6.0-windows/GitExtensions.runtimeconfig.json
<RuntimeFrameworkVersion>6.0.8</RuntimeFrameworkVersion>

Update DotnetRuntimeBootstrapper to latest release 2.3.1

## Test methodology <!-- How did you ensure quality? -->

Set version to 6.0.7, 6.0.8: Normal startup
6.0.9: Popup to install new version.
Note: I had to delete artifacts/ and restart Visual Studio to not get the popup after changing.

## Test environment(s) <!-- Remove any that don't apply -->

.NET 6.0.8 (latest release)

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
