### PR TITLE
CommitInfo: Fixup handling of detached head

### DIFF
--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -809,10 +809,12 @@ namespace GitUI.CommitInfo
                 RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
             private readonly string _currentBranch;
+            private readonly bool _isDetachedHead;
 
             public BranchComparer(string currentBranch)
             {
                 _currentBranch = currentBranch;
+                _isDetachedHead = DetachedHeadParser.IsDetachedHead(currentBranch);
             }
 
             public int Compare(string a, string b)
@@ -825,7 +827,7 @@ namespace GitUI.CommitInfo
 
             private int GetBranchPriority(string branch)
             {
-                return branch == _currentBranch ? 0
+                return (_isDetachedHead ? DetachedHeadParser.IsDetachedHead(branch) : branch == _currentBranch) ? 0
                     : IsImportantLocalBranch() ? 1
                     : IsImportantRemoteBranch() ? IsImportantRepo() ? 2 : 3
                     : IsLocalBranch() ? 4

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -1,10 +1,11 @@
-﻿using System.ComponentModel;
+﻿#nullable enable
+
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Net;
 using System.Reactive.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 using GitCommands;
 using GitCommands.ExternalLinks;
 using GitCommands.Git;
@@ -452,7 +453,7 @@ namespace GitUI.CommitInfo
 
                         Dictionary<string, string> result = new();
 
-                        foreach (var gitRef in refs)
+                        foreach (IGitRef gitRef in refs)
                         {
                             #region Note on annotated tags
                             // Notice that for the annotated tags, gitRef's come in pairs because they're produced
@@ -481,8 +482,7 @@ namespace GitUI.CommitInfo
 
                             if (gitRef.IsTag && gitRef.IsDereference)
                             {
-                                string content = WebUtility.HtmlEncode(Module.GetTagMessage(gitRef.LocalName));
-
+                                string? content = WebUtility.HtmlEncode(Module.GetTagMessage(gitRef.LocalName));
                                 if (content is not null)
                                 {
                                     result.Add(gitRef.LocalName, content);
@@ -817,8 +817,13 @@ namespace GitUI.CommitInfo
                 _isDetachedHead = DetachedHeadParser.IsDetachedHead(currentBranch);
             }
 
-            public int Compare(string a, string b)
+            public int Compare(string? a, string? b)
             {
+                if (a is null || b is null)
+                {
+                    return -1;
+                }
+
                 int priorityA = GetBranchPriority(a);
                 int priorityB = GetBranchPriority(b);
                 return priorityA == priorityB ? StringComparer.Ordinal.Compare(a, b)
@@ -853,9 +858,9 @@ namespace GitUI.CommitInfo
                 _prefix = prefix;
             }
 
-            public int Compare(string a, string b)
+            public int Compare(string? a, string? b)
             {
-                return IndexOf(a) - IndexOf(b);
+                return a is null || b is null ? -1 : IndexOf(a) - IndexOf(b);
 
                 int IndexOf(string s)
                 {

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -819,9 +819,14 @@ namespace GitUI.CommitInfo
 
             public int Compare(string? a, string? b)
             {
-                if (a is null || b is null)
+                if (b is null)
                 {
                     return -1;
+                }
+
+                if (a is null)
+                {
+                    return 1;
                 }
 
                 int priorityA = GetBranchPriority(a);
@@ -860,7 +865,7 @@ namespace GitUI.CommitInfo
 
             public int Compare(string? a, string? b)
             {
-                return a is null || b is null ? -1 : IndexOf(a) - IndexOf(b);
+                return b is null ? -1 : a is null ? 1 : IndexOf(a) - IndexOf(b);
 
                 int IndexOf(string s)
                 {

--- a/ResourceManager/LinkFactory.cs
+++ b/ResourceManager/LinkFactory.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using GitCommands.Git;
 using GitUIPluginInterfaces;
 
 namespace ResourceManager
@@ -49,7 +50,8 @@ namespace ResourceManager
         {
             if (noPrefixBranch != "…")
             {
-                return CreateLink(noPrefixBranch, $"{InternalScheme}://gotobranch/" + noPrefixBranch);
+                string linkTarget = DetachedHeadParser.IsDetachedHead(noPrefixBranch) ? "HEAD" : noPrefixBranch;
+                return CreateLink(noPrefixBranch, $"{InternalScheme}://gotobranch/{linkTarget}");
             }
 
             return WebUtility.HtmlEncode(noPrefixBranch);

--- a/UnitTests/GitUI.Tests/UserControls/CommitInfo/BranchComparerTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/CommitInfo/BranchComparerTests.cs
@@ -8,7 +8,7 @@ namespace GitUITests.UserControls.CommitInfo
         [SetCulture("en-US")]
         [SetUICulture("en-US")]
         [Test]
-        public void BranchComparer([Values(null, "current")] string currentBranch)
+        public void BranchComparer([Values(null, "current", "(no branch)")] string currentBranch)
         {
             List<string> expectedBranches = new()
             {

--- a/UnitTests/GitUI.Tests/UserControls/CommitInfo/BranchComparerTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/CommitInfo/BranchComparerTests.cs
@@ -8,7 +8,7 @@ namespace GitUITests.UserControls.CommitInfo
         [SetCulture("en-US")]
         [SetUICulture("en-US")]
         [Test]
-        public void BranchComparer([Values(null, "current", "(no branch)")] string currentBranch)
+        public void BranchComparer([Values(null, "", "current", "(no branch)")] string? currentBranch)
         {
             List<string> expectedBranches = new()
             {
@@ -73,7 +73,7 @@ namespace GitUITests.UserControls.CommitInfo
 
             void SortAndCheckListsForEquality()
             {
-                branches.Sort(new GitUI.CommitInfo.CommitInfo.BranchComparer(currentBranch));
+                branches.Sort(new GitUI.CommitInfo.CommitInfo.BranchComparer(currentBranch ?? ""));
 
                 branches.Count.Should().Be(expectedBranches.Count);
                 for (int index = 0; index < branches.Count; ++index)

--- a/UnitTests/ResourceManager.Tests/LinkFactoryTests.cs
+++ b/UnitTests/ResourceManager.Tests/LinkFactoryTests.cs
@@ -37,6 +37,16 @@ namespace ResourceManagerTests
             Assert.That(actualUri.AbsoluteUri, Is.EqualTo(expected));
         }
 
+        public void ParseGoToBranchLinkWithDetachedHead()
+        {
+            const string linkCaption = "(HEAD detached at 178264)";
+            LinkFactory linkFactory = new();
+            linkFactory.CreateBranchLink(linkCaption);
+            string expected = "gitext://gotobranch/HEAD";
+            Assert.True(linkFactory.GetTestAccessor().TryParseLink($"{linkCaption}#{expected}", out Uri? actualUri));
+            Assert.That(actualUri.AbsoluteUri, Is.EqualTo(expected));
+        }
+
         private static void TestCreateLink(string caption, string uri)
         {
             LinkFactory linkFactory = new();


### PR DESCRIPTION
Fixes #10317

## Proposed changes

- `LinkFactory`: Create working internal links for detached head
- `BranchComparer`: Recognize detached head as current branch

## Test methodology <!-- How did you ensure quality? -->

- extend tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).