### PR TITLE
Improve robustness of GitStatusMonitor

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -437,6 +437,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                                 GitWorkingDirectoryStatusChanged?.Invoke(this, new GitWorkingDirectoryStatusEventArgs(changedFiles));
                             }
                         }
+                        catch (OperationCanceledException)
+                        {
+                            // No action
+                        }
                         catch
                         {
                             try
@@ -455,7 +459,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                         {
                             lock (_statusSequence)
                             {
-                                if (_commandIsRunning && !ModuleHasChanged() && !cancelToken.IsCancellationRequested)
+                                if (!ModuleHasChanged() && !cancelToken.IsCancellationRequested)
                                 {
                                     // Adjust the min time to next update
                                     int endTime = Environment.TickCount;
@@ -469,10 +473,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                                     }
                                 }
 
-                                if (!cancelToken.IsCancellationRequested)
-                                {
-                                    _commandIsRunning = false;
-                                }
+                                _commandIsRunning = false;
                             }
                         }
                     })
@@ -518,7 +519,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             // Start commands, also if running already
             lock (_statusSequence)
             {
-                _commandIsRunning = false;
                 _statusSequence.CancelCurrent();
 
                 int ticks = Environment.TickCount;


### PR DESCRIPTION
Fixes #9955

## Proposed changes

- GitStatusMonitor: Correctly handle cancellation
  - There is no need to stop the monitor on OperationCanceledException.
  - There is no more command running if cancelled.
- GitStatusMonitor: Stop only if retry fails, too
  - E.g. I have seen the git index being locked perhaps due to VS Code getting the status.
- GitStatusMonitor: Call `InvalidateGitWorkingDirectoryStatus()`, too, on enter of `GitStatusMonitorState.Stopped`

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build cf19d8dc7ec512991faf8fbf8bd01bc1f7459a9c
- Git 2.39.2.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.12
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

Please do **not squash merge** this PR

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).