### PR TITLE
Stabilize FormBrowseTests regarding Left Panel

### DIFF
--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -169,6 +169,8 @@ namespace GitExtensions.UITests.CommandsDialogs
                         using ReferenceRepository repository = new();
                         form.SetWorkingDir(repository.Module.WorkingDir);
                         WaitForRevisionsToBeLoaded(form);
+                        form.RevisionGridControl.Invalidate();
+                        UITest.ProcessEventsFor(1000);
                         // Assert
                         AppSettings.BranchFilterEnabled.Should().BeFalse();
                         AppSettings.ShowCurrentBranchOnly.Should().BeTrue();
@@ -256,6 +258,8 @@ namespace GitExtensions.UITests.CommandsDialogs
                         Console.WriteLine("Scenario 1: change 'Show stashes' to enabled");
                         form.GetTestAccessor().RevisionGrid.ToggleShowStashes();
                         WaitForRevisionsToBeLoaded(form);
+                        form.RevisionGridControl.Invalidate();
+                        UITest.ProcessEventsFor(1000);
                         // Assert
                         AppSettings.ShowStashes.Should().BeTrue();
                         form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(7);
@@ -302,6 +306,8 @@ namespace GitExtensions.UITests.CommandsDialogs
                         Console.WriteLine("Scenario 2: change 'Show stash' to disabled");
                         form.GetTestAccessor().RevisionGrid.ToggleShowStashes();
                         WaitForRevisionsToBeLoaded(form);
+                        form.RevisionGridControl.Invalidate();
+                        UITest.ProcessEventsFor(1000);
                         // Assert
                         AppSettings.ShowStashes.Should().BeFalse();
 #if DEBUG

--- a/IntegrationTests/UI.IntegrationTests/UITest.cs
+++ b/IntegrationTests/UI.IntegrationTests/UITest.cs
@@ -118,7 +118,7 @@ namespace GitExtensions.UITests
                 runTestAsync: form => runTestAsync(control));
         }
 
-        public static void ProcessUntil(string processName, Func<bool> condition, int maxIterations = 25)
+        public static void ProcessUntil(string processName, Func<bool> condition, int maxIterations = 50)
         {
             for (int iteration = 0; iteration < maxIterations; ++iteration)
             {

--- a/IntegrationTests/UI.IntegrationTests/UITest.cs
+++ b/IntegrationTests/UI.IntegrationTests/UITest.cs
@@ -8,6 +8,7 @@ namespace GitExtensions.UITests
 {
     public static class UITest
     {
+        // Same delay as RevisionDataGridView.BackgroundThreadUpdatePeriod
         private const int _processDelayMilliseconds = 25;
 
         public static async Task WaitForIdleAsync()

--- a/IntegrationTests/UI.IntegrationTests/UITest.cs
+++ b/IntegrationTests/UI.IntegrationTests/UITest.cs
@@ -135,6 +135,17 @@ namespace GitExtensions.UITests
             Assert.Fail($"'{processName}' didn't finish in {maxIterations} iterations");
         }
 
+        public static void ProcessEventsFor(int milliseconds)
+        {
+            const int delay = 25;
+            int maxIterations = milliseconds / delay;
+            for (int iteration = 0; iteration < maxIterations; ++iteration)
+            {
+                Application.DoEvents();
+                Thread.Sleep(delay);
+            }
+        }
+
         private readonly struct VoidResult
         {
         }

--- a/IntegrationTests/UI.IntegrationTests/UITest.cs
+++ b/IntegrationTests/UI.IntegrationTests/UITest.cs
@@ -8,6 +8,8 @@ namespace GitExtensions.UITests
 {
     public static class UITest
     {
+        private const int _processDelayMilliseconds = 25;
+
         public static async Task WaitForIdleAsync()
         {
             TaskCompletionSource<VoidResult> idleCompletionSource = new();
@@ -118,8 +120,9 @@ namespace GitExtensions.UITests
                 runTestAsync: form => runTestAsync(control));
         }
 
-        public static void ProcessUntil(string processName, Func<bool> condition, int maxIterations = 50)
+        public static void ProcessUntil(string processName, Func<bool> condition, int maxMilliseconds = 1500)
         {
+            int maxIterations = (maxMilliseconds + _processDelayMilliseconds - 1) / _processDelayMilliseconds;
             for (int iteration = 0; iteration < maxIterations; ++iteration)
             {
                 if (condition())
@@ -129,7 +132,7 @@ namespace GitExtensions.UITests
                 }
 
                 Application.DoEvents();
-                Thread.Sleep(25);
+                Thread.Sleep(_processDelayMilliseconds);
             }
 
             Assert.Fail($"'{processName}' didn't finish in {maxIterations} iterations");
@@ -137,12 +140,11 @@ namespace GitExtensions.UITests
 
         public static void ProcessEventsFor(int milliseconds)
         {
-            const int delay = 25;
-            int maxIterations = milliseconds / delay;
+            int maxIterations = (milliseconds + _processDelayMilliseconds - 1) / _processDelayMilliseconds;
             for (int iteration = 0; iteration < maxIterations; ++iteration)
             {
                 Application.DoEvents();
-                Thread.Sleep(delay);
+                Thread.Sleep(_processDelayMilliseconds);
             }
         }
 


### PR DESCRIPTION
## Proposed changes

Workaround for hanging `FormBrowseTests` regarding Left Panel
- Invalidate `RevisionGridControl` and call `DoEvents()` for 1 second after `WaitForRevisionsToBeLoaded()`
- `UITest.ProcessUntil()`: Double `maxIterations`

## Test methodology <!-- How did you ensure quality? -->

- existing testcases

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build a4c7bbac4e6e978be75bf74862217a0e31716ea1
- Git 2.39.0.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).