### PR TITLE
RevDiff: Allow path filter for several files

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
@@ -103,7 +103,7 @@ namespace GitUI.CommandsDialogs
 
                 if (!string.IsNullOrWhiteSpace(pathFilter))
                 {
-                    SetPathFilter(pathFilter);
+                    SetPathFilter(pathFilter.QuoteNE());
                 }
             }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -641,9 +641,13 @@ namespace GitUI.CommandsDialogs
 
         #endregion
 
+        /// <summary>
+        /// Set the path filter.
+        /// </summary>
+        /// <param name="pathFilter">Zero or more quoted paths, separated by spaces.</param>
         public void SetPathFilter(string pathFilter)
         {
-            RevisionGrid.SetAndApplyPathFilter(pathFilter.QuoteNE());
+            RevisionGrid.SetAndApplyPathFilter(pathFilter);
         }
 
         private void ShowDashboard()

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -654,7 +654,7 @@ namespace GitUI.CommandsDialogs
 
         private void diffFilterFileInGridToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            (FindForm() as FormBrowse)?.SetPathFilter(DiffFiles.SelectedItems.First().Item.Name.ToPosixPath());
+            (FindForm() as FormBrowse)?.SetPathFilter(string.Join(" ", DiffFiles.SelectedItems.Select(f => f.Item.Name.ToPosixPath().QuoteNE())));
         }
 
         private void UpdateStatusOfMenuItems()
@@ -719,7 +719,7 @@ namespace GitUI.CommandsDialogs
 
             // Visibility of FileTree is not known, assume (CommitInfoTabControl.Contains(TreeTabPage);)
             diffShowInFileTreeToolStripMenuItem.Visible = _revisionDiffController.ShouldShowMenuShowInFileTree(selectionInfo);
-            diffFilterFileInGridToolStripMenuItem.Enabled = _revisionDiffController.ShouldShowMenuFileHistory(selectionInfo);
+            diffFilterFileInGridToolStripMenuItem.Enabled = _revisionDiffController.ShouldShowResetFileMenus(selectionInfo);
             fileHistoryDiffToolstripMenuItem.Enabled = _revisionDiffController.ShouldShowMenuFileHistory(selectionInfo);
             blameToolStripMenuItem.Enabled = AppSettings.UseDiffViewerForBlame.Value
                 ? _revisionDiffController.ShouldShowMenuBlame(selectionInfo)

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -564,7 +564,7 @@ See the changes in the commit form.");
         {
             if (TryGetSelectedName(out string name))
             {
-                (FindForm() as FormBrowse)?.SetPathFilter(name.ToPosixPath());
+                (FindForm() as FormBrowse)?.SetPathFilter(name.ToPosixPath().QuoteNE());
             }
         }
 


### PR DESCRIPTION
Companion to #10295 

## Proposed changes

Allow multi select files in rev diff to filter multiple files. See #10295 for a use case.
It is possible to filter folders in file tree today, but no GUI way to select multiple files.
Multiple files can be added in the advanced filter form though.
The first file is visible in the title
![image](https://user-images.githubusercontent.com/6248932/198745218-b22a5d3f-b8c3-495d-866f-909d33192d03.png)
All files are visible in the tool tip
![image](https://user-images.githubusercontent.com/6248932/198745410-1f9ceb48-57c8-4c23-ab2e-ec858cdb58f3.png)

This exposes the possibility to add several files in rev diff file status list.
I believe this covers the important use case, I have thought about some enhancements and rejected them:

- Possibility to add/remove files to the filter in any form. 
  Adding would be simple, but not so easy to explain in the menu.
- Context menu to remove files in the filter in any form. 
  Would require some data structure changes (files stored as string right now), easier to understand in context menus though.
- Multi-select files in FileTree
  Not enabled now.
- Open a separate window (browse or old file history) with the selected files.
  Possible, but would require some call changes.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Multiselect disables file filters.

### After

![image](https://user-images.githubusercontent.com/6248932/198746508-25e2e4a5-7719-470b-84a1-9a54720ffa6c.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
