### PR TITLE
Replace IProcess.WaitForProcessExitAsync with WaitForExitAsync

### DIFF
--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -4,6 +4,7 @@ using GitCommands.Logging;
 using GitExtUtils;
 using GitUI;
 using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Threading;
 
 namespace GitCommands
 {
@@ -220,10 +221,7 @@ namespace GitCommands
             public Task<int> WaitForExitAsync() => _exitTaskCompletionSource.Task;
 
             /// <inheritdoc />
-            public Task WaitForProcessExitAsync(CancellationToken token)
-            {
-                return _process.WaitForExitAsync(token);
-            }
+            public Task<int> WaitForExitAsync(CancellationToken token) => WaitForExitAsync().WithCancellation(token);
 
             /// <inheritdoc />
             public int WaitForExit()

--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -318,16 +318,13 @@ namespace GitCommands
             }
 #endif
 
-            // Wait for the process to exit (or be cancelled)
-            await process.WaitForProcessExitAsync(cancellationToken);
-
-            // Await the output and exit status
-            var exitTask = process.WaitForExitAsync();
+            // Wait for the process to exit (or be cancelled) and for the output
+            Task<int> exitTask = process.WaitForExitAsync(cancellationToken);
             await Task.WhenAll(outputTask, errorTask, exitTask);
 
             var output = outputEncoding.GetString(outputBuffer.GetBuffer(), 0, (int)outputBuffer.Length);
             var error = outputEncoding.GetString(errorBuffer.GetBuffer(), 0, (int)errorBuffer.Length);
-            var exitCode = await process.WaitForExitAsync();
+            int exitCode = await exitTask;
 
             if (cache is not null && exitCode == 0)
             {

--- a/Plugins/GitUIPluginInterfaces/IProcess.cs
+++ b/Plugins/GitUIPluginInterfaces/IProcess.cs
@@ -49,13 +49,13 @@ namespace GitUIPluginInterfaces
         /// <summary>
         /// Returns a task that completes when the process exits, or when this object is disposed.
         /// </summary>
-        /// <returns>A task that yields the process's exit code, or <c>null</c> if this object was disposed before the process exited.</returns>
+        /// <returns>A task that yields the process's exit code, or throws an exception if this object was disposed before the process exited.</returns>
         Task<int> WaitForExitAsync();
 
         /// <summary>
         /// Returns a cancellable task that completes when the process exits, or when this object is disposed.
         /// </summary>
-        /// <returns>A task that yields the process's exit code, or <c>null</c> if this object was disposed before the process exited.</returns>
+        /// <returns>A task that yields the process's exit code, or throws an exception if this object was disposed before the process exited.</returns>
         Task<int> WaitForExitAsync(CancellationToken token);
 
         /// <summary>

--- a/Plugins/GitUIPluginInterfaces/IProcess.cs
+++ b/Plugins/GitUIPluginInterfaces/IProcess.cs
@@ -53,12 +53,10 @@ namespace GitUIPluginInterfaces
         Task<int> WaitForExitAsync();
 
         /// <summary>
-        /// Instructs the process component to wait for the associated process to exit, or for the cancellationToken to be cancelled (cancells the process).
-        /// Note that the exit task must be awaited too.
+        /// Returns a cancellable task that completes when the process exits, or when this object is disposed.
         /// </summary>
-        /// <param name="token">An optional token to cancel the asynchronous operation.</param>
-        /// <returns>A task that will complete when the process has exited, cancellation has been requested, or an error occurs.</returns>
-        Task WaitForProcessExitAsync(CancellationToken token);
+        /// <returns>A task that yields the process's exit code, or <c>null</c> if this object was disposed before the process exited.</returns>
+        Task<int> WaitForExitAsync(CancellationToken token);
 
         /// <summary>
         /// Waits for the process to reach an idle state.

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -136,9 +136,9 @@ namespace CommonTestUtils
                 }
             }
 
-            public Task WaitForProcessExitAsync(CancellationToken token)
+            public Task<int> WaitForExitAsync(CancellationToken token)
             {
-                return Task.CompletedTask;
+                return Task.FromResult(0);
             }
 
             public void WaitForInputIdle()


### PR DESCRIPTION
Fixes #10398

## Proposed changes

- Replace `IProcess.WaitForProcessExitAsync` with cancellable variant of `WaitForExitAsync` as proposed by @vjdw

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 70ebb97a824f4487ca5665630275859e51559dc2
- Git 2.39.2.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.14
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.14 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.3 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).