### PR TITLE
SidePanel: Show Stashes

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3051,7 +3051,6 @@ namespace GitCommands
 
             ArgumentString cmd = GitCommandHelpers.GetRefsCmd(getRef, noLocks, AppSettings.RefsSortBy, AppSettings.RefsSortOrder);
             ExecutionResult result = _gitExecutable.Execute(cmd, throwOnErrorExit: false);
-            ////TODO: Handle non-empty result.StandardError
             return result.ExitedSuccessfully
                 ? ParseRefs(result.StandardOutput)
                 : Array.Empty<IGitRef>();

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1884,6 +1884,12 @@ namespace GitCommands
             set => SetBool("RepoObjectsTree.ShowTags", value);
         }
 
+        public static bool RepoObjectsTreeShowStashes
+        {
+            get => GetBool("RepoObjectsTree.ShowStashes", true);
+            set => SetBool("RepoObjectsTree.ShowStashes", value);
+        }
+
         public static bool RepoObjectsTreeShowSubmodules
         {
             get => GetBool("RepoObjectsTree.ShowSubmodules", true);
@@ -1912,6 +1918,12 @@ namespace GitCommands
         {
             get => GetInt("RepoObjectsTree.SubmodulesIndex", 3);
             set => SetInt("RepoObjectsTree.SubmodulesIndex", value);
+        }
+
+        public static int RepoObjectsTreeStashesIndex
+        {
+            get => GetInt("RepoObjectsTree.StashesIndex", 4);
+            set => SetInt("RepoObjectsTree.StashesIndex", value);
         }
 
         public static bool BlameDisplayAuthorFirst

--- a/GitUI/BranchTreePanel/BaseBranchLeafNode.cs
+++ b/GitUI/BranchTreePanel/BaseBranchLeafNode.cs
@@ -3,7 +3,7 @@ using GitUIPluginInterfaces;
 
 namespace GitUI.BranchTreePanel
 {
-    internal abstract class BaseBranchLeafNode : BaseBranchNode
+    internal abstract class BaseBranchLeafNode : BaseRevisionNode
     {
         private readonly string _imageKeyMerged;
         private readonly string _imageKeyUnmerged;
@@ -34,9 +34,7 @@ namespace GitUI.BranchTreePanel
             }
         }
 
-        public ObjectId? ObjectId { get; }
-
-        protected override void ApplyStyle()
+        public override void ApplyStyle()
         {
             base.ApplyStyle();
 

--- a/GitUI/BranchTreePanel/BaseBranchLeafNode.cs
+++ b/GitUI/BranchTreePanel/BaseBranchLeafNode.cs
@@ -18,6 +18,10 @@ namespace GitUI.BranchTreePanel
             _imageKeyMerged = imageKeyMerged;
         }
 
+        protected string? AheadBehind { get; set; }
+
+        protected string? RelatedBranch { get; set; }
+
         public bool IsMerged
         {
             get => _isMerged;
@@ -50,6 +54,29 @@ namespace GitUI.BranchTreePanel
             {
                 TreeViewNode.ToolTipText = string.Format(TranslatedStrings.ContainedInCurrentCommit, Name);
             }
+        }
+
+        public void UpdateAheadBehind(string aheadBehindData, string relatedBranch)
+        {
+            AheadBehind = aheadBehindData;
+            RelatedBranch = relatedBranch;
+        }
+
+        protected override string DisplayText()
+        {
+            return string.IsNullOrEmpty(AheadBehind) ? Name : $"{Name} ({AheadBehind})";
+        }
+
+        protected override void SelectRevision()
+        {
+            TreeViewNode.TreeView?.BeginInvoke(() =>
+            {
+                string branch = RelatedBranch is null || !Control.ModifierKeys.HasFlag(Keys.Alt)
+                    ? FullPath
+                    : RelatedBranch;
+                UICommands.BrowseGoToRef(branch, showNoRevisionMsg: true, toggleSelection: Control.ModifierKeys.HasFlag(Keys.Control));
+                TreeViewNode.TreeView?.Focus();
+            });
         }
     }
 }

--- a/GitUI/BranchTreePanel/BasePathNode.cs
+++ b/GitUI/BranchTreePanel/BasePathNode.cs
@@ -2,13 +2,13 @@
 
 namespace GitUI.BranchTreePanel
 {
-    internal class BasePathNode : BaseBranchNode
+    internal class BasePathNode : BaseRevisionNode
     {
         public BasePathNode(Tree tree, string fullPath) : base(tree, fullPath, visible: true)
         {
         }
 
-        protected override void ApplyStyle()
+        public override void ApplyStyle()
         {
             base.ApplyStyle();
 

--- a/GitUI/BranchTreePanel/BaseRefTree.cs
+++ b/GitUI/BranchTreePanel/BaseRefTree.cs
@@ -1,0 +1,91 @@
+﻿using GitUI.UserControls.RevisionGrid;
+using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Threading;
+
+namespace GitUI.BranchTreePanel
+{
+    internal abstract class BaseRefTree : BaseRevisionTree
+    {
+        // A flag to indicate whether the data is being filtered (e.g. Show Current Branch Only).
+        private protected System.Threading.AsyncLocal<bool> IsFiltering = new();
+
+        // Retains the list of currently loaded refs (branches/tags).
+        // This is needed to apply filtering without reloading the data.
+        // Whether or not force the reload of data is controlled by <see cref="_isFiltering"/> flag.
+        protected IReadOnlyList<IGitRef>? _loadedRefs;
+
+        protected readonly RefsFilter _filter;
+
+        protected BaseRefTree(TreeNode treeNode, IGitUICommandsSource uiCommands, ICheckRefs refsSource, RefsFilter filter)
+            : base(treeNode, uiCommands, refsSource)
+        {
+            _filter = filter;
+        }
+
+        protected override void OnAttached()
+        {
+            IsFiltering.Value = false;
+            base.OnAttached();
+        }
+
+        private async Task<Nodes> LoadNodesAsync(CancellationToken token, Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
+        {
+            await TaskScheduler.Default;
+            token.ThrowIfCancellationRequested();
+
+            if (!IsFiltering.Value || _loadedRefs is null)
+            {
+                _loadedRefs = getRefs(_filter);
+                token.ThrowIfCancellationRequested();
+            }
+
+            return FillTree(_loadedRefs, token);
+        }
+
+        protected abstract Nodes FillTree(IReadOnlyList<IGitRef> branches, CancellationToken token);
+
+        /// <summary>
+        /// Requests (from FormBrowse) to refresh the data tree and to apply filtering, if necessary.
+        /// </summary>
+        /// <param name="getRefs">Function to get refs.</param>
+        /// <param name="forceRefresh">Refresh may be required as references may have been changed.</param>
+        /// <param name="isFiltering">
+        ///  <see langword="true"/>, if the data is being filtered; otherwise <see langword="false"/>.
+        /// </param>
+        internal void Refresh(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs, bool forceRefresh, bool isFiltering)
+        {
+            if (!IsAttached)
+            {
+                return;
+            }
+
+            // If we're not currently filtering and no need to filter now -> exit.
+            // Else we need to iterate over the list and rebind the tree - whilst there
+            // could be a situation whether a user just refreshed the grid, there could
+            // also be a situation where the user applied a different filter, or checked
+            // out a different ref (e.g. a branch or commit), and we have a different
+            // set of branches to show/hide.
+            if (!forceRefresh && (!isFiltering && !IsFiltering.Value))
+            {
+                return;
+            }
+
+            IsFiltering.Value = isFiltering;
+            Refresh(getRefs);
+        }
+
+        /// <summary>
+        /// Requests to refresh the data tree and to apply filtering, if necessary.
+        /// </summary>
+        protected internal void Refresh(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
+        {
+            // Break the local cache to ensure the data is requeried to reflect the required sort order.
+            _loadedRefs = null;
+
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ReloadNodesAsync(LoadNodesAsync, getRefs);
+            });
+        }
+    }
+}

--- a/GitUI/BranchTreePanel/BaseRevisionTree.cs
+++ b/GitUI/BranchTreePanel/BaseRevisionTree.cs
@@ -1,0 +1,37 @@
+﻿using GitUI.UserControls.RevisionGrid;
+
+namespace GitUI.BranchTreePanel
+{
+    internal abstract class BaseRevisionTree : Tree
+    {
+        protected readonly ICheckRefs _refsSource;
+
+        public BaseRevisionTree(TreeNode treeNode, IGitUICommandsSource uiCommands, ICheckRefs refsSource)
+            : base(treeNode, uiCommands)
+        {
+            _refsSource = refsSource;
+        }
+
+        internal void UpdateVisibility()
+        {
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                foreach (Node node in Nodes)
+                {
+                    if (node is not BaseRevisionNode baseNode || baseNode.ObjectId is null)
+                    {
+                        continue;
+                    }
+
+                    bool isVisible = _refsSource.Contains(baseNode.ObjectId);
+                    if (baseNode.Visible != isVisible)
+                    {
+                        baseNode.Visible = isVisible;
+                        baseNode.ApplyStyle();
+                    }
+                }
+            }).FileAndForget();
+        }
+    }
+}

--- a/GitUI/BranchTreePanel/BaseRevisionTree.cs
+++ b/GitUI/BranchTreePanel/BaseRevisionTree.cs
@@ -1,4 +1,5 @@
-﻿using GitUI.UserControls.RevisionGrid;
+﻿using System.Threading;
+using GitUI.UserControls.RevisionGrid;
 
 namespace GitUI.BranchTreePanel
 {
@@ -12,24 +13,32 @@ namespace GitUI.BranchTreePanel
             _refsSource = refsSource;
         }
 
-        internal void UpdateVisibility()
+        internal virtual void UpdateVisibility()
         {
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                foreach (Node node in Nodes)
+                await _updateSemaphore.WaitAsync();
+                try
                 {
-                    if (node is not BaseRevisionNode baseNode || baseNode.ObjectId is null)
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    foreach (BaseRevisionNode node in Nodes.DepthEnumerator<BaseRevisionNode>())
                     {
-                        continue;
-                    }
+                        if (node.ObjectId is null)
+                        {
+                            continue;
+                        }
 
-                    bool isVisible = _refsSource.Contains(baseNode.ObjectId);
-                    if (baseNode.Visible != isVisible)
-                    {
-                        baseNode.Visible = isVisible;
-                        baseNode.ApplyStyle();
+                        bool isVisible = _refsSource.Contains(node.ObjectId);
+                        if (node.Visible != isVisible)
+                        {
+                            node.Visible = isVisible;
+                            node.ApplyStyle();
+                        }
                     }
+                }
+                finally
+                {
+                    _updateSemaphore.Release();
                 }
             }).FileAndForget();
         }

--- a/GitUI/BranchTreePanel/LocalBranchNode.cs
+++ b/GitUI/BranchTreePanel/LocalBranchNode.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using GitCommands;
 using GitUI.BranchTreePanel.Interfaces;
 using GitUI.Properties;
 using GitUIPluginInterfaces;
@@ -14,10 +13,6 @@ namespace GitUI.BranchTreePanel
         {
             IsCurrent = isCurrent;
         }
-
-        protected string? AheadBehind { get; set; }
-
-        protected string? RelatedBranch { get; set; }
 
         /// <summary>Indicates whether this is the currently checked-out branch.</summary>
         public bool IsCurrent { get; }
@@ -80,29 +75,6 @@ namespace GitUI.BranchTreePanel
         public bool Rename()
         {
             return UICommands.StartRenameDialog(ParentWindow(), branch: FullPath);
-        }
-
-        public void UpdateAheadBehind(string aheadBehindData, string relatedBranch)
-        {
-            AheadBehind = aheadBehindData;
-            RelatedBranch = relatedBranch;
-        }
-
-        protected override string DisplayText()
-        {
-            return string.IsNullOrEmpty(AheadBehind) ? Name : $"{Name} ({AheadBehind})";
-        }
-
-        protected override void SelectRevision()
-        {
-            TreeViewNode.TreeView?.BeginInvoke(() =>
-            {
-                string branch = RelatedBranch is null || !Control.ModifierKeys.HasFlag(Keys.Alt)
-                    ? FullPath
-                    : RelatedBranch.Substring(startIndex: GitRefName.RefsRemotesPrefix.Length);
-                UICommands.BrowseGoToRef(branch, showNoRevisionMsg: true, toggleSelection: Control.ModifierKeys.HasFlag(Keys.Control));
-                TreeViewNode.TreeView?.Focus();
-            });
         }
     }
 }

--- a/GitUI/BranchTreePanel/LocalBranchTree.cs
+++ b/GitUI/BranchTreePanel/LocalBranchTree.cs
@@ -58,8 +58,7 @@ namespace GitUI.BranchTreePanel
 
                 Validates.NotNull(branch.ObjectId);
 
-                bool isVisible = !IsFiltering.Value || _refsSource.Contains(branch.ObjectId);
-                LocalBranchNode localBranchNode = new(this, branch.ObjectId, branch.Name, branch.Name == currentBranch, isVisible);
+                LocalBranchNode localBranchNode = new(this, branch.ObjectId, branch.Name, branch.Name == currentBranch, visible: true);
 
                 if (aheadBehindData is not null && aheadBehindData.TryGetValue(localBranchNode.FullPath, out AheadBehindData aheadBehind))
                 {

--- a/GitUI/BranchTreePanel/NodeBase.cs
+++ b/GitUI/BranchTreePanel/NodeBase.cs
@@ -37,7 +37,7 @@ namespace GitUI.BranchTreePanel
         }
 
         #region style / appearance
-        protected virtual void ApplyStyle()
+        public virtual void ApplyStyle()
         {
             SetFont(GetFontStyle());
             TreeViewNode.ToolTipText = string.Empty;

--- a/GitUI/BranchTreePanel/RemoteBranchTree.cs
+++ b/GitUI/BranchTreePanel/RemoteBranchTree.cs
@@ -32,11 +32,10 @@ namespace GitUI.BranchTreePanel
 
                 Validates.NotNull(branch.ObjectId);
 
-                bool isVisible = !IsFiltering.Value || _refsSource.Contains(branch.ObjectId);
                 var remoteName = branch.Name.SubstringUntil('/');
                 if (remoteByName.TryGetValue(remoteName, out Remote remote))
                 {
-                    RemoteBranchNode remoteBranchNode = new(this, branch.ObjectId, branch.Name, isVisible);
+                    RemoteBranchNode remoteBranchNode = new(this, branch.ObjectId, branch.Name, visible: true);
 
                     var parent = remoteBranchNode.CreateRootNode(
                         pathToNodes,

--- a/GitUI/BranchTreePanel/RemoteRepoFolderNode.cs
+++ b/GitUI/BranchTreePanel/RemoteRepoFolderNode.cs
@@ -4,13 +4,13 @@ using GitUI.Properties;
 namespace GitUI.BranchTreePanel
 {
     [DebuggerDisplay("(Folder) FullPath = {FullPath}")]
-    internal sealed class RemoteRepoFolderNode : BaseBranchNode
+    internal sealed class RemoteRepoFolderNode : BaseRevisionNode
     {
         public RemoteRepoFolderNode(Tree tree, string name) : base(tree, name, true)
         {
         }
 
-        protected override void ApplyStyle()
+        public override void ApplyStyle()
         {
             base.ApplyStyle();
             TreeViewNode.ImageKey = TreeViewNode.SelectedImageKey = nameof(Images.EyeClosed);

--- a/GitUI/BranchTreePanel/RemoteRepoNode.cs
+++ b/GitUI/BranchTreePanel/RemoteRepoNode.cs
@@ -8,7 +8,7 @@ using GitUIPluginInterfaces.RepositoryHosts;
 namespace GitUI.BranchTreePanel
 {
     [DebuggerDisplay("Remote = {_remote.Name}, FullPath = {FullPath}")]
-    internal sealed class RemoteRepoNode : BaseBranchNode
+    internal sealed class RemoteRepoNode : BaseRevisionNode
     {
         private readonly Remote _remote;
         private readonly IConfigFileRemoteSettingsManager _remotesManager;
@@ -69,7 +69,7 @@ namespace GitUI.BranchTreePanel
             UICommands.RepoChangedNotifier.Notify();
         }
 
-        protected override void ApplyStyle()
+        public override void ApplyStyle()
         {
             base.ApplyStyle();
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -92,6 +92,13 @@ namespace GitUI.BranchTreePanel
             _sortOrderContextMenuItem.Enable(isSingleRefSelected && showSortOrder);
         }
 
+        private void EnableStashContextMenu(bool hasSingleSelection, NodeBase selectedNode)
+        {
+            bool isSingleStashSelected = hasSingleSelection && selectedNode is StashNode;
+            bool isBareRepository = Module.IsBareRepository();
+            EnableMenuItems(isSingleStashSelected && !isBareRepository, mnubtnOpenStash, mnubtnApplyStash, mnubtnPopStash, mnubtnDropStash);
+        }
+
         private void EnableSubmoduleContextMenu(bool hasSingleSelection, NodeBase selectedNode)
         {
             bool isSingleSubmoduleSelected = hasSingleSelection && selectedNode is SubmoduleNode;
@@ -171,6 +178,15 @@ namespace GitUI.BranchTreePanel
             RegisterClick<BranchPathNode>(mnubtnDeleteAllBranches, branchPath => branchPath.DeleteAll());
             RegisterClick<BranchPathNode>(mnubtnCreateBranch, branchPath => branchPath.CreateBranch());
 
+            // Stash
+            RegisterClick(mnubtnStashAllFromRootNode, () => _stashTree.StashAll(this));
+            RegisterClick(mnubtnStashStagedFromRootNode, () => _stashTree.StashStaged(this));
+            RegisterClick(mnubtnManageStashFromRootNode, () => _stashTree.OpenStash(this));
+            RegisterClick<StashNode>(mnubtnOpenStash, node => node.OpenStash(this));
+            RegisterClick<StashNode>(mnubtnApplyStash, node => node.ApplyStash(this));
+            RegisterClick<StashNode>(mnubtnPopStash, node => node.PopStash(this));
+            RegisterClick<StashNode>(mnubtnDropStash, node => node.DropStash(this));
+
             // Expand / Collapse
             RegisterClick(mnubtnCollapse, () => GetSelectedNodes().HavingChildren().Collapsible().ForEach(node => node.TreeViewNode.Collapse()));
             RegisterClick(mnubtnExpand, () => GetSelectedNodes().HavingChildren().Expandable().ForEach(node => node.TreeViewNode.ExpandAll()));
@@ -196,7 +212,7 @@ namespace GitUI.BranchTreePanel
             bool hasSingleSelection = selectedNodes.Length <= 1;
             var selectedNode = treeMain.SelectedNode.Tag as NodeBase;
 
-            copyContextMenuItem.Enable(hasSingleSelection && selectedNode is BaseBranchLeafNode branch && branch.Visible);
+            copyContextMenuItem.Enable(hasSingleSelection && ((selectedNode is BaseBranchLeafNode branch && branch.Visible) || selectedNode is StashNode));
             filterForSelectedRefsMenuItem.Enable(selectedNodes.OfType<IGitRefActions>().Any()); // enable if selection contains refs
 
             var selectedLocalBranch = selectedNode as LocalBranchNode;
@@ -219,6 +235,8 @@ namespace GitUI.BranchTreePanel
             EnableMenuItems(_tagNodeMenuItems, _ => hasSingleSelection && selectedNode is TagNode);
             EnableMenuItems(hasSingleSelection && selectedNode is RemoteBranchTree, mnuBtnManageRemotesFromRootNode, mnuBtnFetchAllRemotes, mnuBtnPruneAllRemotes);
             EnableRemoteRepoContextMenu(hasSingleSelection, selectedNode);
+            EnableMenuItems(hasSingleSelection && selectedNode is StashTree, mnubtnStashAllFromRootNode, mnubtnStashStagedFromRootNode, mnubtnManageStashFromRootNode);
+            EnableStashContextMenu(hasSingleSelection, selectedNode);
             EnableSubmoduleContextMenu(hasSingleSelection, selectedNode);
             EnableMenuItems(hasSingleSelection && selectedNode is BranchPathNode, mnubtnCreateBranch, mnubtnDeleteAllBranches);
             EnableExpandCollapseContextMenu(selectedNodes);

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -180,8 +180,8 @@ namespace GitUI.BranchTreePanel
             RegisterClick(mnubtnMoveDown, () => ReorderTreeNode(treeMain.SelectedNode, up: false));
 
             // Sort by / order
-            _sortByContextMenuItem = new GitRefsSortByContextMenuItem(() => Refresh(new FilteredGitRefsProvider(UICommands.GitModule).GetRefs));
-            _sortOrderContextMenuItem = new GitRefsSortOrderContextMenuItem(() => Refresh(new FilteredGitRefsProvider(UICommands.GitModule).GetRefs));
+            _sortByContextMenuItem = new GitRefsSortByContextMenuItem(() => ResortRefs(new FilteredGitRefsProvider(UICommands.GitModule).GetRefs));
+            _sortOrderContextMenuItem = new GitRefsSortOrderContextMenuItem(() => ResortRefs(new FilteredGitRefsProvider(UICommands.GitModule).GetRefs));
             menuMain.InsertItems(new ToolStripItem[] { new ToolStripSeparator(), _sortByContextMenuItem, _sortOrderContextMenuItem }, after: mnubtnMoveDown);
         }
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -40,6 +40,7 @@ namespace GitUI.BranchTreePanel
                 _remotesTree?.Dispose();
                 _tagTree?.Dispose();
                 _submoduleTree?.Dispose();
+                _stashTree?.Dispose();
             }
 
             base.Dispose(disposing);
@@ -88,7 +89,16 @@ namespace GitUI.BranchTreePanel
             this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this.mnubtnCreateBranch = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnDeleteAllBranches = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
+            this.mnubtnStashAllFromRootNode = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnStashStagedFromRootNode = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnManageStashFromRootNode = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+            this.mnubtnOpenStash = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnApplyStash = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnPopStash = new System.Windows.Forms.ToolStripMenuItem();
+            this.mnubtnDropStash = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
             this.mnubtnCollapse = new System.Windows.Forms.ToolStripMenuItem();
             this.mnubtnExpand = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
@@ -104,6 +114,7 @@ namespace GitUI.BranchTreePanel
             this.tsbShowBranches = new System.Windows.Forms.ToolStripButton();
             this.tsbShowRemotes = new System.Windows.Forms.ToolStripButton();
             this.tsbShowTags = new System.Windows.Forms.ToolStripButton();
+            this.tsbShowStashes = new System.Windows.Forms.ToolStripButton();
             this.tsbShowSubmodules = new System.Windows.Forms.ToolStripButton();
             this.branchSearchPanel = new System.Windows.Forms.TableLayoutPanel();
             this.btnSearch = new System.Windows.Forms.Button();
@@ -163,7 +174,16 @@ namespace GitUI.BranchTreePanel
             this.toolStripSeparator6,
             this.mnubtnCreateBranch,
             this.mnubtnDeleteAllBranches,
+            this.toolStripSeparator10,
+            this.mnubtnStashAllFromRootNode,
+            this.mnubtnStashStagedFromRootNode,
+            this.mnubtnManageStashFromRootNode,
             this.toolStripSeparator7,
+            this.mnubtnOpenStash,
+            this.mnubtnApplyStash,
+            this.mnubtnPopStash,
+            this.mnubtnDropStash,
+            this.toolStripSeparator9,
             this.mnubtnCollapse,
             this.mnubtnExpand,
             this.toolStripSeparator4,
@@ -408,10 +428,66 @@ namespace GitUI.BranchTreePanel
             this.mnubtnDeleteAllBranches.ToolTipText = "Delete all child branchs, which must all be fully merged in its upstream branch o" +
     "r in HEAD";
             // 
+            // toolStripSeparator10
+            // 
+            this.toolStripSeparator10.Name = "toolStripSeparator10";
+            this.toolStripSeparator10.Size = new System.Drawing.Size(263, 6);
+            // 
+            // mnubtnStashAllFromRootNode
+            // 
+            this.mnubtnStashAllFromRootNode.Name = "mnubtnStashAllFromRootNode";
+            this.mnubtnStashAllFromRootNode.Size = new System.Drawing.Size(266, 26);
+            this.mnubtnStashAllFromRootNode.Text = "&Stash";
+            // 
+            // mnubtnStashStagedFromRootNode
+            // 
+            this.mnubtnStashStagedFromRootNode.Name = "mnubtnStashStagedFromRootNode";
+            this.mnubtnStashStagedFromRootNode.Size = new System.Drawing.Size(266, 26);
+            this.mnubtnStashStagedFromRootNode.Text = "S&tash staged";
+            // 
+            // mnubtnManageStashFromRootNode
+            // 
+            this.mnubtnManageStashFromRootNode.Name = "mnubtnManageStashFromRootNode";
+            this.mnubtnManageStashFromRootNode.Size = new System.Drawing.Size(266, 26);
+            this.mnubtnManageStashFromRootNode.Text = "&Manage stashes...";
+            // 
             // toolStripSeparator7
             // 
             this.toolStripSeparator7.Name = "toolStripSeparator7";
             this.toolStripSeparator7.Size = new System.Drawing.Size(263, 6);
+            // 
+            // mnubtnOpenStash
+            // 
+            this.mnubtnOpenStash.Name = "mnubtnOpenStash";
+            this.mnubtnOpenStash.Size = new System.Drawing.Size(266, 26);
+            this.mnubtnOpenStash.Text = "&Open stash";
+            this.mnubtnOpenStash.ToolTipText = "Open this stash";
+            // 
+            // mnubtnApplyStash
+            // 
+            this.mnubtnApplyStash.Name = "mnubtnApplyStash";
+            this.mnubtnApplyStash.Size = new System.Drawing.Size(266, 26);
+            this.mnubtnApplyStash.Text = "&Apply stash";
+            this.mnubtnApplyStash.ToolTipText = "Apply this stash";
+            // 
+            // mnubtnPopStash
+            // 
+            this.mnubtnPopStash.Name = "mnubtnPopStash";
+            this.mnubtnPopStash.Size = new System.Drawing.Size(266, 26);
+            this.mnubtnPopStash.Text = "&Pop stash";
+            this.mnubtnPopStash.ToolTipText = "Pop this stash";
+            // 
+            // mnubtnDropStash
+            // 
+            this.mnubtnDropStash.Name = "mnubtnDropStash";
+            this.mnubtnDropStash.Size = new System.Drawing.Size(266, 26);
+            this.mnubtnDropStash.Text = "&Drop stash...";
+            this.mnubtnDropStash.ToolTipText = "Drop this stash";
+            // 
+            // toolStripSeparator9
+            // 
+            this.toolStripSeparator9.Name = "toolStripSeparator9";
+            this.toolStripSeparator9.Size = new System.Drawing.Size(263, 6);
             // 
             // mnubtnCollapse
             // 
@@ -502,7 +578,8 @@ namespace GitUI.BranchTreePanel
             this.tsbShowBranches,
             this.tsbShowRemotes,
             this.tsbShowTags,
-            this.tsbShowSubmodules});
+            this.tsbShowSubmodules,
+            this.tsbShowStashes});
             this.leftPanelToolStrip.Location = new System.Drawing.Point(0, 0);
             this.leftPanelToolStrip.Name = "leftPanelToolStrip";
             this.leftPanelToolStrip.Size = new System.Drawing.Size(300, 27);
@@ -560,6 +637,17 @@ namespace GitUI.BranchTreePanel
             this.tsbShowSubmodules.Size = new System.Drawing.Size(29, 24);
             this.tsbShowSubmodules.Text = "&Submodules";
             this.tsbShowSubmodules.Click += new System.EventHandler(this.tsbShowSubmodules_Click);
+            // 
+            // tsbShowStashes
+            // 
+            this.tsbShowStashes.CheckOnClick = true;
+            this.tsbShowStashes.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.tsbShowStashes.Image = global::GitUI.Properties.Images.Stash;
+            this.tsbShowStashes.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tsbShowStashes.Name = "tsbShowStashes";
+            this.tsbShowStashes.Size = new System.Drawing.Size(29, 24);
+            this.tsbShowStashes.Text = "St&ashes";
+            this.tsbShowStashes.Click += new System.EventHandler(this.tsbShowStashes_Click);
             // 
             // branchSearchPanel
             // 
@@ -636,6 +724,7 @@ namespace GitUI.BranchTreePanel
         private ToolStripButton tsbShowBranches;
         private ToolStripButton tsbShowRemotes;
         private ToolStripButton tsbShowTags;
+        private ToolStripButton tsbShowStashes;
         private ToolStripButton tsbShowSubmodules;
         private UserControls.RevisionGrid.CopyContextMenuItem copyContextMenuItem;
         private ToolStripMenuItem filterForSelectedRefsMenuItem;
@@ -670,7 +759,16 @@ namespace GitUI.BranchTreePanel
         private ToolStripMenuItem mnubtnFetchOneBranch;
         private ToolStripMenuItem mnubtnCreateBranch;
         private ToolStripMenuItem mnubtnDeleteAllBranches;
+        private ToolStripSeparator toolStripSeparator10;
+        private ToolStripMenuItem mnubtnStashAllFromRootNode;
+        private ToolStripMenuItem mnubtnStashStagedFromRootNode;
+        private ToolStripMenuItem mnubtnManageStashFromRootNode;
         private ToolStripSeparator toolStripSeparator7;
+        private ToolStripMenuItem mnubtnOpenStash;
+        private ToolStripMenuItem mnubtnApplyStash;
+        private ToolStripMenuItem mnubtnPopStash;
+        private ToolStripMenuItem mnubtnDropStash;
+        private ToolStripSeparator toolStripSeparator9;
         private ToolStripSeparator toolStripSeparator1;
         private ToolStripMenuItem runScriptToolStripMenuItem;
 

--- a/GitUI/BranchTreePanel/RepoObjectsTree.SettingsContextMenu.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.SettingsContextMenu.cs
@@ -31,7 +31,8 @@ namespace GitUI.BranchTreePanel
                 [_branchesTree] = AppSettings.RepoObjectsTreeBranchesIndex,
                 [_remotesTree] = AppSettings.RepoObjectsTreeRemotesIndex,
                 [_tagTree] = AppSettings.RepoObjectsTreeTagsIndex,
-                [_submoduleTree] = AppSettings.RepoObjectsTreeSubmodulesIndex
+                [_submoduleTree] = AppSettings.RepoObjectsTreeSubmodulesIndex,
+                [_stashTree] = AppSettings.RepoObjectsTreeStashesIndex
             };
         }
 
@@ -41,6 +42,7 @@ namespace GitUI.BranchTreePanel
             AppSettings.RepoObjectsTreeRemotesIndex = treeToPositionIndex[_remotesTree];
             AppSettings.RepoObjectsTreeTagsIndex = treeToPositionIndex[_tagTree];
             AppSettings.RepoObjectsTreeSubmodulesIndex = treeToPositionIndex[_submoduleTree];
+            AppSettings.RepoObjectsTreeStashesIndex = treeToPositionIndex[_stashTree];
         }
 
         private void ReorderTreeNode(TreeNode node, bool up)
@@ -79,6 +81,7 @@ namespace GitUI.BranchTreePanel
             RemoveTree(_remotesTree);
             RemoveTree(_tagTree);
             RemoveTree(_submoduleTree);
+            RemoveTree(_stashTree);
             ShowEnabledTrees();
         }
 
@@ -102,6 +105,11 @@ namespace GitUI.BranchTreePanel
             if (tsbShowSubmodules.Checked)
             {
                 AddTree(_submoduleTree);
+            }
+
+            if (tsbShowStashes.Checked)
+            {
+                AddTree(_stashTree);
             }
         }
 
@@ -162,6 +170,21 @@ namespace GitUI.BranchTreePanel
             else
             {
                 RemoveTree(_submoduleTree);
+            }
+        }
+
+        private void tsbShowStashes_Click(object sender, EventArgs e)
+        {
+            AppSettings.RepoObjectsTreeShowStashes = tsbShowStashes.Checked;
+            _searchResult = null;
+            if (tsbShowStashes.Checked)
+            {
+                AddTree(_stashTree);
+                _searchResult = null;
+            }
+            else
+            {
+                RemoveTree(_stashTree);
             }
         }
     }

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -234,8 +234,8 @@ namespace GitUI.BranchTreePanel
         }
 
         /// <summary>
-        /// Toggles filtering mode on or off to the git refs present in the left panel depending on the app's global filtering rules .
-        /// These rules include: show all branches / show current branch / show filtered branches, etc.
+        /// FormBrowse refreshing the side panel when refreshing the grid.
+        /// (Update the objects in the panel.)
         /// </summary>
         /// <param name="getRefs">Function to get refs.</param>
         /// <param name="forceRefresh">Refresh may be required as references may have been changed.</param>
@@ -250,6 +250,18 @@ namespace GitUI.BranchTreePanel
         }
 
         /// <summary>
+        /// FormBrowse refreshing the side panel after updating the grid.
+        /// (Update the visibility for side panel objects.)
+        /// </summary>
+        public void RefreshRevisionsLoaded()
+        {
+            // Some refs may not be visible
+            _branchesTree.UpdateVisibility();
+            _remotesTree.UpdateVisibility();
+            _tagTree.UpdateVisibility();
+        }
+
+        /// <summary>
         /// Refresh after resorting.
         /// </summary>
         /// <param name="getRefs">Git references</param>
@@ -258,6 +270,10 @@ namespace GitUI.BranchTreePanel
             _branchesTree.Refresh(getRefs);
             _remotesTree.Refresh(getRefs);
             _tagTree.Refresh(getRefs);
+
+            _branchesTree.UpdateVisibility();
+            _remotesTree.UpdateVisibility();
+            _tagTree.UpdateVisibility();
         }
 
         public void ReloadHotkeys()

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -382,7 +382,7 @@ namespace GitUI.BranchTreePanel
                 SelectedImageKey = nameof(Images.BranchRemoteRoot)
             };
 
-            _remotesTree = new RemoteBranchTree(rootNode, UICommandsSource, _refsSource);
+            _remotesTree = new RemoteBranchTree(rootNode, UICommandsSource, _aheadBehindDataProvider, _refsSource);
         }
 
         private void CreateTags()

--- a/GitUI/BranchTreePanel/StashNode.cs
+++ b/GitUI/BranchTreePanel/StashNode.cs
@@ -1,0 +1,108 @@
+﻿using System.Diagnostics;
+using GitCommands;
+using GitUI.Properties;
+using GitUIPluginInterfaces;
+
+namespace GitUI.BranchTreePanel
+{
+    [DebuggerDisplay("(Tag) FullPath = {FullPath}, Hash = {ObjectId}, Visible: {Visible}")]
+    internal sealed class StashNode : BaseRevisionNode
+    {
+        public StashNode(Tree tree, in ObjectId? objectId, string reflogSelector, string subject, bool visible)
+            : base(tree, reflogSelector.RemovePrefix("refs/"), visible)
+        {
+            ObjectId = objectId;
+            DisplayName = $"{reflogSelector.RemovePrefix(GitRefName.RefsStashPrefix)}: {subject}";
+            ReflogSelector = reflogSelector;
+        }
+
+        public string DisplayName { get; }
+        public string ReflogSelector { get; }
+
+        internal override void OnSelected()
+        {
+            if (Tree.IgnoreSelectionChangedEvent)
+            {
+                return;
+            }
+
+            base.OnSelected();
+            SelectRevision();
+        }
+
+        internal override void OnDoubleClick()
+        {
+            OpenStash(TreeViewNode.TreeView);
+        }
+
+        internal bool OpenStash(IWin32Window owner)
+        {
+            return UICommands.StartStashDialog(owner, manageStashes: true, ReflogSelector);
+        }
+
+        public void ApplyStash(IWin32Window owner)
+        {
+            UICommands.StashApply(owner, ReflogSelector);
+        }
+
+        public void PopStash(IWin32Window owner)
+        {
+            UICommands.StashPop(owner, ReflogSelector);
+        }
+
+        public void DropStash(IWin32Window owner)
+        {
+            using (new WaitCursorScope())
+            {
+                TaskDialogButton result;
+                if (AppSettings.DontConfirmStashDrop)
+                {
+                    result = TaskDialogButton.Yes;
+                }
+                else
+                {
+                    TaskDialogPage page = new()
+                    {
+                        Text = TranslatedStrings.AreYouSure,
+                        Caption = TranslatedStrings.StashDropConfirmTitle,
+                        Heading = TranslatedStrings.CannotBeUndone,
+                        Buttons = { TaskDialogButton.Yes, TaskDialogButton.No },
+                        Icon = TaskDialogIcon.Information,
+                        Verification = new TaskDialogVerificationCheckBox
+                        {
+                            Text = TranslatedStrings.DontShowAgain
+                        },
+                        SizeToContent = true
+                    };
+
+                    result = TaskDialog.ShowDialog(owner, page);
+
+                    if (page.Verification.Checked)
+                    {
+                        AppSettings.DontConfirmStashDrop = true;
+                    }
+                }
+
+                if (result == TaskDialogButton.Yes)
+                {
+                    UICommands.StashDrop(owner, ReflogSelector);
+                }
+            }
+        }
+
+        public override void ApplyStyle()
+        {
+            base.ApplyStyle();
+
+            TreeViewNode.ImageKey = TreeViewNode.SelectedImageKey =
+                Visible
+                    ? nameof(Images.Stash)
+                    : nameof(Images.EyeClosed);
+        }
+
+        protected override string DisplayText()
+        {
+            return DisplayName;
+        }
+    }
+}

--- a/GitUI/BranchTreePanel/StashTree.cs
+++ b/GitUI/BranchTreePanel/StashTree.cs
@@ -1,0 +1,95 @@
+﻿using GitCommands;
+using GitUI.UserControls.RevisionGrid;
+using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Threading;
+
+namespace GitUI.BranchTreePanel
+{
+    internal sealed class StashTree : BaseRevisionTree
+    {
+        public StashTree(TreeNode treeNode, IGitUICommandsSource uiCommands, ICheckRefs refsSource)
+            : base(treeNode, uiCommands, refsSource)
+        {
+        }
+
+        internal void Refresh(Lazy<IReadOnlyCollection<GitRevision>> getStashRevs)
+        {
+            if (!IsAttached)
+            {
+                return;
+            }
+
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ReloadNodesAsync((token, _) =>
+                {
+                    Task<Nodes>? loadNodesTask = null;
+                    _updateSemaphore.WaitAsync();
+                    try
+                    {
+                        loadNodesTask = LoadNodesAsync(token, getStashRevs);
+                    }
+                    finally
+                    {
+                        _updateSemaphore.Release();
+                    }
+
+                    return loadNodesTask;
+                }, null).ConfigureAwait(false);
+            });
+        }
+
+        private async Task<Nodes> LoadNodesAsync(CancellationToken token, Lazy<IReadOnlyCollection<GitRevision>> getStashRevs)
+        {
+            await TaskScheduler.Default;
+            token.ThrowIfCancellationRequested();
+
+            return FillStashTree(getStashRevs.Value, token);
+        }
+
+        private Nodes FillStashTree(IReadOnlyCollection<GitRevision> stashes, CancellationToken token)
+        {
+            Nodes nodes = new(this);
+            Dictionary<string, BaseRevisionNode> pathToNodes = new();
+
+            foreach (GitRevision stash in stashes)
+            {
+                token.ThrowIfCancellationRequested();
+
+                // Visibility is set after the grid is loaded
+                StashNode node = new(this, stash.ObjectId, stash.ReflogSelector, stash.Subject, visible: false);
+                Node? parent = node.CreateRootNode(pathToNodes, (tree, parentPath) => new BasePathNode(tree, parentPath));
+
+                if (parent is not null)
+                {
+                    nodes.AddNode(parent);
+                }
+            }
+
+            return nodes;
+        }
+
+        protected override void PostFillTreeViewNode(bool firstTime)
+        {
+            if (firstTime)
+            {
+                TreeViewNode.Collapse();
+            }
+        }
+
+        public void StashAll(IWin32Window owner)
+        {
+            UICommands.StashSave(owner, AppSettings.IncludeUntrackedFilesInManualStash);
+        }
+
+        public void StashStaged(IWin32Window owner)
+        {
+            UICommands.StashStaged(owner);
+        }
+
+        public void OpenStash(IWin32Window owner)
+        {
+            UICommands.StartStashDialog(owner, manageStashes: true);
+        }
+    }
+}

--- a/GitUI/BranchTreePanel/SubmoduleFolderNode.cs
+++ b/GitUI/BranchTreePanel/SubmoduleFolderNode.cs
@@ -18,7 +18,7 @@ namespace GitUI.BranchTreePanel
             return string.Format(_name);
         }
 
-        protected override void ApplyStyle()
+        public override void ApplyStyle()
         {
             base.ApplyStyle();
             TreeViewNode.ImageKey = TreeViewNode.SelectedImageKey = nameof(Images.FolderClosed);

--- a/GitUI/BranchTreePanel/SubmoduleNode.cs
+++ b/GitUI/BranchTreePanel/SubmoduleNode.cs
@@ -120,7 +120,7 @@ namespace GitUI.BranchTreePanel
             }
         }
 
-        protected override void ApplyStyle()
+        public override void ApplyStyle()
         {
             base.ApplyStyle();
             ApplyStatus(); // Note that status is applied also after the tree is created, when status is applied

--- a/GitUI/BranchTreePanel/SubmoduleTree.cs
+++ b/GitUI/BranchTreePanel/SubmoduleTree.cs
@@ -20,11 +20,6 @@ namespace GitUI.BranchTreePanel
             SubmoduleStatusProvider.Default.StatusUpdated += Provider_StatusUpdated;
         }
 
-        protected override Task<Nodes> LoadNodesAsync(CancellationToken token, Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
-        {
-            return Task.FromResult(new Nodes(null));
-        }
-
         private void Provider_StatusUpdating(object sender, EventArgs e)
         {
             _currentNodes = null;
@@ -89,11 +84,11 @@ namespace GitUI.BranchTreePanel
                 {
                     // Module.GetRefs() is not used for Submodules
                     await ReloadNodesAsync((token, _) =>
-                {
-                    cts = CancellationTokenSource.CreateLinkedTokenSource(e.Token, token);
-                    loadNodesTask = LoadNodesAsync(e.Info, cts.Token);
-                    return loadNodesTask;
-                }, null).ConfigureAwait(false);
+                    {
+                        cts = CancellationTokenSource.CreateLinkedTokenSource(e.Token, token);
+                        loadNodesTask = LoadNodesAsync(e.Info, cts.Token);
+                        return loadNodesTask;
+                    }, null).ConfigureAwait(false);
                 }
 
                 if (cts is not null && loadNodesTask is not null)

--- a/GitUI/BranchTreePanel/TagNode.cs
+++ b/GitUI/BranchTreePanel/TagNode.cs
@@ -7,15 +7,13 @@ using GitUIPluginInterfaces;
 namespace GitUI.BranchTreePanel
 {
     [DebuggerDisplay("(Tag) FullPath = {FullPath}, Hash = {ObjectId}, Visible: {Visible}")]
-    internal sealed class TagNode : BaseBranchNode, IGitRefActions, ICanDelete
+    internal sealed class TagNode : BaseRevisionNode, IGitRefActions, ICanDelete
     {
         public TagNode(Tree tree, in ObjectId? objectId, string fullPath, bool visible)
             : base(tree, fullPath, visible)
         {
             ObjectId = objectId;
         }
-
-        public ObjectId? ObjectId { get; }
 
         internal override void OnSelected()
         {
@@ -53,7 +51,7 @@ namespace GitUI.BranchTreePanel
             return UICommands.StartMergeBranchDialog(TreeViewNode.TreeView, FullPath);
         }
 
-        protected override void ApplyStyle()
+        public override void ApplyStyle()
         {
             base.ApplyStyle();
 

--- a/GitUI/BranchTreePanel/TagTree.cs
+++ b/GitUI/BranchTreePanel/TagTree.cs
@@ -19,8 +19,7 @@ namespace GitUI.BranchTreePanel
             {
                 token.ThrowIfCancellationRequested();
 
-                bool isVisible = !IsFiltering.Value || (tag.ObjectId is not null && _refsSource.Contains(tag.ObjectId));
-                TagNode tagNode = new(this, tag.ObjectId, tag.Name, isVisible);
+                TagNode tagNode = new(this, tag.ObjectId, tag.Name, visible: true);
                 var parent = tagNode.CreateRootNode(pathToNodes, (tree, parentPath) => new BasePathNode(tree, parentPath));
 
                 if (parent is not null)

--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -60,6 +60,18 @@ namespace GitUI.CommandsDialogs
                 RefreshLeftPanel(e.GetRefs, e.ForceRefresh);
             };
 
+            RevisionGrid.RevisionsLoaded += (sender, e) =>
+            {
+                if (sender is null || MainSplitContainer.Panel1Collapsed)
+                {
+                    // - the event is either not originated from the revision grid, or
+                    // - the left panel is hidden
+                    return;
+                }
+
+                repoObjectsTree.RefreshRevisionsLoaded();
+            };
+
             RevisionGrid.SelectionChanged += (sender, e) =>
             {
                 _selectedRevisionUpdatedTargets = UpdateTargets.None;

--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -57,7 +57,7 @@ namespace GitUI.CommandsDialogs
                     return;
                 }
 
-                RefreshLeftPanel(e.GetRefs, e.ForceRefresh);
+                RefreshLeftPanel(e.GetRefs, e.GetStashRevs, e.ForceRefresh);
             };
 
             RevisionGrid.RevisionsLoaded += (sender, e) =>

--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -57,7 +57,7 @@ namespace GitUI.CommandsDialogs
                     return;
                 }
 
-                RefreshLeftPanel(e.ForceRefresh, e.GetRefs);
+                RefreshLeftPanel(e.GetRefs, e.ForceRefresh);
             };
 
             RevisionGrid.SelectionChanged += (sender, e) =>

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1208,7 +1208,7 @@ namespace GitUI.CommandsDialogs
             revisionGpgInfo1.DisplayGpgInfo(info);
         }
 
-        private void RefreshLeftPanel(bool forceRefresh, Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs)
+        private void RefreshLeftPanel(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs, bool forceRefresh)
         {
             // Apply filtering when:
             // 1. don't show reflog, and
@@ -1218,7 +1218,7 @@ namespace GitUI.CommandsDialogs
             // (this check ignores other revision filters)
             bool isFiltering = !AppSettings.ShowReflogReferences
                             && (AppSettings.ShowCurrentBranchOnly || AppSettings.BranchFilterEnabled);
-            repoObjectsTree.Refresh(isFiltering, forceRefresh, getRefs);
+            repoObjectsTree.RefreshRevisionsLoading(getRefs, forceRefresh, isFiltering);
         }
 
         private void OpenToolStripMenuItemClick(object sender, EventArgs e)
@@ -2937,7 +2937,7 @@ namespace GitUI.CommandsDialogs
 
             if (!MainSplitContainer.Panel1Collapsed)
             {
-                RefreshLeftPanel(forceRefresh: true, new FilteredGitRefsProvider(UICommands.GitModule).GetRefs);
+                RefreshLeftPanel(new FilteredGitRefsProvider(UICommands.GitModule).GetRefs, forceRefresh: true);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1210,15 +1210,7 @@ namespace GitUI.CommandsDialogs
 
         private void RefreshLeftPanel(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs, bool forceRefresh)
         {
-            // Apply filtering when:
-            // 1. don't show reflog, and
-            // 2. one of the following
-            //      a) show the current branch only, or
-            //      b) filter on specific branch
-            // (this check ignores other revision filters)
-            bool isFiltering = !AppSettings.ShowReflogReferences
-                            && (AppSettings.ShowCurrentBranchOnly || AppSettings.BranchFilterEnabled);
-            repoObjectsTree.RefreshRevisionsLoading(getRefs, forceRefresh, isFiltering);
+            repoObjectsTree.RefreshRevisionsLoading(getRefs, forceRefresh, RevisionGrid.FilterIsApplied());
         }
 
         private void OpenToolStripMenuItemClick(object sender, EventArgs e)
@@ -2937,7 +2929,9 @@ namespace GitUI.CommandsDialogs
 
             if (!MainSplitContainer.Panel1Collapsed)
             {
+                // Refresh the side panel, update visibility of objects separately
                 RefreshLeftPanel(new FilteredGitRefsProvider(UICommands.GitModule).GetRefs, forceRefresh: true);
+                repoObjectsTree.RefreshRevisionsLoaded();
             }
         }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -577,6 +577,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
+            _aheadBehindDataProvider.ResetCache();
             bool isDashboard = string.IsNullOrEmpty(Module.WorkingDir) || (_dashboard?.Visible ?? false);
             if (isDashboard)
             {
@@ -905,7 +906,9 @@ namespace GitUI.CommandsDialogs
 
                     _formBrowseMenus.InsertRevisionGridMainMenuItems(repositoryToolStripMenuItem);
 
-                    toolStripButtonPush.DisplayAheadBehindInformation(RevisionGrid.CurrentBranch.Value);
+                    // Request for all branches if side panel is shown
+                    var aheadBehindData = _aheadBehindDataProvider?.GetData(MainSplitContainer.Panel1Collapsed ? RevisionGrid.CurrentBranch.Value : "");
+                    toolStripButtonPush.DisplayAheadBehindInformation(aheadBehindData, RevisionGrid.CurrentBranch.Value);
 
                     ActiveControl = RevisionGrid;
                 }

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -27,13 +27,22 @@ namespace GitUI.CommandsDialogs
             CompleteTheInitialization();
         }
 
-        public FormStash(GitUICommands commands)
+        public FormStash(GitUICommands commands, string? initialStash = null)
             : base(commands)
         {
             InitializeComponent();
             View.ExtraDiffArgumentsChanged += delegate { StashedSelectedIndexChanged(this, EventArgs.Empty); };
             View.TopScrollReached += FileViewer_TopScrollReached;
             View.BottomScrollReached += FileViewer_BottomScrollReached;
+            if (initialStash is not null)
+            {
+                string initialIndex = initialStash.SubstringAfter('{').SubstringUntil('}');
+                if (int.TryParse(initialIndex, out int res))
+                {
+                    _lastSelectedStashIndex = res + 1;
+                }
+            }
+
             CompleteTheInitialization();
         }
 

--- a/GitUI/CommandsDialogs/ToolStripPushButton.cs
+++ b/GitUI/CommandsDialogs/ToolStripPushButton.cs
@@ -24,7 +24,7 @@ namespace GitUI.CommandsDialogs
             ResetToDefaultState();
         }
 
-        public void DisplayAheadBehindInformation(string branchName)
+        public void DisplayAheadBehindInformation(IDictionary<string, AheadBehindData>? aheadBehindData, string branchName)
         {
             ResetToDefaultState();
 
@@ -33,7 +33,6 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var aheadBehindData = _aheadBehindDataProvider?.GetData(branchName);
             if (aheadBehindData is null || aheadBehindData.Count < 1 || !aheadBehindData.ContainsKey(branchName))
             {
                 return;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -677,11 +677,11 @@ namespace GitUI
             return DoActionOnRepo(owner, Action, changesRepo: false);
         }
 
-        public bool StartStashDialog(IWin32Window? owner = null, bool manageStashes = true)
+        public bool StartStashDialog(IWin32Window? owner = null, bool manageStashes = true, string initialStash = null)
         {
             bool Action()
             {
-                using FormStash form = new(this) { ManageStashes = manageStashes };
+                using FormStash form = new(this, initialStash) { ManageStashes = manageStashes };
                 form.ShowDialog(owner);
                 return true;
             }

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -36,6 +36,7 @@ namespace GitUI
         private readonly TranslationString _branchesText = new("Branches");
         private readonly TranslationString _remotesText = new("Remotes");
         private readonly TranslationString _tagsText = new("Tags");
+        private readonly TranslationString _stashesText = new("Stashes");
         private readonly TranslationString _submodulesText = new("Submodules");
         private readonly TranslationString _bodyNotLoaded = new("\n\nFull message text is not present in older commits.\nSelect this commit to populate the full message.");
         private readonly TranslationString _searchingFor = new("Searching for: ");
@@ -182,6 +183,7 @@ the last selected commit.");
         public static string Branches => _instance.Value._branchesText.Text;
         public static string Remotes => _instance.Value._remotesText.Text;
         public static string Tags => _instance.Value._tagsText.Text;
+        public static string Stashes => _instance.Value._stashesText.Text;
         public static string Submodules => _instance.Value._submodulesText.Text;
 
         public static string BodyNotLoaded => _instance.Value._bodyNotLoaded.Text;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9141,6 +9141,14 @@ Reset the filter via View &gt; Show all branches.</source>
         <source>Fetch and prune all remotes</source>
         <target />
       </trans-unit>
+      <trans-unit id="mnubtnApplyStash.Text">
+        <source>&amp;Apply stash</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnApplyStash.ToolTipText">
+        <source>Apply this stash</source>
+        <target />
+      </trans-unit>
       <trans-unit id="mnubtnCollapse.Text">
         <source>Collapse</source>
         <target />
@@ -9175,6 +9183,14 @@ Reset the filter via View &gt; Show all branches.</source>
       </trans-unit>
       <trans-unit id="mnubtnDisableRemote.Text">
         <source>&amp;Deactivate</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnDropStash.Text">
+        <source>&amp;Drop stash...</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnDropStash.ToolTipText">
+        <source>Drop this stash</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnEnableRemote.Text">
@@ -9229,6 +9245,10 @@ Reset the filter via View &gt; Show all branches.</source>
         <source>Manage remotes</source>
         <target />
       </trans-unit>
+      <trans-unit id="mnubtnManageStashFromRootNode.Text">
+        <source>&amp;Manage stashes...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="mnubtnManageSubmodules.Text">
         <source>&amp;Manage...</source>
         <target />
@@ -9261,12 +9281,28 @@ Reset the filter via View &gt; Show all branches.</source>
         <source>Open selected submodule in a new instance</source>
         <target />
       </trans-unit>
+      <trans-unit id="mnubtnOpenStash.Text">
+        <source>&amp;Open stash</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnOpenStash.ToolTipText">
+        <source>Open this stash</source>
+        <target />
+      </trans-unit>
       <trans-unit id="mnubtnOpenSubmodule.Text">
         <source>&amp;Open</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnOpenSubmodule.ToolTipText">
         <source>Open selected submodule</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnPopStash.Text">
+        <source>&amp;Pop stash</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnPopStash.ToolTipText">
+        <source>Pop this stash</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnPullFromRemoteBranch.Text">
@@ -9287,6 +9323,14 @@ Reset the filter via View &gt; Show all branches.</source>
       </trans-unit>
       <trans-unit id="mnubtnResetSubmodule.ToolTipText">
         <source>Reset selected submodule</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnStashAllFromRootNode.Text">
+        <source>&amp;Stash</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="mnubtnStashStagedFromRootNode.Text">
+        <source>S&amp;tash staged</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnStashSubmodule.Text">
@@ -9335,6 +9379,14 @@ Reset the filter via View &gt; Show all branches.</source>
       </trans-unit>
       <trans-unit id="tsbShowRemotes.ToolTipText">
         <source>Remotes</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsbShowStashes.Text">
+        <source>St&amp;ashes</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="tsbShowStashes.ToolTipText">
+        <source>Stashes</source>
         <target />
       </trans-unit>
       <trans-unit id="tsbShowSubmodules.Text">
@@ -10994,6 +11046,10 @@ the last selected commit.</source>
       </trans-unit>
       <trans-unit id="_stashDropConfirmTitle.Text">
         <source>Drop Stash Confirmation</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_stashesText.Text">
+        <source>Stashes</source>
         <target />
       </trans-unit>
       <trans-unit id="_submodulesText.Text">

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -24,6 +24,7 @@ using GitUI.UserControls.RevisionGrid;
 using GitUI.UserControls.RevisionGrid.Columns;
 using GitUIPluginInterfaces;
 using Microsoft;
+using Microsoft.VisualBasic;
 using Microsoft.VisualStudio.Threading;
 using ResourceManager;
 using TaskDialog = System.Windows.Forms.TaskDialog;
@@ -888,6 +889,12 @@ namespace GitUI
             Lazy<IReadOnlyList<IGitRef>> getUnfilteredRefs = new(() => (getRefs ?? capturedModule.GetRefs)(RefsFilter.NoFilter));
             _ambiguousRefs = new(() => GitRef.GetAmbiguousRefNames(getUnfilteredRefs.Value));
 
+            // Get the "main" stash commit, including the reflog selector
+            Lazy<IReadOnlyCollection<GitRevision>> getStashRevs = new(() =>
+                !AppSettings.ShowStashes
+                ? Array.Empty<GitRevision>()
+                : new RevisionReader(capturedModule, hasReflogSelector: true).GetStashes(cancellationToken));
+
             try
             {
                 _revisionGraphColumnProvider.RevisionGraphDrawStyle = RevisionGraphDrawStyleEnum.DrawNonRelativesGray;
@@ -986,9 +993,7 @@ namespace GitUI
 
                     await TaskScheduler.Default;
 
-                    // Get the "main" stash commit, including the reflog selector
-                    IReadOnlyCollection<GitRevision> stashRevs = new RevisionReader(capturedModule, hasReflogSelector: true).GetStashes(cancellationToken);
-                    stashesById = stashRevs.ToDictionary(r => r.ObjectId);
+                    stashesById = getStashRevs.Value.ToDictionary(r => r.ObjectId);
 
                     // Git stores stashes in 2 or 3 commits. The (first) "stash" commit is listed by git-stash-list,
                     // does not include untracked files, may be stored in the third "untracked" commit.
@@ -1004,10 +1009,10 @@ namespace GitUI
                     }
 
                     // "stash" commits to insert (before regular commit)
-                    stashesByParentId = stashRevs.ToLookup(r => r.FirstParentId);
+                    stashesByParentId = getStashRevs.Value.ToLookup(r => r.FirstParentId);
 
                     // "untracked" commits to insert (parent to "stash" commits)
-                    Dictionary<ObjectId, ObjectId> untrackedChildIds = stashRevs.Where(stash => stash.ParentIds.Count >= 3)
+                    Dictionary<ObjectId, ObjectId> untrackedChildIds = getStashRevs.Value.Where(stash => stash.ParentIds.Count >= 3)
                         .Take(AppSettings.MaxStashesWithUntrackedFiles)
                         .ToDictionary(stash => stash.ParentIds[2], stash => stash.ObjectId);
                     IReadOnlyCollection<GitRevision> untrackedRevs = new RevisionReader(capturedModule, hasReflogSelector: false)
@@ -1015,7 +1020,7 @@ namespace GitUI
                     untrackedByStashId = untrackedRevs.ToDictionary(r => untrackedChildIds[r.ObjectId]);
 
                     // Remove parents not included ("index" and empty "untracked" commits).
-                    foreach (GitRevision stash in stashRevs)
+                    foreach (GitRevision stash in getStashRevs.Value)
                     {
                         if (!untrackedByStashId.ContainsKey(stash.ObjectId))
                         {
@@ -1054,7 +1059,7 @@ namespace GitUI
                     });
 
                 // Initiate update side panel
-                RevisionsLoading?.Invoke(this, new RevisionLoadEventArgs(this, UICommands, getUnfilteredRefs, forceRefresh));
+                RevisionsLoading?.Invoke(this, new RevisionLoadEventArgs(this, UICommands, getUnfilteredRefs, getStashRevs, forceRefresh));
             }
             catch
             {
@@ -1338,7 +1343,7 @@ namespace GitUI
                         }
 
                         _isRefreshingRevisions = false;
-                        RevisionsLoaded?.Invoke(this, new RevisionLoadEventArgs(this, UICommands, getUnfilteredRefs, forceRefresh));
+                        RevisionsLoaded?.Invoke(this, new RevisionLoadEventArgs(this, UICommands, getUnfilteredRefs, getStashRevs, forceRefresh));
                     }).FileAndForget();
                     return;
                 }
@@ -1403,7 +1408,7 @@ namespace GitUI
 
                     SetPage(_gridView);
                     _isRefreshingRevisions = false;
-                    RevisionsLoaded?.Invoke(this, new RevisionLoadEventArgs(this, UICommands, getUnfilteredRefs, forceRefresh));
+                    RevisionsLoaded?.Invoke(this, new RevisionLoadEventArgs(this, UICommands, getUnfilteredRefs, getStashRevs, forceRefresh));
                     HighlightRevisionsByAuthor(GetSelectedRevisions());
 
                     await TaskScheduler.Default;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -865,12 +865,13 @@ namespace GitUI
                       ? Module.GetSelectedBranch(setDefaultIfEmpty: false)
                       : "");
 
-            // Revision info is read in two parallel steps:
+            // Revision info is read in three parallel steps:
             // 1. Read current commit, refs, prepare grid etc.
-            // 2. Read all revisions with git-log.
+            // 2. Read stashes (if enabled).
+            // 3. Read all revisions with git-log.
             //    Git will provide log information when available (so slower to first revision if sorting).
-            // Both these operations can take a long time and is done async in parallel.
-            // Step 2. requires that the information in 1. is available when adding revisions,
+            // These operations can take a long time and is done async in parallel.
+            // Step 3. requires that the information in 1 and 2 is available when adding revisions,
             // and is therefore protected with a semaphore.
             SemaphoreSlim semaphoreUpdateGrid = new(initialCount: 0, maxCount: 2);
             CancellationToken cancellationToken = _refreshRevisionsSequence.Next();

--- a/GitUI/UserControls/RevisionGrid/RevisionLoadEventArgs.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionLoadEventArgs.cs
@@ -4,12 +4,14 @@ namespace GitUI.UserControls.RevisionGrid
 {
     public class RevisionLoadEventArgs : GitUIEventArgs
     {
-        public RevisionLoadEventArgs(IWin32Window? ownerForm, IGitUICommands gitUICommands, Lazy<IReadOnlyList<IGitRef>> getRefs, bool forceRefresh)
+        public RevisionLoadEventArgs(IWin32Window? ownerForm, IGitUICommands gitUICommands, Lazy<IReadOnlyList<IGitRef>> getRefs, Lazy<IReadOnlyCollection<GitRevision>> getStashRevs, bool forceRefresh)
             : base(ownerForm, gitUICommands, getRefs)
         {
+            GetStashRevs = getStashRevs;
             ForceRefresh = forceRefresh;
         }
 
+        public Lazy<IReadOnlyCollection<GitRevision>> GetStashRevs { get; init; }
         public bool ForceRefresh { get; init; }
     }
 }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.ReorderNodes.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.ReorderNodes.cs
@@ -44,10 +44,12 @@ namespace GitExtensions.UITests.CommandsDialogs
             _originalRepoObjectsTreeShow.Add(AppSettings.RepoObjectsTreeShowBranches);
             _originalRepoObjectsTreeShow.Add(AppSettings.RepoObjectsTreeShowRemotes);
             _originalRepoObjectsTreeShow.Add(AppSettings.RepoObjectsTreeShowTags);
+            _originalRepoObjectsTreeShow.Add(AppSettings.RepoObjectsTreeShowStashes);
             _originalRepoObjectsTreeShow.Add(AppSettings.RepoObjectsTreeShowSubmodules);
             AppSettings.RepoObjectsTreeShowBranches = true;
             AppSettings.RepoObjectsTreeShowRemotes = true;
             AppSettings.RepoObjectsTreeShowTags = true;
+            AppSettings.RepoObjectsTreeShowStashes = true;
             AppSettings.RepoObjectsTreeShowSubmodules = true;
         }
 
@@ -61,6 +63,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             AppSettings.RepoObjectsTreeShowRemotes = _originalRepoObjectsTreeShow[1];
             AppSettings.RepoObjectsTreeShowTags = _originalRepoObjectsTreeShow[2];
             AppSettings.RepoObjectsTreeShowSubmodules = _originalRepoObjectsTreeShow[3];
+            AppSettings.RepoObjectsTreeShowStashes = _originalRepoObjectsTreeShow[4];
         }
 
         [SetUp]
@@ -97,19 +100,19 @@ namespace GitExtensions.UITests.CommandsDialogs
                     List<TreeNode> initialNodes = currNodes.OfType<TreeNode>().ToList();
 
                     // assert
-                    AssertListCount(currNodes, 4);
-                    ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3);
+                    AssertListCount(currNodes, 5);
+                    ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3, 4);
 
                     int first = 0;
                     int last = currNodes.Count - 1;
 
                     // Trying to move first node up should do nothing
                     testAccessor.ReorderTreeNode(currNodes[first], up: true);
-                    ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3);
+                    ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3, 4);
 
                     // Similarly, moving last node down should do nothing
                     testAccessor.ReorderTreeNode(currNodes[last], up: false);
-                    ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3);
+                    ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3, 4);
                 });
         }
 
@@ -126,24 +129,24 @@ namespace GitExtensions.UITests.CommandsDialogs
                     List<TreeNode> initialNodes = currNodes.OfType<TreeNode>().ToList();
 
                     // assert
-                    AssertListCount(currNodes, 4);
-                    ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3);
+                    AssertListCount(currNodes, 5);
+                    ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3, 4);
 
                     // Move first down
                     testAccessor.ReorderTreeNode(currNodes[0], up: false);
-                    ValidateOrder(initialNodes, currNodes, 1, 0, 2, 3);
+                    ValidateOrder(initialNodes, currNodes, 1, 0, 2, 3, 4);
                     testAccessor.ReorderTreeNode(currNodes[1], up: false);
-                    ValidateOrder(initialNodes, currNodes, 1, 2, 0, 3);
+                    ValidateOrder(initialNodes, currNodes, 1, 2, 0, 3, 4);
                     testAccessor.ReorderTreeNode(currNodes[2], up: false);
-                    ValidateOrder(initialNodes, currNodes, 1, 2, 3, 0);
+                    ValidateOrder(initialNodes, currNodes, 1, 2, 3, 0, 4);
 
                     // Then back up
                     testAccessor.ReorderTreeNode(currNodes[3], up: true);
-                    ValidateOrder(initialNodes, currNodes, 1, 2, 0, 3);
+                    ValidateOrder(initialNodes, currNodes, 1, 2, 0, 3, 4);
                     testAccessor.ReorderTreeNode(currNodes[2], up: true);
-                    ValidateOrder(initialNodes, currNodes, 1, 0, 2, 3);
+                    ValidateOrder(initialNodes, currNodes, 1, 0, 2, 3, 4);
                     testAccessor.ReorderTreeNode(currNodes[1], up: true);
-                    ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3);
+                    ValidateOrder(initialNodes, currNodes, 0, 1, 2, 3, 4);
                 });
         }
 
@@ -158,14 +161,14 @@ namespace GitExtensions.UITests.CommandsDialogs
                     // act
                     var currNodes = testAccessor.TreeView.Nodes;
                     List<TreeNode> initialNodes = currNodes.OfType<TreeNode>().ToList();
-                    AssertListCount(initialNodes, 4);
+                    AssertListCount(initialNodes, 5);
 
                     // Hide nodes between first and last
                     testAccessor.SetTreeVisibleByIndex(1, false);
                     testAccessor.SetTreeVisibleByIndex(2, false);
 
                     // assert
-                    AssertListCount(currNodes, 2);
+                    AssertListCount(currNodes, 3);
 
                     // Move node 0 down, which should move it to index 3
                     testAccessor.ReorderTreeNode(currNodes[0], up: false);
@@ -174,11 +177,11 @@ namespace GitExtensions.UITests.CommandsDialogs
                     testAccessor.SetTreeVisibleByIndex(1, true);
                     testAccessor.SetTreeVisibleByIndex(2, true);
 
-                    // Reset currNodes, should be back to 4
-                    AssertListCount(currNodes, 4);
+                    // Reset currNodes, should be back
+                    AssertListCount(currNodes, 5);
 
                     // Only first and last nodes should have swapped
-                    ValidateOrder(initialNodes, currNodes, 3, 1, 2, 0);
+                    ValidateOrder(initialNodes, currNodes, 3, 1, 2, 0, 4);
                 });
         }
 

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.cs
@@ -42,6 +42,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             AppSettings.ShowAuthorAvatarColumn = false;
 
             AppSettings.RepoObjectsTreeShowTags = true;
+            AppSettings.RepoObjectsTreeShowStashes = true;
         }
 
         [OneTimeTearDown]

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -326,11 +326,13 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.RepoObjectsTreeShowBranches)], true, false, false);
                 yield return (properties[nameof(AppSettings.RepoObjectsTreeShowRemotes)], true, false, false);
                 yield return (properties[nameof(AppSettings.RepoObjectsTreeShowTags)], true, false, false);
+                yield return (properties[nameof(AppSettings.RepoObjectsTreeShowStashes)], true, false, false);
                 yield return (properties[nameof(AppSettings.RepoObjectsTreeShowSubmodules)], true, false, false);
                 yield return (properties[nameof(AppSettings.RepoObjectsTreeBranchesIndex)], 0, false, false);
                 yield return (properties[nameof(AppSettings.RepoObjectsTreeRemotesIndex)], 1, false, false);
                 yield return (properties[nameof(AppSettings.RepoObjectsTreeTagsIndex)], 2, false, false);
                 yield return (properties[nameof(AppSettings.RepoObjectsTreeSubmodulesIndex)], 3, false, false);
+                yield return (properties[nameof(AppSettings.RepoObjectsTreeStashesIndex)], 4, false, false);
                 yield return (properties[nameof(AppSettings.BlameDisplayAuthorFirst)], false, false, false);
                 yield return (properties[nameof(AppSettings.BlameShowAuthor)], true, false, false);
                 yield return (properties[nameof(AppSettings.BlameShowAuthorDate)], true, false, false);

--- a/UnitTests/GitUI.Tests/UserControls/ToolStripPushButtonTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/ToolStripPushButtonTests.cs
@@ -40,7 +40,7 @@ namespace GitUITests.UserControls
         {
             _sut.Initialize(null);
 
-            _sut.DisplayAheadBehindInformation("any-branchName");
+            _sut.DisplayAheadBehindInformation(_aheadBehindDataProvider?.GetData(), "any-branchName");
 
             _sut.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.Image);
             _sut.ToolTipText.Should().Be("Push");
@@ -81,7 +81,7 @@ namespace GitUITests.UserControls
             var branchName = "(no branch) or any-branch";
             _aheadBehindDataProvider.GetData(branchName).Returns(x => null);
 
-            _sut.DisplayAheadBehindInformation(branchName);
+            _sut.DisplayAheadBehindInformation(_aheadBehindDataProvider?.GetData(branchName), branchName);
 
             _sut.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.Image);
             _sut.ToolTipText.Should().Be("Push");
@@ -98,7 +98,7 @@ namespace GitUITests.UserControls
             };
             _aheadBehindDataProvider.GetData(branchName).Returns(x => data);
 
-            _sut.DisplayAheadBehindInformation(branchName);
+            _sut.DisplayAheadBehindInformation(_aheadBehindDataProvider?.GetData(branchName), branchName);
 
             _sut.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.ImageAndText);
             _sut.ToolTipText.Should().Contain("9 new commit(s) will be pushed");
@@ -116,7 +116,7 @@ namespace GitUITests.UserControls
             };
             _aheadBehindDataProvider.GetData(branchName).Returns(x => data);
 
-            _sut.DisplayAheadBehindInformation(branchName);
+            _sut.DisplayAheadBehindInformation(_aheadBehindDataProvider?.GetData(branchName), branchName);
 
             _sut.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.ImageAndText);
             _sut.ToolTipText.Should().NotContain("new commit(s) will be pushed");
@@ -134,7 +134,7 @@ namespace GitUITests.UserControls
             };
             _aheadBehindDataProvider.GetData(branchName).Returns(x => data);
 
-            _sut.DisplayAheadBehindInformation(branchName);
+            _sut.DisplayAheadBehindInformation(_aheadBehindDataProvider?.GetData(branchName), branchName);
 
             _sut.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.ImageAndText);
             _sut.ToolTipText.Should().Contain("99 new commit(s) will be pushed");
@@ -149,7 +149,7 @@ namespace GitUITests.UserControls
 
             var branchName = "my-branch";
 
-            _sut.DisplayAheadBehindInformation(branchName);
+            _sut.DisplayAheadBehindInformation(_aheadBehindDataProvider?.GetData(branchName), branchName);
 
             _sut.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.Image);
             _sut.ToolTipText.Should().NotContain("99 new commit(s) will be pushed");


### PR DESCRIPTION
Fixes #5460 
Follow-up to #10138 (that added stashes to the grid)

## Proposed changes

1. Side panel: Refactor classes and names

Renamed and restructured Node/Tree classes.
Some methods were added on parents but only used in leaves
(especially for submodule vs the "revision grid" branches/tags).
Example for a moved method is aheadBehind for LocalBranchNode.

Renamed and added some classes:
* BaseRevisionTree and BaseBranchNode.cs -> BaseRevisionNode.cs
  for methods pointing to revisions in the grid (i.e. all but submodules).
* BaseRefTree for Refs (Branches/Tags).

Methods were moved to the class where they were used

2. SidePanel:  Visibility for branches and tags was not updated.

If the revision grid had another filter than current branch or
filtered branches, the branches/tags were always set as visible.

The refs are always set as visible at creation and set as
not visible after the grid has loaded.

3.  SidePanel: Show Stashes

Context menu to open/apply/pop/drop as well as stash/stash-staged/manage.

4. RemoteBranches: Show ahead/behind for remotes

Supprt Alt-Click to select the tracking local branches

This is a candidate for 4.0

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/195948912-6ed7ea2d-4a92-41ff-a31f-06335669e1a4.png)

Revision filter hiding these branches
![image](https://user-images.githubusercontent.com/6248932/196061745-56b43863-f3a5-44b2-b7a8-d2e30b1eb1f5.png)

### After

![image](https://user-images.githubusercontent.com/6248932/195950064-45ce4cb0-d0ad-430f-97db-c61fdbc33d8a.png)

![image](https://user-images.githubusercontent.com/6248932/196055958-86e4f09e-35f3-48a3-867c-35a2f7ecb101.png)

![image](https://user-images.githubusercontent.com/6248932/196061784-02a9bb86-2faa-4350-b76b-f444b1f9600e.png)

![image](https://user-images.githubusercontent.com/6248932/196813425-669d50de-a49b-4ae8-b660-1abc82f893f1.png)

Remote had no ahaed/behind info (no alt-click)
![image](https://user-images.githubusercontent.com/6248932/197304858-71334c62-ac63-4910-b0fc-2b82101f5731.png)
![image](https://user-images.githubusercontent.com/6248932/197304940-591250ac-c067-47a6-939b-7c47c1bc8dbc.png)

## Test methodology <!-- How did you ensure quality? -->

Tests are adapted to additions.

## Merge strategy

Rebase merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
