### PR TITLE
Update .NET references

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "6.0.201",
+      "version": "6.0",
       "rollForward": "feature"
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "6.0",
+      "version": "6.0.400",
       "rollForward": "feature"
     }
 }

--- a/scripts/RepoLayout.props
+++ b/scripts/RepoLayout.props
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <!-- Set version for runtimeconfig.json, used by DotnetRuntimeBootstrapper for minimal version to support -->
-    <RuntimeFrameworkVersion>6.0.7</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>6.0.8</RuntimeFrameworkVersion>
     <SolutionTargetFramework>net6.0-windows</SolutionTargetFramework>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>

--- a/scripts/RepoLayout.props
+++ b/scripts/RepoLayout.props
@@ -6,7 +6,9 @@
   -->
 
   <PropertyGroup>
-    <!-- Set version for runtimeconfig.json, used by DotnetRuntimeBootstrapper for minimal version to support -->
+    <!-- Set version for runtimeconfig.json, used by DotnetRuntimeBootstrapper for minimal version to support
+         To be kept in sync with the .NET SDK version in global.json
+    -->
     <RuntimeFrameworkVersion>6.0.8</RuntimeFrameworkVersion>
     <SolutionTargetFramework>net6.0-windows</SolutionTargetFramework>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>


### PR DESCRIPTION
Fixes #10177

## Proposed changes

- Use any installed .NET SDK 6.0 for building GE
- Set RuntimeFrameworkVersion for DotnetRuntimeBootstrapper to the same version 6.0.8 as on the release branch

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- build GE

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 8ccac05c4667d48169db44a0ab5ec3b2ee67faa4
- Git 2.35.2.windows.1 (recommended: 2.37.1 or later)
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.8
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).