### PR TITLE
Better handle corrupted .gitsubmodule (#10691)

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1219,7 +1219,14 @@ namespace GitCommands
 
         public GitModule GetSubmodule(string? localPath)
         {
-            return new GitModule(GetSubmoduleFullPath(localPath));
+            try
+            {
+                return new GitModule(GetSubmoduleFullPath(localPath));
+            }
+            catch (GitConfigurationException)
+            {
+                return new GitModule(null);
+            }
         }
 
         IGitModule IGitModule.GetSubmodule(string submoduleName)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10691

## Proposed changes

- Add try/catch around function that throw due to wrong .gitsubmodule file.

## Test environment(s)

- Git Extensions 4.0.2.16100
- Build 25100ec1f7c8da8f798613da74826038af81a50e
- Git 2.39.1.windows.1
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.13
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 3.1.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 3.1.32 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.7 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.10 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.11 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.13 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
