### PR TITLE
FileStatusList: Create group also for orphan commit

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1027,23 +1027,18 @@ namespace GitUI
             List<ListViewItem> list = new();
             foreach (var i in GitItemStatusesWithDescription)
             {
-                ListViewGroup? group = null;
-                if (i.FirstRev is not null)
+                string name = i.Statuses.Count == 1 && i.Statuses[0].IsRangeDiff
+                    ? i.Summary
+                    : $"({i.Statuses.Count}) {i.Summary}";
+                ListViewGroup group = new(name)
                 {
-                    string name = i.Statuses.Count == 1 && i.Statuses[0].IsRangeDiff
-                        ? i.Summary
-                        : $"({i.Statuses.Count}) {i.Summary}";
-                    group = new ListViewGroup(name)
-                    {
-                        // Collapse some groups for diffs with common BASE
-                        CollapsedState = i.Statuses.Count <= 7 || GitItemStatusesWithDescription.Count < 3 || i == GitItemStatusesWithDescription[0]
-                            ? ListViewGroupCollapsedState.Expanded
-                            : ListViewGroupCollapsedState.Collapsed,
-                        Tag = i.FirstRev
-                    };
-
-                    FileStatusListView.Groups.Add(group);
-                }
+                    // Collapse some groups for diffs with common BASE
+                    CollapsedState = i.Statuses.Count <= 7 || GitItemStatusesWithDescription.Count < 3 || i == GitItemStatusesWithDescription[0]
+                        ? ListViewGroupCollapsedState.Expanded
+                        : ListViewGroupCollapsedState.Collapsed,
+                    Tag = i.FirstRev
+                };
+                FileStatusListView.Groups.Add(group);
 
                 IReadOnlyList<GitItemStatus> itemStatuses;
                 if (hasChanges && i.Statuses.Count == 0)


### PR DESCRIPTION
Fixes #10694

## Proposed changes

- `FileStatusList`: Create a `ListViewGroup` for all commits including for orphan commits
   because of consistency and mainly because the text search implementation is based on groups 

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/36601201/216432387-4798db49-b690-437d-b4f9-c6300506bfaf.png)

### After

![image](https://user-images.githubusercontent.com/36601201/218281251-a6b23e3d-d548-4b6e-9119-7628358bfee6.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 879bc4f5ef538872e75f8704ba60c3e63d764cd7
- Git 2.39.0.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).