### PR TITLE
Blame: fix path displayed in the gutter

### DIFF
--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -353,6 +353,8 @@ namespace GitUI.Blame
             // If it could be done with a solid rectangle around the text,
             // the extra spaces added here could be omitted.
 
+            filename = filename?.ToPosixPath();
+
             var filePathLengthEstimate = _blame.Lines.Where(l => filename != l.Commit.FileName)
                                                      .Select(l => l.Commit.FileName.Length)
                                                      .DefaultIfEmpty(0)


### PR DESCRIPTION

## Proposed changes

It should be displayed **only** when the path is different than the current file blamed but the comparison failed because the relative path passed is in Windows format whereas the ones of blame lines are in Unix format.

So converting the one passed in Unix format for comparison.


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/189354788-0e035168-4226-47bc-b3b3-80c7cf952723.png)

### After

![image](https://user-images.githubusercontent.com/460196/189355239-bfad2883-713f-4bd0-80e0-8d41739a0de0.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build aca5a9519c8d1febda80a0b3c2f3c65d89603554 (Dirty)
- Git 2.35.1.windows.2 (recommended: 2.37.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.8
- DPI 96dpi (no scaling)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
