### PR TITLE
Worktree: redesign 'Manage worktree' form

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -99,8 +99,6 @@ namespace GitUI.CommandsDialogs
             this.updateAllSubmodulesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.synchronizeAllSubmodulesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripMenuItemWorktrees = new System.Windows.Forms.ToolStripMenuItem();
-            this.createWorktreeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.manageWorktreeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator44 = new System.Windows.Forms.ToolStripSeparator();
             this.editgitignoreToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
@@ -944,7 +942,7 @@ namespace GitUI.CommandsDialogs
             this.updateAllSubmodulesToolStripMenuItem,
             this.synchronizeAllSubmodulesToolStripMenuItem,
             this.toolStripSeparator10,
-            this.toolStripMenuItemWorktrees,
+            this.manageWorktreeToolStripMenuItem,
             this.toolStripSeparator44,
             this.editgitignoreToolStripMenuItem1,
             this.editgitinfoexcludeToolStripMenuItem,
@@ -1007,28 +1005,12 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator10.Name = "toolStripSeparator10";
             this.toolStripSeparator10.Size = new System.Drawing.Size(218, 6);
             // 
-            // toolStripMenuItemWorktrees
-            // 
-            this.toolStripMenuItemWorktrees.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.createWorktreeToolStripMenuItem,
-            this.manageWorktreeToolStripMenuItem});
-            this.toolStripMenuItemWorktrees.Image = global::GitUI.Properties.Images.WorkTree;
-            this.toolStripMenuItemWorktrees.Name = "toolStripMenuItemWorktrees";
-            this.toolStripMenuItemWorktrees.Size = new System.Drawing.Size(221, 22);
-            this.toolStripMenuItemWorktrees.Text = "&Worktrees";
-            // 
-            // createWorktreeToolStripMenuItem
-            // 
-            this.createWorktreeToolStripMenuItem.Name = "createWorktreeToolStripMenuItem";
-            this.createWorktreeToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.createWorktreeToolStripMenuItem.Text = "&Create a worktree...";
-            this.createWorktreeToolStripMenuItem.Click += new System.EventHandler(this.createWorktreeToolStripMenuItem_Click);
-            // 
             // manageWorktreeToolStripMenuItem
             // 
+            this.manageWorktreeToolStripMenuItem.Image = global::GitUI.Properties.Images.WorkTree;
             this.manageWorktreeToolStripMenuItem.Name = "manageWorktreeToolStripMenuItem";
             this.manageWorktreeToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.manageWorktreeToolStripMenuItem.Text = "&Manage worktrees...";
+            this.manageWorktreeToolStripMenuItem.Text = "Manage &worktrees...";
             this.manageWorktreeToolStripMenuItem.Click += new System.EventHandler(this.manageWorktreeToolStripMenuItem_Click);
             // 
             // toolStripSeparator44
@@ -1914,8 +1896,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem editgitinfoexcludeToolStripMenuItem;
         private ToolStripMenuItem toolStripMenuItemReflog;
         private ToolStripMenuItem manageWorktreeToolStripMenuItem;
-        private ToolStripMenuItem createWorktreeToolStripMenuItem;
-        private ToolStripMenuItem toolStripMenuItemWorktrees;
         private ToolStripMenuItem tsmiRecentRepositoriesClear;
         private ToolStripSeparator clearRecentRepositoriesListToolStripMenuItem;
         private ToolStripButton toolStripFileExplorer;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3060,22 +3060,6 @@ namespace GitUI.CommandsDialogs
             formManageWorktree.ShowDialog(this);
         }
 
-        private void createWorktreeToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            using FormCreateWorktree formCreateWorktree = new(UICommands);
-            DialogResult dialogResult = formCreateWorktree.ShowDialog(this);
-            if (dialogResult != DialogResult.OK || !formCreateWorktree.OpenWorktree)
-            {
-                return;
-            }
-
-            GitModule newModule = new(formCreateWorktree.WorktreeDirectory);
-            if (newModule.IsValidGitWorkingDir())
-            {
-                SetGitModule(this, new GitModuleEventArgs(newModule));
-            }
-        }
-
         private void toolStripSplitStash_DropDownOpened(object sender, EventArgs e)
         {
             ToolStripFilters.PreventToolStripSplitButtonClosing(sender as ToolStripSplitButton);

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.Designer.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.Designer.cs
@@ -29,18 +29,16 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             this.panel1 = new System.Windows.Forms.Panel();
             this.Worktrees = new System.Windows.Forms.DataGridView();
             this.Path = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Type = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Branch = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Sha1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.IsDeleted = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.Open = new System.Windows.Forms.DataGridViewImageColumn();
-            this.Delete = new System.Windows.Forms.DataGridViewImageColumn();
-            this._NO_TRANSLATE_Close = new System.Windows.Forms.Button();
             this.buttonPruneWorktrees = new System.Windows.Forms.Button();
+            this.buttonDeleteSelectedWorktree = new System.Windows.Forms.Button();
+            this.buttonOpenSelectedWorktree = new System.Windows.Forms.Button();
+            this.buttonCreateNewWorktree = new System.Windows.Forms.Button();
             this.panel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.Worktrees)).BeginInit();
             this.SuspendLayout();
@@ -53,7 +51,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             this.panel1.Controls.Add(this.Worktrees);
             this.panel1.Location = new System.Drawing.Point(-2, 0);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(834, 250);
+            this.panel1.Size = new System.Drawing.Size(696, 214);
             this.panel1.TabIndex = 0;
             // 
             // Worktrees
@@ -61,26 +59,26 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             this.Worktrees.AllowUserToAddRows = false;
             this.Worktrees.AllowUserToDeleteRows = false;
             this.Worktrees.AllowUserToResizeRows = false;
+            this.Worktrees.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.Worktrees.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
             this.Worktrees.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.Worktrees.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Path,
             this.Type,
             this.Branch,
-            this.Sha1,
-            this.IsDeleted,
-            this.Open,
-            this.Delete});
-            this.Worktrees.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.Worktrees.Location = new System.Drawing.Point(0, 0);
+            this.Sha1});
+            this.Worktrees.Location = new System.Drawing.Point(10, 10);
+            this.Worktrees.Margin = new System.Windows.Forms.Padding(10);
             this.Worktrees.MultiSelect = false;
             this.Worktrees.Name = "Worktrees";
             this.Worktrees.ReadOnly = true;
             this.Worktrees.RowHeadersVisible = false;
             this.Worktrees.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.Worktrees.Size = new System.Drawing.Size(834, 250);
+            this.Worktrees.Size = new System.Drawing.Size(674, 204);
             this.Worktrees.TabIndex = 2;
-            this.Worktrees.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.Worktrees_CellClick);
+            this.Worktrees.SelectionChanged += new System.EventHandler(this.Worktrees_SelectionChanged);
             // 
             // Path
             // 
@@ -89,6 +87,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             this.Path.Name = "Path";
             this.Path.ReadOnly = true;
             this.Path.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            this.Path.Width = 37;
             // 
             // Type
             // 
@@ -97,6 +96,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             this.Type.Name = "Type";
             this.Type.ReadOnly = true;
             this.Type.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            this.Type.Width = 37;
             // 
             // Branch
             // 
@@ -105,62 +105,64 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             this.Branch.Name = "Branch";
             this.Branch.ReadOnly = true;
             this.Branch.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            this.Branch.Width = 50;
             // 
             // Sha1
             // 
-            this.Sha1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.Sha1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.Sha1.HeaderText = "SHA-1";
+            this.Sha1.MinimumWidth = 90;
             this.Sha1.Name = "Sha1";
             this.Sha1.ReadOnly = true;
             this.Sha1.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
             // 
-            // IsDeleted
+            // buttonOpenSelectedWorktree
             // 
-            this.IsDeleted.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.IsDeleted.HeaderText = "Deleted";
-            this.IsDeleted.Name = "IsDeleted";
-            this.IsDeleted.ReadOnly = true;
-            this.IsDeleted.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.buttonOpenSelectedWorktree.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.buttonOpenSelectedWorktree.Image = global::GitUI.Properties.Images.BrowseFileExplorer;
+            this.buttonOpenSelectedWorktree.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.buttonOpenSelectedWorktree.Location = new System.Drawing.Point(8, 226);
+            this.buttonOpenSelectedWorktree.Name = "buttonOpenSelectedWorktree";
+            this.buttonOpenSelectedWorktree.Size = new System.Drawing.Size(151, 23);
+            this.buttonOpenSelectedWorktree.TabIndex = 1;
+            this.buttonOpenSelectedWorktree.Text = "&Open selected";
+            this.buttonOpenSelectedWorktree.UseVisualStyleBackColor = true;
+            this.buttonOpenSelectedWorktree.Click += new System.EventHandler(this.buttonOpenSelectedWorktree_Click);
             // 
-            // Open
+            // buttonDeleteSelectedWorktree
             // 
-            this.Open.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.Open.HeaderText = "Open";
-            this.Open.Image = global::GitUI.Properties.Images.BrowseFileExplorer;
-            this.Open.Name = "Open";
-            this.Open.ReadOnly = true;
-            this.Open.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.buttonDeleteSelectedWorktree.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.buttonDeleteSelectedWorktree.Image = global::GitUI.Properties.Images.DeleteFile;
+            this.buttonDeleteSelectedWorktree.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.buttonDeleteSelectedWorktree.Location = new System.Drawing.Point(165, 226);
+            this.buttonDeleteSelectedWorktree.Name = "buttonDeleteSelectedWorktree";
+            this.buttonDeleteSelectedWorktree.Size = new System.Drawing.Size(151, 23);
+            this.buttonDeleteSelectedWorktree.TabIndex = 1;
+            this.buttonDeleteSelectedWorktree.Text = "&Delete selected";
+            this.buttonDeleteSelectedWorktree.UseVisualStyleBackColor = true;
+            this.buttonDeleteSelectedWorktree.Click += new System.EventHandler(this.buttonDeleteSelectedWorktree_Click);
             // 
-            // Delete
+            // buttonCreateNewWorktree
             // 
-            this.Delete.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            this.Delete.DefaultCellStyle = dataGridViewCellStyle1;
-            this.Delete.HeaderText = "Delete";
-            this.Delete.Image = global::GitUI.Properties.Images.Delete;
-            this.Delete.Name = "Delete";
-            this.Delete.ReadOnly = true;
-            this.Delete.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            // 
-            // _NO_TRANSLATE_Close
-            // 
-            this._NO_TRANSLATE_Close.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this._NO_TRANSLATE_Close.Location = new System.Drawing.Point(450, 262);
-            this._NO_TRANSLATE_Close.Name = "Close";
-            this._NO_TRANSLATE_Close.Size = new System.Drawing.Size(178, 23);
-            this._NO_TRANSLATE_Close.TabIndex = 1;
-            this._NO_TRANSLATE_Close.Text = TranslatedStrings.Close;
-            this._NO_TRANSLATE_Close.UseVisualStyleBackColor = true;
-            this._NO_TRANSLATE_Close.Click += new System.EventHandler(this.buttonClose_Click);
+            this.buttonCreateNewWorktree.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.buttonCreateNewWorktree.Image = global::GitUI.Properties.Images.FileStatusAdded;
+            this.buttonCreateNewWorktree.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.buttonCreateNewWorktree.Location = new System.Drawing.Point(322, 226);
+            this.buttonCreateNewWorktree.Name = "buttonCreateNewWorktree";
+            this.buttonCreateNewWorktree.Size = new System.Drawing.Size(151, 23);
+            this.buttonCreateNewWorktree.TabIndex = 1;
+            this.buttonCreateNewWorktree.Text = "&Create...";
+            this.buttonCreateNewWorktree.UseVisualStyleBackColor = true;
+            this.buttonCreateNewWorktree.Click += new System.EventHandler(this.buttonCreateNewWorktree_Click);
             // 
             // buttonPruneWorktrees
             // 
-            this.buttonPruneWorktrees.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.buttonPruneWorktrees.Location = new System.Drawing.Point(213, 262);
+            this.buttonPruneWorktrees.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonPruneWorktrees.Location = new System.Drawing.Point(493, 226);
             this.buttonPruneWorktrees.Name = "buttonPruneWorktrees";
-            this.buttonPruneWorktrees.Size = new System.Drawing.Size(178, 23);
+            this.buttonPruneWorktrees.Size = new System.Drawing.Size(189, 23);
             this.buttonPruneWorktrees.TabIndex = 1;
-            this.buttonPruneWorktrees.Text = "Prune the deleted worktrees";
+            this.buttonPruneWorktrees.Text = "&Prune deleted worktrees";
             this.buttonPruneWorktrees.UseVisualStyleBackColor = true;
             this.buttonPruneWorktrees.Click += new System.EventHandler(this.buttonPruneWorktrees_Click);
             // 
@@ -168,13 +170,15 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(832, 297);
+            this.ClientSize = new System.Drawing.Size(694, 261);
+            this.Controls.Add(this.buttonOpenSelectedWorktree);
+            this.Controls.Add(this.buttonDeleteSelectedWorktree);
+            this.Controls.Add(this.buttonCreateNewWorktree);
             this.Controls.Add(this.buttonPruneWorktrees);
-            this.Controls.Add(this._NO_TRANSLATE_Close);
             this.Controls.Add(this.panel1);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(670, 333);
+            this.MinimumSize = new System.Drawing.Size(710, 200);
             this.Name = "FormManageWorktree";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Existing worktrees";
@@ -187,15 +191,14 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         #endregion
         private System.Windows.Forms.Panel panel1;
-        private System.Windows.Forms.Button _NO_TRANSLATE_Close;
         private System.Windows.Forms.DataGridView Worktrees;
         private System.Windows.Forms.Button buttonPruneWorktrees;
+        private System.Windows.Forms.Button buttonDeleteSelectedWorktree;
+        private System.Windows.Forms.Button buttonOpenSelectedWorktree;
         private System.Windows.Forms.DataGridViewTextBoxColumn Path;
         private System.Windows.Forms.DataGridViewTextBoxColumn Type;
         private System.Windows.Forms.DataGridViewTextBoxColumn Branch;
         private System.Windows.Forms.DataGridViewTextBoxColumn Sha1;
-        private System.Windows.Forms.DataGridViewCheckBoxColumn IsDeleted;
-        private System.Windows.Forms.DataGridViewImageColumn Open;
-        private System.Windows.Forms.DataGridViewImageColumn Delete;
+        private System.Windows.Forms.Button buttonCreateNewWorktree;
     }
 }

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using GitCommands;
+using GitCommands.Git;
 using GitExtUtils;
 using GitExtUtils.GitUI;
-using GitExtUtils.GitUI.Theming;
-using GitUI.Properties;
 using Microsoft;
 using ResourceManager;
 
@@ -33,22 +33,17 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             : base(commands)
         {
             InitializeComponent();
-            Path.Width = DpiUtil.Scale(35);
-            Type.Width = DpiUtil.Scale(37);
-            Branch.Width = DpiUtil.Scale(46);
-            Sha1.Width = DpiUtil.Scale(37);
-            IsDeleted.Width = DpiUtil.Scale(50);
-            Open.Width = DpiUtil.Scale(39);
-            Delete.Width = DpiUtil.Scale(44);
+            Sha1.Width = DpiUtil.Scale(53);
             Worktrees.AutoGenerateColumns = false;
-            Delete.Image = Images.Delete.AdaptLightness();
             InitializeComplete();
 
             Path.DataPropertyName = nameof(WorkTree.Path);
             Type.DataPropertyName = nameof(WorkTree.Type);
             Branch.DataPropertyName = nameof(WorkTree.Branch);
             Sha1.DataPropertyName = nameof(WorkTree.Sha1);
-            IsDeleted.DataPropertyName = nameof(WorkTree.IsDeleted);
+
+            Worktrees.Columns[3].DefaultCellStyle.Font = AppSettings.MonospaceFont;
+            Worktrees.Columns[3].DefaultCellStyle.WrapMode = DataGridViewTriState.True;
         }
 
         private void FormManageWorktree_Load(object sender, EventArgs e)
@@ -102,7 +97,11 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
                             break;
                         case "branch":
                             currentWorktree.Type = HeadType.Branch;
-                            currentWorktree.Branch = strings[1];
+                            currentWorktree.Branch = CleanBranchName(strings[1]);
+
+                            string? CleanBranchName(string? branch)
+                                => branch != null && branch.StartsWith(GitRefName.RefsHeadsPrefix) ? branch.Substring(GitRefName.RefsHeadsPrefix.Length) : branch;
+
                             break;
                         case "detached":
                             currentWorktree.Type = HeadType.Detached;
@@ -112,51 +111,19 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             }
 
             Worktrees.DataSource = _worktrees;
+
+            Font font = Worktrees.DefaultCellStyle.Font;
+            Font deletedFont = new(font.FontFamily, font.Size, font.Style | FontStyle.Strikeout);
+
             for (var i = 0; i < Worktrees.Rows.Count; i++)
             {
-                if (i == 0)
+                if (_worktrees[i].IsDeleted)
                 {
-                    Worktrees.Rows[i].Cells["Delete"].Value = Images.Blank;
-                    if (IsCurrentlyOpenedWorktree(_worktrees[0]))
-                    {
-                        Worktrees.Rows[i].Cells["Open"].Value = Images.Blank;
-                    }
-                }
-                else if (!CanDeleteWorkspace(_worktrees[i]))
-                {
-                    Worktrees.Rows[i].Cells["Open"].Value = Images.Blank;
-                    Worktrees.Rows[i].Cells["Delete"].Value = Images.Blank;
+                    Worktrees.Rows[i].DefaultCellStyle.Font = deletedFont;
                 }
             }
 
             buttonPruneWorktrees.Enabled = _worktrees.Skip(1).Any(w => w.IsDeleted);
-        }
-
-        private bool CanDeleteWorkspace(WorkTree workTree)
-        {
-            if (workTree.IsDeleted)
-            {
-                return false;
-            }
-
-            Validates.NotNull(_worktrees);
-
-            if (_worktrees.Count == 1)
-            {
-                return false;
-            }
-
-            if (IsCurrentlyOpenedWorktree(workTree))
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        private bool IsCurrentlyOpenedWorktree(WorkTree workTree)
-        {
-            return new DirectoryInfo(UICommands.GitModule.WorkingDir).FullName.TrimEnd('\\') == new DirectoryInfo(workTree.Path).FullName.TrimEnd('\\');
         }
 
         /// <summary>
@@ -192,15 +159,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             Detached
         }
 
-        private void buttonClose_Click(object sender, EventArgs e)
-        {
-            Close();
-        }
-
-        private void buttonPruneWorktrees_Click(object sender, EventArgs e)
-        {
-            PruneWorktrees();
-        }
+        private void buttonPruneWorktrees_Click(object sender, EventArgs e) => PruneWorktrees();
 
         private void PruneWorktrees()
         {
@@ -208,58 +167,104 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             Initialize();
         }
 
-        private void Worktrees_CellClick(object sender, DataGridViewCellEventArgs e)
+        private void buttonDeleteSelectedWorktree_Click(object sender, EventArgs e)
         {
-            if (e.ColumnIndex < 5)
+            if (!CanActOnSelectedWorkspace(out var workTree))
             {
                 return;
             }
 
-            Validates.NotNull(_worktrees);
+            if (MessageBox.Show(this, _deleteWorktreeText.Text, _deleteWorktreeTitle.Text,
+                    MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
+            {
+                Validates.NotNull(workTree.Path);
 
-            var workTree = _worktrees[e.RowIndex];
-            if (!CanDeleteWorkspace(workTree))
+                if (workTree.Path.TryDeleteDirectory(out string? errorMessage))
+                {
+                    PruneWorktrees();
+                }
+                else
+                {
+                    MessageBox.Show(this, $@"{_deleteWorktreeFailedText.Text}: {workTree.Path}{Environment.NewLine}{errorMessage}", TranslatedStrings.Error,
+                        MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
+        }
+
+        private void buttonOpenSelectedWorktree_Click(object sender, EventArgs e)
+        {
+            if (!CanActOnSelectedWorkspace(out var workTree))
             {
                 return;
             }
 
-            if (e.ColumnIndex == 5)
+            if (AppSettings.DontConfirmSwitchWorktree || MessageBox.Show(this,
+                    _switchWorktreeText.Text, _switchWorktreeTitle.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
             {
-                if (AppSettings.DontConfirmSwitchWorktree || MessageBox.Show(this,
-                        _switchWorktreeText.Text, _switchWorktreeTitle.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+                if (Directory.Exists(workTree.Path))
                 {
-                    if (Directory.Exists(workTree.Path))
-                    {
-                        ((FormBrowse)Owner).SetWorkingDir(System.IO.Path.GetFullPath(workTree.Path));
-                        Close();
-                    }
+                    OpenWorktree(workTree.Path);
                 }
+            }
+        }
 
+        private void OpenWorktree(string workTreePath)
+        {
+            ((FormBrowse)Owner).SetWorkingDir(System.IO.Path.GetFullPath(workTreePath));
+            Close();
+        }
+
+        private void Worktrees_SelectionChanged(object sender, EventArgs e)
+        {
+            buttonDeleteSelectedWorktree.Enabled = CanDeleteSelectedWorkspace();
+            buttonOpenSelectedWorktree.Enabled = CanActOnSelectedWorkspace(out _);
+        }
+
+        private bool CanDeleteSelectedWorkspace()
+            => CanActOnSelectedWorkspace(out _) && Worktrees.SelectedRows[0].Index != 0;
+
+        private bool CanActOnSelectedWorkspace(out WorkTree workTree)
+        {
+            workTree = null;
+
+            if (_worktrees == null || _worktrees.Count == 1 || Worktrees.SelectedRows.Count == 0)
+            {
+                return false;
+            }
+
+            workTree = _worktrees[Worktrees.SelectedRows[0].Index];
+
+            if (workTree.IsDeleted)
+            {
+                return false;
+            }
+
+            return !IsCurrentlyOpenedWorktree(workTree);
+        }
+
+        private bool IsCurrentlyOpenedWorktree(WorkTree workTree)
+            => new DirectoryInfo(UICommands.GitModule.WorkingDir).FullName.TrimEnd('\\') == new DirectoryInfo(workTree.Path).FullName.TrimEnd('\\');
+
+        private void buttonCreateNewWorktree_Click(object sender, EventArgs e)
+        {
+            using FormCreateWorktree formCreateWorktree = new(UICommands);
+            DialogResult dialogResult = formCreateWorktree.ShowDialog(this);
+            if (dialogResult != DialogResult.OK)
+            {
                 return;
             }
 
-            if (e.ColumnIndex == 6)
+            if (formCreateWorktree.OpenWorktree)
             {
-                if (e.RowIndex == 0)
+                GitModule newModule = new(formCreateWorktree.WorktreeDirectory);
+                if (newModule.IsValidGitWorkingDir())
                 {
-                    return;
+                    OpenWorktree(formCreateWorktree.WorktreeDirectory);
                 }
-
-                if (MessageBox.Show(this, _deleteWorktreeText.Text, _deleteWorktreeTitle.Text,
-                                    MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
-                {
-                    Validates.NotNull(workTree.Path);
-
-                    if (workTree.Path.TryDeleteDirectory(out string? errorMessage))
-                    {
-                        PruneWorktrees();
-                    }
-                    else
-                    {
-                        MessageBox.Show(this, $@"{_deleteWorktreeFailedText.Text}: {workTree.Path}{Environment.NewLine}{errorMessage}", TranslatedStrings.Error,
-                            MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    }
-                }
+            }
+            else
+            {
+                Initialize();
             }
         }
     }

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.resx
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.resx
@@ -1,64 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -118,15 +58,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="Branch.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="IsDeleted.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Open.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Delete.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
 </root>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2883,10 +2883,6 @@ Do you want to continue?</source>
         <source>&amp;Create a stash...</source>
         <target />
       </trans-unit>
-      <trans-unit id="createWorktreeToolStripMenuItem.Text">
-        <source>&amp;Create a worktree...</source>
-        <target />
-      </trans-unit>
       <trans-unit id="dashboardToolStripMenuItem.Text">
         <source>&amp;Dashboard</source>
         <target />
@@ -3016,7 +3012,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="manageWorktreeToolStripMenuItem.Text">
-        <source>&amp;Manage worktrees...</source>
+        <source>Manage &amp;worktrees...</source>
         <target />
       </trans-unit>
       <trans-unit id="menuCommitInfoPosition.ToolTipText">
@@ -3193,10 +3189,6 @@ Do you want to continue?</source>
       </trans-unit>
       <trans-unit id="toolStripMenuItemReflog.Text">
         <source>Show reflo&amp;g...</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="toolStripMenuItemWorktrees.Text">
-        <source>&amp;Worktrees</source>
         <target />
       </trans-unit>
       <trans-unit id="toolStripSplitStash.ToolTipText">
@@ -5647,18 +5639,6 @@ command "git help shortlog"</source>
         <source>Branch</source>
         <target />
       </trans-unit>
-      <trans-unit id="Delete.HeaderText">
-        <source>Delete</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="IsDeleted.HeaderText">
-        <source>Deleted</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="Open.HeaderText">
-        <source>Open</source>
-        <target />
-      </trans-unit>
       <trans-unit id="Path.HeaderText">
         <source>Path</source>
         <target />
@@ -5691,8 +5671,20 @@ command "git help shortlog"</source>
         <source>Open a worktree</source>
         <target />
       </trans-unit>
+      <trans-unit id="buttonCreateNewWorktree.Text">
+        <source>&amp;Create...</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="buttonDeleteSelectedWorktree.Text">
+        <source>&amp;Delete selected</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="buttonOpenSelectedWorktree.Text">
+        <source>&amp;Open selected</source>
+        <target />
+      </trans-unit>
       <trans-unit id="buttonPruneWorktrees.Text">
-        <source>Prune the deleted worktrees</source>
+        <source>&amp;Prune deleted worktrees</source>
         <target />
       </trans-unit>
     </body>


### PR DESCRIPTION
## Proposed changes

* Add "Open" and "Delete" buttons instead of having it in the grid
* Strike line when a worktree is deleted (and so remove "Deleted" column)
* Change font of Sha1 column & last column fill the remaining width
* name of branch displayed more user friendly (without '/refs/heads' prefix)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/194112529-5ea0a0c0-b9cd-4b46-819d-3cdbd4ab1b5f.png)

### After

![image](https://user-images.githubusercontent.com/460196/194262978-4ebc4252-6aa2-433a-835d-bb2be83dffbc.png)

![image](https://user-images.githubusercontent.com/460196/194263041-abb5ad46-7560-4e91-9240-567cadeee5af.png)



## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build b9e701c3a3bb431d5ce6b4a7099ff60c80fe461f (Dirty)
- Git 2.35.1.windows.2 (recommended: 2.37.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.8
- DPI 96dpi (no scaling)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
