### PR TITLE
Restore from minimized: Configurable avoid async Git

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -2005,9 +2005,14 @@ namespace GitCommands
         }
 
         // Set manually in settings file
-        public static bool WorkaroundRestoreFromMinimize
+        public static bool WorkaroundActivateFromMinimize
         {
-            get => GetBool("WorkaroundRestoreFromMinimize", false);
+            get => GetBool("WorkaroundActivateFromMinimize", false);
+        }
+
+        public static bool GitAsyncWhenMinimized
+        {
+            get => GetBool("GitAsyncWhenMinimized", true);
         }
 
         private static IEnumerable<(string name, string value)> GetSettingsFromRegistry()

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1059,7 +1059,8 @@ namespace GitUI.CommandsDialogs
             notificationBarBisectInProgress.RefreshBisect();
 
             // check if we are in the middle of an action (merge/rebase/etc.)
-            notificationBarGitActionInProgress.RefreshGitAction();
+            notificationBarGitActionInProgress.RefreshGitAction(
+                checkForConflicts: AppSettings.GitAsyncWhenMinimized || (WindowState != FormWindowState.Minimized));
         }
 
         private void UpdateStashCount()

--- a/GitUI/UserControls/InteractiveGitActionControl.cs
+++ b/GitUI/UserControls/InteractiveGitActionControl.cs
@@ -59,7 +59,11 @@ namespace GitUI.UserControls
             SetGitAction(GitAction.None, false);
         }
 
-        public void RefreshGitAction()
+        /// <summary>
+        /// Refresh the banner in the revision grid after reactivation.
+        /// </summary>
+        /// <param name="checkForConflicts">Allow running Git command to check for conflicts.</param>
+        public void RefreshGitAction(bool checkForConflicts)
         {
             // get the current state of the repo
 
@@ -72,9 +76,9 @@ namespace GitUI.UserControls
             try
             {
                 // This command can be executed seemingly in the background (selecting Browse),
-                // do not notify the user (this can occur if Git is upgraded)
-                // The command also occasionally fails when "reactivating" WSL Git.
-                hasConflicts = Module.InTheMiddleOfConflictedMerge(throwOnErrorExit: false);
+                // do not notify the user (this can occur if Git is upgraded).
+                // Running Git commands async when restoring may fail.
+                hasConflicts = checkForConflicts && Module.InTheMiddleOfConflictedMerge(throwOnErrorExit: false);
             }
             catch (Win32Exception)
             {

--- a/ResourceManager/GitExtensionsFormBase.cs
+++ b/ResourceManager/GitExtensionsFormBase.cs
@@ -93,9 +93,9 @@ namespace ResourceManager
                 if (m.Msg == NativeMethods.WM_ACTIVATEAPP && m.WParam != IntPtr.Zero)
                 {
                     OnApplicationActivated();
-                    if (WindowState == FormWindowState.Minimized && Owner is null && AppSettings.WorkaroundRestoreFromMinimize)
+                    if (WindowState == FormWindowState.Minimized && Owner is null && AppSettings.WorkaroundActivateFromMinimize)
                     {
-                        // Changed behavior from .NET4 to .NET5, application occasionally requires explicit "restore" in Taskbar.
+                        // Application occasionally requires explicit "restore" in Taskbar.
                         // See https://github.com/gitextensions/gitextensions/pull/10119.
                         Trace.WriteLine("WindowState is unexpectedly Minimized in OnApplicationActivated(), restoring.");
                         WindowState = FormWindowState.Normal;


### PR DESCRIPTION
## Proposed changes

Add an experimental setting to not run git-ls-files when the window is minimized on activation, as async commands when minimized seem to block the app from being restored.

Rename configuration added in #10119 to
deactivate at upgrade as this setting may give a negative experience after #10802 mostly fixes the problem.

--

The "restore from minimize" issue is occurring often for some users in 4.0
There has been occasional reports of similar issues in 2.x and 3.x too, so it is not exactly new though.
#10802 mostly fixes the problem but not completely.
It may be resolved by not running Git commands async while being minimized. I thought I had tested that, but am not sure anymore.
https://github.com/gitextensions/gitextensions/pull/10802#issuecomment-1481845774
further usage points that async Git may be the issue.

This fix adds a setting to not run async Gic, so the following banner may not appear after a restore (but after switching back to normal/maximized state):
![image](https://user-images.githubusercontent.com/6248932/229296929-70d403d5-ab83-47cb-9e9b-5be42484f3b9.png)

I hope that we do not need to keep this fix in the production version, that a better fix is found.
The UI refresh check could maybe be done later too (like a check if needed and run after the grid is refreshed).
If not found or improved, this is a kind of workaround.

Anyway, it simplifies narrowing the problem for users.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
