### PR TITLE
DeleteUnusedBranches plugin: Fix branch deletion

### DIFF
--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -201,7 +201,6 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
                         "-d",
                         localBranch.Name
                     };
-                    _gitCommands.GitExecutable.GetOutput(args);
 
                     // Delete branches one by one, because it is possible one fails
                     _gitCommands.GitExecutable.GetOutput(args);


### PR DESCRIPTION
Remove a duplicated git delete command run that will always return an exit code different than 0 (because the 1st command already deleted the branch)

because the plugin doesn't handle well exception thrown when exit code is not zero (new development done in v4.0 where exception is thrown by default)

Fixes #10662

## Screenshots <!-- Remove this section if PR does not change UI -->

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build ca3100f5cedcac39a038eeb62cebbdce05e32841 (Dirty)
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.13
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
