### PR TITLE
Left panel contextual menu: improve menu items labels and tooltips

### DIFF
--- a/GitUI/BranchTreePanel/ContextMenu/MenuItemsStrings.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/MenuItemsStrings.cs
@@ -1,5 +1,6 @@
 ﻿using GitCommands;
 using GitUI.BranchTreePanel.Interfaces;
+using ICSharpCode.TextEditor.Actions;
 using ResourceManager;
 
 namespace GitUI.BranchTreePanel.ContextMenu
@@ -9,17 +10,17 @@ namespace GitUI.BranchTreePanel.ContextMenu
         // the name of the members act as keys for the generated entries in the translation files (xlf)
 
         /// <see cref="IGitRefActions"/>
-        internal readonly TranslationString Checkout = new("Chec&kout branch...");
-        internal readonly TranslationString Merge = new("&Merge branches...");
-        internal readonly TranslationString Rebase = new("&Rebase...");
+        internal TranslationString Checkout;
+        internal TranslationString Rebase;
+        internal readonly TranslationString Merge = new("&Merge into current branch...");
         internal readonly TranslationString CreateBranch = new("Create &branch...");
         internal readonly TranslationString Reset = new("Re&set current branch to here...");
 
         /// <see cref="ICanRename"/>
-        internal readonly TranslationString Rename = new("R&ename branch...");
+        internal TranslationString Rename = new("R&ename branch...");
 
         /// <see cref="ICanDelete"/>
-        internal readonly TranslationString Delete = new("&Delete branch...");
+        internal TranslationString Delete;
 
         internal Dictionary<MenuItemKey, TranslationString> Tooltips { get; } = new Dictionary<MenuItemKey, TranslationString>();
 
@@ -31,10 +32,14 @@ namespace GitUI.BranchTreePanel.ContextMenu
 
     public class BranchMenuItemsStrings : Translate
     {
+        internal readonly TranslationString Checkout = new("Chec&kout branch...");
+        internal readonly TranslationString Rebase = new("&Rebase current branch on this branch...");
+        internal readonly TranslationString Delete = new("&Delete branch...");
+
         internal readonly TranslationString CheckoutTooltip = new("Checkout this branch");
         internal readonly TranslationString MergeTooltip = new("Merge this branch into current branch");
         internal readonly TranslationString CreateTooltip = new("Create a local branch from this branch");
-        internal readonly TranslationString RebaseTooltip = new("Rebase current branch to this branch");
+        internal readonly TranslationString RebaseTooltip = new("Rebase current branch on this branch");
         internal readonly TranslationString ResetTooltip = new("Reset current branch to here");
         internal readonly TranslationString RenameTooltip = new("Rename this branch");
 
@@ -45,6 +50,10 @@ namespace GitUI.BranchTreePanel.ContextMenu
 
         public void ApplyTo(MenuItemsStrings strings)
         {
+            strings.Checkout = Checkout;
+            strings.Rebase = Rebase;
+            strings.Delete = Delete;
+
             strings.Tooltips[MenuItemKey.GitRefCheckout] = CheckoutTooltip;
             strings.Tooltips[MenuItemKey.GitRefCreateBranch] = CreateTooltip;
             strings.Tooltips[MenuItemKey.GitRefMerge] = MergeTooltip;

--- a/GitUI/BranchTreePanel/ContextMenu/RemoteBranchMenuItems.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/RemoteBranchMenuItems.cs
@@ -15,6 +15,9 @@ namespace GitUI.BranchTreePanel.ContextMenu
 
     public class RemoteBranchMenuItemsStrings : Translate
     {
+        internal readonly TranslationString Checkout = new("Chec&kout remote branch...");
+        internal readonly TranslationString Rebase = new("&Rebase current branch on this remote branch...");
+        internal readonly TranslationString Delete = new("&Delete remote branch...");
         internal readonly TranslationString DeleteTooltip = new("Delete the branch from the remote");
 
         public RemoteBranchMenuItemsStrings()
@@ -25,6 +28,9 @@ namespace GitUI.BranchTreePanel.ContextMenu
         public void ApplyTo(MenuItemsStrings strings)
         {
             new BranchMenuItemsStrings().ApplyTo(strings);
+            strings.Checkout = Checkout;
+            strings.Rebase = Rebase;
+            strings.Delete = Delete;
             strings.Tooltips[MenuItemKey.Delete] = DeleteTooltip;
         }
     }

--- a/GitUI/BranchTreePanel/ContextMenu/TagMenuItems.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/TagMenuItems.cs
@@ -15,10 +15,14 @@ namespace GitUI.BranchTreePanel.ContextMenu
 
     public class TagMenuItemsStrings : Translate
     {
-        internal readonly TranslationString CheckoutTooltip = new("Checkout this tag");
+        internal readonly TranslationString Checkout = new("Chec&kout tag revision...");
+        internal readonly TranslationString Rebase = new("&Rebase current branch on this tag revision...");
+        internal readonly TranslationString Delete = new("&Delete tag...");
+
+        internal readonly TranslationString CheckoutTooltip = new("Checkout this tag revision");
         internal readonly TranslationString CreateTooltip = new("Create a local branch from this tag");
         internal readonly TranslationString MergeTooltip = new("Merge this tag into current branch");
-        internal readonly TranslationString RebaseTooltip = new("Rebase current branch to this tag");
+        internal readonly TranslationString RebaseTooltip = new("Rebase current branch on this tag");
         internal readonly TranslationString ResetTooltip = new("Reset current branch to here");
         internal readonly TranslationString DeleteTooltip = new("Delete this tag");
 
@@ -29,6 +33,9 @@ namespace GitUI.BranchTreePanel.ContextMenu
 
         public void ApplyTo(MenuItemsStrings strings)
         {
+            strings.Checkout = Checkout;
+            strings.Rebase = Rebase;
+            strings.Delete = Delete;
             strings.Tooltips[MenuItemKey.GitRefCheckout] = CheckoutTooltip;
             strings.Tooltips[MenuItemKey.GitRefCreateBranch] = CreateTooltip;
             strings.Tooltips[MenuItemKey.GitRefMerge] = MergeTooltip;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.Designer.cs
@@ -373,7 +373,7 @@ namespace GitUI.BranchTreePanel
             this.mnubtnRemoteBranchFetchAndCheckout.Name = "mnubtnRemoteBranchFetchAndCheckout";
             this.mnubtnRemoteBranchFetchAndCheckout.Size = new System.Drawing.Size(266, 26);
             this.mnubtnRemoteBranchFetchAndCheckout.Text = "&Fetch && Checkout";
-            this.mnubtnRemoteBranchFetchAndCheckout.ToolTipText = "Checkout this branch";
+            this.mnubtnRemoteBranchFetchAndCheckout.ToolTipText = "Fetch then checkout this remote branch";
             // 
             // mnubtnPullFromRemoteBranch
             // 
@@ -381,6 +381,7 @@ namespace GitUI.BranchTreePanel
             this.mnubtnPullFromRemoteBranch.Name = "mnubtnPullFromRemoteBranch";
             this.mnubtnPullFromRemoteBranch.Size = new System.Drawing.Size(266, 26);
             this.mnubtnPullFromRemoteBranch.Text = "Fetch && Merge (&Pull)";
+            this.mnubtnPullFromRemoteBranch.ToolTipText = "Fetch then merge this remote branch into current branch";
             // 
             // mnubtnFetchRebase
             // 
@@ -388,7 +389,7 @@ namespace GitUI.BranchTreePanel
             this.mnubtnFetchRebase.Name = "mnubtnFetchRebase";
             this.mnubtnFetchRebase.Size = new System.Drawing.Size(266, 26);
             this.mnubtnFetchRebase.Text = "Fetch && Re&base";
-            this.mnubtnFetchRebase.ToolTipText = "Fetch & Rebase current branch to this branch";
+            this.mnubtnFetchRebase.ToolTipText = "Fetch then rebase current branch on this remote branch";
             // 
             // mnubtnFetchCreateBranch
             // 
@@ -404,7 +405,7 @@ namespace GitUI.BranchTreePanel
             this.mnubtnFetchOneBranch.Name = "mnubtnFetchOneBranch";
             this.mnubtnFetchOneBranch.Size = new System.Drawing.Size(266, 26);
             this.mnubtnFetchOneBranch.Text = "Fe&tch";
-            this.mnubtnFetchOneBranch.ToolTipText = "Fetch the new remote branch";
+            this.mnubtnFetchOneBranch.ToolTipText = "Fetch this remote branch";
             // 
             // toolStripSeparator6
             // 
@@ -425,7 +426,7 @@ namespace GitUI.BranchTreePanel
             this.mnubtnDeleteAllBranches.Name = "mnubtnDeleteAllBranches";
             this.mnubtnDeleteAllBranches.Size = new System.Drawing.Size(266, 26);
             this.mnubtnDeleteAllBranches.Text = "Delete All";
-            this.mnubtnDeleteAllBranches.ToolTipText = "Delete all child branchs, which must all be fully merged in its upstream branch o" +
+            this.mnubtnDeleteAllBranches.ToolTipText = "Delete all child branches, which must all be fully merged in its upstream branch o" +
     "r in HEAD";
             // 
             // toolStripSeparator10

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -384,6 +384,10 @@ Click this info icon for more details.</source>
   </file>
   <file datatype="plaintext" original="BranchMenuItemsStrings" source-language="en">
     <body>
+      <trans-unit id="Checkout.Text">
+        <source>Chec&amp;kout branch...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="CheckoutTooltip.Text">
         <source>Checkout this branch</source>
         <target />
@@ -392,12 +396,20 @@ Click this info icon for more details.</source>
         <source>Create a local branch from this branch</source>
         <target />
       </trans-unit>
+      <trans-unit id="Delete.Text">
+        <source>&amp;Delete branch...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="MergeTooltip.Text">
         <source>Merge this branch into current branch</source>
         <target />
       </trans-unit>
+      <trans-unit id="Rebase.Text">
+        <source>&amp;Rebase current branch on this branch...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="RebaseTooltip.Text">
-        <source>Rebase current branch to this branch</source>
+        <source>Rebase current branch on this branch</source>
         <target />
       </trans-unit>
       <trans-unit id="RenameTooltip.Text">
@@ -7982,24 +7994,12 @@ help</source>
   </file>
   <file datatype="plaintext" original="MenuItemsStrings" source-language="en">
     <body>
-      <trans-unit id="Checkout.Text">
-        <source>Chec&amp;kout branch...</source>
-        <target />
-      </trans-unit>
       <trans-unit id="CreateBranch.Text">
         <source>Create &amp;branch...</source>
         <target />
       </trans-unit>
-      <trans-unit id="Delete.Text">
-        <source>&amp;Delete branch...</source>
-        <target />
-      </trans-unit>
       <trans-unit id="Merge.Text">
-        <source>&amp;Merge branches...</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="Rebase.Text">
-        <source>&amp;Rebase...</source>
+        <source>&amp;Merge into current branch...</source>
         <target />
       </trans-unit>
       <trans-unit id="Rename.Text">
@@ -8178,8 +8178,20 @@ This will just checkout on the submodule the commit determined by the superproje
   </file>
   <file datatype="plaintext" original="RemoteBranchMenuItemsStrings" source-language="en">
     <body>
+      <trans-unit id="Checkout.Text">
+        <source>Chec&amp;kout remote branch...</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="Delete.Text">
+        <source>&amp;Delete remote branch...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="DeleteTooltip.Text">
         <source>Delete the branch from the remote</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="Rebase.Text">
+        <source>&amp;Rebase current branch on this remote branch...</source>
         <target />
       </trans-unit>
     </body>
@@ -8277,7 +8289,7 @@ Reset the filter via View &gt; Show all branches.</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnDeleteAllBranches.ToolTipText">
-        <source>Delete all child branchs, which must all be fully merged in its upstream branch or in HEAD</source>
+        <source>Delete all child branches, which must all be fully merged in its upstream branch or in HEAD</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnDisableRemote.Text">
@@ -8325,7 +8337,7 @@ Reset the filter via View &gt; Show all branches.</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnFetchOneBranch.ToolTipText">
-        <source>Fetch the new remote branch</source>
+        <source>Fetch this remote branch</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnFetchRebase.Text">
@@ -8333,7 +8345,7 @@ Reset the filter via View &gt; Show all branches.</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnFetchRebase.ToolTipText">
-        <source>Fetch &amp; Rebase current branch to this branch</source>
+        <source>Fetch then rebase current branch on this remote branch</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnManageRemotes.Text">
@@ -8408,12 +8420,16 @@ Reset the filter via View &gt; Show all branches.</source>
         <source>Fetch &amp;&amp; Merge (&amp;Pull)</source>
         <target />
       </trans-unit>
+      <trans-unit id="mnubtnPullFromRemoteBranch.ToolTipText">
+        <source>Fetch then merge this remote branch into current branch</source>
+        <target />
+      </trans-unit>
       <trans-unit id="mnubtnRemoteBranchFetchAndCheckout.Text">
         <source>&amp;Fetch &amp;&amp; Checkout</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnRemoteBranchFetchAndCheckout.ToolTipText">
-        <source>Checkout this branch</source>
+        <source>Fetch then checkout this remote branch</source>
         <target />
       </trans-unit>
       <trans-unit id="mnubtnResetSubmodule.Text">
@@ -9571,12 +9587,20 @@ When OpenSSH is used, command line dialogs are shown!
   </file>
   <file datatype="plaintext" original="TagMenuItemsStrings" source-language="en">
     <body>
+      <trans-unit id="Checkout.Text">
+        <source>Chec&amp;kout tag revision...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="CheckoutTooltip.Text">
-        <source>Checkout this tag</source>
+        <source>Checkout this tag revision</source>
         <target />
       </trans-unit>
       <trans-unit id="CreateTooltip.Text">
         <source>Create a local branch from this tag</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="Delete.Text">
+        <source>&amp;Delete tag...</source>
         <target />
       </trans-unit>
       <trans-unit id="DeleteTooltip.Text">
@@ -9587,8 +9611,12 @@ When OpenSSH is used, command line dialogs are shown!
         <source>Merge this tag into current branch</source>
         <target />
       </trans-unit>
+      <trans-unit id="Rebase.Text">
+        <source>&amp;Rebase current branch on this tag revision...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="RebaseTooltip.Text">
-        <source>Rebase current branch to this tag</source>
+        <source>Rebase current branch on this tag</source>
         <target />
       </trans-unit>
       <trans-unit id="ResetTooltip.Text">


### PR DESCRIPTION
* Different menu entries depending on the type handled (local, remote and tag)
* Other tooltip fixes around "Fetch & ..." menu items

Fixes #10670


## Screenshots <!-- Remove this section if PR does not change UI -->

### For Tag:
* Before

![image](https://user-images.githubusercontent.com/460196/214140425-cf0b7f55-76ba-4a4c-8f7e-231c1a895c1f.png)

* After

![image](https://user-images.githubusercontent.com/460196/216272727-9eb1fba5-b3d9-4f97-8267-705bc21fe245.png)

### For branch
* Before
![image](https://user-images.githubusercontent.com/460196/214140828-f87e464b-da86-45ff-be6d-b382556bbdf2.png)

* After

![image](https://user-images.githubusercontent.com/460196/216272498-08c534f9-df6b-4afd-9bba-df1b0eb583be.png)


### For Remote

* After: 

![image](https://user-images.githubusercontent.com/460196/216336582-b868a611-f394-43fc-bb57-9354e1c75d13.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 33.33.33
- Build d97d6df550ad7a983afbffdb40eb589cf16b1d9c (Dirty)
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.13
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.11 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.13 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.2 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
