### PR TITLE
Set branchfilter from sidepanel without checking dropdown

### DIFF
--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -39,19 +39,6 @@ namespace GitUI.UserControls
             tscboBranchFilter.ComboBox.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
         }
 
-        public RefsFilter BranchesFilter
-        {
-            get
-            {
-                // Options are interpreted as the refs the search should be limited too
-                // If neither option is selected all refs will be queried also including stash and notes
-                RefsFilter refs = (tsmiBranchLocal.Checked ? RefsFilter.Heads : RefsFilter.NoFilter)
-                    | (tsmiBranchTag.Checked ? RefsFilter.Tags : RefsFilter.NoFilter)
-                    | (tsmiBranchRemote.Checked ? RefsFilter.Remotes : RefsFilter.NoFilter);
-                return refs;
-            }
-        }
-
         private IRevisionGridFilter RevisionGridFilter
         {
             get => _revisionGridFilter ?? throw new InvalidOperationException($"{nameof(Bind)} is not called.");
@@ -85,12 +72,8 @@ namespace GitUI.UserControls
             // The user has accepted the filter
             _filterBeingChanged = false;
 
-            string filter = tscboBranchFilter.Items.Count > 0 ? tscboBranchFilter.Text : string.Empty;
-            if (filter == TranslatedStrings.NoResultsFound)
-            {
-                filter = string.Empty;
-            }
-
+            // Apply the textbox contents, no check if the (multiple) options is in tscboBranchFilter.Items (or that the list is generated)
+            string filter = tscboBranchFilter.Text == TranslatedStrings.NoResultsFound ? string.Empty : tscboBranchFilter.Text;
             RevisionGridFilter.SetAndApplyBranchFilter(filter);
 
             _isApplyingFilter = false;
@@ -255,6 +238,12 @@ namespace GitUI.UserControls
             tscboBranchFilter.Items.Clear();
         }
 
+        /// <summary>
+        /// Update the tscboBranchFilter dropdown items matching the current filter.
+        /// This is called when dropdown clicked or text is manually changed
+        /// (so tscboBranchFilter.Items is not necessarily available when set externally
+        /// from the sidepanel or FormBrowse).
+        /// </summary>
         private void UpdateBranchFilterItems()
         {
             IGitModule module = GetModule();
@@ -265,7 +254,6 @@ namespace GitUI.UserControls
             }
 
             Enabled = true;
-            RefsFilter branchesFilter = BranchesFilter;
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await TaskScheduler.Default;
@@ -276,6 +264,7 @@ namespace GitUI.UserControls
                     return;
                 }
 
+                RefsFilter branchesFilter = BranchesFilter();
                 IReadOnlyList<IGitRef> refs = _getRefs(branchesFilter);
                 string[] branches = refs.Select(branch => branch.Name).ToArray();
 
@@ -284,6 +273,16 @@ namespace GitUI.UserControls
             }).FileAndForget();
 
             return;
+
+            RefsFilter BranchesFilter()
+            {
+                // Options are interpreted as the refs the search should be limited too
+                // If neither option is selected all refs will be queried also including stash and notes
+                RefsFilter refs = (tsmiBranchLocal.Checked ? RefsFilter.Heads : RefsFilter.NoFilter)
+                    | (tsmiBranchTag.Checked ? RefsFilter.Tags : RefsFilter.NoFilter)
+                    | (tsmiBranchRemote.Checked ? RefsFilter.Remotes : RefsFilter.NoFilter);
+                return refs;
+            }
 
             void BindBranches(string[] branches)
             {


### PR DESCRIPTION
## Proposed changes

The branchfilters from the sidepanel was not applied unless the
filter dropdown contained any items, but the items were not updated
by default since #10136, only when needed (dropdown clicked or text typed).

The dropdown was updated async FileAndForget, so 'external' usage was not
always successful. This was a reason why the test
'Filters_should_behave_as_expected' had to be disabled in AppVeyor
(the test still occasionally fails though).
(The test was the primary reason why I looked at this, the side panel was detected after.)

## Test methodology <!-- How did you ensure quality? -->

Manual
Test Filters_should_behave_as_expected works slightly better but still fails though.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
