### PR TITLE
Better handle git security exception

### DIFF
--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -22,7 +22,7 @@ namespace GitUI.CommandsDialogs
             InitializeComponent();
         }
 
-        public FormEditor(GitUICommands commands, string? fileName, bool showWarning)
+        public FormEditor(GitUICommands commands, string? fileName, bool showWarning, bool readOnly = false)
             : base(commands)
         {
             _fileName = fileName;
@@ -40,6 +40,8 @@ namespace GitUI.CommandsDialogs
             fileViewer.TextChanged += (s, e) => HasChanges = true;
             fileViewer.TextLoaded += (s, e) => HasChanges = false;
             panelMessage.Visible = showWarning;
+
+            fileViewer.IsReadOnly = readOnly;
         }
 
         private bool HasChanges

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -140,6 +140,30 @@ the last selected commit.");
         private readonly TranslationString _errorSshPuTTYNotConfigured = new("PuTTY is not configured as SSH client");
         private readonly TranslationString _errorSshPuTTYWhereConfigure = new("SSH client can be configured in Settings > SSH.");
 
+        // Dubious ownership popup
+        private readonly TranslationString _gitSecurityError = new("Git security error");
+        private readonly TranslationString _gitDubiousOwnershipHeader = new("Do you want to trust this repository by adding a security exception?");
+        private readonly TranslationString _gitDubiousOwnershipText = new(@"Git detected a security problem that prevents opening the repository.
+Git-tracked directories are considered unsafe if they are owned by someone other than the current user.
+
+To be able to open this repository, you need to either:
+- add a security exception for the repository to make git trust it, or
+- correct the ownership of the repository.");
+        private readonly TranslationString _gitDubiousOwnershipTrustRepository = new("Trust this repository");
+        private readonly TranslationString _gitDubiousOwnershipTrustAllRepositories = new("Trust all repositories");
+        private readonly TranslationString _gitDubiousOwnershipOpenRepositoryFolder = new("Open repository in Explorer");
+        private readonly TranslationString _gitDubiousOwnershipSeeGitCommandOutput = new("See git command output...");
+        private readonly TranslationString _gitDubiousOwnershipHideGitCommandOutput = new("Hide git command output...");
+        private readonly TranslationString _gitDubiousOwnershipTrustAllInstruction = new(@"Git-tracked directories are considered unsafe if they are owned by someone other than the current user.
+By default, Git will refuse to even parse a Git config of a repository owned by someone else, let alone
+run its hooks, and this config setting allows users to specify exceptions, e.g. for intentionally shared
+repositories.
+
+If you wish to trust all git repositories on your system even if they are owned by someone else, run the
+following command.
+
+!!! THIS CAN BE DANGEROUS !!!");
+
         // public only because of FormTranslate
         public TranslatedStrings()
         {
@@ -300,5 +324,15 @@ the last selected commit.");
         public static string StashDropConfirmTitle => _instance.Value._stashDropConfirmTitle.Text;
         public static string CannotBeUndone => _instance.Value._cannotBeUndone.Text;
         public static string AreYouSure => _instance.Value._areYouSure.Text;
+
+        public static string GitSecurityError => _instance.Value._gitSecurityError.Text;
+        public static string GitDubiousOwnershipHeader => _instance.Value._gitDubiousOwnershipHeader.Text;
+        public static string GitDubiousOwnershipText => _instance.Value._gitDubiousOwnershipText.Text;
+        public static string GitDubiousOwnershipTrustRepository => _instance.Value._gitDubiousOwnershipTrustRepository.Text;
+        public static string GitDubiousOwnershipTrustAllRepositories => _instance.Value._gitDubiousOwnershipTrustAllRepositories.Text;
+        public static string GitDubiousOwnershipOpenRepositoryFolder => _instance.Value._gitDubiousOwnershipOpenRepositoryFolder.Text;
+        public static string GitDubiousOwnershipSeeGitCommandOutput => _instance.Value._gitDubiousOwnershipSeeGitCommandOutput.Text;
+        public static string GitDubiousOwnershipHideGitCommandOutput => _instance.Value._gitDubiousOwnershipHideGitCommandOutput.Text;
+        public static string GitDubiousOwnershipTrustAllInstruction => _instance.Value._gitDubiousOwnershipTrustAllInstruction.Text;
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -10786,8 +10786,57 @@ Select this commit to populate the full message.</source>
         <source>Failed to read "{0}" due to the following error:{1}{1}{2}{1}{1}Due to the nature of this problem, the behavior of the application cannot be guaranteed and it must be closed.{1}{1}Please correct this issue and re-open Git Extensions.</source>
         <target />
       </trans-unit>
+      <trans-unit id="_gitDubiousOwnershipHeader.Text">
+        <source>Do you want to trust this repository by adding a security exception?</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_gitDubiousOwnershipHideGitCommandOutput.Text">
+        <source>Hide git command output...</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_gitDubiousOwnershipOpenRepositoryFolder.Text">
+        <source>Open repository in Explorer</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_gitDubiousOwnershipSeeGitCommandOutput.Text">
+        <source>See git command output...</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_gitDubiousOwnershipText.Text">
+        <source>Git detected a security problem that prevents opening the repository.
+Git-tracked directories are considered unsafe if they are owned by someone other than the current user.
+
+To be able to open this repository, you need to either:
+- add a security exception for the repository to make git trust it, or
+- correct the ownership of the repository.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_gitDubiousOwnershipTrustAllInstruction.Text">
+        <source>Git-tracked directories are considered unsafe if they are owned by someone other than the current user.
+By default, Git will refuse to even parse a Git config of a repository owned by someone else, let alone
+run its hooks, and this config setting allows users to specify exceptions, e.g. for intentionally shared
+repositories.
+
+If you wish to trust all git repositories on your system even if they are owned by someone else, run the
+following command.
+
+!!! THIS CAN BE DANGEROUS !!!</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_gitDubiousOwnershipTrustAllRepositories.Text">
+        <source>Trust all repositories</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_gitDubiousOwnershipTrustRepository.Text">
+        <source>Trust this repository</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_gitExecutableNotFoundText.Text">
         <source>The Git executable could not be located on your system.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_gitSecurityError.Text">
+        <source>Git security error</source>
         <target />
       </trans-unit>
       <trans-unit id="_hoursAgo.Text">


### PR DESCRIPTION
by presenting a user frendly popup
that allows the user to add a security exception
for the current repository

Fixes #9954

## Proposed changes

Display a user frendly popup that allows the user to add a security exception for the current repository

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/203290308-3629d417-6157-4e1c-848f-af3df40152e2.png)

### After

Without git output details:
![image](https://user-images.githubusercontent.com/460196/204128066-9b80782a-7c11-40d9-9b3a-fa141621fabf.png)


With git output details:
![image](https://user-images.githubusercontent.com/460196/204128087-1c905181-caf0-45e6-bacc-923477034d58.png)


![git_security_warning](https://user-images.githubusercontent.com/460196/203291490-35bb32af-5a25-486a-95f7-07d23947dd56.gif)

## Test methodology <!-- How did you ensure quality? -->

Manual: 
- Clone a (small) repo (like `https://github.com/gitextensions/gitextensions.github.io`) in a console with Admin rights
- Open this repo into GitExtensions (without admin rights)
- See error

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 8b2f138ce975609f5ba6d513652b9bf4b221257b (Dirty)
- Git 2.38.0.windows.1 (recommended: 2.38.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.10
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 5.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 5.0.17 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.9 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.10 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
