### PR TITLE
Remove delay from BackgroundUpdater

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.BackgroundUpdater.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.BackgroundUpdater.cs
@@ -8,16 +8,14 @@
         private class BackgroundUpdater
         {
             private readonly Func<Task> _operation;
-            private readonly int _cooldownMilliseconds;
             private readonly object _sync = new();
 
             private volatile bool _executing;
             private volatile bool _rerunRequested;
 
-            public BackgroundUpdater(Func<Task> operation, int cooldownMilliseconds)
+            public BackgroundUpdater(Func<Task> operation)
             {
                 _operation = operation ?? throw new ArgumentNullException(nameof(operation));
-                _cooldownMilliseconds = cooldownMilliseconds;
             }
 
             public void ScheduleExcecution()
@@ -41,11 +39,6 @@
             private async Task WrappedOperationAsync()
             {
                 await _operation();
-
-                if (_rerunRequested)
-                {
-                    await Task.Delay(_cooldownMilliseconds);
-                }
 
                 lock (_sync)
                 {

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -72,7 +72,7 @@ namespace GitUI.UserControls.RevisionGrid
         {
             InitFonts();
 
-            _backgroundUpdater = new BackgroundUpdater(UpdateVisibleRowRangeInternalAsync, BackgroundThreadUpdatePeriod);
+            _backgroundUpdater = new BackgroundUpdater(UpdateVisibleRowRangeInternalAsync);
 
             InitializeComponent();
             DoubleBuffered = true;


### PR DESCRIPTION
I noticed this while investigating  #10672.

As I understand, the BackgroundUpdater waits for the current _operation() to complete before executing another task. Also, execution happens asynchronously. Therefore I cannot see a reason for the delay before executing the next task.

This makes the UI feel more responsive by removing a noticeable delay between scrolling the revision grid and the subsequent update of the revision graph.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

Remove the delay from BackgroundUpdater.

## Test methodology <!-- How did you ensure quality? -->

I compared the scrolling behaviour against v3.5.4.12724 and the current master using this repo, and had an eye on visual appearance and performance.

## Test environment(s) <!-- Remove any that don't apply -->

Windows 10.0.19045.0 (134dpi, 140% scaling)
VS2022 Community
Git 2.38.1

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
