### PR TITLE
#6564 - make labels in putty "please load key" modal not overlap

### DIFF
--- a/GitUI/FormPuttyError.Designer.cs
+++ b/GitUI/FormPuttyError.Designer.cs
@@ -43,7 +43,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.lblMustAuthenticate.Location = new System.Drawing.Point(65, 47);
             this.lblMustAuthenticate.Name = "lblMustAuthenticate";
-            this.lblMustAuthenticate.Size = new System.Drawing.Size(258, 22);
+            this.lblMustAuthenticate.AutoSize = true;
             this.lblMustAuthenticate.TabIndex = 3;
             this.lblMustAuthenticate.Text = "You must authenticate to run this command.";
             // 
@@ -89,7 +89,7 @@
             this.lblPleaseLoadKey.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
             this.lblPleaseLoadKey.Location = new System.Drawing.Point(64, 18);
             this.lblPleaseLoadKey.Name = "lblPleaseLoadKey";
-            this.lblPleaseLoadKey.Size = new System.Drawing.Size(259, 34);
+            this.lblPleaseLoadKey.AutoSize = true;
             this.lblPleaseLoadKey.TabIndex = 2;
             this.lblPleaseLoadKey.Text = "Please load your SSH private key";
             // 

--- a/contributors.txt
+++ b/contributors.txt
@@ -180,3 +180,4 @@ YYYY/MM/DD, github id, Full name, email
 2022/08/23, huangsunyang, SunYang Huang, huangsunyang(at)126.com
 2022/10/03, ralphromero, Ralph Romero, ralph(at)romero.id.au
 2022/10/15, TanukiSharp, Sebastien ROBERT, sebastien.saigo(at)gmail.com
+2022/10/26, zachesposito, Zach Esposito, zach(at)zachesposito.me


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6564 

## Proposed changes

- Reduce height of top label

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/1486613/198174422-c4d017bf-5861-4ed9-99eb-e63bc2f93d73.png)

### After
![image](https://user-images.githubusercontent.com/1486613/198174441-c3190aad-ddce-4c8c-ae72-13a7dc3eb001.png)

## Test methodology 
Manual verification. To reproduce:
* Install PuTTY
* Configure PuTTY for SSH in settings
* Attempt to fetch a repo with an SSH URL, without an SSH key set up

## Test environment(s)

- GIT version 2.35.1.windows.2
- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
