### PR TITLE
Do not add BOM when commitEncoding is set to upcase UTF-8

### DIFF
--- a/GitCommands/Settings/ConfigFileSettings.cs
+++ b/GitCommands/Settings/ConfigFileSettings.cs
@@ -136,7 +136,12 @@ namespace GitCommands.Settings
 
         private Encoding? GetEncoding(string settingName)
         {
-            string encodingName = GetValue(settingName);
+            // The keys in AppSettings.AvailableEncodings are lower-case, and the actual
+            // configuration is case-insensitive, and can be configured uppercase on the
+            // command line. If configured as UTF-8, then if we don't use the predefined
+            // encoding, it will use the default, which adds BOM.
+            // Convert it to lowercase, to ensure matching.
+            string encodingName = GetValue(settingName).ToLowerInvariant();
 
             if (string.IsNullOrEmpty(encodingName))
             {

--- a/contributors.txt
+++ b/contributors.txt
@@ -182,3 +182,4 @@ YYYY/MM/DD, github id, Full name, email
 2022/10/15, TanukiSharp, Sebastien ROBERT, sebastien.saigo(at)gmail.com
 2022/10/26, zachesposito, Zach Esposito, zach(at)zachesposito.me
 2022/11/07, Dub1shu, Kazuki Watanabe, dubian1shu(at)gmail.com
+2022/11/29, orgads, Orgad Shaneh, orgads(at)gmail.com


### PR DESCRIPTION
commitEncoding is case-insensitive, and the predefined UTF8 encoding is using lowercase key utf-8. Convert to lowercase to guarantee that it matches.

## Test methodology <!-- How did you ensure quality? -->
- `git config i18n.commitEncoding UTF-8`
- Commit using Git Extensions
- `git show` shows a leading space before the commit subject.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.38.1
- Windows 10

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
