### PR TITLE
Fixup splitter settings

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2219,7 +2219,7 @@ namespace GitUI.CommandsDialogs
 
             // Since #8849 and #8557 we have a geometry bug, which pushes the splitter up by 4px.
             // Account for this shift. This is a workaround at best in the same way as for FormCommit.
-            if (!RevisionsSplitContainer.Panel2Collapsed)
+            if (!RevisionsSplitContainer.Panel2Collapsed && RevisionsSplitContainer.FixedPanel == FixedPanel.Panel2)
             {
                 RevisionsSplitContainer.SplitterDistance -= 4;
             }

--- a/GitUI/SplitterManager.cs
+++ b/GitUI/SplitterManager.cs
@@ -59,6 +59,7 @@ namespace GitUI
             private string DistanceSettingsKey => _settingName + "_Distance";
             private string FontSizeSettingsKey => _settingName + "_FontSize";
             private string Panel1CollapsedSettingsKey => _settingName + "_Panel1Collapsed";
+            private string Panel2CollapsedSettingsKey => _settingName + "_Panel2Collapsed";
 
             public void RestoreFromSettings(ISettingsSource settings)
             {
@@ -100,6 +101,7 @@ namespace GitUI
                 }
 
                 _splitter.Panel1Collapsed = settings.GetBool(Panel1CollapsedSettingsKey, defaultValue: false);
+                _splitter.Panel2Collapsed = settings.GetBool(Panel2CollapsedSettingsKey, defaultValue: false);
 
                 _splitter.ResumeLayout();
                 _splitter.EndInit();
@@ -112,6 +114,7 @@ namespace GitUI
                 settings.SetInt(DistanceSettingsKey, _splitter.SplitterDistance);
                 settings.SetFloat(FontSizeSettingsKey, _splitter.Font.Size);
                 settings.SetBool(Panel1CollapsedSettingsKey, _splitter.Panel1Collapsed);
+                settings.SetBool(Panel2CollapsedSettingsKey, _splitter.Panel2Collapsed);
             }
 
             private void SetSplitterDistance(float distance)


### PR DESCRIPTION
Fixes splitter position not being restored correctly if CommitInfo is displayed "left of graph".

## Proposed changes

- Do not apply the workaround in `FormBrowse.SetSplitterPositions` if not necessary, i.e. if CommitInfo is displayed "left of graph"
- `SplitterManager`: Also store `Panel2Collapsed` (generic issue)

## Test methodology <!-- How did you ensure quality? -->

- manual with CommitInfo both "left of graph" and "right of graph"

## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 33.33.33
- Build adf518415a85e0f23dbc913f27213089559182ff
- Git 2.39.0.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).