### PR TITLE
Conemu: fix switch of repo folder in console tab

### DIFF
--- a/GitUI/Shells/ConEmuControlExtensions.cs
+++ b/GitUI/Shells/ConEmuControlExtensions.cs
@@ -16,14 +16,17 @@ namespace GitUI.Shells
             switch (shell.Name)
             {
                 case BashShell.ShellName:
+                    // Use a ConEmu macro to send the sequence for clearing the bash command line
                     terminal.RunningSession.BeginGuiMacro("Keys").WithParam("^A").WithParam("^K").ExecuteSync();
-                    terminal.RunningSession.WriteInputTextAsync(command + Environment.NewLine);
+                    terminal.RunningSession.WriteInputTextAsync(command);
                     break;
 
                 default:
-                    terminal.RunningSession.WriteInputTextAsync($"\x1B{command}{Environment.NewLine}");
+                    terminal.RunningSession.WriteInputTextAsync($"\x1B{command}");
                     break;
             }
+
+            terminal.RunningSession.BeginGuiMacro("Keys").WithParam("Enter").ExecuteSync();
         }
     }
 }


### PR DESCRIPTION
ConEmu handling of new line should have changed
(and the cursor is now passing to the next line and no more run the command entered in the prompt) so now sending the "Enter" key so that the "cd" command is run

Fixes https://github.com/gitextensions/gitextensions/issues/9761#issuecomment-1312139285

For ConEmu macro keys: https://conemu.github.io/en/GuiMacro.html#Keys

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![console_switch_failed](https://user-images.githubusercontent.com/460196/210895410-e4daa1be-e0ce-4a80-b331-70d07b57576d.gif)

### After
![console_switch_succeed](https://user-images.githubusercontent.com/460196/210895767-ea0c97fc-4f67-499f-8096-2eb3577017c9.gif)

<!-- TODO -->

## Test methodology <!-- How did you ensure quality? -->

- Manual with bash and cmd

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 88ccf3298246037f10992435997792fab50d7c96
- Git 2.38.0.windows.1 (recommended: 2.38.1 or later)
- Microsoft Windows NT 10.0.19042.0
- .NET 6.0.12
- DPI 96dpi (no scaling)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
