### PR TITLE
Fix: "copy new version" and "old version" in diff view keep unwanted text

### DIFF
--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -786,9 +786,12 @@ namespace GitUI.Editor
                     code = " " + code;
                 }
 
-                var lines = code.LazySplit('\n')
-                    .Where(s => s.Length == 0 || s[0] != startChar || (s.Length > 2 && s[1] == s[0] && s[2] == s[0]));
                 var hpos = fileText.IndexOf("\n@@");
+
+                var lines = code.LazySplit('\n')
+                    .Where(s => !s.StartsWith("@@")
+                    && code.IndexOf(s) > hpos
+                    && (s.Length == 0 || s[0] != startChar || (s.Length > 2 && s[1] == s[0] && s[2] == s[0])));
 
                 // if header is selected then don't remove diff extra chars
                 if (hpos <= pos)


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/issues/8439

## Proposed changes

- Added fix to filter lines before hpos character on FileViewer.cs

## Screenshots

![image](https://user-images.githubusercontent.com/71405194/221444400-c48eef16-3e20-41e9-b754-6a447df28dad.png)

## Test methodology

- Manual


## Test environment(s)

- GIT git version 2.33.0.windows.2
- Windows 10 Pro 21H2 19044.2486

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
