### PR TITLE
range-diff with path filter

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2427,6 +2427,7 @@ namespace GitCommands
             ObjectId? firstBase,
             ObjectId? secondBase,
             string extraDiffArguments,
+            string? pathFilter,
             CancellationToken cancellationToken)
         {
             // range-diff is not possible for artificial commits, use HEAD
@@ -2445,7 +2446,9 @@ namespace GitCommands
                 "--find-copies",
                 { AppSettings.UseHistogramDiffAlgorithm, "--histogram" },
                 extraDiffArguments,
-                { firstBase is null || secondBase is null,  $"{first}...{second}", $"{firstBase}..{first} {secondBase}..{second}" }
+                { firstBase is null || secondBase is null,  $"{first}...{second}", $"{firstBase}..{first} {secondBase}..{second}" },
+                { GitVersion.SupportRangeDiffPath && !string.IsNullOrWhiteSpace(pathFilter), "--" },
+                { GitVersion.SupportRangeDiffPath && !string.IsNullOrWhiteSpace(pathFilter), pathFilter }
             };
 
             ExecutionResult result = await _gitExecutable.ExecuteAsync(

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -121,6 +121,7 @@ namespace GitCommands
         public bool SupportRangeDiffTool => this >= v2_19_0;
         public bool SupportStashStaged => this >= v2_35_0;
         public bool SupportUpdateRefs => this >= v2_38_0;
+        public bool SupportRangeDiffPath => this >= v2_38_0;
 
         public bool IsUnknown => _a == 0 && _b == 0 && _c == 0 && _d == 0;
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -577,6 +577,7 @@ namespace GitUI.CommandsDialogs
 
             await DiffText.ViewChangesAsync(DiffFiles.SelectedItem,
                 openWithDiffTool: () => firstToSelectedToolStripMenuItem.PerformClick(),
+                additionalCommandInfo: (DiffFiles.SelectedItem?.Item?.IsRangeDiff is true) && Module.GitVersion.SupportRangeDiffPath ? _revisionGrid.CurrentFilter.PathFilter : "",
                 cancellationToken: _viewChangesSequence.Next());
         }
 

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -19,12 +19,14 @@ namespace GitUI
         /// <param name="item">The FileStatusItem to present changes for.</param>
         /// <param name="defaultText">default text if no diff is possible.</param>
         /// <param name="openWithDiffTool">The difftool command to open with.</param>
+        /// <param name="additionalCommandInfo">If the diff is range-diff, this contains the current path filter.</param>
         /// <returns>Task to view.</returns>
         public static async Task ViewChangesAsync(this FileViewer fileViewer,
             FileStatusItem? item,
             CancellationToken cancellationToken,
             string defaultText = "",
-            Action? openWithDiffTool = null)
+            Action? openWithDiffTool = null,
+            string additionalCommandInfo = null)
         {
             if (item?.Item.IsStatusOnly ?? false)
             {
@@ -63,8 +65,7 @@ namespace GitUI
                 string range = item.BaseA is null || item.BaseB is null
                     ? $"{firstId}...{item.SecondRevision.ObjectId}"
                     : $"{item.BaseA}..{firstId} {item.BaseB}..{item.SecondRevision.ObjectId}";
-
-                await fileViewer.ViewTextAsync("git-range-diff.sh", $"git range-diff {range}");
+                await fileViewer.ViewTextAsync("git-range-diff.sh", $"git range-diff {range} -- {additionalCommandInfo}");
 
                 string output = await fileViewer.Module.GetRangeDiffAsync(
                         firstId,
@@ -72,6 +73,7 @@ namespace GitUI
                         item.BaseA,
                         item.BaseB,
                         fileViewer.GetExtraDiffArguments(isRangeDiff: true),
+                        additionalCommandInfo,
                         cancellationToken);
 
                 // Try set highlighting from first found filename


### PR DESCRIPTION
## Proposed changes

Use new feature in Git 2.38

A use case for the feature: Check differences from release/4.0 to master

range-diff is a great way to compare branches, but is too slow when there are many changes.
Displaying the diff requires a long time (I gave up after 6 minutes)
![image](https://user-images.githubusercontent.com/6248932/197891157-e4b4c338-9740-498b-bc40-ddc2ea3fb667.png)

There are still few changes in source files.
![image](https://user-images.githubusercontent.com/6248932/197891363-010e6fac-3106-4c84-8f9f-64722c89f117.png)

To find where the changes occurs is very hard though.
Also the range-diff is likely to be huge here, just the different commit messages will be hard to filter manually.

Git 2.38 adds the possibility to filter by path.
(It is not possible to filter several paths in the GUI even if paths can be manually entered in the form - a separate feature in RevDiff).

If filtering for  FormManageWorktree.cs, range-diff displays within a second.
FormManageWorktree.cs has appeared in 5 "pairs" of commits, 1:/-: just applied in a different order, 3: is identical except for the commit message, these can relative easily be visually filtered.
4:, 5: are missing in 4.0

![image](https://user-images.githubusercontent.com/6248932/197893451-29524ba5-60df-4294-8a8f-53f957ce0246.png)

## Screenshots <!-- Remove this section if PR does not change UI -->

See above.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.38, 2.25 in wsl

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
