### PR TITLE
FormBrowse: Hide Reflog button by default

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using GitCommands;
 using GitUI.CommandsDialogs.BrowseDialog;
+using GitUI.UserControls;
 using Microsoft;
 using ResourceManager;
 
@@ -153,7 +154,8 @@ namespace GitUI.CommandsDialogs
                     key = toolbarItem.Name;
                 }
 
-                bool visible = LoadVisibilitySetting(key);
+                bool visible = LoadVisibilitySetting(key, IsVisibleByDefault(key));
+
                 toolbarItem.Visible = visible;
 
                 ToolStripMenuItem menuToolbarItem = new(toolbarItem.ToolTipText)
@@ -170,11 +172,11 @@ namespace GitUI.CommandsDialogs
 
                     if (!BelongToAGroup(toolbarItem, out var group))
                     {
-                        SaveVisibilitySetting(toolbarItem.Name, toolbarItem.Visible);
+                        SaveVisibilitySetting(toolbarItem.Name, toolbarItem.Visible, IsVisibleByDefault(toolbarItem.Name));
                     }
                     else
                     {
-                        SaveVisibilitySetting(group, toolbarItem.Visible);
+                        SaveVisibilitySetting(group, toolbarItem.Visible, IsVisibleByDefault(toolbarItem.Name));
                         foreach (ToolStripItem item in senderToolStrip.Items)
                         {
                             if (item.Tag == (object)group)
@@ -195,8 +197,11 @@ namespace GitUI.CommandsDialogs
 
             return;
 
-            static void SaveVisibilitySetting(string key, bool visible) => AppSettings.SetBool(toolbarSettingsPrefix + key, visible ? null : false);
-            static bool LoadVisibilitySetting(string key) => AppSettings.GetBool(toolbarSettingsPrefix + key, true);
+            bool IsVisibleByDefault(string buttonKey) => !buttonKey.Contains(FilterToolBar.ReflogButtonName);
+            static void SaveVisibilitySetting(string key, bool visible, bool defaultValue = true)
+                => AppSettings.SetBool(toolbarSettingsPrefix + key, visible == defaultValue ? null : visible);
+            static bool LoadVisibilitySetting(string key, bool defaultValue = true)
+                => AppSettings.GetBool(toolbarSettingsPrefix + key, defaultValue);
 
             static bool BelongToAGroup(ToolStripItem toolbarItem, out string groupName)
             {

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -8,6 +8,7 @@ namespace GitUI.UserControls
 {
     internal partial class FilterToolBar : ToolStripEx
     {
+        internal const string ReflogButtonName = nameof(tsbShowReflog);
         private static readonly string[] _noResultsFound = { TranslatedStrings.NoResultsFound };
         private Func<IGitModule>? _getModule;
         private IRevisionGridFilter? _revisionGridFilter;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Alternative to #10235

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/197865711-551bad50-56a0-4713-88e0-98e43d7be9cd.png)

### After

By default:

![image](https://user-images.githubusercontent.com/460196/197865602-42f9b96e-6abf-4dfd-b3cd-1245490c5747.png)

![image](https://user-images.githubusercontent.com/460196/197865674-ba761a5f-ca46-46ee-89e7-9d2655d01f48.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 80f823749a6fda767bd547af21b8f460d4b391e8
- Git 2.38.0.windows.1 (recommended: 2.38.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.10
- DPI 96dpi (no scaling)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
