### PR TITLE
Store view settings on request only

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -34,6 +34,7 @@ namespace GitCommands
 
         private static readonly SettingsPath ConfirmationsSettingsPath = new AppSettingsPath("Confirmations");
         private static readonly SettingsPath DetailedSettingsPath = new AppSettingsPath("Detailed");
+        private static readonly SettingsPath RootSettingsPath = new AppSettingsPath(pathName: "");
 
         private static Mutex _globalMutex;
 
@@ -495,11 +496,7 @@ namespace GitCommands
             set => SetBool("showgitstatusforartificialcommits", value);
         }
 
-        public static RevisionSortOrder RevisionSortOrder
-        {
-            get => GetEnum("RevisionSortOrder", RevisionSortOrder.GitDefault);
-            set => SetEnum("RevisionSortOrder", value);
-        }
+        public static EnumRuntimeSetting<RevisionSortOrder> RevisionSortOrder { get; } = new(RootSettingsPath, nameof(RevisionSortOrder), GitCommands.RevisionSortOrder.GitDefault);
 
         public static bool CommitInfoShowContainedInBranches => CommitInfoShowContainedInBranchesLocal ||
                                                                 CommitInfoShowContainedInBranchesRemote ||
@@ -1096,11 +1093,7 @@ namespace GitCommands
             set => SetBool("showRemoteBranches", value);
         }
 
-        public static bool ShowReflogReferences
-        {
-            get => GetBool("showReflogReferences", false);
-            set => SetBool("showReflogReferences", value);
-        }
+        public static BoolRuntimeSetting ShowReflogReferences { get; } = new(RootSettingsPath, nameof(ShowReflogReferences), false);
 
         public static bool ShowStashes
         {
@@ -1263,11 +1256,7 @@ namespace GitCommands
             set => SetBool("closeprocessdialog", value);
         }
 
-        public static bool ShowCurrentBranchOnly
-        {
-            get => GetBool("showcurrentbranchonly", false);
-            set => SetBool("showcurrentbranchonly", value);
-        }
+        public static BoolRuntimeSetting ShowCurrentBranchOnly { get; } = new(RootSettingsPath, nameof(ShowCurrentBranchOnly), false);
 
         public static bool ShowSimplifyByDecoration
         {
@@ -1275,11 +1264,7 @@ namespace GitCommands
             set => SetBool("showsimplifybydecoration", value);
         }
 
-        public static bool BranchFilterEnabled
-        {
-            get => GetBool("branchfilterenabled", false);
-            set => SetBool("branchfilterenabled", value);
-        }
+        public static BoolRuntimeSetting BranchFilterEnabled { get; } = new(RootSettingsPath, nameof(BranchFilterEnabled), false);
 
         public static bool ShowOnlyFirstParent
         {
@@ -1526,11 +1511,7 @@ namespace GitCommands
             set => SetString("lastformatpatchdir", value);
         }
 
-        public static IgnoreWhitespaceKind IgnoreWhitespaceKind
-        {
-            get => GetEnum("IgnoreWhitespaceKind", IgnoreWhitespaceKind.None);
-            set => SetEnum("IgnoreWhitespaceKind", value);
-        }
+        public static EnumRuntimeSetting<IgnoreWhitespaceKind> IgnoreWhitespaceKind { get; } = new(RootSettingsPath, nameof(IgnoreWhitespaceKind), Settings.IgnoreWhitespaceKind.None);
 
         public static bool RememberIgnoreWhiteSpacePreference
         {
@@ -1538,17 +1519,7 @@ namespace GitCommands
             set => SetBool("rememberIgnoreWhiteSpacePreference", value);
         }
 
-        public static bool ShowNonPrintingChars
-        {
-            get => RememberShowNonPrintingCharsPreference && GetBool("ShowNonPrintingChars", false);
-            set
-            {
-                if (RememberShowNonPrintingCharsPreference)
-                {
-                    SetBool("ShowNonPrintingChars", value);
-                }
-            }
-        }
+        public static BoolRuntimeSetting ShowNonPrintingChars { get; } = new(RootSettingsPath, nameof(ShowNonPrintingChars), false);
 
         public static bool RememberShowNonPrintingCharsPreference
         {
@@ -1556,17 +1527,7 @@ namespace GitCommands
             set => SetBool("RememberShowNonPrintableCharsPreference", value);
         }
 
-        public static bool ShowEntireFile
-        {
-            get => RememberShowEntireFilePreference && GetBool("ShowEntireFile", false);
-            set
-            {
-                if (RememberShowEntireFilePreference)
-                {
-                    SetBool("ShowEntireFile", value);
-                }
-            }
-        }
+        public static BoolRuntimeSetting ShowEntireFile { get; } = new(RootSettingsPath, nameof(ShowEntireFile), false);
 
         public static bool RememberShowEntireFilePreference
         {
@@ -1596,17 +1557,7 @@ namespace GitCommands
             set => SetBool("RememberNumberOfContextLines", value);
         }
 
-        public static bool ShowSyntaxHighlightingInDiff
-        {
-            get => RememberShowSyntaxHighlightingInDiff && GetBool("ShowSyntaxHighlightingInDiff", true);
-            set
-            {
-                if (RememberShowSyntaxHighlightingInDiff)
-                {
-                    SetBool("ShowSyntaxHighlightingInDiff", value);
-                }
-            }
-        }
+        public static BoolRuntimeSetting ShowSyntaxHighlightingInDiff { get; } = new(RootSettingsPath, nameof(ShowSyntaxHighlightingInDiff), true);
 
         public static bool RememberShowSyntaxHighlightingInDiff
         {

--- a/GitCommands/Settings/BoolRuntimeSetting.cs
+++ b/GitCommands/Settings/BoolRuntimeSetting.cs
@@ -1,0 +1,24 @@
+﻿namespace GitCommands.Settings;
+
+/// <inheritdoc />
+public sealed class BoolRuntimeSetting : RuntimeSetting<bool>
+{
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="BoolRuntimeSetting"/> class with the settings details.
+    /// </summary>
+    /// <param name="settingsSource">The source containing the value.</param>
+    /// <param name="name">The setting name.</param>
+    /// <param name="defaultValue">The default value.</param>
+    public BoolRuntimeSetting(SettingsPath settingsSource, string name, bool defaultValue)
+        : base(Setting.Create(settingsSource, name, defaultValue))
+    {
+    }
+
+    /// <summary>
+    ///  Toggles the setting value.
+    /// </summary>
+    public void Toggle()
+    {
+        Value = !Value;
+    }
+}

--- a/GitCommands/Settings/EnumRuntimeSetting.cs
+++ b/GitCommands/Settings/EnumRuntimeSetting.cs
@@ -1,0 +1,16 @@
+namespace GitCommands.Settings;
+
+/// <inheritdoc />
+public sealed class EnumRuntimeSetting<T> : RuntimeSetting<T> where T : struct, Enum
+{
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="BoolRuntimeSetting"/> class with the settings details.
+    /// </summary>
+    /// <param name="settingsSource">The source containing the value.</param>
+    /// <param name="name">The setting name.</param>
+    /// <param name="defaultValue">The default value.</param>
+    public EnumRuntimeSetting(SettingsPath settingsSource, string name, T defaultValue)
+        : base(Setting.Create(settingsSource, name, defaultValue))
+    {
+    }
+}

--- a/GitCommands/Settings/IRuntimeSetting.cs
+++ b/GitCommands/Settings/IRuntimeSetting.cs
@@ -1,0 +1,23 @@
+﻿namespace GitCommands.Settings;
+
+/// <summary>
+///  Interface for settings which are persisted on explicit request only.
+/// </summary>
+public interface IRuntimeSetting
+{
+    /// <summary>
+    ///  Reloads the value from the settings file.
+    /// </summary>
+    void Reload();
+
+    /// <summary>
+    ///  Resets the value to the hard-coded default value.
+    /// </summary>
+    void ResetToDefault();
+
+    /// <summary>
+    ///  Saves the value to the persistent setting,
+    ///  which is not written to the settings file at once but latest on app exit.
+    /// </summary>
+    void Save();
+}

--- a/GitCommands/Settings/ISetting.cs
+++ b/GitCommands/Settings/ISetting.cs
@@ -1,0 +1,49 @@
+﻿namespace GitCommands.Settings;
+
+public interface ISetting<T>
+{
+    /// <summary>
+    ///  Event triggered after settings update.
+    /// </summary>
+    event EventHandler Updated;
+
+    /// <summary>
+    ///  Settings provider.
+    /// </summary>
+    SettingsPath SettingsSource { get; }
+
+    /// <summary>
+    /// Name of the setting.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    ///  Default value for setting type.
+    ///  For nullable except "string" is default(T).
+    ///  For "string" is the defaultValue ?? string.Empty from constructor.
+    ///  For non nullable is the defaultValue from constructor.
+    /// </summary>
+    T? Default { get; }
+
+    /// <summary>
+    ///  Value of the setting.
+    ///  For nullable except "string" is the value from storage.
+    ///  For "string" is the value from storage or <see cref="Default"/>.
+    ///  For non nullable is the value from storage or <see cref="Default"/>.
+    /// </summary>
+    T? Value { get; set; }
+
+    /// <summary>
+    ///  Value of the setting.
+    ///  For nullable except "string" always false (null is value too).
+    ///  For "string" is true when the stored value is null or is false when the stored value not null.
+    ///  For non nullable is true when the stored value is null or is false when the stored value not null.
+    /// </summary>
+    bool IsUnset { get; }
+
+    /// <summary>
+    ///  Full name of the setting.
+    ///  Includes section name and setting name.
+    /// </summary>
+    string FullPath { get; }
+}

--- a/GitCommands/Settings/RuntimeSetting.cs
+++ b/GitCommands/Settings/RuntimeSetting.cs
@@ -1,0 +1,94 @@
+﻿namespace GitCommands.Settings;
+
+/// <summary>
+///  Represents a setting which has to be explicitly saved, if changed at runtime.
+/// </summary>
+/// <typeparam name="T">The type of setting.</typeparam>
+public interface IRuntimeSetting<T> : ISetting<T>, IRuntimeSetting
+{
+    /// <summary>
+    ///  Optionally calls <cref>Reload</cref> and returns the current value.
+    /// </summary>
+    public T GetValue(bool reload = false);
+}
+
+/// <summary>
+///  Represents a setting which has to be explicitly saved, if changed at runtime.
+/// </summary>
+/// <typeparam name="T">The type of setting.</typeparam>
+public class RuntimeSetting<T> : IRuntimeSetting<T>
+{
+    private bool _loaded;
+    private readonly ISetting<T> _persistentSetting;
+    private T _value;
+
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="RuntimeSetting{T}"/> class.
+    /// </summary>
+    /// <param name="persistentSetting">
+    ///  The <see cref="ISetting{T}"/> instance used to persist the default value of the setting.
+    /// </param>
+    public RuntimeSetting(ISetting<T> persistentSetting)
+    {
+        _persistentSetting = persistentSetting;
+    }
+
+    public T Default => _persistentSetting.Default;
+
+    public string FullPath => _persistentSetting.FullPath;
+
+    public bool IsUnset => _persistentSetting.IsUnset;
+
+    public string Name => _persistentSetting.Name;
+
+    public SettingsPath SettingsSource => _persistentSetting.SettingsSource;
+
+    public T Value
+    {
+        get => GetValue();
+        set
+        {
+            if (_value.Equals(value))
+            {
+                return;
+            }
+
+            _value = value;
+            if (_loaded)
+            {
+                Updated?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+
+    public event EventHandler? Updated;
+
+    public T GetValue(bool reload = false)
+    {
+        if (reload || !_loaded)
+        {
+            Reload();
+        }
+
+        return _value;
+    }
+
+    public void Reload()
+    {
+        Value = _persistentSetting.Value;
+        _loaded = true;
+    }
+
+    public void ResetToDefault() => Value = Default;
+
+    public void Save()
+    {
+        _persistentSetting.Value = Value;
+    }
+
+    /// <summary>
+    ///  Implicit conversion for direct access to the RuntimeSetting value.
+    /// </summary>
+    /// <param name="setting">The RuntimeSetting whose value is returned as conversion result.</param>
+    public static implicit operator T(RuntimeSetting<T> setting) => setting.Value;
+}

--- a/GitCommands/Settings/Setting.cs
+++ b/GitCommands/Settings/Setting.cs
@@ -3,54 +3,6 @@ using Newtonsoft.Json;
 
 namespace GitCommands.Settings
 {
-    public interface ISetting<T>
-    {
-        /// <summary>
-        /// Event triggered after settings update.
-        /// </summary>
-        event EventHandler Updated;
-
-        /// <summary>
-        /// Settings provider.
-        /// </summary>
-        SettingsPath SettingsSource { get; }
-
-        /// <summary>
-        /// Name of the setting.
-        /// </summary>
-        string Name { get; }
-
-        /// <summary>
-        /// Default value for setting type.
-        /// For nullable except "string" is default(T).
-        /// For "string" is the defaultValue ?? string.Empty from constructor.
-        /// For non nullable is the defaultValue from constructor.
-        /// </summary>
-        T? Default { get; }
-
-        /// <summary>
-        /// Value of the setting.
-        /// For nullable except "string" is the value from storage.
-        /// For "string" is the value from storage or <see cref="Default"/>.
-        /// For non nullable is the value from storage or <see cref="Default"/>.
-        /// </summary>
-        T? Value { get; set; }
-
-        /// <summary>
-        /// Value of the setting.
-        /// For nullable except "string" always false (null is value too).
-        /// For "string" is true when the stored value is null or is false when the stored value not null.
-        /// For non nullable is true when the stored value is null or is false when the stored value not null.
-        /// </summary>
-        bool IsUnset { get; }
-
-        /// <summary>
-        /// Full name of the setting.
-        /// Includes section name and setting name.
-        /// </summary>
-        string FullPath { get; }
-    }
-
     public static class Setting
     {
         public static ISetting<string> Create(SettingsPath settingsSource, string name, string? defaultValue)

--- a/GitCommands/Settings/SettingsPath.cs
+++ b/GitCommands/Settings/SettingsPath.cs
@@ -6,17 +6,17 @@ namespace GitCommands.Settings
     public class SettingsPath : ISettingsSource
     {
         private readonly ISettingsSource? _parent;
-        private readonly string _pathName;
+        private readonly string _pathNameWithSeparator;
 
         public SettingsPath(ISettingsSource? parent, string pathName)
         {
             _parent = parent;
-            _pathName = pathName;
+            _pathNameWithSeparator = string.IsNullOrWhiteSpace(pathName) ? "" : $"{pathName}.";
         }
 
         public string PathFor(string subPath)
         {
-            return $"{_pathName}.{subPath}";
+            return $"{_pathNameWithSeparator}{subPath}";
         }
 
         public override string? GetValue(string name)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1694,7 +1694,6 @@ namespace GitUI.CommandsDialogs
                     // If we're applying custom branch or revision filters - reset them
                     RevisionGrid.ResetAllFilters();
                     ToolStripFilters.ClearQuickFilters();
-                    AppSettings.BranchFilterEnabled = AppSettings.BranchFilterEnabled;
                     revisionDiff.RepositoryChanged();
                 }
 

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -398,9 +398,9 @@ namespace GitUI.CommandsDialogs
             finally
             {
                 AppSettings.ShowStashes = previousValueShowStashes;
-                AppSettings.BranchFilterEnabled = previousValueBranchFilterEnabled;
-                AppSettings.ShowCurrentBranchOnly = previousValueShowCurrentBranchOnly;
-                AppSettings.ShowReflogReferences = previousValueShowReflogReferences;
+                AppSettings.BranchFilterEnabled.Value = previousValueBranchFilterEnabled;
+                AppSettings.ShowCurrentBranchOnly.Value = previousValueShowCurrentBranchOnly;
+                AppSettings.ShowReflogReferences.Value = previousValueShowReflogReferences;
             }
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/SortingSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/SortingSettingsPage.cs
@@ -55,7 +55,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         protected override void SettingsToPage()
         {
-            _NO_TRANSLATE_cmbRevisionsSortBy.SelectedIndex = (int)AppSettings.RevisionSortOrder;
+            _NO_TRANSLATE_cmbRevisionsSortBy.SelectedIndex = (int)AppSettings.RevisionSortOrder.Value;
             _NO_TRANSLATE_cmbBranchesOrder.SelectedIndex = (int)AppSettings.RefsSortOrder;
             _NO_TRANSLATE_cmbBranchesSortBy.SelectedIndex = (int)AppSettings.RefsSortBy;
             txtPrioBranchNames.Text = AppSettings.PrioritizedBranchNames;
@@ -66,7 +66,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         protected override void PageToSettings()
         {
-            AppSettings.RevisionSortOrder = (RevisionSortOrder)_NO_TRANSLATE_cmbRevisionsSortBy.SelectedIndex;
+            AppSettings.RevisionSortOrder.Value = (RevisionSortOrder)_NO_TRANSLATE_cmbRevisionsSortBy.SelectedIndex;
+            AppSettings.RevisionSortOrder.Save();
             AppSettings.RefsSortOrder = (GitRefsSortOrder)_NO_TRANSLATE_cmbBranchesOrder.SelectedIndex;
             AppSettings.RefsSortBy = (GitRefsSortBy)_NO_TRANSLATE_cmbBranchesSortBy.SelectedIndex;
             AppSettings.PrioritizedBranchNames = txtPrioBranchNames.Text;

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -119,7 +119,7 @@ namespace GitUI.Editor
                     }
                 };
 
-            IgnoreWhitespace = AppSettings.IgnoreWhitespaceKind;
+            IgnoreWhitespace = AppSettings.IgnoreWhitespaceKind.GetValue(reload: !AppSettings.RememberIgnoreWhiteSpacePreference);
             OnIgnoreWhitespaceChanged();
 
             ignoreWhitespaceAtEol.Image = Images.WhitespaceIgnoreEol.AdaptLightness();
@@ -131,7 +131,7 @@ namespace GitUI.Editor
             ignoreAllWhitespaces.Image = Images.WhitespaceIgnoreAll.AdaptLightness();
             ignoreAllWhitespaceChangesToolStripMenuItem.Image = ignoreAllWhitespaces.Image;
 
-            ShowEntireFile = AppSettings.ShowEntireFile;
+            ShowEntireFile = AppSettings.ShowEntireFile.GetValue(reload: !AppSettings.RememberShowEntireFilePreference);
             showEntireFileButton.Checked = ShowEntireFile;
             showEntireFileToolStripMenuItem.Checked = ShowEntireFile;
             SetStateOfContextLinesButtons();
@@ -141,11 +141,12 @@ namespace GitUI.Editor
 
             showNonPrintChars.Image = Images.ShowWhitespace.AdaptLightness();
             showNonprintableCharactersToolStripMenuItem.Image = showNonPrintChars.Image;
-            showNonPrintChars.Checked = AppSettings.ShowNonPrintingChars;
-            showNonprintableCharactersToolStripMenuItem.Checked = AppSettings.ShowNonPrintingChars;
-            ToggleNonPrintingChars(AppSettings.ShowNonPrintingChars);
+            bool showNonPrintingChars = AppSettings.ShowNonPrintingChars.GetValue(reload: !AppSettings.RememberShowNonPrintingCharsPreference);
+            showNonPrintChars.Checked = showNonPrintingChars;
+            showNonprintableCharactersToolStripMenuItem.Checked = showNonPrintingChars;
+            ToggleNonPrintingChars(showNonPrintingChars);
 
-            ShowSyntaxHighlightingInDiff = AppSettings.ShowSyntaxHighlightingInDiff;
+            ShowSyntaxHighlightingInDiff = AppSettings.ShowSyntaxHighlightingInDiff.GetValue(reload: !AppSettings.RememberShowSyntaxHighlightingInDiff);
             showSyntaxHighlighting.Image = Resources.SyntaxHighlighting.AdaptLightness();
             showSyntaxHighlighting.Checked = ShowSyntaxHighlightingInDiff;
             automaticContinuousScrollToolStripMenuItem.Text = TranslatedStrings.ContScrollToNextFileOnlyWithAlt;
@@ -985,7 +986,7 @@ namespace GitUI.Editor
                     throw new NotSupportedException("Unsupported value for IgnoreWhitespaceKind: " + IgnoreWhitespace);
             }
 
-            AppSettings.IgnoreWhitespaceKind = IgnoreWhitespace;
+            AppSettings.IgnoreWhitespaceKind.Value = IgnoreWhitespace;
         }
 
         /// <summary>
@@ -1293,7 +1294,7 @@ namespace GitUI.Editor
         {
             ShowSyntaxHighlightingInDiff = !ShowSyntaxHighlightingInDiff;
             showSyntaxHighlighting.Checked = ShowSyntaxHighlightingInDiff;
-            AppSettings.ShowSyntaxHighlightingInDiff = ShowSyntaxHighlightingInDiff;
+            AppSettings.ShowSyntaxHighlightingInDiff.Value = ShowSyntaxHighlightingInDiff;
             OnExtraDiffArgumentsChanged();
         }
 
@@ -1303,7 +1304,7 @@ namespace GitUI.Editor
             showEntireFileButton.Checked = ShowEntireFile;
             showEntireFileToolStripMenuItem.Checked = ShowEntireFile;
             SetStateOfContextLinesButtons();
-            AppSettings.ShowEntireFile = ShowEntireFile;
+            AppSettings.ShowEntireFile.Value = ShowEntireFile;
             OnExtraDiffArgumentsChanged();
         }
 
@@ -1876,7 +1877,7 @@ namespace GitUI.Editor
             showNonPrintChars.Checked = showNonprintableCharactersToolStripMenuItem.Checked;
 
             ToggleNonPrintingChars(show: showNonprintableCharactersToolStripMenuItem.Checked);
-            AppSettings.ShowNonPrintingChars = showNonPrintChars.Checked;
+            AppSettings.ShowNonPrintingChars.Value = showNonPrintChars.Checked;
         }
 
         private void FindToolStripMenuItemClick(object sender, EventArgs e)

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9109,6 +9109,14 @@ See the changes in the commit form.</source>
         <source>Start typing in revision grid to start quick search.</source>
         <target />
       </trans-unit>
+      <trans-unit id="SaveAsDefault.Text">
+        <source>Save current view settings as default</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="Settings_persistenceToolStripMenuItem.Text">
+        <source>Settings persistence</source>
+        <target />
+      </trans-unit>
       <trans-unit id="ShowAllBranches.Text">
         <source>Show &amp;all branches</source>
         <target />

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -99,7 +99,7 @@ namespace GitUI.UserControls.RevisionGrid
         public bool ByBranchFilter
         {
             get => AppSettings.BranchFilterEnabled;
-            set => AppSettings.BranchFilterEnabled = value;
+            set => AppSettings.BranchFilterEnabled.Value = value;
         }
 
         public string BranchFilter
@@ -128,7 +128,7 @@ namespace GitUI.UserControls.RevisionGrid
         public bool ShowCurrentBranchOnly
         {
             get => AppSettings.ShowCurrentBranchOnly;
-            set => AppSettings.ShowCurrentBranchOnly = value;
+            set => AppSettings.ShowCurrentBranchOnly.Value = value;
         }
 
         public bool ShowOnlyFirstParent
@@ -140,7 +140,7 @@ namespace GitUI.UserControls.RevisionGrid
         public bool ShowReflogReferences
         {
             get => AppSettings.ShowReflogReferences;
-            set => AppSettings.ShowReflogReferences = value;
+            set => AppSettings.ShowReflogReferences.Value = value;
         }
 
         public bool ShowSimplifyByDecoration

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2224,13 +2224,13 @@ namespace GitUI
 
         internal void ToggleAuthorDateSort()
         {
-            AppSettings.RevisionSortOrder = AppSettings.RevisionSortOrder != RevisionSortOrder.AuthorDate ? RevisionSortOrder.AuthorDate : RevisionSortOrder.GitDefault;
+            AppSettings.RevisionSortOrder.Value = AppSettings.RevisionSortOrder != RevisionSortOrder.AuthorDate ? RevisionSortOrder.AuthorDate : RevisionSortOrder.GitDefault;
             PerformRefreshRevisions();
         }
 
         internal void ToggleTopoOrder()
         {
-            AppSettings.RevisionSortOrder = AppSettings.RevisionSortOrder != RevisionSortOrder.Topology ? RevisionSortOrder.Topology : RevisionSortOrder.GitDefault;
+            AppSettings.RevisionSortOrder.Value = AppSettings.RevisionSortOrder != RevisionSortOrder.Topology ? RevisionSortOrder.Topology : RevisionSortOrder.GitDefault;
             PerformRefreshRevisions();
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -1,4 +1,6 @@
-﻿using GitCommands;
+﻿using System.Reflection;
+using GitCommands;
+using GitCommands.Settings;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.Hotkey;
 using GitUI.Properties;
@@ -446,6 +448,15 @@ namespace GitUI.UserControls.RevisionGrid
                     Text = "Arrange c&ommits by topo order (ancestor order)",
                     ExecuteAction = () => _revisionGrid.ToggleTopoOrder(),
                     IsCheckedFunc = () => AppSettings.RevisionSortOrder == RevisionSortOrder.Topology
+                },
+                MenuCommand.CreateSeparator(),
+
+                MenuCommand.CreateGroupHeader("Settings persistence"),
+                new MenuCommand
+                {
+                    Name = "SaveAsDefault",
+                    Text = "Save current view settings as default",
+                    ExecuteAction = SaveAsDefaultViewSettings
                 }
             };
         }
@@ -492,6 +503,17 @@ namespace GitUI.UserControls.RevisionGrid
             {
                 MessageBoxes.CannotFindGitRevision(owner: _revisionGrid);
             }
+        }
+
+        private void SaveAsDefaultViewSettings()
+        {
+            foreach (FieldInfo staticAppSettingField in typeof(AppSettings).GetFields(BindingFlags.Public | BindingFlags.NonPublic | System.Reflection.BindingFlags.Static))
+            {
+                IRuntimeSetting? runtimeSetting = staticAppSettingField.GetValue(null) as IRuntimeSetting;
+                runtimeSetting?.Save();
+            }
+
+            AppSettings.SaveSettings();
         }
     }
 }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -79,9 +79,9 @@ namespace GitExtensions.UITests.CommandsDialogs
             bool branchFilterEnabled = AppSettings.BranchFilterEnabled;
             bool showCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
             bool revisionGraphShowArtificialCommits = AppSettings.RevisionGraphShowArtificialCommits;
-            AppSettings.ShowReflogReferences = false;
-            AppSettings.BranchFilterEnabled = false;
-            AppSettings.ShowCurrentBranchOnly = false;
+            AppSettings.ShowReflogReferences.Value = false;
+            AppSettings.BranchFilterEnabled.Value = false;
+            AppSettings.ShowCurrentBranchOnly.Value = false;
             AppSettings.RevisionGraphShowArtificialCommits = false;
 
             RunFormTest(
@@ -96,23 +96,23 @@ namespace GitExtensions.UITests.CommandsDialogs
                         WaitForRevisionsToBeLoaded(form);
                         // Assert
                         form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(4);
-                        AppSettings.BranchFilterEnabled.Should().BeFalse();
-                        AppSettings.ShowCurrentBranchOnly.Should().BeFalse();
+                        AppSettings.BranchFilterEnabled.Value.Should().BeFalse();
+                        AppSettings.ShowCurrentBranchOnly.Value.Should().BeFalse();
 
                         Console.WriteLine("Scenario 1: set 'Show current branch'");
                         form.GetTestAccessor().ToolStripFilters.GetTestAccessor().tsmiShowBranchesCurrent.PerformClick();
                         WaitForRevisionsToBeLoaded(form);
                         // Assert
-                        AppSettings.BranchFilterEnabled.Should().BeFalse();
-                        AppSettings.ShowCurrentBranchOnly.Should().BeTrue();
+                        AppSettings.BranchFilterEnabled.Value.Should().BeFalse();
+                        AppSettings.ShowCurrentBranchOnly.Value.Should().BeTrue();
                         form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(2);
 
                         Console.WriteLine("Scenario 1: set 'Show filtered branches'");
                         form.GetTestAccessor().ToolStripFilters.GetTestAccessor().tsmiShowBranchesFiltered.PerformClick();
                         WaitForRevisionsToBeLoaded(form);
                         // Assert
-                        AppSettings.BranchFilterEnabled.Should().BeTrue();
-                        AppSettings.ShowCurrentBranchOnly.Should().BeFalse();
+                        AppSettings.BranchFilterEnabled.Value.Should().BeTrue();
+                        AppSettings.ShowCurrentBranchOnly.Value.Should().BeFalse();
                         form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(4);
 
                         // 2. Apply a branch filter
@@ -122,16 +122,16 @@ namespace GitExtensions.UITests.CommandsDialogs
                         form.GetTestAccessor().ToolStripFilters.SetBranchFilter("Branch2");
                         WaitForRevisionsToBeLoaded(form);
                         // Assert
-                        AppSettings.BranchFilterEnabled.Should().BeTrue();
-                        AppSettings.ShowCurrentBranchOnly.Should().BeFalse();
+                        AppSettings.BranchFilterEnabled.Value.Should().BeTrue();
+                        AppSettings.ShowCurrentBranchOnly.Value.Should().BeFalse();
                         form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(3);
 
                         Console.WriteLine("Scenario 2: set 'Show current branch'");
                         form.GetTestAccessor().ToolStripFilters.GetTestAccessor().tsmiShowBranchesCurrent.PerformClick();
                         WaitForRevisionsToBeLoaded(form);
                         // Assert
-                        AppSettings.BranchFilterEnabled.Should().BeFalse();
-                        AppSettings.ShowCurrentBranchOnly.Should().BeTrue();
+                        AppSettings.BranchFilterEnabled.Value.Should().BeFalse();
+                        AppSettings.ShowCurrentBranchOnly.Value.Should().BeTrue();
                         form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(2);
                         // The filter text is still present
                         form.GetTestAccessor().ToolStripFilters.GetTestAccessor().tscboBranchFilter.Text.Should().Be("Branch2");
@@ -146,15 +146,15 @@ namespace GitExtensions.UITests.CommandsDialogs
                         form.RevisionGridControl.Invalidate();
                         UITest.ProcessEventsFor(1000);
                         // Assert
-                        AppSettings.BranchFilterEnabled.Should().BeFalse();
-                        AppSettings.ShowCurrentBranchOnly.Should().BeTrue();
+                        AppSettings.BranchFilterEnabled.Value.Should().BeFalse();
+                        AppSettings.ShowCurrentBranchOnly.Value.Should().BeTrue();
                         form.GetTestAccessor().ToolStripFilters.GetTestAccessor().tscboBranchFilter.Text.Should().BeEmpty();
                     }
                     finally
                     {
-                        AppSettings.ShowReflogReferences = reflogEnabled;
-                        AppSettings.BranchFilterEnabled = branchFilterEnabled;
-                        AppSettings.ShowCurrentBranchOnly = showCurrentBranchOnly;
+                        AppSettings.ShowReflogReferences.Value = reflogEnabled;
+                        AppSettings.BranchFilterEnabled.Value = branchFilterEnabled;
+                        AppSettings.ShowCurrentBranchOnly.Value = showCurrentBranchOnly;
                         AppSettings.RevisionGraphShowArtificialCommits = revisionGraphShowArtificialCommits;
                     }
                 });

--- a/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/RevisionGridControlTests.cs
@@ -67,9 +67,9 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
         [Test]
         public void Assert_default_filter_related_settings()
         {
-            AppSettings.ShowReflogReferences = false;
-            AppSettings.BranchFilterEnabled = false;
-            AppSettings.ShowCurrentBranchOnly = false;
+            AppSettings.ShowReflogReferences.Value = false;
+            AppSettings.BranchFilterEnabled.Value = false;
+            AppSettings.ShowCurrentBranchOnly.Value = false;
             AppSettings.ShowGitNotes = true;
 
             RunSetAndApplyBranchFilterTest(
@@ -115,9 +115,9 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
         [Test]
         public void View_reflects_applied_branch_filter()
         {
-            AppSettings.ShowReflogReferences = false;
-            AppSettings.BranchFilterEnabled = false;
-            AppSettings.ShowCurrentBranchOnly = false;
+            AppSettings.ShowReflogReferences.Value = false;
+            AppSettings.BranchFilterEnabled.Value = false;
+            AppSettings.ShowCurrentBranchOnly.Value = false;
             AppSettings.ShowGitNotes = true;
 
             RunSetAndApplyBranchFilterTest(
@@ -157,9 +157,9 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
         [Test]
         public void View_reflects_reset_branch_filter()
         {
-            AppSettings.ShowReflogReferences = false;
-            AppSettings.BranchFilterEnabled = false;
-            AppSettings.ShowCurrentBranchOnly = false;
+            AppSettings.ShowReflogReferences.Value = false;
+            AppSettings.BranchFilterEnabled.Value = false;
+            AppSettings.ShowCurrentBranchOnly.Value = false;
             AppSettings.ShowGitNotes = true;
 
             RunSetAndApplyBranchFilterTest(

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -291,9 +291,12 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.LastFormatPatchDir)], string.Empty, true, false);
                 yield return (properties[nameof(AppSettings.IgnoreWhitespaceKind)], IgnoreWhitespaceKind.None, false, false);
                 yield return (properties[nameof(AppSettings.RememberIgnoreWhiteSpacePreference)], true, false, false);
+                yield return (properties[nameof(AppSettings.ShowNonPrintingChars)], false, false, false);
                 yield return (properties[nameof(AppSettings.RememberShowNonPrintingCharsPreference)], false, false, false);
+                yield return (properties[nameof(AppSettings.ShowEntireFile)], false, false, false);
                 yield return (properties[nameof(AppSettings.RememberShowEntireFilePreference)], false, false, false);
                 yield return (properties[nameof(AppSettings.RememberNumberOfContextLines)], false, false, false);
+                yield return (properties[nameof(AppSettings.ShowSyntaxHighlightingInDiff)], true, false, false);
                 yield return (properties[nameof(AppSettings.RememberShowSyntaxHighlightingInDiff)], true, false, false);
                 yield return (properties[nameof(AppSettings.ShowRepoCurrentBranch)], true, false, false);
                 yield return (properties[nameof(AppSettings.OwnScripts)], string.Empty, true, false);

--- a/UnitTests/GitCommands.Tests/Settings/RuntimeSettingTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/RuntimeSettingTests.cs
@@ -1,0 +1,67 @@
+﻿using FluentAssertions;
+using GitCommands;
+using GitCommands.Settings;
+
+namespace GitCommandsTests.Settings
+{
+    [TestFixture]
+    internal sealed class RuntimeSettingTests
+    {
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+        }
+
+        private enum Enum
+        {
+            Foo,
+            Bar,
+            HardCodedDefault,
+            PersistentValue,
+            RuntimeValue,
+        }
+
+        [Test]
+        public void EnumRuntimeSetting()
+        {
+            SettingsPath rootSettingsPath = new AppSettingsPath(pathName: "");
+            const string name = "SettingX";
+
+            ISetting<Enum> persistentSetting = Setting.Create(rootSettingsPath, name, Enum.HardCodedDefault);
+            RuntimeSetting<Enum> runtimeSetting = new(persistentSetting);
+
+            runtimeSetting.Value.Should().Be(Enum.HardCodedDefault);
+            runtimeSetting.IsUnset.Should().BeTrue();
+
+            runtimeSetting.Value = Enum.PersistentValue;
+            runtimeSetting.Value.Should().Be(Enum.PersistentValue);
+            persistentSetting.Value.Should().Be(Enum.HardCodedDefault);
+            runtimeSetting.IsUnset.Should().BeTrue();
+
+            runtimeSetting.Save();
+            runtimeSetting.Value.Should().Be(Enum.PersistentValue);
+            persistentSetting.Value.Should().Be(Enum.PersistentValue);
+            runtimeSetting.IsUnset.Should().BeFalse();
+
+            runtimeSetting.Value = Enum.RuntimeValue;
+            runtimeSetting.Value.Should().Be(Enum.RuntimeValue);
+            persistentSetting.Value.Should().Be(Enum.PersistentValue);
+            runtimeSetting.IsUnset.Should().BeFalse();
+
+            runtimeSetting.Reload();
+            runtimeSetting.Value.Should().Be(Enum.PersistentValue);
+            persistentSetting.Value.Should().Be(Enum.PersistentValue);
+            runtimeSetting.IsUnset.Should().BeFalse();
+
+            runtimeSetting.ResetToDefault();
+            runtimeSetting.Value.Should().Be(Enum.HardCodedDefault);
+            persistentSetting.Value.Should().Be(Enum.PersistentValue);
+            runtimeSetting.IsUnset.Should().BeFalse();
+        }
+    }
+}

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
@@ -30,9 +30,9 @@ namespace GitUITests.UserControls
             bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
             bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
             bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
-            AppSettings.ShowReflogReferences = false;
-            AppSettings.ShowCurrentBranchOnly = false;
-            AppSettings.BranchFilterEnabled = false;
+            AppSettings.ShowReflogReferences.Value = false;
+            AppSettings.ShowCurrentBranchOnly.Value = false;
+            AppSettings.BranchFilterEnabled.Value = false;
             AppSettings.MaxRevisionGraphCommits = 1;
 
             try
@@ -42,9 +42,9 @@ namespace GitUITests.UserControls
             }
             finally
             {
-                AppSettings.BranchFilterEnabled = originalBranchFilterEnabled;
-                AppSettings.ShowCurrentBranchOnly = originalShowCurrentBranchOnly;
-                AppSettings.ShowReflogReferences = originalShowReflogReferences;
+                AppSettings.BranchFilterEnabled.Value = originalBranchFilterEnabled;
+                AppSettings.ShowCurrentBranchOnly.Value = originalShowCurrentBranchOnly;
+                AppSettings.ShowReflogReferences.Value = originalShowReflogReferences;
             }
         }
 
@@ -54,9 +54,9 @@ namespace GitUITests.UserControls
             bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
             bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
             bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
-            AppSettings.ShowReflogReferences = false;
-            AppSettings.ShowCurrentBranchOnly = false;
-            AppSettings.BranchFilterEnabled = false;
+            AppSettings.ShowReflogReferences.Value = false;
+            AppSettings.ShowCurrentBranchOnly.Value = false;
+            AppSettings.BranchFilterEnabled.Value = false;
             AppSettings.MaxRevisionGraphCommits = 1;
 
             try
@@ -66,9 +66,9 @@ namespace GitUITests.UserControls
             }
             finally
             {
-                AppSettings.BranchFilterEnabled = originalBranchFilterEnabled;
-                AppSettings.ShowCurrentBranchOnly = originalShowCurrentBranchOnly;
-                AppSettings.ShowReflogReferences = originalShowReflogReferences;
+                AppSettings.BranchFilterEnabled.Value = originalBranchFilterEnabled;
+                AppSettings.ShowCurrentBranchOnly.Value = originalShowCurrentBranchOnly;
+                AppSettings.ShowReflogReferences.Value = originalShowReflogReferences;
             }
         }
 
@@ -435,36 +435,36 @@ namespace GitUITests.UserControls
             bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
             bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
             bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
-            AppSettings.ShowReflogReferences = false;
-            AppSettings.ShowCurrentBranchOnly = false;
-            AppSettings.BranchFilterEnabled = false;
+            AppSettings.ShowReflogReferences.Value = false;
+            AppSettings.ShowCurrentBranchOnly.Value = false;
+            AppSettings.BranchFilterEnabled.Value = false;
 
             try
             {
                 FilterInfo filterInfo = new();
                 filterInfo.ByBranchFilter.Should().BeFalse();
-                AppSettings.BranchFilterEnabled.Should().BeFalse();
+                AppSettings.BranchFilterEnabled.Value.Should().BeFalse();
                 filterInfo.HasFilter.Should().BeFalse();
 
                 filterInfo.ByBranchFilter = true;
                 filterInfo.ByBranchFilter.Should().BeTrue();
-                AppSettings.BranchFilterEnabled.Should().BeTrue();
+                AppSettings.BranchFilterEnabled.Value.Should().BeTrue();
                 filterInfo.HasFilter.Should().BeFalse();
 
                 filterInfo.ByBranchFilter = false;
                 filterInfo.ByBranchFilter.Should().BeFalse();
-                AppSettings.BranchFilterEnabled.Should().BeFalse();
+                AppSettings.BranchFilterEnabled.Value.Should().BeFalse();
                 filterInfo.HasFilter.Should().BeFalse();
 
-                AppSettings.BranchFilterEnabled = true;
+                AppSettings.BranchFilterEnabled.Value = true;
                 filterInfo.ByBranchFilter.Should().BeTrue();
                 filterInfo.HasFilter.Should().BeFalse();
             }
             finally
             {
-                AppSettings.BranchFilterEnabled = originalBranchFilterEnabled;
-                AppSettings.ShowCurrentBranchOnly = originalShowCurrentBranchOnly;
-                AppSettings.ShowReflogReferences = originalShowReflogReferences;
+                AppSettings.BranchFilterEnabled.Value = originalBranchFilterEnabled;
+                AppSettings.ShowCurrentBranchOnly.Value = originalShowCurrentBranchOnly;
+                AppSettings.ShowReflogReferences.Value = originalShowReflogReferences;
             }
         }
 
@@ -477,9 +477,9 @@ namespace GitUITests.UserControls
             bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
             bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
             bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
-            AppSettings.ShowReflogReferences = false;
-            AppSettings.ShowCurrentBranchOnly = false;
-            AppSettings.BranchFilterEnabled = false;
+            AppSettings.ShowReflogReferences.Value = false;
+            AppSettings.ShowCurrentBranchOnly.Value = false;
+            AppSettings.BranchFilterEnabled.Value = false;
 
             try
             {
@@ -502,9 +502,9 @@ namespace GitUITests.UserControls
             }
             finally
             {
-                AppSettings.BranchFilterEnabled = originalBranchFilterEnabled;
-                AppSettings.ShowCurrentBranchOnly = originalShowCurrentBranchOnly;
-                AppSettings.ShowReflogReferences = originalShowReflogReferences;
+                AppSettings.BranchFilterEnabled.Value = originalBranchFilterEnabled;
+                AppSettings.ShowCurrentBranchOnly.Value = originalShowCurrentBranchOnly;
+                AppSettings.ShowReflogReferences.Value = originalShowReflogReferences;
             }
         }
 
@@ -517,9 +517,9 @@ namespace GitUITests.UserControls
             bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
             bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
             bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
-            AppSettings.ShowReflogReferences = false;
-            AppSettings.ShowCurrentBranchOnly = false;
-            AppSettings.BranchFilterEnabled = false;
+            AppSettings.ShowReflogReferences.Value = false;
+            AppSettings.ShowCurrentBranchOnly.Value = false;
+            AppSettings.BranchFilterEnabled.Value = false;
 
             try
             {
@@ -535,9 +535,9 @@ namespace GitUITests.UserControls
             }
             finally
             {
-                AppSettings.BranchFilterEnabled = originalBranchFilterEnabled;
-                AppSettings.ShowCurrentBranchOnly = originalShowCurrentBranchOnly;
-                AppSettings.ShowReflogReferences = originalShowReflogReferences;
+                AppSettings.BranchFilterEnabled.Value = originalBranchFilterEnabled;
+                AppSettings.ShowCurrentBranchOnly.Value = originalShowCurrentBranchOnly;
+                AppSettings.ShowReflogReferences.Value = originalShowReflogReferences;
             }
         }
 
@@ -550,9 +550,9 @@ namespace GitUITests.UserControls
             bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
             bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
             bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
-            AppSettings.ShowReflogReferences = false;
-            AppSettings.ShowCurrentBranchOnly = false;
-            AppSettings.BranchFilterEnabled = false;
+            AppSettings.ShowReflogReferences.Value = false;
+            AppSettings.ShowCurrentBranchOnly.Value = false;
+            AppSettings.BranchFilterEnabled.Value = false;
 
             try
             {
@@ -568,9 +568,9 @@ namespace GitUITests.UserControls
             }
             finally
             {
-                AppSettings.BranchFilterEnabled = originalBranchFilterEnabled;
-                AppSettings.ShowCurrentBranchOnly = originalShowCurrentBranchOnly;
-                AppSettings.ShowReflogReferences = originalShowReflogReferences;
+                AppSettings.BranchFilterEnabled.Value = originalBranchFilterEnabled;
+                AppSettings.ShowCurrentBranchOnly.Value = originalShowCurrentBranchOnly;
+                AppSettings.ShowReflogReferences.Value = originalShowReflogReferences;
             }
         }
 
@@ -583,9 +583,9 @@ namespace GitUITests.UserControls
             bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
             bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
             bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
-            AppSettings.ShowReflogReferences = false;
-            AppSettings.ShowCurrentBranchOnly = false;
-            AppSettings.BranchFilterEnabled = false;
+            AppSettings.ShowReflogReferences.Value = false;
+            AppSettings.ShowCurrentBranchOnly.Value = false;
+            AppSettings.BranchFilterEnabled.Value = false;
 
             try
             {
@@ -601,9 +601,9 @@ namespace GitUITests.UserControls
             }
             finally
             {
-                AppSettings.BranchFilterEnabled = originalBranchFilterEnabled;
-                AppSettings.ShowCurrentBranchOnly = originalShowCurrentBranchOnly;
-                AppSettings.ShowReflogReferences = originalShowReflogReferences;
+                AppSettings.BranchFilterEnabled.Value = originalBranchFilterEnabled;
+                AppSettings.ShowCurrentBranchOnly.Value = originalShowCurrentBranchOnly;
+                AppSettings.ShowReflogReferences.Value = originalShowReflogReferences;
             }
         }
 
@@ -613,36 +613,36 @@ namespace GitUITests.UserControls
             bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
             bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
             bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
-            AppSettings.ShowReflogReferences = false;
-            AppSettings.ShowCurrentBranchOnly = false;
-            AppSettings.BranchFilterEnabled = false;
+            AppSettings.ShowReflogReferences.Value = false;
+            AppSettings.ShowCurrentBranchOnly.Value = false;
+            AppSettings.BranchFilterEnabled.Value = false;
 
             try
             {
                 FilterInfo filterInfo = new();
                 filterInfo.ShowCurrentBranchOnly.Should().BeFalse();
-                AppSettings.ShowCurrentBranchOnly.Should().BeFalse();
+                AppSettings.ShowCurrentBranchOnly.Value.Should().BeFalse();
                 filterInfo.HasFilter.Should().BeFalse();
 
                 filterInfo.ShowCurrentBranchOnly = true;
                 filterInfo.ShowCurrentBranchOnly.Should().BeTrue();
-                AppSettings.ShowCurrentBranchOnly.Should().BeTrue();
+                AppSettings.ShowCurrentBranchOnly.Value.Should().BeTrue();
                 filterInfo.HasFilter.Should().BeFalse();
 
                 filterInfo.ShowCurrentBranchOnly = false;
                 filterInfo.ShowCurrentBranchOnly.Should().BeFalse();
-                AppSettings.ShowCurrentBranchOnly.Should().BeFalse();
+                AppSettings.ShowCurrentBranchOnly.Value.Should().BeFalse();
                 filterInfo.HasFilter.Should().BeFalse();
 
-                AppSettings.ShowCurrentBranchOnly = true;
+                AppSettings.ShowCurrentBranchOnly.Value = true;
                 filterInfo.ShowCurrentBranchOnly.Should().BeTrue();
                 filterInfo.HasFilter.Should().BeFalse();
             }
             finally
             {
-                AppSettings.BranchFilterEnabled = originalBranchFilterEnabled;
-                AppSettings.ShowCurrentBranchOnly = originalShowCurrentBranchOnly;
-                AppSettings.ShowReflogReferences = originalShowReflogReferences;
+                AppSettings.BranchFilterEnabled.Value = originalBranchFilterEnabled;
+                AppSettings.ShowCurrentBranchOnly.Value = originalShowCurrentBranchOnly;
+                AppSettings.ShowReflogReferences.Value = originalShowReflogReferences;
             }
         }
 
@@ -685,36 +685,36 @@ namespace GitUITests.UserControls
             bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
             bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
             bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
-            AppSettings.ShowReflogReferences = false;
-            AppSettings.ShowCurrentBranchOnly = false;
-            AppSettings.BranchFilterEnabled = false;
+            AppSettings.ShowReflogReferences.Value = false;
+            AppSettings.ShowCurrentBranchOnly.Value = false;
+            AppSettings.BranchFilterEnabled.Value = false;
 
             try
             {
                 FilterInfo filterInfo = new();
                 filterInfo.ShowReflogReferences.Should().BeFalse();
-                AppSettings.ShowReflogReferences.Should().BeFalse();
+                AppSettings.ShowReflogReferences.Value.Should().BeFalse();
                 filterInfo.HasFilter.Should().BeFalse();
 
                 filterInfo.ShowReflogReferences = true;
                 filterInfo.ShowReflogReferences.Should().BeTrue();
-                AppSettings.ShowReflogReferences.Should().BeTrue();
+                AppSettings.ShowReflogReferences.Value.Should().BeTrue();
                 filterInfo.HasFilter.Should().BeFalse();
 
                 filterInfo.ShowReflogReferences = false;
                 filterInfo.ShowReflogReferences.Should().BeFalse();
-                AppSettings.ShowReflogReferences.Should().BeFalse();
+                AppSettings.ShowReflogReferences.Value.Should().BeFalse();
                 filterInfo.HasFilter.Should().BeFalse();
 
-                AppSettings.ShowReflogReferences = true;
+                AppSettings.ShowReflogReferences.Value = true;
                 filterInfo.ShowReflogReferences.Should().BeTrue();
                 filterInfo.HasFilter.Should().BeFalse();
             }
             finally
             {
-                AppSettings.BranchFilterEnabled = originalBranchFilterEnabled;
-                AppSettings.ShowCurrentBranchOnly = originalShowCurrentBranchOnly;
-                AppSettings.ShowReflogReferences = originalShowReflogReferences;
+                AppSettings.BranchFilterEnabled.Value = originalBranchFilterEnabled;
+                AppSettings.ShowCurrentBranchOnly.Value = originalShowCurrentBranchOnly;
+                AppSettings.ShowReflogReferences.Value = originalShowReflogReferences;
             }
         }
 
@@ -731,9 +731,9 @@ namespace GitUITests.UserControls
             bool originalBranchFilterEnabled = AppSettings.BranchFilterEnabled;
             bool originalShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
             bool originalShowReflogReferences = AppSettings.ShowReflogReferences;
-            AppSettings.ShowReflogReferences = false;
-            AppSettings.ShowCurrentBranchOnly = false;
-            AppSettings.BranchFilterEnabled = false;
+            AppSettings.ShowReflogReferences.Value = false;
+            AppSettings.ShowCurrentBranchOnly.Value = false;
+            AppSettings.BranchFilterEnabled.Value = false;
 
             try
             {
@@ -753,18 +753,18 @@ namespace GitUITests.UserControls
                 filterInfo.IsShowFilteredBranchesChecked.Should().Be(byBranchFilter && !showCurrentBranchOnly);
 
                 filterInfo.ByBranchFilter.Should().Be(byBranchFilter);
-                AppSettings.BranchFilterEnabled.Should().Be(byBranchFilter);
+                AppSettings.BranchFilterEnabled.Value.Should().Be(byBranchFilter);
                 filterInfo.ShowCurrentBranchOnly.Should().Be(showCurrentBranchOnly);
-                AppSettings.ShowCurrentBranchOnly.Should().Be(showCurrentBranchOnly);
+                AppSettings.ShowCurrentBranchOnly.Value.Should().Be(showCurrentBranchOnly);
 
                 filterInfo.HasFilter.Should().BeFalse();
             }
             finally
             {
-                AppSettings.ShowReflogReferences = false;
-                AppSettings.BranchFilterEnabled = originalBranchFilterEnabled;
-                AppSettings.ShowCurrentBranchOnly = originalShowCurrentBranchOnly;
-                AppSettings.ShowReflogReferences = originalShowReflogReferences;
+                AppSettings.ShowReflogReferences.Value = false;
+                AppSettings.BranchFilterEnabled.Value = originalBranchFilterEnabled;
+                AppSettings.ShowCurrentBranchOnly.Value = originalShowCurrentBranchOnly;
+                AppSettings.ShowReflogReferences.Value = originalShowReflogReferences;
             }
         }
 

--- a/UnitTests/GitUI.Tests/UserControls/FilterToolBarTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterToolBarTests.cs
@@ -26,7 +26,7 @@ namespace GitUITests.UserControls
             _originalShowOnlyFirstParent = AppSettings.ShowOnlyFirstParent;
             _originalShowReflogReferences = AppSettings.ShowReflogReferences;
             AppSettings.ShowOnlyFirstParent = false;
-            AppSettings.ShowReflogReferences = false;
+            AppSettings.ShowReflogReferences.Value = false;
 
             _gitModule = Substitute.For<IGitModule>();
             _revisionGridFilter = Substitute.For<IRevisionGridFilter>();
@@ -39,7 +39,7 @@ namespace GitUITests.UserControls
         public void TearDown()
         {
             AppSettings.ShowOnlyFirstParent = _originalShowOnlyFirstParent;
-            AppSettings.ShowReflogReferences = _originalShowReflogReferences;
+            AppSettings.ShowReflogReferences.Value = _originalShowReflogReferences;
         }
 
         [Test]
@@ -258,14 +258,14 @@ namespace GitUITests.UserControls
             bool original = AppSettings.ShowReflogReferences;
             try
             {
-                AppSettings.ShowReflogReferences = settingValue;
+                AppSettings.ShowReflogReferences.Value = settingValue;
 
                 _revisionGridFilter.FilterChanged += Raise.EventWith(_revisionGridFilter, new FilterChangedEventArgs(new()));
                 _filterToolBar.GetTestAccessor().tsbShowReflog.Checked.Should().Be(settingValue);
             }
             finally
             {
-                AppSettings.ShowReflogReferences = original;
+                AppSettings.ShowReflogReferences.Value = original;
             }
         }
 


### PR DESCRIPTION
Fixes #10009

## Proposed changes

- Store the most important view settings on request only
  (RefLog, CurrentBranchOnly, BranchFilterEnabled, RevisionSortOrder, FileViewer toolbar flags)

## Screenshots <!-- Remove this section if PR does not change UI -->

Before|After
-|-
![image](https://user-images.githubusercontent.com/36601201/229378377-21779de4-7291-4b9b-8504-07a5da71b42f.png)|![image](https://github.com/gitextensions/gitextensions/assets/36601201/fd333449-c16e-4b5c-a5e2-9b707b353ac0)

## Test methodology <!-- How did you ensure quality? -->

- manual
- new tests for `RuntimeSetting<T>`

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).