### PR TITLE
Update version of Ubuntu for fix up check

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   block-fixup:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2.0.0


### PR DESCRIPTION
Fixes build failing as brownout warning of v18.04 deprecation

## Proposed changes

Switch to last LTS version of Ubunto used by the fixup check

## Test methodology <!-- How did you ensure quality? -->

- Triggered a PR that should failed and one that should succeed.

## Test environment(s) <!-- Remove any that don't apply -->

- GitHub PR
