### PR TITLE
Explorer integration hide menuitems

### DIFF
--- a/GitExtensionsShellEx/GitExtensionsShellEx.cpp
+++ b/GitExtensionsShellEx/GitExtensionsShellEx.cpp
@@ -56,6 +56,7 @@ C_ASSERT(gcMaxValue == _countof(gitExCommandNames));
 // Forward declaration of functions not declared in the header
 static CString GetRegistryValue (HKEY hOpenKey, LPCTSTR szKey, LPCTSTR path);
 static bool GetRegistryBoolValue(HKEY hOpenKey, LPCTSTR szKey, LPCTSTR path);
+static bool DisplayMenuItem(CString settings, int id);
 static bool DisplayInSubmenu(CString settings, int id);
 
 static HRESULT Create32BitHBITMAP(HDC hdc, const SIZE* psize, __deref_opt_out void** ppvBits, __out HBITMAP* phBmp);
@@ -467,88 +468,139 @@ STDMETHODIMP CGitExtensionsShellEx::QueryContextMenu(
 
     if (alwaysShowAllCommands || !isValidDir)
     {
-        isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcClone);
-        cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Clone...", IDI_ICONCLONEREPOGIT, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-        commandsId[cmdid]=gcClone;
+        if (DisplayMenuItem(szCascadeShellMenuItems, gcClone))
+        {
+            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcClone);
+            cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Clone...", IDI_ICONCLONEREPOGIT, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+            commandsId[cmdid]=gcClone;
+        }
 
-        isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcCreateRepository);
-        cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Create new repository...", IDI_ICONCREATEREPOSITORY, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-        commandsId[cmdid]=gcCreateRepository;
+        if (DisplayMenuItem(szCascadeShellMenuItems, gcCreateRepository))
+        {
+            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcCreateRepository);
+            cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Create new repository...", IDI_ICONCREATEREPOSITORY, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+            commandsId[cmdid]=gcCreateRepository;
+        }
     }
     if (isValidDir)
     {
-        isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcBrowse);
-        cmdid = AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Open repository", IDI_ICONBROWSEFILEEXPLORER, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-        commandsId[cmdid]=gcBrowse;
+        if (DisplayMenuItem(szCascadeShellMenuItems, gcBrowse))
+        {
+            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcBrowse);
+            cmdid = AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Open repository", IDI_ICONBROWSEFILEEXPLORER, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+            commandsId[cmdid]=gcBrowse;
+        }
 
         if (isFolder)
         {
-            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcCommit);
-            cmdid = AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Commit...", IDI_ICONCOMMIT, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-            commandsId[cmdid]=gcCommit;
+            if (DisplayMenuItem(szCascadeShellMenuItems, gcCommit))
+            {
+                isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcCommit);
+                cmdid = AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Commit...", IDI_ICONCOMMIT, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+                commandsId[cmdid]=gcCommit;
+            }
 
-            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcPull);
-            cmdid = AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Pull...", IDI_ICONPULL, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-            commandsId[cmdid]=gcPull;
+            if (DisplayMenuItem(szCascadeShellMenuItems, gcPull))
+            {
+                isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcPull);
+                cmdid = AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Pull...", IDI_ICONPULL, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+                commandsId[cmdid]=gcPull;
+            }
 
-            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcPush);
-            cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Push...", IDI_ICONPUSH, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-            commandsId[cmdid]=gcPush;
+            if (DisplayMenuItem(szCascadeShellMenuItems, gcPush))
+            {
+                isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcPush);
+                cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Push...", IDI_ICONPUSH, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+                commandsId[cmdid]=gcPush;
+            }
 
-            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcStash);
-            cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"View stash", IDI_ICONSTASH, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-            commandsId[cmdid]=gcStash;
+            if (DisplayMenuItem(szCascadeShellMenuItems, gcStash))
+            {
+                isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcStash);
+                cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"View stash", IDI_ICONSTASH, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+                commandsId[cmdid]=gcStash;
+            }
 
-            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcViewDiff);
-            cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"View changes", IDI_ICONVIEWCHANGES, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-            commandsId[cmdid]=gcViewDiff;
+            if (DisplayMenuItem(szCascadeShellMenuItems, gcViewDiff))
+            {
+                isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcViewDiff);
+                cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"View changes", IDI_ICONVIEWCHANGES, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+                commandsId[cmdid]=gcViewDiff;
+            }
 
-            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcCheckoutBranch);
+            if (DisplayMenuItem(szCascadeShellMenuItems, gcCheckoutBranch))
+            {
+                isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcCheckoutBranch);
+                if (isSubMenu && submenuIndex > 0) {
+                    InsertMenu(popupMenu, submenuIndex++, MF_SEPARATOR|MF_BYPOSITION, 0, NULL); ++id;
+                }
+                cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Checkout branch...", IDI_ICONBRANCHCHECKOUT, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+                commandsId[cmdid]=gcCheckoutBranch;
+            }
+
+            if (DisplayMenuItem(szCascadeShellMenuItems, gcCheckoutRevision))
+            {
+                isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcCheckoutRevision);
+                cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Checkout revision...", IDI_ICONREVISIONCHECKOUT, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+                commandsId[cmdid]=gcCheckoutRevision;
+            }
+
+            if (DisplayMenuItem(szCascadeShellMenuItems, gcCreateBranch))
+            {
+                isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcCreateBranch);
+                cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Create branch...", IDI_ICONBRANCHCREATE, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+                commandsId[cmdid]=gcCreateBranch;
+            }
+        }
+
+        if (DisplayMenuItem(szCascadeShellMenuItems, gcDiffTool))
+        {
+            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcDiffTool);
             if (isSubMenu && submenuIndex > 0) {
                 InsertMenu(popupMenu, submenuIndex++, MF_SEPARATOR|MF_BYPOSITION, 0, NULL); ++id;
             }
-            cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Checkout branch...", IDI_ICONBRANCHCHECKOUT, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-            commandsId[cmdid]=gcCheckoutBranch;
-
-            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcCheckoutRevision);
-            cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Checkout revision...", IDI_ICONREVISIONCHECKOUT, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-            commandsId[cmdid]=gcCheckoutRevision;
-
-            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcCreateBranch);
-            cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Create branch...", IDI_ICONBRANCHCREATE, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-            commandsId[cmdid]=gcCreateBranch;
+            cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Open with difftool", IDI_ICONVIEWCHANGES, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+            commandsId[cmdid]=gcDiffTool;
         }
 
-        isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcDiffTool);
+        if (DisplayMenuItem(szCascadeShellMenuItems, gcFileHistory))
+        {
+            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcFileHistory);
+            cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"File history", IDI_ICONFILEHISTORY, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+            commandsId[cmdid]=gcFileHistory;
+        }
+
+        if (DisplayMenuItem(szCascadeShellMenuItems, gcResetFileChanges))
+        {
+            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcResetFileChanges);
+            cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Reset file changes...", IDI_ICONTRESETFILETO, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+            commandsId[cmdid]=gcResetFileChanges;
+        }
+
+        if (DisplayMenuItem(szCascadeShellMenuItems, gcAddFiles))
+        {
+            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcAddFiles);
+            cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Add files...", IDI_ICONADDED, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+            commandsId[cmdid]=gcAddFiles;
+        }
+
+        if (DisplayMenuItem(szCascadeShellMenuItems, gcApplyPatch))
+        {
+            isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcApplyPatch);
+            cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Apply patch...", IDI_ICONPATCHAPPLY, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+            commandsId[cmdid]=gcApplyPatch;
+        }
+    }
+
+    if (DisplayMenuItem(szCascadeShellMenuItems, gcSettings))
+    {
+        isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcSettings);
         if (isSubMenu && submenuIndex > 0) {
             InsertMenu(popupMenu, submenuIndex++, MF_SEPARATOR|MF_BYPOSITION, 0, NULL); ++id;
         }
-        cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Open with difftool", IDI_ICONVIEWCHANGES, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-        commandsId[cmdid]=gcDiffTool;
-
-        isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcFileHistory);
-        cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"File history", IDI_ICONFILEHISTORY, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-        commandsId[cmdid]=gcFileHistory;
-
-        isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcResetFileChanges);
-        cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Reset file changes...", IDI_ICONTRESETFILETO, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-        commandsId[cmdid]=gcResetFileChanges;
-
-        isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcAddFiles);
-        cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Add files...", IDI_ICONADDED, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-        commandsId[cmdid]=gcAddFiles;
-
-        isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcApplyPatch);
-        cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Apply patch...", IDI_ICONPATCHAPPLY, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-        commandsId[cmdid]=gcApplyPatch;
+        cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Settings", IDI_ICONSETTINGS, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
+        commandsId[cmdid]=gcSettings;
     }
-
-    isSubMenu = DisplayInSubmenu(szCascadeShellMenuItems, gcSettings);
-    if (isSubMenu && submenuIndex > 0) {
-        InsertMenu(popupMenu, submenuIndex++, MF_SEPARATOR|MF_BYPOSITION, 0, NULL); ++id;
-    }
-    cmdid=AddMenuItem(!isSubMenu ? hMenu : popupMenu, L"Settings", IDI_ICONSETTINGS, uidFirstCmd, ++id, !isSubMenu ? menuIndex++ : submenuIndex++, isSubMenu);
-    commandsId[cmdid]=gcSettings;
 
     if (cascadeContextMenu)
     {
@@ -596,6 +648,18 @@ UINT CGitExtensionsShellEx::AddMenuItem(HMENU hMenu, LPTSTR text, int resource, 
 
     InsertMenuItem(hMenu, position, TRUE, &mii);
     return id;
+}
+
+static bool DisplayMenuItem(CString settings, int id)
+{
+    if (settings.GetLength() < id)
+    {
+        return false;
+    }
+    else
+    {
+        return (settings[id] != '2');
+    }
 }
 
 static bool DisplayInSubmenu(CString settings, int id)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.Designer.cs
@@ -28,9 +28,9 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.Windows.Forms.Panel panel1;
             this.labelPreview = new System.Windows.Forms.Label();
-            this.label1 = new System.Windows.Forms.Label();
             this.lblMenuEntries = new System.Windows.Forms.Label();
             this._NO_TRANSLATE_chlMenuEntries = new System.Windows.Forms.CheckedListBox();
             this.cbAlwaysShowAllCommands = new System.Windows.Forms.CheckBox();
@@ -41,6 +41,9 @@
             this.UnregisterButton = new System.Windows.Forms.Button();
             this.gbCascadingMenu = new System.Windows.Forms.GroupBox();
             this.tlpnlCascadingMenu = new System.Windows.Forms.TableLayoutPanel();
+            this.menuHelp = new System.Windows.Forms.PictureBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             panel1 = new System.Windows.Forms.Panel();
             panel1.SuspendLayout();
             this.tlpnlMain.SuspendLayout();
@@ -48,6 +51,7 @@
             this.flpnlExplorerIntegration.SuspendLayout();
             this.gbCascadingMenu.SuspendLayout();
             this.tlpnlCascadingMenu.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.menuHelp)).BeginInit();
             this.SuspendLayout();
             // 
             // panel1
@@ -55,49 +59,40 @@
             panel1.AutoSize = true;
             panel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             panel1.Controls.Add(this.labelPreview);
-            panel1.Controls.Add(this.label1);
             panel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            panel1.Location = new System.Drawing.Point(746, 77);
+            panel1.Location = new System.Drawing.Point(323, 71);
             panel1.Margin = new System.Windows.Forms.Padding(2);
             panel1.Name = "panel1";
             panel1.Padding = new System.Windows.Forms.Padding(3);
-            panel1.Size = new System.Drawing.Size(741, 484);
+            panel1.Size = new System.Drawing.Size(1139, 397);
             panel1.TabIndex = 0;
             // 
             // labelPreview
             // 
             this.labelPreview.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.labelPreview.Location = new System.Drawing.Point(3, 18);
+            this.labelPreview.Location = new System.Drawing.Point(3, 3);
             this.labelPreview.Name = "labelPreview";
-            this.labelPreview.Size = new System.Drawing.Size(735, 463);
+            this.labelPreview.Size = new System.Drawing.Size(1133, 391);
             this.labelPreview.TabIndex = 1;
             this.labelPreview.Text = "...";
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Dock = System.Windows.Forms.DockStyle.Top;
-            this.label1.Location = new System.Drawing.Point(3, 3);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(130, 15);
-            this.label1.TabIndex = 0;
-            this.label1.Text = "Context menu preview:";
             // 
             // lblMenuEntries
             // 
             this.lblMenuEntries.AutoSize = true;
-            this.tlpnlCascadingMenu.SetColumnSpan(this.lblMenuEntries, 2);
             this.lblMenuEntries.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblMenuEntries.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.lblMenuEntries.Location = new System.Drawing.Point(3, 45);
+            this.lblMenuEntries.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
             this.lblMenuEntries.Name = "lblMenuEntries";
-            this.lblMenuEntries.Size = new System.Drawing.Size(1483, 30);
+            this.lblMenuEntries.Size = new System.Drawing.Size(237, 24);
             this.lblMenuEntries.TabIndex = 4;
-            this.lblMenuEntries.Text = "Select items to be shown in the cascaded context menu.\r\n(Unchecked items will be " +
-    "shown top level for direct access.)";
+            this.lblMenuEntries.Text = "Configuration of items in the context menu";
+            this.lblMenuEntries.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // _NO_TRANSLATE_chlMenuEntries
             // 
             this._NO_TRANSLATE_chlMenuEntries.CheckOnClick = true;
+            this.tlpnlCascadingMenu.SetColumnSpan(this._NO_TRANSLATE_chlMenuEntries, 2);
             this._NO_TRANSLATE_chlMenuEntries.FormattingEnabled = true;
             this._NO_TRANSLATE_chlMenuEntries.Items.AddRange(new object[] {
             "Add files...",
@@ -118,7 +113,7 @@
             "Settings",
             "View stash",
             "View changes"});
-            this._NO_TRANSLATE_chlMenuEntries.Location = new System.Drawing.Point(3, 78);
+            this._NO_TRANSLATE_chlMenuEntries.Location = new System.Drawing.Point(3, 72);
             this._NO_TRANSLATE_chlMenuEntries.Name = "_NO_TRANSLATE_chlMenuEntries";
             this._NO_TRANSLATE_chlMenuEntries.Size = new System.Drawing.Size(315, 94);
             this._NO_TRANSLATE_chlMenuEntries.TabIndex = 5;
@@ -128,11 +123,11 @@
             // cbAlwaysShowAllCommands
             // 
             this.cbAlwaysShowAllCommands.AutoSize = true;
-            this.tlpnlCascadingMenu.SetColumnSpan(this.cbAlwaysShowAllCommands, 2);
+            this.tlpnlCascadingMenu.SetColumnSpan(this.cbAlwaysShowAllCommands, 3);
             this.cbAlwaysShowAllCommands.Dock = System.Windows.Forms.DockStyle.Fill;
             this.cbAlwaysShowAllCommands.Location = new System.Drawing.Point(3, 3);
             this.cbAlwaysShowAllCommands.Name = "cbAlwaysShowAllCommands";
-            this.cbAlwaysShowAllCommands.Size = new System.Drawing.Size(1483, 19);
+            this.cbAlwaysShowAllCommands.Size = new System.Drawing.Size(1458, 19);
             this.cbAlwaysShowAllCommands.TabIndex = 3;
             this.cbAlwaysShowAllCommands.Text = "Always show all commands";
             this.cbAlwaysShowAllCommands.UseVisualStyleBackColor = true;
@@ -151,7 +146,7 @@
             this.tlpnlMain.RowCount = 1;
             this.tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 508F));
-            this.tlpnlMain.Size = new System.Drawing.Size(1511, 670);
+            this.tlpnlMain.Size = new System.Drawing.Size(1486, 315);
             this.tlpnlMain.TabIndex = 0;
             // 
             // gbExplorerIntegration
@@ -162,7 +157,7 @@
             this.gbExplorerIntegration.Location = new System.Drawing.Point(3, 3);
             this.gbExplorerIntegration.Name = "gbExplorerIntegration";
             this.gbExplorerIntegration.Padding = new System.Windows.Forms.Padding(8);
-            this.gbExplorerIntegration.Size = new System.Drawing.Size(1505, 63);
+            this.gbExplorerIntegration.Size = new System.Drawing.Size(1480, 63);
             this.gbExplorerIntegration.TabIndex = 0;
             this.gbExplorerIntegration.TabStop = false;
             this.gbExplorerIntegration.Text = "Windows Explorer integration";
@@ -175,7 +170,7 @@
             this.flpnlExplorerIntegration.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flpnlExplorerIntegration.Location = new System.Drawing.Point(8, 24);
             this.flpnlExplorerIntegration.Name = "flpnlExplorerIntegration";
-            this.flpnlExplorerIntegration.Size = new System.Drawing.Size(1489, 31);
+            this.flpnlExplorerIntegration.Size = new System.Drawing.Size(1464, 31);
             this.flpnlExplorerIntegration.TabIndex = 0;
             // 
             // RegisterButton
@@ -211,7 +206,7 @@
             this.gbCascadingMenu.Location = new System.Drawing.Point(3, 72);
             this.gbCascadingMenu.Name = "gbCascadingMenu";
             this.gbCascadingMenu.Padding = new System.Windows.Forms.Padding(8);
-            this.gbCascadingMenu.Size = new System.Drawing.Size(1505, 595);
+            this.gbCascadingMenu.Size = new System.Drawing.Size(1480, 502);
             this.gbCascadingMenu.TabIndex = 0;
             this.gbCascadingMenu.TabStop = false;
             this.gbCascadingMenu.Text = "Cascaded Context Menu";
@@ -220,13 +215,16 @@
             // 
             this.tlpnlCascadingMenu.AutoSize = true;
             this.tlpnlCascadingMenu.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tlpnlCascadingMenu.ColumnCount = 2;
-            this.tlpnlCascadingMenu.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tlpnlCascadingMenu.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tlpnlCascadingMenu.ColumnCount = 3;
+            this.tlpnlCascadingMenu.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tlpnlCascadingMenu.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tlpnlCascadingMenu.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tlpnlCascadingMenu.Controls.Add(this.menuHelp, 1, 2);
+            this.tlpnlCascadingMenu.Controls.Add(this.label1, 2, 2);
             this.tlpnlCascadingMenu.Controls.Add(this.cbAlwaysShowAllCommands, 0, 0);
             this.tlpnlCascadingMenu.Controls.Add(this.lblMenuEntries, 0, 2);
             this.tlpnlCascadingMenu.Controls.Add(this._NO_TRANSLATE_chlMenuEntries, 0, 3);
-            this.tlpnlCascadingMenu.Controls.Add(panel1, 1, 3);
+            this.tlpnlCascadingMenu.Controls.Add(panel1, 2, 3);
             this.tlpnlCascadingMenu.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tlpnlCascadingMenu.Location = new System.Drawing.Point(8, 24);
             this.tlpnlCascadingMenu.Name = "tlpnlCascadingMenu";
@@ -235,8 +233,31 @@
             this.tlpnlCascadingMenu.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tlpnlCascadingMenu.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlCascadingMenu.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tlpnlCascadingMenu.Size = new System.Drawing.Size(1489, 563);
+            this.tlpnlCascadingMenu.Size = new System.Drawing.Size(1464, 470);
             this.tlpnlCascadingMenu.TabIndex = 0;
+            // 
+            // menuHelp
+            // 
+            this.menuHelp.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.menuHelp.Image = global::GitUI.Properties.Resources.information;
+            this.menuHelp.Location = new System.Drawing.Point(240, 50);
+            this.menuHelp.Margin = new System.Windows.Forms.Padding(0, 5, 3, 3);
+            this.menuHelp.Name = "menuHelp";
+            this.menuHelp.Size = new System.Drawing.Size(16, 16);
+            this.menuHelp.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
+            this.menuHelp.TabIndex = 13;
+            this.menuHelp.TabStop = false;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label1.Location = new System.Drawing.Point(324, 45);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(1137, 24);
+            this.label1.TabIndex = 4;
+            this.label1.Text = "Context menu preview:";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // ShellExtensionSettingsPage
             // 
@@ -245,9 +266,8 @@
             this.Controls.Add(this.tlpnlMain);
             this.Name = "ShellExtensionSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
-            this.Size = new System.Drawing.Size(1527, 686);
+            this.Size = new System.Drawing.Size(1502, 331);
             panel1.ResumeLayout(false);
-            panel1.PerformLayout();
             this.tlpnlMain.ResumeLayout(false);
             this.tlpnlMain.PerformLayout();
             this.gbExplorerIntegration.ResumeLayout(false);
@@ -258,6 +278,7 @@
             this.gbCascadingMenu.PerformLayout();
             this.tlpnlCascadingMenu.ResumeLayout(false);
             this.tlpnlCascadingMenu.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.menuHelp)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -267,7 +288,6 @@
 
         private System.Windows.Forms.Label lblMenuEntries;
         private System.Windows.Forms.CheckedListBox _NO_TRANSLATE_chlMenuEntries;
-        private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label labelPreview;
         private System.Windows.Forms.CheckBox cbAlwaysShowAllCommands;
         private System.Windows.Forms.FlowLayoutPanel flpnlExplorerIntegration;
@@ -277,5 +297,8 @@
         private System.Windows.Forms.GroupBox gbExplorerIntegration;
         private Button RegisterButton;
         private Button UnregisterButton;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.PictureBox menuHelp;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.Designer.cs
@@ -122,6 +122,7 @@
             this._NO_TRANSLATE_chlMenuEntries.Name = "_NO_TRANSLATE_chlMenuEntries";
             this._NO_TRANSLATE_chlMenuEntries.Size = new System.Drawing.Size(315, 94);
             this._NO_TRANSLATE_chlMenuEntries.TabIndex = 5;
+            this._NO_TRANSLATE_chlMenuEntries.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.chlMenuEntries_ItemCheck);
             this._NO_TRANSLATE_chlMenuEntries.SelectedValueChanged += new System.EventHandler(this.chlMenuEntries_SelectedValueChanged);
             // 
             // cbAlwaysShowAllCommands

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.cs
@@ -1,10 +1,18 @@
 ﻿using GitCommands;
 using GitUI.CommandsDialogs.SettingsDialog.ShellExtension;
+using ResourceManager;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class ShellExtensionSettingsPage : SettingsPageWithHeader
     {
+        private const char Checked_InMenu = '0';
+        private const char Indeterminate_InSubMenu = '1';
+        private const char Unchecked_NotInMenu = '2';
+
+        private readonly TranslationString _noItems = new("no items");
+
+        private bool _isLoading = false;
         public ShellExtensionSettingsPage()
         {
             InitializeComponent();
@@ -18,10 +26,24 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         protected override void SettingsToPage()
         {
+            _isLoading = true;
             for (int i = 0; i < AppSettings.CascadeShellMenuItems.Length; i++)
             {
-                _NO_TRANSLATE_chlMenuEntries.SetItemChecked(i, AppSettings.CascadeShellMenuItems[i] == '1');
+                switch (AppSettings.CascadeShellMenuItems[i])
+                {
+                    case Checked_InMenu:
+                        _NO_TRANSLATE_chlMenuEntries.SetItemCheckState(i, CheckState.Checked);
+                        break;
+                    case Indeterminate_InSubMenu:
+                        _NO_TRANSLATE_chlMenuEntries.SetItemCheckState(i, CheckState.Indeterminate);
+                        break;
+                    case Unchecked_NotInMenu:
+                        _NO_TRANSLATE_chlMenuEntries.SetItemCheckState(i, CheckState.Unchecked);
+                        break;
+                }
             }
+
+            _isLoading = false;
 
             cbAlwaysShowAllCommands.Checked = AppSettings.AlwaysShowAllCommands;
 
@@ -34,13 +56,17 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             for (int i = 0; i < _NO_TRANSLATE_chlMenuEntries.Items.Count; i++)
             {
-                if (_NO_TRANSLATE_chlMenuEntries.GetItemChecked(i))
+                switch (_NO_TRANSLATE_chlMenuEntries.GetItemCheckState(i))
                 {
-                    l_CascadeShellMenuItems += "1";
-                }
-                else
-                {
-                    l_CascadeShellMenuItems += "0";
+                    case CheckState.Indeterminate:
+                        l_CascadeShellMenuItems += Indeterminate_InSubMenu;
+                        break;
+                    case CheckState.Checked:
+                        l_CascadeShellMenuItems += Checked_InMenu;
+                        break;
+                    case CheckState.Unchecked:
+                        l_CascadeShellMenuItems += Unchecked_NotInMenu;
+                        break;
                 }
             }
 
@@ -60,17 +86,26 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             for (int i = 0; i < _NO_TRANSLATE_chlMenuEntries.Items.Count; i++)
             {
-                if (_NO_TRANSLATE_chlMenuEntries.GetItemChecked(i))
+                switch (_NO_TRANSLATE_chlMenuEntries.GetItemCheckState(i))
                 {
-                    cascaded += "       " + _NO_TRANSLATE_chlMenuEntries.Items[i] + "\r\n";
-                }
-                else
-                {
-                    topLevel += "GitExt " + _NO_TRANSLATE_chlMenuEntries.Items[i] + "\r\n";
+                    case CheckState.Checked:
+                        topLevel += "GitExt " + _NO_TRANSLATE_chlMenuEntries.Items[i] + "\r\n";
+                        break;
+                    case CheckState.Indeterminate:
+                        cascaded += "       " + _NO_TRANSLATE_chlMenuEntries.Items[i] + "\r\n";
+                        break;
                 }
             }
 
-            labelPreview.Text = topLevel + "Git Extensions > \r\n" + cascaded;
+            labelPreview.Text = topLevel;
+            if (!string.IsNullOrWhiteSpace(cascaded))
+            {
+                labelPreview.Text += "Git Extensions > \r\n" + cascaded;
+            }
+            else if (string.IsNullOrWhiteSpace(topLevel))
+            {
+                labelPreview.Text += $"({_noItems.Text})";
+            }
         }
 
         private void RegisterButton_Click(object sender, EventArgs e)
@@ -89,6 +124,29 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             gbExplorerIntegration.Enabled = ShellExtensionManager.FilesExist();
             RegisterButton.Enabled = !ShellExtensionManager.IsRegistered();
+        }
+
+        private void chlMenuEntries_ItemCheck(object sender, ItemCheckEventArgs e)
+        {
+            if (_isLoading)
+            {
+                return;
+            }
+
+            switch (e.CurrentValue)
+            {
+                case CheckState.Checked:
+                    e.NewValue = CheckState.Unchecked;
+                    break;
+
+                case CheckState.Indeterminate:
+                    e.NewValue = CheckState.Checked;
+                    break;
+
+                case CheckState.Unchecked:
+                    e.NewValue = CheckState.Indeterminate;
+                    break;
+            }
         }
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.cs
@@ -11,6 +11,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private const char Unchecked_NotInMenu = '2';
 
         private readonly TranslationString _noItems = new("no items");
+        private readonly TranslationString _menuHelp = new(@"* Checked: at top level for direct access
+* Intermediate: in a cascaded context menu
+* Unchecked: not added to the menu");
 
         private bool _isLoading = false;
         public ShellExtensionSettingsPage()
@@ -22,6 +25,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             // when the dock is set in the designer it causes weird visual artifacts in scaled Windows environments
             _NO_TRANSLATE_chlMenuEntries.Dock = DockStyle.Fill;
+
+            toolTip1.SetToolTip(menuHelp, _menuHelp.Text);
         }
 
         protected override void SettingsToPage()

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.resx
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.resx
@@ -60,4 +60,7 @@
   <metadata name="panel1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -10387,6 +10387,16 @@ Please ensure that the url is valid and that the API token has access to build a
         <source>&amp;Disable shell extension</source>
         <target />
       </trans-unit>
+      <trans-unit id="_menuHelp.Text">
+        <source>* Checked: at top level for direct access
+* Intermediate: in a cascaded context menu
+* Unchecked: not added to the menu</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_noItems.Text">
+        <source>no items</source>
+        <target />
+      </trans-unit>
       <trans-unit id="cbAlwaysShowAllCommands.Text">
         <source>Always show all commands</source>
         <target />
@@ -10404,8 +10414,7 @@ Please ensure that the url is valid and that the API token has access to build a
         <target />
       </trans-unit>
       <trans-unit id="lblMenuEntries.Text">
-        <source>Select items to be shown in the cascaded context menu.
-(Unchecked items will be shown top level for direct access.)</source>
+        <source>Configuration of items in the context menu</source>
         <target />
       </trans-unit>
     </body>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->
Fixes #7863

## Proposed changes

- Being able to hide some menu items in the file explorer contextual menu
- Slight UI refactoring

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/207096903-390fd881-5698-4f12-ad5c-e4d20ba14e5e.png)

### After

When migrating from previous version:

![image](https://user-images.githubusercontent.com/460196/207097040-053d4739-3285-4cee-83a7-196428fa7415.png)

When hiding some menu items:

![image](https://user-images.githubusercontent.com/460196/207097155-0a3ae5d9-88d4-401e-bdf8-04e026725d3f.png)

Explanation of the 3 state checkox with a tooltip:

![image](https://user-images.githubusercontent.com/460196/207097307-fd32164b-8a00-4bb3-aeb4-7630c13bdae2.png)

Result:

![image](https://user-images.githubusercontent.com/460196/207097797-12e56651-4610-419b-9aee-00c00450f0a6.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 65eb496535859a73bdd47f184bf7cc90098f53de
- Git 2.38.0.windows.1 (recommended: 2.38.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.11
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 5.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 5.0.17 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.10 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.11 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.0 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
