### PR TITLE
Filtered branches: Check validility of filter toolbar branch filter box

### DIFF
--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -133,6 +133,8 @@ the last selected commit.");
         private readonly TranslationString _stashDropConfirmTitle = new("Drop Stash Confirmation");
         private readonly TranslationString _cannotBeUndone = new("This action cannot be undone.");
         private readonly TranslationString _areYouSure = new("Are you sure you want to drop the stash? This action cannot be undone.");
+        private readonly TranslationString _nonexistingGitRevision = new("Git revision does not exist");
+        private readonly TranslationString _ignoringReference = new("\"{0}\" is not a Git revision and will be ignored.");
 
         private readonly TranslationString _errorPuTTYNotFound = new("SSH agent could not be found");
         private readonly TranslationString _errorSshKeyNotFound = new("SSH key file could not be found");
@@ -324,6 +326,8 @@ following command.
         public static string StashDropConfirmTitle => _instance.Value._stashDropConfirmTitle.Text;
         public static string CannotBeUndone => _instance.Value._cannotBeUndone.Text;
         public static string AreYouSure => _instance.Value._areYouSure.Text;
+        public static string NonexistingGitRevision => _instance.Value._nonexistingGitRevision.Text;
+        public static string IgnoringReference => _instance.Value._ignoringReference.Text;
 
         public static string GitSecurityError => _instance.Value._gitSecurityError.Text;
         public static string GitDubiousOwnershipHeader => _instance.Value._gitDubiousOwnershipHeader.Text;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -10129,6 +10129,10 @@ following command.
         <source>{0} {1:hour|hours} ago</source>
         <target />
       </trans-unit>
+      <trans-unit id="_ignoringReference.Text">
+        <source>"{0}" is not a Git revision and will be ignored.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_indexText.Text">
         <source>Commit index</source>
         <target />
@@ -10195,6 +10199,10 @@ following command.
       </trans-unit>
       <trans-unit id="_noRevision.Text">
         <source>No revision</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_nonexistingGitRevision.Text">
+        <source>Git revision does not exist</source>
         <target />
       </trans-unit>
       <trans-unit id="_okText.Text">

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -69,6 +69,9 @@ namespace GitUI.UserControls
             {
                 List<string> newFilter = new();
                 IReadOnlyList<IGitRef> refs = _getRefs(RefsFilter.NoFilter);
+
+                // Split at whitespace (char[])null is default) but with split options.
+                // Ignore quouting, Git revisions do not allow spaces.
                 foreach (string branch in filter.Split((char[])null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
                 {
                     bool wildcardBranchFilter = branch.IndexOfAny(new[] { '?', '*', '[' }) >= 0;

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -51,7 +51,7 @@ namespace GitUI.UserControls
         /// <summary>
         ///  Applies custom branch filters supplied via the filter textbox.
         /// </summary>
-        private void ApplyCustomBranchFilter()
+        private void ApplyCustomBranchFilter(bool checkBranch = true)
         {
             if (_isApplyingFilter)
             {
@@ -65,6 +65,46 @@ namespace GitUI.UserControls
 
             // Apply the textbox contents, no check if the (multiple) options is in tscboBranchFilter.Items (or that the list is generated)
             string filter = tscboBranchFilter.Text == TranslatedStrings.NoResultsFound ? string.Empty : tscboBranchFilter.Text;
+            if (checkBranch && !string.IsNullOrWhiteSpace(filter))
+            {
+                List<string> newFilter = new();
+                IReadOnlyList<IGitRef> refs = _getRefs(RefsFilter.NoFilter);
+                foreach (string branch in filter.Split((char[])null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+                {
+                    bool wildcardBranchFilter = branch.IndexOfAny(new[] { '?', '*', '[' }) >= 0;
+                    if (branch.StartsWith("--") || refs.Any(r => r.LocalName == branch))
+                    {
+                        // Added as git-log option or revision filter
+                    }
+                    else if (wildcardBranchFilter)
+                    {
+                        // Added as --branches= option
+                    }
+                    else
+                    {
+                        ObjectId oid = GetModule().RevParse(branch);
+                        if (oid is null)
+                        {
+                            TaskDialogPage page = new()
+                            {
+                                Heading = string.Format(TranslatedStrings.IgnoringReference, branch),
+                                Caption = TranslatedStrings.NonexistingGitRevision,
+                                Buttons = { TaskDialogButton.OK },
+                                Icon = TaskDialogIcon.Warning,
+                                SizeToContent = true
+                            };
+
+                            TaskDialog.ShowDialog(this, page);
+                            continue;
+                        }
+                    }
+
+                    newFilter.Add(branch);
+                }
+
+                filter = string.Join(" ", newFilter);
+            }
+
             RevisionGridFilter.SetAndApplyBranchFilter(filter);
 
             _isApplyingFilter = false;
@@ -176,12 +216,13 @@ namespace GitUI.UserControls
 
         /// <summary>
         ///  Sets the branches filter.
+        ///  No check that the branches exist (must be checked already, expected to be called from side panel).
         /// </summary>
-        /// <param name="filter">The filter to apply.</param>
+        /// <param name="filter">The branches to filter separated by whitespace.</param>
         public void SetBranchFilter(string? filter)
         {
             tscboBranchFilter.Text = filter;
-            ApplyCustomBranchFilter();
+            ApplyCustomBranchFilter(checkBranch: false);
         }
 
         /// <summary>
@@ -401,7 +442,7 @@ namespace GitUI.UserControls
         {
             if (e.KeyCode == Keys.Enter)
             {
-                ApplyCustomBranchFilter();
+                ApplyCustomBranchFilter(checkBranch: true);
             }
         }
 
@@ -465,6 +506,7 @@ namespace GitUI.UserControls
             public ToolStripMenuItem tsmiShowBranchesCurrent => _control.tsmiShowBranchesCurrent;
             public ToolStripMenuItem tsmiShowBranchesFiltered => _control.tsmiShowBranchesFiltered;
             public ToolStripComboBox tscboBranchFilter => _control.tscboBranchFilter;
+            public void RefreshRevisionFunction(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs) => _control.RefreshRevisionFunction(getRefs);
             public ToolStripDropDownButton tsddbtnBranchFilter => _control.tsddbtnBranchFilter;
             public ToolStripDropDownButton tsddbtnRevisionFilter => _control.tsddbtnRevisionFilter;
             public bool _isApplyingFilter => _control._isApplyingFilter;
@@ -472,7 +514,7 @@ namespace GitUI.UserControls
 
             public IRevisionGridFilter RevisionGridFilter => _control.RevisionGridFilter;
 
-            public void ApplyCustomBranchFilter() => _control.ApplyCustomBranchFilter();
+            public void ApplyCustomBranchFilter(bool checkBranch) => _control.ApplyCustomBranchFilter(checkBranch);
 
             public void ApplyRevisionFilter() => _control.ApplyRevisionFilter();
 

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -71,7 +71,7 @@ namespace GitUI.UserControls
                 IReadOnlyList<IGitRef> refs = _getRefs(RefsFilter.NoFilter);
 
                 // Split at whitespace (char[])null is default) but with split options.
-                // Ignore quouting, Git revisions do not allow spaces.
+                // Ignore quoting, Git revisions do not allow spaces.
                 foreach (string branch in filter.Split((char[])null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
                 {
                     bool wildcardBranchFilter = branch.IndexOfAny(new[] { '?', '*', '[' }) >= 0;

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -449,7 +449,10 @@ namespace GitUI.UserControls.RevisionGrid
                 // If BranchFilter contains wildcards, "--branches=" must be prepended.
                 // Use the simple branch filter if without wildcards (must be Git revision)
                 // in order to avoid git adding implicit /* to the "--branches=" filter.
-                // Also add apparent options
+                // Also add apparent options.
+
+                // Split at whitespace (char[])null is default) but with split options.
+                // Ignore quouting, Git revisions do not allow spaces.
                 foreach (string branch in BranchFilter.Split((char[])null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
                 {
                     bool wildcardBranchFilter = branch.IndexOfAny(new[] { '?', '*', '[' }) >= 0;

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using GitCommands;
 using GitExtUtils;
+using GitUIPluginInterfaces;
 
 namespace GitUI.UserControls.RevisionGrid
 {
@@ -111,6 +112,16 @@ namespace GitUI.UserControls.RevisionGrid
         {
             get => GetValue(ByBranchFilter, _branchFilter, string.Empty);
             set => _branchFilter = value ?? string.Empty;
+        }
+
+        public void SetBranchFilter(string filter)
+        {
+            // Set filtered branches if there is a filter, handled as all branches otherwise
+            ShowCurrentBranchOnly = false;
+
+            string newFilter = filter?.Trim() ?? string.Empty;
+            ByBranchFilter = !string.IsNullOrWhiteSpace(newFilter);
+            BranchFilter = newFilter;
         }
 
         public bool IsShowAllBranchesChecked => !ByBranchFilter && !ShowCurrentBranchOnly;
@@ -436,10 +447,16 @@ namespace GitUI.UserControls.RevisionGrid
                 AddFirstStashRef();
 
                 // If BranchFilter contains wildcards, "--branches=" must be prepended.
-                // Use the simple branch filter if without wildcards (must be Git reference)
+                // Use the simple branch filter if without wildcards (must be Git revision)
                 // in order to avoid git adding implicit /* to the "--branches=" filter.
-                bool useSimpleBranchFilter = BranchFilter.IndexOfAny(new[] { '?', '*', '[' }) == -1;
-                filter.Add(useSimpleBranchFilter ? BranchFilter : $"--branches={BranchFilter}");
+                // Also add apparent options
+                foreach (string branch in BranchFilter.Split((char[])null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+                {
+                    bool wildcardBranchFilter = branch.IndexOfAny(new[] { '?', '*', '[' }) >= 0;
+                    filter.Add(wildcardBranchFilter && !branch.StartsWith("--")
+                        ? $"--branches={branch}"
+                        : branch);
+                }
             }
             else
             {
@@ -573,7 +590,7 @@ namespace GitUI.UserControls.RevisionGrid
                 filter.AppendLine(TranslatedStrings.ShowReflog);
             }
 
-            if (ShowCurrentBranchOnly)
+            if (IsShowCurrentBranchOnlyChecked)
             {
                 filter.AppendLine(TranslatedStrings.ShowCurrentBranchOnly);
             }

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -112,6 +112,8 @@ namespace GitUI.UserControls.RevisionGrid
 
         private void OkClick(object sender, EventArgs e)
         {
+            // Note: There is no validation that information (like branch filters) are valid
+
             _filterInfo.ByDateFrom = SinceCheck.Checked;
             _filterInfo.DateFrom = Since.Value;
             _filterInfo.ByDateTo = CheckUntil.Checked;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -488,15 +488,7 @@ namespace GitUI
 
         public void SetAndApplyBranchFilter(string filter)
         {
-            // TODO: clean up and move all internals to FilterInfo
-
-            _filterInfo.ShowCurrentBranchOnly = false;
-
-            // Set filtered branches if there is a filter, handled as all branches otherwise
-            string newFilter = filter?.Trim() ?? string.Empty;
-            _filterInfo.ByBranchFilter = !string.IsNullOrWhiteSpace(newFilter);
-            _filterInfo.BranchFilter = newFilter;
-
+            _filterInfo.SetBranchFilter(filter);
             PerformRefreshRevisions();
         }
 

--- a/UnitTests/GitUI.Tests/UserControls/FilterToolBarTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterToolBarTests.cs
@@ -62,7 +62,7 @@ namespace GitUITests.UserControls
         {
             _filterToolBar.GetTestAccessor().tscboBranchFilter.Items.Count.Should().Be(0);
 
-            _filterToolBar.GetTestAccessor().ApplyCustomBranchFilter();
+            _filterToolBar.GetTestAccessor().ApplyCustomBranchFilter(checkBranch: true);
 
             _revisionGridFilter.Received().SetAndApplyBranchFilter(string.Empty);
             _filterToolBar.GetTestAccessor()._isApplyingFilter.Should().BeFalse();
@@ -74,7 +74,7 @@ namespace GitUITests.UserControls
             _filterToolBar.GetTestAccessor().tscboBranchFilter.Items.AddRange(new[] { "one", "two" });
             _filterToolBar.GetTestAccessor().tscboBranchFilter.Text = TranslatedStrings.NoResultsFound;
 
-            _filterToolBar.GetTestAccessor().ApplyCustomBranchFilter();
+            _filterToolBar.GetTestAccessor().ApplyCustomBranchFilter(checkBranch: true);
 
             _revisionGridFilter.Received().SetAndApplyBranchFilter(string.Empty);
             _filterToolBar.GetTestAccessor()._isApplyingFilter.Should().BeFalse();
@@ -85,10 +85,69 @@ namespace GitUITests.UserControls
         {
             _filterToolBar.GetTestAccessor().tscboBranchFilter.Items.AddRange(new[] { "one", "two" });
             _filterToolBar.GetTestAccessor().tscboBranchFilter.Text = "on";
+            _filterToolBar.GetTestAccessor().RefreshRevisionFunction((x) =>
+            new List<IGitRef>
+            {
+                new GitRef(_filterToolBar.GetTestAccessor().GetModule(),
+                ObjectId.Random(),
+                GitRefName.GetFullBranchName(_filterToolBar.GetTestAccessor().tscboBranchFilter.Text))
+            });
 
-            _filterToolBar.GetTestAccessor().ApplyCustomBranchFilter();
+            _filterToolBar.GetTestAccessor().ApplyCustomBranchFilter(checkBranch: true);
 
             _revisionGridFilter.Received().SetAndApplyBranchFilter("on");
+            _filterToolBar.GetTestAccessor()._isApplyingFilter.Should().BeFalse();
+        }
+
+        [Test]
+        public void ApplyBranchFilter_should_allow_multiple_branches()
+        {
+            _filterToolBar.GetTestAccessor().tscboBranchFilter.Items.AddRange(new[] { "one", "two" });
+            _filterToolBar.GetTestAccessor().tscboBranchFilter.Text = "one two";
+            _filterToolBar.GetTestAccessor().RefreshRevisionFunction((x) =>
+            new List<IGitRef>
+            {
+                new GitRef(_filterToolBar.GetTestAccessor().GetModule(),
+                ObjectId.Random(),
+                GitRefName.GetFullBranchName("one")),
+                new GitRef(_filterToolBar.GetTestAccessor().GetModule(),
+                ObjectId.Random(),
+                GitRefName.GetFullBranchName("two"))
+            });
+
+            _filterToolBar.GetTestAccessor().ApplyCustomBranchFilter(checkBranch: true);
+
+            _revisionGridFilter.Received().SetAndApplyBranchFilter("one two");
+            _filterToolBar.GetTestAccessor()._isApplyingFilter.Should().BeFalse();
+        }
+
+        [Test]
+        public void ApplyBranchFilter_should_allow_git_option()
+        {
+            _filterToolBar.GetTestAccessor().tscboBranchFilter.Items.AddRange(new[] { "one", "two" });
+            _filterToolBar.GetTestAccessor().tscboBranchFilter.Text = "--some_option";
+
+            // Empty git ref list
+            _filterToolBar.GetTestAccessor().RefreshRevisionFunction((x) => new List<IGitRef>());
+
+            _filterToolBar.GetTestAccessor().ApplyCustomBranchFilter(checkBranch: true);
+
+            _revisionGridFilter.Received().SetAndApplyBranchFilter("--some_option");
+            _filterToolBar.GetTestAccessor()._isApplyingFilter.Should().BeFalse();
+        }
+
+        [Test]
+        public void ApplyBranchFilter_should_allow_wildcard_branch()
+        {
+            _filterToolBar.GetTestAccessor().tscboBranchFilter.Items.AddRange(new[] { "one", "two" });
+            _filterToolBar.GetTestAccessor().tscboBranchFilter.Text = "wildcard*";
+
+            // Empty git ref list
+            _filterToolBar.GetTestAccessor().RefreshRevisionFunction((x) => new List<IGitRef>());
+
+            _filterToolBar.GetTestAccessor().ApplyCustomBranchFilter(checkBranch: true);
+
+            _revisionGridFilter.Received().SetAndApplyBranchFilter("wildcard*");
             _filterToolBar.GetTestAccessor()._isApplyingFilter.Should().BeFalse();
         }
 


### PR DESCRIPTION
Depends on #10831 - only last commit to be reviewed
There is no functional requirement, but it is easier to not have to resolve merge conflicts multiple times.

Fixes #10740

## Proposed changes

- Validate the contents in the filtered branches text box. If a revision is not valid, show a popup and ignore the revision.
- Handle multiple revisions (branches) was not properly none when handling options

There is no check in the Advanced filter form. This is partly due to that GitModule and the cached branches/refs are not available which require some more step, but also to allow use cases that may have been missed.

The data is not cleared in the box, so the user can edit. But no further feedback that the data is ignored.

The text box is still a mess, should be improved...
(since .net5 migration I believe.)

See also #10168, not included in a released version yet

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

After refresh

![image](https://user-images.githubusercontent.com/6248932/227746581-ad3ac282-ceb8-471c-bb91-6cbd63f7b89a.png)

### After

Enter in text box

![image](https://user-images.githubusercontent.com/6248932/227746567-a59ef56e-7ff4-4845-a668-a759f1a46421.png)

## Test methodology <!-- How did you ensure quality? -->

- Tests added
Note: There is no test for invalid revisions when the popup appear.

## Merge strategy

After dependencies are merged:

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
