### PR TITLE
Update build scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,12 +2,16 @@
 *.xml diff -text
 *.patch diff -text
 *.blame diff -text
+*.xlf text
 *.cs text diff=csharp
 *.sln text eol=crlf
+*.targets text eol=crlf
 *.bat text eol=crlf
 *.cmd text eol=crlf
+*.yml text eol=lf
 *.sh text eol=lf
 *.py text eol=lf
+.gitattributes text eol=lf
 
 # Used in unit tests - try text diff
 *.bin binary diff=text

--- a/GitExtensions.sln
+++ b/GitExtensions.sln
@@ -156,6 +156,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{472B
 		scripts\Download-PluginManager.ps1 = scripts\Download-PluginManager.ps1
 		scripts\Mark-RepoClean.ps1 = scripts\Mark-RepoClean.ps1
 		scripts\stylecop.json = scripts\stylecop.json
+		update-loc.cmd = update-loc.cmd
 		scripts\vs-threading.MainThreadAssertingMethods.txt = scripts\vs-threading.MainThreadAssertingMethods.txt
 		scripts\vs-threading.MainThreadSwitchingMethods.txt = scripts\vs-threading.MainThreadSwitchingMethods.txt
 		scripts\vs-threading.TypesRequiringMainThread.txt = scripts\vs-threading.TypesRequiringMainThread.txt

--- a/GitExtensions/Project.Loc.targets
+++ b/GitExtensions/Project.Loc.targets
@@ -68,7 +68,7 @@
           ContinueOnError="false" />
 
     <!-- 5. Verify no changes to English*.xlf -->
-    <Exec Command="git add *.xlf --ignore-errors"
+    <Exec Command="git -c core.autocrlf=false add *.xlf --ignore-errors"
           IgnoreStandardErrorWarningFormat="true"
           WorkingDirectory="$(RepoRoot)"
           IgnoreExitCode="true">

--- a/GitExtensions/Project.Publish.targets
+++ b/GitExtensions/Project.Publish.targets
@@ -229,9 +229,9 @@
 
       <!-- Resolve the output file -->
       <_PublishPortableVersionSuffix>-$(CurrentBuildVersion.ToString())</_PublishPortableVersionSuffix>
+
+      <!-- This property comes from GitInfo package, but can be overriden on AppVeyor -->
       <_PublishPortableCommitHashSuffix Condition="'$(GitCommit)' != ''">-$(GitCommit)</_PublishPortableCommitHashSuffix>
-      <_PublishPortableCommitHashSuffix Condition="'$(env:APPVEYOR_REPO_COMMIT)' != ''">-$(env:APPVEYOR_REPO_COMMIT)</_PublishPortableCommitHashSuffix>
-      <_PublishPortableCommitHashSuffix Condition="'$(env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)' != ''">-$(env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)</_PublishPortableCommitHashSuffix>
       <_PublishPortableFileName>GitExtensions-Portable$(_PublishPortableVersionSuffix)$(_PublishPortableCommitHashSuffix).zip</_PublishPortableFileName>
       <_PublishPortablePath>$([MSBuild]::NormalizePath('$(ArtifactsPublishDir)', '$(_PublishPortableFileName)'))</_PublishPortablePath>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ install:
 - cmd: git submodule update --init --recursive
 - cmd: |-
     cd scripts
-    C:\\Python35\\python set_version_to.py -v %APPVEYOR_BUILD_VERSION% -t %APPVEYOR_BUILD_VERSION%
+    C:\\Python311\\python set_version_to.py -v %APPVEYOR_BUILD_VERSION% -t %APPVEYOR_BUILD_VERSION%
     cd ..
     git --version
 
@@ -56,35 +56,28 @@ install:
 # to run your custom scripts instead of automatic MSBuild
 build_script:
 - ps: |
-    $isBuildingPR = $false;
-    # if building a temporary merge with master, soft reset to the PR commit so the build contains the PR's hash instead of the merge-commit's hash
+    $buildArgs = '/p:ContinuousIntegrationBuild=true'
+    # if building a PR override the hash with the PR commit's so the build contains the PR's hash instead of the merge-commit's hash
     if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -and ($env:APPVEYOR_REPO_COMMIT -ne $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT))
     {
-        git reset --soft "$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT" --
-        $isBuildingPR = $true;
+        $gitCommit = $(git rev-parse --short $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)
+        $buildArgs += " /p:GitCommit=$gitCommit /p:GitSha=$($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)"
     }
+- ps: |
+    # add to index, to adjust crlf configured in .gitattributes
+    git -c core.autocrlf=false add -A
+    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 - ps: |
     # build VC++
     dotnet build .\scripts\native.proj -c Release --verbosity q --nologo /bl:.\artifacts\log\native.binlog
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 - ps: |
     # build .NET
-    dotnet build -c Release --verbosity q --nologo /bl:.\artifacts\log\build.binlog /p:ContinuousIntegrationBuild=true
+    $cmd = "dotnet build -c Release --verbosity q --nologo /bl:.\artifacts\log\build.binlog $buildArgs"
+    Invoke-Expression $cmd
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 - ps: |
-    # if we have reset above, we need to restore the merge commit, otherwise the loc verification step will fail
-    # there is no need to have the same commit hash, but there must be no pending changes before the loc verification
-    # refer to https://github.com/gitextensions/gitextensions/issues/7979
-    if ($isBuildingPR) {
-        git config user.email "gitextensions@github.com"
-        git config user.name "Git Extensions"
-        git -c core.autocrlf=false commit -a -m "restore merge commit" | Out-Null
-        # ignore warning about line-endings conversion
-        $global:LASTEXITCODE = 0
-    }
-- ps: |
     # Verify that new strings (if any) have been processed and ready for localisation
-    # it would be nice to run '.\cibuild.cmd -loc -logFileName localise.binlog /p:NoBuild=true' but it doesn't work without `-build` switch :\
     Push-Location .\GitExtensions
     dotnet msbuild /p:Configuration=Release /t:_UpdateEnglishTranslations /p:RunTranslationApp=true /p:ContinuousIntegrationBuild=true /v:m /bl:..\artifacts\log\localise.binlog
     Pop-Location
@@ -100,7 +93,8 @@ test_script:
 after_test:
 - ps: |
     Write-Host "Preparing build artifacts..."
-    dotnet publish -c Release --no-build /bl:.\artifacts\log\publish.binlog /p:ContinuousIntegrationBuild=true
+    $cmd = "dotnet publish -c Release --no-build /bl:.\artifacts\log\publish.binlog $buildArgs"
+    Invoke-Expression $cmd
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 - ps: |
     if ([bool]$env:APPVEYOR_PULL_REQUEST_TITLE -and [bool]$env:ARTIFACT_PUBLISH_PULL_REQUEST_MSI) {


### PR DESCRIPTION
* Disable these:
   ![image](https://user-images.githubusercontent.com/4403806/210937389-7753cea1-0add-466a-9b5e-3e46b8f8f6ac.png)
   ![image](https://user-images.githubusercontent.com/4403806/210937557-05b63b44-386b-4292-aa19-7c2cabd76b49.png)

* Simply build structure removing reset-commit steps that were responsible for setting original PR commit's hash. Override `$(GitCommit)` and `$(GitSha)` MSBuild properties instead.
For example: https://ci.appveyor.com/project/gitextensions/gitextensions/builds/45871126
  ![image](https://user-images.githubusercontent.com/4403806/211187979-de1a03f2-4b73-471d-99ec-8160545fc0d4.png)
  ![image](https://user-images.githubusercontent.com/4403806/211187984-d4cd9ed3-bd75-4442-b75d-d2e281878a06.png)
  ![image](https://user-images.githubusercontent.com/4403806/211187988-d98b32e9-53f7-4f51-b61a-3215c252b017.png)