### PR TITLE
Cleanup handling of AllOutput for processes

### DIFF
--- a/GitCommands/Git/GitGpgController.cs
+++ b/GitCommands/Git/GitGpgController.cs
@@ -232,13 +232,13 @@ namespace GitCommands.Gpg
                 return null;
             }
 
-            var module = GetModule();
+            // '--raw' returns info in stderr
             GitArgumentBuilder args = new("verify-tag")
             {
                 { raw, "--raw" },
                 tagName
             };
-            return module.GitExecutable.GetOutput(args);
+            return GetModule().GitExecutable.Execute(args).StandardError;
         }
 
         private string? EvaluateTagVerifyMessage(IReadOnlyList<IGitRef> usefulTagRefs)

--- a/GitCommands/Git/SystemEncodingReader.cs
+++ b/GitCommands/Git/SystemEncodingReader.cs
@@ -48,15 +48,10 @@ namespace GitCommands.Git
                 };
 
                 ExecutionResult result = _module.GitExecutable.Execute(arguments, outputEncoding: Encoding.UTF8, throwOnErrorExit: false);
-                string? s = result.AllOutput;
-                if (s is not null && s.IndexOf(controlStr) != -1)
-                {
-                    systemEncoding = new UTF8Encoding(false);
-                }
-                else
-                {
-                    systemEncoding = Encoding.Default;
-                }
+                string? s = result.StandardError;
+                systemEncoding = s is not null && s.IndexOf(controlStr) != -1
+                    ? new UTF8Encoding(false)
+                    : Encoding.Default;
 
                 Debug.WriteLine("System encoding: " + systemEncoding.EncodingName);
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1958,18 +1958,10 @@ namespace GitUI.CommandsDialogs
                         files.Add(item);
                     }
 
-                    bool wereErrors = false;
-                    if (AppSettings.ShowErrorsWhenStagingFiles)
+                    bool wereErrors = !Module.StageFiles(files, out string output);
+                    if (wereErrors && AppSettings.ShowErrorsWhenStagingFiles)
                     {
-                        var output = Module.StageFiles(files, out wereErrors);
-                        if (wereErrors)
-                        {
-                            FormStatus.ShowErrorDialog(this, _stageDetails.Text, string.Format(_stageFiles.Text + "\n", files.Count), output);
-                        }
-                    }
-                    else
-                    {
-                        Module.StageFiles(files, out wereErrors);
+                        FormStatus.ShowErrorDialog(this, _stageDetails.Text, string.Format(_stageFiles.Text + "\n", files.Count), output);
                     }
 
                     if (wereErrors)
@@ -2525,7 +2517,7 @@ namespace GitUI.CommandsDialogs
 
             SelectedDiff.Clear();
 
-            Module.SkipWorktreeFiles(Unstaged.SelectedItems.Items().ToList(), true);
+            Module.SkipWorktreeFiles(Unstaged.SelectedItems.Items().ToList(), true, out _);
 
             Initialize();
         }
@@ -2539,7 +2531,7 @@ namespace GitUI.CommandsDialogs
 
             SelectedDiff.Clear();
 
-            Module.SkipWorktreeFiles(Unstaged.SelectedItems.Items().ToList(), false);
+            Module.SkipWorktreeFiles(Unstaged.SelectedItems.Items().ToList(), false, out _);
 
             Initialize();
         }

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -894,7 +894,7 @@ See the changes in the commit form.");
                 return;
             }
 
-            Module.AssumeUnchangedFiles(new List<GitItemStatus> { itemStatus }, true, out var wereErrors);
+            bool wereErrors = !Module.AssumeUnchangedFiles(new List<GitItemStatus> { itemStatus }, true, out _);
 
             if (wereErrors)
             {

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1608,6 +1608,7 @@ namespace GitUI.Editor
 
         private void ProcessApplyOutput(GitArgumentBuilder args, byte[] patch, bool patchUpdateDiff = false)
         {
+            // TODO Cleanup the handling and separate AllOutput to StandardOutput/StandardError
             ExecutionResult result = Module.GitExecutable.Execute(args, inputWriter => inputWriter.BaseStream.Write(patch), throwOnErrorExit: false);
             string output = result.AllOutput.Trim();
             if (EnvUtils.RunningOnWindows())

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -315,6 +315,7 @@ namespace GitExtensions.Plugins.GitFlow
             ttDebug.RemoveAll();
             ttDebug.SetToolTip(lblDebug, "cmd: git " + commandText + "\n" + "exit code:" + result.ExitCode);
 
+            // TODO Can AllOutput be replaced with StandardOutput?
             var resultText = Regex.Replace(result.AllOutput, @"\r\n?|\n", Environment.NewLine);
 
             if (result.ExitedSuccessfully)

--- a/UnitTests/GitCommands.Tests/Git/Gpg/GitGpgControllerTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/Gpg/GitGpgControllerTests.cs
@@ -102,7 +102,7 @@ namespace GitCommandsTests.Git.Gpg
                 gitRef.LocalName
             };
 
-            using var _ = _executable.StageOutput(args.ToString(), gitCmdReturn);
+            using var _ = _executable.StageOutput(args.ToString(), output: "", error: gitCmdReturn);
 
             var actual = await _gpgController.GetRevisionTagSignatureStatusAsync(revision);
 
@@ -168,7 +168,7 @@ namespace GitCommandsTests.Git.Gpg
                         revision.Refs = new[] { gitRef };
 
                         GitArgumentBuilder args = new("verify-tag") { gitRef.LocalName };
-                        validate = _executable.StageOutput(args.ToString(), gitRef.LocalName);
+                        validate = _executable.StageOutput(args.ToString(), output: "", error: gitRef.LocalName);
 
                         break;
                     }
@@ -179,13 +179,13 @@ namespace GitCommandsTests.Git.Gpg
                         GitRef gitRef1 = new(_module, objectId, "refs/tags/FirstTag^{}");
 
                         GitArgumentBuilder args = new("verify-tag") { gitRef1.LocalName };
-                        _executable.StageOutput(args.ToString(), gitRef1.LocalName);
+                        _executable.StageOutput(args.ToString(), output: "", error: gitRef1.LocalName);
 
                         GitRef gitRef2 = new(_module, objectId, "refs/tags/SecondTag^{}");
                         revision.Refs = new[] { gitRef1, gitRef2 };
 
                         args = new GitArgumentBuilder("verify-tag") { gitRef2.LocalName };
-                        validate = _executable.StageOutput(args.ToString(), gitRef2.LocalName);
+                        validate = _executable.StageOutput(args.ToString(), output: "", error: gitRef2.LocalName);
 
                         break;
                     }


### PR DESCRIPTION
Initiated from #10242 
Some parts were initially in #10261 , separated to this PR

## Proposed changes

AllOutput is combined use of stderr and stdout and should only be used to display messages for users.

* Change a few commands to explicitly read stderr where required. Some tests had to be adapted (including MockExecutable).

* Clarify usage that AllOutput is used for user popups. Most of these occurrences are related to FormCommit. The structure of these command was changed to return a bool for result and the output as a string, also if result/output were unused.

* Set TODO on a few occurrences that were not investigated.

## Test methodology <!-- How did you ensure quality? -->

Tests updated

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
