### PR TITLE
Blame: fix blame revision older revision when the file has been renamed

### DIFF
--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -190,7 +190,14 @@ See the changes in the commit form.");
 
                 // Save state only when there is selected node
                 List<string> tryNodes = new();
-                if (tvGitTree.SelectedNode is not null)
+
+                // When blame control is visible, taking the filename from the revision selected to blame
+                // because the file could have been renamed in between
+                if (BlameControl.Visible && !string.IsNullOrWhiteSpace(BlameControl.PathToBlame))
+                {
+                    tryNodes.Add(BlameControl.PathToBlame);
+                }
+                else if (tvGitTree.SelectedNode is not null)
                 {
                     TreeNode node = tvGitTree.SelectedNode;
                     string path = "";

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -618,7 +618,7 @@ namespace GitUI
                 {
                     gridView.Select();
 
-                    // Prevent exception when changing of reporsitory because the grid still contains no rows.
+                    // Prevent exception when changing of repository because the grid still contains no rows.
                     if (index >= gridView.Rows.Count)
                     {
                         return;


### PR DESCRIPTION
## Proposed changes

by providing the old path to blame and selecting it in the filetree
so that the blame view is not empty anymore
failing to find a not existing file in the filetree

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![blame_broken](https://user-images.githubusercontent.com/460196/188594895-38cd250f-732a-48eb-92e9-91e279f50821.gif)

### After

![blame_fixed](https://user-images.githubusercontent.com/460196/188594303-2bdf164a-b6a6-4d43-a478-b9d2a194564b.gif)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 7447469d3f686c3d28fba1fffbded9f39607688d (Dirty)
- Git 2.35.1.windows.2 (recommended: 2.37.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.8
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
