### PR TITLE
Form rebase: some small fixes

### DIFF
--- a/GitUI/CommandsDialogs/FormRebase.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRebase.Designer.cs
@@ -398,6 +398,7 @@ namespace GitUI.CommandsDialogs
             // PatchGrid
             // 
             this.PatchGrid.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.PatchGrid.IsManagingRebase = true;
             this.PatchGrid.Location = new System.Drawing.Point(3, 180);
             this.PatchGrid.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.PatchGrid.Name = "PatchGrid";

--- a/GitUI/CommandsDialogs/FormRebase.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRebase.Designer.cs
@@ -514,7 +514,6 @@ namespace GitUI.CommandsDialogs
             // 
             // Ok
             // 
-            this.Ok.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.Ok.Location = new System.Drawing.Point(3, 54);
             this.Ok.Name = "Ok";
             this.Ok.Size = new System.Drawing.Size(162, 25);

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -75,6 +75,8 @@ namespace GitUI.CommandsDialogs
                 ShowOptions_LinkClicked(this, null!);
             }
 
+            Currentbranch.Font = new Font(Currentbranch.Font.FontFamily, Currentbranch.Font.Size, FontStyle.Bold);
+
             Shown += FormRebase_Shown;
         }
 

--- a/GitUI/UserControls/PatchGrid.Designer.cs
+++ b/GitUI/UserControls/PatchGrid.Designer.cs
@@ -79,14 +79,16 @@
             this.FileName.HeaderText = "Name";
             this.FileName.Name = "FileName";
             this.FileName.ReadOnly = true;
+            this.FileName.SortMode = DataGridViewColumnSortMode.NotSortable;
             // 
             // Action
             // 
-            this.Action.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.Action.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.Action.DataPropertyName = "Action";
             this.Action.HeaderText = "Action";
             this.Action.Name = "Action";
             this.Action.ReadOnly = true;
+            this.Action.SortMode = DataGridViewColumnSortMode.NotSortable;
             // 
             // CommitHash
             // 
@@ -95,12 +97,14 @@
             this.CommitHash.HeaderText = "Commit hash";
             this.CommitHash.Name = "CommitHash";
             this.CommitHash.ReadOnly = true;
+            this.CommitHash.SortMode = DataGridViewColumnSortMode.NotSortable;
             // 
             // subjectDataGridViewTextBoxColumn
             // 
             this.subjectDataGridViewTextBoxColumn.HeaderText = "Subject";
             this.subjectDataGridViewTextBoxColumn.Name = "subjectDataGridViewTextBoxColumn";
             this.subjectDataGridViewTextBoxColumn.ReadOnly = true;
+            this.subjectDataGridViewTextBoxColumn.SortMode = DataGridViewColumnSortMode.NotSortable;
             // 
             // authorDataGridViewTextBoxColumn
             // 
@@ -108,20 +112,23 @@
             this.authorDataGridViewTextBoxColumn.HeaderText = "Author";
             this.authorDataGridViewTextBoxColumn.Name = "authorDataGridViewTextBoxColumn";
             this.authorDataGridViewTextBoxColumn.ReadOnly = true;
+            this.authorDataGridViewTextBoxColumn.SortMode = DataGridViewColumnSortMode.NotSortable;
             // 
             // dateDataGridViewTextBoxColumn
             // 
-            this.dateDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.dateDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.dateDataGridViewTextBoxColumn.HeaderText = "Date";
             this.dateDataGridViewTextBoxColumn.Name = "dateDataGridViewTextBoxColumn";
             this.dateDataGridViewTextBoxColumn.ReadOnly = true;
+            this.dateDataGridViewTextBoxColumn.SortMode = DataGridViewColumnSortMode.NotSortable;
             // 
             // Status
             // 
-            this.Status.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.Status.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.Status.HeaderText = "Status";
             this.Status.Name = "Status";
             this.Status.ReadOnly = true;
+            this.Status.SortMode = DataGridViewColumnSortMode.NotSortable;
             // 
             // PatchGrid
             // 


### PR DESCRIPTION
## Proposed changes

- Prevent the rebase form to **always** close when conflicts are detected whereas it should stay open to display the conflicts to the user
- PatchGrid: small fixes
    * Prevent sorting of columns (that cause crashes and doesn't make sense)
    * Better size 'Action', 'Date' and 'Status' columns (autosizing)
- Display patchgrid in 'Rebase' mode and not in 'patch' mode to display more meaningfull columns
- Current branch to rebase displayed in bold

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/194934636-b5343efc-3313-43ff-9ea8-718abd017445.png)


### After

![image](https://user-images.githubusercontent.com/460196/194934887-49b7d2f0-46fd-4461-80aa-0eb8ea8f8d69.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build ad22840dd6944d3993ff35402cfc55c815840a87 (Dirty)
- Git 2.38.0.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.9
- DPI 96dpi (no scaling)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
