### PR TITLE
Redo selection of the first item to fix shift-select of multiple items

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -892,6 +892,7 @@ namespace GitUI
                 if (firstSelectedItem is not null)
                 {
                     firstSelectedItem.Focused = true;
+                    firstSelectedItem.Selected = true;
                     firstSelectedItem.EnsureVisible();
                 }
             }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Fixes

When opening FormCommit - first item in unstaged files is selected. Then when shift-clicking on 2nd and further items to select 1fst through _clicked_ items, the selection is made not from the top but from the bottom.

## Proposed changes

- Reset internal ListView "last selected item" index by resetting `Selected` to `true` for the first selected item.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Notice that when `shift-clicking` after refresh control acts as if last item in the list has focus and selection happens from it till the item being clicked on.

![shift-click-before](https://user-images.githubusercontent.com/483659/195720331-c1a9a0c5-dcc1-4fe9-aaa3-be2e178ddbc7.gif)


### After

![shift-click-after](https://user-images.githubusercontent.com/483659/195719866-b8c7185d-0a87-4b6c-ac87-2202889b1ab9.gif)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build cb8954cc0cc839d7b33976e6befa492e5a6fde07 (Dirty)
- Git 2.37.3.windows.1
- Microsoft Windows NT 10.0.22000.0
- .NET 6.0.10
- DPI 192dpi (200% scaling)

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
