### PR TITLE
Improve deletion of local branches

### DIFF
--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -48,15 +48,22 @@ namespace GitUI.CommandsDialogs
             base.OnRuntimeLoad(e);
 
             Branches.BranchesToSelect = Module.GetRefs(RefsFilter.Heads).ToList();
-            foreach (string branch in Module.GetMergedBranches())
+            if (AppSettings.DontConfirmDeleteUnmergedBranch)
             {
-                if (!branch.StartsWith("* "))
+                _currentBranch = Module.GetSelectedBranch();
+            }
+            else
+            {
+                foreach (string branch in Module.GetMergedBranches())
                 {
-                    _mergedBranches.Add(branch.Trim());
-                }
-                else if (!branch.StartsWith("* ") || !DetachedHeadParser.IsDetachedHead(branch[2..]))
-                {
-                    _currentBranch = branch.Trim('*', ' ');
+                    if (!branch.StartsWith("* "))
+                    {
+                        _mergedBranches.Add(branch.Trim());
+                    }
+                    else if (!branch.StartsWith("* ") || !DetachedHeadParser.IsDetachedHead(branch[2..]))
+                    {
+                        _currentBranch = branch.Trim('*', ' ');
+                    }
                 }
             }
 
@@ -104,7 +111,7 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            GitDeleteBranchCmd cmd = new(selectedBranches, force: hasUnmergedBranches);
+            GitDeleteBranchCmd cmd = new(selectedBranches, force: true);
             bool success = UICommands.StartCommandLineProcessDialog(Owner, cmd);
             if (success)
             {

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -56,13 +56,13 @@ namespace GitUI.CommandsDialogs
             {
                 foreach (string branch in Module.GetMergedBranches())
                 {
-                    if (!branch.StartsWith("* "))
-                    {
-                        _mergedBranches.Add(branch.Trim());
-                    }
-                    else if (!branch.StartsWith("* ") || !DetachedHeadParser.IsDetachedHead(branch[2..]))
+                    if (branch.StartsWith("* "))
                     {
                         _currentBranch = branch.Trim('*', ' ');
+                    }
+                    else
+                    {
+                        _mergedBranches.Add(branch.Trim());
                     }
                 }
             }
@@ -90,7 +90,8 @@ namespace GitUI.CommandsDialogs
             }
 
             // always treat branches as unmerged if there is no current branch (HEAD is detached)
-            bool hasUnmergedBranches = _currentBranch is null || selectedBranches.Any(branch => !_mergedBranches.Contains(branch.Name));
+            bool hasUnmergedBranches = _currentBranch is null || DetachedHeadParser.IsDetachedHead(_currentBranch)
+                || selectedBranches.Any(branch => !_mergedBranches.Contains(branch.Name));
             if (hasUnmergedBranches && !AppSettings.DontConfirmDeleteUnmergedBranch)
             {
                 TaskDialogPage page = new()

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -7,6 +7,7 @@ using GitCommands;
 using GitCommands.Git;
 using GitCommands.Git.Commands;
 using GitUIPluginInterfaces;
+using Microsoft;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs
@@ -20,8 +21,8 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _useReflogHint = new("Did you know you can use reflog to restore deleted branches?");
 
         private readonly IEnumerable<string> _defaultBranches;
-        private readonly HashSet<string> _mergedBranches = new();
         private string? _currentBranch;
+        private HashSet<string>? _mergedBranches;
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -50,10 +51,12 @@ namespace GitUI.CommandsDialogs
             Branches.BranchesToSelect = Module.GetRefs(RefsFilter.Heads).ToList();
             if (AppSettings.DontConfirmDeleteUnmergedBranch)
             {
+                // no need to fill _mergedBranches
                 _currentBranch = Module.GetSelectedBranch();
             }
             else
             {
+                _mergedBranches = new();
                 foreach (string branch in Module.GetMergedBranches())
                 {
                     if (branch.StartsWith("* "))
@@ -89,26 +92,31 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            // always treat branches as unmerged if there is no current branch (HEAD is detached)
-            bool hasUnmergedBranches = _currentBranch is null || DetachedHeadParser.IsDetachedHead(_currentBranch)
-                || selectedBranches.Any(branch => !_mergedBranches.Contains(branch.Name));
-            if (hasUnmergedBranches && !AppSettings.DontConfirmDeleteUnmergedBranch)
+            if (!AppSettings.DontConfirmDeleteUnmergedBranch)
             {
-                TaskDialogPage page = new()
-                {
-                    Text = _deleteBranchQuestion.Text,
-                    Caption = _deleteBranchConfirmTitle.Text,
-                    Icon = TaskDialogIcon.Warning,
-                    Buttons = { TaskDialogButton.Yes, TaskDialogButton.No },
-                    DefaultButton = TaskDialogButton.No,
-                    Footnote = _useReflogHint.Text,
-                    SizeToContent = true,
-                };
+                Validates.NotNull(_mergedBranches);
 
-                bool isConfirmed = TaskDialog.ShowDialog(Handle, page) == TaskDialogButton.Yes;
-                if (!isConfirmed)
+                // always treat branches as unmerged if there is no current branch (HEAD is detached)
+                bool hasUnmergedBranches = _currentBranch is null || DetachedHeadParser.IsDetachedHead(_currentBranch)
+                    || selectedBranches.Any(branch => !_mergedBranches.Contains(branch.Name));
+                if (hasUnmergedBranches)
                 {
-                    return;
+                    TaskDialogPage page = new()
+                    {
+                        Text = _deleteBranchQuestion.Text,
+                        Caption = _deleteBranchConfirmTitle.Text,
+                        Icon = TaskDialogIcon.Warning,
+                        Buttons = { TaskDialogButton.Yes, TaskDialogButton.No },
+                        DefaultButton = TaskDialogButton.No,
+                        Footnote = _useReflogHint.Text,
+                        SizeToContent = true,
+                    };
+
+                    bool isConfirmed = TaskDialog.ShowDialog(Handle, page) == TaskDialogButton.Yes;
+                    if (!isConfirmed)
+                    {
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #10122

## Proposed changes

- Always force-delete local branches regardless of the merged state (for unmerged branches after confirmation unless disabled)
- Do not load merged branches if `DontConfirmDeleteUnmergedBranch`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 5a21c57542fc869811c9804869b11e8039236eae
- Git 2.35.2.windows.1 (recommended: 2.37.1 or later)
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.9
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).