### PR TITLE
Simplify devex

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
   # Disable the .NET first time experience to skip caching NuGet packages and speed up the build.
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   # Use latest version of current used .NET version.  6.0 could use the latest of 6.0.  See .\Scripts\Update-DotnetVersion.ps1
-  GE_USE_LATEST_DOTNET: false
+  GE_USE_LATEST_DOTNET: true
 
 init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
-    "sdk":  {
-                "version":  "6.0.402",
-                "rollForward":  "feature"
-            }
+    "sdk": {
+        "version": "6.0.400",
+        "rollForward": "feature"
+    }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
     "sdk": {
-        "version": "6.0.400",
+        "version": "6.0.401",
         "rollForward": "feature"
     }
 }

--- a/scripts/RepoLayout.props
+++ b/scripts/RepoLayout.props
@@ -9,7 +9,7 @@
     <!-- Set version for runtimeconfig.json, used by DotnetRuntimeBootstrapper for minimal version to support
          To be kept in sync with the .NET SDK version in global.json
     -->
-    <RuntimeFrameworkVersion>6.0.10</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>6.0.0</RuntimeFrameworkVersion>
     <SolutionTargetFramework>net6.0-windows</SolutionTargetFramework>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>


### PR DESCRIPTION
* Allow developers to use any SDK equal or above the specified.
* Do not demand a specific runtime during dev cycle
* Only demand the min runtime for AppVeyor builds