### PR TITLE
Reduce string allocation in StringExtensions.ShortenTo

### DIFF
--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -258,7 +258,7 @@ namespace System
                 return str.Substring(0, maxLength);
             }
 
-            return str.Substring(0, maxLength - 3) + "...";
+            return $"{str.AsSpan(0, maxLength - 3)}...";
         }
 
         /// <summary>


### PR DESCRIPTION
Here is comparison of decompiled code of both methods https://sharplab.io/#v2:D4AQTAjAsAUCDMACciDCiDetE+UkEAbMhAAyIDKAFgPYBOALgKYB2AKjagK512sMAKAqQD8iAM4M6AGkQBLFg0QBbAIYAPADKsA5gyoBKbLiwxc5+QDNEQsgDoAkuIByXADZuA8nQCiygA4MAJ4CknQGRmYWOKbR0SAA7CSkdn6BQQDcxtEAvtkWctahUnbaLHpUiAA8ALwqGmUVkXGY+S2JElJZUbltuIU2alq6+tWI8M1xsS24HWF2FFwARsICpLJDjfoG3S15MH04cyWLK2RrGw0jlQC04waIANSIAER27y+7uPvZCCTEwkotEYrA4AAU6DR/DRxEwACa2USdGTyRT1Yblbb5abRAaIxwudxeXwBYLFcKTaI4mYdYSpUmZQ6IfYtPHzLaVWrojmUizU9pJMJfXo9ApFTbXMYTJn8uLHOgLZardbc647Jk/UXmDoAEheGHmAEFxBR/KoWBdVZjbvccu87J98vsckA=
As you can see instead of string.Concat, DefaultInterpolatedStringHandler directly appends `ReadOnlySpan<char>`, so we don't need to allocate the span on the heap.