### PR TITLE
Avoid "git : warning: in the working copy of '<file>', LF will be replaced by CRLF the next time Git touches it"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,10 +67,6 @@ build_script:
         $buildArgs += " /p:GitCommit=$gitCommit /p:GitSha=$($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)"
     }
 - ps: |
-    # add to index, to adjust crlf configured in .gitattributes
-    git -c core.autocrlf=false add -A
-    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
-- ps: |
     # build VC++
     dotnet build .\scripts\native.proj -c Release --verbosity q --nologo /bl:.\artifacts\log\native.binlog
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,6 +76,9 @@ build_script:
     Invoke-Expression $cmd
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 - ps: |
+    # We are done with the build, reset all pending changes
+    git reset --hard HEAD
+- ps: |
     # Verify that new strings (if any) have been processed and ready for localisation
     Push-Location .\GitExtensions
     dotnet msbuild /p:Configuration=Release /t:_UpdateEnglishTranslations /p:RunTranslationApp=true /p:ContinuousIntegrationBuild=true /v:m /bl:..\artifacts\log\localise.binlog
@@ -86,7 +89,7 @@ build_script:
 # to run your custom scripts instead of automatic tests
 test_script:
 - ps: |
-    dotnet test -c Release --no-restore --nologo --verbosity q --test-adapter-path:. --logger:Appveyor --logger:trx /bl:.\artifacts\log\tests.binlog
+    dotnet test -c Release --no-restore --no-build --nologo --verbosity q --test-adapter-path:. --logger:Appveyor --logger:trx /bl:.\artifacts\log\tests.binlog
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 
 

--- a/scripts/set_version_to.py
+++ b/scripts/set_version_to.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
                     data[1] = args.text
                     line = '"'.join(data)
             o += line
-        outfile = open(filename, "w")
+        outfile = open(filename, "w", newline='\n')
         outfile.writelines(o)
     
     filename = "..\GitExtensionsShellEx\GitExtensionsShellEx.rc"
@@ -79,7 +79,7 @@ if __name__ == '__main__':
             data[1] = '"' + args.text + '"\n'
             line = ', '.join(data)
         o += line
-    outfile = open(filename, "w")
+    outfile = open(filename, "w", newline='\n')
     outfile.writelines(o)
     
     filename = "..\GitExtSshAskPass\SshAskPass.rc2"
@@ -104,7 +104,7 @@ if __name__ == '__main__':
             data[1] = '"' + args.text + '"\n'
             line = ', '.join(data)
         o += line
-    outfile = open(filename, "w")
+    outfile = open(filename, "w", newline='\n')
     outfile.writelines(o)
 
     for i in range(1, len(verSplitted)):


### PR DESCRIPTION
This is a partial reversal of https://github.com/gitextensions/gitextensions/pull/10618. The build warnings are back, but at least we're not failing the build because of those:
![image](https://user-images.githubusercontent.com/4403806/212570831-dc4fbca1-3a23-4eca-9d27-e33345ccddb1.png)
