### PR TITLE
WslGit: Configurable path to Git executable

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -78,7 +78,7 @@ namespace GitCommands
             _wslDistro = AppSettings.WslGitEnabled ? PathUtil.GetWslDistro(WorkingDir) : "";
             if (!string.IsNullOrEmpty(_wslDistro))
             {
-                _gitExecutable = new Executable(() => AppSettings.WslGitCommand, WorkingDir, $"-d {_wslDistro} git ");
+                _gitExecutable = new Executable(() => AppSettings.WslGitCommand, WorkingDir, $"-d {_wslDistro} {AppSettings.WslGitPath} ");
                 _gitCommandRunner = new GitCommandRunner(_gitExecutable, () => SystemEncoding);
             }
             else

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -361,6 +361,12 @@ namespace GitCommands
             get => GetString("WslGitCommand", "wsl");
         }
 
+        // Currently not configurable
+        public static string WslGitPath
+        {
+            get => GetString("WslGitPath", "git");
+        }
+
         public static bool StashKeepIndex
         {
             get => GetBool("stashkeepindex", false);


### PR DESCRIPTION
Fixes #10274

## Proposed changes

WSL git command path is configurable in the settings file.

This allows using Git not in default path as the path (for instance if a newer version is installed separately, not replacing the default version). Changing the PATH is not trivial.
It also allows wrapping the command as asked for in #10274 (but in a different way).

WSL is still handled as experimental, manual change in the settings file required to change this.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
