### PR TITLE
IScriptHostControl.CurrentBranch() to decrease overhead

### DIFF
--- a/GitUI/BranchTreePanel/LocalBranchTree.cs
+++ b/GitUI/BranchTreePanel/LocalBranchTree.cs
@@ -52,7 +52,7 @@ namespace GitUI.BranchTreePanel
 
             Nodes nodes = new(this);
             var aheadBehindData = _aheadBehindDataProvider?.GetData();
-            string currentBranch = _scriptHost.CurrentBranch();
+            string currentBranch = _scriptHost.GetCurrentBranch();
             Dictionary<string, BaseRevisionNode> pathToNode = new();
             foreach (IGitRef branch in branches)
             {

--- a/GitUI/BranchTreePanel/LocalBranchTree.cs
+++ b/GitUI/BranchTreePanel/LocalBranchTree.cs
@@ -1,4 +1,5 @@
 ﻿using GitCommands.Git;
+using GitUI.Script;
 using GitUI.UserControls.RevisionGrid;
 using GitUIPluginInterfaces;
 using Microsoft;
@@ -8,11 +9,13 @@ namespace GitUI.BranchTreePanel
     internal sealed class LocalBranchTree : BaseRefTree
     {
         private readonly IAheadBehindDataProvider? _aheadBehindDataProvider;
+        private readonly IScriptHostControl _scriptHost;
 
-        public LocalBranchTree(TreeNode treeNode, IGitUICommandsSource uiCommands, IAheadBehindDataProvider? aheadBehindDataProvider, ICheckRefs refsSource)
+        public LocalBranchTree(TreeNode treeNode, IGitUICommandsSource uiCommands, IAheadBehindDataProvider? aheadBehindDataProvider, ICheckRefs refsSource, IScriptHostControl scriptHost)
             : base(treeNode, uiCommands, refsSource, RefsFilter.Heads)
         {
             _aheadBehindDataProvider = aheadBehindDataProvider;
+            _scriptHost = scriptHost;
         }
 
         protected override Nodes FillTree(IReadOnlyList<IGitRef> branches, CancellationToken token)
@@ -49,8 +52,7 @@ namespace GitUI.BranchTreePanel
 
             Nodes nodes = new(this);
             var aheadBehindData = _aheadBehindDataProvider?.GetData();
-
-            var currentBranch = Module.GetSelectedBranch();
+            string currentBranch = _scriptHost.CurrentBranch();
             Dictionary<string, BaseRevisionNode> pathToNode = new();
             foreach (IGitRef branch in branches)
             {

--- a/GitUI/BranchTreePanel/RepoObjectsTree.cs
+++ b/GitUI/BranchTreePanel/RepoObjectsTree.cs
@@ -367,7 +367,7 @@ namespace GitUI.BranchTreePanel
                 SelectedImageKey = nameof(Images.BranchLocalRoot)
             };
 
-            _branchesTree = new LocalBranchTree(rootNode, UICommandsSource, _aheadBehindDataProvider, _refsSource);
+            _branchesTree = new LocalBranchTree(rootNode, UICommandsSource, _aheadBehindDataProvider, _refsSource, _scriptHost);
         }
 
         private void CreateRemotes()

--- a/GitUI/CommandsDialogs/FormFormatPatch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.Designer.cs
@@ -295,7 +295,7 @@ namespace GitUI.CommandsDialogs
             this.CurrentBranch.AutoSize = true;
             this.CurrentBranch.Location = new System.Drawing.Point(75, 0);
             this.CurrentBranch.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.CurrentBranch.Name = "CurrentBranch";
+            this.CurrentBranch.Name = "GetCurrentBranch";
             this.CurrentBranch.Size = new System.Drawing.Size(0, 23);
             this.CurrentBranch.TabIndex = 5;
             // 

--- a/GitUI/CommandsDialogs/FormFormatPatch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.Designer.cs
@@ -295,7 +295,7 @@ namespace GitUI.CommandsDialogs
             this.CurrentBranch.AutoSize = true;
             this.CurrentBranch.Location = new System.Drawing.Point(75, 0);
             this.CurrentBranch.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.CurrentBranch.Name = "GetCurrentBranch";
+            this.CurrentBranch.Name = "CurrentBranch";
             this.CurrentBranch.Size = new System.Drawing.Size(0, 23);
             this.CurrentBranch.TabIndex = 5;
             // 

--- a/GitUI/Script/IScriptHostControl.cs
+++ b/GitUI/Script/IScriptHostControl.cs
@@ -8,5 +8,6 @@ namespace GitUI.Script
         GitRevision? GetLatestSelectedRevision();
         IReadOnlyList<GitRevision> GetSelectedRevisions();
         Point GetQuickItemSelectorLocation();
+        string CurrentBranch();
     }
 }

--- a/GitUI/Script/IScriptHostControl.cs
+++ b/GitUI/Script/IScriptHostControl.cs
@@ -8,6 +8,6 @@ namespace GitUI.Script
         GitRevision? GetLatestSelectedRevision();
         IReadOnlyList<GitRevision> GetSelectedRevisions();
         Point GetQuickItemSelectorLocation();
-        string CurrentBranch();
+        string GetCurrentBranch();
     }
 }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -3064,7 +3064,7 @@ namespace GitUI
         Point IScriptHostControl.GetQuickItemSelectorLocation()
             => GetQuickItemSelectorLocation();
 
-        string IScriptHostControl.CurrentBranch() => CurrentBranch.Value;
+        string IScriptHostControl.GetCurrentBranch() => CurrentBranch.Value;
         #endregion
 
         bool ICheckRefs.Contains(ObjectId objectId) => _gridView.Contains(objectId);

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -3064,6 +3064,7 @@ namespace GitUI
         Point IScriptHostControl.GetQuickItemSelectorLocation()
             => GetQuickItemSelectorLocation();
 
+        string IScriptHostControl.CurrentBranch() => CurrentBranch.Value;
         #endregion
 
         bool ICheckRefs.Contains(ObjectId objectId) => _gridView.Contains(objectId);


### PR DESCRIPTION
## Proposed changes

Module.GetSelectedBranch() requires about 1 ms (15000 ticks) also if no Git command is required.
This info is already calculated in the revision grid and can be made available in the IScriptHostControl interface.
(An alternative is to add this to the event like for FilteredGitRefsProvider.)

Adding this in side panel, could be added elsewhere.
In for instance CommitInfo the reference to IScriptHostControl  need to be provided after creation, so a few more steps.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
