### PR TITLE
Stop endless dashboard repaint loop

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -26,7 +26,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             InitializeComponent();
             InitializeComplete();
 
-            SetStyle(ControlStyles.OptimizedDoubleBuffer, true);
+            SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.AllPaintingInWmPaint, true);
             Visible = false;
 
             tableLayoutPanel1.AutoSize = true;
@@ -50,17 +50,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
             // Focus the control in order for the search bar to have focus once the dashboard is shown
             userRepositoriesList.Focus();
-        }
-
-        // need this to stop flickering of the background images, nothing else works
-        protected override CreateParams CreateParams
-        {
-            get
-            {
-                CreateParams cp = base.CreateParams;
-                cp.ExStyle |= 0x02000000;
-                return cp;
-            }
         }
 
         public void RefreshContent()


### PR DESCRIPTION
It appears that WS_EX_COMPOSITED window extended style (0x02000000L) is causing the dashboard to enter into an endless repaint loop that burns CPU (~6-8% while the dashboard is open).

It also prevents the Settings dialog from closing, if it's opened while the dashboard is shown.

Resolves #10215


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
