### PR TITLE
Improve tooltips translation

### DIFF
--- a/GitUI/CommandsDialogs/FormPull.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPull.Designer.cs
@@ -127,7 +127,7 @@
             this.lblLocalBranch.Size = new System.Drawing.Size(75, 15);
             this.lblLocalBranch.TabIndex = 11;
             this.lblLocalBranch.Text = "&Local branch";
-            this.Tooltip.SetToolTip(this.lblLocalBranch, "Remote branch to pull. Leave empty to pull all branches.");
+            this.Tooltip.SetToolTip(this.lblLocalBranch, "Local branch to create or reset to the remote branch selected.");
             // 
             // lblRemoteBranch
             // 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -5625,7 +5625,7 @@ This will initialize and update all submodules recursive.</source>
         <target />
       </trans-unit>
       <trans-unit id="lblLocalBranch.Tooltip">
-        <source>Remote branch to pull. Leave empty to pull all branches.</source>
+        <source>Local branch to create or reset to the remote branch selected.</source>
         <target />
       </trans-unit>
       <trans-unit id="lblRemoteBranch.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1484,6 +1484,10 @@ the last selected commit.</source>
   </file>
   <file datatype="plaintext" original="FileStatusList" source-language="en">
     <body>
+      <trans-unit id="FilterToolTip.ToolTipTitle">
+        <source>RegEx</source>
+        <target />
+      </trans-unit>
       <trans-unit id="FilterWatermarkLabel.Text">
         <source>Filter files using a regular expression...</source>
         <target />
@@ -2259,6 +2263,10 @@ compare with first:</source>
       </trans-unit>
       <trans-unit id="EditSettings.ToolTipText">
         <source>Settings</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="FilterToolTip.ToolTipTitle">
+        <source>RegEx</source>
         <target />
       </trans-unit>
       <trans-unit id="GpgInfoTabPage.Text">
@@ -5375,6 +5383,10 @@ command "git help shortlog"</source>
       </trans-unit>
       <trans-unit id="label1.Text">
         <source>&amp;Directory:</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="toolTip1.ToolTipTitle">
+        <source>Help</source>
         <target />
       </trans-unit>
     </body>

--- a/ResourceManager/Xliff/TranslationUtil.cs
+++ b/ResourceManager/Xliff/TranslationUtil.cs
@@ -143,11 +143,18 @@ namespace ResourceManager.Xliff
             {
                 if (itemObj is ToolTip tooltip)
                 {
+                    string toolTipTitle = tooltip.ToolTipTitle;
+
+                    if (!string.IsNullOrEmpty(toolTipTitle))
+                    {
+                        translation.AddTranslationItem(category, itemName, "ToolTipTitle", toolTipTitle);
+                    }
+
                     foreach (var (itemNameForTooltip, itemObjForTooltip) in items)
                     {
                         if (itemObjForTooltip is Control control)
                         {
-                            var tooltipString = tooltip.GetToolTip(control);
+                            string tooltipString = tooltip.GetToolTip(control);
                             if (!string.IsNullOrEmpty(tooltipString))
                             {
                                 // Will add an entry in the xlf file with id `NameOfControl.NameOfTooltipControl` ex: "PushToRemote.toolTip1"
@@ -211,6 +218,13 @@ namespace ResourceManager.Xliff
                 if (itemObj is ToolTip tooltip)
                 {
                     static string ProvideDefaultValue() => null;
+
+                    string? toolTipTitle = translation.TranslateItem(category, itemName, "ToolTipTitle", ProvideDefaultValue);
+
+                    if (!string.IsNullOrEmpty(toolTipTitle))
+                    {
+                        tooltip.ToolTipTitle = toolTipTitle;
+                    }
 
                     foreach (var (itemNameForTooltip, itemObjForTooltip) in items)
                     {


### PR DESCRIPTION
## Proposed changes

Last 2 points raised by PR #10824 (Thanks again to them!)

- Handle ToolTipTitle in tooltips translations
- Fix bad tooltip on local branch label (in Pull form)

## Screenshots <!-- Remove this section if PR does not change UI -->

###  Tooltip title
* Before
![image](https://user-images.githubusercontent.com/460196/227910775-cd288cf1-a399-4b69-9845-d5edc8ce8e5c.png)

* After (ToolTip Title translated)
![image](https://user-images.githubusercontent.com/460196/227910561-9eae6311-73ef-41a2-8add-359bfe914473.png)

### Pull form tooltip

* Before (same tooltip than remote label just below):
![image](https://user-images.githubusercontent.com/460196/227911224-85fcba61-b70c-4721-9fe1-8116fcbcdd8b.png)

* AFter
![image](https://user-images.githubusercontent.com/460196/227911555-4e40c4d0-d592-4041-9bed-22a90b5b59d0.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build d50fd6a135438b5e8c1332126ff5c2c8198bd2c5 (Dirty)
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.14
- DPI 96dpi (no scaling)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
