### PR TITLE
Reset conflicted files

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -536,10 +536,18 @@ namespace GitUI.CommandsDialogs
                     foreach (ObjectId parentId in selectedItems.FirstIds())
                     {
                         List<string> itemsToCheckout = selectedItems
-                            .Where(item => !item.Item.IsNew && item.FirstRevision?.ObjectId == parentId)
+                            .Where(item => !item.Item.IsNew && !(item.Item.IsConflict && parentId == ObjectId.IndexId) && item.FirstRevision?.ObjectId == parentId)
                             .Select(item => RenamedIndexItem(item) ? item.Item.OldName : item.Item.Name)
                             .ToList();
                         Module.CheckoutFiles(itemsToCheckout, parentId, force: false);
+
+                        // Special handling for conflicted files, shown in worktree (with the raw diff).
+                        // Must be reset to HEAD as Index is just a status marker.
+                        List<string> conflictsToCheckout = selectedItems
+                            .Where(item => item.Item.IsConflict && parentId == ObjectId.IndexId)
+                            .Select(item => RenamedIndexItem(item) ? item.Item.OldName : item.Item.Name)
+                            .ToList();
+                        Module.CheckoutFiles(conflictsToCheckout, _revisionGrid.CurrentCheckout, force: false);
                     }
                 }
             }


### PR DESCRIPTION
Depends on #10852 - no behavior dependency but (assumed in code comments, the behavior when resetting will be hard to describe without #10852 too.
~~Depends on #10853 - no behavior dependency but the same files are changed.~~

~~First commit is not be reviewed in this PR.~~
Set to draft due to dependency but reviewable.

Fixes #10423 (where both are modified)
Does not handle #10470 that relates to added/removed files

## Proposed changes

It was only possible to reset changes to the Index item, the error occurred when resetting the worktree file status item.
The reset must be done to HEAD.

Same behavior in worktree and index, separate implementations.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
