### PR TITLE
SidePanel: Context menu at no selection

### DIFF
--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -77,9 +77,9 @@ namespace GitUI.BranchTreePanel
             bool isSingleRemoteRepoSelected = hasSingleSelection && selectedNode is RemoteRepoNode;
             RemoteRepoNode? remoteRepo = selectedNode as RemoteRepoNode;
             mnubtnManageRemotes.Enable(isSingleRemoteRepoSelected);
-            EnableMenuItems(isSingleRemoteRepoSelected && remoteRepo?.Enabled is not null, mnubtnFetchAllBranchesFromARemote, mnubtnDisableRemote, mnuBtnPruneAllBranchesFromARemote);
-            mnuBtnOpenRemoteUrlInBrowser.Enable(isSingleRemoteRepoSelected && remoteRepo?.IsRemoteUrlUsingHttp is not null);
-            EnableMenuItems(isSingleRemoteRepoSelected && !remoteRepo?.Enabled is not null, mnubtnEnableRemote, mnubtnEnableRemoteAndFetch);
+            EnableMenuItems(isSingleRemoteRepoSelected && remoteRepo?.Enabled is true, mnubtnFetchAllBranchesFromARemote, mnubtnDisableRemote, mnuBtnPruneAllBranchesFromARemote);
+            mnuBtnOpenRemoteUrlInBrowser.Enable(isSingleRemoteRepoSelected && remoteRepo?.IsRemoteUrlUsingHttp is true);
+            EnableMenuItems(isSingleRemoteRepoSelected && remoteRepo?.Enabled is false, mnubtnEnableRemote, mnubtnEnableRemoteAndFetch);
         }
 
         private void EnableSortContextMenu(bool hasSingleSelection, NodeBase? selectedNode)
@@ -104,9 +104,9 @@ namespace GitUI.BranchTreePanel
             bool isSingleSubmoduleSelected = hasSingleSelection && selectedNode is SubmoduleNode;
             SubmoduleNode? submoduleNode = selectedNode as SubmoduleNode;
             bool isBareRepository = Module.IsBareRepository();
-            mnubtnOpenSubmodule.Enable(isSingleSubmoduleSelected && !submoduleNode?.IsCurrent is not null);
+            mnubtnOpenSubmodule.Enable(isSingleSubmoduleSelected && submoduleNode?.IsCurrent is false);
             EnableMenuItems(isSingleSubmoduleSelected, mnubtnOpenGESubmodule, mnubtnUpdateSubmodule);
-            EnableMenuItems(isSingleSubmoduleSelected && !isBareRepository && submoduleNode?.IsCurrent is not null, mnubtnManageSubmodules, mnubtnSynchronizeSubmodules);
+            EnableMenuItems(isSingleSubmoduleSelected && !isBareRepository && submoduleNode?.IsCurrent is true, mnubtnManageSubmodules, mnubtnSynchronizeSubmodules);
             EnableMenuItems(isSingleSubmoduleSelected && !isBareRepository, mnubtnResetSubmodule, mnubtnStashSubmodule, mnubtnCommitSubmodule);
         }
 


### PR DESCRIPTION
Menu items for remotes and submodules were incorrectly shown.

Follow up to #10340, 60a27c239f18051d80ebaab322f3422c3f78a9ce.
https://github.com/gitextensions/gitextensions/pull/10340#discussion_r1018489072

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/201486289-d4d3b838-024d-4ce1-904f-feafb70dccb6.png)

![image](https://user-images.githubusercontent.com/6248932/201486329-e32b5914-e278-4d2e-97a1-a96528034795.png)

![image](https://user-images.githubusercontent.com/6248932/201486406-3b3a599a-e7cd-41a7-833b-3eaea9cce491.png)

![image](https://user-images.githubusercontent.com/6248932/201486470-e4719be3-2163-4cea-94b5-bae5f18059ea.png)

### After

![image](https://user-images.githubusercontent.com/6248932/201485947-9b730ddc-8dc0-484c-89e3-91a4b31fbfdb.png)

![image](https://user-images.githubusercontent.com/6248932/201486012-e56ae41e-8068-431c-9064-c792642c5026.png)

![image](https://user-images.githubusercontent.com/6248932/201486182-e35f57f0-e22f-4a04-932a-bca4d08a8ecc.png)

![image](https://user-images.githubusercontent.com/6248932/201486212-d00b58f8-87ff-464d-87a2-f0a780cd9a97.png)

No screenshot for remote url, all here were https

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
