### PR TITLE
Do not cache current GetRevision data

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -961,7 +961,7 @@ namespace GitCommands
                 /* Committer EMail*/ "%cE%n" +
                 /* Committer Date */ "%ct%n";
 
-            var format = formatString + (shortFormat ? "%s" : "%B%nNotes:%n%-N");
+            string format = formatString + (shortFormat ? "%s" : "%B%nNotes:%n%-N");
 
             GitArgumentBuilder args = new("log")
             {
@@ -970,7 +970,10 @@ namespace GitCommands
                 objectId
             };
 
-            var revInfo = _gitExecutable.GetOutput(args, cache: objectId is null ? null : GitCommandCache, outputEncoding: LosslessEncoding);
+            // cache output only if revision is specified
+            CommandCache? cache = objectId is null ? null : GitCommandCache;
+
+            string revInfo = _gitExecutable.GetOutput(args, cache: cache, outputEncoding: LosslessEncoding);
 
             // TODO improve parsing to reduce temporary string (see similar code in RevisionReader)
             string[] lines = revInfo.Split(Delimiters.LineFeed);

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -970,7 +970,7 @@ namespace GitCommands
                 objectId
             };
 
-            var revInfo = _gitExecutable.GetOutput(args, cache: GitCommandCache, outputEncoding: LosslessEncoding);
+            var revInfo = _gitExecutable.GetOutput(args, cache: objectId is null ? null : GitCommandCache, outputEncoding: LosslessEncoding);
 
             // TODO improve parsing to reduce temporary string (see similar code in RevisionReader)
             string[] lines = revInfo.Split(Delimiters.LineFeed);


### PR DESCRIPTION
Fixes #10223

## Proposed changes

- Do not cache the git output if querying the current checkout, i.e. let `GetRevision` use the cache only if an `ObjectId` is specified

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 22636a7d67522cb59de51fd9e38ec9145eeeeb30
- Git 2.35.2.windows.1 (recommended: 2.37.1 or later)
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.9
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).