### PR TITLE
RevGrid: Custom tools were only loaded at settings changes

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -560,6 +560,12 @@ namespace GitUI
             ShowLoading();
         }
 
+        protected override void OnRuntimeLoad()
+        {
+            base.OnRuntimeLoad();
+            LoadCustomDifftools();
+        }
+
         public new void Load()
         {
             if (!DesignMode)
@@ -568,8 +574,6 @@ namespace GitUI
             }
 
             PerformRefreshRevisions();
-
-            LoadCustomDifftools();
         }
 
         public void LoadCustomDifftools()


### PR DESCRIPTION
## Proposed changes

Custom diff/mergetools (all known to Git) is available in RevDiff, Commit, FileHistory, ResolveConflicts
In RevGrid it is available only after settings, as the loading at startup was incorrect.

Custom difftool is useful for dir diff, as some difftools does not support dir diffs (like TortoiseDiff) and also if supported, may not be the best for dir diff.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/186009385-46e8b807-4b21-42c1-a88b-8bfe23bba470.png)

### After

![image](https://user-images.githubusercontent.com/6248932/186009744-5c8b3090-1a67-4492-a4c9-9f8bd15e9f28.png)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
