### PR TITLE
Avoid losing git exception in background

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -169,6 +169,9 @@ namespace GitCommands
                 // TODO Make it possible to explicitly activate Trace printouts like this
                 Debug.WriteLine($"**** [{nameof(RevisionReader)}] Emitted {revisionCount} revisions in {sw.Elapsed.TotalMilliseconds:#,##0.#} ms. bufferSize={buffer.Length} parseErrors={_noOfParseError}");
 #endif
+
+                // Wait for possible exceptions from the process, which has been started with throwOnErrorExit activated
+                process.WaitForExit();
             }
 
             if (!cancellationToken.IsCancellationRequested)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -847,7 +847,7 @@ namespace GitUI
         /// <summary>
         ///  Queries git for the new set of revisions and refreshes the grid.
         /// </summary>
-        /// <exception cref="AggregateException"></exception>
+        /// <exception cref="Exception"></exception>
         /// <param name="forceRefresh">Refresh may be required as references may be changed.</param>
         public void PerformRefreshRevisions(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs = null, bool forceRefresh = false)
         {
@@ -1313,7 +1313,7 @@ namespace GitUI
                 _isRefreshingRevisions = false;
 
                 // Rethrow the exception on the UI thread
-                this.InvokeAsync(() => throw new AggregateException(exception))
+                this.InvokeAsync(() => throw exception)
                     .FileAndForget();
             }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10488

## Proposed changes

- RevisionReader: Wait for possible exceptions from the process, which has been started with `throwOnErrorExit: true`
- Do not wrap exceptions from revision reader (into `AggregateException` any longer) in order to show the appropriate exception dialog

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

empty repo

### After

![image](https://user-images.githubusercontent.com/36601201/207970447-40824625-2e25-46ed-afb1-d708ad9516dd.png)

## Test methodology <!-- How did you ensure quality? -->

- manual (see issue)

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build d61cc87112412440642619a12fae43c82a9740a2
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).