### PR TITLE
FormCommit: Read committer info using git

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2318,6 +2318,12 @@ namespace GitCommands
             return EffectiveConfigFile.GetValue(setting);
         }
 
+        public string GetEffectiveGitSetting(string setting, bool cache = true)
+        {
+            GitArgumentBuilder args = new("config") { "--includes", "--get", setting };
+            return GitExecutable.GetOutput(args, cache: cache ? GitCommandCache : null).Trim();
+        }
+
         public void UnsetSetting(string setting)
         {
             SetSetting(setting, null);

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2819,14 +2819,21 @@ namespace GitUI.CommandsDialogs
 
         private void UpdateAuthorInfo()
         {
-            var userName = Module.GetEffectiveSetting(SettingKeyString.UserName);
-            var userEmail = Module.GetEffectiveSetting(SettingKeyString.UserEmail);
+            ThreadHelper.JoinableTaskFactory.RunAsync(
+                async () =>
+                {
+                    await TaskScheduler.Default;
 
-            var committer = $"{_commitCommitterInfo.Text} {userName} <{userEmail}>";
+                    // Do not cache results in order to update the info on FormActivate
+                    string userName = Module.GetEffectiveGitSetting(SettingKeyString.UserName, cache: false);
+                    string userEmail = Module.GetEffectiveGitSetting(SettingKeyString.UserEmail, cache: false);
+                    string committer = $"{_commitCommitterInfo.Text} {userName} <{userEmail}>";
 
-            commitAuthorStatus.Text = string.IsNullOrEmpty(toolAuthor.Text?.Trim())
-                ? committer
-                : $"{committer} {_commitAuthorInfo.Text} {toolAuthor.Text}";
+                    await this.SwitchToMainThreadAsync();
+                    commitAuthorStatus.Text = string.IsNullOrEmpty(toolAuthor.Text?.Trim())
+                        ? committer
+                        : $"{committer} {_commitAuthorInfo.Text} {toolAuthor.Text}";
+                });
         }
 
         private bool SenderToFileStatusList(object sender, [NotNullWhen(returnValue: true)] out FileStatusList? list)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2830,7 +2830,7 @@ namespace GitUI.CommandsDialogs
                     string committer = $"{_commitCommitterInfo.Text} {userName} <{userEmail}>";
 
                     await this.SwitchToMainThreadAsync();
-                    commitAuthorStatus.Text = string.IsNullOrEmpty(toolAuthor.Text?.Trim())
+                    commitAuthorStatus.Text = string.IsNullOrWhiteSpace(toolAuthor.Text)
                         ? committer
                         : $"{committer} {_commitAuthorInfo.Text} {toolAuthor.Text}";
                 });

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -52,9 +52,12 @@ namespace GitExtensions.UITests.CommandsDialogs
         [Test]
         public void Should_show_committer_info_on_open()
         {
-            RunFormTest(form =>
+            RunFormTest(async form =>
             {
                 var commitAuthorStatus = form.GetTestAccessor().CommitAuthorStatusToolStripStatusLabel;
+
+                await Task.Delay(1000);
+                await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
 
                 Assert.AreEqual("Committer author <author@mail.com>", commitAuthorStatus.Text);
             });
@@ -80,7 +83,9 @@ namespace GitExtensions.UITests.CommandsDialogs
                 }
 
                 form.Focus();
+                Application.DoEvents();
 
+                await Task.Delay(1000);
                 await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
 
                 Assert.AreEqual("Committer new author <new_author@mail.com>", commitAuthorStatus.Text);

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -70,6 +70,8 @@ namespace GitExtensions.UITests.CommandsDialogs
             {
                 var commitAuthorStatus = form.GetTestAccessor().CommitAuthorStatusToolStripStatusLabel;
 
+                await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
+
                 Assert.AreEqual("Committer author <author@mail.com>", commitAuthorStatus.Text);
 
                 using (Form tempForm = new())
@@ -85,7 +87,6 @@ namespace GitExtensions.UITests.CommandsDialogs
                 form.Focus();
                 Application.DoEvents();
 
-                await Task.Delay(1000);
                 await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
 
                 Assert.AreEqual("Committer new author <new_author@mail.com>", commitAuthorStatus.Text);

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -125,6 +125,7 @@ namespace GitUIPluginInterfaces
 
         string GetSetting(string setting);
         string GetEffectiveSetting(string setting);
+        string GetEffectiveGitSetting(string setting, bool cache = true);
 
         /// <summary>Gets the current branch; or "(no branch)" if HEAD is detached.</summary>
         string GetSelectedBranch();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/gitextensions/gitextensions/issues/5492#issuecomment-1448460964

## Proposed changes

- FormCommit: Read committer info using git,
  use `RunAsync` and
  do not cache the git output in order to update on FormActivate (existing testcase)

## Screenshots <!-- Remove this section if PR does not change UI -->

unchanged

## Test methodology <!-- How did you ensure quality? -->

- manual
- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).