### PR TITLE
Change default hotkey of `CheckoutBranch` to `Ctrl+.`

### DIFF
--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -255,7 +255,7 @@ namespace GitUI.Hotkey
                 new HotkeySettings(
                     FormBrowse.HotkeySettingsName,
                     Hk(FormBrowse.Command.AddNotes, Keys.Control | Keys.Shift | Keys.N),
-                    Hk(FormBrowse.Command.CheckoutBranch, Keys.Control | Keys.Decimal),
+                    Hk(FormBrowse.Command.CheckoutBranch, Keys.Control | Keys.OemPeriod),
                     Hk(FormBrowse.Command.CloseRepository, Keys.Control | Keys.W),
                     Hk(FormBrowse.Command.Commit, Keys.Control | Keys.Space),
                     Hk(FormBrowse.Command.CreateBranch, Keys.Control | Keys.B),


### PR DESCRIPTION
Closes #10495

## Proposed changes

- Change default hotkey of `CheckoutBranch` to `Ctrl+.` of main keyboard instead of of numpad (which had changed somehow by the switch to .NET in v4)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://user-images.githubusercontent.com/36601201/207727597-951a080d-3153-42e3-abe2-5f6033806545.png)

### After

![grafik](https://user-images.githubusercontent.com/36601201/207727730-830dbea8-8ab8-4f2c-8197-7a454ed79740.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 35169a18e0f6e730cbd111dbe068ddd9bdd380fa
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.10
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.10 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).