### PR TITLE
Filter toolbar: Show reflog first and default

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
@@ -197,7 +197,7 @@ namespace GitUI.CommandsDialogs
 
             return;
 
-            bool IsVisibleByDefault(string buttonKey) => !buttonKey.Contains(FilterToolBar.ReflogButtonName) && !buttonKey.Contains(FormBrowse.FetchPullToolbarShortcutsPrefix);
+            bool IsVisibleByDefault(string buttonKey) => !buttonKey.Contains(FormBrowse.FetchPullToolbarShortcutsPrefix);
             static void SaveVisibilitySetting(string key, bool visible, bool defaultValue = true)
                 => AppSettings.SetBool(toolbarSettingsPrefix + key, visible == defaultValue ? null : visible);
             static bool LoadVisibilitySetting(string key, bool defaultValue = true)

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -274,7 +274,6 @@ namespace GitUI.UserControls
             this.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tsbtnAdvancedFilter,
             this.tsbShowReflog,
-            this.tsmiShowOnlyFirstParent,
             this.tssbtnShowBranches,
             this.toolStripLabel1,
             this.tscboBranchFilter,
@@ -282,7 +281,8 @@ namespace GitUI.UserControls
             this.toolStripSeparator19,
             this.tslblRevisionFilter,
             this.tstxtRevisionFilter,
-            this.tsddbtnRevisionFilter});
+            this.tsddbtnRevisionFilter,
+            this.tsmiShowOnlyFirstParent});
             this.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
             this.Location = new System.Drawing.Point(584, 0);
             this.Name = "ToolStripFilters";

--- a/GitUI/UserControls/FilterToolBar.Designer.cs
+++ b/GitUI/UserControls/FilterToolBar.Designer.cs
@@ -273,12 +273,12 @@ namespace GitUI.UserControls
             this.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tsbtnAdvancedFilter,
+            this.tsbShowReflog,
+            this.tsmiShowOnlyFirstParent,
             this.tssbtnShowBranches,
             this.toolStripLabel1,
             this.tscboBranchFilter,
             this.tsddbtnBranchFilter,
-            this.tsbShowReflog,
-            this.tsmiShowOnlyFirstParent,
             this.toolStripSeparator19,
             this.tslblRevisionFilter,
             this.tstxtRevisionFilter,


### PR DESCRIPTION
[formbrowse_toolbar_visibility_](https://github.com/gitextensions/gitextensions/pull/10831#issuecomment-1496690268)
https://github.com/gitextensions/gitextensions/pull/10831#pullrequestreview-1358125079

## Proposed changes

Show reflog button first and by default
first-parents button last, after filter

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Reflog is not visible by default, button activated
![image](https://user-images.githubusercontent.com/6248932/230493108-0495591f-b253-40da-afb0-cc75e04f2f52.png)

### After

![image](https://user-images.githubusercontent.com/6248932/230677396-76e47fcb-bac0-4f1f-8050-6e169235ba30.png)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
