### PR TITLE
Persist Current Branch setting

### DIFF
--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -199,7 +199,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         /// <summary>
         /// Disables all active filters.
-        /// Reflog is not disabled.
+        /// CurrentBranch and Reflog are not disabled.
         /// FullHistory and SimplifyMerges are considered settings and not reset.
         /// </summary>
         public void ResetAllFilters()
@@ -212,7 +212,6 @@ namespace GitUI.UserControls.RevisionGrid
             ByDiffContent = false;
             ByPathFilter = false;
             ByBranchFilter = false;
-            ShowCurrentBranchOnly = false;
             ShowOnlyFirstParent = false;
             ShowMergeCommits = true;
             ShowSimplifyByDecoration = false;

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -137,9 +137,8 @@ namespace GitUI.UserControls.RevisionGrid
             get => AppSettings.ShowReflogReferences;
             set
             {
-                // Do not unset ByBranchFilter or ShowCurrentBranchOnly.
-                // ShowReflogReferences dominates those settings and if the user
-                // toggles the Reflog button, the curremt branch fílter should appear.
+                // ShowReflogReferences dominates ByBranchFilter and ShowCurrentBranchOnly,
+                // if the user toggles the Reflog button, the curremt branch fílter should appear.
                 AppSettings.ShowReflogReferences = value;
             }
         }
@@ -171,14 +170,13 @@ namespace GitUI.UserControls.RevisionGrid
         /// <summary>
         /// Has any filters in addition to revision filters that sets the history.
         /// Currently, this is only branch and date filters.
-        /// Note that All/Reflog are not considered as filters.
+        /// Note that Current/Reflog are not considered as filters (All is default).
         /// </summary>
         public bool HasFilter
         {
             get => HasRevisionFilter
                 || ByDateFrom
                 || ByDateTo
-                || ShowCurrentBranchOnly
                 || ShowOnlyFirstParent
                 || !string.IsNullOrWhiteSpace(BranchFilter);
         }

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
@@ -757,9 +757,12 @@ namespace GitUITests.UserControls
                                                 {
                                                     foreach (bool showCurrentBranchOnly in new[] { false, true })
                                                     {
-                                                        foreach (string branchFilter in new[] { "branch1", "", null })
+                                                        foreach (bool showReflogReferences in new[] { false, true })
                                                         {
-                                                            yield return new TestCaseData(byDateFrom, byDateTo, byAuthor, byCommitter, byMessage, byDiffContent, showSimplifyByDecoration, showMergeCommits, pathFilter, showCurrentBranchOnly, branchFilter);
+                                                            foreach (string branchFilter in new[] { "branch1", "", null })
+                                                            {
+                                                                yield return new TestCaseData(byDateFrom, byDateTo, byAuthor, byCommitter, byMessage, byDiffContent, showSimplifyByDecoration, showMergeCommits, pathFilter, showCurrentBranchOnly, showReflogReferences, branchFilter);
+                                                            }
                                                         }
                                                     }
                                                 }
@@ -775,7 +778,7 @@ namespace GitUITests.UserControls
         }
 
         [TestCaseSource(nameof(FilterInfo_HasFilterTestCases))]
-        public void FilterInfo_HasFilter_expected(bool byDateFrom, bool byDateTo, bool byAuthor, bool byCommitter, bool byMessage, bool byDiffContent, bool showSimplifyByDecoration, bool showMergeCommits, string pathFilter, bool showCurrentBranchOnly, string branchFilter)
+        public void FilterInfo_HasFilter_expected(bool byDateFrom, bool byDateTo, bool byAuthor, bool byCommitter, bool byMessage, bool byDiffContent, bool showSimplifyByDecoration, bool showMergeCommits, string pathFilter, bool showCurrentBranchOnly, bool showReflogReferences, string branchFilter)
         {
             FilterInfo filterInfo = new()
             {
@@ -790,15 +793,16 @@ namespace GitUITests.UserControls
                 ByPathFilter = true,
                 PathFilter = pathFilter,
                 ShowCurrentBranchOnly = showCurrentBranchOnly,
+                ShowReflogReferences = showReflogReferences,
                 ByBranchFilter = true,
                 BranchFilter = branchFilter
             };
 
-            filterInfo.HasFilter.Should().Be(byDateFrom || byDateTo || byAuthor || byCommitter || byMessage || byDiffContent || showSimplifyByDecoration || !showMergeCommits || !string.IsNullOrWhiteSpace(pathFilter) || showCurrentBranchOnly || !string.IsNullOrWhiteSpace(branchFilter));
+            filterInfo.HasFilter.Should().Be(byDateFrom || byDateTo || byAuthor || byCommitter || byMessage || byDiffContent || showSimplifyByDecoration || !showMergeCommits || !string.IsNullOrWhiteSpace(pathFilter) || !string.IsNullOrWhiteSpace(branchFilter));
         }
 
         [TestCaseSource(nameof(FilterInfo_HasFilterTestCases))]
-        public void FilterInfo_ResetAllFilters_expected(bool byDateFrom, bool byDateTo, bool byAuthor, bool byCommitter, bool byMessage, bool byDiffContent, bool showSimplifyByDecoration, bool showMergeCommits, string pathFilter, bool showCurrentBranchOnly, string branchFilter)
+        public void FilterInfo_ResetAllFilters_expected(bool byDateFrom, bool byDateTo, bool byAuthor, bool byCommitter, bool byMessage, bool byDiffContent, bool showSimplifyByDecoration, bool showMergeCommits, string pathFilter, bool showCurrentBranchOnly, bool showReflogReferences, string branchFilter)
         {
             FilterInfo filterInfo = new()
             {
@@ -813,6 +817,7 @@ namespace GitUITests.UserControls
                 ByPathFilter = true,
                 PathFilter = pathFilter,
                 ShowCurrentBranchOnly = showCurrentBranchOnly,
+                ShowReflogReferences = showReflogReferences,
                 ByBranchFilter = true,
                 BranchFilter = branchFilter
             };
@@ -828,8 +833,10 @@ namespace GitUITests.UserControls
             filterInfo.ShowSimplifyByDecoration.Should().BeFalse();
             filterInfo.ShowMergeCommits.Should().BeTrue();
             filterInfo.ByPathFilter.Should().BeFalse();
-            filterInfo.ShowCurrentBranchOnly.Should().BeFalse();
             filterInfo.ByBranchFilter.Should().BeFalse();
+
+            filterInfo.IsShowCurrentBranchOnlyChecked.Should().Be(showCurrentBranchOnly && !showReflogReferences);
+            filterInfo.ShowReflogReferences.Should().Be(showReflogReferences);
         }
 
         [TestCase("author1", "committer2", "message3", "diffContent4", true, false, "pathFilter7", false, false, "branchFilter8",


### PR DESCRIPTION
Fixes #10424

## Proposed changes

Revert change to reset to All when changing repo

Note: This could be replaced with resetting Reflog->All instead, to be consistent
(Filtered branches should always be reset, more or less quering the repo twice needed to find if the filtered branches are available in the new repo.

Tests are not adapted - there are a lot of changes needed.

For 4.0.1 too

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
