### PR TITLE
Fix: "Ctrl+Enter" creates commit when Enter is released, not pressed

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1104,6 +1104,7 @@ namespace GitUI.CommandsDialogs
             this.Message.SelectionChanged += new System.EventHandler(this.Message_SelectionChanged);
             this.Message.Enter += new System.EventHandler(this.Message_Enter);
             this.Message.KeyDown += new System.Windows.Forms.KeyEventHandler(this.Message_KeyDown);
+            this.Message.KeyUp += new System.Windows.Forms.KeyEventHandler(this.Message_KeyUp);
             // 
             // flowCommitButtons
             // 

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1104,7 +1104,6 @@ namespace GitUI.CommandsDialogs
             this.Message.SelectionChanged += new System.EventHandler(this.Message_SelectionChanged);
             this.Message.Enter += new System.EventHandler(this.Message_Enter);
             this.Message.KeyDown += new System.Windows.Forms.KeyEventHandler(this.Message_KeyDown);
-            this.Message.KeyUp += new System.Windows.Forms.KeyEventHandler(this.Message_KeyUp);
             // 
             // flowCommitButtons
             // 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -863,7 +863,7 @@ namespace GitUI.CommandsDialogs
                 case Command.Refresh: RescanChanges(); return true;
                 case Command.SelectNext:
                 case Command.SelectNext_AlternativeHotkey1:
-                case Command.SelectNext_AlternativeHotkey2: MoveSelection(1); return true;
+                case Command.SelectNext_AlternativeHotkey2: MoveSelection(1);  return true;
                 case Command.SelectPrevious:
                 case Command.SelectPrevious_AlternativeHotkey1:
                 case Command.SelectPrevious_AlternativeHotkey2: MoveSelection(-1); return true;
@@ -2804,6 +2804,16 @@ namespace GitUI.CommandsDialogs
             }
         }
 
+        private void Message_KeyUp(object sender, KeyEventArgs e)
+        {
+            // Ctrl + Enter = Commit
+            if (e.Control && e.KeyCode == Keys.Enter)
+            {
+                ExecuteCommitCommand();
+                e.Handled = true;
+            }
+        }
+
         private void ExecuteCommitCommand()
         {
             CheckForStagedAndCommit(amend: Amend.Checked, push: false, resetAuthor: Amend.Checked && ResetAuthor.Checked);
@@ -2812,10 +2822,8 @@ namespace GitUI.CommandsDialogs
         private void Message_KeyDown(object sender, KeyEventArgs e)
         {
             // Prevent adding a line break when all we want is to commit
-            // Ctrl + Enter = Commit
             if (e.Control && e.KeyCode == Keys.Enter)
             {
-                ExecuteCommitCommand();
                 e.Handled = true;
             }
         }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -863,7 +863,7 @@ namespace GitUI.CommandsDialogs
                 case Command.Refresh: RescanChanges(); return true;
                 case Command.SelectNext:
                 case Command.SelectNext_AlternativeHotkey1:
-                case Command.SelectNext_AlternativeHotkey2: MoveSelection(1);  return true;
+                case Command.SelectNext_AlternativeHotkey2: MoveSelection(1); return true;
                 case Command.SelectPrevious:
                 case Command.SelectPrevious_AlternativeHotkey1:
                 case Command.SelectPrevious_AlternativeHotkey2: MoveSelection(-1); return true;
@@ -2804,16 +2804,6 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void Message_KeyUp(object sender, KeyEventArgs e)
-        {
-            // Ctrl + Enter = Commit
-            if (e.Control && e.KeyCode == Keys.Enter)
-            {
-                ExecuteCommitCommand();
-                e.Handled = true;
-            }
-        }
-
         private void ExecuteCommitCommand()
         {
             CheckForStagedAndCommit(amend: Amend.Checked, push: false, resetAuthor: Amend.Checked && ResetAuthor.Checked);
@@ -2822,8 +2812,10 @@ namespace GitUI.CommandsDialogs
         private void Message_KeyDown(object sender, KeyEventArgs e)
         {
             // Prevent adding a line break when all we want is to commit
+            // Ctrl + Enter = Commit
             if (e.Control && e.KeyCode == Keys.Enter)
             {
+                ExecuteCommitCommand();
                 e.Handled = true;
             }
         }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2811,8 +2811,6 @@ namespace GitUI.CommandsDialogs
 
         private void Message_KeyDown(object sender, KeyEventArgs e)
         {
-            // Prevent adding a line break when all we want is to commit
-            // Ctrl + Enter = Commit
             if (e.Control && e.KeyCode == Keys.Enter)
             {
                 ExecuteCommitCommand();

--- a/contributors.txt
+++ b/contributors.txt
@@ -186,3 +186,4 @@ YYYY/MM/DD, github id, Full name, email
 2022/11/30, SaumyaBhushan, Saumya, saumya@knoldus.com
 2022/12/15, siyavash1984,Siyavash Khojasteh, khojasteh(at)outlook.com
 2023/01/27, MaxKoll, Maximilian Koll, maximiliankoll(at)web(dot)de
+2023/02/24, RauulDev, Raul Molina, remolina7@gmail.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Fix: Replaced KeyUp event with KeyDown in order to handle commit action in FormCommit.cs

## Test methodology

- Manual and I ran all tests:
![image](https://user-images.githubusercontent.com/71405194/221253494-f955d365-c1e0-4f7a-a0e0-c81d22775e6c.png)

## Test environment(s)

- GIT git version 2.33.0.windows.2
- Windows 10 Pro 21H2 19044.2486

## Merge strategy
I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
