### PR TITLE
Have alternate merge strategies help button point to online manual

### DIFF
--- a/GitUI/CommandsDialogs/FormMergeBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.Designer.cs
@@ -29,7 +29,6 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.strategyToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.Ok = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
@@ -61,16 +60,6 @@
             this.flowLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nbMessages)).BeginInit();
             this.SuspendLayout();
-            // 
-            // strategyToolTip
-            // 
-            this.strategyToolTip.AutomaticDelay = 100;
-            this.strategyToolTip.AutoPopDelay = 0;
-            this.strategyToolTip.InitialDelay = 1;
-            this.strategyToolTip.ReshowDelay = 1;
-            this.strategyToolTip.ShowAlways = true;
-            this.strategyToolTip.UseAnimation = false;
-            this.strategyToolTip.UseFading = false;
             // 
             // Ok
             // 
@@ -454,7 +443,6 @@
 
         #endregion
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.ToolTip strategyToolTip;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private Help.HelpImageDisplayUserControl helpImageDisplayUserControl1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -13,7 +13,6 @@ namespace GitUI.CommandsDialogs
     /// <summary>Form to merge a branch into the current branch.</summary>
     public partial class FormMergeBranch : GitModuleForm
     {
-        private readonly TranslationString _strategyTooltipText = new("resolve " + Environment.NewLine + "This can only resolve two heads (i.e. the current branch and another branch you pulled from) using a 3-way merge algorithm." + Environment.NewLine + "It tries to carefully detect criss-cross merge ambiguities and is considered generally safe and fast. " + Environment.NewLine + Environment.NewLine + "recursive " + Environment.NewLine + "This can only resolve two heads using a 3-way merge algorithm. When there is more than one common ancestor that can be " + Environment.NewLine + "used for 3-way merge, it creates a merged tree of the common ancestors and uses that as the reference tree for the 3-way" + Environment.NewLine + "merge. Additionally this can detect and handle merges involving renames. This is the default merge strategy when pulling or " + Environment.NewLine + "merging one branch. " + Environment.NewLine + Environment.NewLine + "octopus " + Environment.NewLine + "This resolves cases with more than two heads, but refuses to do a complex merge that needs manual resolution. It is " + Environment.NewLine + "primarily meant to be used for bundling topic branch heads together. This is the default merge strategy when pulling or " + Environment.NewLine + "merging more than one branch. " + Environment.NewLine + Environment.NewLine + "ours " + Environment.NewLine + "This resolves any number of heads, but the resulting tree of the merge is always that of the current branch head, effectively " + Environment.NewLine + "ignoring all changes from all other branches. It is meant to be used to supersede old development history of side branches." + Environment.NewLine + Environment.NewLine + "subtree " + Environment.NewLine + "This is a modified recursive strategy. When merging trees A and B, if B corresponds to a subtree of A, B is first adjusted to " + Environment.NewLine + "match the tree structure of A, instead of reading the trees at the same level. This adjustment is also done to the common " + Environment.NewLine + "ancestor tree.");
         private readonly TranslationString _formMergeBranchHoverShowImageLabelText = new("Hover to see scenario when fast forward is possible.");
         private readonly string? _defaultBranch;
         private ICommitMessageManager _commitMessageManager;
@@ -144,7 +143,8 @@ namespace GitUI.CommandsDialogs
 
         private void strategyHelp_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            strategyToolTip.SetToolTip(strategyHelp, _strategyTooltipText.Text);
+            OsShellUtil.OpenUrlInDefaultBrowser(
+                UserManual.UserManual.UrlFor("branches", "advanced-merge-options"));
         }
 
         private void advanced_CheckedChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormMergeBranch.resx
+++ b/GitUI/CommandsDialogs/FormMergeBranch.resx
@@ -117,7 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="strategyToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
 </root>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5715,32 +5715,6 @@ command "git help shortlog"</source>
         <source>Hover to see scenario when fast forward is possible.</source>
         <target />
       </trans-unit>
-      <trans-unit id="_strategyTooltipText.Text">
-        <source>resolve 
-This can only resolve two heads (i.e. the current branch and another branch you pulled from) using a 3-way merge algorithm.
-It tries to carefully detect criss-cross merge ambiguities and is considered generally safe and fast. 
-
-recursive 
-This can only resolve two heads using a 3-way merge algorithm. When there is more than one common ancestor that can be 
-used for 3-way merge, it creates a merged tree of the common ancestors and uses that as the reference tree for the 3-way
-merge. Additionally this can detect and handle merges involving renames. This is the default merge strategy when pulling or 
-merging one branch. 
-
-octopus 
-This resolves cases with more than two heads, but refuses to do a complex merge that needs manual resolution. It is 
-primarily meant to be used for bundling topic branch heads together. This is the default merge strategy when pulling or 
-merging more than one branch. 
-
-ours 
-This resolves any number of heads, but the resulting tree of the merge is always that of the current branch head, effectively 
-ignoring all changes from all other branches. It is meant to be used to supersede old development history of side branches.
-
-subtree 
-This is a modified recursive strategy. When merging trees A and B, if B corresponds to a subtree of A, B is first adjusted to 
-match the tree structure of A, instead of reading the trees at the same level. This adjustment is also done to the common 
-ancestor tree.</source>
-        <target />
-      </trans-unit>
       <trans-unit id="addLogMessages.Text">
         <source>Add log messages</source>
         <target />


### PR DESCRIPTION
Move merge strategies help tooltip to online documentation, open link on click

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9259

See proposed documentation changes here (and complete the doc PR prior to this PR):
https://github.com/gitextensions/GitExtensionsDoc/pull/144

## Proposed changes

- the help button next to the alternate merge strategies selector in the branch merge advanced options will now open the online documentation when clicked (rather than showing a length tooltip that fades in a relatively short amount of time)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/14078392/198154264-2091c7bc-9e6c-4a30-a8c6-8066c134eb9d.png)

### After

There is no longer a tooltip and clicking the Help link brings us to https://git-extensions-documentation.readthedocs.io/en/main/branches.html#advanced-merge-options

![image](https://user-images.githubusercontent.com/14078392/198154578-16bfd69d-ff99-45ae-aedb-2ffa1e6f52f4.png)


## Test methodology <!-- How did you ensure quality? -->

- tested the link to see if it goes to an appropriate URL, verified it will bring us to the correct URL once the doc page update goes in

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 10

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
