### PR TITLE
FormBrowse: transform Settings button in split button for easy access…

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -57,7 +57,7 @@ namespace GitUI.CommandsDialogs
             toolStripSeparator2 = new ToolStripSeparator();
             toolStripFileExplorer = new ToolStripButton();
             userShell = new ToolStripSplitButton();
-            EditSettings = new ToolStripButton();
+            EditSettings = new ToolStripSplitButton();
             MainSplitContainer = new SplitContainer();
             repoObjectsTree = new GitUI.LeftPanel.RepoObjectsTree();
             RightSplitContainer = new SplitContainer();
@@ -153,6 +153,9 @@ namespace GitUI.CommandsDialogs
             ToolStripFilters = new GitUI.UserControls.FilterToolBar();
             ToolStripScripts = new GitUI.ToolStripEx();
             pluginsLoadingToolStripMenuItem = new ToolStripMenuItem();
+            gitextSettingsToolStripMenuItem = new ToolStripMenuItem();
+            gitSettingsToolStripMenuItem = new ToolStripMenuItem();
+            pluginsSettingsToolStripMenuItem = new ToolStripMenuItem();
             toolStripSeparator14 = new ToolStripSeparator();
             toolStripSeparator11 = new ToolStripSeparator();
             ToolStripMain.SuspendLayout();
@@ -529,11 +532,15 @@ namespace GitUI.CommandsDialogs
             // EditSettings
             // 
             EditSettings.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            EditSettings.DropDownItems.AddRange(new ToolStripItem[] {
+                gitextSettingsToolStripMenuItem,
+                gitSettingsToolStripMenuItem,
+                pluginsSettingsToolStripMenuItem});
             EditSettings.Image = Properties.Images.Settings;
             EditSettings.Name = "EditSettings";
-            EditSettings.Size = new Size(23, 22);
+            EditSettings.Size = new Size(32, 22);
             EditSettings.ToolTipText = "Settings";
-            EditSettings.Click += OnShowSettingsClick;
+            EditSettings.ButtonClick += OnShowSettingsClick;
             // 
             // MainSplitContainer
             // 
@@ -1393,6 +1400,30 @@ namespace GitUI.CommandsDialogs
             pluginsLoadingToolStripMenuItem.Size = new Size(180, 22);
             pluginsLoadingToolStripMenuItem.Text = "Loading...";
             // 
+            // gitextSettingsToolStripMenuItem
+            // 
+            gitextSettingsToolStripMenuItem.Image = Properties.Images.GitExtensionsLogo16;
+            gitextSettingsToolStripMenuItem.Name = "gitextSettingsToolStripMenuItem";
+            gitextSettingsToolStripMenuItem.Size = new Size(180, 22);
+            gitextSettingsToolStripMenuItem.Text = "Git Extensions &settings";
+            gitextSettingsToolStripMenuItem.Click += GitextSettingsToolStripMenuItem_Click;
+            // 
+            // gitSettingsToolStripMenuItem
+            // 
+            gitSettingsToolStripMenuItem.Image = Properties.Images.GitLogo16;
+            gitSettingsToolStripMenuItem.Name = "gitSettingsToolStripMenuItem";
+            gitSettingsToolStripMenuItem.Size = new Size(180, 22);
+            gitSettingsToolStripMenuItem.Text = "&Git settings";
+            gitSettingsToolStripMenuItem.Click += gitSettingsToolStripMenuItem_Click;
+            // 
+            // pluginsSettingsToolStripMenuItem
+            // 
+            this.pluginsSettingsToolStripMenuItem.Image = Properties.Images.Plugin;
+            this.pluginsSettingsToolStripMenuItem.Name = "pluginsSettingsToolStripMenuItem";
+            this.pluginsSettingsToolStripMenuItem.Size = new Size(180, 22);
+            this.pluginsSettingsToolStripMenuItem.Text = "&Plugins settings";
+            this.pluginsSettingsToolStripMenuItem.Click += pluginsSettingsToolStripMenuItem_Click;
+            // 
             // FormBrowse
             // 
             AutoScaleDimensions = new SizeF(96F, 96F);
@@ -1438,7 +1469,6 @@ namespace GitUI.CommandsDialogs
             ResumeLayout(false);
             PerformLayout();
         }
-
         #endregion
 
         internal SplitContainer MainSplitContainer;
@@ -1473,7 +1503,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripSeparator toolStripSeparator1;
         private ToolStripSplitButton userShell;
         private ToolStripSeparator toolStripSeparator2;
-        private ToolStripButton EditSettings;
+        private ToolStripSplitButton EditSettings;
         private ToolStripButton RefreshButton;
         private ToolStripPushButton toolStripButtonPush;
         private ToolStripSplitButton toolStripSplitStash;
@@ -1575,5 +1605,8 @@ namespace GitUI.CommandsDialogs
         private UserControls.InteractiveGitActionControl notificationBarBisectInProgress;
         private UserControls.InteractiveGitActionControl notificationBarGitActionInProgress;
         private ToolStripMenuItem pluginsLoadingToolStripMenuItem;
+        private ToolStripMenuItem gitextSettingsToolStripMenuItem;
+        private ToolStripMenuItem gitSettingsToolStripMenuItem;
+        private ToolStripMenuItem pluginsSettingsToolStripMenuItem;
     }
 }

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -21,6 +21,7 @@ using GitExtUtils.GitUI.Theming;
 using GitUI.Avatars;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.CommandsDialogs.BrowseDialog.DashboardControl;
+using GitUI.CommandsDialogs.SettingsDialog;
 using GitUI.CommandsDialogs.WorktreeDialog;
 using GitUI.HelperDialogs;
 using GitUI.Infrastructure.Telemetry;
@@ -1476,10 +1477,16 @@ namespace GitUI.CommandsDialogs
 
         private void OnShowSettingsClick(object sender, EventArgs e)
         {
+            // Open settings on the last opened page
+            OpenSettings();
+        }
+
+        private void OpenSettings(SettingsPageReference? initialPage = null)
+        {
             string translation = AppSettings.Translation;
             CommitInfoPosition commitInfoPosition = AppSettings.CommitInfoPosition;
 
-            UICommands.StartSettingsDialog(this);
+            UICommands.StartSettingsDialog(this, initialPage);
 
             HandleSettingsChanged(translation, commitInfoPosition);
         }
@@ -1526,6 +1533,21 @@ namespace GitUI.CommandsDialogs
             _gitStatusMonitor.Active = NeedsGitStatusMonitor() && Module.IsValidGitWorkingDir();
 
             RefreshDefaultPullAction();
+        }
+
+        private void GitextSettingsToolStripMenuItem_Click(object sender, System.EventArgs e)
+        {
+            OpenSettings(SettingsDialog.Pages.GeneralSettingsPage.GetPageReference());
+        }
+
+        private void gitSettingsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            UICommands.StartRepoSettingsDialog(this);
+        }
+
+        private void pluginsSettingsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            UICommands.StartPluginSettingsDialog(this);
         }
 
         private void TagToolStripMenuItemClick(object sender, EventArgs e)
@@ -2121,7 +2143,7 @@ namespace GitUI.CommandsDialogs
                 case Command.OpenWithDifftool: OpenWithDifftool(); break;
                 case Command.OpenWithDifftoolFirstToLocal: OpenWithDifftoolFirstToLocal(); break;
                 case Command.OpenWithDifftoolSelectedToLocal: OpenWithDifftoolSelectedToLocal(); break;
-                case Command.OpenSettings: EditSettings.PerformClick(); break;
+                case Command.OpenSettings: OpenSettings(); break;
                 case Command.ToggleLeftPanel: toggleLeftPanel.PerformClick(); break;
                 case Command.EditFile: EditFile(); break;
                 case Command.OpenAsTempFile when fileTree.Visible: fileTree.ExecuteCommand(RevisionFileTreeControl.Command.OpenAsTempFile); break;

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -2678,8 +2678,16 @@ Do you want to continue?</source>
         <source>&amp;Git maintenance</source>
         <target />
       </trans-unit>
+      <trans-unit id="gitSettingsToolStripMenuItem.Text">
+        <source>&amp;Git settings</source>
+        <target />
+      </trans-unit>
       <trans-unit id="gitcommandLogToolStripMenuItem.Text">
         <source>Git &amp;command log</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="gitextSettingsToolStripMenuItem.Text">
+        <source>Git Extensions &amp;settings</source>
         <target />
       </trans-unit>
       <trans-unit id="helpToolStripMenuItem.Text">
@@ -2748,6 +2756,10 @@ Do you want to continue?</source>
       </trans-unit>
       <trans-unit id="pluginsLoadingToolStripMenuItem.Text">
         <source>Loading...</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="pluginsSettingsToolStripMenuItem.Text">
+        <source>&amp;Plugins settings</source>
         <target />
       </trans-unit>
       <trans-unit id="pluginsToolStripMenuItem.Text">


### PR DESCRIPTION
… of other settings

## Proposed changes

- The gear open the previously opened setting page or the general page the first time (like before)
- "Git Extensions settings" open the "General" page
- "Git settings" open the Git "config" page
- "Plugins settings" open the "Plugins page"

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

(just the gear)

### After

![image](https://user-images.githubusercontent.com/460196/197635299-757b8258-9fcc-4fed-8b57-03d923b8bab5.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual
- 
## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 33.33.33
- Build b78e768d55af39e5d79310d8f1b7e772cefcf30a (Dirty)
- Git 2.38.0.windows.1
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.10
- DPI 96dpi (no scaling)


<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
