### PR TITLE
SidePanel: Disallow copy context for not visible stashes

### DIFF
--- a/GitUI/BranchTreePanel/BaseRevisionNode.cs
+++ b/GitUI/BranchTreePanel/BaseRevisionNode.cs
@@ -38,11 +38,6 @@ namespace GitUI.BranchTreePanel
         public string FullPath => ParentPath.Combine(PathSeparator.ToString(), Name)!;
 
         /// <summary>
-        /// Gets whether the commit that the node represents is currently visible in the revision grid.
-        /// </summary>
-        public bool Visible { get; set; }
-
-        /// <summary>
         /// ObjectId for nodes with a revision.
         /// </summary>
         public ObjectId? ObjectId { get; init; }

--- a/GitUI/BranchTreePanel/NodeBase.cs
+++ b/GitUI/BranchTreePanel/NodeBase.cs
@@ -21,6 +21,11 @@ namespace GitUI.BranchTreePanel
         /// </summary>
         protected internal bool IsSelected { get; set; }
 
+        /// <summary>
+        /// Gets whether the commit that the node represents is currently visible in the revision grid.
+        /// </summary>
+        public bool Visible { get; set; }
+
         protected internal void Select(bool select, bool includingDescendants = false)
         {
             IsSelected = select;

--- a/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.ContextActions.cs
@@ -212,7 +212,7 @@ namespace GitUI.BranchTreePanel
             bool hasSingleSelection = selectedNodes.Length == 1;
             NodeBase? selectedNode = treeMain.SelectedNode?.Tag as NodeBase;
 
-            copyContextMenuItem.Enable(hasSingleSelection && ((selectedNode is BaseBranchLeafNode branch && branch.Visible) || selectedNode is StashNode));
+            copyContextMenuItem.Enable(hasSingleSelection && (selectedNode is BaseBranchLeafNode or StashNode) && selectedNode.Visible);
             filterForSelectedRefsMenuItem.Enable(selectedNodes.OfType<IGitRefActions>().Any()); // enable if selection contains refs
 
             var selectedLocalBranch = selectedNode as LocalBranchNode;


### PR DESCRIPTION
## Proposed changes

The information for the selected commit was used instead of the right clicked stash.

An alternative is to get the data from the rightclicked revision, but the copy uses IScriptHostControl that gets the copy from the revision grid, so this is a much bigger task.

Sidenote: The primary reason I am changing this is to make it simpler to investigate why "git-log --reflog" occasionally hides branches that "git-log --all" shows. No info there, it is Git that delivers this info...

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

See Message matching the first stash
![image](https://user-images.githubusercontent.com/6248932/227725468-3fcf5a98-be0b-4231-b0db-b5f589a608dd.png)

### After

![image](https://user-images.githubusercontent.com/6248932/227725495-1f835e31-37da-461f-8921-70bd3625b0de.png)

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
