### PR TITLE
FormBrowse: let the user add fetch/pull custom icons in the toolbar

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
@@ -197,7 +197,7 @@ namespace GitUI.CommandsDialogs
 
             return;
 
-            bool IsVisibleByDefault(string buttonKey) => !buttonKey.Contains(FilterToolBar.ReflogButtonName);
+            bool IsVisibleByDefault(string buttonKey) => !buttonKey.Contains(FilterToolBar.ReflogButtonName) && !buttonKey.Contains(FormBrowse.FetchPullToolbarShortcutsPrefix);
             static void SaveVisibilitySetting(string key, bool visible, bool defaultValue = true)
                 => AppSettings.SetBool(toolbarSettingsPrefix + key, visible == defaultValue ? null : visible);
             static bool LoadVisibilitySetting(string key, bool defaultValue = true)

--- a/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
@@ -12,6 +12,8 @@ namespace GitUI.CommandsDialogs
     {
         // This file is dedicated to init logic for FormBrowse menus and toolbars
 
+        internal static readonly string FetchPullToolbarShortcutsPrefix = "pull_shortcut_";
+
         private void InitMenusAndToolbars(string? revFilter, string? pathFilter)
         {
             commandsToolStripMenuItem.DropDownOpening += CommandsToolStripMenuItem_DropDownOpening;
@@ -43,6 +45,8 @@ namespace GitUI.CommandsDialogs
                 pushToolStripMenuItem,
                 branchToolStripMenuItem,
             }.ForEach(ColorHelper.AdaptImageLightness);
+
+            InsertFetchPullShortcuts();
 
             if (!EnvUtils.RunningOnWindows())
             {
@@ -136,6 +140,35 @@ namespace GitUI.CommandsDialogs
                     Debug.Assert(toolStrips[i].Left < toolStrips[i - 1].Left, $"{toolStrips[i - 1].Name} must be placed before {toolStrips[i].Name}");
                 }
 #endif
+            }
+        }
+
+        private void InsertFetchPullShortcuts()
+        {
+            int i = ToolStripMain.Items.IndexOf(toolStripButtonPull);
+            ToolStripMain.Items.Insert(i++, CreateCorrespondingToolbarButton(fetchToolStripMenuItem));
+            ToolStripMain.Items.Insert(i++, CreateCorrespondingToolbarButton(fetchAllToolStripMenuItem));
+            ToolStripMain.Items.Insert(i++, CreateCorrespondingToolbarButton(fetchPruneAllToolStripMenuItem));
+            ToolStripMain.Items.Insert(i++, CreateCorrespondingToolbarButton(mergeToolStripMenuItem));
+            ToolStripMain.Items.Insert(i++, CreateCorrespondingToolbarButton(rebaseToolStripMenuItem1));
+            ToolStripMain.Items.Insert(i++, CreateCorrespondingToolbarButton(pullToolStripMenuItem1));
+
+            ToolStripButton CreateCorrespondingToolbarButton(ToolStripMenuItem toolStripMenuItem)
+            {
+                string toolTipText = toolStripMenuItem.Text.Replace("&", string.Empty);
+                ToolStripButton clonedToolStripMenuItem = new()
+                {
+                    Image = toolStripMenuItem.Image,
+                    ImageTransparentColor = toolStripMenuItem.ImageTransparentColor,
+                    Name = FetchPullToolbarShortcutsPrefix + toolStripMenuItem.Name,
+                    Size = toolStripMenuItem.Size,
+                    Text = toolTipText,
+                    ToolTipText = toolTipText,
+                    DisplayStyle = ToolStripItemDisplayStyle.Image,
+                };
+
+                clonedToolStripMenuItem.Click += (_, _) => toolStripMenuItem.PerformClick();
+                return clonedToolStripMenuItem;
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Improvement over #3923

## Proposed changes

- The user is able to add a direct access button for the fetch/pull actions he wants (because split button is painful to use on high resolution screens)
- By default, the button are not displayed, so nothing changed

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

Configuration:

![image](https://user-images.githubusercontent.com/460196/197841710-015cd4d3-df78-4d60-b4b2-31bc33f5b664.png)

Result (because I want a fetch button distinct of a pull button --like in all the other git GUIs--):

![image](https://user-images.githubusercontent.com/460196/197841883-46bcd0d7-1082-469b-95a9-47803313cecb.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build b5ec77dbdf12b00702b5212419a369e6a536bc9b
- Git 2.38.0.windows.1 (recommended: 2.38.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.10
- DPI 96dpi (no scaling)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
