### PR TITLE
CommitInfoTests: Disable GitNotes

### DIFF
--- a/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/CommitInfo/CommitInfoTests.cs
@@ -28,6 +28,7 @@ namespace GitExtensions.UITests.UserControls.CommitInfo
         [SetUp]
         public void SetUp()
         {
+            AppSettings.ShowGitNotes = false;
             ReferenceRepository.ResetRepo(ref _referenceRepository);
             _commands = new GitUICommands(_referenceRepository.Module);
 


### PR DESCRIPTION
## Proposed changes

If AppSettings.ShowGitNotes is set, -cimmitInfo tests will try to fetch notes which will fail (with popup).
It happened to work mostly, but slight timing changes for #8741 causes the setting to active from earlier tests.

## Test methodology <!-- How did you ensure quality? -->

Updated tests.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
