### PR TITLE
Refactor and fixup graph loading

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -247,7 +247,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                             return;
                         }
 
-                        IRevisionGraphRow? previousRow = _revisionGraph.GetSegmentsForRow(Math.Max(0, index - 1));
+                        IRevisionGraphRow? previousRow = _revisionGraph.GetSegmentsForRow(index - 1);
                         IRevisionGraphRow? nextRow = _revisionGraph.GetSegmentsForRow(index + 1);
 
                         int centerY = top + (rowHeight / 2);

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -154,7 +154,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         {
             // Use a local variable, because the cached list can be reset
             var localOrderedRowCache = _orderedRowCache;
-            if (localOrderedRowCache is null || row >= localOrderedRowCache.Count)
+            if (localOrderedRowCache is null || row < 0 || row >= localOrderedRowCache.Count)
             {
                 return null;
             }

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -80,8 +80,10 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 return 0;
             }
 
+            // _loadingCompleted is set already when all _nodes have been loaded.
+            // Return the full number of rows only if the straightening of segments has finished, too.
             int cachedCount = _orderedRowCache.Count;
-            return _loadingCompleted ? cachedCount : cachedCount - _straightenLanesLookAhead;
+            return _loadingCompleted && cachedCount == Count ? cachedCount : Math.Max(0, cachedCount - _straightenLanesLookAhead);
         }
 
         /// <summary>

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -662,8 +662,8 @@ namespace GitUI.UserControls.RevisionGrid
 
         private async Task UpdateVisibleRowRangeInternalAsync()
         {
-            var fromIndex = Math.Max(0, FirstDisplayedScrollingRowIndex);
-            var visibleRowCount = _rowHeight > 0 ? (Height / _rowHeight) + 2 /*Add 2 for rounding*/ : 0;
+            int fromIndex = Math.Max(0, FirstDisplayedScrollingRowIndex);
+            int visibleRowCount = _rowHeight <= 0 ? 0 : (Height / _rowHeight) + 2 /*Add 2 for rounding*/;
 
             visibleRowCount = Math.Min(_revisionGraph.Count - fromIndex, visibleRowCount);
 
@@ -682,16 +682,13 @@ namespace GitUI.UserControls.RevisionGrid
 
                         if (AppSettings.ShowRevisionGridGraphColumn)
                         {
-                            int scrollTo;
                             int curCount;
-
                             do
                             {
-                                scrollTo = newBackgroundScrollTo;
                                 curCount = _revisionGraph.GetCachedCount();
-                                await UpdateGraphAsync(fromIndex: curCount, toIndex: scrollTo);
+                                await UpdateGraphAsync(fromIndex: curCount, toIndex: newBackgroundScrollTo);
                             }
-                            while (curCount < scrollTo);
+                            while (curCount < newBackgroundScrollTo);
                         }
                         else
                         {

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -673,7 +673,8 @@ namespace GitUI.UserControls.RevisionGrid
 
                 if (visibleRowCount > 0)
                 {
-                    int newBackgroundScrollTo = fromIndex + visibleRowCount;
+                    // Preload the next page, too, in order to avoid delayed display of the graph when scrolling down
+                    int newBackgroundScrollTo = fromIndex + (2 * visibleRowCount);
 
                     // We always want to set _backgroundScrollTo. Because we want the backgroundthread to stop working when we scroll up
                     if (_backgroundScrollTo != newBackgroundScrollTo)

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -687,8 +687,14 @@ namespace GitUI.UserControls.RevisionGrid
                             {
                                 curCount = _revisionGraph.GetCachedCount();
                                 await UpdateGraphAsync(fromIndex: curCount, toIndex: newBackgroundScrollTo);
+
+                                // Take changes to _backgroundScrollTo and IsDataLoadComplete by another thread into account
+                                if (IsDataLoadComplete)
+                                {
+                                    _backgroundScrollTo = Math.Min(_backgroundScrollTo, _revisionGraph.Count);
+                                }
                             }
-                            while (curCount < newBackgroundScrollTo);
+                            while (curCount < _backgroundScrollTo);
                         }
                         else
                         {

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
@@ -141,7 +141,7 @@ namespace GitUITests.UserControls.RevisionGrid
             Assert.AreEqual(1, _revisionGraph.GetSegmentsForRow(1).GetCurrentRevisionLane());
         }
 
-        private static int LookAhead => 20;
+        private const int LookAhead = 20 * 2;
 
         private static IEnumerable<GitRevision> Revisions
         {


### PR DESCRIPTION
Alternative to #10680

## Proposed changes

- Refactoring
  * `RevisionGraph.GetSegmentsForRow`: Handle negative `row`
  * Make `UpdateVisibleRowRangeInternalAsync` clearer
  * Make `StraightenLanes` clearer (taken from #10778)
- Fixes
  * Fixup incomplete condition for graph cache loaded
  * Avoid unnecessary and incomplete lookahead for graph straightening
  * Fixup endless graph loading loop
- Feature
  * Preload next graph page

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

Please do *not squash merge* the commits!

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).