### PR TITLE
Fixup "Derived from tag"

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -4184,7 +4184,7 @@ namespace GitCommands
             };
 
             ExecutionResult exec = _gitExecutable.Execute(args, throwOnErrorExit: false);
-            return !exec.ExitedSuccessfully
+            return exec.ExitedSuccessfully
                 ? exec.StandardOutput.TrimEnd()
                 : null;
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10414

## Proposed changes

- fixup a wrongly inverted condition from #9059

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/202545245-255d5fc7-01fa-4b9f-8ef4-9b7d05a03ae9.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/202545598-1a124a31-bd1e-498d-a723-eb18c618e418.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 4948ebac03dd135991428b786343385f8d9fd209 (Dirty)
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.10
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 3.1.21 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 5.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.9 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.10 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).