### PR TITLE
Improve recent repository list keyboard navigation

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.Designer.cs
@@ -334,6 +334,8 @@
             this.listView1.MouseClick += new System.Windows.Forms.MouseEventHandler(this.listView1_MouseClick);
             this.listView1.MouseLeave += new System.EventHandler(this.listView1_MouseLeave);
             this.listView1.MouseMove += new System.Windows.Forms.MouseEventHandler(this.listView1_MouseMove);
+            this.listView1.GotFocus += new System.EventHandler(this.listView1_GotFocus);
+            this.listView1.KeyDown += listView1_KeyDown;
             // 
             // clmhdrPath
             // 

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -691,18 +691,15 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private void listView1_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.KeyCode == Keys.Up)
+            if (e.KeyCode == Keys.Up && listView1.SelectedItems.Count > 0)
             {
-                if (listView1.SelectedItems.Count > 0)
+                // Compare current item to the very first item to see if it's at the top
+                ListViewItem selectedItem = listView1.SelectedItems[0];
+                if (selectedItem.Bounds.Y == listView1.Items[0].Bounds.Y)
                 {
-                    // Compare current item to the very first item to see if it's at the top
-                    ListViewItem selectedItem = listView1.SelectedItems[0];
-                    if (selectedItem.Bounds.Y == listView1.Items[0].Bounds.Y)
-                    {
-                        textBoxSearch.Focus();
-                        selectedItem.Selected = true;
-                        e.Handled = true;
-                    }
+                    textBoxSearch.Focus();
+                    selectedItem.Selected = true;
+                    e.Handled = true;
                 }
             }
         }

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -291,7 +291,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
                 _hasInvalidRepos = false;
 
-                var groups = Enumerable.Repeat(_lvgRecentRepositories, 1)
+                var groups = new[] { _lvgRecentRepositories }
                     .Concat(recentRepositories.Concat(favouriteRepositories)
                         .Select(repo => repo.Repo.Category)
                         .Where(c => !string.IsNullOrWhiteSpace(c))
@@ -388,7 +388,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         {
             return listView1.Items.Cast<ListViewItem>()
                 .Select(lvi => (Repository)lvi.Tag)
-                .Where(_ => _ is not null);
+                .Where(r => r is not null);
         }
 
         private static SelectedRepositoryItem? GetSelectedRepositoryItem(ToolStripItem? menuItem)
@@ -665,6 +665,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
                 TryOpenRepository(items[0].Tag as Repository);
             }
+            else if (e.KeyCode == Keys.Down)
+            {
+                listView1.Focus();
+            }
         }
 
         private void listView1_MouseMove(object sender, MouseEventArgs e)
@@ -675,6 +679,32 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         private void listView1_MouseLeave(object sender, EventArgs e)
         {
             HoveredItem = null;
+        }
+
+        private void listView1_GotFocus(object sender, EventArgs e)
+        {
+            if (listView1.Items.Count > 0 && listView1.SelectedItems.Count == 0)
+            {
+                listView1.Items[0].Selected = true;
+            }
+        }
+
+        private void listView1_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Up)
+            {
+                if (listView1.SelectedItems.Count > 0)
+                {
+                    // Compare current item to the very first item to see if it's at the top
+                    ListViewItem selectedItem = listView1.SelectedItems[0];
+                    if (selectedItem.Bounds.Y == listView1.Items[0].Bounds.Y)
+                    {
+                        textBoxSearch.Focus();
+                        selectedItem.Selected = true;
+                        e.Handled = true;
+                    }
+                }
+            }
         }
 
         private void mnuConfigure_Click(object sender, EventArgs e)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes _(none)_

## Proposed changes

- Select the first item when recent repository list gets focus
- Give focus to recent repository list when pressing ⬇️ arrow key in a filter search box
- Give focus to filter search box when pressing ⬆️ in a recent repository list when the top item (in any column) is selected

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Notice how when pressing tab while in a filter search box it's not obvious which control gets focus
![recent-repo-arrow-no-keys](https://user-images.githubusercontent.com/483659/201610867-fe711eac-8ab1-43a0-b8ad-b172cf7a198f.gif)

### After

Full back and forth navigation between the list and the search box with arrow keys
![recent-repo-arrow-keys](https://user-images.githubusercontent.com/483659/201610402-b28b7b02-264c-4e15-bad2-a9724f82223f.gif)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
