### PR TITLE
Misc fixes

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -59,8 +59,8 @@ namespace GitUI.BranchTreePanel
             bool isSingleTreeSelected = hasSingleSelection && selectedNode is Tree;
             TreeNode treeNode = (selectedNode as Tree)?.TreeViewNode;
             mnubtnMoveUp.Visible = mnubtnMoveDown.Visible = isSingleTreeSelected;
-            mnubtnMoveUp.Enabled = isSingleTreeSelected && treeNode.PrevNode is not null;
-            mnubtnMoveDown.Enabled = isSingleTreeSelected && treeNode.NextNode is not null;
+            mnubtnMoveUp.Enabled = isSingleTreeSelected && treeNode?.PrevNode is not null;
+            mnubtnMoveDown.Enabled = isSingleTreeSelected && treeNode?.NextNode is not null;
         }
 
         private void EnableRemoteBranchContextMenu(bool hasSingleSelection, NodeBase selectedNode)

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -57,7 +57,7 @@ namespace GitUI.BranchTreePanel
         private void EnableMoveTreeUpDownContexMenu(bool hasSingleSelection, NodeBase selectedNode)
         {
             bool isSingleTreeSelected = hasSingleSelection && selectedNode is Tree;
-            TreeNode treeNode = (selectedNode as Tree)?.TreeViewNode;
+            TreeNode? treeNode = (selectedNode as Tree)?.TreeViewNode;
             mnubtnMoveUp.Visible = mnubtnMoveDown.Visible = isSingleTreeSelected;
             mnubtnMoveUp.Enabled = isSingleTreeSelected && treeNode?.PrevNode is not null;
             mnubtnMoveDown.Enabled = isSingleTreeSelected && treeNode?.NextNode is not null;

--- a/GitUI/UserControls/RevisionGrid/IndexWatcher.cs
+++ b/GitUI/UserControls/RevisionGrid/IndexWatcher.cs
@@ -55,7 +55,7 @@ namespace GitUI.UserControls.RevisionGrid
 
                     GitIndexWatcher.Path = _gitDirPath;
                     GitIndexWatcher.Filter = "index";
-                    GitIndexWatcher.NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.LastWrite | NotifyFilters.CreationTime;
+                    GitIndexWatcher.NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.LastWrite;
                     GitIndexWatcher.IncludeSubdirectories = false;
                     GitIndexWatcher.EnableRaisingEvents = _enabled;
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Small fixes

## Proposed changes

- Remove duplicate sub-expression when setting GitIndexWatcher.NotifyFilter (might be a bug?)
- Treat treeNode value as nullable

## Test methodology <!-- How did you ensure quality? -->

- Ran unit tests
- Compiled and ran the application

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.38
- Windows 10

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
