### PR TITLE
Load/store console style settings

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.cs
@@ -19,12 +19,16 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             // Bind settings with controls
             AddSettingBinding(AppSettings.ConEmuStyle, _NO_TRANSLATE_cboStyle);
             SetCurrentConsoleFont(AppSettings.ConEmuConsoleFont);
+
+            base.SettingsToPage();
         }
 
         protected override void PageToSettings()
         {
             Validates.NotNull(_consoleFont);
             AppSettings.ConEmuConsoleFont = _consoleFont;
+
+            base.PageToSettings();
         }
 
         public static SettingsPageReference GetPageReference()


### PR DESCRIPTION
Fixes #10471

## Proposed changes

- ConsoleStyleSettingsPage: Call `base.SettingsToPage()` / `base.PageToSettings()` in order to load/store bound settings.
- Since this is the only settings page using bindings (`AddSettingBinding(...)`), it suffices to call the `base` implementation for this page only.

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build b607cbd1c2c92933d74b6a56ba24c8d3038abf31
- Git 2.39.0.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).