### PR TITLE
CommitInfo: Copy only essential & stable data to clipboard

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -648,7 +648,7 @@ namespace GitUI.CommitInfo
 
         private void copyCommitInfoToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var commitInfo = $"{commitInfoHeader.GetPlainText()}{Environment.NewLine}{Environment.NewLine}{rtbxCommitMessage.GetPlainText()}{Environment.NewLine}{RevisionInfo.GetPlainText()}";
+            string commitInfo = $"{commitInfoHeader.GetPlainText()}{Environment.NewLine}{Environment.NewLine}{rtbxCommitMessage.GetPlainText()}";
             ClipboardUtil.TrySetText(commitInfo);
         }
 

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -74,7 +74,7 @@ namespace GitUI.CommitInfo
 
         public string GetPlainText()
         {
-            return rtbRevisionHeader.GetPlainText();
+            return _commitDataHeaderRenderer.GetPlainText(rtbRevisionHeader.GetPlainText());
         }
 
         private void LoadAuthorImage(GitRevision? revision)

--- a/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
+++ b/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using System.Text.RegularExpressions;
 using GitCommands;
 using GitUIPluginInterfaces;
 using Microsoft;
@@ -11,6 +12,11 @@ namespace ResourceManager.CommitDataRenders
     /// </summary>
     public interface ICommitDataHeaderRenderer
     {
+        /// <summary>
+        /// Gets the plain text for the clipboard - without tabs, relative date, children and parents.
+        /// </summary>
+        string GetPlainText(string header);
+
         Font GetFont(Graphics g);
 
         IEnumerable<int> GetTabStops();
@@ -42,6 +48,16 @@ namespace ResourceManager.CommitDataRenders
             _dateFormatter = dateFormatter;
             _headerRendererStyleProvider = headerRendererStyleProvider;
             _linkFactory = linkFactory;
+        }
+
+        public string GetPlainText(string header)
+        {
+            string children = $"({TranslatedStrings.GetChildren(1)})|({TranslatedStrings.GetChildren(2)})|({TranslatedStrings.GetChildren(10)})";
+            string parents = $"({TranslatedStrings.GetParents(1)})|({TranslatedStrings.GetParents(2)})|({TranslatedStrings.GetParents(10)})";
+            header = Regex.Replace(header, @"[ \t]+", " ");
+            header = Regex.Replace(header, @"(\n[^:]+: ).* ago \(([^)]+)\)", "$1$2");
+            header = Regex.Replace(header, @$"\n({children}|{parents})[^\n]*", "");
+            return header;
         }
 
         public Font GetFont(Graphics g)

--- a/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererTests.cs
+++ b/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataHeaderRendererTests.cs
@@ -337,5 +337,42 @@ namespace ResourceManagerTests.CommitDataRenders
             _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.Date, Arg.Any<int>());
             _labelFormatter.DidNotReceive().FormatLabel(TranslatedStrings.Committer, Arg.Any<int>());
         }
+
+        [Test]
+        public void GetPlainText_should_repace_multiple_spaces_and_tabs()
+        {
+            string header = "label 1:  value 1\nlabel 2:\tvalue 2\nlabel 3:\t value 3\nlabel 4: value 4";
+            string expected = "label 1: value 1\nlabel 2: value 2\nlabel 3: value 3\nlabel 4: value 4";
+            _renderer.GetPlainText(header).Should().Be(expected);
+        }
+
+        [Test]
+        public void GetPlainText_should_remove_relative_time([Values("1 minute", "3 years")] string relativeTime)
+        {
+            string header = $"\ndate: {relativeTime} ago (time)\nlabel 2: value 2";
+            string expected = "\ndate: time\nlabel 2: value 2";
+            _renderer.GetPlainText(header).Should().Be(expected);
+        }
+
+        [Test]
+        public void GetPlainText_should_not_remove_ago_from_author([Values("mago@x.y", "x@blagoq.org", "ago <x@y.z>")] string author)
+        {
+            string header = $"\nAuthor: {author}\nlabel 2: value 2";
+            _renderer.GetPlainText(header).Should().Be(header);
+        }
+
+        [Test]
+        public void GetPlainText_should_remove_child_and_parent_commits([Values(
+            "Child: 123bcdef",
+            "Children: 123bcdef, 234abcd",
+            "Parent: 123bcdef",
+            "Parents: 123bcdef, 234abcd",
+            "Children: 123bcdef, 234abcd\nParent: 345bcdef")]
+            string relatives)
+        {
+            string header = $"label 1: value 1\n{relatives}\nlabel 3: value 3";
+            string expected = $"label 1: value 1\nlabel 3: value 3";
+            _renderer.GetPlainText(header).Should().Be(expected);
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

Do not copy the following `CommitInfo` content to the clipboard any longer:
- tabulator(s) after the `:` 
- relative time
- child and parent hashes
- entire lower panel:
  - related links
  - "contained in branches / tags"
  - "derives from tag"

## Screenshots <!-- Remove this section if PR does not change UI -->

![grafik](https://user-images.githubusercontent.com/36601201/202564588-b3002782-abaf-42b2-b043-4a56fe4c51ed.png)

### Before

```
Author:		Philippe Miossec <pmiossec@gmail.com>
Date:		1 day ago (16.11.2022 07:41:44)
Committer:	GitHub <noreply@github.com>
Commit hash:	6f9591c6ad0d0d4ab6970fa1c837560a9e743e3c
Children:	d10fc120 68d45919 4948ebac 87207d96
Parent:		9fd9895d

FormBrowse: let the user add fetch/pull custom icons in the toolbar (#10293)
Related links: View on GitHub, Issue 10293

Contained in branches:
feature/copy_commit_info
upstream/master
feature/7982_explorer_integration
fix/10414_derived_from_tag
upstream/HEAD
mstv/feature/7982_explorer_integration
mstv/feature/copy_commit_info
mstv/fix/10414_derived_from_tag
z_philippe/all_to_upstream
z_philippe/editnetspell_autocomplete
z_philippe/settings_button_split

Contained in no tag

Derives from no tag
```

### After

```
Author: Philippe Miossec <pmiossec@gmail.com>
Date: 16.11.2022 07:41:44
Committer: GitHub <noreply@github.com>
Commit hash: 6f9591c6ad0d0d4ab6970fa1c837560a9e743e3c

FormBrowse: let the user add fetch/pull custom icons in the toolbar (#10293)
```

## Test methodology <!-- How did you ensure quality? -->

- add NUnit testcases

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 47b630aae095e9f69a9ba666c05f32e17ff953a5
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.10
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.10 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
