### PR TITLE
Decouple reflog from other branch filters

### DIFF
--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2926,14 +2926,6 @@ Do you want to continue?</source>
         <source>Show only first parent</source>
         <target />
       </trans-unit>
-      <trans-unit id="tsmiShowReflog.Text">
-        <source>&amp;Reflog</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="tsmiShowReflog.ToolTipText">
-        <source>Show all reflog references</source>
-        <target />
-      </trans-unit>
       <trans-unit id="tsmiTelemetryEnabled.Text">
         <source>&amp;Yes, I allow telemetry</source>
         <target />

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -27,7 +27,6 @@ namespace GitUI.UserControls
             this.toolStripSeparatorAdvancedFilter = new System.Windows.Forms.ToolStripSeparator();
             this.tsmiAdvancedFilter = new System.Windows.Forms.ToolStripMenuItem();
             this.tssbtnShowBranches = new System.Windows.Forms.ToolStripSplitButton();
-            this.tsmiShowReflog = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiShowBranchesAll = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiShowBranchesCurrent = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiShowBranchesFiltered = new System.Windows.Forms.ToolStripMenuItem();
@@ -125,21 +124,11 @@ namespace GitUI.UserControls
             this.tssbtnShowBranches.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tsmiShowBranchesAll,
             this.tsmiShowBranchesCurrent,
-            this.tsmiShowBranchesFiltered,
-            toolStripSeparator1,
-            this.tsmiShowReflog});
+            this.tsmiShowBranchesFiltered});
             this.tssbtnShowBranches.Image = global::GitUI.Properties.Images.BranchLocal;
             this.tssbtnShowBranches.Name = "tssbtnShowBranches";
             this.tssbtnShowBranches.Size = new System.Drawing.Size(32, 22);
             this.tssbtnShowBranches.Click += new System.EventHandler(this.tssbtnShowBranches_Click);
-            // 
-            // tsmiShowReflog
-            // 
-            this.tsmiShowReflog.Image = global::GitUI.Properties.Images.Book;
-            this.tsmiShowReflog.Name = "tsmiShowReflog";
-            this.tsmiShowReflog.Size = new System.Drawing.Size(259, 22);
-            this.tsmiShowReflog.Text = "&Reflog";
-            this.tsmiShowReflog.Click += new System.EventHandler(this.tsmiShowReflogBranches_Click);
             // 
             // tsmiShowBranchesAll
             // 
@@ -323,7 +312,6 @@ namespace GitUI.UserControls
         private ToolStripSeparator toolStripSeparatorAdvancedFilter;
         private ToolStripMenuItem tsmiAdvancedFilter;
         private ToolStripSplitButton tssbtnShowBranches;
-        private ToolStripMenuItem tsmiShowReflog;
         private ToolStripMenuItem tsmiShowBranchesAll;
         private ToolStripMenuItem tsmiShowBranchesCurrent;
         private ToolStripMenuItem tsmiShowBranchesFiltered;

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -19,7 +19,6 @@ namespace GitUI.UserControls
         public FilterToolBar()
         {
             InitializeComponent();
-            tsmiShowReflog.ToolTipText = TranslatedStrings.ShowReflogTooltip;
             tsbShowReflog.ToolTipText = TranslatedStrings.ShowReflogTooltip;
             tsmiShowOnlyFirstParent.ToolTipText = TranslatedStrings.ShowOnlyFirstParent;
 
@@ -124,12 +123,6 @@ namespace GitUI.UserControls
             // Refer to it for more details.
 
             ToolStripItem selectedItem = tsmiShowBranchesAll;
-
-            if (e.ShowReflogReferences)
-            {
-                // Show reflog
-                selectedItem = tsmiShowReflog;
-            }
 
             if (e.ShowAllBranches)
             {
@@ -468,7 +461,6 @@ namespace GitUI.UserControls
             public ToolStripLabel tslblRevisionFilter => _control.tslblRevisionFilter;
             public ToolStripSplitButton tsbtnAdvancedFilter => _control.tsbtnAdvancedFilter;
             public ToolStripSplitButton tssbtnShowBranches => _control.tssbtnShowBranches;
-            public ToolStripMenuItem tsmiShowReflog => _control.tsmiShowReflog;
             public ToolStripMenuItem tsmiShowBranchesAll => _control.tsmiShowBranchesAll;
             public ToolStripMenuItem tsmiShowBranchesCurrent => _control.tsmiShowBranchesCurrent;
             public ToolStripMenuItem tsmiShowBranchesFiltered => _control.tsmiShowBranchesFiltered;

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -113,12 +113,12 @@ namespace GitUI.UserControls.RevisionGrid
             set => _branchFilter = value ?? string.Empty;
         }
 
-        public bool IsShowAllBranchesChecked => !ByBranchFilter && !ShowCurrentBranchOnly && !ShowReflogReferences;
+        public bool IsShowAllBranchesChecked => !ByBranchFilter && !ShowCurrentBranchOnly;
 
-        public bool IsShowCurrentBranchOnlyChecked => ShowCurrentBranchOnly && !ShowReflogReferences;
+        public bool IsShowCurrentBranchOnlyChecked => ShowCurrentBranchOnly;
 
         // IsChecked is not the same as a filter is active, see ByBranchFilter
-        public bool IsShowFilteredBranchesChecked => ByBranchFilter && !ShowCurrentBranchOnly && !ShowReflogReferences;
+        public bool IsShowFilteredBranchesChecked => ByBranchFilter && !ShowCurrentBranchOnly;
 
         public bool ShowCurrentBranchOnly
         {
@@ -135,12 +135,7 @@ namespace GitUI.UserControls.RevisionGrid
         public bool ShowReflogReferences
         {
             get => AppSettings.ShowReflogReferences;
-            set
-            {
-                // ShowReflogReferences dominates ByBranchFilter and ShowCurrentBranchOnly,
-                // if the user toggles the Reflog button, the curremt branch fílter should appear.
-                AppSettings.ShowReflogReferences = value;
-            }
+            set => AppSettings.ShowReflogReferences = value;
         }
 
         public bool ShowSimplifyByDecoration
@@ -423,7 +418,8 @@ namespace GitUI.UserControls.RevisionGrid
                 // All commits
                 filter.Add("--reflog");
             }
-            else if (IsShowCurrentBranchOnlyChecked && !string.IsNullOrWhiteSpace(currentBranch.Value))
+
+            if (IsShowCurrentBranchOnlyChecked && !string.IsNullOrWhiteSpace(currentBranch.Value))
             {
                 // Git default, no option by default (stashes is special).
 
@@ -576,7 +572,8 @@ namespace GitUI.UserControls.RevisionGrid
             {
                 filter.AppendLine(TranslatedStrings.ShowReflog);
             }
-            else if (ShowCurrentBranchOnly)
+
+            if (ShowCurrentBranchOnly)
             {
                 filter.AppendLine(TranslatedStrings.ShowCurrentBranchOnly);
             }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -496,10 +496,6 @@ namespace GitUI
             string newFilter = filter?.Trim() ?? string.Empty;
             _filterInfo.ByBranchFilter = !string.IsNullOrWhiteSpace(newFilter);
             _filterInfo.BranchFilter = newFilter;
-            if (_filterInfo.ByBranchFilter)
-            {
-                _filterInfo.ShowReflogReferences = false;
-            }
 
             PerformRefreshRevisions();
         }
@@ -1778,8 +1774,6 @@ namespace GitUI
                 return;
             }
 
-            // Do not unset ByBranchFilter or ShowCurrentBranchOnly,
-            // see FilterInfo.ShowReflogReferences.
             _filterInfo.ShowReflogReferences = true;
 
             PerformRefreshRevisions();
@@ -1794,7 +1788,6 @@ namespace GitUI
 
             _filterInfo.ByBranchFilter = false;
             _filterInfo.ShowCurrentBranchOnly = false;
-            _filterInfo.ShowReflogReferences = false;
 
             PerformRefreshRevisions();
         }
@@ -1809,7 +1802,6 @@ namespace GitUI
             // Must be able to set ByBranchFilter without a filter to edit it
             _filterInfo.ByBranchFilter = true;
             _filterInfo.ShowCurrentBranchOnly = false;
-            _filterInfo.ShowReflogReferences = false;
 
             PerformRefreshRevisions();
         }
@@ -1823,7 +1815,6 @@ namespace GitUI
 
             _filterInfo.ByBranchFilter = false;
             _filterInfo.ShowCurrentBranchOnly = true;
-            _filterInfo.ShowReflogReferences = false;
 
             PerformRefreshRevisions();
         }

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
@@ -749,9 +749,9 @@ namespace GitUITests.UserControls
                 filterInfo.HasFilter.Should().BeFalse();
 
                 // showCurrentBranchOnly dominates byBranchFilter
-                filterInfo.IsShowAllBranchesChecked.Should().Be(!byBranchFilter && !showCurrentBranchOnly && !showReflog);
-                filterInfo.IsShowCurrentBranchOnlyChecked.Should().Be(showCurrentBranchOnly && !showReflog);
-                filterInfo.IsShowFilteredBranchesChecked.Should().Be(byBranchFilter && !showCurrentBranchOnly && !showReflog);
+                filterInfo.IsShowAllBranchesChecked.Should().Be(!byBranchFilter && !showCurrentBranchOnly);
+                filterInfo.IsShowCurrentBranchOnlyChecked.Should().Be(showCurrentBranchOnly);
+                filterInfo.IsShowFilteredBranchesChecked.Should().Be(byBranchFilter && !showCurrentBranchOnly);
 
                 filterInfo.ByBranchFilter.Should().Be(byBranchFilter);
                 AppSettings.BranchFilterEnabled.Should().Be(byBranchFilter);
@@ -904,7 +904,7 @@ namespace GitUITests.UserControls
             filterInfo.ByPathFilter.Should().BeFalse();
             filterInfo.ByBranchFilter.Should().BeFalse();
 
-            filterInfo.IsShowCurrentBranchOnlyChecked.Should().Be(showCurrentBranchOnly && !showReflogReferences);
+            filterInfo.IsShowCurrentBranchOnlyChecked.Should().Be(showCurrentBranchOnly);
             filterInfo.ShowReflogReferences.Should().Be(showReflogReferences);
         }
 
@@ -1116,10 +1116,10 @@ namespace GitUITests.UserControls
                 BranchFilter = branchFilter
             };
             string args = filterInfo.GetRevisionFilter(new Lazy<string>(() => currentBranch));
-            bool showAll = (!showReflog && !showCurrentBranchOnly && string.IsNullOrWhiteSpace(branchFilter))
-                || (!showReflog && showCurrentBranchOnly && string.IsNullOrWhiteSpace(currentBranch));
-            bool showCurrent = !showReflog && showCurrentBranchOnly && !string.IsNullOrWhiteSpace(currentBranch);
-            bool showFiltredOrCurrent = !showReflog && (showCurrent || (!showCurrentBranchOnly && !string.IsNullOrWhiteSpace(branchFilter)));
+            bool showAll = (!showCurrentBranchOnly && string.IsNullOrWhiteSpace(branchFilter))
+                || (showCurrentBranchOnly && string.IsNullOrWhiteSpace(currentBranch));
+            bool showCurrent = showCurrentBranchOnly && !string.IsNullOrWhiteSpace(currentBranch);
+            bool showFiltredOrCurrent = showCurrent || (!showCurrentBranchOnly && !string.IsNullOrWhiteSpace(branchFilter));
 
             try
             {

--- a/UnitTests/GitUI.Tests/UserControls/FilterToolBarTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterToolBarTests.cs
@@ -219,13 +219,6 @@ namespace GitUITests.UserControls
         }
 
         [Test]
-        public void ShowBranches_Reflog_should_invoke_ToggleShowReflogReferences()
-        {
-            _filterToolBar.GetTestAccessor().tsmiShowReflog.PerformClick();
-            _revisionGridFilter.Received(1).ShowReflog();
-        }
-
-        [Test]
         public void ShowBranches_ShowAll_should_invoke_ShowAllBranches()
         {
             _filterToolBar.GetTestAccessor().tsmiShowBranchesAll.PerformClick();


### PR DESCRIPTION
Fixes #10830

## Proposed changes

Decouples --reflog from branch filters as --all
The options for e.g. AllBranches and RefLog can appear at the same time.

See also #10172 that decoupled other options

Some updates to be done in the doc too I assume.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/227733798-1d5226e1-db8d-47df-ae69-c353b4b9b7a8.png)
![image](https://user-images.githubusercontent.com/6248932/227733779-ab6c5787-8213-490f-8dcf-de6e290efdab.png)

![image](https://user-images.githubusercontent.com/6248932/227733822-6f3e737c-b957-4fa1-aa77-ddba3f10e7de.png)

### After

![image](https://user-images.githubusercontent.com/6248932/227733726-3a377dd1-4e85-4193-b24a-859d49918491.png)

![image](https://user-images.githubusercontent.com/6248932/227733755-6aff58d4-aa40-4653-b070-1a91173f2d24.png)

## Test methodology <!-- How did you ensure quality? -->

Tests updated

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
