### PR TITLE
`PatchGrid`: Translate all columns

### DIFF
--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -8126,6 +8126,14 @@ This will just checkout on the submodule the commit determined by the superproje
   </file>
   <file datatype="plaintext" original="PatchGrid" source-language="en">
     <body>
+      <trans-unit id="Action.HeaderText">
+        <source>Action</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="CommitHash.HeaderText">
+        <source>Commit hash</source>
+        <target />
+      </trans-unit>
       <trans-unit id="FileName.HeaderText">
         <source>Name</source>
         <target />

--- a/GitUI/UserControls/PatchGrid.Designer.cs
+++ b/GitUI/UserControls/PatchGrid.Designer.cs
@@ -86,7 +86,6 @@
             // Action
             // 
             this.Action.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.Action.DataPropertyName = "Action";
             this.Action.HeaderText = "Action";
             this.Action.Name = "Action";
             this.Action.ReadOnly = true;
@@ -95,7 +94,6 @@
             // CommitHash
             // 
             this.CommitHash.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.CommitHash.DataPropertyName = "ObjectId";
             this.CommitHash.HeaderText = "Commit hash";
             this.CommitHash.Name = "CommitHash";
             this.CommitHash.ReadOnly = true;

--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -33,6 +33,8 @@ namespace GitUI
             InitializeComponent();
             InitializeComplete();
             FileName.DataPropertyName = nameof(PatchFile.Name);
+            Action.DataPropertyName = nameof(PatchFile.Action);
+            CommitHash.DataPropertyName = nameof(PatchFile.ObjectId);
             subjectDataGridViewTextBoxColumn.DataPropertyName = nameof(PatchFile.Subject);
             authorDataGridViewTextBoxColumn.DataPropertyName = nameof(PatchFile.Author);
             dateDataGridViewTextBoxColumn.DataPropertyName = nameof(PatchFile.Date);
@@ -43,7 +45,6 @@ namespace GitUI
             CommitHash.Width = DpiUtil.Scale(55);
             authorDataGridViewTextBoxColumn.Width = DpiUtil.Scale(140);
             Patches.RowTemplate.MinimumHeight = Patches.ColumnHeadersHeight;
-            UpdateState(IsManagingRebase);
         }
 
         private void UpdateState(bool isManagingRebase)
@@ -114,6 +115,7 @@ namespace GitUI
                 return;
             }
 
+            UpdateState(IsManagingRebase);
             DisplayPatches(GetPatches());
         }
 


### PR DESCRIPTION
Fixes #10704

## Proposed changes

- Call `PatchGrid.UpdateState()` on runtime only in order to make translation affect all columns
- Do not set `DataPropertyName` in Designer as for other columns (just for consistency)

## Screenshots <!-- Remove this section if PR does not change UI -->

not changed for English

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build f173aa40d1f15b7b166d4b093e35d952c3a8dc1c
- Git 2.39.0.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).