### PR TITLE
FileViewer: Don't show too many lines in MessageBox

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1636,7 +1636,8 @@ namespace GitUI.Editor
 
             if (!result.ExitedSuccessfully && (patchUpdateDiff || !MergeConflictHandler.HandleMergeConflicts(UICommands, this, false, false)))
             {
-                MessageBox.Show(this, $"{output}\n\n{Encoding.GetString(patch)}", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                string truncated_output = Encoding.GetString(patch).LazySplit('\n').Take(20).Join("\n");
+                MessageBox.Show(this, $"{output}\n\n{truncated_output}", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else if (!result.ExitedSuccessfully || output.StartsWith("error: ") || output.StartsWith("warning: "))
             {

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1636,7 +1636,25 @@ namespace GitUI.Editor
 
             if (!result.ExitedSuccessfully && (patchUpdateDiff || !MergeConflictHandler.HandleMergeConflicts(UICommands, this, false, false)))
             {
-                string truncated_output = Encoding.GetString(patch).LazySplit('\n').Take(20).Join("\n");
+                const int max_lines = 20;
+                int count = 0;
+                string truncated_output = Encoding.GetString(patch).LazySplit('\n').Take(max_lines + 1).Select(x =>
+                {
+                    count++;
+
+                    if (count > max_lines)
+                    {
+                        return "";
+                    }
+
+                    return x;
+                }).Join("\n");
+
+                if (count > max_lines)
+                {
+                    truncated_output += "...\n\nOutput truncated.";
+                }
+
                 MessageBox.Show(this, $"{output}\n\n{truncated_output}", TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else if (!result.ExitedSuccessfully || output.StartsWith("error: ") || output.StartsWith("warning: "))


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10709

## Proposed changes

- Truncate message to limit the number of lines of string in a MessageBox.

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 4.0.2.16100
- Build 25100ec1f7c8da8f798613da74826038af81a50e
- Git 2.39.1.windows.1
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.13
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 3.1.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 3.1.32 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.7 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.10 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.11 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.13 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.2 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/9248729/218404107-83e0cb95-176a-4d63-a625-58a656348c04.png)

The MessageBox takes the whole height of my screen.

### After without "Output truncated" annotation:

![image](https://user-images.githubusercontent.com/9248729/218404548-698ce02d-4a5f-4e9c-90d6-945fd8186d99.png)

### After with "Output truncated" annotation:

![image](https://user-images.githubusercontent.com/9248729/218470080-690f765e-35c2-4176-b1c7-4eaa6ba0a803.png)

### After with TaskDialog

Indent is lost.

![image](https://user-images.githubusercontent.com/9248729/218469806-121f17c2-9d28-479d-9c9e-77bff0bb3326.png)

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
