### PR TITLE
perf: ensure compiled regex are compiled only once

### DIFF
--- a/GitCommands/Git/AheadBehindDataProvider.cs
+++ b/GitCommands/Git/AheadBehindDataProvider.cs
@@ -18,7 +18,7 @@ namespace GitCommands.Git
 
         // Parse info about remote branches, see below for explanation
         // This assumes that the Git output is not localised
-        private readonly Regex _aheadBehindRegEx =
+        private static readonly Regex _aheadBehindRegEx =
             new(
                 @"^((?<gone_p>gone)|((ahead\s(?<ahead_p>\d+))?(,\s)?(behind\s(?<behind_p>\d+))?)|(?<unk_p>.*?))::
                    ((?<gone_u>gone)|((ahead\s(?<ahead_u>\d+))?(,\s)?(behind\s(?<behind_u>\d+))?)|(?<unk_u>.*?))::


### PR DESCRIPTION

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 24e8371e13366c9de155109d4a319ef0c044f9a1 (Dirty)
- Git 2.38.0.windows.1 (recommended: 2.38.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.10
- DPI 96dpi (no scaling)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
