### PR TITLE
Optionally show EOL markers as glyph instead of textually

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1473,6 +1473,12 @@ namespace GitCommands
             set => SetFont("conemuconsolefont", value);
         }
 
+        public static bool ShowEolMarkerAsGlyph
+        {
+            get => GetBool("ShowEolMarkerAsGlyph", false);
+            set => SetBool("ShowEolMarkerAsGlyph", value);
+        }
+
         #endregion
 
         public static bool MulticolorBranches

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -282,6 +282,8 @@ namespace GitUI.CommandsDialogs
                 }
 
                 settingsTreeView.GotoPage(_initialPage);
+
+                settingsTreeView.Focus();
             }
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.Designer.cs
@@ -34,6 +34,7 @@
             this.monospaceFontChangeButton = new System.Windows.Forms.Button();
             this.commitFontChangeButton = new System.Windows.Forms.Button();
             this.diffFontChangeButton = new System.Windows.Forms.Button();
+            this.ShowEolMarkerAsGlyph = new System.Windows.Forms.CheckBox();
             this.applicationFontChangeButton = new System.Windows.Forms.Button();
             this.label36 = new System.Windows.Forms.Label();
             this.label34 = new System.Windows.Forms.Label();
@@ -58,7 +59,7 @@
             this.gbFonts.Size = new System.Drawing.Size(2132, 117);
             this.gbFonts.TabIndex = 2;
             this.gbFonts.TabStop = false;
-            this.gbFonts.Text = "Fonts";
+            this.gbFonts.Text = "Fonts (restart required)";
             // 
             // tableLayoutPanel1
             // 
@@ -69,13 +70,14 @@
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.Controls.Add(this.label56, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.monospaceFontChangeButton, 1, 3);
-            this.tableLayoutPanel1.Controls.Add(this.commitFontChangeButton, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.diffFontChangeButton, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.applicationFontChangeButton, 1, 1);
-            this.tableLayoutPanel1.Controls.Add(this.label36, 0, 3);
-            this.tableLayoutPanel1.Controls.Add(this.label34, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.ShowEolMarkerAsGlyph, 2, 0);
             this.tableLayoutPanel1.Controls.Add(this.label26, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.applicationFontChangeButton, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.label34, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.commitFontChangeButton, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.label36, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.monospaceFontChangeButton, 1, 3);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(8, 22);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
@@ -122,6 +124,18 @@
             this.diffFontChangeButton.Text = "font name";
             this.diffFontChangeButton.UseVisualStyleBackColor = true;
             this.diffFontChangeButton.Click += new System.EventHandler(this.diffFontChangeButton_Click);
+            // 
+            // ShowEolMarkersAsGlyph
+            // 
+            this.ShowEolMarkerAsGlyph.AutoSize = true;
+            this.ShowEolMarkerAsGlyph.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ShowEolMarkerAsGlyph.Location = new System.Drawing.Point(181, 3);
+            this.ShowEolMarkerAsGlyph.Name = "ShowEolMarkerAsGlyph";
+            this.ShowEolMarkerAsGlyph.Padding = new System.Windows.Forms.Padding(8, 2, 0, 0);
+            this.ShowEolMarkerAsGlyph.Size = new System.Drawing.Size(1336, 25);
+            this.ShowEolMarkerAsGlyph.TabIndex = 5;
+            this.ShowEolMarkerAsGlyph.Text = "Show end-of-line markers as glyph instead of \"\\r\\n\" etc.";
+            this.ShowEolMarkerAsGlyph.UseVisualStyleBackColor = true;
             // 
             // applicationFontChangeButton
             // 
@@ -236,5 +250,6 @@
         private System.Windows.Forms.FontDialog monospaceFontDialog;
         private System.Windows.Forms.FontDialog commitFontDialog;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private CheckBox ShowEolMarkerAsGlyph;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.cs
@@ -24,6 +24,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             SetCurrentCommitFont(AppSettings.CommitFont);
             SetCurrentMonospaceFont(AppSettings.MonospaceFont);
 
+            ShowEolMarkerAsGlyph.Checked = AppSettings.ShowEolMarkerAsGlyph;
+
             base.SettingsToPage();
         }
 
@@ -38,6 +40,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.Font = _applicationFont;
             AppSettings.CommitFont = _commitFont;
             AppSettings.MonospaceFont = _monospaceFont;
+
+            AppSettings.ShowEolMarkerAsGlyph = ShowEolMarkerAsGlyph.Checked;
 
             base.PageToSettings();
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.resx
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.resx
@@ -1,64 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
+﻿<root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -118,12 +58,15 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="diffFontDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>196, 17</value>
+    <value>345, 17</value>
   </metadata>
   <metadata name="applicationDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>346, 17</value>
+    <value>474, 17</value>
+  </metadata>
+  <metadata name="monospaceFontDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
   <metadata name="commitFontDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>192, 17</value>
   </metadata>
 </root>

--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -414,7 +414,7 @@ namespace GitUI.Editor
             this.internalFileViewer.Margin = new System.Windows.Forms.Padding(0);
             this.internalFileViewer.Name = "internalFileViewer";
             this.internalFileViewer.VScrollPosition = 0;
-            this.internalFileViewer.ShowEOLMarkers = false;
+            this.internalFileViewer.EolMarkerStyle = ICSharpCode.TextEditor.Document.EolMarkerStyle.None;
             this.internalFileViewer.ShowSpaces = false;
             this.internalFileViewer.ShowTabs = false;
             this.internalFileViewer.Size = new System.Drawing.Size(757, 518);

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1191,7 +1191,11 @@ namespace GitUI.Editor
 
         private void ToggleNonPrintingChars(bool show)
         {
-            internalFileViewer.EolMarkerStyle = show ? ICSharpCode.TextEditor.Document.EolMarkerStyle.Glyph : ICSharpCode.TextEditor.Document.EolMarkerStyle.None;
+            internalFileViewer.EolMarkerStyle = show
+                ? AppSettings.ShowEolMarkerAsGlyph
+                    ? ICSharpCode.TextEditor.Document.EolMarkerStyle.Glyph
+                    : ICSharpCode.TextEditor.Document.EolMarkerStyle.Text
+                : ICSharpCode.TextEditor.Document.EolMarkerStyle.None;
             internalFileViewer.ShowSpaces = show;
             internalFileViewer.ShowTabs = show;
         }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1191,7 +1191,7 @@ namespace GitUI.Editor
 
         private void ToggleNonPrintingChars(bool show)
         {
-            internalFileViewer.ShowEOLMarkers = show;
+            internalFileViewer.EolMarkerStyle = show ? ICSharpCode.TextEditor.Document.EolMarkerStyle.Glyph : ICSharpCode.TextEditor.Document.EolMarkerStyle.None;
             internalFileViewer.ShowSpaces = show;
             internalFileViewer.ShowTabs = show;
         }

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -399,10 +399,10 @@ namespace GitUI.Editor
             }
         }
 
-        public bool ShowEOLMarkers
+        public EolMarkerStyle EolMarkerStyle
         {
-            get => TextEditor.ShowEOLMarkers;
-            set => TextEditor.ShowEOLMarkers = value;
+            get => TextEditor.EolMarkerStyle;
+            set => TextEditor.EolMarkerStyle = value;
         }
 
         public bool ShowSpaces

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.Editor
+﻿using ICSharpCode.TextEditor.Document;
+
+namespace GitUI.Editor
 {
     public class SelectedLineEventArgs : EventArgs
     {
@@ -42,7 +44,7 @@
         int VScrollPosition { get; set; }
 
         bool? ShowLineNumbers { get; set; }
-        bool ShowEOLMarkers { get; set; }
+        EolMarkerStyle EolMarkerStyle { get; set; }
         bool ShowSpaces { get; set; }
         bool ShowTabs { get; set; }
         int VRulerPosition { get; set; }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -85,6 +85,10 @@ This action will be performed without warning while checking out branch.</source
         <source>Fonts</source>
         <target />
       </trans-unit>
+      <trans-unit id="ShowEolMarkerAsGlyph.Text">
+        <source>Show end-of-line markers as glyph instead of "\r\n" etc.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="applicationFontChangeButton.Text">
         <source>font name</source>
         <target />
@@ -98,7 +102,7 @@ This action will be performed without warning while checking out branch.</source
         <target />
       </trans-unit>
       <trans-unit id="gbFonts.Text">
-        <source>Fonts</source>
+        <source>Fonts (restart required)</source>
         <target />
       </trans-unit>
       <trans-unit id="label26.Text">


### PR DESCRIPTION
## Proposed changes

- Add option to toggle end-of-line markers between glyph and text
- Focus `Type to find` field on open of FormSettings

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before / After

![image](https://user-images.githubusercontent.com/36601201/216715745-9183790c-d335-4495-a456-0fc87265316b.png) ![image](https://user-images.githubusercontent.com/36601201/216716364-bc0df95e-e451-4d3a-9b22-19ae28356ee6.png)

### Before

![image](https://user-images.githubusercontent.com/36601201/216715990-97fdcd64-03aa-491f-b2b0-b5fbedc2983b.png)

### After

![image](https://user-images.githubusercontent.com/36601201/216716079-120a2da7-375e-4f62-b629-1493501dfc3f.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 26a3cdb1d3e0f7ffc04158423e36b3357f85a279
- Git 2.39.0.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer **squash merge** this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).