### PR TITLE
Improve delete obsolete branches plugin

### DIFF
--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.Designer.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.Designer.cs
@@ -135,7 +135,7 @@
             // 
             // _NO_TRANSLATE_deleteDataGridViewCheckBoxColumn
             // 
-            this._NO_TRANSLATE_deleteDataGridViewCheckBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this._NO_TRANSLATE_deleteDataGridViewCheckBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this._NO_TRANSLATE_deleteDataGridViewCheckBoxColumn.FillWeight = 20F;
             this._NO_TRANSLATE_deleteDataGridViewCheckBoxColumn.Name = "_NO_TRANSLATE_deleteDataGridViewCheckBoxColumn";
             this._NO_TRANSLATE_deleteDataGridViewCheckBoxColumn.HeaderCell = checkBoxHeaderCell;
@@ -153,7 +153,7 @@
             // 
             // dateDataGridViewTextBoxColumn
             // 
-            this.dateDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.dateDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.dateDataGridViewTextBoxColumn.FillWeight = 300F;
             this.dateDataGridViewTextBoxColumn.HeaderText = "Last activity";
             this.dateDataGridViewTextBoxColumn.Name = "dateDataGridViewTextBoxColumn";
@@ -420,7 +420,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.Cancel;
-            this.ClientSize = new System.Drawing.Size(760, 421);
+            this.ClientSize = new System.Drawing.Size(760, 500);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(statusStrip1);
             this.MinimumSize = new System.Drawing.Size(600, 400);

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -63,8 +63,6 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
             {
                 return;
             }
-
-            ThreadHelper.JoinableTaskFactory.RunAsync(() => RefreshObsoleteBranchesAsync());
         }
 
         protected override void OnLoad(EventArgs e)
@@ -83,6 +81,8 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
 
             checkBoxHeaderCell.CheckBoxClicked += CheckBoxHeader_OnCheckBoxClicked;
             _NO_TRANSLATE_deleteDataGridViewCheckBoxColumn.HeaderText = string.Empty;
+
+            ThreadHelper.JoinableTaskFactory.RunAsync(() => RefreshObsoleteBranchesAsync());
 
             BranchesGrid.DataSource = _branches;
         }

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -34,6 +34,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
         private readonly IGitPlugin _gitPlugin;
         private readonly GitBranchOutputCommandParser _commandOutputParser;
         private CancellationTokenSource? _refreshCancellation;
+        public bool HasDeletedBranch { get; internal set; }
 
         public DeleteUnusedBranchesForm(DeleteUnusedBranchesFormSettings settings, IGitModule gitCommands, IGitUICommands? gitUiCommands, IGitPlugin gitPlugin)
         {
@@ -174,6 +175,8 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
                     return;
                 }
             }
+
+            HasDeletedBranch = true;
 
             var localBranches = selectedBranches.Except(remoteBranches).ToList();
             SetWorkingState(isWorking: true);

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesPlugin.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesPlugin.cs
@@ -55,7 +55,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
             using DeleteUnusedBranchesForm frm = new(settings, args.GitModule, args.GitUICommands, this);
             frm.ShowDialog(args.OwnerForm);
 
-            return true;
+            return frm.HasDeletedBranch;
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Display an error message when one of the git command failed
- Fix bad branches found when opening the plugin form (search context still not loaded when initial search triggered)
- Refresh revision grid only when some branches has been deleted
- Slight UI improvements (increase a little more form height to display more than 2 branches lines,  better size columns)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Apparent stucked plugin (like in https://github.com/gitextensions/gitextensions/issues/10662#issuecomment-1398160549 ): 
![5ea5ed2e-18c2-473f-9f72-12786f3254d4](https://user-images.githubusercontent.com/12046115/213668114-8bc75dec-60bd-4a1d-bdd1-6bbba63c6190.gif)

### After

The error is displayed to the user:
![image](https://user-images.githubusercontent.com/460196/214048930-332f4b1f-17c0-42af-827c-1f8dbca0b8d2.png)

and after the display is refreshed (with branch list refreshed) to give show to the user that the plugin is not stucked:

![image](https://user-images.githubusercontent.com/460196/214049639-bd022b18-311b-4652-8b3a-4aa64c61529a.png)

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build a0d4a8892a9fd5dac6113f170058101369fa950f (Dirty)
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.13
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

Merge commit (as that is multiple not linked small improvements/fixes on the delete obsolete branch plugin)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
