### PR TITLE
Update filter toolbar when filters change

### DIFF
--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -46,24 +46,28 @@ namespace GitUI.UserControls
             this.tsmiCommitFilter.CheckOnClick = true;
             this.tsmiCommitFilter.Name = "tsmiCommitFilter";
             this.tsmiCommitFilter.Text = "Commit &message";
+            this.tsmiCommitFilter.CheckedChanged += new System.EventHandler(this.revisionFilterBox_CheckedChanged); 
             // 
             // tsmiCommitter
             // 
             this.tsmiCommitterFilter.CheckOnClick = true;
             this.tsmiCommitterFilter.Name = "tsmiCommitter";
             this.tsmiCommitterFilter.Text = "&Committer";
+            this.tsmiCommitterFilter.CheckedChanged += new System.EventHandler(this.revisionFilterBox_CheckedChanged);
             // 
             // tsmiAuthor
             // 
             this.tsmiAuthorFilter.CheckOnClick = true;
             this.tsmiAuthorFilter.Name = "tsmiAuthor";
             this.tsmiAuthorFilter.Text = "&Author";
+            this.tsmiAuthorFilter.CheckedChanged += new System.EventHandler(this.revisionFilterBox_CheckedChanged);
             // 
             // tsmiDiffContains
             // 
             this.tsmiDiffContainsFilter.CheckOnClick = true;
             this.tsmiDiffContainsFilter.Name = "tsmiDiffContains";
             this.tsmiDiffContainsFilter.Text = "&Diff contains (SLOW)";
+            this.tsmiDiffContainsFilter.CheckedChanged += new System.EventHandler(this.revisionFilterBox_CheckedChanged);
             // 
             // toolStripLabel1
             // 

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -152,6 +152,9 @@ namespace GitUI.UserControls
             {
                 // Show filtered branches
                 selectedIndex = 2;
+
+                // Keep value if other filter
+                tscboBranchFilter.Text = e.BranchFilter;
             }
 
             if (e.ShowCurrentBranchOnly)
@@ -329,11 +332,49 @@ namespace GitUI.UserControls
             tsmiShowOnlyFirstParent.Checked = e.ShowOnlyFirstParent;
             tsbShowReflog.Checked = e.ShowReflogReferences;
             InitBranchSelectionFilter(e);
+
+            List<(string filter, ToolStripMenuItem menuItem)> revFilters = new()
+            {
+                (e.MessageFilter, tsmiCommitFilter),
+                (e.CommitterFilter, tsmiCommitterFilter),
+                (e.AuthorFilter, tsmiAuthorFilter),
+                (e.DiffContentFilter, tsmiDiffContainsFilter),
+            };
+
+            // If there are no changes in the filter keep also "uncommitted" changes
+            if (revFilters.Any(item => !string.IsNullOrWhiteSpace(item.filter)))
+            {
+                tstxtRevisionFilter.Text = "";
+                foreach ((string filter, ToolStripMenuItem menuItem) item in revFilters)
+                {
+                    // Check the first menuitem that matches and following identical filters
+                    if (!string.IsNullOrWhiteSpace(item.filter)
+                        && (string.IsNullOrWhiteSpace(tstxtRevisionFilter.Text)
+                            || item.filter == tstxtRevisionFilter.Text))
+                    {
+                        tstxtRevisionFilter.Text = item.filter;
+                        item.menuItem.Checked = true;
+                    }
+                    else
+                    {
+                        item.menuItem.Checked = false;
+                    }
+                }
+            }
+
             tsbtnAdvancedFilter.ToolTipText = e.FilterSummary;
             tsbtnAdvancedFilter.AutoToolTip = !string.IsNullOrEmpty(tsbtnAdvancedFilter.ToolTipText);
             tsbtnAdvancedFilter.Image = e.HasFilter ? Properties.Images.FunnelExclamation : Properties.Images.FunnelPencil;
             tsmiResetPathFilters.Enabled = !string.IsNullOrEmpty(e.PathFilter);
             tsmiResetAllFilters.Enabled = e.HasFilter;
+        }
+
+        private void revisionFilterBox_CheckedChanged(object sender, System.EventArgs e)
+        {
+            if (!string.IsNullOrWhiteSpace(tstxtRevisionFilter.Text))
+            {
+                ApplyRevisionFilter();
+            }
         }
 
         private static void ToolStripSplitButtonDropDownClosed(object sender, EventArgs e)

--- a/GitUI/UserControls/RevisionGrid/FilterChangedEventArgs.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterChangedEventArgs.cs
@@ -14,6 +14,11 @@ namespace GitUI
             ShowReflogReferences = filter.ShowReflogReferences;
             HasFilter = filter.HasFilter;
             PathFilter = filter.PathFilter;
+            BranchFilter = filter.BranchFilter;
+            MessageFilter = filter.Message;
+            CommitterFilter = filter.Committer;
+            AuthorFilter = filter.Author;
+            DiffContentFilter = filter.DiffContent;
             FilterSummary = filter.GetSummary();
         }
 
@@ -28,6 +33,31 @@ namespace GitUI
         ///  Gets the currently applied Path filter.
         /// </summary>
         public string PathFilter { get; }
+
+        /// <summary>
+        ///  Gets the currently applied Branch filter.
+        /// </summary>
+        public string BranchFilter { get; }
+
+        /// <summary>
+        ///  Gets the currently applied Message filter.
+        /// </summary>
+        public string MessageFilter { get; }
+
+        /// <summary>
+        ///  Gets the currently applied Committer filter.
+        /// </summary>
+        public string CommitterFilter { get; }
+
+        /// <summary>
+        ///  Gets the currently applied Author filter.
+        /// </summary>
+        public string AuthorFilter { get; }
+
+        /// <summary>
+        ///  Gets the currently applied Diff contains filter.
+        /// </summary>
+        public string DiffContentFilter { get; }
 
         /// <summary>
         ///  Gets a summary of the current filter.


### PR DESCRIPTION
https://github.com/gitextensions/gitextensions/pull/10205#issuecomment-1262772044

## Proposed changes

BranchFilter for named branches as well as the revision filter for Message/Committer/Author/DiffContent is now updated when the filters have changed.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
