### PR TITLE
GitFlow: Do not throw if git-flow is not init

### DIFF
--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -49,7 +49,8 @@ namespace GitExtensions.Plugins.GitFlow
                     "--get",
                     "gitflow.branch.master"
                 };
-                return !string.IsNullOrWhiteSpace(_gitUiCommands.GitModule.GitExecutable.GetOutput(args));
+                ExecutionResult exec = _gitUiCommands.GitModule.GitExecutable.Execute(args, throwOnErrorExit: false);
+                return exec.ExitedSuccessfully && !string.IsNullOrWhiteSpace(exec.StandardOutput);
             }
         }
 


### PR DESCRIPTION
Fixes #10334

## Proposed changes

git-config returns exit code 1 if the key cannot be found.
#9056 requires all error exit to be explicitly suppressed to not raise the exception. 
As the result was empty in this situation this was handled (but if something was added to the error output, this would have failed...).

## Test methodology <!-- How did you ensure quality? -->

Started git-flow plugin without having git-flow init.
(the init button is the only available button).

![image](https://user-images.githubusercontent.com/6248932/200143050-accc9574-bcee-4b26-b399-9eefa121cf36.png)

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
