### PR TITLE
Debug/windowpos

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -435,6 +435,36 @@ namespace GitUI.CommandsDialogs
             base.OnHandleCreated(e);
         }
 
+        public void FixForOwnerScreenLocation(IWin32Window? owner)
+        {
+            if (owner != null)
+            {
+                Screen screenOwner = Screen.FromHandle(owner.Handle);
+                if (!screenOwner.Bounds.IntersectsWith(Bounds))
+                {
+                    // This form appear to be not in the same monitor as owner window
+                    // thus may become invisible when owner is in secondary screen
+                    // with negative left coordinates and last saved position of the
+                    // form was with positive coordinates in case dpi are different.
+                    // Attempting to correct the saved position may be unsuccessful
+                    // because it depends on the screen layout of extended desktop.
+                    if (screenOwner.Bounds.Width - screenOwner.Bounds.X < 0 && Left > 0)
+                    {
+                        // Move to the owner screen
+                        Left = screenOwner.Bounds.X + Left;
+
+                        // Show in taskbar so user can potentially recover the window
+                        // if the title bar is no more reachable by user.
+                        ShowInTaskbar = true;
+                    }
+                }
+
+                // This should be always applied, but maybe it is better that each form
+                // may declare on the constructor if ShowInTaskbar is true or false
+                ShowInTaskbar = true;
+            }
+        }
+
         [DllImport("user32.dll")]
         private static extern IntPtr SendMessage(IntPtr hwnd, int msg, IntPtr wp, IntPtr lp);
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -439,30 +439,29 @@ namespace GitUI.CommandsDialogs
         {
             if (owner != null)
             {
-                Screen screenOwner = Screen.FromHandle(owner.Handle);
-                if (!screenOwner.Bounds.IntersectsWith(Bounds))
+                Screen ownerScreen = Screen.FromHandle(owner.Handle);
+                if (!ownerScreen.Bounds.IntersectsWith(Bounds))
                 {
                 	// Fix #10121 - Commit form appear out of screen in dual monitor setup
-                	//
-                    // This form appear to be not in the same monitor as owner window
-                    // thus may become invisible when owner is in secondary screen
+                    // The form appears to be not in the same monitor as owner window
+                    // thus may become invisible when owner win is in a secondary screen
                     // with negative left coordinates and last saved position of the
-                    // form was with positive coordinates in case dpi are different.
+                    // form was with positive coordinates, in case dpi are different.
                     // Attempting to correct the saved position may be unsuccessful
                     // because it depends on the screen layout of extended desktop.
-                    if (screenOwner.Bounds.Width - screenOwner.Bounds.X < 0 && Left > 0)
+                    if (ownerScreen.Bounds.Width - ownerScreen.Bounds.X < 0 && Left > 0)
                     {
-                        // Move to the owner screen
-                        Left = screenOwner.Bounds.X + Left;
+                        // Reinterpret saved left position as an offset from the owner's form screen
+                        Left = ownerScreen.Bounds.X + Left;
 
                         // Show in taskbar so user can potentially recover the window
-                        // if the title bar is no more reachable by user.
+                        // if the draggable title bar is no more reachable by mouse.
                         ShowInTaskbar = true;
                     }
                 }
 
-                // This should be always applied, but maybe it is better that each form
-                // may declare on the constructor if ShowInTaskbar is true or false
+                // This could always be applied, but maybe it is better that each form
+                // may declare in the constructor if ShowInTaskbar needs to be true or false
                 // ShowInTaskbar = true;
             }
         }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -442,6 +442,8 @@ namespace GitUI.CommandsDialogs
                 Screen screenOwner = Screen.FromHandle(owner.Handle);
                 if (!screenOwner.Bounds.IntersectsWith(Bounds))
                 {
+                	// Fix #10121 - Commit form appear out of screen in dual monitor setup
+                	//
                     // This form appear to be not in the same monitor as owner window
                     // thus may become invisible when owner is in secondary screen
                     // with negative left coordinates and last saved position of the
@@ -461,7 +463,7 @@ namespace GitUI.CommandsDialogs
 
                 // This should be always applied, but maybe it is better that each form
                 // may declare on the constructor if ShowInTaskbar is true or false
-                ShowInTaskbar = true;
+                // ShowInTaskbar = true;
             }
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -437,33 +437,35 @@ namespace GitUI.CommandsDialogs
 
         public void FixForOwnerScreenLocation(IWin32Window? owner)
         {
-            if (owner != null)
+            if (owner == null)
             {
-                Screen ownerScreen = Screen.FromHandle(owner.Handle);
-                if (!ownerScreen.Bounds.IntersectsWith(Bounds))
-                {
-                	// Fix #10121 - Commit form appear out of screen in dual monitor setup
-                    // The form appears to be not in the same monitor as owner window
-                    // thus may become invisible when owner win is in a secondary screen
-                    // with negative left coordinates and last saved position of the
-                    // form was with positive coordinates, in case dpi are different.
-                    // Attempting to correct the saved position may be unsuccessful
-                    // because it depends on the screen layout of extended desktop.
-                    if (ownerScreen.Bounds.Width - ownerScreen.Bounds.X < 0 && Left > 0)
-                    {
-                        // Reinterpret saved left position as an offset from the owner's form screen
-                        Left = ownerScreen.Bounds.X + Left;
-
-                        // Show in taskbar so user can potentially recover the window
-                        // if the draggable title bar is no more reachable by mouse.
-                        ShowInTaskbar = true;
-                    }
-                }
-
-                // This could always be applied, but maybe it is better that each form
-                // may declare in the constructor if ShowInTaskbar needs to be true or false
-                // ShowInTaskbar = true;
+                return;
             }
+
+            Screen ownerScreen = Screen.FromHandle(owner.Handle);
+            if (!ownerScreen.Bounds.IntersectsWith(Bounds))
+            {
+                // Fix #10121 - Commit form appear out of screen in dual monitor setup
+                // The form appears to be not in the same monitor as owner window
+                // thus may become invisible when owner win is in a secondary screen
+                // with negative left coordinates and last saved position of the
+                // form was with positive coordinates, in case dpi are different.
+                // Attempting to correct the saved position may be unsuccessful
+                // because it depends on the screen layout of extended desktop.
+                if (ownerScreen.Bounds.Width - ownerScreen.Bounds.X < 0 && Left > 0)
+                {
+                    // Reinterpret saved left position as an offset from the owner's form screen
+                    Left = ownerScreen.Bounds.X + Left;
+
+                    // Show in taskbar so user can potentially recover the window
+                    // if the draggable title bar is no more reachable by mouse.
+                    ShowInTaskbar = true;
+                }
+            }
+
+            // This could always be applied, but maybe it is better that each form
+            // may declare in the constructor if ShowInTaskbar needs to be true or false
+            // ShowInTaskbar = true;
         }
 
         [DllImport("user32.dll")]

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -534,6 +534,11 @@ namespace GitUI
                     }
 
                     using FormCommit form = new(this, commitMessage: commitMessage);
+
+                    // WORKAROUND: Marani Paolo 8/9/22
+                    // Ensure the form can be always displayed when owner is in a different screen
+                    form.FixForOwnerScreenLocation(owner);
+
                     if (showOnlyWhenChanges)
                     {
                         form.ShowDialogWhenChanges(owner);

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -535,8 +535,7 @@ namespace GitUI
 
                     using FormCommit form = new(this, commitMessage: commitMessage);
 
-                    // WORKAROUND: Marani Paolo 8/9/22
-                    // Ensure the form can be always displayed when owner is in a different screen
+                    // WORKAROUND: Ensure the form can be always displayed when owner is in a different screen
                     form.FixForOwnerScreenLocation(owner);
 
                     if (showOnlyWhenChanges)

--- a/contributors.txt
+++ b/contributors.txt
@@ -178,3 +178,4 @@ YYYY/MM/DD, github id, Full name, email
 2022/05/19, zvirja, Oleksandr Povar, zvirja1[.@)gmail.com
 2022/05/20, Rhumborl, Philip Cole, pccole[at)gmail.com
 2022/08/23, huangsunyang, SunYang Huang, huangsunyang(at)126.com
+2022/09/16, eng-marani, Paolo Marani, paolo.marani@engineering.it


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10121

## Proposed changes

- See comments on the code changes
- It basically detect when multiple screens are in use, and attempt
-  to recover an invisible window by pushing the form on the right screen

## Test methodology <!-- How did you ensure quality? -->

- I have compiled the product using both Visual Studio Code and JetBrains Rider
- I've tried various combination of dual screen layout, and verified that in MY
- combination, a saved window cannot be restored from settings where intended

## Test environment(s) <!-- Remove any that don't apply -->

- GIT (latest)
- Windows 10

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
