### PR TITLE
FormCommit: Clearer button labels

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1164,7 +1164,7 @@ namespace GitUI.CommandsDialogs
             this.Amend.Name = "Amend";
             this.Amend.Size = new System.Drawing.Size(97, 17);
             this.Amend.TabIndex = 0;
-            this.Amend.Text = "&Amend Commit";
+            this.Amend.Text = "&Amend commit";
             this.Amend.UseVisualStyleBackColor = true;
             this.Amend.CheckedChanged += new System.EventHandler(this.Amend_CheckedChanged);
             // 
@@ -1176,7 +1176,7 @@ namespace GitUI.CommandsDialogs
             this.ResetAuthor.Name = "ResetAuthor";
             this.ResetAuthor.Size = new System.Drawing.Size(97, 17);
             this.ResetAuthor.TabIndex = 0;
-            this.ResetAuthor.Text = "R&eset Author";
+            this.ResetAuthor.Text = "R&eset author";
             this.ResetAuthor.UseVisualStyleBackColor = true;
             this.ResetAuthor.Visible = false;
             // 

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -382,7 +382,7 @@ namespace GitUI.CommandsDialogs
             this.StageInSuperproject.Margin = new System.Windows.Forms.Padding(0, 9, 0, 3);
             this.StageInSuperproject.Name = "StageInSuperproject";
             this.StageInSuperproject.Size = new System.Drawing.Size(130, 17);
-            this.StageInSuperproject.TabIndex = 13;
+            this.StageInSuperproject.TabIndex = 103;
             this.StageInSuperproject.Text = "Stage &in Superproject";
             this.fileTooltip.SetToolTip(this.StageInSuperproject, "Stage current submodule in superproject after commit");
             this.StageInSuperproject.UseVisualStyleBackColor = true;
@@ -1126,7 +1126,7 @@ namespace GitUI.CommandsDialogs
             this.flowCommitButtons.Name = "flowCommitButtons";
             this.tableLayoutPanel1.SetRowSpan(this.flowCommitButtons, 2);
             this.flowCommitButtons.Size = new System.Drawing.Size(171, 192);
-            this.flowCommitButtons.TabIndex = 1;
+            this.flowCommitButtons.TabIndex = 100;
             this.flowCommitButtons.WrapContents = false;
             // 
             // Commit
@@ -1137,8 +1137,7 @@ namespace GitUI.CommandsDialogs
             this.Commit.Margin = new System.Windows.Forms.Padding(0, 0, 0, 3);
             this.Commit.Name = "Commit";
             this.Commit.Size = new System.Drawing.Size(171, 26);
-            this.Commit.TabIndex = 1;
-            this.Commit.TabStop = false;
+            this.Commit.TabIndex = 101;
             this.Commit.Text = "&Commit";
             this.Commit.UseVisualStyleBackColor = true;
             this.Commit.Click += new System.EventHandler(this.CommitClick);
@@ -1151,8 +1150,7 @@ namespace GitUI.CommandsDialogs
             this.CommitAndPush.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
             this.CommitAndPush.Name = "CommitAndPush";
             this.CommitAndPush.Size = new System.Drawing.Size(171, 26);
-            this.CommitAndPush.TabIndex = 9;
-            this.CommitAndPush.TabStop = false;
+            this.CommitAndPush.TabIndex = 102;
             this.CommitAndPush.UseVisualStyleBackColor = true;
             this.CommitAndPush.Click += new System.EventHandler(this.CommitAndPush_Click);
             // 
@@ -1163,7 +1161,7 @@ namespace GitUI.CommandsDialogs
             this.Amend.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
             this.Amend.Name = "Amend";
             this.Amend.Size = new System.Drawing.Size(97, 17);
-            this.Amend.TabIndex = 0;
+            this.Amend.TabIndex = 104;
             this.Amend.Text = "&Amend commit";
             this.Amend.UseVisualStyleBackColor = true;
             this.Amend.CheckedChanged += new System.EventHandler(this.Amend_CheckedChanged);
@@ -1175,7 +1173,7 @@ namespace GitUI.CommandsDialogs
             this.ResetAuthor.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
             this.ResetAuthor.Name = "ResetAuthor";
             this.ResetAuthor.Size = new System.Drawing.Size(97, 17);
-            this.ResetAuthor.TabIndex = 0;
+            this.ResetAuthor.TabIndex = 105;
             this.ResetAuthor.Text = "R&eset author";
             this.ResetAuthor.UseVisualStyleBackColor = true;
             this.ResetAuthor.Visible = false;
@@ -1188,8 +1186,7 @@ namespace GitUI.CommandsDialogs
             this.StashStaged.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
             this.StashStaged.Name = "StashStaged";
             this.StashStaged.Size = new System.Drawing.Size(171, 26);
-            this.StashStaged.TabIndex = 14;
-            this.StashStaged.TabStop = false;
+            this.StashStaged.TabIndex = 107;
             this.StashStaged.Text = "Stas&h staged changes";
             this.StashStaged.UseVisualStyleBackColor = true;
             this.StashStaged.Click += new System.EventHandler(this.StashStagedClick);
@@ -1202,8 +1199,7 @@ namespace GitUI.CommandsDialogs
             this.Reset.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
             this.Reset.Name = "Reset";
             this.Reset.Size = new System.Drawing.Size(171, 26);
-            this.Reset.TabIndex = 11;
-            this.Reset.TabStop = false;
+            this.Reset.TabIndex = 108;
             this.Reset.Text = "&Reset all changes";
             this.Reset.UseVisualStyleBackColor = true;
             this.Reset.Click += new System.EventHandler(this.ResetClick);
@@ -1216,8 +1212,7 @@ namespace GitUI.CommandsDialogs
             this.ResetUnStaged.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
             this.ResetUnStaged.Name = "ResetUnStaged";
             this.ResetUnStaged.Size = new System.Drawing.Size(171, 26);
-            this.ResetUnStaged.TabIndex = 14;
-            this.ResetUnStaged.TabStop = false;
+            this.ResetUnStaged.TabIndex = 109;
             this.ResetUnStaged.Text = "Reset u&nstaged changes";
             this.ResetUnStaged.UseVisualStyleBackColor = true;
             this.ResetUnStaged.Click += new System.EventHandler(this.ResetUnStagedClick);
@@ -1240,7 +1235,7 @@ namespace GitUI.CommandsDialogs
             this.toolbarCommit.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
             this.toolbarCommit.Size = new System.Drawing.Size(340, 28);
             this.toolbarCommit.Stretch = true;
-            this.toolbarCommit.TabIndex = 5;
+            this.toolbarCommit.TabIndex = 110;
             // 
             // commitMessageToolStripMenuItem
             // 

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1190,7 +1190,7 @@ namespace GitUI.CommandsDialogs
             this.StashStaged.Size = new System.Drawing.Size(171, 26);
             this.StashStaged.TabIndex = 14;
             this.StashStaged.TabStop = false;
-            this.StashStaged.Text = "S&tash staged changes";
+            this.StashStaged.Text = "Stas&h staged changes";
             this.StashStaged.UseVisualStyleBackColor = true;
             this.StashStaged.Click += new System.EventHandler(this.StashStagedClick);
             // 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -44,6 +44,8 @@ namespace GitUI.CommandsDialogs
 
         private readonly TranslationString _commitAndPush = new("Commit && &push");
 
+        private readonly TranslationString _commitAndForcePush = new("Commit && force &push");
+
         private readonly TranslationString _deleteFailed = new("Delete file failed");
 
         private readonly TranslationString _deleteSelectedFiles =
@@ -3360,7 +3362,9 @@ namespace GitUI.CommandsDialogs
 
         private void SetCommitAndPushText()
         {
-            CommitAndPush.Text = Reset.Enabled || Amend.Checked ? _commitAndPush.Text : TranslatedStrings.ButtonPush;
+            CommitAndPush.Text = Amend.Checked && AppSettings.CommitAndPushForcedWhenAmend ? _commitAndForcePush.Text
+                : Reset.Enabled || Amend.Checked ? _commitAndPush.Text
+                : TranslatedStrings.ButtonPush;
         }
 
         internal TestAccessor GetTestAccessor()

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3452,6 +3452,10 @@ Use this feature when a file is big and never change.
 Git will never check if the file has changed that will improve status check performance.</source>
         <target />
       </trans-unit>
+      <trans-unit id="_commitAndForcePush.Text">
+        <source>Commit &amp;&amp; force &amp;push</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_commitAndPush.Text">
         <source>Commit &amp;&amp; &amp;push</source>
         <target />

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3387,7 +3387,7 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         <target />
       </trans-unit>
       <trans-unit id="Amend.Text">
-        <source>&amp;Amend Commit</source>
+        <source>&amp;Amend commit</source>
         <target />
       </trans-unit>
       <trans-unit id="Cancel.Text">
@@ -3407,7 +3407,7 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         <target />
       </trans-unit>
       <trans-unit id="ResetAuthor.Text">
-        <source>R&amp;eset Author</source>
+        <source>R&amp;eset author</source>
         <target />
       </trans-unit>
       <trans-unit id="ResetUnStaged.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3428,7 +3428,7 @@ gitex.cmd / gitex (located in the same folder as GitExtensions.exe):</source>
         <target />
       </trans-unit>
       <trans-unit id="StashStaged.Text">
-        <source>S&amp;tash staged changes</source>
+        <source>Stas&amp;h staged changes</source>
         <target />
       </trans-unit>
       <trans-unit id="_addSelectionToCommitMessage.Text">


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/issues/2260#issuecomment-1345702136 amongst others

## Proposed changes

- Add button text "Commit & force push" if amending and force push enabled in settings
  ![image](https://user-images.githubusercontent.com/6248932/206933558-727ddde0-58c6-4770-a66f-dac1b5f5f6dd.png)
- Fixup capitalization of `Amend commit` and `Reset author`
- Make mnemonic `Alt+T` unique: `Stash staged changes` vs. `Commit templates`
- Support Tab for buttons

## Screenshots <!-- Remove this section if PR does not change UI -->

Before|After
-|-
![image](https://user-images.githubusercontent.com/36601201/209880538-89f26274-76a1-4583-9afd-6b863da25533.png)|![image](https://user-images.githubusercontent.com/36601201/209880583-b1bf8899-e671-4f86-8274-cae95249ec79.png)
![image](https://user-images.githubusercontent.com/36601201/209880060-2b693e94-8fbe-4353-a88c-dd65d22b1d2b.png)|![image](https://user-images.githubusercontent.com/36601201/209880284-b67920fc-11b7-49b7-a415-3ac9ba1c23b3.png)
![image](https://user-images.githubusercontent.com/36601201/209880428-da82da18-9c41-4537-9b0a-f314ad2bbfda.png)|![image](https://user-images.githubusercontent.com/36601201/209880376-1844e1e0-6733-428f-aba9-9d7f94dfccbc.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 42e29f42c7704db04c1a9f8ffd9d111f9dfc95dd
- Git 2.39.0.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).