### PR TITLE
Tests: Disable some commonly failed tests

### DIFF
--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -269,7 +269,10 @@ namespace GitExtensions.UITests.CommandsDialogs
                         WaitForRevisionsToBeLoaded(form);
                         // Assert
                         AppSettings.ShowLatestStash.Should().BeFalse();
+#if DEBUG
+                        // This test occasionaly fails with 3 visible revisions
                         form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(4);
+#endif
                     }
                     finally
                     {

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -270,6 +270,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                         // Assert
                         AppSettings.ShowLatestStash.Should().BeFalse();
 #if DEBUG
+                        // https://github.com/gitextensions/gitextensions/issues/10170
                         // This test occasionaly fails with 3 visible revisions
                         form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(4);
 #endif

--- a/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
@@ -149,7 +149,8 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                     Assert.True(revisionGridControl.CurrentFilter.IsShowFilteredBranchesChecked);
 
 #if DEBUG
-                    // TBD 'Loading Revisions' didn't finish in 25 iterations
+                    // https://github.com/gitextensions/gitextensions/issues/10170
+                    // This step occasionaly fails with 'Loading Revisions' didn't finish in 25 iterations
                     WaitForRevisionsToBeLoaded(revisionGridControl);
 
                     // Confirm the filter has been applied
@@ -184,7 +185,8 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                     Assert.False(revisionGridControl.CurrentFilter.IsShowFilteredBranchesChecked);
 
 #if DEBUG
-                    // TBD 'Loading Revisions' didn't finish in 25 iterations
+                    // https://github.com/gitextensions/gitextensions/issues/10170
+                    // This step occasionaly fails with 'Loading Revisions' didn't finish in 25 iterations
                     WaitForRevisionsToBeLoaded(revisionGridControl);
 
                     // Confirm the filter has been reset, all commits are shown

--- a/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
@@ -148,10 +148,14 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                     revisionGridControl.SetAndApplyBranchFilter("Branch1");
                     Assert.True(revisionGridControl.CurrentFilter.IsShowFilteredBranchesChecked);
 
+#if DEBUG
+                    // TBD 'Loading Revisions' didn't finish in 25 iterations
                     WaitForRevisionsToBeLoaded(revisionGridControl);
 
                     // Confirm the filter has been applied
+                    // This test occasionaly fails with 4 visible revisions
                     ta.VisibleRevisionCount.Should().Be(2);
+#endif
                 });
         }
 
@@ -179,10 +183,14 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
                     revisionGridControl.SetAndApplyBranchFilter(string.Empty);
                     Assert.False(revisionGridControl.CurrentFilter.IsShowFilteredBranchesChecked);
 
+#if DEBUG
+                    // TBD 'Loading Revisions' didn't finish in 25 iterations
                     WaitForRevisionsToBeLoaded(revisionGridControl);
 
                     // Confirm the filter has been reset, all commits are shown
+                    // This test occasionaly fails with 3 visible revisions
                     ta.VisibleRevisionCount.Should().Be(4);
+#endif
                 });
         }
 


### PR DESCRIPTION
## Proposed changes

A few tests fail frequently, close to half the tests.
This PR disables the flaky asserts in these tests, so the tests can be trusted better.
Another common issue is downloading the plugin manager.

Disable checks in Release builds, keep them in Debug

I have tried to look into the tests and spent considerable time in trying to improve the loading sequence, but have not solved this.
One reason for this may be some FileAndForget() like the cause for #10168 (even if #10136 changed that further).

## Test methodology <!-- How did you ensure quality? -->

Reviewing AppVeyor test logs

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
