### PR TITLE
Avoid double quoting while showing File History dialog

### DIFF
--- a/GitExtensions/Properties/launchSettings.json
+++ b/GitExtensions/Properties/launchSettings.json
@@ -10,6 +10,10 @@
     "Blame": {
       "commandName": "Project",
       "commandLineArgs": "blame GitExtensions.settings"
+    },
+    "FileHistory": {
+      "commandName": "Project",
+      "commandLineArgs": "filehistory GitExtensions.settings"
     }
   }
 }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1717,8 +1717,6 @@ namespace GitUI
                 return false;
             }
 
-            fileHistoryFileName = fileHistoryFileName.QuoteNE();
-
             GitRevision? revision = null;
             if (args.Count > 3)
             {
@@ -1744,6 +1742,9 @@ namespace GitUI
             // Similar to StartFileHistoryDialog()
             if (AppSettings.UseBrowseForFileHistory.Value)
             {
+                // NOTE: fileHistoryFileName doesn't need to be quoted, as it the filter will get quoted
+                // when the filter gets set.
+
                 ShowModelessForm(owner: null, requiresValidWorkingDir: true, preEvent: null, postEvent: null,
                                  () => new FormBrowse(commands: this, new BrowseArguments
                                  {
@@ -1755,8 +1756,10 @@ namespace GitUI
             }
             else
             {
+                // NOTE: fileHistoryFileName must be quoted.
+
                 ShowModelessForm(owner: null, requiresValidWorkingDir: true, preEvent: null, postEvent: null,
-                                 () => new FormFileHistory(commands: this, fileHistoryFileName, revision, filterByRevision, showBlame));
+                                 () => new FormFileHistory(commands: this, fileHistoryFileName.QuoteNE(), revision, filterByRevision, showBlame));
             }
 
             return true;


### PR DESCRIPTION
#10438 introduced a regression by double quoting file names passed to the File History dialog. However, it didn't take an account that the File History is now primarily shown in Form Browse dialog, where the argument is quoted when it is passed to the filter,

Quote the argument now only for the File History dialog.

Resolves #10537
