### PR TITLE
Do not store the default value of a NumberSetting

### DIFF
--- a/Plugins/GitUIPluginInterfaces/Settings/NumberSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/NumberSetting.cs
@@ -55,23 +55,16 @@
 
             public override void LoadSetting(ISettingsSource settings, NumericUpDown control)
             {
-                object? settingVal = settings.SettingLevel == SettingLevel.Effective
-                    ? Setting.ValueOrDefault(settings)
-                    : Setting[settings];
-
-                control.Value = (int)settingVal;
+                control.Value = Setting.ValueOrDefault(settings);
             }
 
             public override void SaveSetting(ISettingsSource settings, NumericUpDown control)
             {
-                var controlValue = control.Value;
+                decimal controlValue = control.Value;
 
-                if (settings.SettingLevel == SettingLevel.Effective)
+                if (Setting.ValueOrDefault(settings) == controlValue)
                 {
-                    if (Setting.ValueOrDefault(settings) == controlValue)
-                    {
-                        return;
-                    }
+                    return;
                 }
 
                 Setting[settings] = controlValue;


### PR DESCRIPTION
Fixes #10323

## Proposed changes

- Do not store the default value of a NumberSetting
  because NumericUpDown cannot indicate a null value
  (The binding was created in #9119.)
- Always display the default value if nothing is set (not only for "effective")

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

NRE

### After

![grafik](https://user-images.githubusercontent.com/36601201/203651251-2fdbd1c2-13c6-4581-8ebe-79ccbadeed56.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 2d4c0f42c9cd0cdf0a856336d5e2b0eedbe8d4bc
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.10
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).