### PR TITLE
EditNetSpell: Avoid unhandled-key sound for cursor keys

### DIFF
--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using GitCommands;
 using GitCommands.Settings;
 using GitUI.AutoCompletion;
+using GitUI.UserControls;
 using GitUIPluginInterfaces.Settings;
 using Microsoft;
 using Microsoft.VisualStudio.Threading;
@@ -66,6 +67,8 @@ namespace GitUI.SpellChecker
             AutoComplete.DisplayMember = nameof(AutoCompleteWord.Word);
 
             _wordAtCursorExtractor = new WordAtCursorExtractor();
+
+            _ = new TextBoxSilencer(TextBox);
         }
 
         public override string Text

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -727,25 +727,6 @@ namespace GitUI.SpellChecker
             }
 
             OnKeyDown(e);
-
-            // Avoid the unhandled-key sound for cursor keys
-            if (!e.Handled && !e.SuppressKeyPress)
-            {
-                switch (e.KeyCode)
-                {
-                    case Keys.Up:
-                    case Keys.Down:
-                    case Keys.Left:
-                    case Keys.Right:
-                    case Keys.PageUp:
-                    case Keys.PageDown:
-                    case Keys.Home:
-                    case Keys.End:
-                        e.Handled = true;
-                        e.SuppressKeyPress = true;
-                        break;
-                }
-            }
         }
 
         private void PasteTextFromClipboard()

--- a/GitUI/UserControls/TextBoxSilencer.cs
+++ b/GitUI/UserControls/TextBoxSilencer.cs
@@ -1,0 +1,63 @@
+﻿namespace GitUI.UserControls
+{
+    /// <summary>
+    /// Suppresses invalid cursor movement keypresses in order to avoid the "ding" sound.
+    /// </summary>
+    /// The end positions cannot be retrieved in the KeyDown handler
+    /// because they are implemented using SendMessage calls.
+    internal sealed class TextBoxSilencer
+    {
+        private static readonly char[] _lineEndChars = { '\r', '\n' };
+
+        private RichTextBox _textBox;
+
+        private bool _isAtFirstColumn;
+        private bool _isAtEndColumn;
+        private bool _isAtFirstLine;
+        private bool _isAtLastLine;
+
+        public TextBoxSilencer(RichTextBox textBox)
+        {
+            _textBox = textBox;
+            _textBox.SelectionChanged += (s, e) => UpdatePositionFlags();
+            _textBox.KeyDown += OnKeyDown;
+        }
+
+        private void OnKeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Handled)
+            {
+                return;
+            }
+
+            switch (e.KeyCode)
+            {
+                case Keys.Up when _isAtFirstLine:
+                case Keys.Down when _isAtLastLine:
+                case Keys.Home when _isAtFirstColumn:
+                case Keys.End when _isAtEndColumn:
+                case Keys.Left or Keys.PageUp when _isAtFirstLine && _isAtFirstColumn:
+                case Keys.Right or Keys.PageDown when _isAtLastLine && _isAtEndColumn:
+                    e.Handled = true;
+                    break;
+            }
+        }
+
+        private void UpdatePositionFlags()
+        {
+            string text = _textBox.Text;
+            int position = _textBox.SelectionStart;
+
+            _isAtFirstColumn = position == _textBox.GetFirstCharIndexOfCurrentLine();
+            _isAtEndColumn = position == GetLineEnd(text, startIndex: position);
+            _isAtFirstLine = position <= GetLineEnd(text, startIndex: 0);
+            _isAtLastLine = text.IndexOfAny(_lineEndChars, startIndex: position) < 0;
+        }
+
+        private static int GetLineEnd(string text, int startIndex)
+        {
+            int eol = text.IndexOfAny(_lineEndChars, startIndex);
+            return eol >= startIndex ? eol : text.Length;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10715

## Proposed changes

Mark cursor key presses as handled if the `EditNetSpell`'s `RichTextBox` will not handle them
in order to suppress the unhandled-key sound ("ding")
primarily when editing the commit message
This is done in dependency on the current cursor position because the `KeyEventArgs.Handled` flag is not set (yet) if the RichTextBox handles the key.

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 6400348c7fb4b0a94d8f0194014533bd71120be9
- Git 2.39.0.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).