### PR TITLE
Git 2.39 bugs out for fetch --jobs=0

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1452,7 +1452,7 @@ namespace GitCommands
 
         public ArgumentString FetchCmd(string? remote, string? remoteBranch, string? localBranch, bool? fetchTags = false, bool isUnshallow = false, bool pruneRemoteBranches = false, bool pruneRemoteBranchesAndTags = false)
         {
-            return new GitArgumentBuilder("fetch")
+            return new GitArgumentBuilder("fetch", gitOptions: GetFetchOptions())
             {
                 "--progress",
                 {
@@ -1464,7 +1464,7 @@ namespace GitCommands
 
         public ArgumentString PullCmd(string remote, string? remoteBranch, bool rebase, bool? fetchTags = false, bool isUnshallow = false)
         {
-            return new GitArgumentBuilder("pull")
+            return new GitArgumentBuilder("pull", gitOptions: GetFetchOptions())
             {
                 { rebase, "--rebase" },
                 "--progress",
@@ -1495,13 +1495,9 @@ namespace GitCommands
                 }
             }
 
-            bool jobsConfig = string.IsNullOrWhiteSpace(EffectiveConfigFile.GetValue("fetch.parallel"))
-                && string.IsNullOrWhiteSpace(EffectiveConfigFile.GetValue("submodule.fetchJobs"));
-
             // TODO return ArgumentBuilder and add special case ArgumentBuilder.Add(ArgumentBuilder childBuilder)
             return new ArgumentBuilder
             {
-                { jobsConfig, "--jobs=0" },
                 remote.ToPosixPath()?.Trim().Quote(),
                 branchArguments,
                 { fetchTags == true, "--tags" },
@@ -1509,6 +1505,15 @@ namespace GitCommands
                 { isUnshallow, "--unshallow" },
                 { pruneRemoteBranches || pruneRemoteBranchesAndTags, "--prune --force" },
                 { pruneRemoteBranchesAndTags, "--prune-tags" },
+            };
+        }
+
+        private ArgumentString GetFetchOptions()
+        {
+            return new ArgumentBuilder
+            {
+                { string.IsNullOrWhiteSpace(EffectiveConfigFile.GetValue("fetch.parallel")), "-c fetch.parallel=0" },
+                { string.IsNullOrWhiteSpace(EffectiveConfigFile.GetValue("submodule.fetchJobs")), "-c submodule.fetchJobs=0" },
             };
         }
 

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -75,55 +75,55 @@ namespace GitCommandsTests.Git.Commands
             {
                 // Specifying a remote and a local branch creates a local branch
                 var fetchCmd = module.FetchCmd("origin", "some-branch", "local").Arguments;
-                Assert.AreEqual("fetch --progress --jobs=0 \"origin\" +some-branch:refs/heads/local --no-tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"origin\" +some-branch:refs/heads/local --no-tags", fetchCmd);
             }
 
             {
                 var fetchCmd = module.FetchCmd("origin", "some-branch", "local", true).Arguments;
-                Assert.AreEqual("fetch --progress --jobs=0 \"origin\" +some-branch:refs/heads/local --tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"origin\" +some-branch:refs/heads/local --tags", fetchCmd);
             }
 
             {
                 // Using a URL as remote and passing a local branch creates the branch
                 var fetchCmd = module.FetchCmd("https://host.com/repo", "some-branch", "local").Arguments;
-                Assert.AreEqual("fetch --progress --jobs=0 \"https://host.com/repo\" +some-branch:refs/heads/local --no-tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"https://host.com/repo\" +some-branch:refs/heads/local --no-tags", fetchCmd);
             }
 
             {
                 // Using a URL as remote and not passing a local branch
                 var fetchCmd = module.FetchCmd("https://host.com/repo", "some-branch", null).Arguments;
-                Assert.AreEqual("fetch --progress --jobs=0 \"https://host.com/repo\" +some-branch --no-tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"https://host.com/repo\" +some-branch --no-tags", fetchCmd);
             }
 
             {
                 // No remote branch -> No local branch
                 var fetchCmd = module.FetchCmd("origin", "", "local").Arguments;
-                Assert.AreEqual("fetch --progress --jobs=0 \"origin\" --no-tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"origin\" --no-tags", fetchCmd);
             }
 
             {
                 // Pull doesn't accept a local branch ever
                 var fetchCmd = module.PullCmd("origin", "some-branch", false).Arguments;
-                Assert.AreEqual("pull --progress --jobs=0 \"origin\" +some-branch --no-tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 pull --progress \"origin\" +some-branch --no-tags", fetchCmd);
             }
 
             {
                 // Not even for URL remote
                 var fetchCmd = module.PullCmd("https://host.com/repo", "some-branch", false).Arguments;
-                Assert.AreEqual("pull --progress --jobs=0 \"https://host.com/repo\" +some-branch --no-tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 pull --progress \"https://host.com/repo\" +some-branch --no-tags", fetchCmd);
             }
 
             {
                 // Pull with rebase
                 var fetchCmd = module.PullCmd("origin", "some-branch", true).Arguments;
-                Assert.AreEqual("pull --rebase --progress --jobs=0 \"origin\" +some-branch --no-tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 -c submodule.fetchJobs=0 pull --rebase --progress \"origin\" +some-branch --no-tags", fetchCmd);
             }
 
             {
                 // Config test fetch.parallel
                 module.LocalConfigFile.SetString("fetch.parallel", "1");
                 var fetchCmd = module.FetchCmd("fetch.parallel", "some-branch", "local").Arguments;
-                Assert.AreEqual("fetch --progress \"fetch.parallel\" +some-branch:refs/heads/local --no-tags", fetchCmd);
+                Assert.AreEqual("-c submodule.fetchJobs=0 fetch --progress \"fetch.parallel\" +some-branch:refs/heads/local --no-tags", fetchCmd);
                 module.LocalConfigFile.SetString("fetch.parallel", null);
             }
 
@@ -131,7 +131,7 @@ namespace GitCommandsTests.Git.Commands
                 // Config test submodule.fetchJobs
                 module.LocalConfigFile.SetString("submodule.fetchJobs", "0");
                 var fetchCmd = module.FetchCmd("origin", "some-branch", "local").Arguments;
-                Assert.AreEqual("fetch --progress \"origin\" +some-branch:refs/heads/local --no-tags", fetchCmd);
+                Assert.AreEqual("-c fetch.parallel=0 fetch --progress \"origin\" +some-branch:refs/heads/local --no-tags", fetchCmd);
                 module.LocalConfigFile.SetString("submodule.fetchJobs", null);
             }
 

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -115,42 +115,42 @@ namespace GitCommandsTests
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "fetch --progress --jobs=0 \"remote\" +remotebranch:refs/heads/localbranch --no-tags",
+                    "-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch").Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "fetch --progress --jobs=0 \"remote\" +remotebranch:refs/heads/localbranch --tags",
+                    "-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --tags",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", true).Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "fetch --progress --jobs=0 \"remote\" +remotebranch:refs/heads/localbranch",
+                    "-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", null).Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "fetch --progress --jobs=0 \"remote\" +remotebranch:refs/heads/localbranch --no-tags --unshallow",
+                    "-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --unshallow",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", isUnshallow: true).Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "fetch --progress --jobs=0 \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --force",
+                    "-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --force",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", pruneRemoteBranches: true).Arguments);
             }
 
             using (_executable.StageOutput("rev-parse --quiet --verify \"refs/heads/remotebranch~0\"", null))
             {
                 Assert.AreEqual(
-                    "fetch --progress --jobs=0 \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --force --prune-tags",
+                    "-c fetch.parallel=0 -c submodule.fetchJobs=0 fetch --progress \"remote\" +remotebranch:refs/heads/localbranch --no-tags --prune --force --prune-tags",
                     _gitModule.FetchCmd("remote", "remotebranch", "localbranch", pruneRemoteBranches: true, pruneRemoteBranchesAndTags: true).Arguments);
             }
         }


### PR DESCRIPTION
Fixes #10514

## Proposed changes

Provide the options as Git config options instead

If user hast set fetch.parallel or submodule.fetchJobs is set, do not set the options

## Test methodology <!-- How did you ensure quality? -->

Test updated

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.38, 2.39

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
