### PR TITLE
FIX: Periodic Background Fetch was not automatically refreshing the UI after a successful fetch

### DIFF
--- a/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
+++ b/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
@@ -126,7 +126,7 @@ namespace GitExtensions.Plugins.BackgroundFetch
                                       string msg;
                                       try
                                       {
-                                          msg = _currentGitUiCommands.GitModule.GitExecutable.GetOutput(args);
+                                          msg = _currentGitUiCommands.GitModule.GitExecutable.Execute(args).AllOutput;
                                       }
                                       catch
                                       {

--- a/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
+++ b/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
@@ -126,7 +126,10 @@ namespace GitExtensions.Plugins.BackgroundFetch
                                       string msg;
                                       try
                                       {
-                                          msg = _currentGitUiCommands.GitModule.GitExecutable.Execute(args).AllOutput;
+                                          // git fetch is writing result details into standard error and not standard output, see:
+                                          // https://github.com/gitextensions/gitextensions/pull/10793
+                                          // https://lore.kernel.org/git/xmqq7cvqrdu6.fsf@gitster.g/
+                                          msg = _currentGitUiCommands.GitModule.GitExecutable.Execute(args).StandardError;
                                       }
                                       catch
                                       {

--- a/contributors.txt
+++ b/contributors.txt
@@ -189,3 +189,4 @@ YYYY/MM/DD, github id, Full name, email
 2023/02/24, RauulDev, Raul Molina, remolina7@gmail.com
 2023/03/03, pedrolamas, Pedro Lamas, pedrolamas@gmail.com
 2023/03/07, o-kloster, Oddvar Kloster, okloster(at)gmail.com
+2023/03/08, RemiGaudin, Rémi Gaudin, remi.gaudin(at)gmail.com


### PR DESCRIPTION
Fixes #9643

## Proposed changes

- In `BackgroundFetchPlugin.RecreateObservable()`: Retrieve both standard output and standard error from the fetch command because on some configurations the detailed info are written into the error stream.

## Test methodology

- I manually tested that the fix allow now the Periodic Background Fetch to automatically refresh the UI after a successful fetch.

## Test environment(s)

- Git Extensions 4.0.2.16100
- Build 25100ec1f7c8da8f798613da74826038af81a50e
- Git 2.39.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.14
- DPI 96dpi (no scaling)

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
