### PR TITLE
Fixup GetAllBranchesWhichContainGivenCommit

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3146,7 +3146,13 @@ namespace GitCommands
             // Remove symlink targets as in "origin/HEAD -> origin/master"
             for (int i = 0; i < result.Length; i++)
             {
-                string item = Regex.Replace(result[i], @"^[*+ ] ", "");
+                string item = result[i];
+
+                // remove prepended branch state "* ", "+ ", "  "
+                if (item.Length >= 2 && item[1] == ' ' && item[0] is (' ' or '*' or '+'))
+                {
+                    item = item[2..];
+                }
 
                 if (getRemote)
                 {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3141,12 +3141,12 @@ namespace GitCommands
                 return Array.Empty<string>();
             }
 
-            var result = exec.StandardOutput.Split(new[] { '\r', '\n', '*', '+' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] result = exec.StandardOutput.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
             // Remove symlink targets as in "origin/HEAD -> origin/master"
-            for (var i = 0; i < result.Length; i++)
+            for (int i = 0; i < result.Length; i++)
             {
-                var item = result[i].Trim();
+                string item = Regex.Replace(result[i], @"^[*+ ] ", "");
 
                 if (getRemote)
                 {

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -316,8 +316,8 @@ namespace GitCommandsTests
         [TestCase("branch -a --contains",
             true,
             true,
-            "  aaa\n* current\n+ feature/worktree\n  feature/zzz_another\n  remotes/origin/master\n  remotes/origin/current\n  remotes/upstream/master\n",
-            new string[] { "aaa", "current", "feature/worktree", "feature/zzz_another", "remotes/origin/master", "remotes/origin/current", "remotes/upstream/master" })]
+            "  aaa\n* current\n+ feature/worktree\n  feature/zzz_another\n  remotes/origin/master\n  remotes/origin/current\n  remotes/upstream/master\n  a+b",
+            new string[] { "aaa", "current", "feature/worktree", "feature/zzz_another", "remotes/origin/master", "remotes/origin/current", "remotes/upstream/master", "a+b" })]
         [TestCase("branch --contains",
             true,
             false,


### PR DESCRIPTION
Fixes #10819

## Proposed changes

- correctly split git output, i.e. only at line ends
- remove first two columns only if in expected format "* ", "+ " or "  "

## Screenshots <!-- Remove this section if PR does not change UI -->

n/a

## Test methodology <!-- How did you ensure quality? -->

- extended existing testcase

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).