### PR TITLE
Keep recent repositories in the same order when filtering

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
@@ -105,18 +105,9 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 return repositories;
             }
 
-            List<Repository> repos = new();
-            for (var i = repositories.Count - 1; i >= 0; i--)
-            {
-                var repo = repositories[i];
-                if (repo.Path.Contains(pattern, StringComparison.CurrentCultureIgnoreCase))
-                {
-                    repos.Add(repo);
-                    continue;
-                }
-            }
-
-            return repos;
+            return repositories
+                .Where(r => r.Path.Contains(pattern, StringComparison.CurrentCultureIgnoreCase))
+                .ToList();
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes _(no prior issue created)_

I've taken a look at [PR where this feature was introduced](https://github.com/gitextensions/gitextensions/pull/9380) and haven't found anything which would support reversal during filtering. It seems this behavior was introduced by accident.

The effect is especially visible when using a filter which matches all of the repos, such as `\`

## Proposed changes

- Maintain recent repository order when filtering

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

**No filter** _(GE repo comes first)_
![image](https://user-images.githubusercontent.com/483659/201304290-cf77bcd2-c975-4fc4-8f68-db12ef96c6f7.png)

**With filter** _(GE repo comes **last**)_
![image](https://user-images.githubusercontent.com/483659/201305033-67ecc678-22f5-4427-8f44-265a3ad4515a.png)


### After

**With filter** _(GE repo comes first)_
![image](https://user-images.githubusercontent.com/483659/201304547-7858ffb6-14a3-4150-a312-b8e443a44e77.png)

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
