### PR TITLE
Fixed an issue that caused an exception when switching languages.(#10332)

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -218,7 +218,7 @@ namespace GitUI.UserControls.RevisionGrid
                 //
                 // After refactoring the three items should be added to RevisionGrid
                 // as done with "ShowRemoteBranches" and not via RevisionGrid.Designer.cs
-                MenuCommand.CreateGroupHeader(TranslatedStrings.Branches),
+                MenuCommand.CreateGroupHeader("Branches"),
                 new MenuCommand
                 {
                     Name = "ShowAllBranches",

--- a/contributors.txt
+++ b/contributors.txt
@@ -181,3 +181,4 @@ YYYY/MM/DD, github id, Full name, email
 2022/10/03, ralphromero, Ralph Romero, ralph(at)romero.id.au
 2022/10/15, TanukiSharp, Sebastien ROBERT, sebastien.saigo(at)gmail.com
 2022/10/26, zachesposito, Zach Esposito, zach(at)zachesposito.me
+2022/11/07, Dub1shu, Kazuki Watanabe, dubian1shu(at)gmail.com


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10332

## Proposed changes

- Prevent exceptions from being thrown when switching languages.
    - The CreateGroupHeader function in MenuCommand.cs does not expect different strings to be entered depending on the language. 
    - Change it to enter a fixed string so that no exception occurs.
    - ~~Displaying commands in the View menu in multiple languages probably requires another fix.~~

## Test methodology <!-- How did you ensure quality? -->

- Switch language, no exceptions(manual test)
- I ran automated tests and found no new errors with this fix.

## Test environment(s) <!-- Remove any that don't apply -->

- Git version 2.38.1.windows.1
- Windows 11 Pro 21H2 22000.1098

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
