### PR TITLE
Remove reflog toolstrip button

### DIFF
--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3215,10 +3215,6 @@ Do you want to continue?</source>
         <source>&amp;Translate</source>
         <target />
       </trans-unit>
-      <trans-unit id="tsbShowReflog.ToolTipText">
-        <source>Show reflog</source>
-        <target />
-      </trans-unit>
       <trans-unit id="tsbtnAdvancedFilter.ToolTipText">
         <source>Advanced filter</source>
         <target />

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -36,7 +36,6 @@ namespace GitUI.UserControls
             this.tslblRevisionFilter = new System.Windows.Forms.ToolStripLabel();
             this.tstxtRevisionFilter = new System.Windows.Forms.ToolStripTextBox();
             this.tsddbtnRevisionFilter = new System.Windows.Forms.ToolStripDropDownButton();
-            this.tsbShowReflog = new System.Windows.Forms.ToolStripButton();
             this.tsmiShowOnlyFirstParent = new System.Windows.Forms.ToolStripButton();
             this.SuspendLayout();
             // 
@@ -162,14 +161,6 @@ namespace GitUI.UserControls
             this.tsmiShowBranchesFiltered.ToolTipText = "Show filtered branches";
             this.tsmiShowBranchesFiltered.Click += new System.EventHandler(this.tsmiShowBranchesFiltered_Click);
             // 
-            // tsbShowReflog
-            // 
-            this.tsbShowReflog.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
-            this.tsbShowReflog.Image = global::GitUI.Properties.Images.Book;
-            this.tsbShowReflog.Name = "tsbShowReflog";
-            this.tsbShowReflog.Size = new System.Drawing.Size(23, 22);
-            this.tsbShowReflog.Click += new System.EventHandler(this.tsmiShowReflog_Click);
-            // 
             // tscboBranchFilter
             // 
             this.tscboBranchFilter.AutoSize = false;
@@ -275,7 +266,6 @@ namespace GitUI.UserControls
             this.toolStripLabel1,
             this.tscboBranchFilter,
             this.tsddbtnBranchFilter,
-            this.tsbShowReflog,
             this.tsmiShowOnlyFirstParent,
             this.toolStripSeparator19,
             this.tslblRevisionFilter,
@@ -299,7 +289,6 @@ namespace GitUI.UserControls
         private ToolStripMenuItem tsmiCommitterFilter;
         private ToolStripMenuItem tsmiAuthorFilter;
         private ToolStripMenuItem tsmiDiffContainsFilter;
-        private ToolStripButton tsbShowReflog;
         private ToolStripButton tsmiShowOnlyFirstParent;
         private ToolStripTextBox tstxtRevisionFilter;
         private ToolStripLabel tslblRevisionFilter;

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -25,7 +25,6 @@ namespace GitUI.UserControls
         {
             InitializeComponent();
             tsmiShowReflog.ToolTipText = TranslatedStrings.ShowReflog;
-            tsbShowReflog.ToolTipText = TranslatedStrings.ShowReflog;
             tsmiShowOnlyFirstParent.ToolTipText = TranslatedStrings.ShowOnlyFirstParent;
 
             // Select an option until we get a filter bound.
@@ -327,7 +326,6 @@ namespace GitUI.UserControls
         private void revisionGridFilter_FilterChanged(object? sender, FilterChangedEventArgs e)
         {
             tsmiShowOnlyFirstParent.Checked = e.ShowOnlyFirstParent;
-            tsbShowReflog.Checked = e.ShowReflogReferences;
             InitBranchSelectionFilter(e);
             tsbtnAdvancedFilter.ToolTipText = e.FilterSummary;
             tsbtnAdvancedFilter.AutoToolTip = !string.IsNullOrEmpty(tsbtnAdvancedFilter.ToolTipText);
@@ -415,8 +413,6 @@ namespace GitUI.UserControls
 
         private void tsmiShowOnlyFirstParent_Click(object sender, EventArgs e) => RevisionGridFilter.ToggleShowOnlyFirstParent();
 
-        private void tsmiShowReflog_Click(object sender, EventArgs e) => RevisionGridFilter.ToggleShowReflogReferences();
-
         private void tssbtnShowBranches_Click(object sender, EventArgs e) => tssbtnShowBranches.ShowDropDown();
 
         internal TestAccessor GetTestAccessor()
@@ -439,7 +435,6 @@ namespace GitUI.UserControls
             public ToolStripMenuItem tsmiAuthorFilter => _control.tsmiAuthorFilter;
             public ToolStripMenuItem tsmiDiffContainsFilter => _control.tsmiDiffContainsFilter;
             public ToolStripButton tsmiShowOnlyFirstParent => _control.tsmiShowOnlyFirstParent;
-            public ToolStripButton tsbShowReflog => _control.tsbShowReflog;
             public ToolStripTextBox tstxtRevisionFilter => _control.tstxtRevisionFilter;
             public ToolStripLabel tslblRevisionFilter => _control.tslblRevisionFilter;
             public ToolStripSplitButton tsbtnAdvancedFilter => _control.tsbtnAdvancedFilter;

--- a/UnitTests/GitUI.Tests/UserControls/FilterToolBarTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterToolBarTests.cs
@@ -196,31 +196,6 @@ namespace GitUITests.UserControls
             _revisionGridFilter.Received(1).ToggleShowOnlyFirstParent();
         }
 
-        [TestCase(false)]
-        [TestCase(true)]
-        public void ShowReflog_should_be_bound_via_FilterChanged(bool settingValue)
-        {
-            bool original = AppSettings.ShowReflogReferences;
-            try
-            {
-                AppSettings.ShowReflogReferences = settingValue;
-
-                _revisionGridFilter.FilterChanged += Raise.EventWith(_revisionGridFilter, new FilterChangedEventArgs(new()));
-                _filterToolBar.GetTestAccessor().tsbShowReflog.Checked.Should().Be(settingValue);
-            }
-            finally
-            {
-                AppSettings.ShowReflogReferences = original;
-            }
-        }
-
-        [Test]
-        public void ShowReflogButton_should_invoke_ToggleShowReflogReferences()
-        {
-            _filterToolBar.GetTestAccessor().tsbShowReflog.PerformClick();
-            _revisionGridFilter.Received(1).ToggleShowReflogReferences();
-        }
-
         [Test]
         public void ShowBranches_Reflog_should_invoke_ToggleShowReflogReferences()
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

- Remove the "reflog" toolstrip buttons introduced in #9528 as the reflog option is now available in the toolstrip dropdown.

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
