### PR TITLE
FormRebase: edit-todo

### DIFF
--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -467,6 +467,11 @@ namespace GitCommands.Git.Commands
             return new GitArgumentBuilder("rebase") { "--abort" };
         }
 
+        public static ArgumentString EditTodoRebaseCmd()
+        {
+            return new GitArgumentBuilder("rebase") { "--edit-todo" };
+        }
+
         public static ArgumentString ResolvedCmd()
         {
             return new GitArgumentBuilder("am")

--- a/GitUI/CommandsDialogs/FormRebase.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRebase.Designer.cs
@@ -392,7 +392,7 @@ namespace GitUI.CommandsDialogs
             this.chkSpecificRange.Name = "chkSpecificRange";
             this.chkSpecificRange.Size = new System.Drawing.Size(100, 19);
             this.chkSpecificRange.TabIndex = 19;
-            this.chkSpecificRange.Text = "Sp&ecific range";
+            this.chkSpecificRange.Text = "Specific ra&nge";
             this.chkSpecificRange.UseVisualStyleBackColor = true;
             this.chkSpecificRange.CheckedChanged += new System.EventHandler(this.chkUseFromOnto_CheckedChanged);
             // 

--- a/GitUI/CommandsDialogs/FormRebase.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRebase.Designer.cs
@@ -34,6 +34,7 @@ namespace GitUI.CommandsDialogs
             System.Windows.Forms.FlowLayoutPanel PanelCurrentBranch;
             this.btnAddFiles = new System.Windows.Forms.Button();
             this.btnCommit = new System.Windows.Forms.Button();
+            this.btnEditTodo = new System.Windows.Forms.Button();
             this.btnSkip = new System.Windows.Forms.Button();
             this.lblCurrent = new System.Windows.Forms.Label();
             this.Currentbranch = new System.Windows.Forms.Label();
@@ -107,6 +108,7 @@ namespace GitUI.CommandsDialogs
             flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             flowLayoutPanel1.Controls.Add(this.btnAddFiles);
             flowLayoutPanel1.Controls.Add(this.btnCommit);
+            flowLayoutPanel1.Controls.Add(this.btnEditTodo);
             flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             flowLayoutPanel1.Location = new System.Drawing.Point(3, 3);
             flowLayoutPanel1.Name = "flowLayoutPanel1";
@@ -139,6 +141,19 @@ namespace GitUI.CommandsDialogs
             this.btnCommit.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
             this.btnCommit.UseVisualStyleBackColor = true;
             this.btnCommit.Click += new System.EventHandler(this.Commit_Click);
+            // 
+            // btnEditTodo
+            // 
+            this.btnEditTodo.AutoSize = true;
+            this.btnEditTodo.Image = global::GitUI.Properties.Images.EditFile;
+            this.btnEditTodo.Location = new System.Drawing.Point(180, 3);
+            this.btnEditTodo.Name = "btnEditTodo";
+            this.btnEditTodo.Size = new System.Drawing.Size(79, 25);
+            this.btnEditTodo.TabIndex = 36;
+            this.btnEditTodo.Text = "&Edit todo...";
+            this.btnEditTodo.UseVisualStyleBackColor = true;
+            this.btnEditTodo.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
+            this.btnEditTodo.Click += new System.EventHandler(this.EditTodoClick);
             // 
             // flowLayoutPanel2
             // 
@@ -478,7 +493,7 @@ namespace GitUI.CommandsDialogs
             this.btnSolveMergeconflicts.Location = new System.Drawing.Point(12, 426);
             this.btnSolveMergeconflicts.Name = "btnSolveMergeconflicts";
             this.btnSolveMergeconflicts.Size = new System.Drawing.Size(213, 27);
-            this.btnSolveMergeconflicts.TabIndex = 41;
+            this.btnSolveMergeconflicts.TabIndex = 42;
             this.btnSolveMergeconflicts.Text = "There are unresolved merge conflicts\r\n";
             this.btnSolveMergeconflicts.UseVisualStyleBackColor = false;
             this.btnSolveMergeconflicts.Visible = false;
@@ -682,6 +697,7 @@ namespace GitUI.CommandsDialogs
         private Help.HelpImageDisplayUserControl PanelLeftImage;
         private System.Windows.Forms.CheckBox chkStash;
         private System.Windows.Forms.Button btnCommit;
+        private System.Windows.Forms.Button btnEditTodo;
         private System.Windows.Forms.CheckBox chkIgnoreDate;
         private System.Windows.Forms.ToolTip toolTip1;
         private System.Windows.Forms.CheckBox chkCommitterDateIsAuthorDate;

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -144,6 +144,7 @@ namespace GitUI.CommandsDialogs
 
         private void EnableButtons()
         {
+            bool conflictedMerge = Module.InTheMiddleOfConflictedMerge();
             if (Module.InTheMiddleOfRebase())
             {
                 if (Height < 200)
@@ -157,8 +158,9 @@ namespace GitUI.CommandsDialogs
 
                 btnAddFiles.Visible = true;
                 btnCommit.Visible = true;
-                btnContinueRebase.Visible = !Module.InTheMiddleOfConflictedMerge();
-                btnSolveConflicts.Visible = Module.InTheMiddleOfConflictedMerge();
+                btnEditTodo.Visible = true;
+                btnContinueRebase.Visible = !conflictedMerge;
+                btnSolveConflicts.Visible = conflictedMerge;
                 btnSkip.Visible = true;
                 btnAbort.Visible = true;
             }
@@ -168,6 +170,7 @@ namespace GitUI.CommandsDialogs
                 btnRebase.Visible = true;
                 btnAddFiles.Visible = false;
                 btnCommit.Visible = false;
+                btnEditTodo.Visible = false;
                 btnContinueRebase.Visible = false;
                 btnSolveConflicts.Visible = false;
                 btnSkip.Visible = false;
@@ -175,7 +178,7 @@ namespace GitUI.CommandsDialogs
                 chkStash.Enabled = Module.IsDirtyDir();
             }
 
-            btnSolveMergeconflicts.Visible = Module.InTheMiddleOfConflictedMerge();
+            btnSolveMergeconflicts.Visible = conflictedMerge;
 
             btnContinueRebase.Text = _continueRebaseText.Text;
             btnSolveConflicts.Text = _solveConflictsText.Text;
@@ -185,7 +188,7 @@ namespace GitUI.CommandsDialogs
 
             var highlightColor = Color.Yellow.AdaptBackColor();
 
-            if (Module.InTheMiddleOfConflictedMerge())
+            if (conflictedMerge)
             {
                 AcceptButton = btnSolveConflicts;
                 btnSolveConflicts.Focus();
@@ -280,6 +283,23 @@ namespace GitUI.CommandsDialogs
             using (WaitCursorScope.Enter())
             {
                 FormProcess.ShowDialog(this, arguments: GitCommandHelpers.AbortRebaseCmd(), Module.WorkingDir, input: null, useDialogSettings: true);
+
+                if (!Module.InTheMiddleOfRebase())
+                {
+                    Skipped.Clear();
+                    Close();
+                }
+
+                EnableButtons();
+                PatchGrid.Initialize();
+            }
+        }
+
+        private void EditTodoClick(object sender, EventArgs e)
+        {
+            using (WaitCursorScope.Enter())
+            {
+                FormProcess.ShowDialog(this, arguments: GitCommandHelpers.EditTodoRebaseCmd(), Module.WorkingDir, input: null, useDialogSettings: true);
 
                 if (!Module.InTheMiddleOfRebase())
                 {

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5865,6 +5865,10 @@ Nothing to rebase.</source>
         <source>&amp;Continue rebase</source>
         <target />
       </trans-unit>
+      <trans-unit id="btnEditTodo.Text">
+        <source>&amp;Edit todo...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="btnRebase.Text">
         <source>Rebase</source>
         <target />

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5907,7 +5907,7 @@ Nothing to rebase.</source>
         <target />
       </trans-unit>
       <trans-unit id="chkSpecificRange.Text">
-        <source>Sp&amp;ecific range</source>
+        <source>Specific ra&amp;nge</source>
         <target />
       </trans-unit>
       <trans-unit id="chkStash.Text">


### PR DESCRIPTION
## Proposed changes

Rearrange commit apply order at a rebase.
I often like to change this in bigger rebases, for instance when realizing that a series of commits should be removed.

Note: Keyboard accelerator is in conflict with "Specific range", no other char is available.
I do not think range need an accelrator at all, but could change it to R if preferred.

* Avoid multiple calls to git-ls-files --unmerged
One instead of 4 calls, each requires 40 ms in my small test repo
(Could have been separate.)
Module.InTheMiddleOfRebase() is just file I/O

## Screenshots <!-- Remove this section if PR does not change UI -->

### After

Adding `Edit todo...`

![image](https://user-images.githubusercontent.com/6248932/215339170-0f0f9b7b-0a7a-4b29-b58c-56fd6132544e.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
