### PR TITLE
Improve blame performance

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3378,7 +3378,10 @@ namespace GitCommands
             // is a blank line, and third is an introductory paragraph about the project.
 
             Dictionary<ObjectId, GitBlameCommit> commitByObjectId = new();
-            List<GitBlameLine> lines = new(capacity: 256);
+
+            // Pre-allocate the list with a capacity estimated from the approximate git blame length to describe a file line
+            const int GitBlameLengthPerLineHeuristicValue = 120;
+            List<GitBlameLine> lines = new(capacity: Math.Min(Math.Max(256, output.Length / GitBlameLengthPerLineHeuristicValue), 5000));
 
             bool hasCommitHeader;
             ObjectId? objectId;
@@ -3417,7 +3420,7 @@ namespace GitCommands
                     {
                         // TODO quite a few nullable suppressions here (via ! character) which should be addressed as they hint at a design flaw
 
-                        if (!commitByObjectId.ContainsKey(objectId!))
+                        if (!commitByObjectId.TryGetValue(objectId!, out GitBlameCommit? commitData))
                         {
                             commit = new GitBlameCommit(
                                 objectId!,
@@ -3435,7 +3438,6 @@ namespace GitCommands
                         }
                         else
                         {
-                            var commitData = commitByObjectId[objectId!];
                             if (filename == commitData.FileName)
                             {
                                 commit = commitData;

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -365,6 +365,7 @@ namespace GitUI.Blame
             string emptyLine = new(' ', lineLength);
             Dictionary<string, Image?> cacheAvatars = new();
             var noAuthorImage = (Image)new Bitmap(Images.User80, avatarSize, avatarSize);
+            Dictionary<ObjectId, string> authorLineCache = new();
             for (var index = 0; index < _blame.Lines.Count; index++)
             {
                 var line = _blame.Lines[index];
@@ -379,9 +380,9 @@ namespace GitUI.Blame
                     {
                         if (authorEmail is not null)
                         {
-                            if (cacheAvatars.ContainsKey(authorEmail))
+                            if (cacheAvatars.TryGetValue(authorEmail, out Image? avatarImage))
                             {
-                                gitBlameDisplays[index].Avatar = cacheAvatars[authorEmail];
+                                gitBlameDisplays[index].Avatar = avatarImage;
                             }
                             else
                             {
@@ -398,11 +399,14 @@ namespace GitUI.Blame
                         }
                     }
 
-                    BuildAuthorLine(line, lineBuilder, dateTimeFormat, filename, AppSettings.BlameShowAuthor, AppSettings.BlameShowAuthorDate, AppSettings.BlameShowOriginalFilePath, AppSettings.BlameDisplayAuthorFirst);
+                    if (!authorLineCache.TryGetValue(line.Commit.ObjectId, out string authorLine))
+                    {
+                        authorLine = BuildAuthorLine(line, lineBuilder, lineLength, dateTimeFormat, filename, AppSettings.BlameShowAuthor, AppSettings.BlameShowAuthorDate, AppSettings.BlameShowOriginalFilePath, AppSettings.BlameDisplayAuthorFirst);
+                        authorLineCache.Add(line.Commit.ObjectId, authorLine);
+                        lineBuilder.Clear();
+                    }
 
-                    gutter.Append(lineBuilder);
-                    gutter.Append(' ', lineLength - lineBuilder.Length).AppendLine();
-                    lineBuilder.Clear();
+                    gutter.Append(authorLine);
                 }
 
                 body.AppendLine(line.Text);
@@ -413,38 +417,42 @@ namespace GitUI.Blame
             return (gutter.ToString(), body.ToString(), gitBlameDisplays);
         }
 
-        private void BuildAuthorLine(GitBlameLine line, StringBuilder lineBuilder, string dateTimeFormat,
+        private string BuildAuthorLine(GitBlameLine line, StringBuilder authorLineBuilder, int lineLength, string dateTimeFormat,
             string? filename, bool showAuthor, bool showAuthorDate, bool showOriginalFilePath, bool displayAuthorFirst)
         {
             if (showAuthor && displayAuthorFirst)
             {
-                lineBuilder.Append(line.Commit.Author);
+                authorLineBuilder.Append(line.Commit.Author);
                 if (showAuthorDate)
                 {
-                    lineBuilder.Append(" - ");
+                    authorLineBuilder.Append(" - ");
                 }
             }
 
             if (showAuthorDate)
             {
-                lineBuilder.Append(line.Commit.AuthorTime.ToString(dateTimeFormat));
+                authorLineBuilder.Append(line.Commit.AuthorTime.ToString(dateTimeFormat));
             }
 
             if (showAuthor && !displayAuthorFirst)
             {
                 if (showAuthorDate)
                 {
-                    lineBuilder.Append(" - ");
+                    authorLineBuilder.Append(" - ");
                 }
 
-                lineBuilder.Append(line.Commit.Author);
+                authorLineBuilder.Append(line.Commit.Author);
             }
 
             if (showOriginalFilePath && filename != line.Commit.FileName)
             {
-                lineBuilder.Append(" - ");
-                lineBuilder.Append(line.Commit.FileName);
+                authorLineBuilder.Append(" - ");
+                authorLineBuilder.Append(line.Commit.FileName);
             }
+
+            authorLineBuilder.Append(' ', lineLength - authorLineBuilder.Length).AppendLine();
+
+            return authorLineBuilder.ToString();
         }
 
         private static IList<Color> GetAgeBucketGradientColors()
@@ -704,8 +712,8 @@ namespace GitUI.Blame
 
             public DateTime ArtificialOldBoundary => _control.ArtificialOldBoundary;
 
-            public void BuildAuthorLine(GitBlameLine line, StringBuilder lineBuilder, string dateTimeFormat, string filename, bool showAuthor, bool showAuthorDate, bool showOriginalFilePath, bool displayAuthorFirst)
-                => _control.BuildAuthorLine(line, lineBuilder, dateTimeFormat, filename, showAuthor, showAuthorDate, showOriginalFilePath, displayAuthorFirst);
+            public void BuildAuthorLine(GitBlameLine line, StringBuilder lineBuilder, int lineLength, string dateTimeFormat, string filename, bool showAuthor, bool showAuthorDate, bool showOriginalFilePath, bool displayAuthorFirst)
+                => _control.BuildAuthorLine(line, lineBuilder, lineLength, dateTimeFormat, filename, showAuthor, showAuthorDate, showOriginalFilePath, displayAuthorFirst);
 
             public (string gutter, string body, List<GitBlameEntry> avatars) BuildBlameContents(string filename) => _control.BuildBlameContents(filename, avatarSize: 10);
 

--- a/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
@@ -109,7 +109,7 @@ namespace GitUITests.UserControls
         {
             StringBuilder line = new();
 
-            _blameControl.GetTestAccessor().BuildAuthorLine(_gitBlameLine, line, CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern,
+            _blameControl.GetTestAccessor().BuildAuthorLine(_gitBlameLine, line, expectedResult.Length + 10, CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern,
                 "fileName_different.txt", showAuthor, showAuthorDate, showFilePath, displayAuthorFirst);
 
             line.ToString().Should().StartWith(expectedResult);
@@ -120,7 +120,7 @@ namespace GitUITests.UserControls
         {
             StringBuilder line = new();
 
-            _blameControl.GetTestAccessor().BuildAuthorLine(_gitBlameLine, line, CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern,
+            _blameControl.GetTestAccessor().BuildAuthorLine(_gitBlameLine, line, 50, CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern,
                 "fileName.txt", true, true, true, false);
 
             line.ToString().Should().StartWith("3/22/2010 - author1");


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

 Some small improvements on blame data generation:
    * cache author lines instead of building it every times
(because it happens often that multiple lines belong to same commit)
    * Use TryGetValue to get the commit and avatar image
    * better heuristic for initial line capacity

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 25c13145f0e10caa840621380f8cf1c2441819de (Dirty)
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.14
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

Merge commit

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
