### PR TITLE
Quote file name for the File History form

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -688,5 +688,20 @@ namespace GitUI.CommandsDialogs
         {
             FormGitCommandLog.ShowOrActivate(this);
         }
+
+        internal TestAccessor GetTestAccessor()
+            => new(this);
+
+        internal readonly struct TestAccessor
+        {
+            private readonly FormFileHistory _form;
+
+            public TestAccessor(FormFileHistory form)
+            {
+                _form = form;
+            }
+
+            public RevisionGridControl RevisionGrid => _form.RevisionGrid;
+        }
     }
 }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1154,6 +1154,16 @@ namespace GitUI
             return true;
         }
 
+        public void ShowFileHistoryDialog(string fileName)
+        {
+            RunFileHistoryCommand(new[]
+            {
+                "",
+                "filehistory",
+                fileName,
+            }, showBlame: false);
+        }
+
         public void StartFileHistoryDialog(IWin32Window? owner, string fileName, GitRevision? revision = null, bool filterByRevision = false, bool showBlame = false)
         {
             string arguments = AppSettings.UseBrowseForFileHistory.Value ? $"browse {PathFilterArg}={fileName.Quote()} -commit={revision?.ObjectId}"

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1154,16 +1154,6 @@ namespace GitUI
             return true;
         }
 
-        public void ShowFileHistoryDialog(string fileName)
-        {
-            RunFileHistoryCommand(new[]
-            {
-                "",
-                "filehistory",
-                fileName,
-            }, showBlame: false);
-        }
-
         public void StartFileHistoryDialog(IWin32Window? owner, string fileName, GitRevision? revision = null, bool filterByRevision = false, bool showBlame = false)
         {
             string arguments = AppSettings.UseBrowseForFileHistory.Value ? $"browse {PathFilterArg}={fileName.Quote()} -commit={revision?.ObjectId}"
@@ -1997,6 +1987,9 @@ namespace GitUI
             internal string NormalizeFileName(string fileName) => _commands.NormalizeFileName(fileName);
 
             internal bool RunCommandBasedOnArgument(string[] args) => _commands.RunCommandBasedOnArgument(args, InitializeArguments(args));
+
+            internal void ShowFileHistoryDialog(string fileName)
+                => _commands.RunFileHistoryCommand(args: new string[] { "", "", fileName }, showBlame: false);
         }
     }
 }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1746,7 +1746,7 @@ namespace GitUI
                                  () => new FormBrowse(commands: this, new BrowseArguments
                                  {
                                      RevFilter = filterByRevision ? revision?.ObjectId.ToString() : null,
-                                     PathFilter = fileHistoryFileName,
+                                     PathFilter = fileHistoryFileName.QuoteNE(),
                                      SelectedId = revision?.ObjectId,
                                      IsFileBlameHistory = true
                                  }));
@@ -1754,7 +1754,7 @@ namespace GitUI
             else
             {
                 ShowModelessForm(owner: null, requiresValidWorkingDir: true, preEvent: null, postEvent: null,
-                                 () => new FormFileHistory(commands: this, fileHistoryFileName, revision, filterByRevision, showBlame));
+                                 () => new FormFileHistory(commands: this, fileHistoryFileName.QuoteNE(), revision, filterByRevision, showBlame));
             }
 
             return true;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1727,6 +1727,8 @@ namespace GitUI
                 return false;
             }
 
+            fileHistoryFileName = fileHistoryFileName.QuoteNE();
+
             GitRevision? revision = null;
             if (args.Count > 3)
             {
@@ -1756,7 +1758,7 @@ namespace GitUI
                                  () => new FormBrowse(commands: this, new BrowseArguments
                                  {
                                      RevFilter = filterByRevision ? revision?.ObjectId.ToString() : null,
-                                     PathFilter = fileHistoryFileName.QuoteNE(),
+                                     PathFilter = fileHistoryFileName,
                                      SelectedId = revision?.ObjectId,
                                      IsFileBlameHistory = true
                                  }));
@@ -1764,7 +1766,7 @@ namespace GitUI
             else
             {
                 ShowModelessForm(owner: null, requiresValidWorkingDir: true, preEvent: null, postEvent: null,
-                                 () => new FormFileHistory(commands: this, fileHistoryFileName.QuoteNE(), revision, filterByRevision, showBlame));
+                                 () => new FormFileHistory(commands: this, fileHistoryFileName, revision, filterByRevision, showBlame));
             }
 
             return true;

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormFileHistoryTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormFileHistoryTests.cs
@@ -18,11 +18,11 @@ public class FormFileHistoryTests
     {
         AppSettings.UseBrowseForFileHistory.Value = false;
 
-            _composition = TestComposition.Empty
-                .AddParts(typeof(MockLinkFactory))
-                .AddParts(typeof(MockWindowsJumpListManager))
-                .AddParts(typeof(MockRepositoryDescriptionProvider))
-                .AddParts(typeof(MockAppTitleGenerator));
+        var composition = TestComposition.Empty
+            .AddParts(typeof(MockLinkFactory))
+            .AddParts(typeof(MockWindowsJumpListManager))
+            .AddParts(typeof(MockRepositoryDescriptionProvider))
+            .AddParts(typeof(MockAppTitleGenerator));
 
         ExportProvider mefExportProvider = composition.ExportProviderFactory.CreateExportProvider();
         ManagedExtensibility.SetTestExportProvider(mefExportProvider);

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormFileHistoryTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormFileHistoryTests.cs
@@ -18,7 +18,7 @@ public class FormFileHistoryTests
     {
         AppSettings.UseBrowseForFileHistory.Value = false;
 
-        var composition = TestComposition.Empty
+        TestComposition composition = TestComposition.Empty
             .AddParts(typeof(MockLinkFactory))
             .AddParts(typeof(MockWindowsJumpListManager))
             .AddParts(typeof(MockRepositoryDescriptionProvider))
@@ -54,7 +54,7 @@ public class FormFileHistoryTests
     private static void RunFormTest(Action<FormFileHistory> testDriver, string fileName, GitUICommands commands)
     {
         UITest.RunForm(
-            showForm: () => commands.ShowFileHistoryDialog(fileName),
+            showForm: () => commands.GetTestAccessor().ShowFileHistoryDialog(fileName),
             (FormFileHistory form) =>
             {
                 testDriver(form);

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormFileHistoryTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormFileHistoryTests.cs
@@ -18,8 +18,11 @@ public class FormFileHistoryTests
     {
         AppSettings.UseBrowseForFileHistory.Value = false;
 
-        TestComposition? composition = TestComposition.Empty
-            .AddParts(typeof(MockLinkFactory));
+            _composition = TestComposition.Empty
+                .AddParts(typeof(MockLinkFactory))
+                .AddParts(typeof(MockWindowsJumpListManager))
+                .AddParts(typeof(MockRepositoryDescriptionProvider))
+                .AddParts(typeof(MockAppTitleGenerator));
 
         ExportProvider mefExportProvider = composition.ExportProviderFactory.CreateExportProvider();
         ManagedExtensibility.SetTestExportProvider(mefExportProvider);

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormFileHistoryTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormFileHistoryTests.cs
@@ -1,0 +1,67 @@
+﻿using CommonTestUtils;
+using CommonTestUtils.MEF;
+using FluentAssertions;
+using GitCommands;
+using GitUI;
+using GitUI.CommandsDialogs;
+using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Composition;
+using NUnit.Framework;
+
+namespace GitExtensions.UITests.CommandsDialogs;
+
+[Apartment(ApartmentState.STA)]
+public class FormFileHistoryTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        AppSettings.UseBrowseForFileHistory.Value = false;
+
+        TestComposition? composition = TestComposition.Empty
+            .AddParts(typeof(MockLinkFactory));
+
+        ExportProvider mefExportProvider = composition.ExportProviderFactory.CreateExportProvider();
+        ManagedExtensibility.SetTestExportProvider(mefExportProvider);
+    }
+
+    [TestCase("", "file.txt")]
+    [TestCase("", "file with spaces.txt")]
+    [TestCase("Dir with spaces", "file.txt")]
+    [TestCase("Dir with spaces", "file with spaces.txt")]
+    public void File_history_should_behave_as_expected(string fileRelativePath, string fileName)
+    {
+        using ReferenceRepository referenceRepository = new();
+        GitUICommands commands = new(referenceRepository.Module);
+
+        string revision1 = referenceRepository.CreateCommitRelative(fileRelativePath, fileName, $"Create '{fileName}' in directory '{fileRelativePath}'");
+        string revision2 = referenceRepository.CreateCommitRelative(fileRelativePath, fileName, $"Update '{fileName}' in directory '{fileRelativePath}'");
+        string revision3 = referenceRepository.CreateCommitRelative(fileRelativePath, fileName, $"Update '{fileName}' in directory '{fileRelativePath}' again");
+
+        RunFormTest(
+            form =>
+            {
+                WaitForRevisionsToBeLoaded(form);
+                form.GetTestAccessor().RevisionGrid.GetRevision(ObjectId.Parse(revision1)).Should().NotBeNull();
+                form.GetTestAccessor().RevisionGrid.GetRevision(ObjectId.Parse(revision2)).Should().NotBeNull();
+                form.GetTestAccessor().RevisionGrid.GetRevision(ObjectId.Parse(revision3)).Should().NotBeNull();
+            }, Path.Combine(fileRelativePath, fileName), commands);
+    }
+
+    private static void RunFormTest(Action<FormFileHistory> testDriver, string fileName, GitUICommands commands)
+    {
+        UITest.RunForm(
+            showForm: () => commands.ShowFileHistoryDialog(fileName),
+            (FormFileHistory form) =>
+            {
+                testDriver(form);
+
+                return Task.CompletedTask;
+            });
+    }
+
+    private static void WaitForRevisionsToBeLoaded(FormFileHistory form)
+    {
+        UITest.ProcessUntil("Loading Revisions", () => form.GetTestAccessor().RevisionGrid.GetTestAccessor().IsDataLoadComplete);
+    }
+}

--- a/UnitTests/CommonTestUtils/ReferenceRepository.cs
+++ b/UnitTests/CommonTestUtils/ReferenceRepository.cs
@@ -91,6 +91,18 @@ namespace CommonTestUtils
 
         public string CreateRepoFile(string fileName, string fileContent) => _moduleTestHelper.CreateRepoFile(fileName, fileContent);
 
+        public string CreateCommitRelative(string fileRelativePath, string fileName, string commitMessage, string content = null)
+        {
+            using Repository repository = new(_moduleTestHelper.Module.WorkingDir);
+            _moduleTestHelper.CreateRepoFile(fileRelativePath, fileName, content ?? commitMessage);
+            repository.Index.Add(Path.Combine(fileRelativePath, fileName));
+
+            CommitHash = Commit(repository, commitMessage);
+            Console.WriteLine($"Created commit: {CommitHash}, message: {commitMessage}");
+
+            return CommitHash;
+        }
+
         public string DeleteRepoFile(string fileName) => _moduleTestHelper.DeleteRepoFile(fileName);
 
         public void CreateAnnotatedTag(string tagName, string commitHash, string message)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

Fixes the display of history for files which include a space in their path.

## Test methodology <!-- How did you ensure quality? -->

Manual testing - created a file with a space in its path, committed several changes and tried to view its history.

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 4afd375249ceede4e08a5aa49379e961409c09a7
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.11
- DPI 96dpi (no scaling)


<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
