### PR TITLE
Add Update-DotnetVersion script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,8 @@ environment:
   DOTNET_NOLOGO: true
   # Disable the .NET first time experience to skip caching NuGet packages and speed up the build.
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  # Use latest version of current used .NET version.  6.0 could use the latest of 6.0.  See .\Scripts\Update-DotnetVersion.ps1
+  GE_USE_LATEST_DOTNET: false
 
 init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
@@ -35,6 +37,11 @@ build:
   verbosity: minimal
 
 install:
+- ps: |
+      if($env:GE_USE_LATEST_DOTNET -eq $true)
+      {
+        .\scripts\Update-DotnetVersion.ps1
+      }
 - ps: |
       Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile "./dotnet-install.ps1"
       ./dotnet-install.ps1 -JsonFile global.json -InstallDir 'C:\Program Files\dotnet'

--- a/scripts/Mark-RepoClean.ps1
+++ b/scripts/Mark-RepoClean.ps1
@@ -2,6 +2,10 @@
 
 pushd $PSScriptRoot\..
 
+# If the .NET SDK/runtime version was updated - make build clean
+& git update-index --skip-worktree global.json
+& git update-index --skip-worktree scripts/RepoLayout.props
+
 # iterate through each submodule and mark each AssemblyInfo.cs in a submodule as clean
 $submodules = git submodule --quiet foreach --recursive 'echo $name'
 $submodules | ForEach-Object {

--- a/scripts/Update-DotnetVersion.ps1
+++ b/scripts/Update-DotnetVersion.ps1
@@ -1,0 +1,35 @@
+param ( [string]$version = "6.0")
+
+$encoding = [System.Text.UTF8Encoding]::new($false)
+
+$path = Split-Path $MyInvocation.MyCommand.Path -Parent
+$uri = "https://raw.githubusercontent.com/dotnet/core/main/release-notes/$version/releases.json"
+
+# Get .NET version info
+$releaseJson = Invoke-WebRequest -Uri $uri -ContentType "application/json" -Method Get -UseBasicParsing
+$versionResult = $releaseJson.Content | Out-String | ConvertFrom-Json 
+Write-Output "Dotnet version info"
+$versionResult | Format-List -Property channel-version, latest-release, latest-release-date, latest-runtime, latest-sdk, support-phase, eol-date
+
+# Update global.json file
+$globalJson = [System.IO.Path]::Combine($path, "..\global.json")
+$globalJson = Resolve-Path $globalJson
+$json = Get-Content $globalJson | ConvertFrom-Json
+Write-Output "Updating SDK version from $($json.sdk.version) to $($versionResult.'latest-sdk')"
+$json.sdk.version = $versionResult.'latest-sdk'
+$json | ConvertTo-Json  | Out-File -Encoding utf8 $globalJson
+
+# Update RepoLayout.props file
+$propsPath = [System.IO.Path]::Combine($path, "RepoLayout.props")
+[xml]$props = Get-Content -Path $propsPath
+$nd = $props.SelectSingleNode("/Project/PropertyGroup/RuntimeFrameworkVersion")
+Write-Output "Updating Runtime version from $($nd.'#text') to $($versionResult.'latest-runtime')"
+$nd.'#text' = $versionResult.'latest-runtime'
+$settings = [System.Xml.XmlWriterSettings]@{
+  Encoding = $encoding
+  Indent   = $true    
+}
+$writer = [System.Xml.XmlWriter]::Create($propsPath, $settings)
+$nd.OwnerDocument.Save($writer)
+$writer.Dispose()
+


### PR DESCRIPTION
Updates dotnet SDK and Runtime versions together

Allows for
```powershell
.\Scripts\Update-DotnetVersion.ps1
```
OR
```powershell
.\Scripts\Update-DotnetVersion.ps1 7.0
```

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

resolves #10192 
## Proposed changes

- Add script to allow updating dotnet version to latest of current version used or passing in a specified version
- Update appveyor build to allow user to set flag that causes the latest version to be used in build.  Useful to test version bump before applying the change.


## Test methodology <!-- How did you ensure quality? -->

- Ran script and verified change

## Test environment(s) <!-- Remove any that don't apply -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
