### PR TITLE
Improve avatar handling

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -576,7 +576,7 @@ namespace GitCommands
 
         public static int AvatarImageCacheDays
         {
-            get => GetInt("authorimagecachedays", 5);
+            get => GetInt("authorimagecachedays", 13);
             set => SetInt("authorimagecachedays", value);
         }
 
@@ -588,8 +588,14 @@ namespace GitCommands
 
         public static AvatarProvider AvatarProvider
         {
-            get => GetEnumViaString("Appearance.AvatarProvider", AvatarProvider.Default);
+            get => GetEnumViaString("Appearance.AvatarProvider", AvatarProvider.None);
             set => SetString("Appearance.AvatarProvider", value.ToString());
+        }
+
+        public static int AvatarCacheSize
+        {
+            get => GetInt("Appearance.AvatarCacheSize", 50);
+            set => SetInt("Appearance.AvatarCacheSize", value);
         }
 
         /// <summary>

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -2066,60 +2066,31 @@ namespace GitCommands
             SettingsContainer.SettingsCache.Import(GetSettingsFromRegistry());
         }
 
-        public static bool? GetBool(string name)
-        {
-            return SettingsContainer.GetBool(name);
-        }
+        #region Save in settings file
 
-        public static bool GetBool(string name, bool defaultValue)
-        {
-            return SettingsContainer.GetBool(name, defaultValue);
-        }
+        // String
+        [return: NotNullIfNotNull("defaultValue")]
+        public static string? GetString(string name, string? defaultValue) => SettingsContainer.GetString(name, defaultValue);
+        public static void SetString(string name, string value) => SettingsContainer.SetString(name, value);
 
-        public static void SetBool(string name, bool? value)
-        {
-            SettingsContainer.SetBool(name, value);
-        }
+        // Bool
+        public static bool? GetBool(string name) => SettingsContainer.GetBool(name);
+        public static bool GetBool(string name, bool defaultValue) => SettingsContainer.GetBool(name, defaultValue);
+        public static void SetBool(string name, bool? value) => SettingsContainer.SetBool(name, value);
 
-        public static void SetInt(string name, int? value)
-        {
-            SettingsContainer.SetInt(name, value);
-        }
+        // Int
+        public static int? GetInt(string name) => SettingsContainer.GetInt(name);
+        public static int GetInt(string name, int defaultValue) => SettingsContainer.GetInt(name, defaultValue);
+        public static void SetInt(string name, int? value) => SettingsContainer.SetInt(name, value);
 
-        public static int? GetInt(string name)
-        {
-            return SettingsContainer.GetInt(name);
-        }
+        // Date
+        public static DateTime? GetDate(string name) => SettingsContainer.GetDate(name);
+        public static DateTime GetDate(string name, DateTime defaultValue) => SettingsContainer.GetDate(name, defaultValue);
+        public static void SetDate(string name, DateTime? value) => SettingsContainer.SetDate(name, value);
 
-        public static DateTime GetDate(string name, DateTime defaultValue)
-        {
-            return SettingsContainer.GetDate(name, defaultValue);
-        }
-
-        public static void SetDate(string name, DateTime? value)
-        {
-            SettingsContainer.SetDate(name, value);
-        }
-
-        public static DateTime? GetDate(string name)
-        {
-            return SettingsContainer.GetDate(name);
-        }
-
-        public static int GetInt(string name, int defaultValue)
-        {
-            return SettingsContainer.GetInt(name, defaultValue);
-        }
-
-        public static void SetFont(string name, Font value)
-        {
-            SettingsContainer.SetFont(name, value);
-        }
-
-        public static Font GetFont(string name, Font defaultValue)
-        {
-            return SettingsContainer.GetFont(name, defaultValue);
-        }
+        // Font
+        public static Font GetFont(string name, Font defaultValue) => SettingsContainer.GetFont(name, defaultValue);
+        public static void SetFont(string name, Font value) => SettingsContainer.SetFont(name, value);
 
         [Obsolete("AppSettings is no longer responsible for colors, ThemeModule is")]
         public static Color GetColor(AppColor name)
@@ -2127,36 +2098,13 @@ namespace GitCommands
             return SettingsContainer.GetColor(name.ToString().ToLowerInvariant() + "color", AppColorDefaults.GetBy(name));
         }
 
-        public static void SetEnum<T>(string name, T value) where T : Enum
-        {
-            SettingsContainer.SetEnum(name, value);
-        }
+        // Enum
+        public static T GetEnum<T>(string name, T defaultValue) where T : struct, Enum => SettingsContainer.GetEnum(name, defaultValue);
+        public static void SetEnum<T>(string name, T value) where T : Enum => SettingsContainer.SetEnum(name, value);
 
-        public static T GetEnum<T>(string name, T defaultValue) where T : struct, Enum
-        {
-            return SettingsContainer.GetEnum(name, defaultValue);
-        }
-
-        public static void SetNullableEnum<T>(string name, T? value) where T : struct, Enum
-        {
-            SettingsContainer.SetNullableEnum(name, value);
-        }
-
-        public static T? GetNullableEnum<T>(string name) where T : struct
-        {
-            return SettingsContainer.GetNullableEnum<T>(name);
-        }
-
-        public static void SetString(string name, string value)
-        {
-            SettingsContainer.SetString(name, value);
-        }
-
-        [return: NotNullIfNotNull("defaultValue")]
-        public static string? GetString(string name, string? defaultValue)
-        {
-            return SettingsContainer.GetString(name, defaultValue);
-        }
+        public static T? GetNullableEnum<T>(string name) where T : struct => SettingsContainer.GetNullableEnum<T>(name);
+        public static void SetNullableEnum<T>(string name, T? value) where T : struct, Enum => SettingsContainer.SetNullableEnum(name, value);
+        #endregion
 
         private static void LoadEncodings()
         {

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -2083,6 +2083,9 @@ namespace GitCommands
         public static int GetInt(string name, int defaultValue) => SettingsContainer.GetInt(name, defaultValue);
         public static void SetInt(string name, int? value) => SettingsContainer.SetInt(name, value);
 
+        // Float
+        public static float GetFloat(string name, float defaultValue) => SettingsContainer.GetFloat(name, defaultValue);
+
         // Date
         public static DateTime? GetDate(string name) => SettingsContainer.GetDate(name);
         public static DateTime GetDate(string name, DateTime defaultValue) => SettingsContainer.GetDate(name, defaultValue);

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -598,6 +598,7 @@ namespace GitCommands
             set => SetInt("Appearance.AvatarCacheSize", value);
         }
 
+        // Currently not configurable in UI
         // Names from here: https://learn.microsoft.com/en-us/dotnet/api/system.windows.media.brushes?view=windowsdesktop-7.0
         // or #AARRGGBB code
         public static string AvatarAuthorInitialsPalette
@@ -605,6 +606,9 @@ namespace GitCommands
             get => GetString("Appearance.AvatarAuthorInitialsPalette", "SlateGray,RoyalBlue,Purple,OrangeRed,Teal,OliveDrab");
             set => SetString("Appearance.AvatarAuthorInitialsPalette", value);
         }
+
+        // Currently not configurable in UI
+        public static float AvatarAuthorInitialsLuminanceThreshold => GetFloat("AvatarAuthorInitialsLuminanceThreshold", 0.5f);
 
         /// <summary>
         /// Loads a setting with GetString and parses it to an enum

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -598,6 +598,14 @@ namespace GitCommands
             set => SetInt("Appearance.AvatarCacheSize", value);
         }
 
+        // Names from here: https://learn.microsoft.com/en-us/dotnet/api/system.windows.media.brushes?view=windowsdesktop-7.0
+        // or #AARRGGBB code
+        public static string AvatarAuthorInitialsPalette
+        {
+            get => GetString("Appearance.AvatarAuthorInitialsPalette", "SlateGray,RoyalBlue,Purple,OrangeRed,Teal,OliveDrab");
+            set => SetString("Appearance.AvatarAuthorInitialsPalette", value);
+        }
+
         /// <summary>
         /// Loads a setting with GetString and parses it to an enum
         /// </summary>

--- a/GitExtUtils/GitUI/Theming/ColorHelper.cs
+++ b/GitExtUtils/GitUI/Theming/ColorHelper.cs
@@ -339,10 +339,29 @@
             }
         }
 
+        /// <summary>
+        /// Get contrast color (Black or White) of a background color to use as a foreground color (not using the theme settings).
+        /// </summary>
+        /// <param name="backgroundColor">the background color</param>
+        /// <param name="luminanceThreshold">a custom luminance threshold to let the caller determine the boundary.</param>
+        /// <returns>the black or white color to use as foreground</returns>
+        public static Color GetContrastColor(this Color backgroundColor, float luminanceThreshold = 0.5f)
+        {
+            // (Loosely) Based on https://stackoverflow.com/a/3943023
+            // Calculate the luminance of the background color
+            double luminance = ((0.2126 * backgroundColor.R) + (0.7152 * backgroundColor.G) + (0.0722 * backgroundColor.B)) / 255;
+
+            // Use the threshold value to determine whether to use black or white as the foreground color
+            return (luminance > luminanceThreshold) ? Color.Black : Color.White;
+        }
+
         internal static class TestAccessor
         {
             public static double Transform(double orig, double exampleOrig, double oppositeOrig, double example, double opposite) =>
                 ColorHelper.Transform(orig, exampleOrig, oppositeOrig, example, opposite);
+
+            public static Color GetContrastColor(Color backgroundColor, float luminanceThreshold = 0.5f) =>
+                ColorHelper.GetContrastColor(backgroundColor, luminanceThreshold);
         }
     }
 }

--- a/GitUI/Avatars/AvatarService.cs
+++ b/GitUI/Avatars/AvatarService.cs
@@ -110,7 +110,7 @@ namespace GitUI.Avatars
         private static (IAvatarProvider provider, IAvatarCacheCleaner cacheCleaner) SetupCachingAndFallback()
         {
             FileSystemAvatarCache persistentCacheProvider = new(HotSwapProvider);
-            AvatarMemoryCache memoryCachedProvider = new(persistentCacheProvider);
+            AvatarMemoryCache memoryCachedProvider = new(persistentCacheProvider, AppSettings.AvatarCacheSize);
 
             MultiCacheCleaner cacheCleaner = new(persistentCacheProvider, memoryCachedProvider);
 

--- a/GitUI/Avatars/FileSystemAvatarCache.cs
+++ b/GitUI/Avatars/FileSystemAvatarCache.cs
@@ -88,16 +88,26 @@ namespace GitUI.Avatars
 
                 bool HasExpired()
                 {
-                    var info = _fileSystem.FileInfo.FromFileName(path);
+                    IFileInfo info = _fileSystem.FileInfo.FromFileName(path);
 
-                    var cacheDays = AppSettings.AvatarImageCacheDays;
+                    if (!info.Exists)
+                    {
+                        return true;
+                    }
+
+                    if (AppSettings.AvatarProvider == AvatarProvider.None)
+                    {
+                        // No need to refresh because the image returned is always the same.
+                        return false;
+                    }
+
+                    int cacheDays = AppSettings.AvatarImageCacheDays;
                     if (cacheDays < 1)
                     {
                         cacheDays = DefaultCacheDays;
                     }
 
-                    return !info.Exists ||
-                           info.LastWriteTime < DateTime.Now.AddDays(-cacheDays);
+                    return info.LastWriteTime < DateTime.Now.AddDays(-cacheDays);
                 }
 
                 void TryDelete()

--- a/GitUI/Avatars/InitialsAvatarProvider.cs
+++ b/GitUI/Avatars/InitialsAvatarProvider.cs
@@ -18,10 +18,24 @@ namespace GitUI.Avatars
         {
             var (initials, hashCode) = GetInitialsAndHashCode(email, name);
 
-            var avatarColor = _avatarColors[Math.Abs(hashCode) % _avatarColors.Length];
+            var avatarColor = _avatarColors[hashCode];
             var avatar = DrawText(initials, avatarColor, imageSize);
 
             return Task.FromResult<Image?>(avatar);
+        }
+
+        private int GetDeterministicHashCode(string str)
+        {
+            unchecked
+            {
+                int hash = 23;
+                foreach (char c in str)
+                {
+                    hash = (hash * 31) + c;
+                }
+
+                return Math.Abs(hash) % _avatarColors.Length;
+            }
         }
 
         protected internal (string? initials, int hashCode) GetInitialsAndHashCode(string email, string? name)
@@ -36,7 +50,7 @@ namespace GitUI.Avatars
             var nameParts = selectedName.Split(separator);
             var initials = GetInitialsFromNames(nameParts);
 
-            return (initials, selectedName.GetHashCode());
+            return (initials, GetDeterministicHashCode(selectedName));
         }
 
         private static (string? name, char[]? separator) NameSelector(string? name, string? email)

--- a/GitUI/Avatars/InitialsAvatarProvider.cs
+++ b/GitUI/Avatars/InitialsAvatarProvider.cs
@@ -128,14 +128,19 @@ namespace GitUI.Avatars
         private readonly Graphics _graphics = Graphics.FromImage(new Bitmap(1, 1));
         private readonly Brush _textBrush = new SolidBrush(Color.WhiteSmoke);
 
-        private readonly Color[] _avatarColors =
+        private readonly Color[] _avatarColors = AppSettings.AvatarAuthorInitialsPalette.Split(",").Select(ConvertToColor).ToArray();
+
+        private static Color ConvertToColor(string colorCode)
         {
-            Color.RoyalBlue,
-            Color.DarkRed,
-            Color.Purple,
-            Color.ForestGreen,
-            Color.DarkOrange
-        };
+            try
+            {
+                return ColorTranslator.FromHtml(colorCode);
+            }
+            catch (Exception)
+            {
+                return Color.Black;
+            }
+        }
 
         private Image DrawText(string? text, Color backColor, int size)
         {

--- a/Plugins/GitUIPluginInterfaces/ISettingsSource.cs
+++ b/Plugins/GitUIPluginInterfaces/ISettingsSource.cs
@@ -67,7 +67,12 @@ namespace GitUIPluginInterfaces
         {
             string? stringValue = GetValue(name);
 
-            if (float.TryParse(stringValue, out var result))
+            if (float.TryParse(stringValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var result))
+            {
+                return result;
+            }
+
+            if (float.TryParse(stringValue, out result))
             {
                 return result;
             }
@@ -75,9 +80,11 @@ namespace GitUIPluginInterfaces
             return null;
         }
 
+        public float GetFloat(string name, float defaultValue) => GetFloat(name) ?? defaultValue;
+
         public void SetFloat(string name, float? value)
         {
-            string? stringValue = value.HasValue ? value.ToString() : null;
+            string? stringValue = value.HasValue ? value.Value.ToString(CultureInfo.InvariantCulture) : null;
 
             SetValue(name, stringValue);
         }

--- a/Plugins/GitUIPluginInterfaces/ISettingsSource.cs
+++ b/Plugins/GitUIPluginInterfaces/ISettingsSource.cs
@@ -11,6 +11,11 @@ namespace GitUIPluginInterfaces
 
         public abstract void SetValue(string name, string? value);
 
+        [return: NotNullIfNotNull("defaultValue")]
+        public string? GetString(string name, string? defaultValue) => GetValue(name) ?? defaultValue;
+
+        public void SetString(string name, string? value) => SetValue(name, value);
+
         public bool? GetBool(string name)
         {
             string? stringValue = GetValue(name);
@@ -28,21 +33,11 @@ namespace GitUIPluginInterfaces
             return null;
         }
 
-        public bool GetBool(string name, bool defaultValue)
-        {
-            return GetBool(name) ?? defaultValue;
-        }
+        public bool GetBool(string name, bool defaultValue) => GetBool(name) ?? defaultValue;
 
         public void SetBool(string name, bool? value)
         {
             string? stringValue = value.HasValue ? (value.Value ? "true" : "false") : null;
-
-            SetValue(name, stringValue);
-        }
-
-        public void SetInt(string name, int? value)
-        {
-            string? stringValue = value.HasValue ? value.ToString() : null;
 
             SetValue(name, stringValue);
         }
@@ -59,7 +54,9 @@ namespace GitUIPluginInterfaces
             return null;
         }
 
-        public void SetFloat(string name, float? value)
+        public int GetInt(string name, int defaultValue) => GetInt(name) ?? defaultValue;
+
+        public void SetInt(string name, int? value)
         {
             string? stringValue = value.HasValue ? value.ToString() : null;
 
@@ -78,14 +75,9 @@ namespace GitUIPluginInterfaces
             return null;
         }
 
-        public DateTime GetDate(string name, DateTime defaultValue)
+        public void SetFloat(string name, float? value)
         {
-            return GetDate(name) ?? defaultValue;
-        }
-
-        public void SetDate(string name, DateTime? value)
-        {
-            string? stringValue = value?.ToString("yyyy/M/dd", CultureInfo.InvariantCulture);
+            string? stringValue = value.HasValue ? value.ToString() : null;
 
             SetValue(name, stringValue);
         }
@@ -102,24 +94,18 @@ namespace GitUIPluginInterfaces
             return null;
         }
 
-        public int GetInt(string name, int defaultValue)
-        {
-            return GetInt(name) ?? defaultValue;
-        }
+        public DateTime GetDate(string name, DateTime defaultValue) => GetDate(name) ?? defaultValue;
 
-        public void SetFont(string name, Font value)
+        public void SetDate(string name, DateTime? value)
         {
-            string? stringValue = value.AsString();
+            string? stringValue = value?.ToString("yyyy/M/dd", CultureInfo.InvariantCulture);
 
             SetValue(name, stringValue);
         }
 
-        public Font GetFont(string name, Font defaultValue)
-        {
-            string? stringValue = GetValue(name);
+        public Font GetFont(string name, Font defaultValue) => GetValue(name).Parse(defaultValue);
 
-            return stringValue.Parse(defaultValue);
-        }
+        public void SetFont(string name, Font value) => SetValue(name, value.AsString());
 
         public Color GetColor(string name, Color defaultValue)
         {
@@ -135,13 +121,6 @@ namespace GitUIPluginInterfaces
             }
         }
 
-        public void SetEnum<T>(string name, T value) where T : Enum
-        {
-            string? stringValue = value.ToString();
-
-            SetValue(name, stringValue);
-        }
-
         public T GetEnum<T>(string name, T defaultValue) where T : struct, Enum
         {
             string? stringValue = GetValue(name);
@@ -154,9 +133,9 @@ namespace GitUIPluginInterfaces
             return defaultValue;
         }
 
-        public void SetNullableEnum<T>(string name, T? value) where T : struct, Enum
+        public void SetEnum<T>(string name, T value) where T : Enum
         {
-            string? stringValue = value.HasValue ? value.ToString() : string.Empty;
+            string? stringValue = value.ToString();
 
             SetValue(name, stringValue);
         }
@@ -178,15 +157,11 @@ namespace GitUIPluginInterfaces
             return null;
         }
 
-        public void SetString(string name, string? value)
-            => SetValue(name, value);
-
-        [return: NotNullIfNotNull("defaultValue")]
-        public string? GetString(string name, string? defaultValue)
+        public void SetNullableEnum<T>(string name, T? value) where T : struct, Enum
         {
-            string? stringValue = GetValue(name);
+            string? stringValue = value.HasValue ? value.ToString() : string.Empty;
 
-            return stringValue ?? defaultValue;
+            SetValue(name, stringValue);
         }
     }
 }

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -192,9 +192,9 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.CommitInfoShowContainedInBranchesRemoteIfNoLocal)], false, false, false);
                 yield return (properties[nameof(AppSettings.CommitInfoShowContainedInTags)], true, false, false);
                 yield return (properties[nameof(AppSettings.CommitInfoShowTagThisCommitDerivesFrom)], true, false, false);
-                yield return (properties[nameof(AppSettings.AvatarImageCacheDays)], 5, false, false);
+                yield return (properties[nameof(AppSettings.AvatarImageCacheDays)], 13, false, false);
                 yield return (properties[nameof(AppSettings.ShowAuthorAvatarInCommitInfo)], true, false, false);
-                yield return (properties[nameof(AppSettings.AvatarProvider)], AvatarProvider.Default, false, false);
+                yield return (properties[nameof(AppSettings.AvatarProvider)], AvatarProvider.None, false, false);
                 yield return (properties[nameof(AppSettings.Translation)], string.Empty, true, false);
                 yield return (properties[nameof(AppSettings.UserProfileHomeDir)], false, false, false);
                 yield return (properties[nameof(AppSettings.CustomHomeDir)], string.Empty, true, false);

--- a/UnitTests/GitExtUtils.Tests/ColorTransformationTests.cs
+++ b/UnitTests/GitExtUtils.Tests/ColorTransformationTests.cs
@@ -49,5 +49,25 @@ namespace GitExtUtilsTests
 
             Assert.That(transformed, Is.EqualTo(expected).Within(0.001));
         }
+
+        [TestCase("#000000", 0.5f)]
+        [TestCase("#777777", 0.5f)]
+        [TestCase("#999999", 0.6f)] // the threshold has been increased to still write in black on a darker color
+        public void Should_return_white_when_color_is_dark(string backgroundColor, float luminanceThreshold)
+        {
+            Color correspondingForeColor = ColorHelper.TestAccessor.GetContrastColor(ColorTranslator.FromHtml(backgroundColor), luminanceThreshold);
+
+            Assert.That(correspondingForeColor, Is.EqualTo(Color.White));
+        }
+
+        [TestCase("#FFFFFF", 0.5f)]
+        [TestCase("#999999", 0.5f)]
+        [TestCase("#777777", 0.4f)] // the threshold has been lower to still write in white on a lighter color
+        public void Should_return_black_when_color_is_light(string backgroundColor, float luminanceThreshold)
+        {
+            Color correspondingForeColor = ColorHelper.TestAccessor.GetContrastColor(ColorTranslator.FromHtml(backgroundColor), luminanceThreshold);
+
+            Assert.That(correspondingForeColor, Is.EqualTo(Color.Black));
+        }
     }
 }

--- a/UnitTests/GitUI.Tests/Avatars/AvatarPersistentCacheTests.cs
+++ b/UnitTests/GitUI.Tests/Avatars/AvatarPersistentCacheTests.cs
@@ -34,6 +34,8 @@ namespace GitUITests.Avatars
             _fileInfoFactory.FromFileName(Arg.Any<string>()).Returns(_fileInfo);
             _fileSystem.FileInfo.Returns(_fileInfoFactory);
 
+            AppSettings.AvatarProvider = AvatarProvider.Default;
+
             _folderPath = AppSettings.AvatarImageCachePath;
 
             _cache = new FileSystemAvatarCache(_inner, _fileSystem);

--- a/UnitTests/GitUI.Tests/Avatars/InitialsAvatarGeneratorTests.cs
+++ b/UnitTests/GitUI.Tests/Avatars/InitialsAvatarGeneratorTests.cs
@@ -18,6 +18,11 @@ namespace GitUITests.Avatars
         [TestCase("albert.bose-einstein@noreply.com", null, "AE")]
         [TestCase("albert", "", "Al")]
         [TestCase("albert.einstein", "", "AE")]
+        [TestCase("", "albert.einstein", "AE")]
+        [TestCase("", "AlbertEinstein", "AE")]
+        [TestCase("", "A-Einstein", "AE")]
+        [TestCase("", "Alb-Einstein", "AE")]
+        [TestCase("", "AEinstein", "AE")]
         [TestCase(null, null, "?")]
         public void GetInitialsAndHashCode_return_initials_of_a_user(string email, string name, string expected)
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Improvements over #10020

Note: a lot easier to review commit by commit.

## Proposed changes

* perf: increase a lot perf to download avatars (ex on a blame display: from 1m30s to 6s)
* perf: fix serialization that was broken for some avatars
* Always obtain the same Author initials image between 2 GitExtensions session
* return more meaningful author initials
* Better set of colors for Author initials background colors
* perf: make that cache never expire for avatar that never changes
* Perf: slight optimization of GravatarProvider
* Perf: prevent requesting the same avatar multiple times
* saner performance default values

## Screenshots <!-- Remove this section if PR does not change UI -->

For choice of colors:

### Before
| Before  |  After |
|---|---|
| ![image](https://user-images.githubusercontent.com/460196/229131809-a53290da-24c6-4c71-bde0-a76fdc2d08eb.png)  | ![image](https://user-images.githubusercontent.com/460196/229132118-f5cb5af7-0074-489b-a0b1-80335dd6da44.png) |

## Test methodology <!-- How did you ensure quality? -->

- Manual
- Some unit tests

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build de0dcb3112d960166620a45a5bf6e49f6918ea3b (Dirty)
- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.14
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

Merge commit

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
