### PR TITLE
Report git fatal errors as not app errors

### DIFF
--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -103,7 +103,9 @@ namespace GitUI.NBugReports
                 LogError(exception, isTerminating);
             }
 
-            if (exception is ExternalOperationException externalOperationException
+            ExternalOperationException externalOperationException = exception as ExternalOperationException;
+
+            if (externalOperationException is not null
                 && externalOperationException.InnerException is { }
                 && externalOperationException.InnerException.Message.Contains(_dubiousOwnershipSecurityConfigString))
             {
@@ -132,8 +134,9 @@ namespace GitUI.NBugReports
                                                  or PathTooLongException
                                                  or Win32Exception;
 
-            // Treat all git fatal errors (e.g., those starting with "fatal: ") as user issues
-            if (exception.InnerException?.Message?.StartsWith("fatal: ") ?? false)
+            // Treat all git errors as user issues
+            if (string.Equals(AppSettings.GitCommand, externalOperationException?.Command, StringComparison.InvariantCultureIgnoreCase)
+             || string.Equals(AppSettings.WslGitCommand, externalOperationException?.Command, StringComparison.InvariantCultureIgnoreCase))
             {
                 isUserExternalOperation = true;
             }

--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -132,6 +132,12 @@ namespace GitUI.NBugReports
                                                  or PathTooLongException
                                                  or Win32Exception;
 
+            // Treat all git fatal errors (e.g., those starting with "fatal: ") as user issues
+            if (exception.InnerException?.Message?.StartsWith("fatal: ") ?? false)
+            {
+                isUserExternalOperation = true;
+            }
+
             StringBuilder text = GetExceptionInfo(exception);
             string rootError = GetRootError(exception);
 

--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -105,9 +105,7 @@ namespace GitUI.NBugReports
 
             ExternalOperationException externalOperationException = exception as ExternalOperationException;
 
-            if (externalOperationException is not null
-                && externalOperationException.InnerException is { }
-                && externalOperationException.InnerException.Message.Contains(_dubiousOwnershipSecurityConfigString))
+            if (externalOperationException?.InnerException?.Message?.Contains(_dubiousOwnershipSecurityConfigString) is true)
             {
                 ReportDubiousOwnership(externalOperationException.InnerException);
                 return;


### PR DESCRIPTION
Resolves #10483

## Proposed changes

Report git "fatal" errors as not app errors, that is, without links to raise issues on GitHub, because such issues are generally local-repo specific and should be addressable by the user.

Summary changes for Git errors:
* Do not add test "submit report for GE to investigate".
* Change *Report bug* to *View details*

It is still possible to report to GitHub with _View details_.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/205197150-728c92ae-bd3a-4b5b-b4df-e3cf6d254b9a.png)


### After

![image](https://user-images.githubusercontent.com/4403806/205429198-5bf7b9c2-9d10-4eaf-956b-efa6f48d3523.png)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
