### PR TITLE
Fix 'Delete obsolete branches' plugin

### DIFF
--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -278,10 +278,9 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
 
         private async Task RefreshObsoleteBranchesAsync()
         {
-            Validates.NotNull(_refreshCancellation);
-
             if (IsRefreshing)
             {
+                Validates.NotNull(_refreshCancellation);
                 _refreshCancellation.Cancel();
                 IsRefreshing = false;
                 return;
@@ -290,6 +289,8 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
             Validates.NotNull(_gitUiCommands);
 
             IsRefreshing = true;
+            Validates.NotNull(_refreshCancellation);
+
             var curBranch = _gitUiCommands.GitModule.GetSelectedBranch();
             RefreshContext context = new(
                 _gitCommands,

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -288,6 +288,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
 
             Validates.NotNull(_gitUiCommands);
 
+            // IsRefreshing will set _refreshCancellation
             IsRefreshing = true;
             Validates.NotNull(_refreshCancellation);
 


### PR DESCRIPTION
Fixes #10347

When adding nullable reference types to this code, an incorrect assertion was added. The nullability of the cancellation object here is quite confusing, as setting IsRefreshing to true causes it to be created. It's also known as not-null if IsRefreshing is true. This commit updates the assertions to be correct, fixing the bug.
