### PR TITLE
fix: use posix path on FormBrowse.InitMenusAndToolbars

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -284,7 +284,7 @@ namespace GitUI.CommandsDialogs
             RevisionGrid.SuspendRefreshRevisions();
 
             ToolStripFilters.Bind(() => Module, RevisionGrid);
-            InitMenusAndToolbars(args.RevFilter, args.PathFilter);
+            InitMenusAndToolbars(args.RevFilter, args.PathFilter.ToPosixPath());
 
             InitRevisionGrid(args.SelectedId, args.FirstId, args.IsFileBlameHistory);
             InitCommitDetails();

--- a/contributors.txt
+++ b/contributors.txt
@@ -187,3 +187,4 @@ YYYY/MM/DD, github id, Full name, email
 2022/12/15, siyavash1984,Siyavash Khojasteh, khojasteh(at)outlook.com
 2023/01/27, MaxKoll, Maximilian Koll, maximiliankoll(at)web(dot)de
 2023/02/24, RauulDev, Raul Molina, remolina7@gmail.com
+2023/03/03, pedrolamas, Pedro Lamas, pedrolamas@gmail.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10479

## Proposed changes

Ensure we call `.ToPosixPath()` on the filename before calling `FormBrowse.InitMenusAndToolbars()` method.

## Test methodology <!-- How did you ensure quality? -->

- Manual run to check everything worked as expected in both WSL2 and non-WSL2 repos.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.39.2.windows.1 (Windows), 2.34.1 (Ubuntu in WSL2)
- Windows 11 (latest insider release)

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
