### PR TITLE
Encapsulate several top-level menus

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Drawing;
 using System.Windows.Forms;
+using GitUI.CommandsDialogs.Menus;
 
 namespace GitUI.CommandsDialogs
 {
@@ -162,17 +163,7 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
             this.pluginSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.userManualToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.changelogToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-            this.translateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator16 = new System.Windows.Forms.ToolStripSeparator();
-            this.donateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.reportAnIssueToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.checkForUpdatesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsmiTelemetryEnabled = new System.Windows.Forms.ToolStripMenuItem();
+            this.helpToolStripMenuItem = new GitUI.CommandsDialogs.Menus.HelpToolStripMenuItem();
             this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.gitcommandLogToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
@@ -1500,96 +1491,8 @@ namespace GitUI.CommandsDialogs
             // 
             // helpToolStripMenuItem
             // 
-            this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.userManualToolStripMenuItem,
-            this.changelogToolStripMenuItem,
-            this.toolStripSeparator3,
-            this.translateToolStripMenuItem,
-            this.toolStripSeparator16,
-            this.donateToolStripMenuItem,
-            this.tsmiTelemetryEnabled,
-            this.reportAnIssueToolStripMenuItem,
-            this.checkForUpdatesToolStripMenuItem,
-            this.aboutToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
             this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
-            this.helpToolStripMenuItem.Text = "&Help";
-            this.helpToolStripMenuItem.DropDownOpening += new System.EventHandler(this.HelpToolStripMenuItem_DropDownOpening);
-            // 
-            // userManualToolStripMenuItem
-            // 
-            this.userManualToolStripMenuItem.Image = global::GitUI.Properties.Images.GotoManual;
-            this.userManualToolStripMenuItem.Name = "userManualToolStripMenuItem";
-            this.userManualToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.userManualToolStripMenuItem.Text = "User &manual";
-            this.userManualToolStripMenuItem.Click += new System.EventHandler(this.UserManualToolStripMenuItemClick);
-            // 
-            // changelogToolStripMenuItem
-            // 
-            this.changelogToolStripMenuItem.Image = global::GitUI.Properties.Images.Changelog;
-            this.changelogToolStripMenuItem.Name = "changelogToolStripMenuItem";
-            this.changelogToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.changelogToolStripMenuItem.Text = "&Changelog";
-            this.changelogToolStripMenuItem.Click += new System.EventHandler(this.ChangelogToolStripMenuItemClick);
-            // 
-            // toolStripSeparator3
-            // 
-            this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(167, 6);
-            // 
-            // translateToolStripMenuItem
-            // 
-            this.translateToolStripMenuItem.Image = global::GitUI.Properties.Images.Translate;
-            this.translateToolStripMenuItem.Name = "translateToolStripMenuItem";
-            this.translateToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.translateToolStripMenuItem.Text = "&Translate";
-            this.translateToolStripMenuItem.Click += new System.EventHandler(this.TranslateToolStripMenuItemClick);
-            // 
-            // toolStripSeparator16
-            // 
-            this.toolStripSeparator16.Name = "toolStripSeparator16";
-            this.toolStripSeparator16.Size = new System.Drawing.Size(167, 6);
-            // 
-            // donateToolStripMenuItem
-            // 
-            this.donateToolStripMenuItem.Image = global::GitUI.Properties.Images.DollarSign;
-            this.donateToolStripMenuItem.Name = "donateToolStripMenuItem";
-            this.donateToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.donateToolStripMenuItem.Text = "&Donate";
-            this.donateToolStripMenuItem.Click += new System.EventHandler(this.DonateToolStripMenuItemClick);
-            // 
-            // reportAnIssueToolStripMenuItem
-            // 
-            this.reportAnIssueToolStripMenuItem.Image = global::GitUI.Properties.Images.BugReport;
-            this.reportAnIssueToolStripMenuItem.Name = "reportAnIssueToolStripMenuItem";
-            this.reportAnIssueToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.reportAnIssueToolStripMenuItem.Text = "&Report an issue";
-            this.reportAnIssueToolStripMenuItem.Click += new System.EventHandler(this.reportAnIssueToolStripMenuItem_Click);
-            // 
-            // checkForUpdatesToolStripMenuItem
-            // 
-            this.checkForUpdatesToolStripMenuItem.Image = global::GitUI.Properties.Images.CheckForUpdates;
-            this.checkForUpdatesToolStripMenuItem.Name = "checkForUpdatesToolStripMenuItem";
-            this.checkForUpdatesToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.checkForUpdatesToolStripMenuItem.Text = "Check for &updates";
-            this.checkForUpdatesToolStripMenuItem.Click += new System.EventHandler(this.checkForUpdatesToolStripMenuItem_Click);
-            // 
-            // aboutToolStripMenuItem
-            // 
-            this.aboutToolStripMenuItem.Image = global::GitUI.Properties.Images.Information;
-            this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.aboutToolStripMenuItem.Text = "&About";
-            this.aboutToolStripMenuItem.Click += new System.EventHandler(this.AboutToolStripMenuItemClick);
-            // 
-            // tsmiTelemetryEnabled
-            // 
-            this.tsmiTelemetryEnabled.Checked = true;
-            this.tsmiTelemetryEnabled.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.tsmiTelemetryEnabled.Name = "tsmiTelemetryEnabled";
-            this.tsmiTelemetryEnabled.Size = new System.Drawing.Size(278, 34);
-            this.tsmiTelemetryEnabled.Text = "&Yes, I allow telemetry";
-            this.tsmiTelemetryEnabled.Click += new System.EventHandler(this.TsmiTelemetryEnabled_Click);
             // 
             // toolsToolStripMenuItem
             // 
@@ -1855,15 +1758,8 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem editmailmapToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator13;
         private ToolStripMenuItem settingsToolStripMenuItem;
-        private ToolStripMenuItem helpToolStripMenuItem;
+        private GitUI.CommandsDialogs.Menus.HelpToolStripMenuItem helpToolStripMenuItem;
         private ToolStripMenuItem toolsToolStripMenuItem;
-        private ToolStripMenuItem userManualToolStripMenuItem;
-        private ToolStripMenuItem changelogToolStripMenuItem;
-        private ToolStripSeparator toolStripSeparator3;
-        private ToolStripMenuItem translateToolStripMenuItem;
-        private ToolStripSeparator toolStripSeparator16;
-        private ToolStripMenuItem donateToolStripMenuItem;
-        private ToolStripMenuItem aboutToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator21;
         private ToolStripSeparator toolStripSeparator25;
         private ToolStripSeparator toolStripSeparator22;
@@ -1878,14 +1774,12 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem fetchAllToolStripMenuItem;
         private ToolStripMenuItem fetchPruneAllToolStripMenuItem;
         private ToolStripMenuItem resetToolStripMenuItem;
-        private ToolStripMenuItem reportAnIssueToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator41;
         private ToolStripSeparator toolStripSeparator42;
         private ToolStripSeparator toolStripSeparator43;
         private ToolStripSeparator toolStripSeparator44;
         private ToolStripSeparator toolStripSeparator45;
         private ToolStripSeparator toolStripSeparator46;
-        private ToolStripMenuItem checkForUpdatesToolStripMenuItem;
         private ToolStripMenuItem gitcommandLogToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator7;
         private ToolStripMenuItem menuitemSparse;
@@ -1903,7 +1797,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem commitInfoBelowMenuItem;
         private ToolStripMenuItem commitInfoLeftwardMenuItem;
         private ToolStripMenuItem commitInfoRightwardMenuItem;
-        private ToolStripMenuItem tsmiTelemetryEnabled;
         private Panel RevisionGridContainer;
         private UserControls.InteractiveGitActionControl notificationBarBisectInProgress;
         private UserControls.InteractiveGitActionControl notificationBarGitActionInProgress;

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -115,9 +115,6 @@ namespace GitUI.CommandsDialogs
             this.editLocalGitConfigToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.repoSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
-            this.gitBashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.gitGUIToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.kGitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.commandsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.commitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.undoLastCommitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -148,12 +145,7 @@ namespace GitUI.CommandsDialogs
             this.applyPatchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.patchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator46 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripSeparator41 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripSeparator42 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
-            this.PuTTYToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.startAuthenticationAgentToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.generateOrImportKeyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._repositoryHostsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._forkCloneRepositoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this._viewPullRequestsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -162,11 +154,8 @@ namespace GitUI.CommandsDialogs
             this.pluginsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
             this.pluginSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new GitUI.CommandsDialogs.Menus.HelpToolStripMenuItem();
-            this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.gitcommandLogToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolsToolStripMenuItem = new GitUI.CommandsDialogs.Menus.ToolsToolStripMenuItem();
             this.mainMenuStrip = new GitUI.MenuStripEx();
             this.gitItemBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.gitRevisionBindingSource = new System.Windows.Forms.BindingSource(this.components);
@@ -1104,30 +1093,6 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator13.Name = "toolStripSeparator13";
             this.toolStripSeparator13.Size = new System.Drawing.Size(218, 6);
             // 
-            // gitBashToolStripMenuItem
-            // 
-            this.gitBashToolStripMenuItem.Image = global::GitUI.Properties.Images.GitForWindows;
-            this.gitBashToolStripMenuItem.Name = "gitBashToolStripMenuItem";
-            this.gitBashToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
-            this.gitBashToolStripMenuItem.Text = "Git &bash";
-            this.gitBashToolStripMenuItem.Click += new System.EventHandler(this.userShell_Click);
-            // 
-            // gitGUIToolStripMenuItem
-            // 
-            this.gitGUIToolStripMenuItem.Image = global::GitUI.Properties.Images.GitGui;
-            this.gitGUIToolStripMenuItem.Name = "gitGUIToolStripMenuItem";
-            this.gitGUIToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
-            this.gitGUIToolStripMenuItem.Text = "Git &GUI";
-            this.gitGUIToolStripMenuItem.Click += new System.EventHandler(this.GitGuiToolStripMenuItemClick);
-            // 
-            // kGitToolStripMenuItem
-            // 
-            this.kGitToolStripMenuItem.Image = global::GitUI.Properties.Images.Gitk;
-            this.kGitToolStripMenuItem.Name = "kGitToolStripMenuItem";
-            this.kGitToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
-            this.kGitToolStripMenuItem.Text = "Git&K";
-            this.kGitToolStripMenuItem.Click += new System.EventHandler(this.KGitToolStripMenuItemClick);
-            // 
             // commandsToolStripMenuItem
             // 
             this.commandsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -1377,46 +1342,10 @@ namespace GitUI.CommandsDialogs
             this.toolStripSeparator46.Name = "toolStripSeparator46";
             this.toolStripSeparator46.Size = new System.Drawing.Size(268, 6);
             // 
-            // toolStripSeparator41
-            // 
-            this.toolStripSeparator41.Name = "toolStripSeparator41";
-            this.toolStripSeparator41.Size = new System.Drawing.Size(214, 6);
-            // 
             // toolStripSeparator42
             // 
             this.toolStripSeparator42.Name = "toolStripSeparator42";
             this.toolStripSeparator42.Size = new System.Drawing.Size(110, 6);
-            // 
-            // toolStripSeparator6
-            // 
-            this.toolStripSeparator6.Name = "toolStripSeparator6";
-            this.toolStripSeparator6.Size = new System.Drawing.Size(214, 6);
-            // 
-            // PuTTYToolStripMenuItem
-            // 
-            this.PuTTYToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.startAuthenticationAgentToolStripMenuItem,
-            this.generateOrImportKeyToolStripMenuItem});
-            this.PuTTYToolStripMenuItem.Image = global::GitUI.Properties.Images.Putty;
-            this.PuTTYToolStripMenuItem.Name = "PuTTYToolStripMenuItem";
-            this.PuTTYToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
-            this.PuTTYToolStripMenuItem.Text = "&PuTTY";
-            // 
-            // startAuthenticationAgentToolStripMenuItem
-            // 
-            this.startAuthenticationAgentToolStripMenuItem.Image = global::GitUI.Properties.Images.Pageant16;
-            this.startAuthenticationAgentToolStripMenuItem.Name = "startAuthenticationAgentToolStripMenuItem";
-            this.startAuthenticationAgentToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
-            this.startAuthenticationAgentToolStripMenuItem.Text = "Start authentication agent";
-            this.startAuthenticationAgentToolStripMenuItem.Click += new System.EventHandler(this.StartAuthenticationAgentToolStripMenuItemClick);
-            // 
-            // generateOrImportKeyToolStripMenuItem
-            // 
-            this.generateOrImportKeyToolStripMenuItem.Image = global::GitUI.Properties.Images.PuttyGen;
-            this.generateOrImportKeyToolStripMenuItem.Name = "generateOrImportKeyToolStripMenuItem";
-            this.generateOrImportKeyToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
-            this.generateOrImportKeyToolStripMenuItem.Text = "Generate or import key";
-            this.generateOrImportKeyToolStripMenuItem.Click += new System.EventHandler(this.GenerateOrImportKeyToolStripMenuItemClick);
             // 
             // _repositoryHostsToolStripMenuItem
             // 
@@ -1481,14 +1410,6 @@ namespace GitUI.CommandsDialogs
             this.pluginSettingsToolStripMenuItem.Text = "Plugin &Settings";
             this.pluginSettingsToolStripMenuItem.Click += new System.EventHandler(this.PluginSettingsToolStripMenuItemClick);
             // 
-            // settingsToolStripMenuItem
-            // 
-            this.settingsToolStripMenuItem.Image = global::GitUI.Properties.Images.Settings;
-            this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
-            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
-            this.settingsToolStripMenuItem.Text = "&Settings";
-            this.settingsToolStripMenuItem.Click += new System.EventHandler(this.OnShowSettingsClick);
-            // 
             // helpToolStripMenuItem
             // 
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
@@ -1496,33 +1417,10 @@ namespace GitUI.CommandsDialogs
             // 
             // toolsToolStripMenuItem
             // 
-            this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.gitBashToolStripMenuItem,
-            this.gitGUIToolStripMenuItem,
-            this.kGitToolStripMenuItem,
-            this.toolStripSeparator6,
-            this.PuTTYToolStripMenuItem,
-            this.toolStripSeparator41,
-            this.gitcommandLogToolStripMenuItem,
-            this.toolStripSeparator7,
-            this.settingsToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 20);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 19);
             this.toolsToolStripMenuItem.Text = "&Tools";
-            // 
-            // gitcommandLogToolStripMenuItem
-            // 
-            this.gitcommandLogToolStripMenuItem.Image = global::GitUI.Properties.Images.GitCommandLog;
-            this.gitcommandLogToolStripMenuItem.Name = "gitcommandLogToolStripMenuItem";
-            this.gitcommandLogToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F12;
-            this.gitcommandLogToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
-            this.gitcommandLogToolStripMenuItem.Text = "Git &command log";
-            this.gitcommandLogToolStripMenuItem.Click += new System.EventHandler(this.GitcommandLogToolStripMenuItemClick);
-            // 
-            // toolStripSeparator7
-            // 
-            this.toolStripSeparator7.Name = "toolStripSeparator7";
-            this.toolStripSeparator7.Size = new System.Drawing.Size(214, 6);
+            this.toolsToolStripMenuItem.SettingsChanged += new System.EventHandler<GitUI.CommandsDialogs.Menus.SettingsChangedEventArgs>(this.toolsToolStripMenuItem_SettingsChanged);
             // 
             // mainMenuStrip
             // 
@@ -1702,9 +1600,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripSeparator toolStripMenuItem1;
         private ToolStripMenuItem exitToolStripMenuItem;
         private ToolStripMenuItem repositoryToolStripMenuItem;
-        private ToolStripMenuItem gitBashToolStripMenuItem;
-        private ToolStripMenuItem gitGUIToolStripMenuItem;
-        private ToolStripMenuItem kGitToolStripMenuItem;
         private ToolStripMenuItem commandsToolStripMenuItem;
         private ToolStripMenuItem applyPatchToolStripMenuItem;
         private ToolStripMenuItem archiveToolStripMenuItem;
@@ -1729,10 +1624,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem stashToolStripMenuItem;
         private ToolStripMenuItem patchToolStripMenuItem;
         private ToolStripMenuItem manageRemoteRepositoriesToolStripMenuItem1;
-        private ToolStripSeparator toolStripSeparator6;
-        private ToolStripMenuItem PuTTYToolStripMenuItem;
-        private ToolStripMenuItem startAuthenticationAgentToolStripMenuItem;
-        private ToolStripMenuItem generateOrImportKeyToolStripMenuItem;
         private ToolStripMenuItem _repositoryHostsToolStripMenuItem;
         private ToolStripMenuItem _forkCloneRepositoryToolStripMenuItem;
         private ToolStripMenuItem _viewPullRequestsToolStripMenuItem;
@@ -1757,9 +1648,8 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem editGitAttributesToolStripMenuItem;
         private ToolStripMenuItem editmailmapToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator13;
-        private ToolStripMenuItem settingsToolStripMenuItem;
         private GitUI.CommandsDialogs.Menus.HelpToolStripMenuItem helpToolStripMenuItem;
-        private ToolStripMenuItem toolsToolStripMenuItem;
+        private GitUI.CommandsDialogs.Menus.ToolsToolStripMenuItem toolsToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator21;
         private ToolStripSeparator toolStripSeparator25;
         private ToolStripSeparator toolStripSeparator22;
@@ -1774,14 +1664,11 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem fetchAllToolStripMenuItem;
         private ToolStripMenuItem fetchPruneAllToolStripMenuItem;
         private ToolStripMenuItem resetToolStripMenuItem;
-        private ToolStripSeparator toolStripSeparator41;
         private ToolStripSeparator toolStripSeparator42;
         private ToolStripSeparator toolStripSeparator43;
         private ToolStripSeparator toolStripSeparator44;
         private ToolStripSeparator toolStripSeparator45;
         private ToolStripSeparator toolStripSeparator46;
-        private ToolStripMenuItem gitcommandLogToolStripMenuItem;
-        private ToolStripSeparator toolStripSeparator7;
         private ToolStripMenuItem menuitemSparse;
         private ToolStripSeparator toolStripSeparator10;
         private ToolStripMenuItem editgitinfoexcludeToolStripMenuItem;

--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -20,8 +20,6 @@ namespace GitUI.CommandsDialogs
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.Windows.Forms.ToolStripMenuItem toolStripMenuItem2;
-            System.Windows.Forms.ToolStripMenuItem toolStripMenuItem4;
             System.Windows.Forms.ToolStripSeparator toolStripSeparator14;
             System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
             this.ToolStripMain = new GitUI.ToolStripEx();
@@ -77,17 +75,7 @@ namespace GitUI.CommandsDialogs
             this.GpgInfoTabPage = new System.Windows.Forms.TabPage();
             this.revisionGpgInfo1 = new GitUI.CommandsDialogs.RevisionGpgInfoControl();
             this.FilterToolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.initNewRepositoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsmiFavouriteRepositories = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsmiRecentRepositories = new System.Windows.Forms.ToolStripMenuItem();
-            this.clearRecentRepositoriesListToolStripMenuItem = new System.Windows.Forms.ToolStripSeparator();
-            this.tsmiRecentRepositoriesClear = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
-            this.cloneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
-            this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fileToolStripMenuItem = new GitUI.CommandsDialogs.Menus.StartToolStripMenuItem();
             this.closeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.refreshToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.refreshDashboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -163,8 +151,6 @@ namespace GitUI.CommandsDialogs
             this._addUpstreamRemoteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolStripFilters = new GitUI.UserControls.FilterToolBar();
             this.ToolStripScripts = new GitUI.ToolStripEx();
-            toolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
-            toolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
             toolStripSeparator14 = new System.Windows.Forms.ToolStripSeparator();
             toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
             this.ToolStripMain.SuspendLayout();
@@ -194,18 +180,6 @@ namespace GitUI.CommandsDialogs
             this.toolPanel.TopToolStripPanel.SuspendLayout();
             this.toolPanel.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // toolStripMenuItem2
-            // 
-            toolStripMenuItem2.Name = "toolStripMenuItem2";
-            toolStripMenuItem2.Size = new System.Drawing.Size(122, 22);
-            toolStripMenuItem2.Text = "...";
-            // 
-            // toolStripMenuItem4
-            // 
-            toolStripMenuItem4.Name = "toolStripMenuItem4";
-            toolStripMenuItem4.Size = new System.Drawing.Size(83, 22);
-            toolStripMenuItem4.Text = "...";
             // 
             // toolStripSeparator14
             // 
@@ -782,94 +756,10 @@ namespace GitUI.CommandsDialogs
             // 
             // fileToolStripMenuItem
             // 
-            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.initNewRepositoryToolStripMenuItem,
-            this.openToolStripMenuItem,
-            this.tsmiFavouriteRepositories,
-            this.tsmiRecentRepositories,
-            this.toolStripSeparator12,
-            this.cloneToolStripMenuItem,
-            this.toolStripMenuItem1,
-            this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(43, 20);
-            this.fileToolStripMenuItem.Text = "&Start";
-            // 
-            // initNewRepositoryToolStripMenuItem
-            // 
-            this.initNewRepositoryToolStripMenuItem.Image = global::GitUI.Properties.Images.RepoCreate;
-            this.initNewRepositoryToolStripMenuItem.Name = "initNewRepositoryToolStripMenuItem";
-            this.initNewRepositoryToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
-            this.initNewRepositoryToolStripMenuItem.Text = "&Create new repository...";
-            this.initNewRepositoryToolStripMenuItem.Click += new System.EventHandler(this.InitNewRepositoryToolStripMenuItemClick);
-            // 
-            // openToolStripMenuItem
-            // 
-            this.openToolStripMenuItem.Image = global::GitUI.Properties.Images.RepoOpen;
-            this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
-            this.openToolStripMenuItem.Text = "&Open...";
-            this.openToolStripMenuItem.Click += new System.EventHandler(this.OpenToolStripMenuItemClick);
-            // 
-            // tsmiFavouriteRepositories
-            // 
-            this.tsmiFavouriteRepositories.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            toolStripMenuItem4});
-            this.tsmiFavouriteRepositories.Image = global::GitUI.Properties.Images.Star;
-            this.tsmiFavouriteRepositories.Name = "tsmiFavouriteRepositories";
-            this.tsmiFavouriteRepositories.Size = new System.Drawing.Size(198, 22);
-            this.tsmiFavouriteRepositories.Text = "&Favorite repositories";
-            this.tsmiFavouriteRepositories.DropDownOpening += new System.EventHandler(this.tsmiFavouriteRepositories_DropDownOpening);
-            // 
-            // tsmiRecentRepositories
-            // 
-            this.tsmiRecentRepositories.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            toolStripMenuItem2,
-            this.clearRecentRepositoriesListToolStripMenuItem,
-            this.tsmiRecentRepositoriesClear});
-            this.tsmiRecentRepositories.Image = global::GitUI.Properties.Images.RecentRepositories;
-            this.tsmiRecentRepositories.Name = "tsmiRecentRepositories";
-            this.tsmiRecentRepositories.Size = new System.Drawing.Size(198, 22);
-            this.tsmiRecentRepositories.Text = "&Recent repositories";
-            this.tsmiRecentRepositories.DropDownOpening += new System.EventHandler(this.tsmiRecentRepositories_DropDownOpening);
-            // 
-            // clearRecentRepositoriesListToolStripMenuItem
-            // 
-            this.clearRecentRepositoriesListToolStripMenuItem.Name = "clearRecentRepositoriesListToolStripMenuItem";
-            this.clearRecentRepositoriesListToolStripMenuItem.Size = new System.Drawing.Size(119, 6);
-            // 
-            // tsmiRecentRepositoriesClear
-            // 
-            this.tsmiRecentRepositoriesClear.Name = "tsmiRecentRepositoriesClear";
-            this.tsmiRecentRepositoriesClear.Size = new System.Drawing.Size(122, 22);
-            this.tsmiRecentRepositoriesClear.Text = "Clear list";
-            this.tsmiRecentRepositoriesClear.Click += new System.EventHandler(this.tsmiRecentRepositoriesClear_Click);
-            // 
-            // toolStripSeparator12
-            // 
-            this.toolStripSeparator12.Name = "toolStripSeparator12";
-            this.toolStripSeparator12.Size = new System.Drawing.Size(195, 6);
-            // 
-            // cloneToolStripMenuItem
-            // 
-            this.cloneToolStripMenuItem.Image = global::GitUI.Properties.Images.CloneRepoGit;
-            this.cloneToolStripMenuItem.Name = "cloneToolStripMenuItem";
-            this.cloneToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
-            this.cloneToolStripMenuItem.Text = "C&lone repository...";
-            this.cloneToolStripMenuItem.Click += new System.EventHandler(this.CloneToolStripMenuItemClick);
-            // 
-            // toolStripMenuItem1
-            // 
-            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(195, 6);
-            // 
-            // exitToolStripMenuItem
-            // 
-            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Q)));
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
-            this.exitToolStripMenuItem.Text = "E&xit";
-            this.exitToolStripMenuItem.Click += new System.EventHandler(this.ExitToolStripMenuItemClick);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(43, 19);
+            this.fileToolStripMenuItem.GitModuleChanged += new System.EventHandler<GitCommands.Git.GitModuleEventArgs>(this.SetGitModule);
+            this.fileToolStripMenuItem.RecentRepositoriesCleared += new System.EventHandler(this.fileToolStripMenuItem_RecentRepositoriesCleared);
             // 
             // closeToolStripMenuItem
             // 
@@ -1589,16 +1479,11 @@ namespace GitUI.CommandsDialogs
         private ToolStripSplitButton branchSelect;
         private ToolStripButton toggleBranchTreePanel;
         private ToolStripButton toggleSplitViewLayout;
-        private ToolStripMenuItem fileToolStripMenuItem;
-        private ToolStripMenuItem openToolStripMenuItem;
+        private GitUI.CommandsDialogs.Menus.StartToolStripMenuItem fileToolStripMenuItem;
         private ToolStripMenuItem closeToolStripMenuItem;
         private ToolStripMenuItem refreshToolStripMenuItem;
         private ToolStripMenuItem refreshDashboardToolStripMenuItem;
-        private ToolStripMenuItem tsmiRecentRepositories;
-        private ToolStripSeparator toolStripSeparator12;
         private ToolStripMenuItem fileExplorerToolStripMenuItem;
-        private ToolStripSeparator toolStripMenuItem1;
-        private ToolStripMenuItem exitToolStripMenuItem;
         private ToolStripMenuItem repositoryToolStripMenuItem;
         private ToolStripMenuItem commandsToolStripMenuItem;
         private ToolStripMenuItem applyPatchToolStripMenuItem;
@@ -1608,14 +1493,12 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem checkoutToolStripMenuItem;
         private ToolStripMenuItem cherryPickToolStripMenuItem;
         private ToolStripMenuItem cleanupToolStripMenuItem;
-        private ToolStripMenuItem cloneToolStripMenuItem;
         private ToolStripMenuItem commitToolStripMenuItem;
         private ToolStripMenuItem branchToolStripMenuItem;
         private ToolStripMenuItem tagToolStripMenuItem;
         private ToolStripMenuItem deleteBranchToolStripMenuItem;
         private ToolStripMenuItem deleteTagToolStripMenuItem;
         private ToolStripMenuItem formatPatchToolStripMenuItem;
-        private ToolStripMenuItem initNewRepositoryToolStripMenuItem;
         private ToolStripMenuItem mergeBranchToolStripMenuItem;
         private ToolStripMenuItem pullToolStripMenuItem;
         private ToolStripMenuItem pushToolStripMenuItem;
@@ -1674,12 +1557,9 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem editgitinfoexcludeToolStripMenuItem;
         private ToolStripMenuItem toolStripMenuItemReflog;
         private ToolStripMenuItem manageWorktreeToolStripMenuItem;
-        private ToolStripMenuItem tsmiRecentRepositoriesClear;
-        private ToolStripSeparator clearRecentRepositoriesListToolStripMenuItem;
         private ToolStripButton toolStripFileExplorer;
         private ToolStripMenuItem createAStashToolStripMenuItem;
         private ToolStripMenuItem undoLastCommitToolStripMenuItem;
-        private ToolStripMenuItem tsmiFavouriteRepositories;
         private ToolStripSplitButton menuCommitInfoPosition;
         private ToolStripMenuItem commitInfoBelowMenuItem;
         private ToolStripMenuItem commitInfoLeftwardMenuItem;

--- a/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
@@ -30,7 +30,6 @@ namespace GitUI.CommandsDialogs
 
             new ToolStripItem[]
             {
-                translateToolStripMenuItem,
                 recoverLostObjectsToolStripMenuItem,
                 branchSelect,
                 toolStripButtonPull,

--- a/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
@@ -47,12 +47,6 @@ namespace GitUI.CommandsDialogs
 
             InsertFetchPullShortcuts();
 
-            if (!EnvUtils.RunningOnWindows())
-            {
-                toolStripSeparator6.Visible = false;
-                PuTTYToolStripMenuItem.Visible = false;
-            }
-
             pullToolStripMenuItem1.Tag = AppSettings.PullAction.None;
             mergeToolStripMenuItem.Tag = AppSettings.PullAction.Merge;
             rebaseToolStripMenuItem1.Tag = AppSettings.PullAction.Rebase;
@@ -262,8 +256,6 @@ namespace GitUI.CommandsDialogs
                 userShell.ToolTipText = shell.Name;
                 userShell.Tag = shell;
             }
-
-            gitBashToolStripMenuItem.Tag = _shellProvider.GetShell(BashShell.ShellName);
         }
 
         private void RefreshDefaultPullAction()

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -253,6 +253,7 @@ namespace GitUI.CommandsDialogs
             InitializeComponent();
 
             helpToolStripMenuItem.Initialize(() => UICommands);
+            toolsToolStripMenuItem.Initialize(() => UICommands);
 
             BackColor = OtherColors.BackgroundColor;
 
@@ -897,7 +898,8 @@ namespace GitUI.CommandsDialogs
 
                 stashChangesToolStripMenuItem.Enabled = !bareRepository;
                 stashStagedToolStripMenuItem.Visible = Module.GitVersion.SupportStashStaged;
-                gitGUIToolStripMenuItem.Enabled = !bareRepository;
+
+                toolsToolStripMenuItem.RefreshState(bareRepository);
 
                 SetShortcutKeyDisplayStringsFromHotkeySettings();
 
@@ -989,16 +991,12 @@ namespace GitUI.CommandsDialogs
         {
             // Add shortcuts to the menu items
             openToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.OpenRepo).ToShortcutKeyDisplayString();
-            gitBashToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.GitBash).ToShortcutKeyDisplayString();
             commitToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.Commit).ToShortcutKeyDisplayString();
             stashChangesToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.Stash).ToShortcutKeyDisplayString();
             stashStagedToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.StashStaged).ToShortcutKeyDisplayString();
             stashPopToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.StashPop).ToShortcutKeyDisplayString();
             closeToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.CloseRepository).ToShortcutKeyDisplayString();
-            gitGUIToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.GitGui).ToShortcutKeyDisplayString();
-            kGitToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.GitGitK).ToShortcutKeyDisplayString();
             checkoutBranchToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.CheckoutBranch).ToShortcutKeyDisplayString();
-            settingsToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.OpenSettings).ToShortcutKeyDisplayString();
             branchToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.CreateBranch).ToShortcutKeyDisplayString();
             tagToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.CreateTag).ToShortcutKeyDisplayString();
             mergeBranchToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.MergeBranches).ToShortcutKeyDisplayString();
@@ -1007,6 +1005,9 @@ namespace GitUI.CommandsDialogs
             pushToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.Push).ToShortcutKeyDisplayString();
             rebaseToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.Rebase).ToShortcutKeyDisplayString();
             rebaseToolStripMenuItem1.ShortcutKeyDisplayString = GetShortcutKeys(Command.Rebase).ToShortcutKeyDisplayString();
+
+            helpToolStripMenuItem.RefreshShortcutKeys(Hotkeys);
+            toolsToolStripMenuItem.RefreshShortcutKeys(Hotkeys);
 
             // Set shortcuts on the Browse toolbar with commands in RevGrid
             RevisionGrid.SetFilterShortcutKeys(ToolStripFilters);
@@ -1309,19 +1310,9 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void GitGuiToolStripMenuItemClick(object sender, EventArgs e)
-        {
-            Module.RunGui();
-        }
-
         private void FormatPatchToolStripMenuItemClick(object sender, EventArgs e)
         {
             UICommands.StartFormatPatchDialog(this);
-        }
-
-        private void GitcommandLogToolStripMenuItemClick(object sender, EventArgs e)
-        {
-            FormGitCommandLog.ShowOrActivate(this);
         }
 
         private void CheckoutBranchToolStripMenuItemClick(object sender, EventArgs e)
@@ -1374,19 +1365,29 @@ namespace GitUI.CommandsDialogs
             UICommands.StartMergeBranchDialog(this, null);
         }
 
+        private void toolsToolStripMenuItem_SettingsChanged(object sender, Menus.SettingsChangedEventArgs e)
+        {
+            HandleSettingsChanged(e.OldTranslation, e.OldCommitInfoPosition);
+        }
+
         private void OnShowSettingsClick(object sender, EventArgs e)
         {
-            var translation = AppSettings.Translation;
-            var commitInfoPosition = AppSettings.CommitInfoPosition;
+            string translation = AppSettings.Translation;
+            CommitInfoPosition commitInfoPosition = AppSettings.CommitInfoPosition;
 
             UICommands.StartSettingsDialog(this);
 
-            if (translation != AppSettings.Translation)
+            HandleSettingsChanged(translation, commitInfoPosition);
+        }
+
+        private void HandleSettingsChanged(string oldTranslation, CommitInfoPosition oldCommitInfoPosition)
+        {
+            if (oldTranslation != AppSettings.Translation)
             {
                 Translator.Translate(this, AppSettings.CurrentTranslation);
             }
 
-            if (commitInfoPosition != AppSettings.CommitInfoPosition)
+            if (oldCommitInfoPosition != AppSettings.CommitInfoPosition)
             {
                 LayoutRevisionInfo();
             }
@@ -1426,11 +1427,6 @@ namespace GitUI.CommandsDialogs
         private void TagToolStripMenuItemClick(object sender, EventArgs e)
         {
             UICommands.StartCreateTagDialog(this, RevisionGrid.LatestSelectedRevision);
-        }
-
-        private void KGitToolStripMenuItemClick(object sender, EventArgs e)
-        {
-            Module.RunGitK();
         }
 
         private static void SaveApplicationSettings()
@@ -1527,16 +1523,6 @@ namespace GitUI.CommandsDialogs
             {
                 UICommands.StartRebaseDialog(this, revisions.First().Guid);
             }
-        }
-
-        private void StartAuthenticationAgentToolStripMenuItemClick(object sender, EventArgs e)
-        {
-            PuttyHelpers.StartPageant(Module.WorkingDir);
-        }
-
-        private void GenerateOrImportKeyToolStripMenuItemClick(object sender, EventArgs e)
-        {
-            PuttyHelpers.StartPuttygen(Module.WorkingDir);
         }
 
         private void CommitInfoTabControl_SelectedIndexChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -251,6 +251,9 @@ namespace GitUI.CommandsDialogs
 
             _isFileBlameHistory = args.IsFileBlameHistory;
             InitializeComponent();
+
+            helpToolStripMenuItem.Initialize(() => UICommands);
+
             BackColor = OtherColors.BackgroundColor;
 
             WorkaroundPaddingIncreaseBug();
@@ -1271,12 +1274,6 @@ namespace GitUI.CommandsDialogs
             _dashboard?.RefreshContent();
         }
 
-        private void AboutToolStripMenuItemClick(object sender, EventArgs e)
-        {
-            using FormAbout frm = new();
-            frm.ShowDialog(this);
-        }
-
         private void PatchToolStripMenuItemClick(object sender, EventArgs e)
         {
             UICommands.StartViewPatchDialog(this);
@@ -1436,12 +1433,6 @@ namespace GitUI.CommandsDialogs
             Module.RunGitK();
         }
 
-        private void DonateToolStripMenuItemClick(object sender, EventArgs e)
-        {
-            using FormDonate frm = new();
-            frm.ShowDialog(this);
-        }
-
         private static void SaveApplicationSettings()
         {
             AppSettings.SaveSettings();
@@ -1561,12 +1552,6 @@ namespace GitUI.CommandsDialogs
             {
                 fileTree.SwitchFocus(alreadyContainedFocus: false);
             }
-        }
-
-        private void ChangelogToolStripMenuItemClick(object sender, EventArgs e)
-        {
-            using FormChangeLog frm = new();
-            frm.ShowDialog(this);
         }
 
         private void ToolStripButtonPushClick(object sender, EventArgs e)
@@ -1694,12 +1679,6 @@ namespace GitUI.CommandsDialogs
         private void CloseToolStripMenuItemClick(object sender, EventArgs e)
         {
             SetWorkingDir("");
-        }
-
-        private void UserManualToolStripMenuItemClick(object sender, EventArgs e)
-        {
-            // Point to the default documentation, will work also if the old doc version is removed
-            OsShellUtil.OpenUrlInDefaultBrowser(AppSettings.DocumentationBaseUrl);
         }
 
         private void CleanupToolStripMenuItemClick(object sender, EventArgs e)
@@ -1869,11 +1848,6 @@ namespace GitUI.CommandsDialogs
             }
 
             RegisterPlugins();
-        }
-
-        private void TranslateToolStripMenuItemClick(object sender, EventArgs e)
-        {
-            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/Translations");
         }
 
         private void FileExplorerToolStripMenuItemClick(object sender, EventArgs e)
@@ -2796,18 +2770,6 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void reportAnIssueToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            UserEnvironmentInformation.CopyInformation();
-            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/issues");
-        }
-
-        private void checkForUpdatesToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            FormUpdates updateForm = new(AppSettings.AppVersion);
-            updateForm.SearchForUpdatesAndShow(Owner, true);
-        }
-
         /// <summary>
         /// Adds a tab with console interface to Git over the current working copy. Recreates the terminal on tab activation if user exits the shell.
         /// </summary>
@@ -3174,16 +3136,6 @@ namespace GitUI.CommandsDialogs
             {
                 e.Effect = DragDropEffects.Move;
             }
-        }
-
-        private void TsmiTelemetryEnabled_Click(object sender, EventArgs e)
-        {
-            UICommands.StartGeneralSettingsDialog(this);
-        }
-
-        private void HelpToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
-        {
-            tsmiTelemetryEnabled.Checked = AppSettings.TelemetryEnabled ?? false;
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.resx
+++ b/GitUI/CommandsDialogs/FormBrowse.resx
@@ -57,12 +57,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="toolStripMenuItem2.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </metadata>
-  <metadata name="toolStripMenuItem4.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </metadata>
   <metadata name="toolStripSeparator14.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
@@ -70,25 +64,25 @@
     <value>False</value>
   </metadata>
   <metadata name="ToolStripMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>251, 17</value>
+    <value>408, 17</value>
   </metadata>
   <metadata name="FilterToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>154, 17</value>
   </metadata>
   <metadata name="mainMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>136, 17</value>
+    <value>273, 17</value>
   </metadata>
   <metadata name="gitItemBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>542, 17</value>
+    <value>726, 17</value>
   </metadata>
   <metadata name="gitRevisionBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>352, 17</value>
+    <value>536, 17</value>
   </metadata>
   <metadata name="ToolStripFilters.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>711, 17</value>
+    <value>895, 17</value>
   </metadata>
-  <metadata name="toolStripScripts.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>844, 17</value>
+  <metadata name="ToolStripScripts.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>82</value>

--- a/GitUI/CommandsDialogs/Menus/HelpToolStripMenuItem.Designer.cs
+++ b/GitUI/CommandsDialogs/Menus/HelpToolStripMenuItem.Designer.cs
@@ -1,0 +1,148 @@
+﻿namespace GitUI.CommandsDialogs.Menus
+{
+    partial class HelpToolStripMenuItem
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            this.userManualToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.changelogToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+            this.translateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator16 = new System.Windows.Forms.ToolStripSeparator();
+            this.donateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiTelemetryEnabled = new System.Windows.Forms.ToolStripMenuItem();
+            this.reportAnIssueToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.checkForUpdatesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            // 
+            // userManualToolStripMenuItem
+            // 
+            this.userManualToolStripMenuItem.Image = global::GitUI.Properties.Images.GotoManual;
+            this.userManualToolStripMenuItem.Name = "userManualToolStripMenuItem";
+            this.userManualToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.userManualToolStripMenuItem.Text = "User &manual";
+            this.userManualToolStripMenuItem.Click += new System.EventHandler(this.UserManualToolStripMenuItemClick);
+            // 
+            // changelogToolStripMenuItem
+            // 
+            this.changelogToolStripMenuItem.Image = global::GitUI.Properties.Images.Changelog;
+            this.changelogToolStripMenuItem.Name = "changelogToolStripMenuItem";
+            this.changelogToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.changelogToolStripMenuItem.Text = "&Changelog";
+            this.changelogToolStripMenuItem.Click += new System.EventHandler(this.ChangelogToolStripMenuItemClick);
+            // 
+            // toolStripSeparator3
+            // 
+            this.toolStripSeparator3.Name = "toolStripSeparator3";
+            this.toolStripSeparator3.Size = new System.Drawing.Size(181, 6);
+            // 
+            // translateToolStripMenuItem
+            // 
+            this.translateToolStripMenuItem.Image = global::GitUI.Properties.Images.Translate;
+            this.translateToolStripMenuItem.Name = "translateToolStripMenuItem";
+            this.translateToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.translateToolStripMenuItem.Text = "&Translate";
+            this.translateToolStripMenuItem.Click += new System.EventHandler(this.TranslateToolStripMenuItemClick);
+            // 
+            // toolStripSeparator16
+            // 
+            this.toolStripSeparator16.Name = "toolStripSeparator16";
+            this.toolStripSeparator16.Size = new System.Drawing.Size(181, 6);
+            // 
+            // donateToolStripMenuItem
+            // 
+            this.donateToolStripMenuItem.Image = global::GitUI.Properties.Images.DollarSign;
+            this.donateToolStripMenuItem.Name = "donateToolStripMenuItem";
+            this.donateToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.donateToolStripMenuItem.Text = "&Donate";
+            this.donateToolStripMenuItem.Click += new System.EventHandler(this.DonateToolStripMenuItemClick);
+            // 
+            // tsmiTelemetryEnabled
+            // 
+            this.tsmiTelemetryEnabled.Checked = true;
+            this.tsmiTelemetryEnabled.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.tsmiTelemetryEnabled.Name = "tsmiTelemetryEnabled";
+            this.tsmiTelemetryEnabled.Size = new System.Drawing.Size(184, 22);
+            this.tsmiTelemetryEnabled.Text = "&Yes, I allow telemetry";
+            this.tsmiTelemetryEnabled.Click += new System.EventHandler(this.TsmiTelemetryEnabled_Click);
+            // 
+            // reportAnIssueToolStripMenuItem
+            // 
+            this.reportAnIssueToolStripMenuItem.Image = global::GitUI.Properties.Images.BugReport;
+            this.reportAnIssueToolStripMenuItem.Name = "reportAnIssueToolStripMenuItem";
+            this.reportAnIssueToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.reportAnIssueToolStripMenuItem.Text = "&Report an issue";
+            this.reportAnIssueToolStripMenuItem.Click += new System.EventHandler(this.reportAnIssueToolStripMenuItem_Click);
+            // 
+            // checkForUpdatesToolStripMenuItem
+            // 
+            this.checkForUpdatesToolStripMenuItem.Image = global::GitUI.Properties.Images.CheckForUpdates;
+            this.checkForUpdatesToolStripMenuItem.Name = "checkForUpdatesToolStripMenuItem";
+            this.checkForUpdatesToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.checkForUpdatesToolStripMenuItem.Text = "Check for &updates";
+            this.checkForUpdatesToolStripMenuItem.Click += new System.EventHandler(this.checkForUpdatesToolStripMenuItem_Click);
+            // 
+            // aboutToolStripMenuItem
+            // 
+            this.aboutToolStripMenuItem.Image = global::GitUI.Properties.Images.Information;
+            this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.aboutToolStripMenuItem.Text = "&About";
+            this.aboutToolStripMenuItem.Click += new System.EventHandler(this.AboutToolStripMenuItemClick);
+            // 
+            // HelpToolStripMenuItem
+            // 
+            this.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.userManualToolStripMenuItem,
+            this.changelogToolStripMenuItem,
+            this.toolStripSeparator3,
+            this.translateToolStripMenuItem,
+            this.toolStripSeparator16,
+            this.donateToolStripMenuItem,
+            this.tsmiTelemetryEnabled,
+            this.reportAnIssueToolStripMenuItem,
+            this.checkForUpdatesToolStripMenuItem,
+            this.aboutToolStripMenuItem});
+            this.Text = "&Help";
+            this.DropDownOpening += new System.EventHandler(this.this_DropDownOpening);
+        }
+
+        #endregion
+
+        private ToolStripMenuItem userManualToolStripMenuItem;
+        private ToolStripMenuItem changelogToolStripMenuItem;
+        private ToolStripSeparator toolStripSeparator3;
+        private ToolStripMenuItem translateToolStripMenuItem;
+        private ToolStripSeparator toolStripSeparator16;
+        private ToolStripMenuItem donateToolStripMenuItem;
+        private ToolStripMenuItem tsmiTelemetryEnabled;
+        private ToolStripMenuItem reportAnIssueToolStripMenuItem;
+        private ToolStripMenuItem checkForUpdatesToolStripMenuItem;
+        private ToolStripMenuItem aboutToolStripMenuItem;
+    }
+}

--- a/GitUI/CommandsDialogs/Menus/HelpToolStripMenuItem.cs
+++ b/GitUI/CommandsDialogs/Menus/HelpToolStripMenuItem.cs
@@ -1,0 +1,67 @@
+﻿using GitCommands;
+using GitExtUtils.GitUI.Theming;
+using GitUI.CommandsDialogs.BrowseDialog;
+
+namespace GitUI.CommandsDialogs.Menus
+{
+    internal partial class HelpToolStripMenuItem : ToolStripMenuItemEx
+    {
+        public HelpToolStripMenuItem()
+        {
+            InitializeComponent();
+
+            translateToolStripMenuItem.AdaptImageLightness();
+        }
+
+        private void this_DropDownOpening(object sender, EventArgs e)
+        {
+            tsmiTelemetryEnabled.Checked = AppSettings.TelemetryEnabled ?? false;
+        }
+
+        private void AboutToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            using FormAbout frm = new();
+            frm.ShowDialog(OwnerForm);
+        }
+
+        private void ChangelogToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            using FormChangeLog frm = new();
+            frm.ShowDialog(OwnerForm);
+        }
+
+        private void checkForUpdatesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            FormUpdates updateForm = new(AppSettings.AppVersion);
+            updateForm.SearchForUpdatesAndShow(Owner, true);
+        }
+
+        private void DonateToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            using FormDonate frm = new();
+            frm.ShowDialog(OwnerForm);
+        }
+
+        private void reportAnIssueToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            UserEnvironmentInformation.CopyInformation();
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/issues");
+        }
+
+        private void TranslateToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/wiki/Translations");
+        }
+
+        private void TsmiTelemetryEnabled_Click(object sender, EventArgs e)
+        {
+            UICommands.StartGeneralSettingsDialog(OwnerForm);
+        }
+
+        private void UserManualToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            // Point to the default documentation, will work also if the old doc version is removed
+            OsShellUtil.OpenUrlInDefaultBrowser(AppSettings.DocumentationBaseUrl);
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/Menus/SettingsChangedEventArgs.cs
+++ b/GitUI/CommandsDialogs/Menus/SettingsChangedEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using GitCommands;
+
+namespace GitUI.CommandsDialogs.Menus
+{
+    public class SettingsChangedEventArgs : EventArgs
+    {
+        public SettingsChangedEventArgs(string oldTranslation, CommitInfoPosition oldCommitInfoPosition)
+        {
+            OldTranslation = oldTranslation;
+            OldCommitInfoPosition = oldCommitInfoPosition;
+        }
+
+        public CommitInfoPosition OldCommitInfoPosition { get; }
+        public string OldTranslation { get; }
+    }
+}

--- a/GitUI/CommandsDialogs/Menus/StartToolStripMenuItem.Designer.cs
+++ b/GitUI/CommandsDialogs/Menus/StartToolStripMenuItem.Designer.cs
@@ -1,0 +1,152 @@
+﻿using System.Windows.Forms;
+
+namespace GitUI.CommandsDialogs.Menus
+{
+    partial class StartToolStripMenuItem
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            System.Windows.Forms.ToolStripMenuItem toolStripMenuItem2;
+            System.Windows.Forms.ToolStripMenuItem toolStripMenuItem4;
+            this.clearRecentRepositoriesListToolStripMenuItem = new System.Windows.Forms.ToolStripSeparator();
+            this.tsmiRecentRepositoriesClear = new System.Windows.Forms.ToolStripMenuItem();
+            this.initNewRepositoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiFavouriteRepositories = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiRecentRepositories = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
+            this.cloneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
+            // 
+            // toolStripMenuItem2
+            // 
+            toolStripMenuItem2.Name = "toolStripMenuItem2";
+            toolStripMenuItem2.Size = new System.Drawing.Size(122, 22);
+            toolStripMenuItem2.Text = "...";
+            // 
+            // toolStripMenuItem4
+            // 
+            toolStripMenuItem4.Name = "toolStripMenuItem4";
+            toolStripMenuItem4.Size = new System.Drawing.Size(83, 22);
+            toolStripMenuItem4.Text = "...";
+            // 
+            // initNewRepositoryToolStripMenuItem
+            // 
+            this.initNewRepositoryToolStripMenuItem.Image = global::GitUI.Properties.Images.RepoCreate;
+            this.initNewRepositoryToolStripMenuItem.Name = "initNewRepositoryToolStripMenuItem";
+            this.initNewRepositoryToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.initNewRepositoryToolStripMenuItem.Text = "&Create new repository...";
+            this.initNewRepositoryToolStripMenuItem.Click += new System.EventHandler(this.InitNewRepositoryToolStripMenuItemClick);
+            // 
+            // openToolStripMenuItem
+            // 
+            this.openToolStripMenuItem.Image = global::GitUI.Properties.Images.RepoOpen;
+            this.openToolStripMenuItem.Name = "openToolStripMenuItem";
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.openToolStripMenuItem.Text = "&Open...";
+            this.openToolStripMenuItem.Click += new System.EventHandler(this.OpenToolStripMenuItemClick);
+            // 
+            // tsmiFavouriteRepositories
+            // 
+            this.tsmiFavouriteRepositories.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            toolStripMenuItem4});
+            this.tsmiFavouriteRepositories.Image = global::GitUI.Properties.Images.Star;
+            this.tsmiFavouriteRepositories.Name = "tsmiFavouriteRepositories";
+            this.tsmiFavouriteRepositories.Size = new System.Drawing.Size(198, 22);
+            this.tsmiFavouriteRepositories.Text = "&Favorite repositories";
+            this.tsmiFavouriteRepositories.DropDownOpening += new System.EventHandler(this.tsmiFavouriteRepositories_DropDownOpening);
+            // 
+            // tsmiRecentRepositories
+            // 
+            this.tsmiRecentRepositories.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            toolStripMenuItem2,
+            this.clearRecentRepositoriesListToolStripMenuItem,
+            this.tsmiRecentRepositoriesClear});
+            this.tsmiRecentRepositories.Image = global::GitUI.Properties.Images.RecentRepositories;
+            this.tsmiRecentRepositories.Name = "tsmiRecentRepositories";
+            this.tsmiRecentRepositories.Size = new System.Drawing.Size(198, 22);
+            this.tsmiRecentRepositories.Text = "&Recent repositories";
+            this.tsmiRecentRepositories.DropDownOpening += new System.EventHandler(this.tsmiRecentRepositories_DropDownOpening);
+            // 
+            // clearRecentRepositoriesListToolStripMenuItem
+            // 
+            this.clearRecentRepositoriesListToolStripMenuItem.Name = "clearRecentRepositoriesListToolStripMenuItem";
+            this.clearRecentRepositoriesListToolStripMenuItem.Size = new System.Drawing.Size(119, 6);
+            // 
+            // tsmiRecentRepositoriesClear
+            // 
+            this.tsmiRecentRepositoriesClear.Name = "tsmiRecentRepositoriesClear";
+            this.tsmiRecentRepositoriesClear.Size = new System.Drawing.Size(122, 22);
+            this.tsmiRecentRepositoriesClear.Text = "Clear list";
+            this.tsmiRecentRepositoriesClear.Click += new System.EventHandler(this.tsmiRecentRepositoriesClear_Click);
+            // 
+            // toolStripSeparator12
+            // 
+            this.toolStripSeparator12.Name = "toolStripSeparator12";
+            this.toolStripSeparator12.Size = new System.Drawing.Size(195, 6);
+            // 
+            // cloneToolStripMenuItem
+            // 
+            this.cloneToolStripMenuItem.Image = global::GitUI.Properties.Images.CloneRepoGit;
+            this.cloneToolStripMenuItem.Name = "cloneToolStripMenuItem";
+            this.cloneToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.cloneToolStripMenuItem.Text = "C&lone repository...";
+            this.cloneToolStripMenuItem.Click += new System.EventHandler(this.CloneToolStripMenuItemClick);
+            // 
+            // toolStripMenuItem1
+            // 
+            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(195, 6);
+            // 
+            // exitToolStripMenuItem
+            // 
+            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
+            this.exitToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Q)));
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.exitToolStripMenuItem.Text = "E&xit";
+            this.exitToolStripMenuItem.Click += new System.EventHandler(this.ExitToolStripMenuItemClick);
+            // 
+            // StartToolStripMenuItem
+            // 
+            this.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.initNewRepositoryToolStripMenuItem,
+            this.openToolStripMenuItem,
+            this.tsmiFavouriteRepositories,
+            this.tsmiRecentRepositories,
+            this.toolStripSeparator12,
+            this.cloneToolStripMenuItem,
+            this.toolStripMenuItem1,
+            this.exitToolStripMenuItem});
+            this.Size = new System.Drawing.Size(43, 20);
+            this.Text = "&Start";
+        }
+
+        #endregion
+
+        private ToolStripMenuItem initNewRepositoryToolStripMenuItem;
+        private ToolStripMenuItem openToolStripMenuItem;
+        private ToolStripMenuItem tsmiFavouriteRepositories;
+        private ToolStripMenuItem tsmiRecentRepositories;
+        private ToolStripSeparator toolStripSeparator12;
+        private ToolStripMenuItem cloneToolStripMenuItem;
+        private ToolStripSeparator toolStripMenuItem1;
+        private ToolStripMenuItem exitToolStripMenuItem;
+        private ToolStripMenuItem tsmiRecentRepositoriesClear;
+        private ToolStripSeparator clearRecentRepositoriesListToolStripMenuItem;
+    }
+}

--- a/GitUI/CommandsDialogs/Menus/StartToolStripMenuItem.cs
+++ b/GitUI/CommandsDialogs/Menus/StartToolStripMenuItem.cs
@@ -1,0 +1,114 @@
+﻿using GitCommands;
+using GitCommands.Git;
+using GitCommands.UserRepositoryHistory;
+using GitUI.CommandsDialogs.BrowseDialog;
+using ResourceManager;
+
+namespace GitUI.CommandsDialogs.Menus
+{
+    internal partial class StartToolStripMenuItem : ToolStripMenuItemEx
+    {
+        private readonly RepositoryHistoryUIService _repositoryHistoryUIService = new();
+
+        public event EventHandler<GitModuleEventArgs> GitModuleChanged;
+        public event EventHandler RecentRepositoriesCleared;
+
+        public StartToolStripMenuItem()
+        {
+            InitializeComponent();
+
+            _repositoryHistoryUIService.GitModuleChanged += repositoryHistoryUIService_GitModuleChanged;
+        }
+
+        internal ToolStripMenuItem OpenRepositoryMenuItem => openToolStripMenuItem;
+        internal ToolStripMenuItem FavouriteRepositoriesMenuItem => tsmiFavouriteRepositories;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+
+                _repositoryHistoryUIService.GitModuleChanged -= repositoryHistoryUIService_GitModuleChanged;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override void RefreshShortcutKeys(IEnumerable<HotkeyCommand>? hotkeys)
+        {
+            openToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKey(hotkeys, (int)FormBrowse.Command.OpenRepo);
+
+            base.RefreshShortcutKeys(hotkeys);
+        }
+
+        private void CloneToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            UICommands.StartCloneDialog(OwnerForm, string.Empty, false, GitModuleChanged);
+        }
+
+        private void ExitToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            OwnerForm?.Close();
+        }
+
+        private void InitNewRepositoryToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            UICommands.StartInitializeDialog(OwnerForm, gitModuleChanged: GitModuleChanged);
+        }
+
+        private void OpenToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            GitModule? module = FormOpenDirectory.OpenModule(OwnerForm, UICommands.Module);
+            if (module is not null)
+            {
+                GitModuleChanged?.Invoke(OwnerForm, new GitModuleEventArgs(module));
+            }
+        }
+
+        private void repositoryHistoryUIService_GitModuleChanged(object? sender, GitModuleEventArgs e)
+        {
+            GitModuleChanged?.Invoke(this, e);
+        }
+
+        private void tsmiFavouriteRepositories_DropDownOpening(object sender, EventArgs e)
+        {
+            tsmiFavouriteRepositories.DropDown.SuspendLayout();
+            tsmiFavouriteRepositories.DropDownItems.Clear();
+            _repositoryHistoryUIService.PopulateFavouriteRepositoriesMenu(tsmiFavouriteRepositories);
+            tsmiFavouriteRepositories.DropDown.ResumeLayout();
+        }
+
+        private void tsmiRecentRepositories_DropDownOpening(object sender, EventArgs e)
+        {
+            tsmiRecentRepositories.DropDown.SuspendLayout();
+            tsmiRecentRepositories.DropDownItems.Clear();
+            _repositoryHistoryUIService.PopulateRecentRepositoriesMenu(tsmiRecentRepositories);
+            if (tsmiRecentRepositories.DropDownItems.Count < 1)
+            {
+                return;
+            }
+
+            tsmiRecentRepositories.DropDownItems.Add(clearRecentRepositoriesListToolStripMenuItem);
+            ////TranslateItem(tsmiRecentRepositoriesClear.Name, tsmiRecentRepositoriesClear);
+            tsmiRecentRepositories.DropDownItems.Add(tsmiRecentRepositoriesClear);
+            tsmiRecentRepositories.DropDown.ResumeLayout();
+        }
+
+        private void tsmiRecentRepositoriesClear_Click(object sender, EventArgs e)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                var repositoryHistory = Array.Empty<Repository>();
+                await RepositoryHistoryManager.Locals.SaveRecentHistoryAsync(repositoryHistory);
+
+                await this.SwitchToMainThreadAsync();
+                RecentRepositoriesCleared?.Invoke(sender, e);
+            });
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/Menus/ToolStripMenuItemEx.cs
+++ b/GitUI/CommandsDialogs/Menus/ToolStripMenuItemEx.cs
@@ -1,0 +1,44 @@
+﻿using GitCommands;
+using GitUI.Hotkey;
+using ResourceManager;
+
+namespace GitUI.CommandsDialogs.Menus
+{
+    internal abstract class ToolStripMenuItemEx : ToolStripMenuItem, ITranslate
+    {
+        private Func<GitUICommands>? _getUICommands;
+
+        /// <summary>
+        ///  Gets the current instance of the UI commands.
+        /// </summary>
+        protected GitUICommands UICommands
+            => (_getUICommands ?? throw new InvalidOperationException("The button is not initialized")).Invoke();
+
+        /// <summary>
+        ///  Gets the form that is displaying the menu item.
+        /// </summary>
+        protected static Form? OwnerForm
+            => Form.ActiveForm ?? (Application.OpenForms.Count > 0 ? Application.OpenForms[0] : null);
+
+        /// <summary>
+        ///  Initializes the menu item.
+        /// </summary>
+        /// <param name="getUICommands">The method that returns the current instance of UI commands.</param>
+        public void Initialize(Func<GitUICommands> getUICommands)
+        {
+            Translator.Translate(this, AppSettings.CurrentTranslation);
+
+            _getUICommands = getUICommands;
+        }
+
+        void ITranslate.AddTranslationItems(ITranslation translation)
+        {
+            TranslationUtils.AddTranslationItemsFromFields("FormBrowse", this, translation);
+        }
+
+        void ITranslate.TranslateItems(ITranslation translation)
+        {
+            TranslationUtils.TranslateItemsFromFields("FormBrowse", this, translation);
+        }
+    }
+}

--- a/GitUI/CommandsDialogs/Menus/ToolStripMenuItemEx.cs
+++ b/GitUI/CommandsDialogs/Menus/ToolStripMenuItemEx.cs
@@ -31,6 +31,33 @@ namespace GitUI.CommandsDialogs.Menus
             _getUICommands = getUICommands;
         }
 
+        /// <summary>
+        ///  Returns the string representation of <paramref name="commandCode"/> if it exists in <paramref name="hotkeys"/> collection.
+        /// </summary>
+        /// <param name="hotkeys">The collection of configured shortcut keys.</param>
+        /// <param name="commandCode">The required shortcut identifier.</param>
+        /// <returns>The string representation of the shortcut, if exists; otherwise, the string representation of <see cref="Keys.None"/>.</returns>
+        protected static string GetShortcutKey(IEnumerable<HotkeyCommand>? hotkeys, int commandCode)
+        {
+            return (hotkeys?.FirstOrDefault(h => h.CommandCode == commandCode)?.KeyData ?? Keys.None).ToShortcutKeyDisplayString();
+        }
+
+        /// <summary>
+        ///  Allows reloading/reassigning the configured shortcut key.
+        /// </summary>
+        //// <param name="hotkeys"></param>
+        public virtual void RefreshShortcutKeys(IEnumerable<HotkeyCommand>? hotkeys)
+        {
+        }
+
+        /// <summary>
+        ///  Allows refreshing the state of the menu item depending on the state of the loaded git repository.
+        /// </summary>
+        /// <param name="bareRepository"><see lang="true"/> if the current git repository is bare; otherwise, <see lang="false"/>.</param>
+        public virtual void RefreshState(bool bareRepository)
+        {
+        }
+
         void ITranslate.AddTranslationItems(ITranslation translation)
         {
             TranslationUtils.AddTranslationItemsFromFields("FormBrowse", this, translation);

--- a/GitUI/CommandsDialogs/Menus/ToolsToolStripMenuItem.Designer.cs
+++ b/GitUI/CommandsDialogs/Menus/ToolsToolStripMenuItem.Designer.cs
@@ -1,0 +1,153 @@
+﻿namespace GitUI.CommandsDialogs.Menus
+{
+    partial class ToolsToolStripMenuItem
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            this.gitBashToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.gitGUIToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.kGitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator41 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
+            this.PuTTYToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.gitcommandLogToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+            this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.startAuthenticationAgentToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.generateOrImportKeyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            // 
+            // gitBashToolStripMenuItem
+            // 
+            this.gitBashToolStripMenuItem.Image = global::GitUI.Properties.Images.GitForWindows;
+            this.gitBashToolStripMenuItem.Name = "gitBashToolStripMenuItem";
+            this.gitBashToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
+            this.gitBashToolStripMenuItem.Text = "Git &bash";
+            this.gitBashToolStripMenuItem.Click += new System.EventHandler(this.gitBashToolStripMenuItem_Click);
+            // 
+            // gitGUIToolStripMenuItem
+            // 
+            this.gitGUIToolStripMenuItem.Image = global::GitUI.Properties.Images.GitGui;
+            this.gitGUIToolStripMenuItem.Name = "gitGUIToolStripMenuItem";
+            this.gitGUIToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
+            this.gitGUIToolStripMenuItem.Text = "Git &GUI";
+            this.gitGUIToolStripMenuItem.Click += new System.EventHandler(this.GitGuiToolStripMenuItemClick);
+            // 
+            // kGitToolStripMenuItem
+            // 
+            this.kGitToolStripMenuItem.Image = global::GitUI.Properties.Images.Gitk;
+            this.kGitToolStripMenuItem.Name = "kGitToolStripMenuItem";
+            this.kGitToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
+            this.kGitToolStripMenuItem.Text = "Git&K";
+            this.kGitToolStripMenuItem.Click += new System.EventHandler(this.KGitToolStripMenuItemClick);
+            // 
+            // toolStripSeparator6
+            // 
+            this.toolStripSeparator6.Name = "toolStripSeparator6";
+            this.toolStripSeparator6.Size = new System.Drawing.Size(214, 6);
+            // 
+            // PuTTYToolStripMenuItem
+            // 
+            this.PuTTYToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.startAuthenticationAgentToolStripMenuItem,
+            this.generateOrImportKeyToolStripMenuItem});
+            this.PuTTYToolStripMenuItem.Image = global::GitUI.Properties.Images.Putty;
+            this.PuTTYToolStripMenuItem.Name = "PuTTYToolStripMenuItem";
+            this.PuTTYToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
+            this.PuTTYToolStripMenuItem.Text = "&PuTTY";
+            // 
+            // startAuthenticationAgentToolStripMenuItem
+            // 
+            this.startAuthenticationAgentToolStripMenuItem.Image = global::GitUI.Properties.Images.Pageant16;
+            this.startAuthenticationAgentToolStripMenuItem.Name = "startAuthenticationAgentToolStripMenuItem";
+            this.startAuthenticationAgentToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
+            this.startAuthenticationAgentToolStripMenuItem.Text = "Start authentication agent";
+            this.startAuthenticationAgentToolStripMenuItem.Click += new System.EventHandler(this.StartAuthenticationAgentToolStripMenuItemClick);
+            // 
+            // generateOrImportKeyToolStripMenuItem
+            // 
+            this.generateOrImportKeyToolStripMenuItem.Image = global::GitUI.Properties.Images.PuttyGen;
+            this.generateOrImportKeyToolStripMenuItem.Name = "generateOrImportKeyToolStripMenuItem";
+            this.generateOrImportKeyToolStripMenuItem.Size = new System.Drawing.Size(211, 22);
+            this.generateOrImportKeyToolStripMenuItem.Text = "Generate or import key";
+            this.generateOrImportKeyToolStripMenuItem.Click += new System.EventHandler(this.GenerateOrImportKeyToolStripMenuItemClick);
+            // 
+            // toolStripSeparator41
+            // 
+            this.toolStripSeparator41.Name = "toolStripSeparator41";
+            this.toolStripSeparator41.Size = new System.Drawing.Size(214, 6);
+            // 
+            // gitcommandLogToolStripMenuItem
+            // 
+            this.gitcommandLogToolStripMenuItem.Image = global::GitUI.Properties.Images.GitCommandLog;
+            this.gitcommandLogToolStripMenuItem.Name = "gitcommandLogToolStripMenuItem";
+            this.gitcommandLogToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F12;
+            this.gitcommandLogToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
+            this.gitcommandLogToolStripMenuItem.Text = "Git &command log";
+            this.gitcommandLogToolStripMenuItem.Click += new System.EventHandler(this.GitcommandLogToolStripMenuItemClick);
+            // 
+            // toolStripSeparator7
+            // 
+            this.toolStripSeparator7.Name = "toolStripSeparator7";
+            this.toolStripSeparator7.Size = new System.Drawing.Size(214, 6);
+            // 
+            // settingsToolStripMenuItem
+            // 
+            this.settingsToolStripMenuItem.Image = global::GitUI.Properties.Images.Settings;
+            this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
+            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
+            this.settingsToolStripMenuItem.Text = "&Settings";
+            this.settingsToolStripMenuItem.Click += new System.EventHandler(this.OnShowSettingsClick);
+
+            this.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.gitBashToolStripMenuItem,
+            this.gitGUIToolStripMenuItem,
+            this.kGitToolStripMenuItem,
+            this.toolStripSeparator6,
+            this.PuTTYToolStripMenuItem,
+            this.toolStripSeparator41,
+            this.gitcommandLogToolStripMenuItem,
+            this.toolStripSeparator7,
+            this.settingsToolStripMenuItem});
+            this.Text = "&Tools";
+        }
+
+        #endregion
+
+        private ToolStripMenuItem gitBashToolStripMenuItem;
+        private ToolStripMenuItem gitGUIToolStripMenuItem;
+        private ToolStripMenuItem kGitToolStripMenuItem;
+        private ToolStripSeparator toolStripSeparator6;
+        private ToolStripMenuItem PuTTYToolStripMenuItem;
+        private ToolStripMenuItem startAuthenticationAgentToolStripMenuItem;
+        private ToolStripMenuItem generateOrImportKeyToolStripMenuItem;
+        private ToolStripMenuItem settingsToolStripMenuItem;
+        private ToolStripSeparator toolStripSeparator41;
+        private ToolStripMenuItem gitcommandLogToolStripMenuItem;
+        private ToolStripSeparator toolStripSeparator7;
+    }
+}

--- a/GitUI/CommandsDialogs/Menus/ToolsToolStripMenuItem.cs
+++ b/GitUI/CommandsDialogs/Menus/ToolsToolStripMenuItem.cs
@@ -1,0 +1,100 @@
+﻿using GitCommands;
+using GitCommands.Utils;
+using GitUI.CommandsDialogs.BrowseDialog;
+using GitUI.Infrastructure;
+using GitUI.Shells;
+using Microsoft;
+using ResourceManager;
+
+namespace GitUI.CommandsDialogs.Menus
+{
+    internal partial class ToolsToolStripMenuItem : ToolStripMenuItemEx
+    {
+        public event EventHandler<SettingsChangedEventArgs> SettingsChanged;
+
+        public ToolsToolStripMenuItem()
+        {
+            InitializeComponent();
+
+            gitBashToolStripMenuItem.Tag = new ShellProvider().GetShell(BashShell.ShellName);
+
+            if (!EnvUtils.RunningOnWindows())
+            {
+                toolStripSeparator6.Visible = false;
+                PuTTYToolStripMenuItem.Visible = false;
+            }
+        }
+
+        public override void RefreshShortcutKeys(IEnumerable<HotkeyCommand>? hotkeys)
+        {
+            gitBashToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKey(hotkeys, (int)FormBrowse.Command.GitBash);
+            gitGUIToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKey(hotkeys, (int)FormBrowse.Command.GitGui);
+            kGitToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKey(hotkeys, (int)FormBrowse.Command.GitGitK);
+            settingsToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKey(hotkeys, (int)FormBrowse.Command.OpenSettings);
+
+            base.RefreshShortcutKeys(hotkeys);
+        }
+
+        public override void RefreshState(bool bareRepository)
+        {
+            gitGUIToolStripMenuItem.Enabled = !bareRepository;
+
+            base.RefreshState(bareRepository);
+        }
+
+        private void GitcommandLogToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            FormGitCommandLog.ShowOrActivate(OwnerForm);
+        }
+
+        private void GitGuiToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            UICommands.Module.RunGui();
+        }
+
+        private void KGitToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            UICommands.Module.RunGitK();
+        }
+
+        private void StartAuthenticationAgentToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            PuttyHelpers.StartPageant(UICommands.Module.WorkingDir);
+        }
+
+        private void GenerateOrImportKeyToolStripMenuItemClick(object sender, EventArgs e)
+        {
+            PuttyHelpers.StartPuttygen(UICommands.Module.WorkingDir);
+        }
+
+        private void OnShowSettingsClick(object sender, EventArgs e)
+        {
+            string translation = AppSettings.Translation;
+            CommitInfoPosition commitInfoPosition = AppSettings.CommitInfoPosition;
+
+            UICommands.StartSettingsDialog(OwnerForm);
+
+            SettingsChanged?.Invoke(sender, new(translation, commitInfoPosition));
+        }
+
+        private void gitBashToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (gitBashToolStripMenuItem.Tag is not IShellDescriptor shell)
+            {
+                return;
+            }
+
+            try
+            {
+                Validates.NotNull(shell.ExecutablePath);
+
+                Executable executable = new(shell.ExecutablePath, UICommands.Module.WorkingDir);
+                executable.Start(createWindow: true, throwOnErrorExit: false); // throwOnErrorExit would redirect the output
+            }
+            catch (Exception exception)
+            {
+                MessageBoxes.FailedToRunShell(OwnerForm, shell.Name, exception);
+            }
+        }
+    }
+}

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -41,6 +41,9 @@
       <LastGenOutput>Images.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Update="Properties\Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
+    <Compile Update="CommandsDialogs\Menus\StartToolStripMenuItem.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Update="UserControls\FilterToolBar.Designer.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/GitUI/RepositoryHistoryUIService.cs
+++ b/GitUI/RepositoryHistoryUIService.cs
@@ -1,0 +1,196 @@
+﻿using GitCommands;
+using GitCommands.Git;
+using GitCommands.UserRepositoryHistory;
+using GitUI.CommandsDialogs;
+using Microsoft.VisualStudio.Threading;
+
+namespace GitUI
+{
+    internal class RepositoryHistoryUIService
+    {
+        private readonly IRepositoryCurrentBranchNameProvider _repositoryCurrentBranchNameProvider;
+        private readonly IInvalidRepositoryRemover _invalidRepositoryRemover;
+
+        public event EventHandler<GitModuleEventArgs> GitModuleChanged;
+
+        internal RepositoryHistoryUIService(IRepositoryCurrentBranchNameProvider repositoryCurrentBranchNameProvider, IInvalidRepositoryRemover invalidRepositoryRemover)
+        {
+            _repositoryCurrentBranchNameProvider = repositoryCurrentBranchNameProvider;
+            _invalidRepositoryRemover = invalidRepositoryRemover;
+        }
+
+        public RepositoryHistoryUIService()
+            : this(new RepositoryCurrentBranchNameProvider(), new InvalidRepositoryRemover())
+        {
+        }
+
+        private static Form? OwnerForm
+            => Form.ActiveForm ?? (Application.OpenForms.Count > 0 ? Application.OpenForms[0] : null);
+
+        private void AddRecentRepositories(ToolStripDropDownItem menuItemContainer, Repository repo, string? caption)
+        {
+            ToolStripMenuItem item = new(caption)
+            {
+                DisplayStyle = ToolStripItemDisplayStyle.ImageAndText
+            };
+
+            menuItemContainer.DropDownItems.Add(item);
+
+            item.Click += (obj, args) =>
+            {
+                OpenRepo(repo.Path);
+            };
+
+            if (repo.Path != caption)
+            {
+                item.ToolTipText = repo.Path;
+            }
+
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await TaskScheduler.Default;
+                string branchName = _repositoryCurrentBranchNameProvider.GetCurrentBranchName(repo.Path);
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                item.ShortcutKeyDisplayString = branchName;
+            }).FileAndForget();
+        }
+
+        private void ChangeWorkingDir(string path)
+        {
+            GitModule module = new(path);
+            if (module.IsValidGitWorkingDir())
+            {
+                GitModuleChanged?.Invoke(this, new GitModuleEventArgs(module));
+                return;
+            }
+
+            _invalidRepositoryRemover.ShowDeleteInvalidRepositoryDialog(path);
+        }
+
+        private void OpenRepo(string repoPath)
+        {
+            if (Control.ModifierKeys != Keys.Control)
+            {
+                ChangeWorkingDir(repoPath);
+                return;
+            }
+
+            GitUICommands.LaunchBrowse(repoPath);
+        }
+
+        public void PopulateFavouriteRepositoriesMenu(ToolStripDropDownItem container)
+        {
+            var repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.LoadFavouriteHistoryAsync());
+            if (repositoryHistory.Count < 1)
+            {
+                return;
+            }
+
+            PopulateFavouriteRepositoriesMenu(container, repositoryHistory);
+        }
+
+        private void PopulateFavouriteRepositoriesMenu(ToolStripDropDownItem container, in IList<Repository> repositoryHistory)
+        {
+            List<RecentRepoInfo> pinnedRepos = new();
+            List<RecentRepoInfo> allRecentRepos = new();
+
+            using (var graphics = OwnerForm.CreateGraphics())
+            {
+                RecentRepoSplitter splitter = new()
+                {
+                    MeasureFont = container.Font,
+                    Graphics = graphics
+                };
+
+                splitter.SplitRecentRepos(repositoryHistory, pinnedRepos, allRecentRepos);
+            }
+
+            foreach (var repo in pinnedRepos.Union(allRecentRepos).GroupBy(k => k.Repo.Category).OrderBy(k => k.Key))
+            {
+                AddFavouriteRepositories(repo.Key, repo.ToList());
+            }
+
+            void AddFavouriteRepositories(string? category, IList<RecentRepoInfo> repos)
+            {
+                ToolStripMenuItem menuItemCategory;
+                if (!container.DropDownItems.ContainsKey(category))
+                {
+                    menuItemCategory = new ToolStripMenuItem(category);
+                    container.DropDownItems.Add(menuItemCategory);
+                }
+                else
+                {
+                    menuItemCategory = (ToolStripMenuItem)container.DropDownItems[category];
+                }
+
+                menuItemCategory.DropDown.SuspendLayout();
+                foreach (var r in repos)
+                {
+                    AddRecentRepositories(menuItemCategory, r.Repo, r.Caption);
+                }
+
+                menuItemCategory.DropDown.ResumeLayout();
+            }
+        }
+
+        public void PopulateRecentRepositoriesMenu(ToolStripDropDownItem container)
+        {
+            List<RecentRepoInfo> pinnedRepos = new();
+            List<RecentRepoInfo> allRecentRepos = new();
+
+            var repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.LoadRecentHistoryAsync());
+            if (repositoryHistory.Count < 1)
+            {
+                return;
+            }
+
+            using (var graphics = OwnerForm.CreateGraphics())
+            {
+                RecentRepoSplitter splitter = new()
+                {
+                    MeasureFont = container.Font,
+                    Graphics = graphics
+                };
+
+                splitter.SplitRecentRepos(repositoryHistory, pinnedRepos, allRecentRepos);
+            }
+
+            foreach (var repo in pinnedRepos)
+            {
+                AddRecentRepositories(container, repo.Repo, repo.Caption);
+            }
+
+            if (allRecentRepos.Count > 0)
+            {
+                if (pinnedRepos.Count > 0 && (AppSettings.SortPinnedRepos || AppSettings.SortAllRecentRepos))
+                {
+                    container.DropDownItems.Add(new ToolStripSeparator());
+                }
+
+                foreach (var repo in allRecentRepos)
+                {
+                    AddRecentRepositories(container, repo.Repo, repo.Caption);
+                }
+            }
+        }
+
+        internal TestAccessor GetTestAccessor()
+            => new(this);
+
+        internal readonly struct TestAccessor
+        {
+            private readonly RepositoryHistoryUIService _service;
+
+            public TestAccessor(RepositoryHistoryUIService service)
+            {
+                _service = service;
+            }
+
+            internal void AddRecentRepositories(ToolStripDropDownItem menuItemContainer, Repository repo, string? caption)
+                => _service.AddRecentRepositories(menuItemContainer, repo, caption);
+
+            internal void PopulateFavouriteRepositoriesMenu(ToolStripDropDownItem container, in IList<Repository> repositoryHistory)
+                => _service.PopulateFavouriteRepositoriesMenu(container, repositoryHistory);
+}
+    }
+}

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -63,29 +63,6 @@ namespace GitExtensions.UITests.CommandsDialogs
             ManagedExtensibility.SetTestExportProvider(mefExportProvider);
         }
 
-        [Test]
-        public void PopulateFavouriteRepositoriesMenu_should_order_favourites_alphabetically()
-        {
-            RunFormTest(
-                form =>
-                {
-                    ToolStripMenuItem tsmiFavouriteRepositories = new();
-                    List<Repository> repositoryHistory = new()
-                    {
-                        new Repository(@"c:\") { Category = "D" },
-                        new Repository(@"c:\") { Category = "A" },
-                        new Repository(@"c:\") { Category = "C" },
-                        new Repository(@"c:\") { Category = "B" }
-                    };
-
-                    form.GetTestAccessor().PopulateFavouriteRepositoriesMenu(tsmiFavouriteRepositories, repositoryHistory);
-
-                    // assert
-                    var categories = tsmiFavouriteRepositories.DropDownItems.Cast<ToolStripMenuItem>().Select(x => x.Text).ToList();
-                    categories.Should().BeInAscendingOrder();
-                });
-        }
-
 #if !DEBUG
         [Ignore("This test is unstable in AppVeyor")]
 #endif

--- a/UnitTests/GitUI.Tests/CommandsDialogs/FormBrowseControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/FormBrowseControllerTests.cs
@@ -1,7 +1,4 @@
-﻿using FluentAssertions;
-using GitCommands.Gpg;
-using GitCommands.UserRepositoryHistory;
-using GitUI;
+﻿using GitCommands.Gpg;
 using GitUI.CommandsDialogs;
 using NSubstitute;
 using NUnit.Framework;
@@ -14,88 +11,13 @@ namespace GitUITests.CommandsDialogs
     {
         private FormBrowseController _controller;
         private IGitGpgController _gitGpgController;
-        private IRepositoryCurrentBranchNameProvider _repositoryCurrentBranchNameProvider;
-        private IInvalidRepositoryRemover _invalidRepositoryRemover;
 
         [SetUp]
         public void Setup()
         {
             _gitGpgController = Substitute.For<IGitGpgController>();
-            _repositoryCurrentBranchNameProvider = Substitute.For<IRepositoryCurrentBranchNameProvider>();
-            _invalidRepositoryRemover = Substitute.For<IInvalidRepositoryRemover>();
 
-            _controller = new FormBrowseController(_gitGpgController, _repositoryCurrentBranchNameProvider, _invalidRepositoryRemover);
-        }
-
-        [Test]
-        public void AddRecentRepositories_should_add_new_item()
-        {
-            ToolStripMenuItem containerMenu = new();
-
-            const string path = "";
-            const string caption = "CAPTION";
-            Repository repository = new(path);
-
-            _controller.AddRecentRepositories(containerMenu, repository, caption, (s, e) => { });
-
-            containerMenu.DropDownItems.Count.Should().Be(1);
-        }
-
-        [Test]
-        public void AddRecentRepositories_should_set_properties_correctly()
-        {
-            ToolStripMenuItem containerMenu = new();
-
-            const string path = "";
-            const string caption = "CAPTION";
-            Repository repository = new(path);
-
-            _controller.AddRecentRepositories(containerMenu, repository, caption, (s, e) => { });
-
-            ToolStripMenuItem item = (ToolStripMenuItem)containerMenu.DropDownItems[0];
-            item.Text.Should().Be(caption);
-            item.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.ImageAndText);
-            item.ToolTipText.Should().BeEmpty();
-        }
-
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase("master")]
-        [TestCase("(no branch)")]
-        public void AddRecentRepositories_should_show_branch_correctly(string branch)
-        {
-            _repositoryCurrentBranchNameProvider.GetCurrentBranchName(Arg.Any<string>()).Returns(x => branch);
-
-            ToolStripMenuItem containerMenu = new();
-
-            const string path = "somepath";
-            const string caption = "CAPTION";
-            Repository repository = new(path);
-
-            _controller.AddRecentRepositories(containerMenu, repository, caption, (s, e) => { });
-
-            // await adding branch name in ShortcutKeyDisplayString, done async
-            ThreadHelper.JoinableTaskContext.Factory.Run(() => ThreadHelper.JoinPendingOperationsAsync(default));
-
-            ToolStripMenuItem item = (ToolStripMenuItem)containerMenu.DropDownItems[0];
-            item.ShortcutKeyDisplayString.Should().Be(branch);
-        }
-
-        [Test]
-        public void ChangeWorkingDir_should_promt_user_to_delete_invalid_repo()
-        {
-            ToolStripMenuItem containerMenu = new();
-
-            const string path = "";
-            const string caption = "CAPTION";
-            Repository repository = new(path);
-
-            _controller.AddRecentRepositories(containerMenu, repository, caption, (s, e) => { });
-
-            ToolStripMenuItem item = (ToolStripMenuItem)containerMenu.DropDownItems[0];
-            item.PerformClick();
-
-            _invalidRepositoryRemover.Received(1).ShowDeleteInvalidRepositoryDialog(path);
+            _controller = new FormBrowseController(_gitGpgController);
         }
     }
 }

--- a/UnitTests/GitUI.Tests/RepositoryHistoryUIServiceTests.cs
+++ b/UnitTests/GitUI.Tests/RepositoryHistoryUIServiceTests.cs
@@ -1,0 +1,121 @@
+﻿using System.Windows.Forms;
+using FluentAssertions;
+using GitCommands.UserRepositoryHistory;
+using GitUI;
+using GitUI.CommandsDialogs;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace GitUITests
+{
+    [Apartment(ApartmentState.STA)]
+    [TestFixture]
+    public sealed class RepositoryHistoryUIServiceTests
+    {
+        private RepositoryHistoryUIService _service;
+        private IRepositoryCurrentBranchNameProvider _repositoryCurrentBranchNameProvider;
+        private IInvalidRepositoryRemover _invalidRepositoryRemover;
+
+        [SetUp]
+        public void Setup()
+        {
+            _repositoryCurrentBranchNameProvider = Substitute.For<IRepositoryCurrentBranchNameProvider>();
+            _invalidRepositoryRemover = Substitute.For<IInvalidRepositoryRemover>();
+
+            _service = new RepositoryHistoryUIService(_repositoryCurrentBranchNameProvider, _invalidRepositoryRemover);
+        }
+
+        [Test]
+        public void PopulateRecentRepositoriesMenu_should_add_new_item()
+        {
+            ToolStripMenuItem containerMenu = new();
+
+            const string path = "";
+            const string caption = "CAPTION";
+            Repository repository = new(path);
+
+            _service.GetTestAccessor().AddRecentRepositories(containerMenu, repository, caption);
+
+            containerMenu.DropDownItems.Count.Should().Be(1);
+        }
+
+        [Test]
+        public void AddRecentRepositories_should_set_properties_correctly()
+        {
+            ToolStripMenuItem containerMenu = new();
+
+            const string path = "";
+            const string caption = "CAPTION";
+            Repository repository = new(path);
+
+            _service.GetTestAccessor().AddRecentRepositories(containerMenu, repository, caption);
+
+            ToolStripMenuItem item = (ToolStripMenuItem)containerMenu.DropDownItems[0];
+            item.Text.Should().Be(caption);
+            item.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.ImageAndText);
+            item.ToolTipText.Should().BeEmpty();
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("master")]
+        [TestCase("(no branch)")]
+        public void AddRecentRepositories_should_show_branch_correctly(string branch)
+        {
+            _repositoryCurrentBranchNameProvider.GetCurrentBranchName(Arg.Any<string>()).Returns(x => branch);
+
+            ToolStripMenuItem containerMenu = new();
+
+            const string path = "somepath";
+            const string caption = "CAPTION";
+            Repository repository = new(path);
+
+            _service.GetTestAccessor().AddRecentRepositories(containerMenu, repository, caption);
+
+            // await adding branch name in ShortcutKeyDisplayString, done async
+            ThreadHelper.JoinableTaskContext.Factory.Run(() => ThreadHelper.JoinPendingOperationsAsync(default));
+
+            ToolStripMenuItem item = (ToolStripMenuItem)containerMenu.DropDownItems[0];
+            item.ShortcutKeyDisplayString.Should().Be(branch);
+        }
+
+        [Test]
+        public void ChangeWorkingDir_should_promt_user_to_delete_invalid_repo()
+        {
+            ToolStripMenuItem containerMenu = new();
+
+            const string path = "";
+            const string caption = "CAPTION";
+            Repository repository = new(path);
+
+            _service.GetTestAccessor().AddRecentRepositories(containerMenu, repository, caption);
+
+            ToolStripMenuItem item = (ToolStripMenuItem)containerMenu.DropDownItems[0];
+            item.PerformClick();
+
+            _invalidRepositoryRemover.Received(1).ShowDeleteInvalidRepositoryDialog(path);
+        }
+
+        [Test]
+        public void PopulateFavouriteRepositoriesMenu_should_order_favourites_alphabetically()
+        {
+            ToolStripMenuItem tsmiFavouriteRepositories = new();
+            List<Repository> repositoryHistory = new()
+            {
+                new Repository(@"c:\") { Category = "D" },
+                new Repository(@"c:\") { Category = "A" },
+                new Repository(@"c:\") { Category = "C" },
+                new Repository(@"c:\") { Category = "B" }
+            };
+
+            using Form form = new();
+            form.Show();
+
+            _service.GetTestAccessor().PopulateFavouriteRepositoriesMenu(tsmiFavouriteRepositories, repositoryHistory);
+
+            // assert
+            List<string> categories = tsmiFavouriteRepositories.DropDownItems.Cast<ToolStripMenuItem>().Select(x => x.Text).ToList();
+            categories.Should().BeInAscendingOrder();
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Proposed changes

Encapsulate "Start", "Tools" and "Help" menus, thus reducing the complexity of the `FormBrowse` dialog. 

Why? I'm currently working on a POC that introduces a shell form that hosts different UI - such as the dashboard, the repo browser or the repo history views, as well as introduces dependency injection and UI composition. That work is extremely complex, and having encapsulated "start menu" item helps to avoiding code duplication and significantly reduces associated complexity.


## Test methodology <!-- How did you ensure quality? -->

- existing tests
- manual tests to verify translations are correctly applied


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
