### PR TITLE
FormBrowse: Refresh revisions on main thread

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -552,7 +552,15 @@ namespace GitUI.CommandsDialogs
         {
             // Note that this called in most FormBrowse context to "be sure"
             // that the repo has not been updated externally.
-            RefreshRevisions(e.GetRefs);
+
+            // It can also be called from background tasks, e.g. from BackgroundFetchPlugin.
+            if (ThreadHelper.JoinableTaskContext.IsOnMainThread)
+            {
+                RefreshRevisions(e.GetRefs);
+                return;
+            }
+
+            Invoke(() => RefreshRevisions(e.GetRefs));
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #10491

## Proposed changes

- Since `IGitUICommands.PostRepositoryChanged` can be notified from background tasks, switch to the main thread if necessary
  (Thanks for adding `ThreadHelper.AssertOnUIThread()` to `RevisionConrol.PerformRefreshRevisions()`!)

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manually using BackgroundFetchPlugin

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build e56a5b91e7919a4df530662f11f68baa31f5fa4c
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.10
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.10 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
