### PR TITLE
Fixup text search in diffs (multiple groups)

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -558,20 +558,21 @@ namespace GitUI
                         foundCurrentGroup = true;
                     }
 
-                    if (foundCurrentGroup)
+                    if (foundCurrentGroup && ContainsSearchableItem(FileStatusListView.Groups[i]))
                     {
                         searchInGroups.Add(FileStatusListView.Groups[i]);
                     }
                 }
 
-                int idx = curIdx;
+                int idx = ContainsSearchableItem(currentGroup) ? curIdx : FileStatusListView.Items.Count;
                 foreach (ListViewGroup grp in searchInGroups)
                 {
                     for (int i = idx - 1; i >= 0; i--)
                     {
-                        if (FileStatusListView.Items[i].Group == grp)
+                        ListViewItem item = FileStatusListView.Items[i];
+                        if (item.Group == grp && IsSearchableItem(item))
                         {
-                            return FileStatusListView.Items[i];
+                            return item;
                         }
                     }
 
@@ -592,20 +593,21 @@ namespace GitUI
                         foundCurrentGroup = true;
                     }
 
-                    if (foundCurrentGroup)
+                    if (foundCurrentGroup && ContainsSearchableItem(FileStatusListView.Groups[i]))
                     {
                         searchInGroups.Add(FileStatusListView.Groups[i]);
                     }
                 }
 
-                int idx = curIdx;
+                int idx = ContainsSearchableItem(currentGroup) ? curIdx : -1;
                 foreach (ListViewGroup grp in searchInGroups)
                 {
                     for (int i = idx + 1; i < FileStatusListView.Items.Count; i++)
                     {
-                        if (FileStatusListView.Items[i].Group == grp)
+                        ListViewItem item = FileStatusListView.Items[i];
+                        if (item.Group == grp && IsSearchableItem(item))
                         {
-                            return FileStatusListView.Items[i];
+                            return item;
                         }
                     }
 
@@ -630,7 +632,7 @@ namespace GitUI
                 ListViewGroup? lastNonEmptyGroup = null;
                 for (int i = FileStatusListView.Groups.Count - 1; i >= 0; i--)
                 {
-                    if (FileStatusListView.Groups[i].Items.Count > 0)
+                    if (ContainsSearchableItem(FileStatusListView.Groups[i]))
                     {
                         lastNonEmptyGroup = FileStatusListView.Groups[i];
                         break;
@@ -639,13 +641,34 @@ namespace GitUI
 
                 for (int i = FileStatusListView.Items.Count - 1; i >= 0; i--)
                 {
-                    if (FileStatusListView.Items[i].Group == lastNonEmptyGroup)
+                    ListViewItem item = FileStatusListView.Items[i];
+                    if (item.Group == lastNonEmptyGroup && IsSearchableItem(item))
                     {
                         return i;
                     }
                 }
 
                 return -1;
+            }
+
+            static bool IsSearchableItem(ListViewItem item)
+            {
+                return item.Tag is FileStatusItem fileStatusItem
+                    && !fileStatusItem.Item.IsStatusOnly
+                    && !fileStatusItem.Item.IsRangeDiff;
+            }
+
+            static bool ContainsSearchableItem(ListViewGroup group)
+            {
+                foreach (ListViewItem item in group.Items)
+                {
+                    if (IsSearchableItem(item))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
         }
 

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -830,8 +830,20 @@ namespace GitUI
         public void SetSelectedIndex(int idx, bool notify)
         {
             _enableSelectedIndexChangeEvent = notify;
-            SelectedIndex = idx;
-            _enableSelectedIndexChangeEvent = true;
+            try
+            {
+                SelectedIndex = idx;
+
+                ListViewGroup? group = FileStatusListView.SelectedItems.Cast<ListViewItem>().FirstOrDefault()?.Group;
+                if (group?.CollapsedState is ListViewGroupCollapsedState.Collapsed)
+                {
+                    group.CollapsedState = ListViewGroupCollapsedState.Expanded;
+                }
+            }
+            finally
+            {
+                _enableSelectedIndexChangeEvent = true;
+            }
         }
 
         public int SetSelectionFilter(string selectionFilter)

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -541,7 +541,7 @@ namespace GitUI
                 ListViewItem? nextItem = FindNextItemInGroups();
                 if (nextItem is null)
                 {
-                    return loop ? 0 : curIdx;
+                    return loop ? GetFirstIndex() : curIdx;
                 }
 
                 return nextItem.Index;
@@ -615,6 +615,40 @@ namespace GitUI
                 }
 
                 return null;
+            }
+
+            int GetFirstIndex()
+            {
+                if (FileStatusListView.Items.Count == 0)
+                {
+                    return -1;
+                }
+
+                if (FileStatusListView.Groups.Count < 2)
+                {
+                    return 0;
+                }
+
+                ListViewGroup? firstNonEmptyGroup = null;
+                foreach (ListViewGroup group in FileStatusListView.Groups)
+                {
+                    if (ContainsSearchableItem(group))
+                    {
+                        firstNonEmptyGroup = group;
+                        break;
+                    }
+                }
+
+                for (int i = 0; i < FileStatusListView.Items.Count; ++i)
+                {
+                    ListViewItem item = FileStatusListView.Items[i];
+                    if (item.Group == firstNonEmptyGroup && IsSearchableItem(item))
+                    {
+                        return i;
+                    }
+                }
+
+                return -1;
             }
 
             int GetLastIndex()

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -524,11 +524,11 @@ namespace GitUI
             }
 
             ListViewItem currentItem = FileStatusListView.Items[curIdx];
-            var currentGroup = currentItem.Group;
+            ListViewGroup currentGroup = currentItem.Group;
 
             if (searchBackward)
             {
-                var nextItem = FindPrevItemInGroups();
+                ListViewItem? nextItem = FindPrevItemInGroups();
                 if (nextItem is null)
                 {
                     return loop ? GetLastIndex() : curIdx;
@@ -538,7 +538,7 @@ namespace GitUI
             }
             else
             {
-                var nextItem = FindNextItemInGroups();
+                ListViewItem? nextItem = FindNextItemInGroups();
                 if (nextItem is null)
                 {
                     return loop ? 0 : curIdx;
@@ -550,8 +550,8 @@ namespace GitUI
             ListViewItem? FindPrevItemInGroups()
             {
                 List<ListViewGroup> searchInGroups = new();
-                var foundCurrentGroup = false;
-                for (var i = FileStatusListView.Groups.Count - 1; i >= 0; i--)
+                bool foundCurrentGroup = false;
+                for (int i = FileStatusListView.Groups.Count - 1; i >= 0; i--)
                 {
                     if (FileStatusListView.Groups[i] == currentGroup)
                     {
@@ -564,10 +564,10 @@ namespace GitUI
                     }
                 }
 
-                var idx = curIdx;
-                foreach (var grp in searchInGroups)
+                int idx = curIdx;
+                foreach (ListViewGroup grp in searchInGroups)
                 {
-                    for (var i = idx - 1; i >= 0; i--)
+                    for (int i = idx - 1; i >= 0; i--)
                     {
                         if (FileStatusListView.Items[i].Group == grp)
                         {
@@ -584,8 +584,8 @@ namespace GitUI
             ListViewItem? FindNextItemInGroups()
             {
                 List<ListViewGroup> searchInGroups = new();
-                var foundCurrentGroup = false;
-                for (var i = 0; i < FileStatusListView.Groups.Count; i++)
+                bool foundCurrentGroup = false;
+                for (int i = 0; i < FileStatusListView.Groups.Count; i++)
                 {
                     if (FileStatusListView.Groups[i] == currentGroup)
                     {
@@ -598,10 +598,10 @@ namespace GitUI
                     }
                 }
 
-                var idx = curIdx;
-                foreach (var grp in searchInGroups)
+                int idx = curIdx;
+                foreach (ListViewGroup grp in searchInGroups)
                 {
-                    for (var i = idx + 1; i < FileStatusListView.Items.Count; i++)
+                    for (int i = idx + 1; i < FileStatusListView.Items.Count; i++)
                     {
                         if (FileStatusListView.Items[i].Group == grp)
                         {


### PR DESCRIPTION
Fixes #10469

## Proposed changes

- Do not expect that `ListViewItem.Index` would reflect the visible / chronological order:
  Search the `Index` of the first diff because it can be different from 0
- Skip `StatusOnly` & `RangeDiff` items when searching diffs
- Expand the group on selection of an item in a collapsed group

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

GE not responding forever

### After

"Text not found"

## Test methodology <!-- How did you ensure quality? -->

- manual (select commit 45f0291 or f6b46ad, search for not contained text)

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build d792a68e08f0e9d4e37831b8c16fb829653bc381
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.10
- DPI 96dpi (no scaling)

## Merge strategy

Please keep single commits

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).