### PR TITLE
Fixup standalone blame

### DIFF
--- a/GitExtensions/Properties/launchSettings.json
+++ b/GitExtensions/Properties/launchSettings.json
@@ -6,6 +6,10 @@
     },
     "Dashboard": {
       "commandName": "Project"
+    },
+    "Blame": {
+      "commandName": "Project",
+      "commandLineArgs": "blame GitExtensions.settings"
     }
   }
 }

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -247,7 +247,7 @@ namespace GitUI.Blame
                 return;
             }
 
-            var newBlameLine = _blame.Lines[selectedLine];
+            GitBlameLine newBlameLine = _blame.Lines[selectedLine];
 
             if (ReferenceEquals(_lastBlameLine?.Commit, newBlameLine.Commit))
             {
@@ -255,7 +255,8 @@ namespace GitUI.Blame
             }
 
             _lastBlameLine = newBlameLine;
-            CommitInfo.Revision = _revGrid.GetActualRevision(_lastBlameLine.Commit.ObjectId);
+            ObjectId objectId = _lastBlameLine.Commit.ObjectId;
+            CommitInfo.Revision = _revGrid is null ? Module.GetRevision(objectId) : _revGrid.GetActualRevision(objectId);
         }
 
         private void BlameAuthor_HScrollPositionChanged(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #10314

## Proposed changes

- BlameControl: Restore operation on line selection if used without RevisionGrid

(other usages of ``_revGrid` do not apply for the standalone blame window) 

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 1a72b10cd7da0df44f38fbaff9105ebfc75c724b
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.9
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).