### PR TITLE
Custom options to git-log

### DIFF
--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -78,7 +78,7 @@ namespace GitUI.UserControls
             }
 
             _isApplyingFilter = true;
-            RevisionGridFilter.SetAndApplyRevisionFilter(new RevisionFilter(tstxtRevisionFilter.Text,
+            RevisionGridFilter.SetAndApplyRevisionFilter(new RevisionFilter(tstxtRevisionFilter.Text.Trim(),
                                                                             tsmiCommitFilter.Checked,
                                                                             tsmiCommitterFilter.Checked,
                                                                             tsmiAuthorFilter.Checked,

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -117,13 +117,13 @@ namespace GitUI.UserControls.RevisionGrid
             _filterInfo.ByDateTo = CheckUntil.Checked;
             _filterInfo.DateTo = Until.Value;
             _filterInfo.ByAuthor = AuthorCheck.Checked;
-            _filterInfo.Author = Author.Text;
+            _filterInfo.Author = Author.Text.Trim();
             _filterInfo.ByCommitter = CommitterCheck.Checked;
-            _filterInfo.Committer = Committer.Text;
+            _filterInfo.Committer = Committer.Text.Trim();
             _filterInfo.ByMessage = MessageCheck.Checked;
-            _filterInfo.Message = Message.Text;
+            _filterInfo.Message = Message.Text.Trim();
             _filterInfo.ByDiffContent = DiffContentCheck.Checked;
-            _filterInfo.DiffContent = DiffContent.Text;
+            _filterInfo.DiffContent = DiffContent.Text.Trim();
             _filterInfo.IgnoreCase = IgnoreCase.Checked;
             _filterInfo.ByCommitsLimit = CommitsLimitCheck.Checked;
             _filterInfo.CommitsLimit = (int)_NO_TRANSLATE_CommitsLimit.Value;


### PR DESCRIPTION
Fixes #10213

## Proposed changes

If "Message" starts with "--not " or "--exclude=", interpret the string as options to git-log.
This enables the possibility to enter filters that the GUI does not support (like negating conditions).

The options has no checks for Git syntax or if ParentsAreRewritten etc If need to be adjusted, it is up to the user.

For now, this feature will be described in GitDoc only.
See discussion in #10213
Feature simpler to use with #10239 

## Screenshots <!-- Remove this section if PR does not change UI -->

Example hiding filters with wildcard

### Before

![image](https://user-images.githubusercontent.com/6248932/194729191-56b9a60b-2de1-4f47-bd02-a6cb49b16f59.png)

### After

![image](https://user-images.githubusercontent.com/6248932/194729222-d8beebd5-6281-4c92-b296-848facf0c2e9.png)

## Test methodology <!-- How did you ensure quality? -->

Test added

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
