### PR TITLE
Reorder items in View menu

### DIFF
--- a/GitCommands/RevisionReader.RefFilterOptions.cs
+++ b/GitCommands/RevisionReader.RefFilterOptions.cs
@@ -6,23 +6,26 @@ namespace GitCommands
     [Flags]
     public enum RefFilterOptions
     {
-        None                    = 0x000,
+        None                    = 0x000,    // Git default, current branch
         Branches                = 0x001,    // --branches=<filter>
 
         // Unused
         // Remotes              = 0x002,    // --remotes
         // Tags                 = 0x004,    // --tags
         All                     = 0x007,    // --all (default is HEAD)
+        Reflog                  = 0x200,    // --reflog
 
-        // Exclude some refs from --all
+        // Exclude some refs from other than reflog
         NoStash                 = 0x008,    // --exclude=refs/stash
         NoGitNotes              = 0x010,    // --not --glob=notes --not
 
+        // Other revision filters
         NoMerges                = 0x020,    // --no-merges
         FirstParent             = 0x040,    // --first-parent
-        SimplifyByDecoration    = 0x080,    // --simplify-by-decoration
         Boundary                = 0x100,    // --boundary
-        Reflogs                 = 0x200,    // --reflog
+
+        // history simplification
+        SimplifyByDecoration = 0x080,       // --simplify-by-decoration
     }
 #pragma warning restore SA1025 // Code should not contain multiple whitespace in a row
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
@@ -21,11 +21,34 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             return new MenuCommand { IsSeparator = true };
         }
 
+        public static MenuCommand CreateGroupHeader(string text)
+        {
+            return new MenuCommand
+            {
+                IsGroupHeader = true,
+                Name = text.Replace(' ', '_') + "ToolStripMenuItem",
+                Text = text,
+            };
+        }
+
         public static ToolStripItem CreateToolStripItem(MenuCommand menuCommand)
         {
             if (menuCommand.IsSeparator)
             {
                 return new ToolStripSeparator();
+            }
+
+            if (menuCommand.IsGroupHeader)
+            {
+                ToolStripMenuItem headerToolStripMenuItem = new()
+                {
+                    Name = menuCommand.Name,
+                    Text = menuCommand.Text,
+                    Enabled = false,
+                };
+                UserControls.RevisionGrid.MenuUtil.SetAsCaptionMenuItem(headerToolStripMenuItem);
+
+                return headerToolStripMenuItem;
             }
 
             ToolStripMenuItem toolStripMenuItem = new()
@@ -59,6 +82,11 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         /// if true all other properties have no meaning.
         /// </summary>
         public bool IsSeparator { get; set; }
+
+        /// <summary>
+        /// if true just text property have a meaning.
+        /// </summary>
+        public bool IsGroupHeader { get; set; }
 
         /// <summary>
         /// used for ToolStripItem and translation identification.

--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -56,10 +56,11 @@ namespace GitUI.CommandsDialogs
                 }
 
                 // Apply filtering when:
-                // 1. don't show reflogs, and
+                // 1. don't show reflog, and
                 // 2. one of the following
                 //      a) show the current branch only, or
                 //      b) filter on specific branch
+                // (this check ignores other revision filters)
                 bool isFiltering = !AppSettings.ShowReflogReferences
                                 && (AppSettings.ShowCurrentBranchOnly || AppSettings.BranchFilterEnabled);
                 repoObjectsTree.Refresh(isFiltering, e.ForceRefresh, e.GetRefs);

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3215,6 +3215,10 @@ Do you want to continue?</source>
         <source>&amp;Translate</source>
         <target />
       </trans-unit>
+      <trans-unit id="tsbShowReflog.ToolTipText">
+        <source>Show reflog</source>
+        <target />
+      </trans-unit>
       <trans-unit id="tsbtnAdvancedFilter.ToolTipText">
         <source>Advanced filter</source>
         <target />
@@ -3315,8 +3319,12 @@ Do you want to continue?</source>
         <source>Show first parents</source>
         <target />
       </trans-unit>
-      <trans-unit id="tsmiShowReflogs.ToolTipText">
-        <source>Show reflogs</source>
+      <trans-unit id="tsmiShowReflog.Text">
+        <source>&amp;Reflog</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsmiShowReflog.ToolTipText">
+        <source>Show reflog</source>
         <target />
       </trans-unit>
       <trans-unit id="tsmiTelemetryEnabled.Text">
@@ -9611,6 +9619,18 @@ See the changes in the commit form.</source>
         <source>&amp;Sort commits by author date</source>
         <target />
       </trans-unit>
+      <trans-unit id="BranchesToolStripMenuItem.Text">
+        <source>Branches</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="ColumnsToolStripMenuItem.Text">
+        <source>Columns</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="CommitsToolStripMenuItem.Text">
+        <source>Commits</source>
+        <target />
+      </trans-unit>
       <trans-unit id="GotoChildCommit.Text">
         <source>Go to c&amp;hild commit</source>
         <target />
@@ -9633,6 +9653,14 @@ See the changes in the commit form.</source>
       </trans-unit>
       <trans-unit id="GotoParentCommit.Text">
         <source>Go to &amp;parent commit</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="Grid_infoToolStripMenuItem.Text">
+        <source>Grid info</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="Grid_labelsToolStripMenuItem.Text">
+        <source>Grid labels</source>
         <target />
       </trans-unit>
       <trans-unit id="HighlightSelectedBranch.Text">
@@ -9701,6 +9729,10 @@ See the changes in the commit form.</source>
       </trans-unit>
       <trans-unit id="ShowSuperprojectTags.Text">
         <source>Show su&amp;perproject tags</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="SortingToolStripMenuItem.Text">
+        <source>Sorting</source>
         <target />
       </trans-unit>
       <trans-unit id="ToggleBetweenArtificialAndHeadCommits.Text">

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -26,6 +26,7 @@ namespace GitUI.UserControls
             this.toolStripSeparatorAdvancedFilter = new System.Windows.Forms.ToolStripSeparator();
             this.tsmiAdvancedFilter = new System.Windows.Forms.ToolStripMenuItem();
             this.tssbtnShowBranches = new System.Windows.Forms.ToolStripSplitButton();
+            this.tsmiShowReflog = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiShowBranchesAll = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiShowBranchesCurrent = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiShowBranchesFiltered = new System.Windows.Forms.ToolStripMenuItem();
@@ -35,7 +36,7 @@ namespace GitUI.UserControls
             this.tslblRevisionFilter = new System.Windows.Forms.ToolStripLabel();
             this.tstxtRevisionFilter = new System.Windows.Forms.ToolStripTextBox();
             this.tsddbtnRevisionFilter = new System.Windows.Forms.ToolStripDropDownButton();
-            this.tsmiShowReflogs = new System.Windows.Forms.ToolStripButton();
+            this.tsbShowReflog = new System.Windows.Forms.ToolStripButton();
             this.tsmiShowFirstParent = new System.Windows.Forms.ToolStripButton();
             this.SuspendLayout();
             // 
@@ -117,49 +118,57 @@ namespace GitUI.UserControls
             // 
             this.tssbtnShowBranches.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
             this.tssbtnShowBranches.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.tsmiShowReflog,
             this.tsmiShowBranchesAll,
-            this.tsmiShowBranchesCurrent,
-            this.tsmiShowBranchesFiltered});
+            this.tsmiShowBranchesFiltered,
+            this.tsmiShowBranchesCurrent});
             this.tssbtnShowBranches.Image = global::GitUI.Properties.Images.BranchLocal;
             this.tssbtnShowBranches.Name = "tssbtnShowBranches";
             this.tssbtnShowBranches.Size = new System.Drawing.Size(32, 22);
             this.tssbtnShowBranches.Click += new System.EventHandler(this.tssbtnShowBranches_Click);
             // 
-            // commitInfoBelowMenuItem
+            // tsmiShowReflog
+            // 
+            this.tsmiShowReflog.Image = global::GitUI.Properties.Images.Book;
+            this.tsmiShowReflog.Name = "tsmiShowReflog";
+            this.tsmiShowReflog.Size = new System.Drawing.Size(259, 22);
+            this.tsmiShowReflog.Text = "&Reflog";
+            this.tsmiShowReflog.Click += new System.EventHandler(this.tsmiShowReflogBranches_Click);
+            // 
+            // tsmiShowBranchesAll
             // 
             this.tsmiShowBranchesAll.Image = global::GitUI.Properties.Images.BranchLocal;
-            this.tsmiShowBranchesAll.Name = "tsmiShowAllBranches";
+            this.tsmiShowBranchesAll.Name = "tsmiShowBranchesAll";
             this.tsmiShowBranchesAll.Size = new System.Drawing.Size(259, 22);
             this.tsmiShowBranchesAll.Text = "&All branches";
             this.tsmiShowBranchesAll.ToolTipText = "Show all branches";
             this.tsmiShowBranchesAll.Click += new System.EventHandler(this.tsmiShowBranchesAll_Click);
             // 
-            // commitInfoLeftwardMenuItem
+            // tsmiShowBranchesCurrent
             // 
             this.tsmiShowBranchesCurrent.Image = global::GitUI.Properties.Images.BranchFilter;
-            this.tsmiShowBranchesCurrent.Name = "tsmiShowCurrentBranch";
+            this.tsmiShowBranchesCurrent.Name = "tsmiShowBranchesCurrent";
             this.tsmiShowBranchesCurrent.Size = new System.Drawing.Size(259, 22);
             this.tsmiShowBranchesCurrent.Text = "&Current branch only";
             this.tsmiShowBranchesCurrent.ToolTipText = "Show current branch only";
             this.tsmiShowBranchesCurrent.Click += new System.EventHandler(this.tsmiShowBranchesCurrent_Click);
             // 
-            // commitInfoRightwardMenuItem
+            // tsmiShowBranchesFiltered
             // 
             this.tsmiShowBranchesFiltered.Image = global::GitUI.Properties.Images.BranchFilter;
-            this.tsmiShowBranchesFiltered.Name = "tsmiShowFilteredBranches";
+            this.tsmiShowBranchesFiltered.Name = "tsmiShowBranchesFiltered";
             this.tsmiShowBranchesFiltered.Size = new System.Drawing.Size(259, 22);
             this.tsmiShowBranchesFiltered.Text = "&Filtered branches";
             this.tsmiShowBranchesFiltered.ToolTipText = "Show filtered branches";
             this.tsmiShowBranchesFiltered.Click += new System.EventHandler(this.tsmiShowBranchesFiltered_Click);
             // 
-            // tsmiShowReflogs
+            // tsbShowReflog
             // 
-            this.tsmiShowReflogs.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
-            this.tsmiShowReflogs.Image = global::GitUI.Properties.Images.Book;
-            this.tsmiShowReflogs.Name = "tsmiShowReflogs";
-            this.tsmiShowReflogs.Size = new System.Drawing.Size(23, 22);
-            this.tsmiShowReflogs.ToolTipText = "Show reflogs";
-            this.tsmiShowReflogs.Click += new System.EventHandler(this.tsmiShowReflogs_Click);
+            this.tsbShowReflog.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
+            this.tsbShowReflog.Image = global::GitUI.Properties.Images.Book;
+            this.tsbShowReflog.Name = "tsbShowReflog";
+            this.tsbShowReflog.Size = new System.Drawing.Size(23, 22);
+            this.tsbShowReflog.Click += new System.EventHandler(this.tsmiShowReflog_Click);
             // 
             // tscboBranchFilter
             // 
@@ -267,7 +276,7 @@ namespace GitUI.UserControls
             this.toolStripLabel1,
             this.tscboBranchFilter,
             this.tsddbtnBranchFilter,
-            this.tsmiShowReflogs,
+            this.tsbShowReflog,
             this.tsmiShowFirstParent,
             this.toolStripSeparator19,
             this.tslblRevisionFilter,
@@ -291,7 +300,7 @@ namespace GitUI.UserControls
         private ToolStripMenuItem tsmiCommitterFilter;
         private ToolStripMenuItem tsmiAuthorFilter;
         private ToolStripMenuItem tsmiDiffContainsFilter;
-        private ToolStripButton tsmiShowReflogs;
+        private ToolStripButton tsbShowReflog;
         private ToolStripButton tsmiShowFirstParent;
         private ToolStripTextBox tstxtRevisionFilter;
         private ToolStripLabel tslblRevisionFilter;
@@ -302,6 +311,7 @@ namespace GitUI.UserControls
         private ToolStripSeparator toolStripSeparatorAdvancedFilter;
         private ToolStripMenuItem tsmiAdvancedFilter;
         private ToolStripSplitButton tssbtnShowBranches;
+        private ToolStripMenuItem tsmiShowReflog;
         private ToolStripMenuItem tsmiShowBranchesAll;
         private ToolStripMenuItem tsmiShowBranchesCurrent;
         private ToolStripMenuItem tsmiShowBranchesFiltered;

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -24,9 +24,11 @@ namespace GitUI.UserControls
         public FilterToolBar()
         {
             InitializeComponent();
+            tsmiShowReflog.ToolTipText = TranslatedStrings.ShowReflog;
+            tsbShowReflog.ToolTipText = TranslatedStrings.ShowReflog;
 
             // Select an option until we get a filter bound.
-            SelectShowBranchesFilterOption(selectedIndex: 0);
+            SelectShowBranchesFilterOption(selectedIndex: 1);
 
             tstxtRevisionFilter.KeyUp += (s, e) =>
             {
@@ -131,17 +133,17 @@ namespace GitUI.UserControls
             // Note: it is a weird combination, and it is mimicking the implementations in RevisionGridControl.
             // Refer to it for more details.
 
-            byte selectedIndex = 0;
+            byte selectedIndex = 1;
+
+            if (e.ShowReflogReferences)
+            {
+                // Show reflog
+                selectedIndex = 0;
+            }
 
             if (e.ShowAllBranches)
             {
                 // Show all branches
-                selectedIndex = 0;
-            }
-
-            if (e.ShowCurrentBranchOnly)
-            {
-                // Show current branch only
                 selectedIndex = 1;
             }
 
@@ -149,6 +151,12 @@ namespace GitUI.UserControls
             {
                 // Show filtered branches
                 selectedIndex = 2;
+            }
+
+            if (e.ShowCurrentBranchOnly)
+            {
+                // Show current branch only
+                selectedIndex = 3;
             }
 
             SelectShowBranchesFilterOption(selectedIndex);
@@ -318,7 +326,7 @@ namespace GitUI.UserControls
         private void revisionGridFilter_FilterChanged(object? sender, FilterChangedEventArgs e)
         {
             tsmiShowFirstParent.Checked = e.ShowFirstParent;
-            tsmiShowReflogs.Checked = e.ShowReflogReferences;
+            tsbShowReflog.Checked = e.ShowReflogReferences;
             InitBranchSelectionFilter(e);
             tsbtnAdvancedFilter.ToolTipText = e.FilterSummary;
             tsbtnAdvancedFilter.AutoToolTip = !string.IsNullOrEmpty(tsbtnAdvancedFilter.ToolTipText);
@@ -396,6 +404,8 @@ namespace GitUI.UserControls
 
         private void tsmiAdvancedFilter_Click(object sender, EventArgs e) => RevisionGridFilter.ShowRevisionFilterDialog();
 
+        private void tsmiShowReflogBranches_Click(object sender, EventArgs e) => ApplyPresetBranchesFilter(RevisionGridFilter.ShowReflog);
+
         private void tsmiShowBranchesAll_Click(object sender, EventArgs e) => ApplyPresetBranchesFilter(RevisionGridFilter.ShowAllBranches);
 
         private void tsmiShowBranchesCurrent_Click(object sender, EventArgs e) => ApplyPresetBranchesFilter(RevisionGridFilter.ShowCurrentBranchOnly);
@@ -404,7 +414,7 @@ namespace GitUI.UserControls
 
         private void tsmiShowFirstParent_Click(object sender, EventArgs e) => RevisionGridFilter.ToggleShowFirstParent();
 
-        private void tsmiShowReflogs_Click(object sender, EventArgs e) => RevisionGridFilter.ToggleShowReflogReferences();
+        private void tsmiShowReflog_Click(object sender, EventArgs e) => RevisionGridFilter.ToggleShowReflogReferences();
 
         private void tssbtnShowBranches_Click(object sender, EventArgs e) => tssbtnShowBranches.ShowDropDown();
 
@@ -428,11 +438,12 @@ namespace GitUI.UserControls
             public ToolStripMenuItem tsmiAuthorFilter => _control.tsmiAuthorFilter;
             public ToolStripMenuItem tsmiDiffContainsFilter => _control.tsmiDiffContainsFilter;
             public ToolStripButton tsmiShowFirstParent => _control.tsmiShowFirstParent;
-            public ToolStripButton tsmiShowReflogs => _control.tsmiShowReflogs;
+            public ToolStripButton tsbShowReflog => _control.tsbShowReflog;
             public ToolStripTextBox tstxtRevisionFilter => _control.tstxtRevisionFilter;
             public ToolStripLabel tslblRevisionFilter => _control.tslblRevisionFilter;
             public ToolStripSplitButton tsbtnAdvancedFilter => _control.tsbtnAdvancedFilter;
             public ToolStripSplitButton tssbtnShowBranches => _control.tssbtnShowBranches;
+            public ToolStripMenuItem tsmiShowReflog => _control.tsmiShowReflog;
             public ToolStripMenuItem tsmiShowBranchesAll => _control.tsmiShowBranchesAll;
             public ToolStripMenuItem tsmiShowBranchesCurrent => _control.tsmiShowBranchesCurrent;
             public ToolStripMenuItem tsmiShowBranchesFiltered => _control.tsmiShowBranchesFiltered;

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -120,7 +120,7 @@ namespace GitUI.UserControls.RevisionGrid
                 // Branch filters
                 if (ShowReflogReferences)
                 {
-                    refFilterOptions = RefFilterOptions.Reflogs;
+                    refFilterOptions = RefFilterOptions.Reflog;
                 }
                 else if (ShowCurrentBranchOnly)
                 {
@@ -159,6 +159,7 @@ namespace GitUI.UserControls.RevisionGrid
                     }
                 }
 
+                // other revision filters (see also GetRevisionFilter())
                 if (!AppSettings.ShowMergeCommits)
                 {
                     refFilterOptions |= RefFilterOptions.NoMerges;
@@ -169,6 +170,7 @@ namespace GitUI.UserControls.RevisionGrid
                     refFilterOptions |= RefFilterOptions.FirstParent;
                 }
 
+                // Listed in Git help as history simplification, but is a revision filter
                 if (ShowSimplifyByDecoration)
                 {
                     refFilterOptions |= RefFilterOptions.SimplifyByDecoration;
@@ -178,12 +180,12 @@ namespace GitUI.UserControls.RevisionGrid
             }
         }
 
-        public bool IsShowAllBranchesChecked => !ByBranchFilter && !ShowCurrentBranchOnly;
+        public bool IsShowAllBranchesChecked => !ByBranchFilter && !ShowCurrentBranchOnly && !ShowReflogReferences;
 
-        public bool IsShowCurrentBranchOnlyChecked => ShowCurrentBranchOnly;
+        public bool IsShowCurrentBranchOnlyChecked => ShowCurrentBranchOnly && !ShowReflogReferences;
 
         // IsChecked is not the same as a filter is active, see ByBranchFilter
-        public bool IsShowFilteredBranchesChecked => ByBranchFilter && !ShowCurrentBranchOnly;
+        public bool IsShowFilteredBranchesChecked => ByBranchFilter && !ShowCurrentBranchOnly && !ShowReflogReferences;
 
         public bool ShowCurrentBranchOnly
         {
@@ -202,14 +204,10 @@ namespace GitUI.UserControls.RevisionGrid
             get => AppSettings.ShowReflogReferences;
             set
             {
+                // Do not unset ByBranchFilter or ShowCurrentBranchOnly.
+                // ShowReflogReferences dominates those settings and if the user
+                // toggles the Reflog button, the curremt branch fílter should appear.
                 AppSettings.ShowReflogReferences = value;
-                if (value)
-                {
-                    // If reflogs are shown, then we can't apply any filters
-                    ByBranchFilter = false;
-                    ShowCurrentBranchOnly = false;
-                    ShowSimplifyByDecoration = false;
-                }
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid/IRevisionGridFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/IRevisionGridFilter.cs
@@ -37,6 +37,8 @@ namespace GitUI.UserControls.RevisionGrid
         /// <param name="filter">The filter to apply.</param>
         void SetAndApplyPathFilter(string filter);
 
+        void ShowReflog();
+
         void ShowAllBranches();
 
         void ShowCurrentBranchOnly();

--- a/GitUI/UserControls/RevisionGrid/MenuUtil.cs
+++ b/GitUI/UserControls/RevisionGrid/MenuUtil.cs
@@ -11,18 +11,25 @@ namespace GitUI.UserControls.RevisionGrid
         private static Font? _disabledFont;
 
         /// <summary>
-        /// set the menu item disabled and remove mouse hover effect.
+        /// set the menu item disabled.
         /// </summary>
-        public static void SetAsCaptionMenuItem(ToolStripMenuItem menuItem, ToolStrip menu)
+        public static void SetAsCaptionMenuItem(ToolStripMenuItem menuItem)
         {
-            menu.AttachMenuItemBackgroundFilter(_menuItemBackgroundFilter);
-
             menuItem.Tag = _captionTag;
             menuItem.Enabled = false;
 
             _disabledFont ??= new Font(menuItem.Font, FontStyle.Italic);
 
             menuItem.Font = _disabledFont;
+        }
+
+        /// <summary>
+        /// set the menu item disabled and remove mouse hover effect.
+        /// </summary>
+        public static void SetAsCaptionMenuItem(ToolStripMenuItem menuItem, ToolStrip menu)
+        {
+            menu.AttachMenuItemBackgroundFilter(_menuItemBackgroundFilter);
+            SetAsCaptionMenuItem(menuItem);
         }
 
         /// <summary>

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -498,9 +498,14 @@ namespace GitUI
 
             _filterInfo.ShowCurrentBranchOnly = false;
 
+            // Set filtered branches if there is a filter, handled as all branches otherwise
             string newFilter = filter?.Trim() ?? string.Empty;
             _filterInfo.ByBranchFilter = !string.IsNullOrWhiteSpace(newFilter);
             _filterInfo.BranchFilter = newFilter;
+            if (_filterInfo.ByBranchFilter)
+            {
+                _filterInfo.ShowReflogReferences = false;
+            }
 
             PerformRefreshRevisions();
         }
@@ -1772,16 +1777,16 @@ namespace GitUI
             });
         }
 
-        public void ShowCurrentBranchOnly()
+        public void ShowReflog()
         {
-            if (_filterInfo.IsShowCurrentBranchOnlyChecked)
+            if (_filterInfo.ShowReflogReferences)
             {
                 return;
             }
 
-            _filterInfo.ByBranchFilter = false;
-            _filterInfo.ShowCurrentBranchOnly = true;
-            _filterInfo.ShowReflogReferences = false;
+            // Do not unset ByBranchFilter or ShowCurrentBranchOnly,
+            // see FilterInfo.ShowReflogReferences.
+            _filterInfo.ShowReflogReferences = true;
 
             PerformRefreshRevisions();
         }
@@ -1795,6 +1800,7 @@ namespace GitUI
 
             _filterInfo.ByBranchFilter = false;
             _filterInfo.ShowCurrentBranchOnly = false;
+            _filterInfo.ShowReflogReferences = false;
 
             PerformRefreshRevisions();
         }
@@ -1809,6 +1815,20 @@ namespace GitUI
             // Must be able to set ByBranchFilter without a filter to edit it
             _filterInfo.ByBranchFilter = true;
             _filterInfo.ShowCurrentBranchOnly = false;
+            _filterInfo.ShowReflogReferences = false;
+
+            PerformRefreshRevisions();
+        }
+
+        public void ShowCurrentBranchOnly()
+        {
+            if (_filterInfo.IsShowCurrentBranchOnlyChecked)
+            {
+                return;
+            }
+
+            _filterInfo.ByBranchFilter = false;
+            _filterInfo.ShowCurrentBranchOnly = true;
             _filterInfo.ShowReflogReferences = false;
 
             PerformRefreshRevisions();
@@ -2431,15 +2451,6 @@ namespace GitUI
         internal void ToggleShowMergeCommits()
         {
             AppSettings.ShowMergeCommits = !AppSettings.ShowMergeCommits;
-
-            // hide revision graph when hiding merge commits, reasons:
-            // 1, revision graph is no longer relevant, as we are not showing all commits
-            // 2, performance hit when both revision graph and no merge commits are enabled
-            if (AppSettings.ShowRevisionGridGraphColumn && !AppSettings.ShowMergeCommits)
-            {
-                AppSettings.ShowRevisionGridGraphColumn = !AppSettings.ShowRevisionGridGraphColumn;
-            }
-
             PerformRefreshRevisions();
         }
 
@@ -2512,19 +2523,8 @@ namespace GitUI
         internal void ToggleRevisionGraphColumn()
         {
             AppSettings.ShowRevisionGridGraphColumn = !AppSettings.ShowRevisionGridGraphColumn;
-
-            // must show MergeCommits when showing revision graph
-            if (!AppSettings.ShowMergeCommits && AppSettings.ShowRevisionGridGraphColumn)
-            {
-                AppSettings.ShowMergeCommits = true;
-                PerformRefreshRevisions();
-            }
-            else
-            {
-                Refresh();
-            }
-
             MenuCommands.TriggerMenuChanged();
+            Refresh();
         }
 
         internal void ToggleAuthorAvatarColumn()

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -224,33 +224,129 @@ namespace GitUI.UserControls.RevisionGrid
                 //
                 // After refactoring the three items should be added to RevisionGrid
                 // as done with "ShowRemoteBranches" and not via RevisionGrid.Designer.cs
+                MenuCommand.CreateGroupHeader(TranslatedStrings.Branches),
+                new MenuCommand
+                {
+                    Name = "ShowReflogReferences",
+                    Text = "Show &reflog references",
+                    Image = Images.Book,
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowReflogReferences),
+                    ExecuteAction = () => _revisionGrid.ToggleShowReflogReferences(),
+                    IsCheckedFunc = () => _revisionGrid.CurrentFilter.ShowReflogReferences
+                },
                 new MenuCommand
                 {
                     Name = "ShowAllBranches",
                     Text = "Show &all branches",
+                    Image = Images.BranchLocal,
                     ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowAllBranches),
                     ExecuteAction = () => _revisionGrid.ShowAllBranches(),
                     IsCheckedFunc = () => _revisionGrid.CurrentFilter.IsShowAllBranchesChecked
                 },
                 new MenuCommand
                 {
-                    Name = "ShowCurrentBranchOnly",
-                    Text = "Show &current branch only",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowCurrentBranchOnly),
-                    ExecuteAction = () => _revisionGrid.ShowCurrentBranchOnly(),
-                    IsCheckedFunc = () => _revisionGrid.CurrentFilter.IsShowCurrentBranchOnlyChecked
-                },
-                new MenuCommand
-                {
                     Name = "ShowFilteredBranches",
                     Text = "Show &filtered branches",
+                    Image = Images.BranchFilter,
                     ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowFilteredBranches),
                     ExecuteAction = () => _revisionGrid.ShowFilteredBranches(),
                     IsCheckedFunc = () => _revisionGrid.CurrentFilter.IsShowFilteredBranchesChecked
                 },
+                new MenuCommand
+                {
+                    Name = "ShowCurrentBranchOnly",
+                    Text = "Show &current branch only",
+                    Image = Images.BranchFilter,
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowCurrentBranchOnly),
+                    ExecuteAction = () => _revisionGrid.ShowCurrentBranchOnly(),
+                    IsCheckedFunc = () => _revisionGrid.CurrentFilter.IsShowCurrentBranchOnlyChecked
+                },
 
                 MenuCommand.CreateSeparator(),
 
+                new MenuCommand
+                {
+                    Name = "showFirstParent",
+                    Text = "Show first parents",
+                    Image = Images.ShowFirstParent,
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowFirstParent),
+                    ExecuteAction = () => _revisionGrid.ToggleShowFirstParent(),
+                    IsCheckedFunc = () => _revisionGrid.CurrentFilter.ShowFirstParent
+                },
+                new MenuCommand
+                {
+                    Name = "showMergeCommitsToolStripMenuItem",
+                    Text = "Show &merge commits",
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ToggleShowMergeCommits),
+                    ExecuteAction = () => _revisionGrid.ToggleShowMergeCommits(),
+                    IsCheckedFunc = () => AppSettings.ShowMergeCommits
+                },
+
+                MenuCommand.CreateSeparator(),
+
+                new MenuCommand
+                {
+                    Name = "fullHistory",
+                    Text = "Full history",
+                    ExecuteAction = () => _revisionGrid.ToggleFullHistory(),
+                    IsCheckedFunc = () => AppSettings.FullHistoryInFileHistory
+                },
+                new MenuCommand
+                {
+                    Name = "simplifyMerges",
+                    Text = "Simplify merges",
+                    ExecuteAction = () => _revisionGrid.ToggleSimplifyMerges(),
+                    IsCheckedFunc = () => AppSettings.SimplifyMergesInFileHistory,
+                    IsEnabledFunc = () => AppSettings.FullHistoryInFileHistory
+                },
+
+                MenuCommand.CreateSeparator(),
+
+                new MenuCommand
+                {
+                    Name = "drawNonrelativesGrayToolStripMenuItem",
+                    Text = "Draw non relatives gra&y",
+                    ExecuteAction = () => _revisionGrid.ToggleDrawNonRelativesGray(),
+                    IsCheckedFunc = () => AppSettings.RevisionGraphDrawNonRelativesGray
+                },
+                new MenuCommand
+                {
+                    Name = "HighlightSelectedBranch",
+                    Text = "Highlight selected branch (until refresh)",
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ToggleHighlightSelectedBranch)
+                    + $", {Keys.Alt}+{Keys.LButton}",
+                    ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGridControl.Command.ToggleHighlightSelectedBranch)
+                },
+
+                MenuCommand.CreateSeparator(),
+
+                MenuCommand.CreateGroupHeader("Commits"),
+                new MenuCommand
+                {
+                    Name = "ShowArtificialCommits",
+                    Text = "Show artificial commits",
+                    ExecuteAction = () => _revisionGrid.ToggleShowArtificialCommits(),
+                    IsCheckedFunc = () => AppSettings.RevisionGraphShowArtificialCommits
+                },
+                new MenuCommand
+                {
+                    Name = "ShowStashes",
+                    Text = "Show stashes",
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowStashes),
+                    ExecuteAction = () => _revisionGrid.ToggleShowStashes(),
+                    IsCheckedFunc = () => AppSettings.ShowStashes
+                },
+                new MenuCommand
+                {
+                    Name = "showGitNotesToolStripMenuItem",
+                    Text = "Show git &notes",
+                    ExecuteAction = () => _revisionGrid.ToggleShowGitNotes(),
+                    IsCheckedFunc = () => AppSettings.ShowGitNotes
+                },
+
+                MenuCommand.CreateSeparator(),
+
+                MenuCommand.CreateGroupHeader("Grid labels"),
                 new MenuCommand
                 {
                     Name = "ShowRemoteBranches",
@@ -261,30 +357,12 @@ namespace GitUI.UserControls.RevisionGrid
                 },
                 new MenuCommand
                 {
-                    Name = "ShowArtificialCommits",
-                    Text = "Show artificial commits",
-                    ExecuteAction = () => _revisionGrid.ToggleShowArtificialCommits(),
-                    IsCheckedFunc = () => AppSettings.RevisionGraphShowArtificialCommits
+                    Name = "showTagsToolStripMenuItem",
+                    Text = "Show &tags",
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ToggleShowTags),
+                    ExecuteAction = () => _revisionGrid.ToggleShowTags(),
+                    IsCheckedFunc = () => AppSettings.ShowTags
                 },
-                new MenuCommand
-                {
-                    Name = "ShowReflogReferences",
-                    Text = "Show &reflog references",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowReflogReferences),
-                    ExecuteAction = () => _revisionGrid.ToggleShowReflogReferences(),
-                    IsCheckedFunc = () => _revisionGrid.CurrentFilter.ShowReflogReferences
-                },
-                new MenuCommand
-                {
-                    Name = "ShowStashes",
-                    Text = "Show stashes",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowStashes),
-                    ExecuteAction = () => _revisionGrid.ToggleShowStashes(),
-                    IsCheckedFunc = () => AppSettings.ShowStashes
-                },
-
-                MenuCommand.CreateSeparator(),
-
                 new MenuCommand
                 {
                     Name = "ShowSuperprojectTags",
@@ -294,21 +372,61 @@ namespace GitUI.UserControls.RevisionGrid
                 },
                 new MenuCommand
                 {
-                    Name = "ShowSuperprojectBranches",
-                    Text = "Show sup&erproject branches",
-                    ExecuteAction = () => _revisionGrid.ShowSuperprojectBranches_ToolStripMenuItemClick(),
-                    IsCheckedFunc = () => AppSettings.ShowSuperprojectBranches
-                },
-                new MenuCommand
-                {
                     Name = "ShowSuperprojectRemoteBranches",
                     Text = "Show superpro&ject remote branches",
                     ExecuteAction = () => _revisionGrid.ShowSuperprojectRemoteBranches_ToolStripMenuItemClick(),
                     IsCheckedFunc = () => AppSettings.ShowSuperprojectRemoteBranches
                 },
+                new MenuCommand
+                {
+                    Name = "ShowSuperprojectBranches",
+                    Text = "Show sup&erproject branches",
+                    ExecuteAction = () => _revisionGrid.ShowSuperprojectBranches_ToolStripMenuItemClick(),
+                    IsCheckedFunc = () => AppSettings.ShowSuperprojectBranches
+                },
 
                 MenuCommand.CreateSeparator(),
 
+                MenuCommand.CreateGroupHeader("Grid info"),
+                new MenuCommand
+                {
+                    Name = "showBuildStatusIconToolStripMenuItem",
+                    Text = "Show build status &icon",
+                    ExecuteAction = () => _revisionGrid.ToggleBuildStatusIconColumn(),
+                    IsCheckedFunc = () => AppSettings.ShowBuildStatusIconColumn
+                },
+                new MenuCommand
+                {
+                    Name = "showBuildStatusTextToolStripMenuItem",
+                    Text = "Show build status te&xt",
+                    ExecuteAction = () => _revisionGrid.ToggleBuildStatusTextColumn(),
+                    IsCheckedFunc = () => AppSettings.ShowBuildStatusTextColumn
+                },
+                new MenuCommand
+                {
+                    Name = "showCommitMessageBodyToolStripMenuItem",
+                    Text = "Show commit message body",
+                    ExecuteAction = () => _revisionGrid.ToggleShowCommitBodyInRevisionGrid(),
+                    IsCheckedFunc = () => AppSettings.ShowCommitBodyInRevisionGrid
+                },
+                new MenuCommand
+                {
+                    Name = "showAuthorDateToolStripMenuItem",
+                    Text = "Sho&w author date",
+                    ExecuteAction = () => _revisionGrid.ToggleShowAuthorDate(),
+                    IsCheckedFunc = () => AppSettings.ShowAuthorDate
+                },
+                new MenuCommand
+                {
+                    Name = "showRelativeDateToolStripMenuItem",
+                    Text = "Show relati&ve date",
+                    ExecuteAction = () => _revisionGrid.ToggleShowRelativeDate(EventArgs.Empty),
+                    IsCheckedFunc = () => AppSettings.RelativeDate
+                },
+
+                MenuCommand.CreateSeparator(),
+
+                MenuCommand.CreateGroupHeader("Columns"),
                 new MenuCommand
                 {
                     Name = "showRevisionGraphColumnToolStripMenuItem",
@@ -344,88 +462,10 @@ namespace GitUI.UserControls.RevisionGrid
                     ExecuteAction = () => _revisionGrid.ToggleObjectIdColumn(),
                     IsCheckedFunc = () => AppSettings.ShowObjectIdColumn
                 },
-                new MenuCommand
-                {
-                    Name = "showBuildStatusIconToolStripMenuItem",
-                    Text = "Show build status &icon",
-                    ExecuteAction = () => _revisionGrid.ToggleBuildStatusIconColumn(),
-                    IsCheckedFunc = () => AppSettings.ShowBuildStatusIconColumn
-                },
-                new MenuCommand
-                {
-                    Name = "showBuildStatusTextToolStripMenuItem",
-                    Text = "Show build status te&xt",
-                    ExecuteAction = () => _revisionGrid.ToggleBuildStatusTextColumn(),
-                    IsCheckedFunc = () => AppSettings.ShowBuildStatusTextColumn
-                },
 
                 MenuCommand.CreateSeparator(),
 
-                new MenuCommand
-                {
-                    Name = "showAuthorDateToolStripMenuItem",
-                    Text = "Sho&w author date",
-                    ExecuteAction = () => _revisionGrid.ToggleShowAuthorDate(),
-                    IsCheckedFunc = () => AppSettings.ShowAuthorDate
-                },
-                new MenuCommand
-                {
-                    Name = "showRelativeDateToolStripMenuItem",
-                    Text = "Show relati&ve date",
-                    ExecuteAction = () => _revisionGrid.ToggleShowRelativeDate(EventArgs.Empty),
-                    IsCheckedFunc = () => AppSettings.RelativeDate
-                },
-                new MenuCommand
-                {
-                    Name = "showMergeCommitsToolStripMenuItem",
-                    Text = "Show &merge commits",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ToggleShowMergeCommits),
-                    ExecuteAction = () => _revisionGrid.ToggleShowMergeCommits(),
-                    IsCheckedFunc = () => AppSettings.ShowMergeCommits
-                },
-                new MenuCommand
-                {
-                    Name = "showTagsToolStripMenuItem",
-                    Text = "Show &tags",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ToggleShowTags),
-                    ExecuteAction = () => _revisionGrid.ToggleShowTags(),
-                    IsCheckedFunc = () => AppSettings.ShowTags
-                },
-                new MenuCommand
-                {
-                    Name = "showGitNotesToolStripMenuItem",
-                    Text = "Show git &notes",
-                    ExecuteAction = () => _revisionGrid.ToggleShowGitNotes(),
-                    IsCheckedFunc = () => AppSettings.ShowGitNotes
-                },
-                new MenuCommand
-                {
-                    Name = "showCommitMessageBodyToolStripMenuItem",
-                    Text = "Show commit message body",
-                    ExecuteAction = () => _revisionGrid.ToggleShowCommitBodyInRevisionGrid(),
-                    IsCheckedFunc = () => AppSettings.ShowCommitBodyInRevisionGrid
-                },
-
-                MenuCommand.CreateSeparator(),
-
-                new MenuCommand
-                {
-                    Name = "drawNonrelativesGrayToolStripMenuItem",
-                    Text = "Draw non relatives gra&y",
-                    ExecuteAction = () => _revisionGrid.ToggleDrawNonRelativesGray(),
-                    IsCheckedFunc = () => AppSettings.RevisionGraphDrawNonRelativesGray
-                },
-                new MenuCommand
-                {
-                    Name = "HighlightSelectedBranch",
-                    Text = "Highlight selected branch (until refresh)",
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ToggleHighlightSelectedBranch)
-                    + $", {Keys.Alt}+{Keys.LButton}",
-                    ExecuteAction = () => _revisionGrid.ExecuteCommand(RevisionGridControl.Command.ToggleHighlightSelectedBranch)
-                },
-
-                MenuCommand.CreateSeparator(),
-
+                MenuCommand.CreateGroupHeader("Sorting"),
                 new MenuCommand
                 {
                     Name = "AuthorDateSort",
@@ -440,30 +480,9 @@ namespace GitUI.UserControls.RevisionGrid
                     ExecuteAction = () => _revisionGrid.ToggleTopoOrder(),
                     IsCheckedFunc = () => AppSettings.RevisionSortOrder == RevisionSortOrder.Topology
                 },
-                new MenuCommand
-                {
-                    Name = "showFirstParent",
-                    Text = "Show first parents",
-                    Image = Images.ShowFirstParent,
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowFirstParent),
-                    ExecuteAction = () => _revisionGrid.ToggleShowFirstParent(),
-                    IsCheckedFunc = () => _revisionGrid.CurrentFilter.ShowFirstParent
-                },
-                new MenuCommand
-                {
-                    Name = "fullHistory",
-                    Text = "Full history",
-                    ExecuteAction = () => _revisionGrid.ToggleFullHistory(),
-                    IsCheckedFunc = () => AppSettings.FullHistoryInFileHistory
-                },
-                new MenuCommand
-                {
-                    Name = "simplifyMerges",
-                    Text = "Simplify merges",
-                    ExecuteAction = () => _revisionGrid.ToggleSimplifyMerges(),
-                    IsCheckedFunc = () => AppSettings.SimplifyMergesInFileHistory,
-                    IsEnabledFunc = () => AppSettings.FullHistoryInFileHistory
-                },
+
+                MenuCommand.CreateSeparator(),
+
                 new MenuCommand
                 {
                     Name = "filterToolStripMenuItem",

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
@@ -56,11 +56,11 @@ namespace GitCommandsTests
         }
 
         [TestCase(RefFilterOptions.FirstParent, false)]
-        [TestCase(RefFilterOptions.FirstParent | RefFilterOptions.Reflogs, true)]
+        [TestCase(RefFilterOptions.FirstParent | RefFilterOptions.Reflog, true)]
         [TestCase(RefFilterOptions.Branches, false)]
-        [TestCase(RefFilterOptions.Branches | RefFilterOptions.Reflogs, true)]
+        [TestCase(RefFilterOptions.Branches | RefFilterOptions.Reflog, true)]
         [TestCase(RefFilterOptions.All, false)]
-        [TestCase(RefFilterOptions.All | RefFilterOptions.Reflogs, true)]
+        [TestCase(RefFilterOptions.All | RefFilterOptions.Reflog, true)]
         public void BuildArguments_should_add_reflog_if_requested(RefFilterOptions refFilterOptions, bool expected)
         {
             RevisionReader reader = RevisionReader.TestAccessor.RevisionReader(new GitModule(""), hasReflogSelector: false, _logOutputEncoding, _sixMonths);
@@ -93,10 +93,10 @@ namespace GitCommandsTests
         /* Disable special refs with --all */
         [TestCase(RefFilterOptions.All | RefFilterOptions.NoStash, " --all ", null)]
         [TestCase(RefFilterOptions.All | RefFilterOptions.NoStash, " --exclude=refs/stash ", null)]
-        [TestCase(RefFilterOptions.NoStash, null, " --exclude=refs/stash")]
+        [TestCase(RefFilterOptions.NoStash, " --exclude=refs/stash", null)]
         [TestCase(RefFilterOptions.All | RefFilterOptions.NoGitNotes, " --all ", null)]
         [TestCase(RefFilterOptions.All | RefFilterOptions.NoGitNotes, " --not --glob=notes --not ", null)]
-        [TestCase(RefFilterOptions.NoGitNotes, null, " --not --glob=notes --not ")]
+        [TestCase(RefFilterOptions.NoGitNotes, " --not --glob=notes --not ", null)]
         public void BuildArguments_check_parameters(RefFilterOptions refFilterOptions, string expectedToContain, string notExpectedToContain)
         {
             RevisionReader reader = RevisionReader.TestAccessor.RevisionReader(new GitModule(""), hasReflogSelector: false, _logOutputEncoding, _sixMonths);

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
@@ -591,11 +591,15 @@ namespace GitUITests.UserControls
             }
         }
 
-        [TestCase(false, false)]
-        [TestCase(true, false)]
-        [TestCase(false, true)]
-        [TestCase(true, true)]
-        public void FilterInfo_ShowReflogReferences_resets_filters(bool byBranchFilter, bool showCurrentBranchOnly)
+        [TestCase(false, false, false)]
+        [TestCase(true, false, false)]
+        [TestCase(false, true, false)]
+        [TestCase(true, true, false)]
+        [TestCase(false, false, true)]
+        [TestCase(true, false, true)]
+        [TestCase(false, true, true)]
+        [TestCase(true, true, true)]
+        public void FilterInfo_ShowReflogReferences_dominates_other_filters(bool byBranchFilter, bool showCurrentBranchOnly, bool showReflog)
         {
             bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
             bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
@@ -607,13 +611,21 @@ namespace GitUITests.UserControls
                 FilterInfo filterInfo = new()
                 {
                     ByBranchFilter = byBranchFilter,
-                    ShowCurrentBranchOnly = showCurrentBranchOnly
+                    ShowCurrentBranchOnly = showCurrentBranchOnly,
+                    ShowReflogReferences = showReflog
                 };
 
-                filterInfo.ShowReflogReferences = true;
+                filterInfo.ShowReflogReferences.Should().Be(showReflog);
 
-                filterInfo.ByBranchFilter.Should().BeFalse();
-                filterInfo.ShowCurrentBranchOnly.Should().BeFalse();
+                // showCurrentBranchOnly dominates byBranchFilter
+                filterInfo.IsShowAllBranchesChecked.Should().Be(!byBranchFilter && !showCurrentBranchOnly && !showReflog);
+                filterInfo.IsShowCurrentBranchOnlyChecked.Should().Be(showCurrentBranchOnly && !showReflog);
+                filterInfo.IsShowFilteredBranchesChecked.Should().Be(byBranchFilter && !showCurrentBranchOnly && !showReflog);
+
+                filterInfo.ByBranchFilter.Should().Be(byBranchFilter);
+                AppSettings.BranchFilterEnabled.Should().Be(byBranchFilter);
+                filterInfo.ShowCurrentBranchOnly.Should().Be(showCurrentBranchOnly);
+                AppSettings.ShowCurrentBranchOnly.Should().Be(showCurrentBranchOnly);
             }
             finally
             {

--- a/UnitTests/GitUI.Tests/UserControls/FilterToolBarTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterToolBarTests.cs
@@ -198,7 +198,7 @@ namespace GitUITests.UserControls
 
         [TestCase(false)]
         [TestCase(true)]
-        public void ShowReflogs_should_be_bound_via_FilterChanged(bool settingValue)
+        public void ShowReflog_should_be_bound_via_FilterChanged(bool settingValue)
         {
             bool original = AppSettings.ShowReflogReferences;
             try
@@ -206,7 +206,7 @@ namespace GitUITests.UserControls
                 AppSettings.ShowReflogReferences = settingValue;
 
                 _revisionGridFilter.FilterChanged += Raise.EventWith(_revisionGridFilter, new FilterChangedEventArgs(new()));
-                _filterToolBar.GetTestAccessor().tsmiShowReflogs.Checked.Should().Be(settingValue);
+                _filterToolBar.GetTestAccessor().tsbShowReflog.Checked.Should().Be(settingValue);
             }
             finally
             {
@@ -215,10 +215,17 @@ namespace GitUITests.UserControls
         }
 
         [Test]
-        public void ShowReflogs_should_invoke_ToggleShowReflogReferences()
+        public void ShowReflogButton_should_invoke_ToggleShowReflogReferences()
         {
-            _filterToolBar.GetTestAccessor().tsmiShowReflogs.PerformClick();
+            _filterToolBar.GetTestAccessor().tsbShowReflog.PerformClick();
             _revisionGridFilter.Received(1).ToggleShowReflogReferences();
+        }
+
+        [Test]
+        public void ShowBranches_Reflog_should_invoke_ToggleShowReflogReferences()
+        {
+            _filterToolBar.GetTestAccessor().tsmiShowReflog.PerformClick();
+            _revisionGridFilter.Received(1).ShowReflog();
         }
 
         [Test]


### PR DESCRIPTION
## Proposed changes

Reorder the menu items to reflect how the items are used
This menu has grown without much consideration over the years. The sorting options were recently changed in #10172 to be decoupled.
Changes the muscle memory, but even I have a problem understanding the type of setting today...

* Branch filter mode (reverse order to how they are prioritized) 
Reflog <- current branch <- filtered branches <- All
(Except for reflog visible in Advanced filter)
Note: Any branch filter could be ticked at the same time as Reflog, previously
Reflog added to the branch filter dropdown.


* Further revision filters, mostly independent to filter modes 
Show merges, first parents
(Other revision filters in Advanced filter)

* History simplification, how to handle history with filters
Full history, simplify merges.
(Simplify by decoration in Advanced filter handled as a revision filter despite Git description https://git-scm.com/docs/git-log#Documentation/git-log.txt---simplify-by-decoration)

* Highlighting etc

* Added commits in grid
Artificial commits, stash, Git notes

* Labels in Grid 
Remote branches, tags, superproject info

* Specific details in the grid

* Columns to show

* Sorting

* Advanced filter form

~Submenus could be added to explain the groups, should be a separate PR~
Added group headers to explain usage

This will require an update in the doc too (a few other changes needed as well)
https://git-extensions-documentation.readthedocs.io/en/release-4.0/browse_repository.html

There is some overlap between the Advanced filter and View menu.
All revision filters and simplify history should be moved there as well as the reflog *branch revision filter option* be added.
That should be a separate PR

## Screenshots <!-- Remove this section if PR does not change UI -->

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/6248932/189451145-08deaa7e-506a-4b69-b70f-766c2f32d28f.png) | ![image](https://user-images.githubusercontent.com/6248932/190252116-e679780f-396c-4750-8a5c-a76ad9e6244a.png) |
| ![image](https://user-images.githubusercontent.com/6248932/189500626-37a91740-4e3d-44e1-91db-7770856023d4.png) | ![image](https://user-images.githubusercontent.com/6248932/189551086-7b3a74fd-3cf5-4708-a1b6-10a91269f80d.png)  |

(Before displays _Show stashes_ instead of _Show latest stashes_ as it is from a branch, no other changes.)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
