### PR TITLE
Accelerate builds in Visual Studio

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
     <!-- TODO once all project migrated to SDK-style, remove this and move properties to Directory.Build.props -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 
-    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
 
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,9 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
 
     <IsPublishable>false</IsPublishable>
+
+    <!-- Opt in to build acceleration in VS (from 17.5 onwards): https://github.com/dotnet/project-system/blob/main/docs/build-acceleration.md -->
+    <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Externals/Directory.Build.props
+++ b/Externals/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <UseWindowsForms>true</UseWindowsForms>
-    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
 
     <_SuppressSdkImports>true</_SuppressSdkImports>
     <DeterministicSourcePaths>false</DeterministicSourcePaths>

--- a/Setup/Setup.wixproj
+++ b/Setup/Setup.wixproj
@@ -23,6 +23,8 @@
     <DefineConstants>Version=$(Version);NumericVersion=$(Version);ArtifactsBinPath=$(ArtifactsBinPath);ArtifactsPublishPath=$(ArtifactsPublishPath);PluginManagerSourceDir=$(PluginManagerSourceDir)\GitExtensions.PluginManager\Output</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Debug' ">Debug;$(DefineConstants)</DefineConstants>
     <SuppressIces>ICE61;ICE80;ICE91;ICE38</SuppressIces>
+    <!-- Disable build acceleration for WIX projects -->
+    <AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Product.wxs" />


### PR DESCRIPTION
## Proposed changes

This PR improves developer productivity while working in the Git Extensions repo by speeding up build times considerably.

It does that with two changes:

1. Enable [Reference Assemblies](https://learn.microsoft.com/en-us/dotnet/standard/assembly/reference-assemblies)
2. Enable [Build Acceleration in Visual Studio](https://github.com/dotnet/project-system/blob/main/docs/build-acceleration.md)

## Results

For each of the following tests, a change was made in `GitExtUtils` then the whole solution was built.

- The change did not modify the public API. For example, altering a method body, reformatting code, adding a comment.
- That project was chosen as several other projects depend upon it.

## Before (17.4.2)

- 39 succeeded, 4 up-to-date
- Elapsed times
  - 23.750 seconds
  - 24.710 seconds
  - 23.196 seconds
  - 25.509 seconds

## Enable reference assemblies (17.4.2)

- 29 succeeded, 14 up-to-date
- Elapsed times
  - 18.167 seconds
  - 11.014 seconds
  - 10.148 seconds
  - 10.420 seconds
  - 11.532 seconds

## Enable Build Acceleration (17.5 preview 3)

- 1 succeeded, 41 up-to-date
- Elapsed times
  - 1.628 seconds
  - 1.684 seconds
  - 1.653 seconds
  - 1.906 seconds
  - 1.848 seconds

Overall, this PR cuts build time for the scenario by ~93%.

## Test methodology

- Lots of manual testing

## Test environment(s)

- Visual Studio 2022 version 17.5 preview 3

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

- Merge commit. (PR submitter to rebase and squash before merges).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
