### PR TITLE
Rename to "LeftPanel" in hotkeys

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1881,7 +1881,7 @@ namespace GitUI.CommandsDialogs
             FocusDiff = 5,
             FocusFileTree = 6,
             FocusFilter = 18,
-            ToggleBranchTreePanel = 21,
+            ToggleLeftPanel = 21,
             FocusBranchTree = 25,
             FocusGpgInfo = 26,
             FocusGitConsole = 29,
@@ -2055,7 +2055,7 @@ namespace GitUI.CommandsDialogs
                 case Command.OpenWithDifftoolFirstToLocal: OpenWithDifftoolFirstToLocal(); break;
                 case Command.OpenWithDifftoolSelectedToLocal: OpenWithDifftoolSelectedToLocal(); break;
                 case Command.OpenSettings: EditSettings.PerformClick(); break;
-                case Command.ToggleBranchTreePanel: toggleBranchTreePanel.PerformClick(); break;
+                case Command.ToggleLeftPanel: toggleBranchTreePanel.PerformClick(); break;
                 case Command.EditFile: EditFile(); break;
                 case Command.OpenAsTempFile when fileTree.Visible: fileTree.ExecuteCommand(RevisionFileTreeControl.Command.OpenAsTempFile); break;
                 case Command.OpenAsTempFileWith when fileTree.Visible: fileTree.ExecuteCommand(RevisionFileTreeControl.Command.OpenAsTempFileWith); break;

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -299,7 +299,7 @@ namespace GitUI.Hotkey
                     Hk(FormBrowse.Command.StashPop, Keys.Control | Keys.Alt | Keys.Down),
                     Hk(FormBrowse.Command.StashStaged, Keys.Control | Keys.Shift | Keys.Alt | Keys.Up),
                     Hk(FormBrowse.Command.ToggleBetweenArtificialAndHeadCommits, Keys.Control | Keys.OemBackslash),
-                    Hk(FormBrowse.Command.ToggleBranchTreePanel, Keys.Control | Keys.Alt | Keys.C)),
+                    Hk(FormBrowse.Command.ToggleLeftPanel, Keys.Control | Keys.Alt | Keys.C)),
                 new HotkeySettings(
                     RepoObjectsTree.HotkeySettingsName,
                     Hk(RepoObjectsTree.Command.Delete, Keys.Delete),


### PR DESCRIPTION
because that's how it is named everywhere else (and it is misleading)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/460196/229780662-c52555b7-7bc6-4225-9b70-9b60c3dc4e1a.png)

![image](https://user-images.githubusercontent.com/460196/229780588-20f3fa4a-0923-4ea6-839c-e60f83c46977.png)

### After

![image](https://user-images.githubusercontent.com/460196/229780957-273ebe3b-6c30-401e-bf3b-41b251259960.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 32a99950b8e8ede897e844cc6a10fee321fa8513
- Git 2.40.0.windows.1
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.15
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
