### PR TITLE
FormCreateWorktree: Build potential worktree path using repository path

### DIFF
--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.Designer.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.Designer.cs
@@ -72,6 +72,7 @@
             // radioButtonCheckoutExistingBranch
             //
             this.radioButtonCheckoutExistingBranch.AutoSize = true;
+            this.radioButtonCheckoutExistingBranch.Checked = true;
             this.radioButtonCheckoutExistingBranch.Location = new System.Drawing.Point(3, 3);
             this.radioButtonCheckoutExistingBranch.Name = "radioButtonCheckoutExistingBranch";
             this.radioButtonCheckoutExistingBranch.Size = new System.Drawing.Size(165, 17);

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -9,7 +9,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         private readonly AsyncLoader _branchesLoader = new();
         private readonly char[] _invalidCharsInPath = Path.GetInvalidFileNameChars();
 
-        private string? _initialDirectoryPath;
+        private readonly string? _initialDirectoryPath;
 
         public string WorktreeDirectory => newWorktreeDirectory.Text;
         public bool OpenWorktree => openWorktreeCheckBox.Checked;
@@ -22,22 +22,19 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             InitializeComponent();
         }
 
-        public FormCreateWorktree(GitUICommands commands)
+        public FormCreateWorktree(GitUICommands commands, string? path)
             : base(commands)
         {
             InitializeComponent();
             InitializeComplete();
+            _initialDirectoryPath = path;
         }
 
         private void FormCreateWorktree_Load(object sender, EventArgs e)
         {
-            _initialDirectoryPath = GetWorktreeDirectory();
             LoadBranchesAsync();
 
-            string GetWorktreeDirectory()
-            {
-                return UICommands.GitModule.WorkingDir.TrimEnd('\\', '/');
-            }
+            UpdateWorktreePathAndValidateWorktreeOptions();
 
             void LoadBranchesAsync()
             {
@@ -160,6 +157,9 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         }
 
         private void UpdateWorktreePathAndValidateWorktreeOptions(object sender, EventArgs e)
+            => UpdateWorktreePathAndValidateWorktreeOptions();
+
+        private void UpdateWorktreePathAndValidateWorktreeOptions()
         {
             UpdateWorktreePath();
 
@@ -170,15 +170,12 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             void UpdateWorktreePath()
             {
                 var branchNameNormalized = NormalizeBranchName(radioButtonCheckoutExistingBranch.Checked
-                    ? ((IGitRef)comboBoxBranches.SelectedItem).Name
+                    ? ((IGitRef)comboBoxBranches.SelectedItem)?.Name ?? string.Empty
                     : textBoxNewBranchName.Text);
                 newWorktreeDirectory.Text = $"{_initialDirectoryPath}_{branchNameNormalized}";
             }
 
-            string NormalizeBranchName(string branchName)
-            {
-                return string.Join("_", branchName.Split(_invalidCharsInPath, StringSplitOptions.RemoveEmptyEntries)).TrimEnd('.');
-            }
+            string NormalizeBranchName(string branchName) => string.Join("_", branchName.Split(_invalidCharsInPath, StringSplitOptions.RemoveEmptyEntries)).TrimEnd('.');
         }
     }
 }

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -246,7 +246,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         private void buttonCreateNewWorktree_Click(object sender, EventArgs e)
         {
-            using FormCreateWorktree formCreateWorktree = new(UICommands);
+            using FormCreateWorktree formCreateWorktree = new(UICommands, _worktrees[0].Path);
             DialogResult dialogResult = formCreateWorktree.ShowDialog(this);
             if (dialogResult != DialogResult.OK)
             {


### PR DESCRIPTION
instead of the currently checked out worktree
that probably contains information related to the branch checked out

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The directory path  proposed for the new worktree is based on the current checked out worktree (so the path proposed could be strange if it contains the name of the branch in the path)

![image](https://user-images.githubusercontent.com/460196/197633364-eeecb08f-3f2d-48d4-9dad-b033ef5d7049.png)

### After

Whatever is the worktree checked out, the path proposed is based on the main git repo path

![image](https://user-images.githubusercontent.com/460196/197633865-0cb6dfec-a75b-419f-8536-489f4072fca6.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 33.33.33
- Build 3b780b4e400c7d0f56805fbdbfcb862acb4e8a05 (Dirty)
- Git 2.38.0.windows.1 (recommended: 2.38.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.10
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
