### PR TITLE
Load translation for remaining Left Panel context menu items

### DIFF
--- a/GitUI/BranchTreePanel/ContextMenu/LocalBranchMenuItems.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/LocalBranchMenuItems.cs
@@ -1,4 +1,5 @@
-﻿using GitUI.BranchTreePanel.Interfaces;
+﻿using GitCommands;
+using GitUI.BranchTreePanel.Interfaces;
 using ResourceManager;
 
 namespace GitUI.BranchTreePanel.ContextMenu
@@ -19,6 +20,11 @@ namespace GitUI.BranchTreePanel.ContextMenu
     public class LocalBranchMenuItemsStrings : Translate
     {
         internal readonly TranslationString DeleteTooltip = new("Delete the branch, which must be fully merged in its upstream branch or in HEAD");
+
+        public LocalBranchMenuItemsStrings()
+        {
+            Translator.Translate(this, AppSettings.CurrentTranslation);
+        }
 
         public void ApplyTo(MenuItemsStrings strings)
         {

--- a/GitUI/BranchTreePanel/ContextMenu/MenuItemsStrings.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/MenuItemsStrings.cs
@@ -1,4 +1,5 @@
-﻿using GitUI.BranchTreePanel.Interfaces;
+﻿using GitCommands;
+using GitUI.BranchTreePanel.Interfaces;
 using ResourceManager;
 
 namespace GitUI.BranchTreePanel.ContextMenu
@@ -21,6 +22,11 @@ namespace GitUI.BranchTreePanel.ContextMenu
         internal readonly TranslationString Delete = new("&Delete branch...");
 
         internal Dictionary<MenuItemKey, TranslationString> Tooltips { get; } = new Dictionary<MenuItemKey, TranslationString>();
+
+        public MenuItemsStrings()
+        {
+            Translator.Translate(this, AppSettings.CurrentTranslation);
+        }
     }
 
     public class BranchMenuItemsStrings : Translate
@@ -31,6 +37,11 @@ namespace GitUI.BranchTreePanel.ContextMenu
         internal readonly TranslationString RebaseTooltip = new("Rebase current branch to this branch");
         internal readonly TranslationString ResetTooltip = new("Reset current branch to here");
         internal readonly TranslationString RenameTooltip = new("Rename this branch");
+
+        public BranchMenuItemsStrings()
+        {
+            Translator.Translate(this, AppSettings.CurrentTranslation);
+        }
 
         public void ApplyTo(MenuItemsStrings strings)
         {

--- a/GitUI/BranchTreePanel/ContextMenu/RemoteBranchMenuItems.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/RemoteBranchMenuItems.cs
@@ -1,4 +1,5 @@
-﻿using GitUI.BranchTreePanel.Interfaces;
+﻿using GitCommands;
+using GitUI.BranchTreePanel.Interfaces;
 using ResourceManager;
 
 namespace GitUI.BranchTreePanel.ContextMenu
@@ -15,6 +16,11 @@ namespace GitUI.BranchTreePanel.ContextMenu
     public class RemoteBranchMenuItemsStrings : Translate
     {
         internal readonly TranslationString DeleteTooltip = new("Delete the branch from the remote");
+
+        public RemoteBranchMenuItemsStrings()
+        {
+            Translator.Translate(this, AppSettings.CurrentTranslation);
+        }
 
         public void ApplyTo(MenuItemsStrings strings)
         {

--- a/GitUI/BranchTreePanel/ContextMenu/TagMenuItems.cs
+++ b/GitUI/BranchTreePanel/ContextMenu/TagMenuItems.cs
@@ -1,4 +1,5 @@
-﻿using GitUI.BranchTreePanel.Interfaces;
+﻿using GitCommands;
+using GitUI.BranchTreePanel.Interfaces;
 using ResourceManager;
 
 namespace GitUI.BranchTreePanel.ContextMenu
@@ -20,6 +21,11 @@ namespace GitUI.BranchTreePanel.ContextMenu
         internal readonly TranslationString RebaseTooltip = new("Rebase current branch to this tag");
         internal readonly TranslationString ResetTooltip = new("Reset current branch to here");
         internal readonly TranslationString DeleteTooltip = new("Delete this tag");
+
+        public TagMenuItemsStrings()
+        {
+            Translator.Translate(this, AppSettings.CurrentTranslation);
+        }
 
         public void ApplyTo(MenuItemsStrings strings)
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10660

## Proposed changes

- Add constructors `LocalBranchMenuItems`, `MenuItemsStrings`, `BranchMenuItemsStrings`, `RemoteBranchMenuItemsStrings`, `TagMenuItems`
  which load the translations of contained strings

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 432ad7dee8533cb24fd1d0dd47761d11c6d956b7
- Git 2.39.0.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).