### PR TITLE
Restore the order of the branch view options

### DIFF
--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -125,6 +125,7 @@ the last selected commit.");
         private readonly TranslationString _pathFilter = new("Path filter");
         private readonly TranslationString _showOnlyFirstParent = new("Show only first parent");
         private readonly TranslationString _showReflog = new("Show reflog");
+        private readonly TranslationString _showReflogTooltip = new("Show all reflog references");
         private readonly TranslationString _showCurrentBranchOnly = new("Show current branch only");
         private readonly TranslationString _simplifyByDecoration = new("Simplify by decoration");
 
@@ -260,6 +261,7 @@ the last selected commit.");
         public static string PathFilter = _instance.Value._pathFilter.Text;
         public static string ShowOnlyFirstParent = _instance.Value._showOnlyFirstParent.Text;
         public static string ShowReflog = _instance.Value._showReflog.Text;
+        public static string ShowReflogTooltip = _instance.Value._showReflogTooltip.Text;
         public static string ShowCurrentBranchOnly = _instance.Value._showCurrentBranchOnly.Text;
         public static string SimplifyByDecoration = _instance.Value._simplifyByDecoration.Text;
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3212,7 +3212,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="tsbShowReflog.ToolTipText">
-        <source>Show reflog</source>
+        <source>Show all reflog references</source>
         <target />
       </trans-unit>
       <trans-unit id="tsbtnAdvancedFilter.ToolTipText">
@@ -3320,7 +3320,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="tsmiShowReflog.ToolTipText">
-        <source>Show reflog</source>
+        <source>Show all reflog references</source>
         <target />
       </trans-unit>
       <trans-unit id="tsmiTelemetryEnabled.Text">
@@ -10966,6 +10966,10 @@ the last selected commit.</source>
       </trans-unit>
       <trans-unit id="_showReflog.Text">
         <source>Show reflog</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_showReflogTooltip.Text">
+        <source>Show all reflog references</source>
         <target />
       </trans-unit>
       <trans-unit id="_simplifyByDecoration.Text">

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -12,6 +12,7 @@ namespace GitUI.UserControls
         /// </summary>
         private void InitializeComponent()
         {
+            System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
             this.tsmiBranchLocal = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiBranchRemote = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiBranchTag = new System.Windows.Forms.ToolStripMenuItem();
@@ -38,6 +39,7 @@ namespace GitUI.UserControls
             this.tsddbtnRevisionFilter = new System.Windows.Forms.ToolStripDropDownButton();
             this.tsbShowReflog = new System.Windows.Forms.ToolStripButton();
             this.tsmiShowOnlyFirstParent = new System.Windows.Forms.ToolStripButton();
+            toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.SuspendLayout();
             // 
             // tsmiCommitFilter
@@ -125,6 +127,7 @@ namespace GitUI.UserControls
             this.tsmiShowBranchesAll,
             this.tsmiShowBranchesCurrent,
             this.tsmiShowBranchesFiltered,
+            toolStripSeparator1,
             this.tsmiShowReflog});
             this.tssbtnShowBranches.Image = global::GitUI.Properties.Images.BranchLocal;
             this.tssbtnShowBranches.Name = "tssbtnShowBranches";
@@ -266,6 +269,11 @@ namespace GitUI.UserControls
             this.tsmiShowOnlyFirstParent.Name = "tsmiShowOnlyFirstParent";
             this.tsmiShowOnlyFirstParent.Size = new System.Drawing.Size(23, 20);
             this.tsmiShowOnlyFirstParent.Click += new System.EventHandler(this.tsmiShowOnlyFirstParent_Click);
+            // 
+            // toolStripSeparator1
+            // 
+            toolStripSeparator1.Name = "toolStripSeparator1";
+            toolStripSeparator1.Size = new System.Drawing.Size(6, 6);
             // 
             // FilterToolBar
             // 

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -122,10 +122,10 @@ namespace GitUI.UserControls
             // 
             this.tssbtnShowBranches.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
             this.tssbtnShowBranches.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsmiShowReflog,
             this.tsmiShowBranchesAll,
+            this.tsmiShowBranchesCurrent,
             this.tsmiShowBranchesFiltered,
-            this.tsmiShowBranchesCurrent});
+            this.tsmiShowReflog});
             this.tssbtnShowBranches.Image = global::GitUI.Properties.Images.BranchLocal;
             this.tssbtnShowBranches.Name = "tssbtnShowBranches";
             this.tssbtnShowBranches.Size = new System.Drawing.Size(32, 22);

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -128,24 +128,24 @@ namespace GitUI.UserControls
             // Note: it is a weird combination, and it is mimicking the implementations in RevisionGridControl.
             // Refer to it for more details.
 
-            byte selectedIndex = 1;
+            ToolStripItem selectedItem = tsmiShowBranchesAll;
 
             if (e.ShowReflogReferences)
             {
                 // Show reflog
-                selectedIndex = 3;
+                selectedItem = tsmiShowReflog;
             }
 
             if (e.ShowAllBranches)
             {
                 // Show all branches
-                selectedIndex = 0;
+                selectedItem = tsmiShowBranchesAll;
             }
 
             if (e.ShowFilteredBranches)
             {
                 // Show filtered branches
-                selectedIndex = 2;
+                selectedItem = tsmiShowBranchesFiltered;
 
                 // Keep value if other filter
                 tscboBranchFilter.Text = e.BranchFilter;
@@ -154,9 +154,10 @@ namespace GitUI.UserControls
             if (e.ShowCurrentBranchOnly)
             {
                 // Show current branch only
-                selectedIndex = 1;
+                selectedItem = tsmiShowBranchesCurrent;
             }
 
+            int selectedIndex = tssbtnShowBranches.DropDownItems.IndexOf(selectedItem);
             SelectShowBranchesFilterOption(selectedIndex);
         }
 
@@ -184,7 +185,7 @@ namespace GitUI.UserControls
             control.DropDownClosed += ToolStripSplitButtonDropDownClosed;
         }
 
-        private void SelectShowBranchesFilterOption(byte selectedIndex)
+        private void SelectShowBranchesFilterOption(int selectedIndex)
         {
             if (selectedIndex >= tssbtnShowBranches.DropDownItems.Count)
             {

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -23,7 +23,7 @@ namespace GitUI.UserControls
             tsmiShowOnlyFirstParent.ToolTipText = TranslatedStrings.ShowOnlyFirstParent;
 
             // Select an option until we get a filter bound.
-            SelectShowBranchesFilterOption(selectedIndex: 1);
+            SelectShowBranchesFilterOption(selectedIndex: 0);
 
             tstxtRevisionFilter.KeyUp += (s, e) =>
             {
@@ -133,13 +133,13 @@ namespace GitUI.UserControls
             if (e.ShowReflogReferences)
             {
                 // Show reflog
-                selectedIndex = 0;
+                selectedIndex = 3;
             }
 
             if (e.ShowAllBranches)
             {
                 // Show all branches
-                selectedIndex = 1;
+                selectedIndex = 0;
             }
 
             if (e.ShowFilteredBranches)
@@ -154,7 +154,7 @@ namespace GitUI.UserControls
             if (e.ShowCurrentBranchOnly)
             {
                 // Show current branch only
-                selectedIndex = 3;
+                selectedIndex = 1;
             }
 
             SelectShowBranchesFilterOption(selectedIndex);

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -18,8 +18,8 @@ namespace GitUI.UserControls
         public FilterToolBar()
         {
             InitializeComponent();
-            tsmiShowReflog.ToolTipText = TranslatedStrings.ShowReflog;
-            tsbShowReflog.ToolTipText = TranslatedStrings.ShowReflog;
+            tsmiShowReflog.ToolTipText = TranslatedStrings.ShowReflogTooltip;
+            tsbShowReflog.ToolTipText = TranslatedStrings.ShowReflogTooltip;
             tsmiShowOnlyFirstParent.ToolTipText = TranslatedStrings.ShowOnlyFirstParent;
 
             // Select an option until we get a filter bound.

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -221,21 +221,21 @@ namespace GitUI.UserControls.RevisionGrid
                 MenuCommand.CreateGroupHeader(TranslatedStrings.Branches),
                 new MenuCommand
                 {
-                    Name = "ShowReflogReferences",
-                    Text = "Show &reflog references",
-                    Image = Images.Book,
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowReflogReferences),
-                    ExecuteAction = () => _revisionGrid.ToggleShowReflogReferences(),
-                    IsCheckedFunc = () => _revisionGrid.CurrentFilter.ShowReflogReferences
-                },
-                new MenuCommand
-                {
                     Name = "ShowAllBranches",
                     Text = "Show &all branches",
                     Image = Images.BranchLocal,
                     ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowAllBranches),
                     ExecuteAction = () => _revisionGrid.ShowAllBranches(),
                     IsCheckedFunc = () => _revisionGrid.CurrentFilter.IsShowAllBranchesChecked
+                },
+                new MenuCommand
+                {
+                    Name = "ShowCurrentBranchOnly",
+                    Text = "Show &current branch only",
+                    Image = Images.BranchFilter,
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowCurrentBranchOnly),
+                    ExecuteAction = () => _revisionGrid.ShowCurrentBranchOnly(),
+                    IsCheckedFunc = () => _revisionGrid.CurrentFilter.IsShowCurrentBranchOnlyChecked
                 },
                 new MenuCommand
                 {
@@ -248,12 +248,12 @@ namespace GitUI.UserControls.RevisionGrid
                 },
                 new MenuCommand
                 {
-                    Name = "ShowCurrentBranchOnly",
-                    Text = "Show &current branch only",
-                    Image = Images.BranchFilter,
-                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowCurrentBranchOnly),
-                    ExecuteAction = () => _revisionGrid.ShowCurrentBranchOnly(),
-                    IsCheckedFunc = () => _revisionGrid.CurrentFilter.IsShowCurrentBranchOnlyChecked
+                    Name = "ShowReflogReferences",
+                    Text = "Show &reflog references",
+                    Image = Images.Book,
+                    ShortcutKeyDisplayString = GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command.ShowReflogReferences),
+                    ExecuteAction = () => _revisionGrid.ToggleShowReflogReferences(),
+                    IsCheckedFunc = () => _revisionGrid.CurrentFilter.ShowReflogReferences
                 },
 
                 MenuCommand.CreateSeparator(),


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

I'm struggling with the new order of the branches view options having built a muscle memory for the past 10+ years.

## Screenshots <!-- Remove this section if PR does not change UI -->

### v3.x
![image](https://user-images.githubusercontent.com/4403806/194704465-a6b4cfdb-f4f1-4bbe-9490-80a9c145795b.png)


### v4 beta

<!-- TODO -->
![image](https://user-images.githubusercontent.com/4403806/194704407-92243cd2-5b55-47d4-b505-a20b14cc11e8.png)
![image](https://user-images.githubusercontent.com/4403806/194704411-6f096e4a-2557-4634-bf0b-ea3b99f8c492.png)


### Fixed

![image](https://user-images.githubusercontent.com/4403806/194704377-3aa0e43e-74da-4f54-9c72-9fe04eda3506.png)
![image](https://user-images.githubusercontent.com/4403806/194704380-d99a69b6-fa9a-4b0d-8ff3-ac0ab6e87963.png)



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
