### PR TITLE
RefreshGrid without revisions

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1048,7 +1048,7 @@ namespace GitUI
                     cancellationToken.ThrowIfCancellationRequested();
                     reader.GetLog(
                         observeRevisions,
-                        _filterInfo.GetRevisionFilter(),
+                        _filterInfo.GetRevisionFilter(CurrentBranch),
                         pathFilter,
                         cancellationToken);
                 }).FileAndForget(

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
@@ -941,7 +941,7 @@ namespace GitUITests.UserControls
             };
 
             filterInfo.GetSummary().Should().Be(expectedSummary);
-            filterInfo.GetRevisionFilter().ToString().Should().Be(expectedArgs);
+            filterInfo.GetRevisionFilter(new Lazy<string>(() => "currentBranch")).ToString().Should().Be(expectedArgs);
         }
 
         [TestCase(false, false, "branchFilter")]
@@ -962,7 +962,7 @@ namespace GitUITests.UserControls
                 BranchFilter = branchFilter
             };
 
-            string args = filterInfo.GetRevisionFilter();
+            string args = filterInfo.GetRevisionFilter(new Lazy<string>(() => "currentBranch"));
 
             if (showRefLog)
             {
@@ -999,7 +999,7 @@ namespace GitUITests.UserControls
                 BranchFilter = branchFilter
             };
 
-            string args = filterInfo.GetRevisionFilter();
+            string args = filterInfo.GetRevisionFilter(new Lazy<string>(() => "currentBranch"));
 
             if (expectBranches)
             {
@@ -1021,7 +1021,7 @@ namespace GitUITests.UserControls
                 CommitsLimit = maxCount,
                 ByCommitsLimit = true
             };
-            string args = filterInfo.GetRevisionFilter();
+            string args = filterInfo.GetRevisionFilter(new Lazy<string>(() => "currentBranch"));
 
             if (expected)
             {
@@ -1042,7 +1042,7 @@ namespace GitUITests.UserControls
                 ShowOnlyFirstParent = expected
             };
 
-            string args = filterInfo.GetRevisionFilter();
+            string args = filterInfo.GetRevisionFilter(new Lazy<string>(() => "currentBranch"));
 
             if (expected)
             {
@@ -1063,7 +1063,7 @@ namespace GitUITests.UserControls
                 ShowMergeCommits = expected
             };
 
-            string args = filterInfo.GetRevisionFilter();
+            string args = filterInfo.GetRevisionFilter(new Lazy<string>(() => "currentBranch"));
 
             if (!expected)
             {
@@ -1089,7 +1089,10 @@ namespace GitUITests.UserControls
                             {
                                 foreach (string branchFilter in new[] { "branch1", "", null })
                                 {
-                                    yield return new TestCaseData(showNotes, showStash, showReflog, showCurrentBranchOnly, branchFilter);
+                                    foreach (string currentBranch in new[] { "currentBranch", "" })
+                                    {
+                                        yield return new TestCaseData(showNotes, showStash, showReflog, showCurrentBranchOnly, branchFilter, currentBranch);
+                                    }
                                 }
                             }
                         }
@@ -1099,7 +1102,7 @@ namespace GitUITests.UserControls
         }
 
         [TestCaseSource(nameof(FilterInfo_NotesStash))]
-        public void FilterInfo_GitNotes_Stashes(bool showGitNotes, bool showStash, bool showReflog, bool showCurrentBranchOnly, string branchFilter)
+        public void FilterInfo_GitNotes_Stashes(bool showGitNotes, bool showStash, bool showReflog, bool showCurrentBranchOnly, string branchFilter, string currentBranch)
         {
             bool originalShowGitNotes = AppSettings.ShowGitNotes;
             AppSettings.ShowGitNotes = showGitNotes;
@@ -1112,10 +1115,11 @@ namespace GitUITests.UserControls
                 ByBranchFilter = true,
                 BranchFilter = branchFilter
             };
-            string args = filterInfo.GetRevisionFilter();
-            bool showAll = !showReflog && !showCurrentBranchOnly && string.IsNullOrWhiteSpace(branchFilter);
-            bool showCurrent = !showReflog && showCurrentBranchOnly;
-            bool showFiltredOrCurrent = !showReflog && (showCurrentBranchOnly || !string.IsNullOrWhiteSpace(branchFilter));
+            string args = filterInfo.GetRevisionFilter(new Lazy<string>(() => currentBranch));
+            bool showAll = (!showReflog && !showCurrentBranchOnly && string.IsNullOrWhiteSpace(branchFilter))
+                || (!showReflog && showCurrentBranchOnly && string.IsNullOrWhiteSpace(currentBranch));
+            bool showCurrent = !showReflog && showCurrentBranchOnly && !string.IsNullOrWhiteSpace(currentBranch);
+            bool showFiltredOrCurrent = !showReflog && (showCurrent || (!showCurrentBranchOnly && !string.IsNullOrWhiteSpace(branchFilter)));
 
             try
             {
@@ -1137,16 +1141,17 @@ namespace GitUITests.UserControls
                     args.ToString().Should().NotMatchRegex(@"(^|\s)--exclude=refs/stash($|\s)");
                 }
 
-                if (showCurrent && showStash)
+                string branch = Regex.Escape($"--branches={GetFilterRefName(currentBranch)}");
+                if (showCurrent)
                 {
-                    args.ToString().Should().MatchRegex(@"(^|\s)HEAD($|\s)");
+                    args.ToString().Should().MatchRegex(@$"(^|\s){branch}($|\s)");
                 }
-                else
+                else if (!string.IsNullOrWhiteSpace(branch))
                 {
-                    args.ToString().Should().NotMatchRegex(@"(^|\s)HEAD($|\s)");
+                    args.ToString().Should().NotMatchRegex(@$"(^|\s){branch}($|\s)");
                 }
 
-                string stash = Regex.Escape("--glob=refs/stas[h]");
+                string stash = Regex.Escape($"--glob={"refs/stas[h]"}");
                 if (showFiltredOrCurrent && showStash)
                 {
                     args.ToString().Should().MatchRegex(@$"(^|\s){stash}($|\s)");
@@ -1160,6 +1165,19 @@ namespace GitUITests.UserControls
             {
                 AppSettings.ShowGitNotes = originalShowGitNotes;
                 AppSettings.ShowStashes = originalShowStash;
+            }
+
+            return;
+
+            // return a refname that matches the name but that is not expanded with a a "/*"
+            string GetFilterRefName(string gitRef)
+            {
+                if (string.IsNullOrWhiteSpace(gitRef))
+                {
+                    return "";
+                }
+
+                return $"{gitRef.Substring(0, gitRef.Length - 1)}[{gitRef[^1]}]";
             }
         }
 
@@ -1179,7 +1197,7 @@ namespace GitUITests.UserControls
                 Message = message,
                 ByMessage = true
             };
-            string args = filterInfo.GetRevisionFilter();
+            string args = filterInfo.GetRevisionFilter(new Lazy<string>(() => "currentBranch"));
             string summary = filterInfo.GetSummary();
 
             if (expectGrep)


### PR DESCRIPTION
Fixes #10720

## Proposed changes

If stashes a are shown, the first stash to show requires explicit handling for the Git default "Show only current branch" to show stashes in the grid.
This is not possible in repos without a current branch.

## Test methodology <!-- How did you ensure quality? -->

Updated tests

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
