### PR TITLE
Git Executable: return stderr also if not throwOnErrorExit is suppressed

### DIFF
--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -64,9 +64,6 @@ namespace GitCommands
             private readonly bool _redirectOutput;
             private readonly bool _throwOnErrorExit;
 
-            private MemoryStream? _emptyStream;
-            private StreamReader? _emptyReader;
-
             private bool _disposed;
 
             public ProcessWrapper(string fileName,
@@ -207,19 +204,12 @@ namespace GitCommands
             {
                 get
                 {
-                    if (!_redirectOutput && !_throwOnErrorExit)
+                    if (!_redirectOutput)
                     {
                         throw new InvalidOperationException("Process was not created with redirected output.");
                     }
 
-                    if (!_throwOnErrorExit)
-                    {
-                        return _process.StandardError;
-                    }
-
-                    _emptyStream ??= new();
-                    _emptyReader ??= new(_emptyStream);
-                    return _emptyReader;
+                    return _process.StandardError;
                 }
             }
 
@@ -261,9 +251,6 @@ namespace GitCommands
                 _process.Dispose();
 
                 _logOperation.NotifyDisposed();
-
-                _emptyReader?.Dispose();
-                _emptyStream?.Dispose();
             }
         }
 


### PR DESCRIPTION
Fixes #10242

## Proposed changes

if throwOnErrorExit  was not set to false for Git commands, stderr was always empty.
This is likely a remains of the first implementation of throwOnErrorExit that raised errors for contents in stderr in addition to non zero error code.
Also git-verify-tag should only parse stderr, not stdout.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
