### PR TITLE
Revision filter combobox

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1265,6 +1265,12 @@ namespace GitCommands
             set => SetBool("showfirstparent", value);
         }
 
+        public static string[] RevisionFilterDropdowns
+        {
+            get => GetString("RevisionFilterDropdowns", string.Empty).Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            set => SetString("RevisionFilterDropdowns", string.Join("\n", value ?? Array.Empty<string>()));
+        }
+
         public static bool CommitDialogSelectionFilter
         {
             get => GetBool("commitdialogselectionfilter", false);

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -34,7 +34,7 @@ namespace GitUI.UserControls
             this.tsddbtnBranchFilter = new System.Windows.Forms.ToolStripDropDownButton();
             this.toolStripSeparator19 = new System.Windows.Forms.ToolStripSeparator();
             this.tslblRevisionFilter = new System.Windows.Forms.ToolStripLabel();
-            this.tstxtRevisionFilter = new System.Windows.Forms.ToolStripTextBox();
+            this.tstxtRevisionFilter = new System.Windows.Forms.ToolStripComboBox();
             this.tsddbtnRevisionFilter = new System.Windows.Forms.ToolStripDropDownButton();
             this.tsbShowReflog = new System.Windows.Forms.ToolStripButton();
             this.tsmiShowOnlyFirstParent = new System.Windows.Forms.ToolStripButton();
@@ -236,12 +236,14 @@ namespace GitUI.UserControls
             // 
             // tstxtRevisionFilter
             // 
+            this.tstxtRevisionFilter.AutoSize = false;
             this.tstxtRevisionFilter.BackColor = System.Drawing.SystemColors.Control;
-            this.tstxtRevisionFilter.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.tstxtRevisionFilter.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.tstxtRevisionFilter.DropDownWidth = 300;
+            this.tstxtRevisionFilter.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.tstxtRevisionFilter.Name = "tstxtRevisionFilter";
             this.tstxtRevisionFilter.Size = new System.Drawing.Size(100, 25);
             this.tstxtRevisionFilter.Tag = "ToolBar_group:Text filter";
+            this.tstxtRevisionFilter.KeyUp += new System.Windows.Forms.KeyEventHandler(this.tstxtRevisionFilter_KeyUp);
             // 
             // tsddbtnRevisionFilter
             // 
@@ -305,7 +307,7 @@ namespace GitUI.UserControls
         private ToolStripMenuItem tsmiDiffContainsFilter;
         private ToolStripButton tsbShowReflog;
         private ToolStripButton tsmiShowOnlyFirstParent;
-        private ToolStripTextBox tstxtRevisionFilter;
+        private ToolStripComboBox tstxtRevisionFilter;
         private ToolStripLabel tslblRevisionFilter;
         private ToolStripSeparator toolStripSeparator19;
         private ToolStripSplitButton tsbtnAdvancedFilter;


### PR DESCRIPTION
Part of #10213, can be applied independently

## Proposed changes

Remember last 30 used items in the revision filter

Keep the last used revision filter text (but not the type) in settings, so the filters can easily be retained.
I doubt that the revision filter is used much right now, but it still simplifies.

The "memory" is stored in settings when it is changed. There are other discussions about this behavior...

This is possible to include in 4.0 but maybe the full #10213 function should be added

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/194727269-2f3d6190-3c7e-4cf1-9cca-8443c5c0567a.png)

### After

(--exclude is from another usage, the core #10213 functionality)
![image](https://user-images.githubusercontent.com/6248932/194727700-75589834-d26f-4301-b427-049b494dd335.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
