### PR TITLE
Protect AppSettings saving using global mutex

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1606,7 +1606,9 @@ namespace GitCommands
             {
                 SettingsContainer.LockedAction(() =>
                 {
-                    _globalMutex ??= new Mutex(initiallyOwned: false, name: SettingsFilePath.ToPosixPath());
+                    // prepend "Global\" in order to be safe in preparation for non-Windows OS, too
+                    _globalMutex ??= new Mutex(initiallyOwned: false, name: @$"Global\Mutex{SettingsFilePath.ToPosixPath()}");
+
                     try
                     {
                         _globalMutex.WaitOne();

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Windows.Forms;
 using GitCommands.Settings;
 using GitExtUtils;
@@ -39,6 +40,8 @@ namespace GitCommands
         public static RepoDistSettings SettingsContainer { get; private set; }
 
         private static readonly SettingsPath DetailedSettingsPath = new AppSettingsPath("Detailed");
+
+        private static Mutex _globalMutex;
 
         public static readonly int BranchDropDownMinWidth = 300;
         public static readonly int BranchDropDownMaxWidth = 600;
@@ -1603,7 +1606,16 @@ namespace GitCommands
             {
                 SettingsContainer.LockedAction(() =>
                 {
-                    SettingsContainer.Save();
+                    _globalMutex ??= new Mutex(initiallyOwned: false, name: SettingsFilePath.ToPosixPath());
+                    try
+                    {
+                        _globalMutex.WaitOne();
+                        SettingsContainer.Save();
+                    }
+                    finally
+                    {
+                        _globalMutex.ReleaseMutex();
+                    }
                 });
 
                 Saved?.Invoke();


### PR DESCRIPTION
Fixes #10016

## Proposed changes

- Protect `AppSettings.SaveSettings` using a global mutex common to all GE instances

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 403856d49cf56837f9a746c452dc3ab13b5ecb49
- Git 2.35.2.windows.1 (recommended: 2.37.1 or later)
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.9
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).