### PR TITLE
FormDeleteRemoteBranch: GetMergedRemoteBranches() in background

### DIFF
--- a/GitExtUtils/GitUI/TaskManager.cs
+++ b/GitExtUtils/GitUI/TaskManager.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Microsoft.VisualStudio.Threading;
+
+namespace GitUI
+{
+    public class TaskManager
+    {
+        private readonly JoinableTaskCollection _joinableTaskCollection;
+
+        public TaskManager(JoinableTaskContext joinableTaskContext)
+        {
+            JoinableTaskContext = joinableTaskContext;
+            _joinableTaskCollection = joinableTaskContext.CreateCollection();
+            JoinableTaskFactory = joinableTaskContext.CreateFactory(_joinableTaskCollection);
+        }
+
+        public JoinableTaskContext JoinableTaskContext { get; init; }
+
+        public JoinableTaskFactory JoinableTaskFactory { get; init; }
+
+        public void FileAndForget(Task task, Func<Exception, bool>? fileOnlyIf = null)
+        {
+            JoinableTaskFactory.RunAsync(
+                async () =>
+                {
+                    try
+                    {
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+                        await task.ConfigureAwait(false);
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Do not rethrow these
+                    }
+                    catch (Exception ex) when (fileOnlyIf?.Invoke(ex) ?? true)
+                    {
+                        await JoinableTaskFactory.SwitchToMainThreadAsync();
+                        Application.OnThreadException(ex.Demystify());
+                    }
+                });
+        }
+
+        public void RunAsyncAndForget(Func<Task> asyncAction, Func<Exception, bool>? fileOnlyIf = null)
+        {
+            FileAndForget(JoinableTaskFactory.RunAsync(asyncAction).Task, fileOnlyIf);
+        }
+
+        public void RunAsyncAndForget(Action action, Func<Exception, bool>? fileOnlyIf = null)
+        {
+            RunAsyncAndForget(() =>
+                {
+                    action();
+                    return Task.CompletedTask;
+                },
+                fileOnlyIf);
+        }
+
+        public async Task JoinPendingOperationsAsync(CancellationToken cancellationToken)
+        {
+            await _joinableTaskCollection.JoinTillEmptyAsync(cancellationToken);
+        }
+
+        public void JoinPendingOperations()
+        {
+            // Note that JoinableTaskContext.Factory must be used to bypass the default behavior of JoinableTaskFactory
+            // since the latter adds new tasks to the collection and would therefore never complete.
+            JoinableTaskContext.Factory.Run(_joinableTaskCollection.JoinTillEmptyAsync);
+        }
+    }
+}

--- a/GitExtUtils/GitUI/ThreadHelper.cs
+++ b/GitExtUtils/GitUI/ThreadHelper.cs
@@ -24,7 +24,7 @@ namespace GitUI
 
         public static JoinableTaskFactory JoinableTaskFactory => _taskManager.JoinableTaskFactory;
 
-        public static TaskManager CreateSeparate()
+        public static TaskManager CreateTaskManager()
             => new(_taskManager.JoinableTaskContext);
 
         public static void ThrowIfNotOnUIThread([CallerMemberName] string callerMemberName = "")

--- a/GitExtUtils/GitUI/ThreadHelper.cs
+++ b/GitExtUtils/GitUI/ThreadHelper.cs
@@ -18,7 +18,7 @@ namespace GitUI
 
         public static JoinableTaskContext JoinableTaskContext
         {
-            get => _taskManager.JoinableTaskContext;
+            get => _taskManager?.JoinableTaskContext;
             internal set => _taskManager = value is null ? null : new(value);
         }
 

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using GitCommands;
 using GitCommands.Git.Commands;
@@ -21,8 +21,9 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _confirmDeleteUnmergedRemoteBranchMessage =
             new("At least one remote branch is unmerged. Are you sure you want to delete it?" + Environment.NewLine + "Deleting a branch can cause commits to be deleted too!");
 
-        private readonly HashSet<string> _mergedBranches = new();
         private readonly string _defaultRemoteBranch;
+        private readonly TaskManager _taskManager = ThreadHelper.CreateSeparate();
+        private HashSet<string> _mergedBranches;
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -35,7 +36,10 @@ namespace GitUI.CommandsDialogs
         public FormDeleteRemoteBranch(GitUICommands commands, string defaultRemoteBranch)
             : base(commands, enablePositionRestore: false)
         {
+            _taskManager.RunAsyncAndForget(() => _mergedBranches = Module.GetMergedRemoteBranches().ToHashSet());
+
             _defaultRemoteBranch = defaultRemoteBranch;
+
             InitializeComponent();
 
             InitializeComplete();
@@ -46,10 +50,6 @@ namespace GitUI.CommandsDialogs
             base.OnRuntimeLoad(e);
 
             Branches.BranchesToSelect = Module.GetRefs(RefsFilter.Remotes).ToList();
-            foreach (var branch in Module.GetMergedRemoteBranches())
-            {
-                _mergedBranches.Add(branch);
-            }
 
             if (_defaultRemoteBranch is not null)
             {
@@ -86,6 +86,9 @@ namespace GitUI.CommandsDialogs
             }
 
             List<IGitRef> selectedBranches = Branches.GetSelectedBranches().ToList();
+
+            // wait for _mergedBranches to be filled
+            _taskManager.JoinPendingOperations();
 
             bool hasUnmergedBranches = selectedBranches.Any(branch => !_mergedBranches.Contains(branch.CompleteName));
             if (hasUnmergedBranches)

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -22,7 +22,7 @@ namespace GitUI.CommandsDialogs
             new("At least one remote branch is unmerged. Are you sure you want to delete it?" + Environment.NewLine + "Deleting a branch can cause commits to be deleted too!");
 
         private readonly string _defaultRemoteBranch;
-        private readonly TaskManager _taskManager = ThreadHelper.CreateSeparate();
+        private readonly TaskManager _taskManager = ThreadHelper.CreateTaskManager();
         private HashSet<string> _mergedBranches;
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]


### PR DESCRIPTION
## Proposed changes

- Factor out `TaskManager` from `ThreadHelper`
  in order to have a `JoinableTaskCollection` and `JoinableTaskFactory` per Form.
  So Forms and their tests can await their own async operations in the future.
- `FormDeleteRemoteBranch`:
  - Use `TaskManager` to run `GetMergedRemoteBranches()` in the background.
  - Await the execution when the data is needed. 

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual
- existing tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 5688d4848d9e8bcb5c7e35f40e69ce522b4350a5
- Git 2.35.2.windows.1 (recommended: 2.37.1 or later)
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.9
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).