### PR TITLE
Insert artificial commits if filter without any matches is applied

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1323,19 +1323,10 @@ namespace GitUI
                         {
                             parents = headParents.Skip(index + 1).ToList();
                         }
-                        else
+                        else if (!notSelectedId.IsArtificial)
                         {
-                            if (notSelectedId.IsArtificial)
-                            {
-                                notSelectedId = CurrentCheckout is not null
-                                    ? CurrentCheckout
-                                    : _gridView.ToBeSelectedObjectIds.Where(id => !id.IsArtificial).FirstOrDefault();
-                            }
-
-                            if (notSelectedId is not null)
-                            {
-                                parents = TryGetParents(Module, _filterInfo, notSelectedId);
-                            }
+                            // Ignore if the not selected is artificial, it is likely that the settings was changed
+                            parents = TryGetParents(Module, _filterInfo, notSelectedId);
                         }
 
                         // Try to select the first of the parents


### PR DESCRIPTION
Fixes #10162

## Proposed changes

Handle selection after refresh if artificial commits are
removed from the view

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
