### PR TITLE
Improve Taskbar integration (Close [all], status)

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -541,6 +541,25 @@ namespace GitUI.CommandsDialogs
             base.OnUICommandsChanged(e);
         }
 
+        protected override void WndProc(ref Message m)
+        {
+            if (m.Msg == NativeMethods.WM_SYSCOMMAND && m.WParam == NativeMethods.SC_CLOSE)
+            {
+                // Application close is requested, e.g. using the Taskbar context menu.
+                // This request is directed to the main form also if a modal form like FormCommit is on top.
+                // So forward the request and try to close the modal form.
+                Form? modalForm = Application.OpenForms.Cast<Form>().FirstOrDefault(form => form.Modal);
+                if (modalForm is not null)
+                {
+                    modalForm.Close();
+                }
+
+                Close();
+            }
+
+            base.WndProc(ref m);
+        }
+
         public override void AddTranslationItems(ITranslation translation)
         {
             base.AddTranslationItems(translation);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -168,6 +168,8 @@ namespace GitUI.CommandsDialogs
 
         #region Translation
 
+        private readonly TranslationString _closeAll = new("Close all windows");
+
         private readonly TranslationString _noSubmodulesPresent = new("No submodules");
         private readonly TranslationString _topProjectModuleFormat = new("Top project: {0}");
         private readonly TranslationString _superprojectModuleFormat = new("Superproject: {0}");
@@ -202,6 +204,7 @@ namespace GitUI.CommandsDialogs
 
         #endregion
 
+        private readonly uint _closeAllMessage = NativeMethods.RegisterWindowMessageW("Global.GitExtensions.CloseAllInstances");
         private readonly SplitterManager _splitterManager = new(new AppSettingsPath("FormBrowse"));
         private readonly GitStatusMonitor _gitStatusMonitor;
         private readonly FormBrowseMenus _formBrowseMenus;
@@ -486,7 +489,8 @@ namespace GitUI.CommandsDialogs
                     new WindowsThumbnailToolbarButtons(
                         new WindowsThumbnailToolbarButton(toolStripButtonCommit.Text, toolStripButtonCommit.Image, CommitToolStripMenuItemClick),
                         new WindowsThumbnailToolbarButton(toolStripButtonPush.Text, toolStripButtonPush.Image, PushToolStripMenuItemClick),
-                        new WindowsThumbnailToolbarButton(toolStripButtonPull.Text, toolStripButtonPull.Image, PullToolStripMenuItemClick)));
+                        new WindowsThumbnailToolbarButton(toolStripButtonPull.Text, toolStripButtonPull.Image, PullToolStripMenuItemClick),
+                        new WindowsThumbnailToolbarButton(_closeAll.Text, Images.DeleteFile, (s, e) => NativeMethods.PostMessageW(NativeMethods.HWND_BROADCAST, _closeAllMessage))));
             }
 
             this.InvokeAsync(OnActivate).FileAndForget();
@@ -543,7 +547,7 @@ namespace GitUI.CommandsDialogs
 
         protected override void WndProc(ref Message m)
         {
-            if (m.Msg == NativeMethods.WM_SYSCOMMAND && m.WParam == NativeMethods.SC_CLOSE)
+            if (m.Msg == _closeAllMessage || (m.Msg == NativeMethods.WM_SYSCOMMAND && m.WParam == NativeMethods.SC_CLOSE))
             {
                 // Application close is requested, e.g. using the Taskbar context menu.
                 // This request is directed to the main form also if a modal form like FormCommit is on top.

--- a/GitUI/Interops/Messages.cs
+++ b/GitUI/Interops/Messages.cs
@@ -64,6 +64,12 @@
         public const int WM_NCPAINT = 0x0085;
 
         /// <summary>
+        /// The WM_SYSCOMMAND message is sent when the user chooses a command from the Window menu
+        /// or when the user chooses the maximize button, minimize button, restore button, or close button.
+        /// </summary>
+        public const int WM_SYSCOMMAND = 0x0112;
+
+        /// <summary>
         /// The WM_CTLCOLORSCROLLBAR message is sent to the parent window of a scroll bar control when the control is about to be drawn.
         /// </summary>
         public const int WM_CTLCOLORSCROLLBAR = 0x0137;
@@ -87,5 +93,10 @@
         /// The WM_NCMOUSELEAVE message is posted to a window when the cursor leaves the nonclient area of the window specified in a prior call to TrackMouseEvent.
         /// </summary>
         public const int WM_NCMOUSELEAVE = 0x02A2;
+
+        /// <summary>
+        /// The type of a WM_SYSCOMMAND (given in WParam).
+        /// </summary>
+        public const nint SC_CLOSE = 0xf060;
     }
 }

--- a/GitUI/Interops/User32/PostMessageW.cs
+++ b/GitUI/Interops/User32/PostMessageW.cs
@@ -1,0 +1,39 @@
+﻿using System.Runtime.InteropServices;
+
+namespace System
+{
+    internal static partial class NativeMethods
+    {
+        public static IntPtr HWND_BROADCAST => (IntPtr)0xFFFF;
+
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern IntPtr PostMessageW(
+            IntPtr hWnd,
+            uint Msg,
+            IntPtr wParam = default,
+            IntPtr lParam = default);
+
+        public static IntPtr PostMessageW(
+            HandleRef hWnd,
+            uint Msg,
+            IntPtr wParam = default,
+            IntPtr lParam = default)
+        {
+            IntPtr result = PostMessageW(hWnd.Handle, Msg, wParam, lParam);
+            GC.KeepAlive(hWnd.Wrapper);
+            return result;
+        }
+
+        public static unsafe IntPtr PostMessageW<T>(
+            IntPtr hWnd,
+            uint Msg,
+            IntPtr wParam,
+            ref T lParam) where T : unmanaged
+        {
+            fixed (void* l = &lParam)
+            {
+                return PostMessageW(hWnd, Msg, wParam, (IntPtr)l);
+            }
+        }
+    }
+}

--- a/GitUI/Interops/User32/RegisterWindowMessageW.cs
+++ b/GitUI/Interops/User32/RegisterWindowMessageW.cs
@@ -1,0 +1,10 @@
+﻿using System.Runtime.InteropServices;
+
+namespace System
+{
+    internal static partial class NativeMethods
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true)]
+        public static extern uint RegisterWindowMessageW(string name);
+    }
+}

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2284,6 +2284,10 @@ compare with first:</source>
         <source>Build Report</source>
         <target />
       </trans-unit>
+      <trans-unit id="_closeAll.Text">
+        <source>Close all windows</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_commitButtonText.Text">
         <source>Commit</source>
         <target />

--- a/GitUI/WindowsJumpListManager.cs
+++ b/GitUI/WindowsJumpListManager.cs
@@ -31,6 +31,7 @@ namespace GitUI
     {
         private static readonly Dictionary<Image, Icon> _iconByImage = new();
         private readonly IRepositoryDescriptionProvider _repositoryDescriptionProvider;
+        private ThumbnailToolBarButton? _closeAllButton;
         private ThumbnailToolBarButton? _commitButton;
         private ThumbnailToolBarButton? _pushButton;
         private ThumbnailToolBarButton? _pullButton;
@@ -62,6 +63,7 @@ namespace GitUI
         {
             if (disposing)
             {
+                _closeAllButton?.Dispose();
                 _commitButton?.Dispose();
                 _pushButton?.Dispose();
                 _pullButton?.Dispose();
@@ -122,10 +124,12 @@ namespace GitUI
                     return;
                 }
 
+                Validates.NotNull(_closeAllButton);
                 Validates.NotNull(_commitButton);
                 Validates.NotNull(_pushButton);
                 Validates.NotNull(_pullButton);
 
+                _closeAllButton.Enabled = true;
                 _commitButton.Enabled = true;
                 _pushButton.Enabled = true;
                 _pullButton.Enabled = true;
@@ -193,8 +197,11 @@ namespace GitUI
                 _pullButton = new ThumbnailToolBarButton(MakeIcon(thumbButtons.Pull.Image, 48, true), thumbButtons.Pull.Text);
                 _pullButton.Click += thumbButtons.Pull.Click;
 
+                _closeAllButton = new ThumbnailToolBarButton(MakeIcon(thumbButtons.CloseAll.Image, 48, true), thumbButtons.CloseAll.Text);
+                _closeAllButton.Click += thumbButtons.CloseAll.Click;
+
                 // Call this method using reflection.  This is a workaround to *not* reference WPF libraries, because of how the WindowsAPICodePack was implemented.
-                TaskbarManager.Instance.ThumbnailToolBars.AddButtons(handle, _commitButton, _pullButton, _pushButton);
+                TaskbarManager.Instance.ThumbnailToolBars.AddButtons(handle, _commitButton, _pullButton, _pushButton, _closeAllButton);
             }
         }
 
@@ -210,9 +217,11 @@ namespace GitUI
 
             SafeInvoke(() =>
             {
+                Validates.NotNull(_closeAllButton);
                 Validates.NotNull(_commitButton);
                 Validates.NotNull(_pushButton);
                 Validates.NotNull(_pullButton);
+                _closeAllButton.Enabled = false;
                 _commitButton.Enabled = false;
                 _pushButton.Enabled = false;
                 _pullButton.Enabled = false;

--- a/GitUI/WindowsThumbnailToolbarButtons.cs
+++ b/GitUI/WindowsThumbnailToolbarButtons.cs
@@ -2,13 +2,18 @@
 {
     public sealed class WindowsThumbnailToolbarButtons
     {
-        public WindowsThumbnailToolbarButtons(WindowsThumbnailToolbarButton commit, WindowsThumbnailToolbarButton pull, WindowsThumbnailToolbarButton push)
+        public WindowsThumbnailToolbarButtons(WindowsThumbnailToolbarButton commit,
+            WindowsThumbnailToolbarButton pull,
+            WindowsThumbnailToolbarButton push,
+            WindowsThumbnailToolbarButton closeAll)
         {
+            CloseAll = closeAll;
             Commit = commit;
             Pull = pull;
             Push = push;
         }
 
+        public WindowsThumbnailToolbarButton CloseAll { get; }
         public WindowsThumbnailToolbarButton Commit { get; }
         public WindowsThumbnailToolbarButton Pull { get; }
         public WindowsThumbnailToolbarButton Push { get; }


### PR DESCRIPTION
## Proposed changes

- Set taskbar overlay icon also if unchanged
  because Windows removes the overlay when GE is unresponsive
- Close modal form on application close request, e.g. FormCommit
- Add `WindowsThumbnailToolbarButton` "Close all instances!"

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/36601201/224495114-96cf9338-da2e-4ecb-b60e-3e8aa1bd56a8.png)

### After

![image](https://user-images.githubusercontent.com/36601201/224496044-e00eefdb-fac6-4bb8-b4a9-1061ae39340b.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 4b18f73edfef5ef6bd438f5c127f3d2d08e94719
- Git 2.39.2.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.14
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.14 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.3 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

Please **do not squash merge** this PR.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).