### PR TITLE
SidePanel: AheadBehind null check

### DIFF
--- a/GitCommands/Git/AheadBehindDataProvider.cs
+++ b/GitCommands/Git/AheadBehindDataProvider.cs
@@ -46,13 +46,14 @@ namespace GitCommands.Git
                 return null;
             }
 
-            // Callers setting branchname has the responisibility to ensure that not all are needed
+            // Callers setting branchname has the responsibility to ensure that not all are needed
             if (string.IsNullOrWhiteSpace(branchName) && !string.IsNullOrWhiteSpace(_branchName))
             {
                 // Debug.Fail($"Unexpectedly call for all branches after cache filled with specific branch {_branchName}");
                 ResetCache();
             }
 
+            // Use Lazy<> to syncronize callers
             _lazyData ??= new(() => GetData(null, branchName));
             _branchName = branchName;
             return _lazyData.Value;

--- a/GitUI/BranchTreePanel/RemoteBranchTree.cs
+++ b/GitUI/BranchTreePanel/RemoteBranchTree.cs
@@ -23,7 +23,7 @@ namespace GitUI.BranchTreePanel
             // More than one local can point to a single remote branch, pick one of them.
             Nodes nodes = new(this);
             Dictionary<string, BaseRevisionNode> pathToNodes = new();
-            var aheadBehindData = _aheadBehindDataProvider?.GetData().DistinctBy(r => r.Value.RemoteRef).ToDictionary(r => r.Value.RemoteRef, r => r.Value);
+            IDictionary<string, AheadBehindData>? aheadBehindData = _aheadBehindDataProvider?.GetData()?.DistinctBy(r => r.Value.RemoteRef).ToDictionary(r => r.Value.RemoteRef, r => r.Value);
 
             List<RemoteRepoNode> enabledRemoteRepoNodes = new();
             Dictionary<string, Remote> remoteByName = ThreadHelper.JoinableTaskFactory.Run(async () => (await Module.GetRemotesAsync()).ToDictionary(r => r.Name));

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -906,7 +906,7 @@ namespace GitUI.CommandsDialogs
 
                     _formBrowseMenus.InsertRevisionGridMainMenuItems(repositoryToolStripMenuItem);
 
-                    // Request for all branches if side panel is shown
+                    // Request all branches if side panel is shown
                     var aheadBehindData = _aheadBehindDataProvider?.GetData(MainSplitContainer.Panel1Collapsed ? RevisionGrid.CurrentBranch.Value : "");
                     toolStripButtonPush.DisplayAheadBehindInformation(aheadBehindData, RevisionGrid.CurrentBranch.Value);
 


### PR DESCRIPTION
## Proposed changes

aheadBehindData is null when this info is not shown and the grouping of the data fails.
For some reason I only see this in Debug builds, but it should go into master and 4.0.1 as well (if only to not see this when debugging).

Some comments from a late review comment
https://github.com/gitextensions/gitextensions/pull/10258#discussion_r1004968924

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
