### PR TITLE
Fix resetting selected lines for renamed files in index

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -73,9 +73,7 @@ namespace GitUI.Editor
         private Func<Task>? _deferShowFunc;
         private readonly ContinuousScrollEventManager _continuousScrollEventManager;
         private FileStatusItem? _viewItem;
-
-        // This variable is used by tests to avoid popups
-        private bool _unitTestConfirmResetLines = true;
+        private readonly TaskDialogPage _NO_TRANSLATE_resetSelectedLinesConfirmationDialog;
 
         private static string[] _rangeDiffFullPrefixes = { "      ", "    ++", "    + ", "     +", "    --", "    - ", "     -", "    +-", "    -+", "    " };
         private static string[] _combinedDiffFullPrefixes = { "  ", "++", "+ ", " +", "--", "- ", " -" };
@@ -200,6 +198,16 @@ namespace GitUI.Editor
 
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
             SupportLinePatching = false;
+
+            _NO_TRANSLATE_resetSelectedLinesConfirmationDialog = new()
+            {
+                Text = TranslatedStrings.ResetSelectedLinesConfirmation,
+                Caption = TranslatedStrings.ResetChangesCaption,
+                Icon = TaskDialogIcon.Warning,
+                Buttons = { TaskDialogButton.Yes, TaskDialogButton.No },
+                DefaultButton = TaskDialogButton.Yes,
+                SizeToContent = true,
+            };
         }
 
         // Public properties
@@ -1481,8 +1489,7 @@ namespace GitUI.Editor
                 return;
             }
 
-            if (_unitTestConfirmResetLines && MessageBox.Show(this, TranslatedStrings.ResetSelectedLinesConfirmation, TranslatedStrings.ResetChangesCaption,
-                MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.No)
+            if (TaskDialog.ShowDialog(Handle, _NO_TRANSLATE_resetSelectedLinesConfirmationDialog) == TaskDialogButton.No)
             {
                 return;
             }
@@ -1992,12 +1999,7 @@ namespace GitUI.Editor
                 set => _fileViewer.ShowSyntaxHighlightingInDiff = value;
             }
 
-            public bool ConfirmResetLines
-            {
-                get => _fileViewer._unitTestConfirmResetLines;
-                set => _fileViewer._unitTestConfirmResetLines = value;
-            }
-
+            public TaskDialogPage ResetSelectedLinesConfirmationDialog => _fileViewer._NO_TRANSLATE_resetSelectedLinesConfirmationDialog;
             public ToolStripButton IgnoreWhitespaceAtEolButton => _fileViewer.ignoreWhitespaceAtEol;
             public ToolStripMenuItem IgnoreWhitespaceAtEolMenuItem => _fileViewer.ignoreWhitespaceAtEolToolStripMenuItem;
 

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -2005,6 +2005,8 @@ namespace GitUI.Editor
             public ToolStripButton IgnoreAllWhitespacesButton => _fileViewer.ignoreAllWhitespaces;
             public ToolStripMenuItem IgnoreAllWhitespacesMenuItem => _fileViewer.ignoreAllWhitespaceChangesToolStripMenuItem;
 
+            internal CommandStatus ExecuteCommand(Command command) => _fileViewer.ExecuteCommand((int)command);
+
             internal void IgnoreWhitespaceAtEolToolStripMenuItem_Click(object sender, EventArgs e) => _fileViewer.IgnoreWhitespaceAtEolToolStripMenuItem_Click(sender, e);
             internal void IgnoreWhitespaceChangesToolStripMenuItemClick(object sender, EventArgs e) => _fileViewer.IgnoreWhitespaceChangesToolStripMenuItemClick(sender, e);
             internal void IgnoreAllWhitespaceChangesToolStripMenuItem_Click(object sender, EventArgs e) => _fileViewer.IgnoreAllWhitespaceChangesToolStripMenuItem_Click(sender, e);

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -73,7 +73,9 @@ namespace GitUI.Editor
         private Func<Task>? _deferShowFunc;
         private readonly ContinuousScrollEventManager _continuousScrollEventManager;
         private FileStatusItem? _viewItem;
-        private bool _confirmResetLines = true;
+
+        // This variable is used by tests to avoid popups
+        private bool _unitTestConfirmResetLines = true;
 
         private static string[] _rangeDiffFullPrefixes = { "      ", "    ++", "    + ", "     +", "    --", "    - ", "     -", "    +-", "    -+", "    " };
         private static string[] _combinedDiffFullPrefixes = { "  ", "++", "+ ", " +", "--", "- ", " -" };
@@ -1479,7 +1481,7 @@ namespace GitUI.Editor
                 return;
             }
 
-            if (_confirmResetLines && MessageBox.Show(this, TranslatedStrings.ResetSelectedLinesConfirmation, TranslatedStrings.ResetChangesCaption,
+            if (_unitTestConfirmResetLines && MessageBox.Show(this, TranslatedStrings.ResetSelectedLinesConfirmation, TranslatedStrings.ResetChangesCaption,
                 MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.No)
             {
                 return;
@@ -1992,8 +1994,8 @@ namespace GitUI.Editor
 
             public bool ConfirmResetLines
             {
-                get => _fileViewer._confirmResetLines;
-                set => _fileViewer._confirmResetLines = value;
+                get => _fileViewer._unitTestConfirmResetLines;
+                set => _fileViewer._unitTestConfirmResetLines = value;
             }
 
             public ToolStripButton IgnoreWhitespaceAtEolButton => _fileViewer.ignoreWhitespaceAtEol;

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -73,6 +73,7 @@ namespace GitUI.Editor
         private Func<Task>? _deferShowFunc;
         private readonly ContinuousScrollEventManager _continuousScrollEventManager;
         private FileStatusItem? _viewItem;
+        private bool _confirmResetLines = true;
 
         private static string[] _rangeDiffFullPrefixes = { "      ", "    ++", "    + ", "     +", "    --", "    - ", "     -", "    +-", "    -+", "    " };
         private static string[] _combinedDiffFullPrefixes = { "  ", "++", "+ ", " +", "--", "- ", " -" };
@@ -1478,7 +1479,7 @@ namespace GitUI.Editor
                 return;
             }
 
-            if (MessageBox.Show(this, TranslatedStrings.ResetSelectedLinesConfirmation, TranslatedStrings.ResetChangesCaption,
+            if (_confirmResetLines && MessageBox.Show(this, TranslatedStrings.ResetSelectedLinesConfirmation, TranslatedStrings.ResetChangesCaption,
                 MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.No)
             {
                 return;
@@ -1987,6 +1988,12 @@ namespace GitUI.Editor
             {
                 get => _fileViewer.ShowSyntaxHighlightingInDiff;
                 set => _fileViewer.ShowSyntaxHighlightingInDiff = value;
+            }
+
+            public bool ConfirmResetLines
+            {
+                get => _fileViewer._confirmResetLines;
+                set => _fileViewer._confirmResetLines = value;
             }
 
             public ToolStripButton IgnoreWhitespaceAtEolButton => _fileViewer.ignoreWhitespaceAtEol;

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1446,7 +1446,9 @@ namespace GitUI.Editor
                     GetSelectionLength(),
                     isIndex: !stage,
                     Encoding,
-                    _viewItem.Item.IsNew);
+                    reset: false,
+                    _viewItem.Item.IsNew,
+                    _viewItem.Item.IsRenamed);
             }
 
             if (patch is null || patch.Length == 0)
@@ -1508,7 +1510,9 @@ namespace GitUI.Editor
                     GetSelectionLength(),
                     isIndex: true,
                     Encoding,
-                    _viewItem.Item.IsNew);
+                    reset: true,
+                    _viewItem.Item.IsNew,
+                    _viewItem.Item.IsRenamed);
             }
             else
             {
@@ -1579,7 +1583,9 @@ namespace GitUI.Editor
                     selectionLength,
                     isIndex: false,
                     Encoding,
-                    _viewItem.Item.IsNew);
+                    reset: false,
+                    _viewItem.Item.IsNew,
+                    _viewItem.Item.IsRenamed);
             }
             else
             {

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -23,11 +23,6 @@ namespace GitExtensions.UITests.CommandsDialogs
         // Created once for each test
         private GitUICommands _commands;
 
-        public FormCommitTests()
-        {
-            Application.EnableVisualStyles();
-        }
-
         [SetUp]
         public void SetUp()
         {

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -23,6 +23,11 @@ namespace GitExtensions.UITests.CommandsDialogs
         // Created once for each test
         private GitUICommands _commands;
 
+        public FormCommitTests()
+        {
+            Application.EnableVisualStyles();
+        }
+
         [SetUp]
         public void SetUp()
         {
@@ -507,12 +512,23 @@ namespace GitExtensions.UITests.CommandsDialogs
                 selectedDiffInternal.GetTestAccessor().TextEditor.ActiveTextAreaControl.SelectionManager.SetSelection(
                     new TextLocation(2, 11), new TextLocation(5, 12));
 
-                selectedDiff.ConfirmResetLines = false;
+                int textLengthBeforeReset = selectedDiffInternal.GetTestAccessor().TextEditor.ActiveTextAreaControl.Document.TextLength;
+
+                selectedDiff.ResetSelectedLinesConfirmationDialog.Created += (s, e) =>
+                {
+                    // Auto-press `Yes`
+                    selectedDiff.ResetSelectedLinesConfirmationDialog.Buttons[0].PerformClick();
+                };
                 selectedDiff.ExecuteCommand(FileViewer.Command.ResetLines);
 
                 ta.RescanChanges();
                 ThreadHelper.JoinPendingOperations();
 
+                int textLengthAfterReset = selectedDiffInternal.GetTestAccessor().TextEditor.ActiveTextAreaControl.Document.TextLength;
+
+                textLengthBeforeReset.Should().BeGreaterThan(0);
+                textLengthAfterReset.Should().BeGreaterThan(0);
+                textLengthAfterReset.Should().BeLessThan(textLengthBeforeReset);
                 FileStatusItem? stagedAndRenamed = ta.StagedList.AllItems.FirstOrDefault(i => i.Item.Name.Contains("original2.txt"));
                 stagedAndRenamed.Should().NotBeNull();
                 stagedAndRenamed!.Item.IsRenamed.Should().BeTrue();

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -478,7 +478,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         [Test]
         public void ShouldNotUndoRenameFileWhenResettingStagedLines()
         {
-            RunFormTest(async form =>
+            RunFormTest(form =>
             {
                 FormCommit.TestAccessor ta = form.GetTestAccessor();
 
@@ -502,11 +502,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                 ta.StagedList.SelectedGitItem = ta.StagedList.AllItems.Single(i => i.Item.Name.Contains("original2.txt")).Item;
 
                 selectedDiffInternal.Focus();
-
-                while (selectedDiffInternal.GetTestAccessor().TextEditor.Document.TextLength < 30)
-                {
-                    await Task.Delay(1);
-                }
+                ThreadHelper.JoinPendingOperations();
 
                 selectedDiffInternal.GetTestAccessor().TextEditor.ActiveTextAreaControl.SelectionManager.SetSelection(
                     new TextLocation(2, 11), new TextLocation(5, 12));

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -4,6 +4,8 @@ using FluentAssertions;
 using GitCommands;
 using GitUI;
 using GitUI.CommandsDialogs;
+using GitUI.Editor;
+using GitUI.UserControls;
 using ICSharpCode.TextEditor;
 using NUnit.Framework;
 
@@ -244,7 +246,7 @@ namespace GitExtensions.UITests.CommandsDialogs
 
                 testform.StageAllToolItem.PerformClick();
 
-                var fileNotMatchedByFilterIsStillUnstaged = testform.UnstagedList.AllItems.Where(i => i.Item.Name == "file2.txt").Any();
+                var fileNotMatchedByFilterIsStillUnstaged = testform.UnstagedList.AllItems.Any(i => i.Item.Name == "file2.txt");
 
                 Assert.AreEqual(2, testform.StagedList.AllItemsCount);
                 Assert.AreEqual(1, testform.UnstagedList.AllItemsCount);
@@ -296,7 +298,7 @@ namespace GitExtensions.UITests.CommandsDialogs
 
                 testform.UnstageAllToolItem.PerformClick();
 
-                var fileNotMatchedByFilterIsStillStaged = testform.StagedList.AllItems.Where(i => i.Item.Name == "file2.txt").Any();
+                var fileNotMatchedByFilterIsStillStaged = testform.StagedList.AllItems.Any(i => i.Item.Name == "file2.txt");
 
                 Assert.AreEqual(2, testform.UnstagedList.AllItemsCount);
                 Assert.AreEqual(1, testform.StagedList.AllItemsCount);
@@ -304,7 +306,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             });
         }
 
-        [Test, TestCaseSource(typeof(CommitMessageTestData), "TestCases")]
+        [Test, TestCaseSource(typeof(CommitMessageTestData), nameof(CommitMessageTestData.TestCases))]
         public void AddSelectionToCommitMessage_shall_be_ignored_unless_diff_is_focused(
             string message,
             int selectionStart,
@@ -317,7 +319,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                 expectedResult: false, expectedMessage: message, expectedSelectionStart: selectionStart);
         }
 
-        [Test, TestCaseSource(typeof(CommitMessageTestData), "TestCases")]
+        [Test, TestCaseSource(typeof(CommitMessageTestData), nameof(CommitMessageTestData.TestCases))]
         public void AddSelectionToCommitMessage_shall_be_ignored_if_no_difftext_is_selected(
             string message,
             int selectionStart,
@@ -330,7 +332,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                 expectedResult: false, expectedMessage: message, expectedSelectionStart: selectionStart);
         }
 
-        [Test, TestCaseSource(typeof(CommitMessageTestData), "TestCases")]
+        [Test, TestCaseSource(typeof(CommitMessageTestData), nameof(CommitMessageTestData.TestCases))]
         public void AddSelectionToCommitMessage_shall_modify_the_commit_message(
             string message,
             int selectionStart,
@@ -344,7 +346,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         }
 
         [Test]
-        public void editFileToolStripMenuItem_Click_no_selection_should_not_throw()
+        public void EditFileToolStripMenuItem_Click_no_selection_should_not_throw()
         {
             RunFormTest(async form =>
             {
@@ -470,6 +472,52 @@ namespace GitExtensions.UITests.CommandsDialogs
                 ta.Message.Text.Should().Be(expectedMessage);
                 ta.Message.SelectionStart.Should().Be(expectedSelectionStart);
                 ta.Message.SelectionLength.Should().Be(expectedResult ? 0 : selectionLength);
+            });
+        }
+
+        [Test]
+        public void ShouldNotUndoRenameFileWhenResettingStagedLines()
+        {
+            RunFormTest(async form =>
+            {
+                FormCommit.TestAccessor ta = form.GetTestAccessor();
+
+                FileViewer.TestAccessor selectedDiff = ta.SelectedDiff.GetTestAccessor();
+                FileViewerInternal? selectedDiffInternal = selectedDiff.FileViewerInternal;
+
+                // Commit a file, rename it and introduce a slight content change
+                string contents = "this\nhas\nmany\nlines\nthis\nhas\nmany\nlines\nthis\nhas\nmany\nlines?\n";
+                _referenceRepository.CreateCommit("commit", contents, "original.txt");
+                _referenceRepository.DeleteRepoFile("original.txt");
+                contents = contents.Replace("?", "!");
+                _referenceRepository.CreateRepoFile("original2.txt", contents);
+
+                await ta.RescanChangesAsync();
+
+                ta.UnstagedList.SelectedItems = ta.UnstagedList.AllItems;
+                ta.UnstagedList.Focus();
+                ta.ExecuteCommand(FormCommit.Command.StageSelectedFile);
+
+                ta.StagedList.SelectedGitItem = ta.StagedList.AllItems.Single(i => i.Item.Name.Contains("original2.txt")).Item;
+
+                selectedDiffInternal.Focus();
+
+                while (selectedDiffInternal.GetTestAccessor().TextEditor.Document.TextLength < 30)
+                {
+                    await Task.Delay(1);
+                }
+
+                selectedDiffInternal.GetTestAccessor().TextEditor.ActiveTextAreaControl.SelectionManager.SetSelection(
+                    new TextLocation(2, 11), new TextLocation(5, 12));
+
+                selectedDiff.ConfirmResetLines = false;
+                selectedDiff.ExecuteCommand(FileViewer.Command.ResetLines);
+
+                await ta.RescanChangesAsync();
+
+                FileStatusItem? stagedAndRenamed = ta.StagedList.AllItems.FirstOrDefault(i => i.Item.Name.Contains("original2.txt"));
+                stagedAndRenamed.Should().NotBeNull();
+                stagedAndRenamed!.Item.IsRenamed.Should().BeTrue();
             });
         }
 

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -492,7 +492,8 @@ namespace GitExtensions.UITests.CommandsDialogs
                 contents = contents.Replace("?", "!");
                 _referenceRepository.CreateRepoFile("original2.txt", contents);
 
-                await ta.RescanChangesAsync();
+                ta.RescanChanges();
+                ThreadHelper.JoinPendingOperations();
 
                 ta.UnstagedList.SelectedItems = ta.UnstagedList.AllItems;
                 ta.UnstagedList.Focus();
@@ -513,7 +514,8 @@ namespace GitExtensions.UITests.CommandsDialogs
                 selectedDiff.ConfirmResetLines = false;
                 selectedDiff.ExecuteCommand(FileViewer.Command.ResetLines);
 
-                await ta.RescanChangesAsync();
+                ta.RescanChanges();
+                ThreadHelper.JoinPendingOperations();
 
                 FileStatusItem? stagedAndRenamed = ta.StagedList.AllItems.FirstOrDefault(i => i.Item.Name.Contains("original2.txt"));
                 stagedAndRenamed.Should().NotBeNull();

--- a/IntegrationTests/UI.IntegrationTests/GlobalSetupOnce.cs
+++ b/IntegrationTests/UI.IntegrationTests/GlobalSetupOnce.cs
@@ -1,0 +1,17 @@
+﻿using NUnit.Framework;
+
+[SetUpFixture]
+public class GlobalSetupOnce
+{
+    [OneTimeSetUp]
+    public void RunBeforeAnyTests()
+    {
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+    }
+
+    [OneTimeTearDown]
+    public void RunAfterAnyTests()
+    {
+    }
+}

--- a/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
+++ b/UnitTests/CommonTestUtils/GitModuleTestHelper.cs
@@ -110,6 +110,23 @@ namespace CommonTestUtils
             return CreateRepoFile("", fileName, fileContent);
         }
 
+        public string DeleteRepoFile(string fileName)
+        {
+            string parentDir = Module.WorkingDir;
+            string filePath = Path.Combine(parentDir, fileName);
+            if (!Directory.Exists(parentDir))
+            {
+                return filePath;
+            }
+
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+
+            return filePath;
+        }
+
         /// <summary>
         /// Set dummy user and email locally for the module, no global setting in AppVeyor
         /// Must also be set on the submodule, local settings are not included when adding it

--- a/UnitTests/CommonTestUtils/ReferenceRepository.cs
+++ b/UnitTests/CommonTestUtils/ReferenceRepository.cs
@@ -8,8 +8,8 @@ namespace CommonTestUtils
 {
     public class ReferenceRepository : IDisposable
     {
-        private GitModuleTestHelper _moduleTestHelper;
-        private string _commitHash;
+        private readonly GitModuleTestHelper _moduleTestHelper;
+        private string? _commitHash;
 
         public ReferenceRepository()
         {
@@ -45,7 +45,7 @@ namespace CommonTestUtils
 
         public GitModule Module => _moduleTestHelper.Module;
 
-        public string CommitHash => _commitHash;
+        public string? CommitHash => _commitHash;
 
         private const string _fileName = "A.txt";
 
@@ -76,13 +76,16 @@ namespace CommonTestUtils
             return _commitHash;
         }
 
-        public string CreateCommit(string commitMessage, string content1, string fileName1, string content2, string fileName2)
+        public string CreateCommit(string commitMessage, string content1, string fileName1, string? content2 = null, string? fileName2 = null)
         {
             using LibGit2Sharp.Repository repository = new(_moduleTestHelper.Module.WorkingDir);
             _moduleTestHelper.CreateRepoFile(fileName1, content1);
             repository.Index.Add(fileName1);
-            _moduleTestHelper.CreateRepoFile(fileName2, content2);
-            repository.Index.Add(fileName2);
+            if (content2 != null && fileName2 != null)
+            {
+                _moduleTestHelper.CreateRepoFile(fileName2, content2);
+                repository.Index.Add(fileName2);
+            }
 
             _commitHash = Commit(repository, commitMessage);
             Console.WriteLine($"Created commit: {_commitHash}, message: {commitMessage}");

--- a/UnitTests/CommonTestUtils/ReferenceRepository.cs
+++ b/UnitTests/CommonTestUtils/ReferenceRepository.cs
@@ -8,13 +8,10 @@ namespace CommonTestUtils
 {
     public class ReferenceRepository : IDisposable
     {
-        private readonly GitModuleTestHelper _moduleTestHelper;
-        private string? _commitHash;
+        private readonly GitModuleTestHelper _moduleTestHelper = new();
 
         public ReferenceRepository()
         {
-            _moduleTestHelper = new GitModuleTestHelper();
-
             CreateCommit("A commit message", "A");
         }
 
@@ -22,7 +19,7 @@ namespace CommonTestUtils
         /// Reset the repo if possible, if it is null or reset throws create a new.
         /// </summary>
         /// <param name="refRepo">The repo to reset, possibly null.</param>
-        public static void ResetRepo(ref ReferenceRepository refRepo)
+        public static void ResetRepo(ref ReferenceRepository? refRepo)
         {
             if (refRepo is null)
             {
@@ -45,7 +42,7 @@ namespace CommonTestUtils
 
         public GitModule Module => _moduleTestHelper.Module;
 
-        public string? CommitHash => _commitHash;
+        public string? CommitHash { get; private set; }
 
         private const string _fileName = "A.txt";
 
@@ -71,9 +68,9 @@ namespace CommonTestUtils
             _moduleTestHelper.CreateRepoFile(_fileName, content ?? commitMessage);
             repository.Index.Add(_fileName);
 
-            _commitHash = Commit(repository, commitMessage);
-            Console.WriteLine($"Created commit: {_commitHash}, message: {commitMessage}");
-            return _commitHash;
+            CommitHash = Commit(repository, commitMessage);
+            Console.WriteLine($"Created commit: {CommitHash}, message: {commitMessage}");
+            return CommitHash;
         }
 
         public string CreateCommit(string commitMessage, string content1, string fileName1, string? content2 = null, string? fileName2 = null)
@@ -87,9 +84,9 @@ namespace CommonTestUtils
                 repository.Index.Add(fileName2);
             }
 
-            _commitHash = Commit(repository, commitMessage);
-            Console.WriteLine($"Created commit: {_commitHash}, message: {commitMessage}");
-            return _commitHash;
+            CommitHash = Commit(repository, commitMessage);
+            Console.WriteLine($"Created commit: {CommitHash}, message: {commitMessage}");
+            return CommitHash;
         }
 
         public string CreateRepoFile(string fileName, string fileContent) => _moduleTestHelper.CreateRepoFile(fileName, fileContent);

--- a/UnitTests/CommonTestUtils/ReferenceRepository.cs
+++ b/UnitTests/CommonTestUtils/ReferenceRepository.cs
@@ -91,6 +91,8 @@ namespace CommonTestUtils
 
         public string CreateRepoFile(string fileName, string fileContent) => _moduleTestHelper.CreateRepoFile(fileName, fileContent);
 
+        public string DeleteRepoFile(string fileName) => _moduleTestHelper.DeleteRepoFile(fileName);
+
         public void CreateAnnotatedTag(string tagName, string commitHash, string message)
         {
             LibGit2Sharp.Signature author = new("GitUITests", "unittests@gitextensions.com", DateTimeOffset.Now);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Fixes
Fixes an issue where if you reset selected lines in a staged and renamed file then rename is undone too.

## Proposed changes

- Adjust the patch header to remove "reverse rename" part.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![reset-lines-on-renamed-before](https://user-images.githubusercontent.com/483659/195902537-c08308ca-3420-4e34-a1bd-13349119fec1.gif)

### After

![reset-lines-on-renamed-after](https://user-images.githubusercontent.com/483659/195903062-fb89e95e-fac9-4d84-bded-26bec24ff0ac.gif)

## Test methodology <!-- How did you ensure quality? -->

- Manual
- Integration test

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 023b2d8438aa0758af2018d0fc9e998418989510 (Dirty)
- Git 2.37.3.windows.1
- Microsoft Windows NT 10.0.22000.0
- .NET 6.0.10
- DPI 192dpi (200% scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
