### PR TITLE
Decouple filter options

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -546,20 +546,10 @@ namespace GitUI.CommandsDialogs
         public override void CancelButtonClick(object sender, EventArgs e)
         {
             // If a filter is applied, clear it
-            if (RevisionGrid.FilterIsApplied(false))
+            if (RevisionGrid.FilterIsApplied())
             {
                 // Clear filter
                 ToolStripFilters.SetRevisionFilter(string.Empty);
-            }
-
-            // If a branch filter is applied by text or using the menus "Show current branch only"
-            else if (RevisionGrid.FilterIsApplied(true) || AppSettings.BranchFilterEnabled)
-            {
-                // Clear branch filter
-                ToolStripFilters.SetBranchFilter(string.Empty);
-
-                // Execute the "Show all branches" menu option
-                RevisionGrid.ShowAllBranches();
             }
         }
 
@@ -1850,7 +1840,7 @@ namespace GitUI.CommandsDialogs
                     // If we're applying custom branch or revision filters - reset them
                     RevisionGrid.ResetAllFilters();
                     ToolStripFilters.ClearQuickFilters();
-                    AppSettings.BranchFilterEnabled = AppSettings.BranchFilterEnabled && AppSettings.ShowCurrentBranchOnly;
+                    AppSettings.BranchFilterEnabled = AppSettings.BranchFilterEnabled;
                     revisionDiff.RepositoryChanged();
                 }
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7440,10 +7440,6 @@ Do you want to use this custom merge script?</source>
         <source>Filter</source>
         <target />
       </trans-unit>
-      <trans-unit id="CurrentBranchOnlyCheck.Text">
-        <source>Show current branch only</source>
-        <target />
-      </trans-unit>
       <trans-unit id="Ok.Text">
         <source>OK</source>
         <target />

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
@@ -57,6 +57,7 @@
             this.BranchFilterCheck = new System.Windows.Forms.CheckBox();
             this.BranchFilter = new System.Windows.Forms.TextBox();
             this.CurrentBranchOnlyCheck = new System.Windows.Forms.CheckBox();
+            this._NO_TRANSLATE_lblCurrentBranchOnlyCheck = new System.Windows.Forms.Label();
             this.SimplifyByDecorationCheck = new System.Windows.Forms.CheckBox();
             this._NO_TRANSLATE_lblSimplifyByDecoration = new System.Windows.Forms.Label();
             this.MainPanel.SuspendLayout();
@@ -237,10 +238,11 @@
             this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_lblPathFilter, 0, 7);
             this.tableLayoutPanel1.Controls.Add(this.PathFilterCheck, 1, 7);
             this.tableLayoutPanel1.Controls.Add(this.PathFilter, 2, 7);
-            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_lblBranches, 0, 8);
-            this.tableLayoutPanel1.Controls.Add(this.BranchFilterCheck, 1, 8);
-            this.tableLayoutPanel1.Controls.Add(this.BranchFilter, 2, 8);
-            this.tableLayoutPanel1.Controls.Add(this.CurrentBranchOnlyCheck, 2, 9);
+            this.tableLayoutPanel1.Controls.Add(this.CurrentBranchOnlyCheck, 1, 8);
+            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_lblCurrentBranchOnlyCheck, 2, 8);
+            this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_lblBranches, 0, 9);
+            this.tableLayoutPanel1.Controls.Add(this.BranchFilterCheck, 1, 9);
+            this.tableLayoutPanel1.Controls.Add(this.BranchFilter, 2, 9);
             this.tableLayoutPanel1.Controls.Add(this.SimplifyByDecorationCheck, 1, 10);
             this.tableLayoutPanel1.Controls.Add(this._NO_TRANSLATE_lblSimplifyByDecoration, 2, 10);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -391,12 +393,22 @@
             // 
             this.CurrentBranchOnlyCheck.AutoSize = true;
             this.CurrentBranchOnlyCheck.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.CurrentBranchOnlyCheck.Location = new System.Drawing.Point(96, 255);
+            this.CurrentBranchOnlyCheck.Location = new System.Drawing.Point(76, 255);
             this.CurrentBranchOnlyCheck.Name = "CurrentBranchOnlyCheck";
             this.CurrentBranchOnlyCheck.Size = new System.Drawing.Size(285, 19);
-            this.CurrentBranchOnlyCheck.Text = "Show current branch only";
             this.CurrentBranchOnlyCheck.UseVisualStyleBackColor = true;
             this.CurrentBranchOnlyCheck.CheckedChanged += new System.EventHandler(this.option_CheckedChanged);
+            // 
+            // _NO_TRANSLATE_lblCurrentBranchOnlyCheck
+            // 
+            this._NO_TRANSLATE_lblCurrentBranchOnlyCheck.AutoSize = true;
+            this._NO_TRANSLATE_lblCurrentBranchOnlyCheck.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_lblCurrentBranchOnlyCheck.Location = new System.Drawing.Point(96, 277);
+            this._NO_TRANSLATE_lblCurrentBranchOnlyCheck.Name = "_NO_TRANSLATE_lblCurrentBranchOnlyCheck";
+            this._NO_TRANSLATE_lblCurrentBranchOnlyCheck.Size = new System.Drawing.Size(285, 20);
+            this._NO_TRANSLATE_lblCurrentBranchOnlyCheck.TabIndex = 28;
+            this._NO_TRANSLATE_lblCurrentBranchOnlyCheck.Text = "Show current branch only";
+            this._NO_TRANSLATE_lblCurrentBranchOnlyCheck.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // SimplifyByDecorationCheck
             // 
@@ -415,7 +427,7 @@
             this._NO_TRANSLATE_lblSimplifyByDecoration.Location = new System.Drawing.Point(96, 277);
             this._NO_TRANSLATE_lblSimplifyByDecoration.Name = "_NO_TRANSLATE_lblSimplifyByDecoration";
             this._NO_TRANSLATE_lblSimplifyByDecoration.Size = new System.Drawing.Size(285, 20);
-            this._NO_TRANSLATE_lblSimplifyByDecoration.TabIndex = 28;
+            this._NO_TRANSLATE_lblSimplifyByDecoration.TabIndex = 29;
             this._NO_TRANSLATE_lblSimplifyByDecoration.Text = "Simplify by decoration";
             this._NO_TRANSLATE_lblSimplifyByDecoration.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -470,6 +482,7 @@
         private System.Windows.Forms.Label _NO_TRANSLATE_lblBranches;
         private System.Windows.Forms.TextBox BranchFilter;
         private System.Windows.Forms.CheckBox CurrentBranchOnlyCheck;
+        private System.Windows.Forms.Label _NO_TRANSLATE_lblCurrentBranchOnlyCheck;
         private System.Windows.Forms.CheckBox BranchFilterCheck;
         private System.Windows.Forms.CheckBox SimplifyByDecorationCheck;
         private System.Windows.Forms.Label _NO_TRANSLATE_lblSimplifyByDecoration;

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -28,6 +28,7 @@ namespace GitUI.UserControls.RevisionGrid
             _NO_TRANSLATE_lblLimit.Text = TranslatedStrings.Limit;
             _NO_TRANSLATE_lblPathFilter.Text = TranslatedStrings.PathFilter;
             _NO_TRANSLATE_lblBranches.Text = TranslatedStrings.Branches;
+            _NO_TRANSLATE_lblCurrentBranchOnlyCheck.Text = TranslatedStrings.ShowCurrentBranchOnly;
             _NO_TRANSLATE_lblSimplifyByDecoration.Text = TranslatedStrings.SimplifyByDecoration;
 
             _filterInfo = filterInfo;
@@ -55,7 +56,7 @@ namespace GitUI.UserControls.RevisionGrid
             _NO_TRANSLATE_CommitsLimit.Value = rawFilterInfo.CommitsLimit;
             PathFilterCheck.Checked = rawFilterInfo.ByPathFilter;
             PathFilter.Text = rawFilterInfo.PathFilter;
-            BranchFilterCheck.Checked = rawFilterInfo.IsShowFilteredBranchesChecked || rawFilterInfo.IsShowCurrentBranchOnlyChecked;
+            BranchFilterCheck.Checked = rawFilterInfo.IsShowFilteredBranchesChecked;
             BranchFilter.Text = rawFilterInfo.BranchFilter;
             CurrentBranchOnlyCheck.Checked = rawFilterInfo.ShowCurrentBranchOnly;
             SimplifyByDecorationCheck.Checked = rawFilterInfo.ShowSimplifyByDecoration;
@@ -85,8 +86,8 @@ namespace GitUI.UserControls.RevisionGrid
             _NO_TRANSLATE_CommitsLimit.Enabled = CommitsLimitCheck.Checked;
             PathFilter.Enabled = PathFilterCheck.Checked;
 
-            CurrentBranchOnlyCheck.Enabled = BranchFilterCheck.Checked;
-            BranchFilter.Enabled = BranchFilterCheck.Checked && !CurrentBranchOnlyCheck.Checked;
+            BranchFilterCheck.Enabled = !CurrentBranchOnlyCheck.Checked;
+            BranchFilter.Enabled = BranchFilterCheck.Checked;
         }
 
         private void OkClick(object sender, EventArgs e)
@@ -108,7 +109,7 @@ namespace GitUI.UserControls.RevisionGrid
             _filterInfo.PathFilter = PathFilter.Text;
             _filterInfo.ByBranchFilter = BranchFilterCheck.Checked;
             _filterInfo.BranchFilter = BranchFilter.Text;
-            _filterInfo.ShowCurrentBranchOnly = BranchFilterCheck.Checked && CurrentBranchOnlyCheck.Checked;
+            _filterInfo.ShowCurrentBranchOnly = CurrentBranchOnlyCheck.Checked;
             _filterInfo.ShowSimplifyByDecoration = SimplifyByDecorationCheck.Checked;
         }
     }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -496,9 +496,6 @@ namespace GitUI
         {
             // TODO: clean up and move all internals to FilterInfo
 
-            // ShowCurrentBranchOnly depends on BranchFilterEnabled, and to show the current branch
-            // both flags must be set simultaneously (check SetShowBranches implementation).
-            // And since we set a filter - we can't be showing the current branch.
             _filterInfo.ShowCurrentBranchOnly = false;
 
             string newFilter = filter?.Trim() ?? string.Empty;
@@ -982,7 +979,7 @@ namespace GitUI
                     string pathFilter = BuildPathFilter(_filterInfo.PathFilter);
                     ArgumentBuilder args = reader.BuildArguments(_filterInfo.CommitsLimit,
                         _filterInfo.RefFilterOptions,
-                        _filterInfo.IsShowFilteredBranchesChecked ? _filterInfo.BranchFilter : string.Empty,
+                        _filterInfo.BranchFilter,
                         _filterInfo.GetRevisionFilter(),
                         pathFilter,
                         out bool parentsAreRewritten);
@@ -1233,7 +1230,7 @@ namespace GitUI
 
             void OnRevisionReadCompleted()
             {
-                if (!firstRevisionReceived && !FilterIsApplied(inclBranchFilter: true))
+                if (!firstRevisionReceived && !FilterIsApplied())
                 {
                     ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                     {
@@ -1442,10 +1439,9 @@ namespace GitUI
         /// </summary>
         private bool ParentsAreRewritten { get; set; } = false;
 
-        internal bool FilterIsApplied(bool inclBranchFilter)
+        internal bool FilterIsApplied()
         {
-            // TBD ByBranchFilter should always be set when there is a filter
-            return _filterInfo.HasFilter || (inclBranchFilter && _filterInfo.IsShowFilteredBranchesChecked && !string.IsNullOrEmpty(_filterInfo.BranchFilter));
+            return _filterInfo.HasFilter;
         }
 
         #region Graph event handlers
@@ -1693,7 +1689,7 @@ namespace GitUI
                 return;
             }
 
-            _filterInfo.ByBranchFilter = true;
+            _filterInfo.ByBranchFilter = false;
             _filterInfo.ShowCurrentBranchOnly = true;
             _filterInfo.ShowReflogReferences = false;
 
@@ -1720,7 +1716,7 @@ namespace GitUI
                 return;
             }
 
-            // TBD ByBranchFilter should only be set if !string.IsNullOrWhiteSpace(_filterInfo.BranchFilter)
+            // Must be able to set ByBranchFilter without a filter to edit it
             _filterInfo.ByBranchFilter = true;
             _filterInfo.ShowCurrentBranchOnly = false;
             _filterInfo.ShowReflogReferences = false;

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -134,7 +134,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                         form.GetTestAccessor().ToolStripFilters.GetTestAccessor().tsmiShowBranchesCurrent.PerformClick();
                         WaitForRevisionsToBeLoaded(form);
                         // Assert
-                        AppSettings.BranchFilterEnabled.Should().BeTrue();
+                        AppSettings.BranchFilterEnabled.Should().BeFalse();
                         AppSettings.ShowCurrentBranchOnly.Should().BeTrue();
                         form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(2);
 
@@ -161,7 +161,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                         form.GetTestAccessor().ToolStripFilters.GetTestAccessor().tsmiShowBranchesCurrent.PerformClick();
                         WaitForRevisionsToBeLoaded(form);
                         // Assert
-                        AppSettings.BranchFilterEnabled.Should().BeTrue();
+                        AppSettings.BranchFilterEnabled.Should().BeFalse();
                         AppSettings.ShowCurrentBranchOnly.Should().BeTrue();
                         form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(2);
                         // The filter text is still present
@@ -176,7 +176,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                         WaitForRevisionsToBeLoaded(form);
                         // Assert
                         AppSettings.BranchFilterEnabled.Should().BeFalse();
-                        AppSettings.ShowCurrentBranchOnly.Should().BeTrue();
+                        AppSettings.ShowCurrentBranchOnly.Should().BeFalse();
                         form.GetTestAccessor().ToolStripFilters.GetTestAccessor().tscboBranchFilter.Text.Should().BeEmpty();
                     }
                     finally

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
@@ -56,7 +56,7 @@ namespace GitCommandsTests
         }
 
         [TestCase(RefFilterOptions.FirstParent, false)]
-        [TestCase(RefFilterOptions.FirstParent | RefFilterOptions.Reflogs, false)]
+        [TestCase(RefFilterOptions.FirstParent | RefFilterOptions.Reflogs, true)]
         [TestCase(RefFilterOptions.All, false)]
         [TestCase(RefFilterOptions.All | RefFilterOptions.Reflogs, true)]
         public void BuildArguments_should_add_reflog_if_requested(RefFilterOptions refFilterOptions, bool expected)
@@ -66,11 +66,11 @@ namespace GitCommandsTests
 
             if (expected)
             {
-                args.ToString().Should().Contain(" --reflog ");
+                args.ToString().Should().Contain(" --reflog");
             }
             else
             {
-                args.ToString().Should().NotContain(" --reflog ");
+                args.ToString().Should().NotContain(" --reflog");
             }
 
             parentsAreRewritten.Should().BeFalse();
@@ -82,10 +82,10 @@ namespace GitCommandsTests
         [TestCase(RefFilterOptions.All, null, " --first-parent ")]
         /* if not 'first parent', then 'all' */
         [TestCase(RefFilterOptions.FirstParent, null, " --all ")]
-        [TestCase(RefFilterOptions.FirstParent | RefFilterOptions.All, null, " --all ")]
+        [TestCase(RefFilterOptions.FirstParent | RefFilterOptions.All, " --first-parent ", null)]
         [TestCase(RefFilterOptions.All, " --all ", null)]
         /* if not 'first parent' and not 'all' - selected branches, if requested */
-        [TestCase(RefFilterOptions.FirstParent | RefFilterOptions.Branches, " --first-parent ", " --branches=")]
+        [TestCase(RefFilterOptions.FirstParent | RefFilterOptions.Branches, " --first-parent ", null)]
         [TestCase(RefFilterOptions.All | RefFilterOptions.Branches, " --all ", " --branches=")]
         [TestCase(RefFilterOptions.Branches, " --branches=", null)]
         /* Disable special refs with --all */


### PR DESCRIPTION
Follow up to #10129
The filter handling is confusing, some comments in #10129 was due to that. It is also more limiting than needed.

## Proposed changes

*  Decouple simplify-by-decoration, no-merges, boundry as well as sort
 options from first-parent (they can be applied there too).

*  First-parents can be used together with other types of branch filters
(not relevant with reflog). Before it was dominating
reflog and others.

* Set prio order for the various branch-filters from having first-parent as
dominant to:
  Reflog->ShowCurrent->FilteredBranches (if non null filter)->All branches

* Separate ByBranchFilter from being shared CurrentFilter and
FilteredBranches to only be used for BranchFilter

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/188275665-69a644e4-0eeb-4be3-ba0b-5626114bceeb.png)

### After

![image](https://user-images.githubusercontent.com/6248932/187538985-638607a1-222b-4c67-81a4-bfff94f4525d.png)

## Test methodology <!-- How did you ensure quality? -->

Tests are updated

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
