### PR TITLE
Bump Microsoft.VisualStudio.Composition version

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -14,8 +14,9 @@
     <PackageReference Update="JetBrains.Annotations" Version="2021.2.0" />
     <PackageReference Update="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Update="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
-    <PackageReference Update="Microsoft.VisualStudio.Composition" Version="16.9.20" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading" Version="17.0.64" />
+    <PackageReference Update="System.ComponentModel.Composition" Version="6.0.0" /> <!-- Required by GitExtensions.PluginManager -->
+    <PackageReference Update="Microsoft.VisualStudio.Composition" Version="17.2.41" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading" Version="17.4.27" />
     <PackageReference Update="Microsoft-WindowsAPICodePack-Core" Version="1.1.4" />
     <PackageReference Update="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />
     <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />

--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -161,8 +161,9 @@
       <Component Id="Microsoft.VisualStudio.Composition.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Microsoft.VisualStudio.Composition.dll" />
       </Component>
-      <Component Id="Microsoft.VisualStudio.Composition.NetFxAttributes.dll" Guid="*">
-        <File Source="$(var.ArtifactsPublishPath)\Microsoft.VisualStudio.Composition.NetFxAttributes.dll" />
+      <!-- Remove unused dll, installed in versions <= 4.0.1 -->
+      <Component Id="Microsoft.VisualStudio.Composition.NetFxAttributes.dll" Guid="D4782F6D-044B-5BD2-858A-1A3D8510B277">
+        <RemoveFile Name="Microsoft.VisualStudio.Composition.NetFxAttributes.dll" Id="Microsoft.VisualStudio.Composition.NetFxAttributes.dll" On="both" />
       </Component>
       <Component Id="Microsoft.VisualStudio.Interop.dll" Guid="*">
         <File Source="$(var.ArtifactsPublishPath)\Microsoft.VisualStudio.Interop.dll" />


### PR DESCRIPTION
Microsoft.VisualStudio.Composition v16.9 depended on System.ComponentModel.Composition v4.5+; which led to us shipping v4.6.

The Plugin Manager 184 was built against [System.ComponentModel.Composition v6.0.0.](https://github.com/gitextensions/gitextensions.pluginmanager/blob/bbaafa6eda217877822d0993d1fbea57bc0239f1/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj#L21) As a result, it would fail to load because the dependency was not satisfied.

* Add an explicit dependency on System.ComponentModel.Composition v6.0.
* Bump Microsoft.VisualStudio.Composition to v17.2, as it now depends on System.ComponentModel.Composition v6.0+.

Resolves #10529
