### PR TITLE
EditNetSpell: Avoid unhandled-key sound for cursor keys

### DIFF
--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -727,6 +727,25 @@ namespace GitUI.SpellChecker
             }
 
             OnKeyDown(e);
+
+            // Avoid the unhandled-key sound for cursor keys
+            if (!e.Handled && !e.SuppressKeyPress)
+            {
+                switch (e.KeyCode)
+                {
+                    case Keys.Up:
+                    case Keys.Down:
+                    case Keys.Left:
+                    case Keys.Right:
+                    case Keys.PageUp:
+                    case Keys.PageDown:
+                    case Keys.Home:
+                    case Keys.End:
+                        e.Handled = true;
+                        e.SuppressKeyPress = true;
+                        break;
+                }
+            }
         }
 
         private void PasteTextFromClipboard()


### PR DESCRIPTION
## Proposed changes

- Mark cursor key presses as handled if the `EditNetSpell`'s RichTextBox has not handled them
  in order to suppress the unhandled-key sound ("ding")
  primarily when editing the commit message

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build ce37b9d9a9d2e3612688b4893d1c7a7a2f1f8180
- Git 2.39.0.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).