### PR TITLE
FormStash: Display index of stashes

### DIFF
--- a/GitCommands/Git/GitStash.cs
+++ b/GitCommands/Git/GitStash.cs
@@ -45,9 +45,8 @@ namespace GitCommands.Git
         /// <remarks>"stash@{n}"</remarks>
         public string Name => $"stash@{{{Index}}}";
 
-        public override string ToString()
-        {
-            return Message;
-        }
+        public string Summary => Index == -1 ? Message : $"@{{{Index}}}: {Message}";
+
+        public override string ToString() => Message;
     }
 }

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -136,7 +136,7 @@ namespace GitUI.CommandsDialogs
             Stashes.Text = "";
             StashMessage.Text = "";
             Stashes.SelectedItem = null;
-            Stashes.ComboBox.DisplayMember = nameof(GitStash.Message);
+            Stashes.ComboBox.DisplayMember = nameof(GitStash.Summary);
             Stashes.Items.Clear();
             foreach (GitStash stashedItem in stashedItems)
             {


### PR DESCRIPTION
so that the user could more easily track where he is...

(I always found painful to use the stashes ComboBox when you have a lot of stashs and stash index really help me to find the current selected stash once you scroll in the list --because the ComboBox doesn't highlight the current selected item 😢--)

## Proposed changes

- Display index of stashes (like it is done in the git command output)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Let's play a game: Could you find the currently selected one?

![image](https://user-images.githubusercontent.com/460196/185767499-46014aa5-a39b-49c5-a204-af5aed446bc4.png)

### After

And now?

![image](https://user-images.githubusercontent.com/460196/185767568-0a18d555-19b5-4655-9ae8-41b74a0facda.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual
- 
## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build c92862e1c99a55af34ff69b2698742da81bfbba9
- Git 2.35.1.windows.2 (recommended: 2.37.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.8
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
