### PR TITLE
Verify utility's file exists before invoking it

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1437,47 +1437,12 @@ namespace GitCommands
 
         /// <summary>Tries to start Pageant for the specified remote repo (using the remote's PuTTY key file).</summary>
         /// <returns>true if the remote has a PuTTY key file; otherwise, false.</returns>
-        public bool StartPageantForRemote(string? remote)
-        {
-            var sshKeyFile = GetPuttyKeyFileForRemote(remote);
-            if (string.IsNullOrEmpty(sshKeyFile) || !File.Exists(sshKeyFile))
-            {
-                return false;
-            }
-
-            StartPageantWithKey(sshKeyFile);
-            return true;
-        }
-
-        public static void StartPageantWithKey(string? sshKeyFile)
-        {
-            Executable pageantExecutable = new(AppSettings.Pageant);
-
-            // ensure pageant is loaded, so we can wait for loading a key in the next command
-            // otherwise we'll stuck there waiting until pageant exits
-            if (!IsPageantRunning())
-            {
-                // NOTE we leave the process to dangle here
-                var process = pageantExecutable.Start("");
-
-                process.WaitForInputIdle();
-            }
-
-            pageantExecutable.RunCommand(sshKeyFile.Quote());
-
-            static bool IsPageantRunning()
-            {
-                var pageantProcName = Path.GetFileNameWithoutExtension(AppSettings.Pageant);
-                return Process.GetProcessesByName(pageantProcName).Length != 0;
-            }
-        }
-
         public string GetPuttyKeyFileForRemote(string? remote)
         {
             if (string.IsNullOrEmpty(remote) ||
                 string.IsNullOrEmpty(AppSettings.Pageant) ||
                 !AppSettings.AutoStartPageant ||
-                !GitSshHelpers.Plink())
+                !GitSshHelpers.IsPlink)
             {
                 return "";
             }

--- a/GitCommands/Git/GitSshHelpers.cs
+++ b/GitCommands/Git/GitSshHelpers.cs
@@ -2,34 +2,14 @@ namespace GitCommands
 {
     public static class GitSshHelpers
     {
-        public static bool UseSsh(string arguments)
-        {
-            var x = !Plink() && DoArgumentsRequireSsh();
-            return x || arguments.Contains("plink");
-
-            bool DoArgumentsRequireSsh()
-            {
-                return (arguments.Contains("@") && arguments.Contains("://")) ||
-                       (arguments.Contains("@") && arguments.Contains(":")) ||
-                       arguments.Contains("ssh://") ||
-                       arguments.Contains("http://") ||
-                       arguments.Contains("git://") ||
-                       arguments.Contains("push") ||
-                       arguments.Contains("remote") ||
-                       arguments.Contains("fetch") ||
-                       arguments.Contains("pull");
-            }
-        }
-
         /// <summary>Sets the git SSH command path.</summary>
-        public static void SetSsh(string path)
+        public static void SetGitSshEnvironmentVariable(string path)
         {
             // Git will use the embedded OpenSSH ssh.exe if empty/unset
             Environment.SetEnvironmentVariable("GIT_SSH", path, EnvironmentVariableTarget.Process);
         }
 
         // Note that variants like TortoisePlink.exe are supported too
-        public static bool Plink()
-            => AppSettings.SshPath.EndsWith("plink.exe", StringComparison.CurrentCultureIgnoreCase);
+        public static bool IsPlink => AppSettings.SshPath.EndsWith("plink.exe", StringComparison.CurrentCultureIgnoreCase);
     }
 }

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1633,7 +1633,7 @@ namespace GitCommands
             try
             {
                 // Set environment variable
-                GitSshHelpers.SetSsh(SshPath);
+                GitSshHelpers.SetGitSshEnvironmentVariable(SshPath);
             }
             catch
             {

--- a/GitUI/BrowseForPrivateKey.cs
+++ b/GitUI/BrowseForPrivateKey.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+﻿using GitUI.Infrastructure;
 
 namespace GitUI
 {
@@ -12,12 +12,12 @@ namespace GitUI
         /// </summary>
         public static string? BrowseAndLoad(IWin32Window parent)
         {
-            var path = Browse(parent);
-            if (!string.IsNullOrEmpty(path))
+            string? sshKeyFile = Browse(parent);
+            if (!string.IsNullOrEmpty(sshKeyFile))
             {
-                if (LoadKey(parent, path))
+                if (PuttyHelpers.StartPageantIfConfigured(() => sshKeyFile))
                 {
-                    return path;
+                    return sshKeyFile;
                 }
             }
 
@@ -41,21 +41,6 @@ namespace GitUI
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Tries to load the given key. Returns whether successful.
-        /// </summary>
-        public static bool LoadKey(IWin32Window parent, string? path)
-        {
-            if (!File.Exists(AppSettings.Pageant))
-            {
-                MessageBoxes.PAgentNotFound(parent);
-                return false;
-            }
-
-            GitModule.StartPageantWithKey(path);
-            return true;
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -23,6 +23,7 @@ using GitUI.CommandsDialogs.BrowseDialog.DashboardControl;
 using GitUI.CommandsDialogs.WorktreeDialog;
 using GitUI.HelperDialogs;
 using GitUI.Hotkey;
+using GitUI.Infrastructure;
 using GitUI.Infrastructure.Telemetry;
 using GitUI.NBugReports;
 using GitUI.Properties;
@@ -1535,12 +1536,12 @@ namespace GitUI.CommandsDialogs
 
         private void StartAuthenticationAgentToolStripMenuItemClick(object sender, EventArgs e)
         {
-            new Executable(AppSettings.Pageant, Module.WorkingDir).Start();
+            PuttyHelpers.StartPageant(Module.WorkingDir);
         }
 
         private void GenerateOrImportKeyToolStripMenuItemClick(object sender, EventArgs e)
         {
-            new Executable(AppSettings.Puttygen, Module.WorkingDir).Start();
+            PuttyHelpers.StartPuttygen(Module.WorkingDir);
         }
 
         private void CommitInfoTabControl_SelectedIndexChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -5,6 +5,7 @@ using GitCommands.Git.Commands;
 using GitCommands.UserRepositoryHistory;
 using GitExtUtils.GitUI.Theming;
 using GitUI.HelperDialogs;
+using GitUI.Infrastructure;
 using GitUIPluginInterfaces;
 using ResourceManager;
 
@@ -318,7 +319,7 @@ namespace GitUI.CommandsDialogs
 
         private void FormCloneLoad(object sender, EventArgs e)
         {
-            if (!GitSshHelpers.Plink())
+            if (!GitSshHelpers.IsPlink)
             {
                 LoadSSHKey.Visible = false;
             }

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -2,6 +2,7 @@ using GitCommands;
 using GitCommands.Git.Commands;
 using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
+using GitUI.Infrastructure;
 using GitUI.Script;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -131,16 +132,9 @@ namespace GitUI.CommandsDialogs
 
         private void EnsurePageant(string remote)
         {
-            if (GitSshHelpers.Plink())
+            if (GitSshHelpers.IsPlink)
             {
-                if (!File.Exists(AppSettings.Pageant))
-                {
-                    MessageBoxes.PAgentNotFound(this);
-                }
-                else
-                {
-                    Module.StartPageantForRemote(remote);
-                }
+                PuttyHelpers.StartPageantIfConfigured(() => Module.GetPuttyKeyFileForRemote(remote));
             }
         }
     }

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -10,6 +10,7 @@ using GitCommands.Settings;
 using GitCommands.UserRepositoryHistory;
 using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
+using GitUI.Infrastructure;
 using GitUI.Script;
 using GitUIPluginInterfaces;
 using GitUIPluginInterfaces.Settings;
@@ -318,7 +319,7 @@ namespace GitUI.CommandsDialogs
             else
             {
                 Validates.NotNull(selectedRemoteName);
-                EnsurePageant(selectedRemoteName);
+                StartPageant(selectedRemoteName);
 
                 destination = selectedRemoteName;
                 remote = selectedRemoteName.Trim();
@@ -885,21 +886,9 @@ namespace GitUI.CommandsDialogs
 
         private void StartPageant(string? remote)
         {
-            if (!File.Exists(AppSettings.Pageant))
+            if (GitSshHelpers.IsPlink)
             {
-                MessageBoxes.PAgentNotFound(this);
-            }
-            else
-            {
-                Module.StartPageantForRemote(remote);
-            }
-        }
-
-        private void EnsurePageant(string? remote)
-        {
-            if (GitSshHelpers.Plink())
-            {
-                StartPageant(remote);
+                PuttyHelpers.StartPageantIfConfigured(() => Module.GetPuttyKeyFileForRemote(remote));
             }
         }
 
@@ -968,7 +957,7 @@ namespace GitUI.CommandsDialogs
 
                 if (detailedSettings.GetRemoteBranchesDirectlyFromRemote)
                 {
-                    EnsurePageant(remote);
+                    StartPageant(remote);
 
                     FormRemoteProcess formProcess = new(UICommands, $"ls-remote --heads \"{remote}\"")
                     {

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -3,6 +3,7 @@ using GitCommands.Config;
 using GitCommands.Remotes;
 using GitCommands.UserRepositoryHistory;
 using GitExtUtils.GitUI;
+using GitUI.Infrastructure;
 using GitUI.Properties;
 using GitUIPluginInterfaces;
 using Microsoft;
@@ -54,9 +55,6 @@ namespace GitUI.CommandsDialogs
 
         private readonly TranslationString _sshKeyOpenCaption =
             new("Select ssh key file");
-
-        private readonly TranslationString _errorNoKeyEntered =
-            new("No SSH key file entered");
 
         private readonly TranslationString _labelUrlAsFetch =
             new("Fetch Url");
@@ -321,7 +319,7 @@ Inactive remote is completely invisible to git.");
                     $" Either {nameof(PreselectRemoteOnLoad)} or {nameof(PreselectLocalOnLoad)}");
             }
 
-            pnlMgtPuttySsh.Visible = GitSshHelpers.Plink();
+            pnlMgtPuttySsh.Visible = GitSshHelpers.IsPlink;
 
             // if Putty SSH isn't enabled, reduce the minimum height of the form
             MinimumSize = new Size(MinimumSize.Width, pnlMgtPuttySsh.Visible ? MinimumSize.Height : MinimumSize.Height - pnlMgtPuttySsh.Height);
@@ -516,14 +514,7 @@ Inactive remote is completely invisible to git.");
 
         private void LoadSshKeyClick(object sender, EventArgs e)
         {
-            if (string.IsNullOrEmpty(PuttySshKey.Text))
-            {
-                MessageBox.Show(this, _errorNoKeyEntered.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-            else
-            {
-                GitModule.StartPageantWithKey(PuttySshKey.Text);
-            }
+            PuttyHelpers.StartPageantIfConfigured(() => PuttySshKey.Text);
         }
 
         private void TestConnectionClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -4,6 +4,7 @@ using GitCommands;
 using GitCommands.Config;
 using GitCommands.DiffMergeTools;
 using GitCommands.Utils;
+using GitUI.Infrastructure;
 using Microsoft;
 using Microsoft.Win32;
 using ResourceManager;
@@ -180,7 +181,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void SshConfig_Click(object sender, EventArgs e)
         {
-            if (GitSshHelpers.Plink())
+            if (GitSshHelpers.IsPlink)
             {
                 Validates.NotNull(SshSettingsPage);
                 if (SshSettingsPage.AutoFindPuttyPaths())
@@ -436,7 +437,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private bool CheckSSHSettings()
         {
             SshConfig.Visible = true;
-            if (GitSshHelpers.Plink())
+            if (GitSshHelpers.IsPlink)
             {
                 return RenderSettingSetUnset(() => !File.Exists(AppSettings.Plink) || !File.Exists(AppSettings.Puttygen) || !File.Exists(AppSettings.Pageant),
                                         SshConfig, SshConfig_Fix,

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
@@ -33,7 +33,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             {
                 OpenSSH.Checked = true;
             }
-            else if (GitSshHelpers.Plink())
+            else if (GitSshHelpers.IsPlink)
             {
                 Putty.Checked = true;
             }
@@ -69,7 +69,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
 
             // Set persistent settings as well as the env var used by Git
-            GitSshHelpers.SetSsh(path);
+            GitSshHelpers.SetGitSshEnvironmentVariable(path);
             AppSettings.SshPath = path;
         }
 

--- a/GitUI/HelperDialogs/FormRemoteProcess.cs
+++ b/GitUI/HelperDialogs/FormRemoteProcess.cs
@@ -1,6 +1,7 @@
 using GitCommands;
 using GitCommands.Config;
 using GitExtUtils;
+using GitUI.Infrastructure;
 using GitUI.UserControls;
 using ResourceManager;
 
@@ -66,7 +67,7 @@ Do you want to register the host's fingerprint and restart the process?");
         protected override void BeforeProcessStart()
         {
             _restart = false;
-            Plink = GitSshHelpers.Plink();
+            Plink = GitSshHelpers.IsPlink;
             base.BeforeProcessStart();
         }
 

--- a/GitUI/Infrastructure/Plink.cs
+++ b/GitUI/Infrastructure/Plink.cs
@@ -1,7 +1,9 @@
 ﻿using System.Text;
-using GitUI;
+using GitCommands;
+using GitExtUtils;
+using GitUI.NBugReports;
 
-namespace GitCommands
+namespace GitUI.Infrastructure
 {
     public sealed class Plink
     {
@@ -59,13 +61,14 @@ namespace GitCommands
 
         public Plink(Executable? executable = null)
         {
+            ThrowIfFileNotFound(AppSettings.Plink, $"'{AppSettings.Plink}'\r\n\r\n{TranslatedStrings.ErrorSshPuTTYInstalled}");
+
             _executable = executable ?? new Executable("cmd.exe");
         }
 
         public bool Connect(string host)
         {
-            return ThreadHelper.JoinableTaskFactory.Run(
-                () => ConnectAsync(host));
+            return ThreadHelper.JoinableTaskFactory.Run(() => ConnectAsync(host));
         }
 
         public async Task<bool> ConnectAsync(string host)
@@ -111,6 +114,15 @@ namespace GitCommands
                 .Append('"');
 
             return fixedUrl.ToString();
+        }
+
+        private static void ThrowIfFileNotFound(string filePath, string errorMessage, string? heading = null)
+        {
+            if (!File.Exists(filePath))
+            {
+                throw new UserExternalOperationException(errorMessage,
+                    new ExternalOperationException(innerException: new FileNotFoundException(heading ?? TranslatedStrings.ErrorFileNotFound)));
+            }
         }
     }
 }

--- a/GitUI/Infrastructure/PuttyHelpers.cs
+++ b/GitUI/Infrastructure/PuttyHelpers.cs
@@ -1,0 +1,102 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using GitCommands;
+using GitExtUtils;
+using GitUI.NBugReports;
+using GitUIPluginInterfaces;
+
+namespace GitUI.Infrastructure
+{
+    public static class PuttyHelpers
+    {
+        /// <summary>
+        ///  Starts PuTTY agent for the specified working directory.
+        /// </summary>
+        /// <param name="workingDirectory">The working directory.</param>
+        /// <exception cref="UserExternalOperationException">PuTTY executable cannot be found.</exception>
+        /// <exception cref="COMException">The method was not called on the UI thread.</exception>
+        public static void StartPageant(string workingDirectory)
+        {
+            // Exceptions must be thrown from the UI thread, otherwise we'll crash the app.
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            ThrowIfFileNotFound(AppSettings.Pageant, $"'{AppSettings.Pageant}'\r\n\r\n{TranslatedStrings.ErrorSshPuTTYInstalled}");
+
+            new Executable(AppSettings.Pageant, workingDirectory).Start();
+        }
+
+        /// <summary>
+        ///  Starts PuTTY key generator for the specified working directory.
+        /// </summary>
+        /// <param name="workingDirectory">The working directory.</param>
+        /// <exception cref="UserExternalOperationException">PuTTY executable cannot be found.</exception>
+        /// <exception cref="COMException">The method was not called on the UI thread.</exception>
+        public static void StartPuttygen(string workingDirectory)
+        {
+            // Exceptions must be thrown from the UI thread, otherwise we'll crash the app.
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            ThrowIfFileNotFound(AppSettings.Puttygen, $"'{AppSettings.Puttygen}'\r\n\r\n{TranslatedStrings.ErrorSshPuTTYInstalled}");
+
+            new Executable(AppSettings.Puttygen, workingDirectory).Start();
+        }
+
+        /// <summary>
+        ///  Starts PuTTY agent with the specified SSH key.
+        /// </summary>
+        /// <param name="sshKeyFileLoader">The delegate that provides the key to load.</param>
+        /// <returns><see langword="true"/> if PuTTY agent was started successfully; otherwise, <see langword="false"/>.</returns>
+        /// <exception cref="UserExternalOperationException">
+        ///  <para>PuTTY isn't configured is preferred SSH client.</para>
+        ///  <para>- or -</para>
+        ///  <para>PuTTY executable cannot be found.</para>
+        ///  <para>- or -</para>
+        ///  <para>The SSH key cannot be found.</para>
+        /// </exception>
+        /// <exception cref="COMException">The method was not called on the UI thread.</exception>
+        public static bool StartPageantIfConfigured(Func<string?> sshKeyFileLoader)
+        {
+            // Exceptions must be thrown from the UI thread, otherwise we'll crash the app.
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (!GitSshHelpers.IsPlink)
+            {
+                throw new UserExternalOperationException(TranslatedStrings.ErrorSshPuTTYWhereConfigure,
+                    new ExternalOperationException(innerException: new Exception(TranslatedStrings.ErrorSshPuTTYNotConfigured)));
+            }
+
+            ThrowIfFileNotFound(AppSettings.Pageant, $"'{AppSettings.Pageant}'\r\n\r\n{TranslatedStrings.ErrorSshPuTTYInstalled}");
+
+            string? sshKeyFile = sshKeyFileLoader();
+            ThrowIfFileNotFound(sshKeyFile, $"'{sshKeyFile}'", TranslatedStrings.ErrorSshKeyNotFound);
+
+            Executable pageantExecutable = new(AppSettings.Pageant);
+
+            // ensure pageant is loaded, so we can wait for loading a key in the next command
+            // otherwise we'll stuck there waiting until pageant exits
+            if (!IsPageantRunning())
+            {
+                // NOTE we leave the process to dangle here
+                IProcess process = pageantExecutable.Start();
+                process.WaitForInputIdle();
+            }
+
+            return pageantExecutable.RunCommand(sshKeyFile.Quote());
+
+            static bool IsPageantRunning()
+            {
+                var pageantProcName = Path.GetFileNameWithoutExtension(AppSettings.Pageant);
+                return Process.GetProcessesByName(pageantProcName).Length != 0;
+            }
+        }
+
+        private static void ThrowIfFileNotFound(string filePath, string errorMessage, string? heading = null)
+        {
+            if (!File.Exists(filePath))
+            {
+                throw new UserExternalOperationException(errorMessage,
+                    new ExternalOperationException(innerException: new FileNotFoundException(heading ?? TranslatedStrings.ErrorFileNotFound)));
+            }
+        }
+    }
+}

--- a/GitUI/Infrastructure/Telemetry/AppEnvironmentTelemetryInitializer.cs
+++ b/GitUI/Infrastructure/Telemetry/AppEnvironmentTelemetryInitializer.cs
@@ -14,7 +14,7 @@ namespace GitUI.Infrastructure.Telemetry
             {
                 sshClient = "OpenSSH";
             }
-            else if (GitSshHelpers.Plink())
+            else if (GitSshHelpers.IsPlink)
             {
                 sshClient = "PuTTY";
             }

--- a/GitUI/MessageBoxes.cs
+++ b/GitUI/MessageBoxes.cs
@@ -26,9 +26,6 @@ namespace GitUI
         private readonly TranslationString _middleOfPatchApplyCaption = new("Patch apply");
         private readonly TranslationString _middleOfPatchApply = new("You are in the middle of a patch apply, continue patch apply?");
 
-        private const string _putty = "PuTTY";
-        private readonly TranslationString _pageantNotFound = new("Cannot load SSH key. PuTTY is not configured properly.");
-
         private readonly TranslationString _serverHostkeyNotCachedText =
             new("The server's host key is not cached in the registry.\n\nDo you want to trust this host key and then try again?");
 
@@ -86,9 +83,6 @@ namespace GitUI
 
         public static bool MiddleOfPatchApply(IWin32Window? owner)
             => Confirm(owner, Instance._middleOfPatchApply.Text, Instance._middleOfPatchApplyCaption.Text);
-
-        public static void PAgentNotFound(IWin32Window? owner)
-            => ShowError(owner, Instance._pageantNotFound.Text, _putty);
 
         public static void SelectOnlyOneOrTwoRevisions(IWin32Window? owner)
             => ShowError(owner, Instance._selectOnlyOneOrTwoRevisions.Text, Instance._archiveRevisionCaption.Text);

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -134,6 +134,12 @@ the last selected commit.");
         private readonly TranslationString _cannotBeUndone = new("This action cannot be undone.");
         private readonly TranslationString _areYouSure = new("Are you sure you want to drop the stash? This action cannot be undone.");
 
+        private readonly TranslationString _errorPuTTYNotFound = new("SSH agent could not be found");
+        private readonly TranslationString _errorSshKeyNotFound = new("SSH key file could not be found");
+        private readonly TranslationString _errorSshPuTTYInstalled = new("Is PuTTY installed?");
+        private readonly TranslationString _errorSshPuTTYNotConfigured = new("PuTTY is not configured as SSH client");
+        private readonly TranslationString _errorSshPuTTYWhereConfigure = new("SSH client can be configured in Settings > SSH.");
+
         // public only because of FormTranslate
         public TranslatedStrings()
         {
@@ -213,6 +219,12 @@ the last selected commit.");
         public static string ErrorCaptionFailedDeleteFile => _instance.Value._errorCaptionFailedDeleteFile.Text;
         public static string ErrorCaptionFailedDeleteFolder => _instance.Value._errorCaptionFailedDeleteFolder.Text;
         public static string ErrorCaptionNotOnBranch => _instance.Value._errorCaptionNotOnBranch.Text;
+
+        public static string ErrorFileNotFound => _instance.Value._errorPuTTYNotFound.Text;
+        public static string ErrorSshKeyNotFound => _instance.Value._errorSshKeyNotFound.Text;
+        public static string ErrorSshPuTTYInstalled => _instance.Value._errorSshPuTTYInstalled.Text;
+        public static string ErrorSshPuTTYNotConfigured => _instance.Value._errorSshPuTTYNotConfigured.Text;
+        public static string ErrorSshPuTTYWhereConfigure => _instance.Value._errorSshPuTTYWhereConfigure.Text;
 
         public static string ErrorInstructionNotOnBranch => _instance.Value._mainInstructionNotOnBranch.Text;
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6737,10 +6737,6 @@ Inactive remote is completely invisible to git.</source>
         <source>An active remote named "{0}" already exists.</source>
         <target />
       </trans-unit>
-      <trans-unit id="_errorNoKeyEntered.Text">
-        <source>No SSH key file entered</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_gbMgtPanelHeaderEdit.Text">
         <source>Edit Remote Details</source>
         <target />
@@ -8767,10 +8763,6 @@ help</source>
         <source>The current directory is not a valid git repository.</source>
         <target />
       </trans-unit>
-      <trans-unit id="_pageantNotFound.Text">
-        <source>Cannot load SSH key. PuTTY is not configured properly.</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_reason.Text">
         <source>Reason</source>
         <target />
@@ -10748,6 +10740,26 @@ Select this commit to populate the full message.</source>
       </trans-unit>
       <trans-unit id="_errorCaptionNotOnBranch.Text">
         <source>Not on a branch</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_errorPuTTYNotFound.Text">
+        <source>SSH agent could not be found</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_errorSshKeyNotFound.Text">
+        <source>SSH key file could not be found</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_errorSshPuTTYInstalled.Text">
+        <source>Is PuTTY installed?</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_errorSshPuTTYNotConfigured.Text">
+        <source>PuTTY is not configured as SSH client</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_errorSshPuTTYWhereConfigure.Text">
+        <source>SSH client can be configured in Settings &gt; SSH.</source>
         <target />
       </trans-unit>
       <trans-unit id="_exitCodeText.Text">

--- a/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -3,6 +3,7 @@ using System.Text;
 using GitCommands;
 using GitCommands.Git.Extensions;
 using GitCommands.Logging;
+using GitUI.Infrastructure;
 using Timer = System.Windows.Forms.Timer;
 
 namespace GitUI.UserControls
@@ -99,7 +100,7 @@ namespace GitUI.UserControls
             {
                 EnvironmentConfiguration.SetEnvironmentVariables();
 
-                bool ssh = GitSshHelpers.UseSsh(arguments);
+                bool ssh = UseSsh(arguments);
 
                 KillProcess();
 
@@ -187,6 +188,25 @@ namespace GitUI.UserControls
             }
 
             base.Dispose(disposing);
+        }
+
+        private static bool UseSsh(string arguments)
+        {
+            return arguments.Contains("plink")
+                || (!GitSshHelpers.IsPlink && DoArgumentsRequireSsh());
+
+            bool DoArgumentsRequireSsh()
+            {
+                return (arguments.Contains('@') && arguments.Contains("://")) ||
+                       (arguments.Contains('@') && arguments.Contains(':')) ||
+                       arguments.Contains("ssh://") ||
+                       arguments.Contains("http://") ||
+                       arguments.Contains("git://") ||
+                       arguments.Contains("push") ||
+                       arguments.Contains("remote") ||
+                       arguments.Contains("fetch") ||
+                       arguments.Contains("pull");
+            }
         }
 
         #region ProcessOutputThrottle

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -126,8 +126,6 @@ namespace GitUIPluginInterfaces
         string GetSetting(string setting);
         string GetEffectiveSetting(string setting);
 
-        bool StartPageantForRemote(string remote);
-
         /// <summary>Gets the current branch; or "(no branch)" if HEAD is detached.</summary>
         string GetSelectedBranch();
 

--- a/UnitTests/GitUI.Tests/Infrastructure/PlinkTests.cs
+++ b/UnitTests/GitUI.Tests/Infrastructure/PlinkTests.cs
@@ -1,7 +1,7 @@
-﻿using GitCommands;
+﻿using GitUI.Infrastructure;
 using NUnit.Framework;
 
-namespace GitCommandsTests
+namespace GitUITests.Infrastructure
 {
     [TestFixture]
     public sealed class PlinkTests


### PR DESCRIPTION
Resolves #10321
Resolves #10352

Before invoking PuTTY we'll check for:
* PuTTY is configured as the default SSH agent (in selected scenarios),
* PuTTY executable is present,
* the supplied SSH key is located (if applicable).

Any "NO" response from the above will result in an `UserExternalOperationException`, which will ultimately show the "user-level error" dialog with "Ignore" and "Details" buttons (i.e., no "Report bug!" button).

## Before 

![image](https://user-images.githubusercontent.com/4403806/199875938-2ff34da7-1bbd-4723-9d5b-0a3310450fe5.png)

## After

![image](https://user-images.githubusercontent.com/4403806/204073368-95b7244d-163a-46a0-966d-a89ea2ae9164.png)
![image](https://user-images.githubusercontent.com/4403806/204073377-15fe8225-55cb-44e4-9758-12841f269f28.png)
![image](https://user-images.githubusercontent.com/4403806/204073479-aed667f0-13ed-42a6-b043-06721cb74705.png)
