### PR TITLE
Fix visual glitch in the revision grid

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -25,7 +25,7 @@ namespace GitUI.UserControls.RevisionGrid
         private readonly BackgroundUpdater _backgroundUpdater;
         private readonly Stopwatch _lastRepaint = Stopwatch.StartNew();
         private readonly Stopwatch _lastScroll = Stopwatch.StartNew();
-        private readonly Stopwatch _consecutiveScroll = new();
+        private readonly Stopwatch _consecutiveScroll = Stopwatch.StartNew();
         private readonly List<ColumnProvider> _columnProviders = new();
 
         internal RevisionGraph _revisionGraph = new();
@@ -633,13 +633,9 @@ namespace GitUI.UserControls.RevisionGrid
             // is spinning fast (with free-spinning mouse wheels) or while dragging
             // the scroll bar fast. In such cases, force a repaint to make the GUI
             // feel more responsive.
-            if (_lastScroll.ElapsedMilliseconds < 100)
+            if (_lastScroll.ElapsedMilliseconds > 100)
             {
-                _consecutiveScroll.Start();
-            }
-            else
-            {
-                _consecutiveScroll.Reset();
+                _consecutiveScroll.Restart();
             }
 
             if (_consecutiveScroll.ElapsedMilliseconds > 50

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -24,6 +24,8 @@ namespace GitUI.UserControls.RevisionGrid
 
         private readonly BackgroundUpdater _backgroundUpdater;
         private readonly Stopwatch _lastRepaint = Stopwatch.StartNew();
+        private readonly Stopwatch _lastScroll = Stopwatch.StartNew();
+        private readonly Stopwatch _consecutiveScroll = new();
         private readonly List<ColumnProvider> _columnProviders = new();
 
         internal RevisionGraph _revisionGraph = new();
@@ -33,7 +35,6 @@ namespace GitUI.UserControls.RevisionGrid
         private int _loadedToBeSelectedRevisionsCount = 0;
 
         private int _backgroundScrollTo;
-        private int _consecutiveScrollMessageCnt = 0; // Is used to detect if a forced repaint is needed.
         private int _rowHeight; // Height of elements in the cache. Is equal to the control's row height.
 
         private VisibleRowRange _visibleRowRange;
@@ -91,7 +92,7 @@ namespace GitUI.UserControls.RevisionGrid
                 }
             };
 
-            Scroll += (_, _) => UpdateVisibleRowRange();
+            Scroll += (_, _) => OnScroll();
             Resize += (_, _) => UpdateVisibleRowRange();
             GotFocus += (_, _) => InvalidateSelectedRows();
             LostFocus += (_, _) => InvalidateSelectedRows();
@@ -622,6 +623,35 @@ namespace GitUI.UserControls.RevisionGrid
             SelectRowsIfReady(rowCount);
         }
 
+        private void OnScroll()
+        {
+            UpdateVisibleRowRange();
+
+            // When scrolling many rows within a short time, the message pump is
+            // flooded with WM_CTLCOLORSCROLLBAR messages and the DataGridView
+            // is not repainted. This happens for example when the mouse wheel
+            // is spinning fast (with free-spinning mouse wheels) or while dragging
+            // the scroll bar fast. In such cases, force a repaint to make the GUI
+            // feel more responsive.
+            if (_lastScroll.ElapsedMilliseconds < 100)
+            {
+                _consecutiveScroll.Start();
+            }
+            else
+            {
+                _consecutiveScroll.Reset();
+            }
+
+            if (_consecutiveScroll.ElapsedMilliseconds > 50
+                && _lastRepaint.ElapsedMilliseconds > 50)
+            {
+                Update();
+                _lastRepaint.Restart();
+            }
+
+            _lastScroll.Restart();
+        }
+
         private void UpdateVisibleRowRange()
         {
             if (LicenseManager.UsageMode == LicenseUsageMode.Designtime)
@@ -790,41 +820,6 @@ namespace GitUI.UserControls.RevisionGrid
                 default:
                     base.OnKeyDown(e);
                     break;
-            }
-        }
-
-        protected override void WndProc(ref Message m)
-        {
-            ConditionalRepaintInjector(m);
-            base.WndProc(ref m);
-        }
-
-        /// <summary>
-        /// Forces a repaint if the last repaint was more than 50ms ago.
-        /// </summary>
-        /// <remarks>
-        /// In situations where the mouse wheel is spinning fast (for example with free-spinning mouse wheels),
-        /// the message pump is flooded with WM_CTLCOLORSCROLLBAR messages and the DataGridView is not repainted.
-        /// This method injects a WM_PAINT message in such cases to make the GUI feel more responsive.
-        /// </remarks>
-        private void ConditionalRepaintInjector(Message m)
-        {
-            if (m.Msg != NativeMethods.WM_CTLCOLORSCROLLBAR)
-            {
-                _consecutiveScrollMessageCnt = 0;
-                return;
-            }
-
-            _consecutiveScrollMessageCnt++;
-
-            if (_consecutiveScrollMessageCnt > 5 && _lastRepaint.ElapsedMilliseconds > 50)
-            {
-                // inject paint message
-                var mm = new Message() { HWnd = Handle, Msg = NativeMethods.WM_PAINT };
-                base.WndProc(ref mm);
-
-                _consecutiveScrollMessageCnt = 0;
-                _lastRepaint.Restart();
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10672. Although not knowing C# or the code, I could not resist investigating.

## Proposed changes

- Move the periodic repaint routine to the grid's scroll handler. Message interception via WndProc() seems to happen before the grid even had a chance to handle the message (i.e. move rows up or down). The scroll handler on the other hand seems to be called after the grid handled the scroll event.
- Counting consecutive WM_CTLCOLORSCROLLBAR messages seems to be unreliable in the case of dragging the scroll bar, because even more messages (other than WM_CTLCOLORSCROLLBAR) are being sent to the grid than when scrolling with the mouse wheel. As a result, _consecutiveScrollMessageCnt is reset to 0 before exceeding 5 most of the time, preventing forced repaints. Fix this by using a time-based approach to detect fast scrolling and force periodic repaints, which makes the GUI feel more responsive.
- I replaced
  ```
  var mm = new Message() { HWnd = Handle, Msg = NativeMethods.WM_PAINT };
  base.WndProc(ref mm);
  ```
  with
  ```
  Update();
  ```
  mostly for clarity. `Update()` triggers a repaint only if the grid is invalid. This seems to be the case after scrolling (well, it works), but please correct me if that's not the case.

## Test methodology <!-- How did you ensure quality? -->

I compared the scrolling behaviour against v3.5.4.12724 and the current master using this repo, and had an eye on visual appearance and performance. I used an app that emulates smooth scrolling to test the intended behaviour of the changed code segment.


## Test environment(s) <!-- Remove any that don't apply -->

Windows 10.0.19045.0 (134dpi, 140% scaling)
VS2022 Community
Git 2.38.1


<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
