### PR TITLE
ConEmu 221218

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -6,7 +6,7 @@
     <PackageReference Update="Atlassian.SDK" Version="12.4.0" />
     <PackageReference Update="AppInsights.WindowsDesktop" Version="2.18.1" />
     <PackageReference Update="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Update="ConEmu.Core" Version="22.8.7" />
+    <PackageReference Update="ConEmu.Core" Version="22.12.18" />
     <PackageReference Update="DotnetRuntimeBootstrapper" Version="2.3.1" />
     <PackageReference Update="EnvDTE" Version="17.0.32112.339" />
     <PackageReference Update="ExCSS" Version="4.1.3" />


### PR DESCRIPTION
## Proposed changes

https://conemu.github.io/blog/2022/12/18/Build-221218.html
Minor changes but tagged as 'stable', current is 'alpha'. It was used as the binaries were signed to avoid issue reports with virus scanners - need to check the reports on this before merging.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
