### PR TITLE
`FileTreeContextMenu_Opening`: Handle `null` revision

### DIFF
--- a/GitUI/CommandsDialogs/RememberFileContextMenuController.cs
+++ b/GitUI/CommandsDialogs/RememberFileContextMenuController.cs
@@ -41,11 +41,11 @@ namespace GitUI.CommandsDialogs
         /// <param name="isSecondRevision">true if second revision can be used as the first item.</param>
         /// <returns>If the item can be used.</returns>
         [Pure]
-        public bool ShouldEnableFirstItemDiff(FileStatusItem item, bool isSecondRevision)
+        public bool ShouldEnableFirstItemDiff(FileStatusItem? item, bool isSecondRevision)
         {
             // First item must be a git reference existing in the revision, i.e. other than work tree
             return ShouldEnableSecondItemDiff(item, isSecondRevision: isSecondRevision)
-                   && (isSecondRevision ? item.SecondRevision : item.FirstRevision)?.ObjectId != ObjectId.WorkTreeId;
+                   && (isSecondRevision ? item?.SecondRevision : item?.FirstRevision)?.ObjectId != ObjectId.WorkTreeId;
         }
 
         [Pure]

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -7,6 +7,7 @@ using GitExtUtils.GitUI;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.Hotkey;
 using GitUI.Properties;
+using GitUI.UserControls;
 using GitUIPluginInterfaces;
 using Microsoft;
 using ResourceManager;
@@ -660,16 +661,18 @@ See the changes in the commit form.");
 
         private void FileTreeContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            var gitItem = tvGitTree.SelectedNode?.Tag as GitItem;
-            var itemSelected = gitItem is not null;
-            var isFile = gitItem?.ObjectType == GitObjectType.Blob;
-            var isFolder = gitItem?.ObjectType == GitObjectType.Tree;
-            var isFileOrFolder = isFile || isFolder;
+            GitItem? gitItem = tvGitTree.SelectedNode?.Tag as GitItem;
+            bool itemSelected = gitItem is not null;
+            bool isFile = gitItem?.ObjectType == GitObjectType.Blob;
+            bool isFolder = gitItem?.ObjectType == GitObjectType.Tree;
+            bool isFileOrFolder = isFile || isFolder;
 
             // Many items does not make sense if a local file does not exist, why this is used for Enabled
-            var isExistingFileOrDirectory = gitItem is not null && FormBrowseUtil.IsFileOrDirectory(_fullPathResolver.Resolve(gitItem.FileName));
+            bool isExistingFileOrDirectory = gitItem is not null && FormBrowseUtil.IsFileOrDirectory(_fullPathResolver.Resolve(gitItem.FileName));
 
-            var openSubVisible = gitItem?.ObjectType == GitObjectType.Commit && isExistingFileOrDirectory;
+            filterFileInGridToolStripMenuItem.Enabled = itemSelected;
+
+            bool openSubVisible = gitItem?.ObjectType == GitObjectType.Commit && isExistingFileOrDirectory;
             openSubmoduleMenuItem.Visible = openSubVisible;
             if (openSubVisible)
             {
@@ -700,8 +703,8 @@ See the changes in the commit form.");
             openWithDifftoolToolStripMenuItem.Visible = isFile;
             openWithToolStripMenuItem.Visible = isFile;
             openWithToolStripMenuItem.Enabled = isExistingFileOrDirectory;
-            Validates.NotNull(_revision);
-            var fsi = _rememberFileContextMenuController.CreateFileStatusItem(gitItem?.FileName ?? "", _revision);
+            FileStatusItem fsi = _revision is null ? null
+                : _rememberFileContextMenuController.CreateFileStatusItem(gitItem?.FileName ?? "", _revision);
             diffWithRememberedFileToolStripMenuItem.Visible = _rememberFileContextMenuController.RememberedDiffFileItem is not null;
             diffWithRememberedFileToolStripMenuItem.Enabled = isFile && fsi != _rememberFileContextMenuController.RememberedDiffFileItem
                                                                          && _rememberFileContextMenuController.ShouldEnableSecondItemDiff(fsi);


### PR DESCRIPTION
Fixes #10666

## Proposed changes

- `FileTreeContextMenu_Opening`: Replace `Validates.NotNull(_revision)` with `null`-aware code
- `ShouldEnableFirstItemDiff` handle `null`
- Disable `filterFileInGridToolStripMenuItem`, too, if there is no selection
- Replace `var` by explicit types

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

NRE

### After

![image](https://user-images.githubusercontent.com/36601201/215161073-daa4769f-b7d7-4811-be2e-b651a5d999e7.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 450e4c061e6c4a393efd003001f2a411d9ce46f8
- Git 2.39.0.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).