### PR TITLE
working around context menu strip being positioned incorrectly on first open

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -245,15 +245,20 @@ namespace GitUI.BranchTreePanel
 
         private void contextMenu_Opened(object sender, EventArgs e)
         {
+            if (sender is not ContextMenuStrip contextMenu)
+            {
+                return;
+            }
+
             // Waiting for the ContextMenuStrip (as the visual parent of its menu items) to be visible to
             // toggle (depending on ToolStripItem.Visible) existing separators in between item groups as required.
-            menuMain.ToggleSeparators();
+            contextMenu.ToggleSeparators();
 
             // Working around the context menu strip being positioned incorrectly on first open - which may be a Windows Forms bug,
             // see https://stackoverflow.com/q/15841863/2338036.
-            if (menuMain.Top != Cursor.Position.Y)
+            if (contextMenu.Top != Cursor.Position.Y)
             {
-                menuMain.Top = Cursor.Position.Y;
+                contextMenu.Top = Cursor.Position.Y;
             }
         }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -244,9 +244,18 @@ namespace GitUI.BranchTreePanel
         }
 
         private void contextMenu_Opened(object sender, EventArgs e)
+        {
             /* Waiting for ContextMenuStrip (as the visual parent of its menu items) to be visible to
              * toggle (depending on ToolStripItem.Visible) existing separators in between item groups as required.*/
-            => (sender as ContextMenuStrip)?.ToggleSeparators();
+            (sender as ContextMenuStrip)?.ToggleSeparators();
+
+            /* working around context menu strip being positioned incorrectly on first open - which may be a Windows Forms bug, see
+             * https://stackoverflow.com/questions/15841863/why-does-my-menustrip-appear-in-the-incorrect-location-on-first-click */
+            if (menuMain.Top != Cursor.Position.Y)
+            {
+                menuMain.Top = Cursor.Position.Y;
+            }
+        }
 
         /// <inheritdoc />
         public TMenuItem CreateMenuItem<TMenuItem, TNode>(Action<TNode> onClick, TranslationString text, TranslationString toolTip, Bitmap? icon = null)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -245,8 +245,8 @@ namespace GitUI.BranchTreePanel
 
         private void contextMenu_Opened(object sender, EventArgs e)
         {
-            /* Waiting for ContextMenuStrip (as the visual parent of its menu items) to be visible to
-             * toggle (depending on ToolStripItem.Visible) existing separators in between item groups as required.*/
+            // Waiting for ContextMenuStrip (as the visual parent of its menu items) to be visible to
+            // toggle (depending on ToolStripItem.Visible) existing separators in between item groups as required.
             (sender as ContextMenuStrip)?.ToggleSeparators();
 
             // Working around the context menu strip being positioned incorrectly on first open - which may be a Windows Forms bug,

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -249,8 +249,8 @@ namespace GitUI.BranchTreePanel
              * toggle (depending on ToolStripItem.Visible) existing separators in between item groups as required.*/
             (sender as ContextMenuStrip)?.ToggleSeparators();
 
-            /* working around context menu strip being positioned incorrectly on first open - which may be a Windows Forms bug, see
-             * https://stackoverflow.com/questions/15841863/why-does-my-menustrip-appear-in-the-incorrect-location-on-first-click */
+            // Working around the context menu strip being positioned incorrectly on first open - which may be a Windows Forms bug,
+            // see https://stackoverflow.com/q/15841863/2338036.
             if (menuMain.Top != Cursor.Position.Y)
             {
                 menuMain.Top = Cursor.Position.Y;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -245,9 +245,9 @@ namespace GitUI.BranchTreePanel
 
         private void contextMenu_Opened(object sender, EventArgs e)
         {
-            // Waiting for ContextMenuStrip (as the visual parent of its menu items) to be visible to
+            // Waiting for the ContextMenuStrip (as the visual parent of its menu items) to be visible to
             // toggle (depending on ToolStripItem.Visible) existing separators in between item groups as required.
-            (sender as ContextMenuStrip)?.ToggleSeparators();
+            menuMain.ToggleSeparators();
 
             // Working around the context menu strip being positioned incorrectly on first open - which may be a Windows Forms bug,
             // see https://stackoverflow.com/q/15841863/2338036.


### PR DESCRIPTION
No idea why this happens. I found [this question on stackoverflow](https://stackoverflow.com/questions/15841863/why-does-my-menustrip-appear-in-the-incorrect-location-on-first-click) in which some folk suggest it may be a Windows Forms bug and how to work around it.
I didn't like the proposed work arounds much and think I've found a simpler one that works for me. Please try it and see if your mileage varies.

Fixes #10165

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
