### PR TITLE
git settings: new setting to be able to enable rebase of dependent branches

### DIFF
--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -8,6 +8,7 @@ namespace GitCommands
         private static readonly GitVersion v2_19_0 = new("2.19.0");
         private static readonly GitVersion v2_20_0 = new("2.20.0");
         private static readonly GitVersion v2_35_0 = new("2.35.0");
+        private static readonly GitVersion v2_38_0 = new("2.38.0");
 
         /// <summary>
         /// The recommonded Git version (normally latest official before a GE release).
@@ -119,6 +120,7 @@ namespace GitCommands
         public bool SupportGuiMergeTool => this >= v2_20_0;
         public bool SupportRangeDiffTool => this >= v2_19_0;
         public bool SupportStashStaged => this >= v2_35_0;
+        public bool SupportUpdateRefs => this >= v2_38_0;
 
         public bool IsUnknown => _a == 0 && _b == 0 && _c == 0 && _d == 0;
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.Designer.cs
@@ -32,6 +32,7 @@
             this.checkBoxFetchPrune = new System.Windows.Forms.CheckBox();
             this.checkBoxPullRebase = new System.Windows.Forms.CheckBox();
             this.checkBoxRebaseAutosquash = new System.Windows.Forms.CheckBox();
+            this.checkBoxUpdateRefs = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // checkBoxRebaseAutostash
@@ -74,6 +75,16 @@
             this.checkBoxRebaseAutosquash.Text = "Automatically squash commits when doing an interactive rebase";
             this.checkBoxRebaseAutosquash.UseVisualStyleBackColor = true;
             // 
+            // checkBoxUpdateRefs
+            // 
+            this.checkBoxUpdateRefs.AutoSize = true;
+            this.checkBoxUpdateRefs.Location = new System.Drawing.Point(19, 152);
+            this.checkBoxUpdateRefs.Name = "checkBoxUpdateRefs";
+            this.checkBoxUpdateRefs.Size = new System.Drawing.Size(198, 19);
+            this.checkBoxUpdateRefs.TabIndex = 3;
+            this.checkBoxUpdateRefs.Text = "Rebase also dependent branches";
+            this.checkBoxUpdateRefs.UseVisualStyleBackColor = true;
+            // 
             // GitConfigAdvancedSettingsPage
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -81,9 +92,10 @@
             this.Controls.Add(this.checkBoxRebaseAutostash);
             this.Controls.Add(this.checkBoxFetchPrune);
             this.Controls.Add(this.checkBoxPullRebase);
+            this.Controls.Add(this.checkBoxUpdateRefs);
             this.Controls.Add(this.checkBoxRebaseAutosquash);
             this.Name = "GitConfigAdvancedSettingsPage";
-            this.Size = new System.Drawing.Size(1527, 384);
+            this.Size = new System.Drawing.Size(1439, 516);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -95,5 +107,6 @@
         private System.Windows.Forms.CheckBox checkBoxFetchPrune;
         private System.Windows.Forms.CheckBox checkBoxPullRebase;
         private System.Windows.Forms.CheckBox checkBoxRebaseAutosquash;
+        private System.Windows.Forms.CheckBox checkBoxUpdateRefs;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft;
+﻿using GitCommands;
+using Microsoft;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
@@ -18,8 +19,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 new("pull.rebase", checkBoxPullRebase),
                 new("fetch.prune", checkBoxFetchPrune),
                 new("rebase.autoStash", checkBoxRebaseAutostash),
-                new("rebase.autosquash", checkBoxRebaseAutosquash)
+                new("rebase.autosquash", checkBoxRebaseAutosquash),
+                new("rebase.updateRefs", checkBoxUpdateRefs)
             };
+
+            checkBoxUpdateRefs.Visible = GitVersion.Current.SupportUpdateRefs;
+
             Load += GitConfigAdvancedSettingsPage_Load;
         }
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8093,6 +8093,10 @@ Context menu for additional operations</source>
         <source>Automatically stash before doing a rebase</source>
         <target />
       </trans-unit>
+      <trans-unit id="checkBoxUpdateRefs.Text">
+        <source>Rebase also dependent branches</source>
+        <target />
+      </trans-unit>
     </body>
   </file>
   <file datatype="plaintext" original="GitConfigSettingsPage" source-language="en">


### PR DESCRIPTION

introduced in v2.38 ( https://github.blog/2022-10-03-highlights-from-git-2-38/#rebase-dependent-branches-with-update-refs )

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/197631440-16ba2a72-97a4-4dde-9455-66f4c6a5c2e0.png)

### After

![image](https://user-images.githubusercontent.com/460196/197631298-6ac32de2-8644-43ad-a47d-91b3bb118c0f.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build d5c1facf153a56aa0ddae04907a6f296b1ab5f2c (Dirty)
- Git 2.38.0.windows.1 (recommended: 2.38.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.10
- DPI 96dpi (no scaling)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
