### PR TITLE
CommitInfo: Do not try to parse commit-hash look-alike inside e-mail address

### DIFF
--- a/Plugins/GitUIPluginInterfaces/GitRevision.cs
+++ b/Plugins/GitUIPluginInterfaces/GitRevision.cs
@@ -19,7 +19,7 @@ namespace GitUIPluginInterfaces
         public const string CombinedDiffGuid = "3333333333333333333333333333333333333333";
 
         public static readonly Regex Sha1HashRegex = new(@"^[a-f\d]{40}$", RegexOptions.Compiled);
-        public static readonly Regex Sha1HashShortRegex = new(@"\b[a-f\d]{7,40}\b", RegexOptions.Compiled);
+        public static readonly Regex Sha1HashShortRegex = new(@"\b[a-f\d]{7,40}\b(?![^@\s]*@)", RegexOptions.Compiled);
 
         private BuildInfo? _buildStatus;
         private string? _body;

--- a/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataBodyRendererTests.cs
+++ b/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataBodyRendererTests.cs
@@ -37,14 +37,14 @@ namespace ResourceManagerTests.CommitDataRenders
         [Test]
         public void Render_should_render_body_with_links()
         {
-            _module.TryResolvePartialCommitId("b3e7944792", out _).Returns(x =>
+            _module.TryResolvePartialCommitId(Arg.Any<string>(), out _).Returns(ci =>
             {
-                x[1] = ObjectId.Parse("b3e79447928051cfb3494c9c0ef1a1d0ecde56a8");
-                return true;
-            });
-            _module.TryResolvePartialCommitId("11119447928051cfb3494c9c0ef1a1d0ecde56a8", out _).Returns(x =>
-            {
-                x[1] = ObjectId.Parse("11119447928051cfb3494c9c0ef1a1d0ecde56a8");
+                ci[1] = ci[0] switch
+                {
+                    "b3e7944" => ObjectId.Parse("b3e79447928051cfb3494c9c0ef1a1d0ecde56a8"),
+                    "11119447928051cfb3494c9c0ef1a1d0ecde56a8" => ObjectId.Parse((string)ci[0]),
+                    _ => throw new Exception($"<shall not be called for {ci[0]}>")
+                };
                 return true;
             });
 
@@ -54,16 +54,20 @@ namespace ResourceManagerTests.CommitDataRenders
                 "John Doe <John.Doe@test.com>", DateTime.UtcNow,
                 @"fix\n\nAllow cherry-picking multiple commits from FormBrowse menu
 
+This short hex number shall not be turned into a link 12ab56.
+b3e79447928051cfb3494c9c0ef1a1d0ecde56a8f is too long for a commit hash.
 The ability to do so from the RevisionGrid context menu has been added in commit
-b3e7944792 and 11119447928051cfb3494c9c0ef1a1d0ecde56a8
+b3e7944 and 11119447928051cfb3494c9c0ef1a1d0ecde56a8.
 ");
 
             var result = _rendererReal.Render(data, true);
 
             result.Should().Be(@"fix\n\nAllow cherry-picking multiple commits from FormBrowse menu
 
+This short hex number shall not be turned into a link 12ab56.
+b3e79447928051cfb3494c9c0ef1a1d0ecde56a8f is too long for a commit hash.
 The ability to do so from the RevisionGrid context menu has been added in commit
-<a href='gitext://gotocommit/b3e79447928051cfb3494c9c0ef1a1d0ecde56a8'>b3e7944792</a> and <a href='gitext://gotocommit/11119447928051cfb3494c9c0ef1a1d0ecde56a8'>11119447928051cfb3494c9c0ef1a1d0ecde56a8</a>");
+<a href='gitext://gotocommit/b3e79447928051cfb3494c9c0ef1a1d0ecde56a8'>b3e7944</a> and <a href='gitext://gotocommit/11119447928051cfb3494c9c0ef1a1d0ecde56a8'>11119447928051cfb3494c9c0ef1a1d0ecde56a8</a>.");
         }
 
         [Test]

--- a/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataBodyRendererTests.cs
+++ b/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataBodyRendererTests.cs
@@ -52,11 +52,18 @@ namespace ResourceManagerTests.CommitDataRenders
                 Array.Empty<ObjectId>(),
                 "John Doe (Acme Inc) <John.Doe@test.com>", DateTime.UtcNow,
                 "John Doe <John.Doe@test.com>", DateTime.UtcNow,
-                "fix\n\nAllow cherry-picking multiple commits from FormBrowse menu\r\n\r\nThe ability to do so from the RevisionGrid context menu has been added in commit\r\nb3e7944792 and 11119447928051cfb3494c9c0ef1a1d0ecde56a8\r\n");
+                @"fix\n\nAllow cherry-picking multiple commits from FormBrowse menu
+
+The ability to do so from the RevisionGrid context menu has been added in commit
+b3e7944792 and 11119447928051cfb3494c9c0ef1a1d0ecde56a8
+");
 
             var result = _rendererReal.Render(data, true);
 
-            result.Should().Be("fix\n\nAllow cherry-picking multiple commits from FormBrowse menu\r\n\r\nThe ability to do so from the RevisionGrid context menu has been added in commit\r\n<a href='gitext://gotocommit/b3e79447928051cfb3494c9c0ef1a1d0ecde56a8'>b3e7944792</a> and <a href='gitext://gotocommit/11119447928051cfb3494c9c0ef1a1d0ecde56a8'>11119447928051cfb3494c9c0ef1a1d0ecde56a8</a>");
+            result.Should().Be(@"fix\n\nAllow cherry-picking multiple commits from FormBrowse menu
+
+The ability to do so from the RevisionGrid context menu has been added in commit
+<a href='gitext://gotocommit/b3e79447928051cfb3494c9c0ef1a1d0ecde56a8'>b3e7944792</a> and <a href='gitext://gotocommit/11119447928051cfb3494c9c0ef1a1d0ecde56a8'>11119447928051cfb3494c9c0ef1a1d0ecde56a8</a>");
         }
 
         [Test]

--- a/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataBodyRendererTests.cs
+++ b/UnitTests/ResourceManager.Tests/CommitDataRenders/CommitDataBodyRendererTests.cs
@@ -54,20 +54,22 @@ namespace ResourceManagerTests.CommitDataRenders
                 "John Doe <John.Doe@test.com>", DateTime.UtcNow,
                 @"fix\n\nAllow cherry-picking multiple commits from FormBrowse menu
 
-This short hex number shall not be turned into a link 12ab56.
+This short hex number shall not be turned into a link 12ab56, neither a github e-mail 1234567+user@github.com
 b3e79447928051cfb3494c9c0ef1a1d0ecde56a8f is too long for a commit hash.
 The ability to do so from the RevisionGrid context menu has been added in commit
-b3e7944 and 11119447928051cfb3494c9c0ef1a1d0ecde56a8.
+b3e7944 and 11119447928051cfb3494c9c0ef1a1d0ecde56a8
+@line 42.
 ");
 
             var result = _rendererReal.Render(data, true);
 
             result.Should().Be(@"fix\n\nAllow cherry-picking multiple commits from FormBrowse menu
 
-This short hex number shall not be turned into a link 12ab56.
+This short hex number shall not be turned into a link 12ab56, neither a github e-mail 1234567+user@github.com
 b3e79447928051cfb3494c9c0ef1a1d0ecde56a8f is too long for a commit hash.
 The ability to do so from the RevisionGrid context menu has been added in commit
-<a href='gitext://gotocommit/b3e79447928051cfb3494c9c0ef1a1d0ecde56a8'>b3e7944</a> and <a href='gitext://gotocommit/11119447928051cfb3494c9c0ef1a1d0ecde56a8'>11119447928051cfb3494c9c0ef1a1d0ecde56a8</a>.");
+<a href='gitext://gotocommit/b3e79447928051cfb3494c9c0ef1a1d0ecde56a8'>b3e7944</a> and <a href='gitext://gotocommit/11119447928051cfb3494c9c0ef1a1d0ecde56a8'>11119447928051cfb3494c9c0ef1a1d0ecde56a8</a>
+@line 42.");
         }
 
         [Test]


### PR DESCRIPTION
Fixes #10736

## Proposed changes

- `Sha1HashShortRegex`: Do not match e-mail address
- CommitInfo: Parse commit hashes in commit message asynchronously, namely the call `commitDataBodyRenderer.Render()`

## Test methodology <!-- How did you ensure quality? -->

- improve and extend existing testcase

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 8f4b36162c134ceb0a493a000e5d3a400da40aa2
- Git 2.39.2.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).