### PR TITLE
Make "blame" setting non-sticky

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -849,12 +849,10 @@ namespace GitCommands
             set => SetBool("opensubmodulediffinseparatewindow", value);
         }
 
-        // This is a "view settings" which is configured for the lifetime of the app instance,
-        // and it doesn't get persisted and shared between different instances of the app.
         public static bool RevisionFileTreeShowBlame
         {
-            get;
-            set;
+            get => GetBool("RevisionFileTreeShowBlame", true);
+            set => SetBool("RevisionFileTreeShowBlame", value);
         }
 
         /// <summary>

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -849,12 +849,6 @@ namespace GitCommands
             set => SetBool("opensubmodulediffinseparatewindow", value);
         }
 
-        public static bool RevisionFileTreeShowBlame
-        {
-            get => GetBool("RevisionFileTreeShowBlame", true);
-            set => SetBool("RevisionFileTreeShowBlame", value);
-        }
-
         /// <summary>
         /// Gets or sets whether to show artificial commits in the revision graph.
         /// </summary>

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -849,10 +849,12 @@ namespace GitCommands
             set => SetBool("opensubmodulediffinseparatewindow", value);
         }
 
+        // This is a "view settings" which is configured for the lifetime of the app instance,
+        // and it doesn't get persisted and shared between different instances of the app.
         public static bool RevisionFileTreeShowBlame
         {
-            get => GetBool("RevisionFileTreeShowBlame", true);
-            set => SetBool("RevisionFileTreeShowBlame", value);
+            get;
+            set;
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -250,12 +250,6 @@ namespace GitUI.CommandsDialogs
             SystemEvents.SessionEnding += (sender, args) => SaveApplicationSettings();
 
             _isFileBlameHistory = args.IsFileBlameHistory;
-            if (_isFileBlameHistory)
-            {
-                // Blame was explicitly requested (otherwise start with last used)
-                AppSettings.RevisionFileTreeShowBlame = true;
-            }
-
             InitializeComponent();
             BackColor = OtherColors.BackgroundColor;
 
@@ -315,7 +309,7 @@ namespace GitUI.CommandsDialogs
             toolStripButtonPush.Initialize(_aheadBehindDataProvider);
             repoObjectsTree.Initialize(_aheadBehindDataProvider, filterRevisionGridBySpaceSeparatedRefs: ToolStripFilters.SetBranchFilter, RevisionGrid, RevisionGrid, RevisionGrid);
             revisionDiff.Bind(RevisionGrid, fileTree, RefreshGitStatusMonitor);
-            fileTree.Bind(RevisionGrid, RefreshGitStatusMonitor);
+            fileTree.Bind(RevisionGrid, RefreshGitStatusMonitor, _isFileBlameHistory ? true : AppSettings.RevisionFileTreeShowBlame);
             RevisionGrid.ResumeRefreshRevisions();
 
             // Application is init, the repo related operations are triggered in OnLoad()

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -309,7 +309,9 @@ namespace GitUI.CommandsDialogs
             toolStripButtonPush.Initialize(_aheadBehindDataProvider);
             repoObjectsTree.Initialize(_aheadBehindDataProvider, filterRevisionGridBySpaceSeparatedRefs: ToolStripFilters.SetBranchFilter, RevisionGrid, RevisionGrid, RevisionGrid);
             revisionDiff.Bind(RevisionGrid, fileTree, RefreshGitStatusMonitor);
-            fileTree.Bind(RevisionGrid, RefreshGitStatusMonitor, _isFileBlameHistory ? true : AppSettings.RevisionFileTreeShowBlame);
+
+            // Show blame by default if not started from command line
+            fileTree.Bind(RevisionGrid, RefreshGitStatusMonitor, _isFileBlameHistory);
             RevisionGrid.ResumeRefreshRevisions();
 
             // Application is init, the repo related operations are triggered in OnLoad()

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -310,6 +310,7 @@ namespace GitUI.CommandsDialogs
             repoObjectsTree.Initialize(_aheadBehindDataProvider, filterRevisionGridBySpaceSeparatedRefs: ToolStripFilters.SetBranchFilter, RevisionGrid, RevisionGrid, RevisionGrid);
             revisionDiff.Bind(RevisionGrid, fileTree, RefreshGitStatusMonitor);
 
+            // Show blame by default if not started from command line
             fileTree.Bind(RevisionGrid, RefreshGitStatusMonitor, _isFileBlameHistory);
             RevisionGrid.ResumeRefreshRevisions();
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -310,7 +310,6 @@ namespace GitUI.CommandsDialogs
             repoObjectsTree.Initialize(_aheadBehindDataProvider, filterRevisionGridBySpaceSeparatedRefs: ToolStripFilters.SetBranchFilter, RevisionGrid, RevisionGrid, RevisionGrid);
             revisionDiff.Bind(RevisionGrid, fileTree, RefreshGitStatusMonitor);
 
-            // Show blame by default if not started from command line
             fileTree.Bind(RevisionGrid, RefreshGitStatusMonitor, _isFileBlameHistory);
             RevisionGrid.ResumeRefreshRevisions();
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -61,14 +61,14 @@ See the changes in the commit form.");
                                                                          new GitRevisionInfoProvider(() => Module),
                                                                          new FileAssociatedIconProvider());
             BlameControl.HideCommitInfo();
-            blameToolStripMenuItem1.Checked = AppSettings.RevisionFileTreeShowBlame;
             filterFileInGridToolStripMenuItem.Text = TranslatedStrings.FilterFileInGrid;
         }
 
-        public void Bind(RevisionGridControl revisionGrid, Action? refreshGitStatus)
+        public void Bind(RevisionGridControl revisionGrid, Action? refreshGitStatus, bool isBlame)
         {
             _revisionGrid = revisionGrid;
             _refreshGitStatus = refreshGitStatus;
+            blameToolStripMenuItem1.Checked = isBlame;
         }
 
         /// <summary>
@@ -134,9 +134,10 @@ See the changes in the commit form.");
                     return;
                 }
 
-                if (requestBlame && !AppSettings.RevisionFileTreeShowBlame)
+                if (requestBlame)
                 {
-                    blameToolStripMenuItem1.Checked = AppSettings.RevisionFileTreeShowBlame = true;
+                    // Force blame without changing settings
+                    blameToolStripMenuItem1.Checked = true;
                 }
 
                 // AfterSelect will not fire when selecting again, show manually
@@ -525,7 +526,13 @@ See the changes in the commit form.");
             }
 
             blameToolStripMenuItem1.Checked = !blameToolStripMenuItem1.Checked;
-            AppSettings.RevisionFileTreeShowBlame = blameToolStripMenuItem1.Checked;
+            if (AppSettings.RevisionFileTreeShowBlame != blameToolStripMenuItem1.Checked)
+            {
+                // Update settings only if actually changed
+                // (FileHistory will set the Checked box but not update settings).
+                AppSettings.RevisionFileTreeShowBlame = blameToolStripMenuItem1.Checked;
+            }
+
             int? line = FileText.Visible ? FileText.CurrentFileLine : null;
 
             ThreadHelper.JoinableTaskFactory.RunAsync(() => ShowGitItemAsync(gitItem, line));

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -526,13 +526,6 @@ See the changes in the commit form.");
             }
 
             blameToolStripMenuItem1.Checked = !blameToolStripMenuItem1.Checked;
-            if (AppSettings.RevisionFileTreeShowBlame != blameToolStripMenuItem1.Checked)
-            {
-                // Update settings only if actually changed
-                // (FileHistory will set the Checked box but not update settings).
-                AppSettings.RevisionFileTreeShowBlame = blameToolStripMenuItem1.Checked;
-            }
-
             int? line = FileText.Visible ? FileText.CurrentFileLine : null;
 
             ThreadHelper.JoinableTaskFactory.RunAsync(() => ShowGitItemAsync(gitItem, line));

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -136,7 +136,6 @@ See the changes in the commit form.");
 
                 if (requestBlame)
                 {
-                    // Force blame without changing settings
                     blameToolStripMenuItem1.Checked = true;
                 }
 


### PR DESCRIPTION
Resolves https://github.com/gitextensions/gitextensions/issues/10511

"RevisionFileTreeShowBlame" settings was introduced in #9424.

The issue with this setting is that whenever a file history is opened, blame is turned on for all open instances of the app, and affects the File Tree tab experience.
