### PR TITLE
Fix url openings in plugins

### DIFF
--- a/GitCommands/Git/OsShellUtil.cs
+++ b/GitCommands/Git/OsShellUtil.cs
@@ -1,5 +1,4 @@
-﻿using GitCommands;
-namespace GitUI
+﻿namespace GitCommands
 {
     public static class OsShellUtil
     {
@@ -29,19 +28,10 @@ namespace GitUI
             new Executable("rundll32.exe").Start("shell32.dll,OpenAs_RunDLL " + filePath, redirectOutput: true, outputEncoding: System.Text.Encoding.UTF8);
         }
 
-        public static void SelectPathInFileExplorer(string filePath)
-        {
-            OpenWithFileExplorer($"/select, {filePath.Quote()}", quote: false);
-        }
+        public static void SelectPathInFileExplorer(string filePath) => OpenWithFileExplorer($"/select, {filePath.Quote()}", quote: false);
 
-        public static void OpenWithFileExplorer(string arguments, bool quote = true)
-        {
-            new Executable("explorer.exe").Start(quote ? arguments.Quote() : arguments);
-        }
+        public static void OpenWithFileExplorer(string arguments, bool quote = true) => new Executable("explorer.exe").Start(quote ? arguments.Quote() : arguments);
 
-        /// <summary>
-        /// opens urls even with anchor.
-        /// </summary>
         public static void OpenUrlInDefaultBrowser(string? url)
         {
             if (!string.IsNullOrWhiteSpace(url))

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseUtil.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseUtil.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.CommandsDialogs.BrowseDialog
+﻿using GitCommands;
+
+namespace GitUI.CommandsDialogs.BrowseDialog
 {
     internal static class FormBrowseUtil
     {

--- a/GitUI/CommandsDialogs/BrowseDialog/FormDonate.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormDonate.cs
@@ -1,4 +1,5 @@
-﻿using ResourceManager;
+﻿using GitCommands;
+using ResourceManager;
 
 namespace GitUI.CommandsDialogs.BrowseDialog
 {

--- a/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
+++ b/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Net;
+using GitCommands;
 using GitCommands.Settings;
 using GitUI.UserControls;
 using GitUIPluginInterfaces;

--- a/GitUI/GitExtensionsDialog.cs
+++ b/GitUI/GitExtensionsDialog.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using GitCommands;
 using GitExtUtils.GitUI.Theming;
 
 namespace GitUI

--- a/GitUI/UserControls/FolderBrowserButton.cs
+++ b/GitUI/UserControls/FolderBrowserButton.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft;
+﻿using GitCommands;
+using Microsoft;
 using ResourceManager;
 
 namespace GitUI.UserControls

--- a/GitUI/UserControls/GotoUserManualControl.cs
+++ b/GitUI/UserControls/GotoUserManualControl.cs
@@ -1,4 +1,5 @@
-﻿using ResourceManager;
+﻿using GitCommands;
+using ResourceManager;
 
 namespace GitUI.UserControls
 {

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Text;
+using GitCommands;
 using GitCommands.Git;
 using GitExtUtils;
 using GitUI;
@@ -423,7 +424,7 @@ namespace GitExtensions.Plugins.Bitbucket
                 }
                 else
                 {
-                    System.Diagnostics.Process.Start(link);
+                    OsShellUtil.OpenUrlInDefaultBrowser(link);
                 }
             }
             catch

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.cs
@@ -1,5 +1,5 @@
 using System.ComponentModel.Composition;
-using System.Diagnostics;
+using GitCommands;
 using GitUI;
 using GitUIPluginInterfaces;
 using GitUIPluginInterfaces.BuildServerIntegration;
@@ -123,7 +123,7 @@ namespace AzureDevOpsIntegration.Settings
 
         private void RestApiTokenLink_Click(object sender, EventArgs e)
         {
-            Process.Start(TokenManagementUrl);
+            OsShellUtil.OpenUrlInDefaultBrowser(TokenManagementUrl);
         }
 
         private void ExtractLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using GitCommands;
 using GitExtensions.Plugins.GitFlow.Properties;
@@ -393,7 +392,7 @@ namespace GitExtensions.Plugins.GitFlow
 
         private void lnkGitFlow_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start("https://github.com/nvie/gitflow");
+            OsShellUtil.OpenUrlInDefaultBrowser("https://github.com/nvie/gitflow");
         }
 
         private void DisplayHead()

--- a/Plugins/GitHub3/GitHub3Plugin.cs
+++ b/Plugins/GitHub3/GitHub3Plugin.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.Composition;
-using System.Diagnostics;
 using Git.hub;
+using GitCommands;
 using GitCommands.Config;
 using GitCommands.Remotes;
 using GitExtensions.Plugins.GitHub3.Properties;
@@ -124,13 +124,7 @@ namespace GitExtensions.Plugins.GitHub3
         {
             try
             {
-                ProcessStartInfo psi = new(url)
-                {
-                    UseShellExecute = true,
-                    Verb = "open"
-                };
-
-                Process.Start(psi);
+                OsShellUtil.OpenUrlInDefaultBrowser(url);
             }
             catch (Exception ex)
             {
@@ -267,7 +261,6 @@ namespace GitExtensions.Plugins.GitHub3
 
             ToolStripMenuItem toolStripMenuItem = new(string.Format(_viewInWebSite.Text, Name), Icon);
             contextMenu.Items.Add(toolStripMenuItem);
-            toolStripMenuItem.Click += (s, e) => Process.Start(_hostedRemotesForModule.First().Data);
 
             foreach (IHostedRemote hostedRemote in _hostedRemotesForModule.OrderBy(r => r.Data))
             {
@@ -276,8 +269,7 @@ namespace GitExtensions.Plugins.GitHub3
                 {
                     if (contextMenu.Tag is GitBlameContext blameContext)
                     {
-                        Process.Start(
-                            hostedRemote.GetBlameUrl(
+                        OsShellUtil.OpenUrlInDefaultBrowser(hostedRemote.GetBlameUrl(
                                 blameContext.BlameId.ToString(),
                                 blameContext.FileName,
                                 blameContext.LineIndex + 1));

--- a/Plugins/Gource/GourceStart.cs
+++ b/Plugins/Gource/GourceStart.cs
@@ -155,7 +155,7 @@ namespace GitExtensions.Plugins.Gource
 
         private void linkLabel1_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(@"https://github.com/acaudwell/Gource/");
+            OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/acaudwell/Gource/");
         }
 
         private void linkLabel2_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.Composition;
-using System.Diagnostics;
 using Atlassian.Jira;
+using GitCommands;
 using GitExtensions.Plugins.JiraCommitHintPlugin.Properties;
 using GitExtUtils.GitUI;
 using GitUI;
@@ -124,7 +124,7 @@ namespace GitExtensions.Plugins.JiraCommitHintPlugin
 
             try
             {
-                Process.Start(_urlSettings.CustomControl.Text + "/secure/IssueNavigator.jspa?mode=show&createNew=true");
+                OsShellUtil.OpenUrlInDefaultBrowser(_urlSettings.CustomControl.Text + "/secure/IssueNavigator.jspa?mode=show&createNew=true");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
because the way to open url has changed since .net core

I had to move `OsShellUtil` to `GitCommands.csproj`
so that it is available in plugins
to prevent code duplication

Fixes  #10726 and #10728 (and similar bugs in other plugins)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build f4ca8cfafac6d436200ac2edb7b74f8fc539a53a (Dirty)
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.13
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.11 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.13 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.2 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
