### PR TITLE
Removed changes of PR #3833, suspend/resume redrawn of ToolStripEx when dropdown menu is opened/closed

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -351,7 +351,6 @@ namespace GitUI.CommandsDialogs
             this.toolStripButtonLevelUp.Size = new System.Drawing.Size(32, 22);
             this.toolStripButtonLevelUp.ToolTipText = "Submodules";
             this.toolStripButtonLevelUp.ButtonClick += new System.EventHandler(this.toolStripButtonLevelUp_ButtonClick);
-            this.toolStripButtonLevelUp.DropDownOpening += new System.EventHandler(this.toolStripButtonLevelUp_DropDownOpening);
             // 
             // _NO_TRANSLATE_WorkingDir
             // 
@@ -399,7 +398,6 @@ namespace GitUI.CommandsDialogs
             this.toolStripSplitStash.Size = new System.Drawing.Size(32, 22);
             this.toolStripSplitStash.ToolTipText = "Manage stashes";
             this.toolStripSplitStash.ButtonClick += new System.EventHandler(this.ToolStripSplitStashButtonClick);
-            this.toolStripSplitStash.DropDownOpened += new System.EventHandler(this.toolStripSplitStash_DropDownOpened);
             // 
             // stashChangesToolStripMenuItem
             // 
@@ -475,7 +473,6 @@ namespace GitUI.CommandsDialogs
             this.toolStripButtonPull.Size = new System.Drawing.Size(32, 22);
             this.toolStripButtonPull.Text = "Pull";
             this.toolStripButtonPull.ButtonClick += new System.EventHandler(this.ToolStripButtonPullClick);
-            this.toolStripButtonPull.DropDownOpened += new System.EventHandler(this.toolStripButtonPull_DropDownOpened);
             // 
             // toolStripSeparator11
             // 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1107,7 +1107,6 @@ namespace GitUI.CommandsDialogs
 
             _NO_TRANSLATE_WorkingDir.DropDownItems.Add(mnuRecentReposSettings);
 
-            ToolStripFilters.PreventToolStripSplitButtonClosing((ToolStripSplitButton)sender);
             _NO_TRANSLATE_WorkingDir.DropDown.ResumeLayout();
         }
 
@@ -1935,7 +1934,6 @@ namespace GitUI.CommandsDialogs
             branchSelect.DropDownItems.Add(new ToolStripSeparator());
             AddBranchesMenuItems();
 
-            ToolStripFilters.PreventToolStripSplitButtonClosing(sender as ToolStripSplitButton);
             branchSelect.DropDown.ResumeLayout();
 
             void AddCheckoutBranchMenuItem()
@@ -2567,11 +2565,6 @@ namespace GitUI.CommandsDialogs
             SetWorkingDir(path);
         }
 
-        private void toolStripButtonLevelUp_DropDownOpening(object sender, EventArgs e)
-        {
-            ToolStripFilters.PreventToolStripSplitButtonClosing(sender as ToolStripSplitButton);
-        }
-
         #region Submodules
 
         private ToolStripItem CreateSubmoduleMenuItem(SubmoduleInfo info, string textFormat = "{0}")
@@ -2795,11 +2788,6 @@ namespace GitUI.CommandsDialogs
         {
             FormUpdates updateForm = new(AppSettings.AppVersion);
             updateForm.SearchForUpdatesAndShow(Owner, true);
-        }
-
-        private void toolStripButtonPull_DropDownOpened(object sender, EventArgs e)
-        {
-            ToolStripFilters.PreventToolStripSplitButtonClosing(sender as ToolStripSplitButton);
         }
 
         /// <summary>
@@ -3057,11 +3045,6 @@ namespace GitUI.CommandsDialogs
             {
                 RefreshRevisions();
             }
-        }
-
-        private void toolStripSplitStash_DropDownOpened(object sender, EventArgs e)
-        {
-            ToolStripFilters.PreventToolStripSplitButtonClosing(sender as ToolStripSplitButton);
         }
 
         private void undoLastCommitToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/Interops/Messages.cs
+++ b/GitUI/Interops/Messages.cs
@@ -40,10 +40,18 @@
         public const int EM_CHARFROMPOS = 0x00D7;
         public const int EM_GETFIRSTVISIBLELINE = 0xCE;
 
+        public static readonly IntPtr FALSE = IntPtr.Zero;
+        public static readonly IntPtr TRUE = new(1);
+
         /// <summary>
         /// The WM_NULL message performs no operation. An application sends the WM_NULL message if it wants to post a message that the recipient window will ignore.
         /// </summary>
         public const int WM_NULL = 0x0000;
+
+        /// <summary>
+        /// The WM_SETREDRAW message is sent to a window to allow changes in that window to be redrawn, or to prevent changes in that window from being redrawn.
+        /// </summary>
+        public const int WM_SETREDRAW = 0x000B;
 
         /// <summary>
         /// The WM_PAINT message is sent when the system or another application makes a request to paint a portion of an application's window. The message is sent when the UpdateWindow or RedrawWindow function is called, or by the DispatchMessage function when the application obtains a WM_PAINT message by using the GetMessage or PeekMessage function.

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -92,7 +92,6 @@ namespace GitUI.UserControls
             this.tsbtnAdvancedFilter.Size = new System.Drawing.Size(32, 22);
             this.tsbtnAdvancedFilter.ToolTipText = "Advanced filter";
             this.tsbtnAdvancedFilter.ButtonClick += new System.EventHandler(this.tsbtnAdvancedFilter_ButtonClick);
-            this.tsbtnAdvancedFilter.DropDownOpening += new System.EventHandler(this.tsbtnAdvancedFilter_DropDownOpening);
             // 
             // tsmiResetPathFilters
             // 

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -167,7 +167,7 @@ namespace GitUI.UserControls
             tstxtRevisionFilter.ForeColor = toolForeColor;
         }
 
-        private void SelectShowBranchesFilterOption(byte selectedIndex)
+        private void SelectShowBranchesFilterOption(int selectedIndex)
         {
             if (selectedIndex >= tssbtnShowBranches.DropDownItems.Count)
             {

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -167,19 +167,7 @@ namespace GitUI.UserControls
             tstxtRevisionFilter.ForeColor = toolForeColor;
         }
 
-        public void PreventToolStripSplitButtonClosing(ToolStripSplitButton? control)
-        {
-            if (control is null
-                || Parent is not ContainerControl parentContainer)
-            {
-                return;
-            }
-
-            control.Tag = parentContainer.FindFocusedControl();
-            control.DropDownClosed += ToolStripSplitButtonDropDownClosed;
-        }
-
-        private void SelectShowBranchesFilterOption(int selectedIndex)
+        private void SelectShowBranchesFilterOption(byte selectedIndex)
         {
             if (selectedIndex >= tssbtnShowBranches.DropDownItems.Count)
             {
@@ -382,20 +370,6 @@ namespace GitUI.UserControls
             }
         }
 
-        private static void ToolStripSplitButtonDropDownClosed(object sender, EventArgs e)
-        {
-            if (sender is ToolStripSplitButton control)
-            {
-                control.DropDownClosed -= ToolStripSplitButtonDropDownClosed;
-
-                if (control.Tag is Control controlToFocus)
-                {
-                    controlToFocus.Focus();
-                    control.Tag = null;
-                }
-            }
-        }
-
         private void tsbtnAdvancedFilter_ButtonClick(object sender, EventArgs e)
         {
             if (!tsmiResetAllFilters.Enabled)
@@ -406,11 +380,6 @@ namespace GitUI.UserControls
             {
                 tsbtnAdvancedFilter.ShowDropDown();
             }
-        }
-
-        private void tsbtnAdvancedFilter_DropDownOpening(object sender, EventArgs e)
-        {
-            PreventToolStripSplitButtonClosing(sender as ToolStripSplitButton);
         }
 
         private void tstxtRevisionFilter_KeyUp(object sender, KeyEventArgs e)

--- a/GitUI/UserControls/ToolStripEx.cs
+++ b/GitUI/UserControls/ToolStripEx.cs
@@ -38,36 +38,22 @@ namespace GitUI
             }
         }
 
-        private static void SuspendDrawing(Control control)
-        {
-            if (control != null)
-            {
-                NativeMethods.SendMessageW(control.Handle, NativeMethods.WM_SETREDRAW, NativeMethods.FALSE, IntPtr.Zero);
-            }
-        }
-
-        private static void ResumeDrawing(Control control)
-        {
-            if (control != null)
-            {
-                NativeMethods.SendMessageW(control.Handle, NativeMethods.WM_SETREDRAW, NativeMethods.TRUE, IntPtr.Zero);
-                control.Refresh();
-            }
-        }
-
         private void SplitButton_DropDownOpening(object? sender, EventArgs e)
         {
-            if (sender is ToolStripDropDownItem item)
+            if (sender is ToolStripDropDownItem item && item.Owner is Control control)
             {
-                SuspendDrawing(item.Owner);
+                // Suspends the control's rendering process.
+                NativeMethods.SendMessageW(control.Handle, NativeMethods.WM_SETREDRAW, NativeMethods.FALSE, IntPtr.Zero);
             }
         }
 
         private void SplitButton_DropDownClosed(object? sender, EventArgs e)
         {
-            if (sender is ToolStripDropDownItem item)
+            if (sender is ToolStripDropDownItem item && item.Owner is Control control)
             {
-                ResumeDrawing(item.Owner);
+                // Resumes the control's rendering process and trigger a redraw.
+                NativeMethods.SendMessageW(control.Handle, NativeMethods.WM_SETREDRAW, NativeMethods.TRUE, IntPtr.Zero);
+                control.Refresh();
             }
         }
 

--- a/GitUI/UserControls/ToolStripEx.cs
+++ b/GitUI/UserControls/ToolStripEx.cs
@@ -39,16 +39,11 @@ namespace GitUI
             }
         }
 
-        [DllImport("user32.dll")]
-        private static extern int SendMessage(IntPtr hwnd, int wmsg, bool wparam, int lparam);
-
-        private const int WM_SETREDRAW = 11;
-
         private static void SuspendDrawing(Control control)
         {
             if (control != null)
             {
-                SendMessage(control.Handle, WM_SETREDRAW, false, 0);
+                NativeMethods.SendMessageW(control.Handle, NativeMethods.WM_SETREDRAW, NativeMethods.FALSE, IntPtr.Zero);
             }
         }
 
@@ -56,7 +51,7 @@ namespace GitUI
         {
             if (control != null)
             {
-                SendMessage(control.Handle, WM_SETREDRAW, true, 0);
+                NativeMethods.SendMessageW(control.Handle, NativeMethods.WM_SETREDRAW, NativeMethods.TRUE, IntPtr.Zero);
                 control.Refresh();
             }
         }

--- a/GitUI/UserControls/ToolStripEx.cs
+++ b/GitUI/UserControls/ToolStripEx.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel;
 using System.Reflection;
-using System.Runtime.InteropServices;
 
 namespace GitUI
 {


### PR DESCRIPTION
This PR does:

- remove changes made in PR #3833, which was shitty, let's be honest
- adds a suspend/resume of redraw of the `ToolTipEx` control when a child element of type `ToolStripDropDownItem` opens/closes a dropdown menus

See related issue #10254 (recent) and #3832 (old).

Previous PR as an attempt to fix this problem is #3833. It used to work but the fix was not satisfying (non-sense and dirty hack) and stopped being effective after a few versions of GE.

Also, see #10259 since this is my first PR from after 23 January 2019.