### PR TITLE
theme: remove dark themes from deliverables

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -73,4 +73,13 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="Themes\dark.css">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </Content>
+    <Content Update="Themes\darksilver.css">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/GitUI/Themes/README.md
+++ b/GitUI/Themes/README.md
@@ -56,13 +56,13 @@ Use .css import directive to reuse color values from another theme.
 - To import from a preinstalled theme:
 
 ```css
-@import url("dark.css");
+@import url("bright.css");
 ```
 
 - To import from a user-defined theme:
 
 ```css
-@import url("{UserAppData}/dark.css");
+@import url("{UserAppData}/bright_custom.css");
 ```
 
 ### Specify alternative color values for colorblind users

--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -302,12 +302,6 @@
       <Component Id="Themes.invariant.css" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Themes\invariant.css" />
       </Component>
-      <Component Id="Themes.dark.css" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Themes\dark.css" />
-      </Component>
-      <Component Id="Themes.darksilver.css" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Themes\darksilver.css" />
-      </Component>
       <Component Id="Themes.bright.css" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Themes\bright.css" />
       </Component>
@@ -594,8 +588,6 @@
     <ComponentGroup Id="Component.Themes">
       <ComponentRef Id="Themes.README.md" />
       <ComponentRef Id="Themes.invariant.css" />
-      <ComponentRef Id="Themes.dark.css" />
-      <ComponentRef Id="Themes.darksilver.css" />
       <ComponentRef Id="Themes.bright.css" />
     </ComponentGroup>
     <ComponentGroup Id="Component.Translation">

--- a/UnitTests/GitUI.Tests/Theming/CssUrlResolverTests.cs
+++ b/UnitTests/GitUI.Tests/Theming/CssUrlResolverTests.cs
@@ -16,16 +16,16 @@ namespace GitUITests.Theming
         public void Should_resolve_to_preinstalled_themes_directory_by_default()
         {
             ThemeCssUrlResolver resolver = new(CreateMockThemePathProvider());
-            var resolvedPath = resolver.ResolveCssUrl("dark.css");
-            resolvedPath.Should().Be(Path.Combine(PreinstalledThemesMockPath, "dark.css"));
+            var resolvedPath = resolver.ResolveCssUrl("bright.css");
+            resolvedPath.Should().Be(Path.Combine(PreinstalledThemesMockPath, "bright.css"));
         }
 
         [Test]
         public void Should_resolve_to_user_defined_themes_directory_When_url_starts_with_macro()
         {
             ThemeCssUrlResolver resolver = new(CreateMockThemePathProvider());
-            var resolvedPath = resolver.ResolveCssUrl("{UserAppData}/dark.css");
-            resolvedPath.Should().Be(Path.Combine(UserDefinedThemesMockPath, "dark.css"));
+            var resolvedPath = resolver.ResolveCssUrl("{UserAppData}/bright_custom.css");
+            resolvedPath.Should().Be(Path.Combine(UserDefinedThemesMockPath, "bright_custom.css"));
         }
 
         private static IThemePathProvider CreateMockThemePathProvider()


### PR DESCRIPTION
Fixes #10490

## Proposed changes

- Remove dark themes from setup or portable version to prevent the user to select them (until GE support dark themes again) when he does a fresh install

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/207262449-4402bce8-031b-4d79-9e01-4713e1eb9e80.png)

### After

![image](https://user-images.githubusercontent.com/460196/207262378-745c7289-16c2-4071-9819-20746a1d3337.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual
## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 0eaf625125e34f8f648ab28e5df0cb221688b1f1
- Git 2.38.0.windows.1 (recommended: 2.38.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.11
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 5.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 5.0.17 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.10 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.11 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.0 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
