### PR TITLE
Test for pullAction failed if defaults were changed

### DIFF
--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormPullTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormPullTests.cs
@@ -107,20 +107,29 @@ namespace GitExtensions.UITests.CommandsDialogs
         public void Should_correctly_setup_for_defined_pull_action(AppSettings.PullAction pullAction,
             bool mergeChecked, bool pruneRemoteBranches, bool pruneRemoteBranchesAndTags, bool rebaseChecked, bool fetchChecked, bool autoStashChecked, bool pruneRemoteBranchesEnabled, bool pruneRemoteBranchesAndTagsEnabled)
         {
+            AppSettings.PullAction defaultPullAction = AppSettings.DefaultPullAction;
+            AppSettings.DefaultPullAction = AppSettings.PullAction.Merge;
             RunFormTest(
                 form =>
                 {
-                    var accessor = form.GetTestAccessor();
+                    try
+                    {
+                        var accessor = form.GetTestAccessor();
 
-                    accessor.Merge.Checked.Should().Be(mergeChecked);
-                    accessor.Prune.Checked.Should().Be(pruneRemoteBranches);
-                    accessor.PruneTags.Checked.Should().Be(pruneRemoteBranchesAndTags);
-                    accessor.Rebase.Checked.Should().Be(rebaseChecked);
-                    accessor.Fetch.Checked.Should().Be(fetchChecked);
-                    accessor.AutoStash.Checked.Should().Be(autoStashChecked);
-                    accessor.Prune.Enabled.Should().Be(pruneRemoteBranchesEnabled);
-                    accessor.PruneTags.Enabled.Should().Be(pruneRemoteBranchesAndTagsEnabled);
-                    accessor.Remotes.Text.Should().Be("[ All ]");
+                        accessor.Merge.Checked.Should().Be(mergeChecked);
+                        accessor.Prune.Checked.Should().Be(pruneRemoteBranches);
+                        accessor.PruneTags.Checked.Should().Be(pruneRemoteBranchesAndTags);
+                        accessor.Rebase.Checked.Should().Be(rebaseChecked);
+                        accessor.Fetch.Checked.Should().Be(fetchChecked);
+                        accessor.AutoStash.Checked.Should().Be(autoStashChecked);
+                        accessor.Prune.Enabled.Should().Be(pruneRemoteBranchesEnabled);
+                        accessor.PruneTags.Enabled.Should().Be(pruneRemoteBranchesAndTagsEnabled);
+                        accessor.Remotes.Text.Should().Be("[ All ]");
+                    }
+                    finally
+                    {
+                        AppSettings.DefaultPullAction = defaultPullAction;
+                    }
                 },
                 null, null, pullAction);
         }


### PR DESCRIPTION
## Proposed changes

Test fail if defaults for pull action is changed.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
