### PR TITLE
Reinstate dev build start-up optimisation reverted in 7bd205f23c

### DIFF
--- a/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
+++ b/Plugins/GitUIPluginInterfaces/GitUIPluginInterfaces.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants Condition="$(ContinuousIntegrationBuild) == true">CI_BUILD</DefineConstants>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
+++ b/Plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
@@ -50,6 +50,10 @@ namespace GitUIPluginInterfaces
             string? userPluginsPath = UserPluginsPath;
 
             IEnumerable<FileInfo> pluginFiles = PluginsPathScanner.GetFiles(defaultPluginsPath, userPluginsPath);
+#if !CI_BUILD
+            pluginFiles = pluginFiles.Where(f => f.Name.StartsWith("GitExtensions."));
+#endif
+
             string cacheFile = Path.Combine(applicationDataFolder ?? "ignored", "Plugins", "composition.cache");
             IExportProviderFactory exportProviderFactory;
             if (applicationDataFolder is not null && File.Exists(cacheFile))


### PR DESCRIPTION


Avoid scanning thousands of assemblies while loading plugins.
