### PR TITLE
Set custom difftool list to empty if parsing is cancelled

### DIFF
--- a/GitCommands/CustomDiffMergeToolCache.cs
+++ b/GitCommands/CustomDiffMergeToolCache.cs
@@ -67,16 +67,14 @@ namespace GitCommands
                     _tools = ParseCustomDiffMergeTool(output, defaultTool);
                 }
             }
-            catch
+            finally
             {
                 if (_tools is null)
                 {
                     // Parsing has failed, just provide an empty list, no user notification
                     _tools = Array.Empty<string>();
                 }
-            }
-            finally
-            {
+
                 _mutex.Release();
             }
 

--- a/GitCommands/CustomDiffMergeToolCache.cs
+++ b/GitCommands/CustomDiffMergeToolCache.cs
@@ -67,6 +67,10 @@ namespace GitCommands
                     _tools = ParseCustomDiffMergeTool(output, defaultTool);
                 }
             }
+            catch
+            {
+                // No action.
+            }
             finally
             {
                 if (_tools is null)


### PR DESCRIPTION
Fixes #10435

## Proposed changes

If loading custom diff tools is cancelled, the list could be null and a null exception occur.

This has been around since custom difftools list (3.5?) so not urgent for 4.0.

## Test methodology <!-- How did you ensure quality? -->

Code review

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
