### PR TITLE
Fix git command for unmerged obsolete branches

### DIFF
--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -126,8 +126,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
             {
                  "--list",
                  { context.IncludeRemotes, "-r" },
-                 { !context.IncludeUnmerged, "--merged" },
-                 context.ReferenceBranch
+                 { !context.IncludeUnmerged, "--merged " + context.ReferenceBranch }
             };
 
             var result = context.Commands.GitExecutable.Execute(args, throwOnErrorExit: false);

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -126,7 +126,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
             {
                  "--list",
                  { context.IncludeRemotes, "-r" },
-                 { !context.IncludeUnmerged, "--merged " + context.ReferenceBranch }
+                 { !context.IncludeUnmerged, $"--merged {context.ReferenceBranch}" }
             };
 
             var result = context.Commands.GitExecutable.Execute(args, throwOnErrorExit: false);


### PR DESCRIPTION
Fixes #9293

In the "delete obsolete branches" plugin, when including unmerged branches, the list of branches was always empty.

## Proposed changes

Git command for listing of branches must not contain reference branch when including unmerged.
The command executed when including unmerged was `git branch --list HEAD` and had no results.
With this change it is now `git branch --list` for including unmerged branches and `git branch --list --merged HEAD` for only including branches merged into `HEAD`

## Test environment(s) <!-- Remove any that don't apply -->

- GIT git version 2.39.0.windows.1
- Windows 10 Pro 22H2

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
