### PR TITLE
Straighten revision graph in more cases

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -501,6 +501,11 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
                             segmentOrAncestor = lookaheadRow.FirstParentOrSelf(segmentOrAncestor);
                         }
+
+                        if (moved)
+                        {
+                            break;
+                        }
                     }
 
                     // if moved, check again whether the lanes of the previous row can be moved, too

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -509,11 +509,15 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
                 bool MovingCausesWidthIncrease(int startIndex, int endIndex, int laneToMove)
                 {
-                    int previousRowWidth = localOrderedRowCache[startIndex - 1].GetLaneCount();
+                    int maxRowWidth = 0;
+                    for (int index = Math.Max(0, startIndex - _straightenLanesLookAhead); index < startIndex + _straightenLanesLookAhead && index < lastIndex; ++index)
+                    {
+                        maxRowWidth = Math.Max(maxRowWidth, localOrderedRowCache[index].GetLaneCount());
+                    }
 
                     for (int index = startIndex; index < endIndex; ++index)
                     {
-                        if (localOrderedRowCache[index].LaneCountAfterMovingLanesRight(laneToMove) > previousRowWidth)
+                        if (localOrderedRowCache[index].LaneCountAfterMovingLanesRight(laneToMove) > maxRowWidth)
                         {
                             return true;
                         }

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -463,26 +463,34 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                     {
                         int previousLane = previousRow.GetLaneIndexForSegment(revisionGraphSegment);
                         int currentLane = currentRow.GetLaneIndexForSegment(revisionGraphSegment);
-                        if (previousLane > currentLane)
-                        {
-                            int straightenedCurrentLane = currentLane + 1;
-                            int lookaheadLane = currentLane;
-                            int nextIndex = currentIndex + 1;
-                            for (int lookaheadIndex = nextIndex; lookaheadLane == currentLane && lookaheadIndex <= Math.Min(currentIndex + _straightenLanesLookAhead, lastIndex); ++lookaheadIndex)
-                            {
-                                lookaheadLane = localOrderedRowCache[lookaheadIndex].GetLaneIndexForSegment(revisionGraphSegment);
-                                if ((lookaheadLane == straightenedCurrentLane) || (lookaheadLane > straightenedCurrentLane && previousLane == straightenedCurrentLane))
-                                {
-                                    currentRow.MoveLanesRight(currentLane);
-                                    for (; nextIndex < lookaheadIndex; ++nextIndex)
-                                    {
-                                        localOrderedRowCache[nextIndex].MoveLanesRight(currentLane);
-                                    }
 
-                                    moved = true;
-                                    break;
+                        if (previousLane <= currentLane)
+                        {
+                            continue;
+                        }
+
+                        int straightenedCurrentLane = currentLane + 1;
+                        int lookaheadLane = currentLane;
+                        int nextIndex = currentIndex + 1;
+                        var segmentOrAncestor = localOrderedRowCache[currentIndex].FirstParentOrSelf(revisionGraphSegment);
+
+                        for (int lookaheadIndex = nextIndex; lookaheadLane == currentLane && lookaheadIndex <= Math.Min(currentIndex + _straightenLanesLookAhead, lastIndex); ++lookaheadIndex)
+                        {
+                            RevisionGraphRow lookaheadRow = localOrderedRowCache[lookaheadIndex];
+                            lookaheadLane = lookaheadRow.GetLaneIndexForSegment(segmentOrAncestor);
+                            if ((lookaheadLane == straightenedCurrentLane) || (lookaheadLane > straightenedCurrentLane && previousLane == straightenedCurrentLane))
+                            {
+                                currentRow.MoveLanesRight(currentLane);
+                                for (; nextIndex < lookaheadIndex; ++nextIndex)
+                                {
+                                    localOrderedRowCache[nextIndex].MoveLanesRight(currentLane);
                                 }
+
+                                moved = true;
+                                break;
                             }
+
+                            segmentOrAncestor = lookaheadRow.FirstParentOrSelf(segmentOrAncestor);
                         }
                     }
 

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -471,10 +471,9 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
                         int straightenedCurrentLane = currentLane + 1;
                         int lookaheadLane = currentLane;
-                        int nextIndex = currentIndex + 1;
                         var segmentOrAncestor = localOrderedRowCache[currentIndex].FirstParentOrSelf(revisionGraphSegment);
 
-                        for (int lookaheadIndex = nextIndex; lookaheadLane == currentLane && lookaheadIndex <= Math.Min(currentIndex + _straightenLanesLookAhead, lastIndex); ++lookaheadIndex)
+                        for (int lookaheadIndex = currentIndex + 1; lookaheadLane == currentLane && lookaheadIndex <= Math.Min(currentIndex + _straightenLanesLookAhead, lastIndex); ++lookaheadIndex)
                         {
                             RevisionGraphRow lookaheadRow = localOrderedRowCache[lookaheadIndex];
                             lookaheadLane = lookaheadRow.GetLaneIndexForSegment(segmentOrAncestor);
@@ -490,9 +489,9 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                                     break;
                                 }
 
-                                for (int index = currentIndex; index < lookaheadIndex; ++index)
+                                for (int moveIndex = currentIndex; moveIndex < lookaheadIndex; ++moveIndex)
                                 {
-                                    localOrderedRowCache[index].MoveLanesRight(currentLane);
+                                    localOrderedRowCache[moveIndex].MoveLanesRight(currentLane);
                                 }
 
                                 moved = true;

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -214,5 +214,20 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 ++_segmentLanes[segment];
             }
         }
+
+        /// <summary>
+        /// If this row is the parent row of <paramref name="segment"/>, returns the segment leading
+        /// to this row's first parent (if any). Otherwise, returns <paramref name="segment"/>.
+        /// </summary>
+        public RevisionGraphSegment FirstParentOrSelf(RevisionGraphSegment segment)
+        {
+            if (segment.Parent != Revision)
+            {
+                return segment;
+            }
+
+            return Segments.FirstOrDefault(s => s.Child == Revision)
+                ?? segment;
+        }
     }
 }

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft;
+﻿using System.Runtime.CompilerServices;
+using Microsoft;
 
 namespace GitUI.UserControls.RevisionGrid.Graph
 {
@@ -11,6 +12,8 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         IEnumerable<RevisionGraphSegment> GetSegmentsForIndex(int index);
         int GetLaneIndexForSegment(RevisionGraphSegment revisionGraphRevision);
         void MoveLanesRight(int fromLane);
+        int LaneCountAfterMovingLanesRight(int laneIndex);
+        bool HasGap(int currentLane, int curLane);
     }
 
     // The RevisionGraphRow contains an ordered list of Segments that crosses the row or connects to the revision in the row.
@@ -215,6 +218,21 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             }
         }
 
+        public int LaneCountAfterMovingLanesRight(int laneIndex)
+        {
+            if (laneIndex >= _laneCount)
+            {
+                return _laneCount;
+            }
+
+            if (_gaps?.Any(g => g > laneIndex) == true)
+            {
+                return _laneCount;
+            }
+
+            return _laneCount + 1;
+        }
+
         /// <summary>
         /// If this row is the parent row of <paramref name="segment"/>, returns the segment leading
         /// to this row's first parent (if any). Otherwise, returns <paramref name="segment"/>.
@@ -228,6 +246,28 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
             return Segments.FirstOrDefault(s => s.Child == Revision)
                 ?? segment;
+        }
+
+        /// <summary>
+        /// Returns true if this row has a gap between <paramref name="firstLane"/> and <paramref name="lastLane"/>,
+        /// inclusive
+        /// </summary>
+        public bool HasGap(int firstLane, int lastLane)
+        {
+            if (_gaps is null)
+            {
+                return false;
+            }
+
+            for (int lane = firstLane; lane <= lastLane; ++lane)
+            {
+                if (_gaps.Contains(lane))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphRowTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphRowTests.cs
@@ -52,10 +52,12 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
             List<RevisionGraphSegment> segments = new() { _segment, _segment1, _segment2 };
             IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments);
             revisionGraphRow.GetLaneCount().Should().Be(3);
+            int newLaneCount = revisionGraphRow.LaneCountAfterMovingLanesRight(fromLane);
 
             revisionGraphRow.MoveLanesRight(fromLane);
 
-            revisionGraphRow.GetLaneCount().Should().Be(fromLane >= segments.Count ? segments.Count : segments.Count + 1);
+            newLaneCount.Should().Be(revisionGraphRow.GetLaneCount());
+            revisionGraphRow.GetLaneCount().Should().Be(expectedLane2 + 1);
             revisionGraphRow.GetLaneIndexForSegment(_segment).Should().Be(expectedLane);
             revisionGraphRow.GetLaneIndexForSegment(_segment1).Should().Be(expectedLane1);
             revisionGraphRow.GetLaneIndexForSegment(_segment2).Should().Be(expectedLane2);
@@ -88,8 +90,12 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
             revisionGraphRow.GetLaneCount().Should().Be(3);
 
             revisionGraphRow.MoveLanesRight(fromLane1);
+
+            int newLaneCount = revisionGraphRow.LaneCountAfterMovingLanesRight(fromLane2);
+
             revisionGraphRow.MoveLanesRight(fromLane2);
 
+            newLaneCount.Should().Be(revisionGraphRow.GetLaneCount());
             revisionGraphRow.GetLaneCount().Should().Be(expectedLane2 + 1);
             revisionGraphRow.GetLaneIndexForSegment(_segment).Should().Be(expectedLane);
             revisionGraphRow.GetLaneIndexForSegment(_segment1).Should().Be(expectedLane1);

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
@@ -276,6 +276,30 @@ namespace GitUITests.UserControls.RevisionGrid
         }
 
         [Test]
+        public void SegmentsAreStraightenedWhenGraphIsWideEnoughCloseBy()
+        {
+            var revisionGraph = CreateGraph(" 1  2:1  3:1  6:1  7:1,6  8:3,2  9:7  10:7,9,8 ");
+
+            AssertGraphLayout(revisionGraph, @"
+                *
+                |\--\
+                | * |
+                |/  |
+                |   *
+                |   |\
+                *   | |
+                |\  | |
+                | * | |
+                |/ / /
+                | * |
+                |/ /
+                | *
+                |/
+                *
+            ");
+        }
+
+        [Test]
         public void SegmentsAreNotStraightenedIfThisCausesALargerShiftForAnotherSegment()
         {
             var revisionGraph = CreateGraph(" 1  a:1  b:1  2:1  3:1  4:1  5:4,1  6:3  7:5,6  8:7,2,6  c:8  d:8  e:8  9:8,e,d,c,b,a ");

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
@@ -139,6 +139,114 @@ namespace GitUITests.UserControls.RevisionGrid
             _revisionGraph.CacheTo(_revisionGraph.Count, _revisionGraph.Count);
 
             Assert.AreEqual(1, _revisionGraph.GetSegmentsForRow(1).GetCurrentRevisionLane());
+
+            AssertGraphLayout(_revisionGraph, @"
+                *
+                |
+                | *
+                |
+                *
+            ");
+        }
+
+        [Test]
+        public void SegmentsAreStraightened()
+        {
+            var revisionGraph = CreateGraph(" 1  2:1  3:1  4:1,3  5:4  6:5  7:5,6  8:7,2 ");
+
+            AssertGraphLayout(revisionGraph, @"
+                *
+                |\
+                * |
+                |\ \
+                | * |
+                |/  |
+                *   |
+                |   |
+                *   |
+                |\  |
+                | * |
+                |/ /
+                | *
+                |/
+                *
+            ");
+        }
+
+        [Test]
+        public void SegmentsWithCommitsAreStraightened()
+        {
+            var revisionGraph = CreateGraph(" 1  2:1  3:1  4:1,3  5:2  6:5  7:4  8:4,7  9:8,6 ");
+
+            AssertGraphLayout(revisionGraph, @"
+                *
+                |\
+                * |
+                |\ \
+                | * |
+                |/  |
+                |   *
+                |   |
+                |   *
+                |   |
+                *   |
+                |\  |
+                | * |
+                |/ /
+                | *
+                |/
+                *
+            ");
+        }
+
+        [Test]
+        public void SegmentsWithOutgoingMergesAreStraightened()
+        {
+            var revisionGraph = CreateGraph(" 1  2:1  3:1  4:1,3  5:2  6:4,5  7:6  8:6,7  9:8,5 ");
+
+            AssertGraphLayout(revisionGraph, @"
+                *
+                |\
+                * |
+                |\ \
+                | * |
+                |/  |
+                *   |
+                |\--|
+                |   *
+                |   |
+                *   |
+                |\  |
+                | * |
+                |/ /
+                | *
+                |/
+                *
+            ");
+        }
+
+        [Test]
+        public void SegmentsWithIncomingMergesAreStraightened()
+        {
+            var revisionGraph = CreateGraph(" 1  2:1  3:1  4:1,3  5:2,4  6:4  7:4,6  8:7,5 ");
+
+            AssertGraphLayout(revisionGraph, @"
+                *
+                |\
+                * |
+                |\ \
+                | * |
+                |/  |
+                |   *
+                |--/|
+                *   |
+                |\  |
+                | * |
+                |/ /
+                | *
+                |/
+                *
+            ");
         }
 
         private static int LookAhead => 20;
@@ -194,6 +302,195 @@ namespace GitUITests.UserControls.RevisionGrid
                 prevCommit.ParentIds = new ObjectId[] { };
                 yield return prevCommit;
             }
+        }
+
+        /// <summary>
+        /// Creates a revision graph from a text description that lists commits, space separated, from oldest to newest.
+        /// Each commit spec is {id}:{parent1 id},{parent2 id},...
+        /// or just {id} if it has no parent.
+        ///
+        /// E.g.: " 1   2:1   3:1   4:2,3 "
+        /// </summary>
+        private RevisionGraph CreateGraph(string commitSpecs)
+        {
+            List<GitRevision> commits = new();
+            Dictionary<string, GitRevision> commitsById = new();
+
+            // Parse and create commits
+            foreach (string spec in commitSpecs.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var parts = spec.Split(':');
+                string id = parts[0];
+
+                GitRevision commit = new(ObjectId.Random());
+                commits.Add(commit);
+                commitsById.Add(id, commit);
+
+                if (parts.Length > 1)
+                {
+                    string[] parentIds = parts[1].Split(',');
+                    commit.ParentIds = parentIds.Select(id => commitsById[id].ObjectId).ToList();
+                }
+            }
+
+            // Add commits to graph from newest to oldest
+            var graph = new RevisionGraph();
+            commits.Reverse();
+
+            foreach (var commit in commits)
+            {
+                graph.Add(commit);
+            }
+
+            graph.CacheTo(graph.Count, graph.Count);
+
+            return graph;
+        }
+
+        /// <summary>
+        /// Asserts that the ascii graph of <paramref name="revisionGraph"/> matches <paramref name="expectedLayout"/>.
+        /// For examples of how to specify <paramref name="expectedLayout"/>, see existing usage in tests.
+        /// </summary>
+        private void AssertGraphLayout(RevisionGraph revisionGraph, string expectedLayout)
+        {
+            var expectedLines = expectedLayout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+            var actualLines = AsciiGraphFor(revisionGraph);
+
+            try
+            {
+                CollectionAssert.AreEquivalent(expectedLines, actualLines);
+            }
+            catch (Exception)
+            {
+                // Mismatch: Show graph so it can be copied into test if correct
+                foreach (var l in actualLines)
+                {
+                    Console.WriteLine(l);
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Creates an ascii art representation of the <paramref name="revisionGraph"/> with the same layout
+        /// as the actual GE GUI.
+        /// </summary>
+        private static List<string> AsciiGraphFor(RevisionGraph revisionGraph)
+        {
+            List<string> graph = new();
+
+            int rowIndex = 0;
+            while (true)
+            {
+                // Create a line for commit
+
+                var row = revisionGraph.GetSegmentsForRow(rowIndex);
+                char[] line = Enumerable.Repeat(' ', (row.GetLaneCount() * 2) + 1).ToArray();
+
+                // Show '|' in lanes passing through
+                foreach (var segment in row.Segments)
+                {
+                    line[row.GetLaneIndexForSegment(segment) * 2] = '|';
+                }
+
+                // Show '*' in lane of actual commit
+                line[row.GetCurrentRevisionLane() * 2] = '*';
+
+                graph.Add(new string(line).Trim());
+
+                var nextRow = revisionGraph.GetSegmentsForRow(rowIndex + 1);
+                if (nextRow == null)
+                {
+                    break;
+                }
+
+                // Create a line between commits
+
+                line = Enumerable.Repeat(' ', (Math.Max(row.GetLaneCount(), nextRow.GetLaneCount()) * 2) + 1).ToArray();
+
+                // These drawing actions are done last, to appear on top
+                List<Action> actions = new();
+
+                foreach (var segment in row.Segments)
+                {
+                    int fromPos = row.GetLaneIndexForSegment(segment) * 2;
+                    int toPos = nextRow.GetLaneIndexForSegment(segment) * 2;
+                    if (toPos == -2)
+                    {
+                        // Segment does not continue to next commit
+                        continue;
+                    }
+
+                    if (toPos == fromPos)
+                    {
+                        // Segment stays in lane
+                        actions.Add(() => line[fromPos] = '|');
+                    }
+                    else if (toPos == fromPos + 2)
+                    {
+                        // Segment shifts one lane to the right
+                        actions.Add(() =>
+                        {
+                            if (line[fromPos + 1] == '/')
+                            {
+                                // , crossing another shifting left
+                                line[fromPos + 1] = 'X';
+                            }
+                            else
+                            {
+                                line[fromPos + 1] = '\\';
+                            }
+                        });
+                    }
+                    else if (toPos == fromPos - 2)
+                    {
+                        // Segment shifts one lane to the left
+                        actions.Add(() =>
+                        {
+                            if (line[fromPos - 1] == '\\')
+                            {
+                                // , crossing another shifting right
+                                line[fromPos - 1] = 'X';
+                            }
+                            else
+                            {
+                                line[fromPos - 1] = '/';
+                            }
+                        });
+                    }
+                    else if (toPos > fromPos)
+                    {
+                        // Segment shifts multiple lanes to the right
+                        line[fromPos + 1] = '\\';
+                        line[toPos] = '\\';
+                        for (int pos = fromPos + 2; pos < toPos; ++pos)
+                        {
+                            line[pos] = '-';
+                        }
+                    }
+                    else if (toPos < fromPos)
+                    {
+                        // Segment shifts multiple lanes to the left
+                        line[fromPos - 1] = '/';
+                        line[toPos] = '/';
+                        for (int pos = toPos + 1; pos < fromPos - 1; ++pos)
+                        {
+                            line[pos] = '-';
+                        }
+                    }
+                }
+
+                foreach (var action in actions)
+                {
+                    action();
+                }
+
+                graph.Add(new string(line).Trim());
+                ++rowIndex;
+            }
+
+            return graph;
         }
     }
 }

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
@@ -249,6 +249,71 @@ namespace GitUITests.UserControls.RevisionGrid
             ");
         }
 
+        [Test]
+        public void SegmentsAreNotStraightenedIfThisCausesWidthIncrease()
+        {
+            var revisionGraph = CreateGraph(" 1  2:1  3:1  4:1  5:1,4  6:2  7:2,6  8:5  9:5,8,3,7 ");
+
+            AssertGraphLayout(revisionGraph, @"
+                *
+                |\----\
+                | * | |
+                |/ / /
+                | | *
+                | | |\
+                | | | *
+                | |  \|
+                * |   |
+                |\ \  |
+                | * | |
+                |/ / /
+                | * |
+                |/ /
+                | *
+                |/
+                *
+            ");
+        }
+
+        [Test]
+        public void SegmentsAreNotStraightenedIfThisCausesALargerShiftForAnotherSegment()
+        {
+            var revisionGraph = CreateGraph(" 1  a:1  b:1  2:1  3:1  4:1  5:4,1  6:3  7:5,6  8:7,2,6  c:8  d:8  e:8  9:8,e,d,c,b,a ");
+
+            // Two segments cross at the 'X'. The one going '/' could be straightened, but then the
+            // one going '\' would shift across more lanes where they cross. We should avoid that.
+
+            AssertGraphLayout(revisionGraph, @"
+                *
+                |\--------\
+                | * | | | |
+                |/ / /  | |
+                | * |   | |
+                |/ /    | |
+                | *     | |
+                |/      | |
+                *       | |
+                |\--\   | |
+                * | |   | |
+                |\ X    | |
+                | * |   | |
+                | | |   | |
+                * | |   | |
+                |\ \ \  | |
+                * | | | | |
+                |/ / / / /
+                | * | | |
+                |/ / / /
+                | * | |
+                |/ / /
+                | * |
+                |/ /
+                | *
+                |/
+                *
+            ");
+        }
+
         private static int LookAhead => 20;
 
         private static IEnumerable<GitRevision> Revisions


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5782
Improves on #9050 

## Proposed changes

- As of now, segments in the revision graph are straightened only of they contain no intermediate commits (i.e. it's just one segment). This change allows straightening also when there are intermediate commits and/or merges.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/73586834/221598819-d43df53d-f1aa-4c6c-b42f-c71f48f5eb40.png)

### After

![image](https://user-images.githubusercontent.com/73586834/221599442-47ed7f85-6e2a-4e98-b9be-b675f90b9775.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual with GE repo
- Unit tests verify the graph layout

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 8d823099f8fc7c1a80efb0bd66775b140923f377
- Git 2.36.0.windows.1 (recommended: 2.38.1 or later)
- Microsoft Windows NT 10.0.19044.0
- .NET 6.0.14
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
