### PR TITLE
Avoid ambiguity of branch filter

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -192,7 +192,8 @@ namespace GitCommands
                 { AppSettings.RevisionSortOrder == RevisionSortOrder.Topology, "--topo-order" },
 
                 revisionFilter,
-                { !string.IsNullOrWhiteSpace(pathFilter), $"-- {pathFilter}" }
+                "--",
+                { !string.IsNullOrWhiteSpace(pathFilter), pathFilter }
             };
         }
 


### PR DESCRIPTION
Fixes #10597

## Proposed changes

- RevisionReader: Always append "--" after revision filter

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 6fa3adcf4020ff8645747cbc7011a49eec9c54b0 (Dirty)
- Git 2.39.0.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).