### PR TITLE
Hotkey: Add a hotkey for "Stash Staged" menu item

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -976,6 +976,7 @@ namespace GitUI.CommandsDialogs
             gitBashToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.GitBash).ToShortcutKeyDisplayString();
             commitToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.Commit).ToShortcutKeyDisplayString();
             stashChangesToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.Stash).ToShortcutKeyDisplayString();
+            stashStagedToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.StashStaged).ToShortcutKeyDisplayString();
             stashPopToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.StashPop).ToShortcutKeyDisplayString();
             closeToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.CloseRepository).ToShortcutKeyDisplayString();
             gitGUIToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.GitGui).ToShortcutKeyDisplayString();
@@ -2091,6 +2092,7 @@ namespace GitUI.CommandsDialogs
             QuickPull = 12,
             QuickPush = 13,
             Stash = 16,
+            StashStaged = 46,
             StashPop = 17,
             GoToSuperproject = 27,
             GoToSubmodule = 28,
@@ -2214,6 +2216,7 @@ namespace GitUI.CommandsDialogs
                 case Command.QuickPush: UICommands.StartPushDialog(this, true); break;
                 case Command.CloseRepository: SetWorkingDir(""); break;
                 case Command.Stash: UICommands.StashSave(this, AppSettings.IncludeUntrackedFilesInManualStash); break;
+                case Command.StashStaged: UICommands.StashStaged(this); break;
                 case Command.StashPop: UICommands.StashPop(this); break;
                 case Command.OpenCommitsWithDifftool: RevisionGrid.DiffSelectedCommitsWithDifftool(); break;
                 case Command.OpenWithDifftool: OpenWithDifftool(); break;

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -297,6 +297,7 @@ namespace GitUI.Hotkey
                     Hk(FormBrowse.Command.Rebase, Keys.Control | Keys.Shift | Keys.E),
                     Hk(FormBrowse.Command.Stash, Keys.Control | Keys.Alt | Keys.Up),
                     Hk(FormBrowse.Command.StashPop, Keys.Control | Keys.Alt | Keys.Down),
+                    Hk(FormBrowse.Command.StashStaged, Keys.Control | Keys.Shift | Keys.Alt | Keys.Up),
                     Hk(FormBrowse.Command.ToggleBetweenArtificialAndHeadCommits, Keys.Control | Keys.OemBackslash),
                     Hk(FormBrowse.Command.ToggleBranchTreePanel, Keys.Control | Keys.Alt | Keys.C)),
                 new HotkeySettings(


### PR DESCRIPTION
Follow up of #9848

## Proposed changes

- Add possibility to add a hot key for "Stash staged files" (no hot key defined by default)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/195174667-ad74184b-2c30-46e7-884a-d39417327f31.png)

### After

![image](https://user-images.githubusercontent.com/460196/195174542-bbbb5880-2757-4467-8992-22a19fc53756.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build b78e768d55af39e5d79310d8f1b7e772cefcf30a (Dirty)
- Git 2.38.0.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.9
- DPI 96dpi (no scaling)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
