### PR TITLE
FormClone: Check that current module is valid

### DIFF
--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -109,7 +109,7 @@ namespace GitUI.CommandsDialogs
 
                 // if the From field is empty, then fill it with the current repository remote URL in hope
                 // that the cloned repository is hosted on the same server
-                if (string.IsNullOrWhiteSpace(_NO_TRANSLATE_From.Text))
+                if (string.IsNullOrWhiteSpace(_NO_TRANSLATE_From.Text) && Module.IsValidGitWorkingDir())
                 {
                     var currentBranchRemote = Module.GetSetting(string.Format(SettingKeyString.BranchRemote, Module.GetSelectedBranch()));
                     if (string.IsNullOrEmpty(currentBranchRemote))


### PR DESCRIPTION
Alternative to #10344 
The core of that PR may be done anyway (suppressing throw for git-remote), but git-remote (and following commands) should not be executed if not giving a response anyway.

Fixes #10329

## Proposed changes

When opening the form, only try to access the current module if it is a valid directory to fill in reasonable defaults for a user. More specifically, the Module i normally invalid ff cloning from Explorer or the Dashboard.

## Test methodology <!-- How did you ensure quality? -->

Manual.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
