### PR TITLE
`RevisionGraph`: Retry `Sort` if it stumbled upon rewritten `Score`

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -499,21 +499,34 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 return _orderedNodesCache;
             }
 
-            // Reset the reorder flag and the orderedUntilScore. This makes sure it isn't marked dirty before we even got to
-            // rebuilding it.
-            _orderedUntilScore = int.MinValue;
-            _reorder = false;
-
-            // Use a local variable, because the cached list can be reset
-            var localOrderedNodesCache = _nodes.ToArray();
-            Array.Sort(localOrderedNodesCache, (x, y) => x.Score.CompareTo(y.Score));
-            _orderedNodesCache = localOrderedNodesCache;
-            if (localOrderedNodesCache.Length > 0)
+            // The Score of the referenced nodes can still be rewritten.
+            // Then the cache is invalidated by setting _reorder.
+            // So if Sort() complains in this case, try again.
+            while (true)
             {
-                _orderedUntilScore = localOrderedNodesCache.Last().Score;
-            }
+                try
+                {
+                    // Reset the reorder flag and the orderedUntilScore. This makes sure it isn't marked dirty before we even got to
+                    // rebuilding it.
+                    _orderedUntilScore = int.MinValue;
+                    _reorder = false;
 
-            return localOrderedNodesCache;
+                    // Use a local variable, because the cached list can be reset.
+                    RevisionGraphRevision[] localOrderedNodesCache = _nodes.ToArray();
+                    Array.Sort(localOrderedNodesCache, (x, y) => x.Score.CompareTo(y.Score));
+                    _orderedNodesCache = localOrderedNodesCache;
+                    if (localOrderedNodesCache.Length > 0)
+                    {
+                        _orderedUntilScore = localOrderedNodesCache.Last().Score;
+                    }
+
+                    return localOrderedNodesCache;
+                }
+                catch (ArgumentException ex) when (_reorder && ex.Message.Contains("IComparer.Compare()"))
+                {
+                    // ignore and try again
+                }
+            }
         }
 
         private void MarkCacheAsInvalidIfNeeded(RevisionGraphRevision revisionGraphRevision)

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -499,7 +499,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 return _orderedNodesCache;
             }
 
-            // The Score of the referenced nodes can still be rewritten.
+            // The Score of the referenced nodes can be rewritten by another thread.
             // Then the cache is invalidated by setting _reorder.
             // So if Sort() complains in this case, try again.
             while (true)


### PR DESCRIPTION
Fixes #10706

## Proposed changes

- Add a workaround to `RevisionGraph`: Retry `Array.Sort` if it stumbled upon rewritten `Node.Score`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing unit tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build ad4f39aaeefd9757adeccdfc891d37b9672f8707 (Dirty)
- Git 2.39.0.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).