### PR TITLE
FormPush: Popup when no branch is checked out

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -46,6 +46,8 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _branchNewForRemote =
             new("The branch you are about to push seems to be a new branch for the remote." +
                                   Environment.NewLine + "Are you sure you want to push this branch?");
+        private readonly TranslationString _noCurrentBranch =
+            new("No branch is selected, cannot push.");
 
         private readonly TranslationString _pushCaption = new("Push");
 
@@ -278,6 +280,15 @@ namespace GitUI.CommandsDialogs
             if (TabControlTagBranch.SelectedTab == TagTab && string.IsNullOrEmpty(TagComboBox.Text))
             {
                 MessageBox.Show(owner, _selectTag.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(_NO_TRANSLATE_Branch.Text)
+                || _NO_TRANSLATE_Branch.Text == DetachedHeadParser.DetachedBranch
+                || string.IsNullOrWhiteSpace(RemoteBranch.Text)
+                || RemoteBranch.Text == DetachedHeadParser.DetachedBranch)
+            {
+                MessageBox.Show(owner, _noCurrentBranch.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5754,6 +5754,10 @@ Would you like to do it now?</source>
         <source>Force with lease is a safer way to force push. It ensures you only overwrite work that you have seen in your local repository</source>
         <target />
       </trans-unit>
+      <trans-unit id="_noCurrentBranch.Text">
+        <source>No branch is selected, cannot push.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_pullActionFetch.Text">
         <source>fetch</source>
         <target />


### PR DESCRIPTION
Fixes #10405

## Proposed changes

The error message when pushing and no branch is checked out is quite confusing, partly due to GE presents nocheckout as "(no branch)". That name is illegal, but not obvious in commands.

Note: In addition to checking for the GE hardcoded name, the check could check for illegal characters (like space and parenthesis).

Note: Push could be suppressed in these situations (as was suggested in #10405), this improves the error message only.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/6248932/227799327-62753cb7-7e7a-490c-8973-bbe44bba988f.png)

### After

![image](https://user-images.githubusercontent.com/6248932/227799720-90ef886d-60f9-49dd-b001-b21e49bf6d24.png)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
