### PR TITLE
Retain only Microsoft.WindowsDesktop.App in *.runtimeconfig.json

### DIFF
--- a/GitExtensions/Project.Publish.targets
+++ b/GitExtensions/Project.Publish.targets
@@ -103,6 +103,22 @@
 
   <!--
     ============================================================
+                       _PatchRuntimeConfigJson
+
+    Retain only the reference to Microsoft.WindowsDesktop.App in the packaged *.runtimeconfig.json.
+    See https://github.com/gitextensions/gitextensions/issues/10337 for more details.
+    ============================================================
+    -->
+    <Target Name="_PatchRuntimeConfigJson" AfterTargets="Publish">
+      <ItemGroup>
+        <RuntimeConfigJsonFiles Include="$(AppPublishDir)\*.runtimeconfig.json"/>
+      </ItemGroup>
+  
+      <Exec Command="powershell.exe $(RepoRoot)\scripts\Patch-RuntimeConfigJsonFiles.ps1 '@(RuntimeConfigJsonFiles)'" />
+    </Target>
+  
+  <!--
+    ============================================================
                        _EnsureBundleContent
 
     Copies all necessary files for the pack step.
@@ -201,7 +217,9 @@
   <!-- Any errors in targets that executed as 'AfterTargets' don't break the build: https://github.com/microsoft/msbuild/issues/3345
        A fix is going out in VS16.6p3, but it is way too long for us to wait.
     -->
-  <Target Name="CreatePortable" AfterTargets="Publish" DependsOnTargets="_RetrieveCurrentBuildVersion;_PublishTranslations;_DownloadPluginManager;_EnsureBundleContent;_CleanupBeforePack">
+  <Target Name="CreatePortable"
+          AfterTargets="Publish"
+          DependsOnTargets="_RetrieveCurrentBuildVersion;_PublishTranslations;_DownloadPluginManager;_EnsureBundleContent;_CleanupBeforePack;_PatchRuntimeConfigJson">
     <PropertyGroup>
       <_TargetAppConfig>@(AppConfigFileDestination)</_TargetAppConfig>
 

--- a/scripts/Patch-RuntimeConfigJsonFiles.ps1
+++ b/scripts/Patch-RuntimeConfigJsonFiles.ps1
@@ -1,0 +1,15 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$True, Position=1)]
+    [string] $Files
+)
+
+$Files.Split(';') | `
+    ForEach-Object { 
+        $fileContent = Get-Content $_ | ConvertFrom-Json;
+
+        # Remove all frameworks except "Microsoft.WindowsDesktop.App"
+        $fileContent.runtimeOptions.frameworks = @( $fileContent.runtimeOptions.frameworks | Where-Object { $_.name -eq 'Microsoft.WindowsDesktop.App' } );
+
+        $fileContent | ConvertTo-Json -Depth 5 | Out-File $_ -Encoding ascii;
+    }


### PR DESCRIPTION
Resolves #10337

SDK currently puts the lower level framework first (in runtimeconfig.json), so the hosts sees that first and if it's missing it fails - so that's why it produces the missing Microsoft.NETCore.App message - and the related URL points to that download.
If there are two frameworks listed in runtimeconfig.json with any of them missing, it's impossible for the host to determine which is lower level and which is higher level.

To avoid the issue, only retain the highest level framework - which is the WindowsDesktop, so users see correct message and get the correct link to download the required Runtime.

