### PR TITLE
RemoteNames: Do not throw outside repos when cloning

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2245,13 +2245,13 @@ namespace GitCommands
                 });
         }
 
-        public IReadOnlyList<string> GetRemoteNames()
+        public IReadOnlyList<string> GetRemoteNames(bool throwOnErrorExit = true)
         {
-            return _gitExecutable
-                .Execute("remote")
-                .StandardOutput
-                .LazySplit('\n', StringSplitOptions.RemoveEmptyEntries)
-                .ToList();
+            ExecutionResult result = _gitExecutable.Execute("remote", throwOnErrorExit: throwOnErrorExit);
+            return result.ExitedSuccessfully
+               ? result.StandardOutput.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries)
+                .ToList()
+               : Array.Empty<string>();
         }
 
         private static readonly Regex _remoteVerboseLineRegex = new(@"^(?<name>[^	]+)\t(?<url>.+?) \((?<direction>fetch|push)\)$", RegexOptions.Compiled);

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -114,7 +114,7 @@ namespace GitUI.CommandsDialogs
                     var currentBranchRemote = Module.GetSetting(string.Format(SettingKeyString.BranchRemote, Module.GetSelectedBranch()));
                     if (string.IsNullOrEmpty(currentBranchRemote))
                     {
-                        var remotes = Module.GetRemoteNames();
+                        var remotes = Module.GetRemoteNames(throwOnErrorExit: false);
 
                         if (remotes.Any(s => s.Equals("origin", StringComparison.InvariantCultureIgnoreCase)))
                         {

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -107,8 +107,9 @@ namespace GitUIPluginInterfaces
         /// <summary>
         /// Retrieves registered remotes by running <c>git remote show</c> command.
         /// </summary>
+        /// <param name="throwOnErrorExit">Throw if the Git command exits with an error.</param>
         /// <returns>Registered remotes.</returns>
-        IReadOnlyList<string> GetRemoteNames();
+        IReadOnlyList<string> GetRemoteNames(bool throwOnErrorExit = true);
 
         /// <summary>
         /// Gets the commit ID of the currently checked out commit.

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -559,6 +559,20 @@ namespace GitCommandsTests
         }
 
         [Test]
+        public void GetRemoteNamesNoThrowOutsideRepoIfSet()
+        {
+            var remotes = new GitModule(@"c:\").GetRemoteNames(throwOnErrorExit: false);
+
+            Assert.AreEqual(Array.Empty<string>(), remotes);
+        }
+
+        [Test]
+        public void GetRemoteNamesThrowOutsideRepo()
+        {
+            Assert.Throws<GitExtUtils.ExternalOperationException>(() => new GitModule(@"c:\").GetRemoteNames(throwOnErrorExit: true));
+        }
+
+        [Test]
         public void GetParents_calls_correct_command_and_parses_response()
         {
             GitArgumentBuilder args = new("rev-parse")


### PR DESCRIPTION
Fixes #10329
Fixes #10349

## Proposed changes

FormClone can be executed outside a repo and git-remote will then throw.
This is now handled.

## Test methodology <!-- How did you ensure quality? -->

Added a test to check the throw. Not too happy about it as it assumes that c:\ exists.
Therefore suggest that this test is disabled in Release.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
