### PR TITLE
Add support for SourceLink

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)GitExtensions.ruleset</CodeAnalysisRuleSet>
 
+    <!-- SourceLink: https://github.com/dotnet/sourcelink -->
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>embedded</DebugType>
+
     <!-- TODO once all project migrated to SDK-style, remove this and move properties to Directory.Build.props -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,6 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Stop transitive consumption of JetBrains annotations -->
     <PackageReference Update="JetBrains.Annotations" PrivateAssets="all" />
   </ItemGroup>

--- a/Packages.props
+++ b/Packages.props
@@ -13,6 +13,7 @@
     <PackageReference Update="GitInfo" Version="2.2.0" />
     <PackageReference Update="JetBrains.Annotations" Version="2021.2.0" />
     <PackageReference Update="LibGit2Sharp" Version="0.26.2" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageReference Update="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
     <PackageReference Update="Microsoft.VisualStudio.Composition" Version="16.9.20" />
     <PackageReference Update="Microsoft.VisualStudio.Threading" Version="17.0.64" />


### PR DESCRIPTION
that allows to have access to source code when debugging a released version by attaching to the process.

https://github.com/dotnet/sourcelink

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/gitextensions/gitextensions/issues/10529#issuecomment-1354358923

>Side question, would it be possible to create a debug build (including symbols) of GE on release that would permit attaching without overwriting any of the GE files? Would make it easier to debug issues like these.

## Proposed changes

- When debugging a release version by attaching to the process VisualStudio should fetch the source code directly from the GitHub repository

## Screenshot

When a file content is retrieved
![image](https://user-images.githubusercontent.com/460196/208071569-260dffe8-d18f-4349-a436-19fea0c932bd.png)

What is displayed in the file explorer:
![image](https://user-images.githubusercontent.com/460196/208151716-711ce36b-ed9c-406a-9b5b-b8861d0d3cfa.png)


## Test methodology <!-- How did you ensure quality? -->

- Debugged GE built in RELEASE and saw that the source code was retrieved from GitHub **when the local source path is not available** (so local testing could require moving GE repository temporary otherwise VS find the source code locally and don't try to fetch from GitHub repository) 

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 9ee86f0d9e9daf64e9ae51a9e8fc215f6a22b7c6 (Dirty)
- Git 2.38.0.windows.1 (recommended: 2.38.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.11
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 5.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 5.0.17 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.10 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.11 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.0 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
