### PR TITLE
Worktree form management improvements

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3050,6 +3050,10 @@ namespace GitUI.CommandsDialogs
         {
             using FormManageWorktree formManageWorktree = new(UICommands);
             formManageWorktree.ShowDialog(this);
+            if (formManageWorktree.ShouldRefreshRevisionGrid)
+            {
+                RefreshRevisions();
+            }
         }
 
         private void toolStripSplitStash_DropDownOpened(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -111,8 +111,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
                 }
             };
 
-            UICommands.StartGitCommandProcessDialog(this, args);
-            DialogResult = DialogResult.OK;
+            DialogResult = UICommands.StartGitCommandProcessDialog(this, args) ? DialogResult.OK : DialogResult.None;
         }
 
         private void ValidateWorktreeOptions()

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -16,6 +16,8 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         private List<WorkTree>? _worktrees;
 
+        public bool ShouldRefreshRevisionGrid { get; private set; }
+
         [Obsolete("For VS designer and translation test only. Do not remove.")]
         private FormManageWorktree()
         {
@@ -257,6 +259,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             }
             else
             {
+                ShouldRefreshRevisionGrid = true;
                 Initialize();
             }
         }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -124,14 +124,14 @@ namespace GitUI
             return success;
         }
 
-        public void StartCommandLineProcessDialog(IWin32Window? owner, string? command, ArgumentString arguments)
+        public bool StartCommandLineProcessDialog(IWin32Window? owner, string? command, ArgumentString arguments)
         {
-            FormProcess.ShowDialog(owner, arguments, Module.WorkingDir, input: null, useDialogSettings: true, process: command);
+            return FormProcess.ShowDialog(owner, arguments, Module.WorkingDir, input: null, useDialogSettings: true, process: command);
         }
 
-        public void StartGitCommandProcessDialog(IWin32Window? owner, ArgumentString arguments)
+        public bool StartGitCommandProcessDialog(IWin32Window? owner, ArgumentString arguments)
         {
-            FormProcess.ShowDialog(owner, arguments, Module.WorkingDir, input: null, useDialogSettings: true);
+            return FormProcess.ShowDialog(owner, arguments, Module.WorkingDir, input: null, useDialogSettings: true);
         }
 
         public bool StartDeleteBranchDialog(IWin32Window? owner, string branch)

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -21,7 +21,7 @@ namespace GitUIPluginInterfaces
         /// </summary>
         ILockableNotifier RepoChangedNotifier { get; }
 
-        void StartCommandLineProcessDialog(IWin32Window? owner, string? command, ArgumentString arguments);
+        bool StartCommandLineProcessDialog(IWin32Window? owner, string? command, ArgumentString arguments);
         bool StartCommandLineProcessDialog(IWin32Window? owner, IGitCommand command);
         void StartBatchFileProcessDialog(string batchFile);
 


### PR DESCRIPTION
## Proposed changes

- Don't close the worktree form when the creation failed to let the user fix the issue and retry
- Refresh the revision grid even when user decide not opening a new worktree because ha has created another branch or checked one out and we should display the change in a refreshed revision grid.

Note: commits better reviewed separately.

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build b78e768d55af39e5d79310d8f1b7e772cefcf30a (Dirty)
- Git 2.35.1.windows.2 (recommended: 2.37.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.8
- DPI 96dpi (no scaling)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

- Rebase merge or Merge commit (not squash)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
