### PR TITLE
Do not straighten re-used graph lanes

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -364,7 +364,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         {
             if (row is not null)
             {
-                return row.GetLaneIndexForSegment(revisionGraphRevision);
+                return row.GetLaneForSegment(revisionGraphRevision).Index;
             }
 
             return -1;

--- a/GitUI/UserControls/RevisionGrid/Graph/Lane.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/Lane.cs
@@ -1,0 +1,4 @@
+﻿namespace GitUI.UserControls.RevisionGrid.Graph
+{
+    public readonly record struct Lane(int Index, LaneSharing Sharing);
+}

--- a/GitUI/UserControls/RevisionGrid/Graph/LaneSharing.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneSharing.cs
@@ -1,0 +1,25 @@
+﻿namespace GitUI.UserControls.RevisionGrid.Graph
+{
+    public enum LaneSharing
+    {
+        /// <summary>
+        /// The graph segment uses the lane exclusively or is the initial user of the lane.
+        /// </summary>
+        ExclusiveOrPrimary,
+
+        /// <summary>
+        /// The graph segment entirely re-uses a lane with another one because they have the same parent.
+        /// </summary>
+        Entire,
+
+        /// <summary>
+        /// The graph segment partially re-uses a lane with another one because they have the same parent.
+        /// </summary>
+        DifferentStart,
+
+        /// <summary>
+        /// The graph segment partially re-uses a lane with another one because they have the same child.
+        /// </summary>
+        DifferentEnd
+    }
+}

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -120,6 +120,13 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             currentRowIndex += 2 * _straightenLanesLookAhead;
             lastToCacheRowIndex += 2 * _straightenLanesLookAhead;
 
+            if (_loadingCompleted)
+            {
+                int maxRowIndex = Count - 1;
+                currentRowIndex = Math.Min(currentRowIndex, maxRowIndex);
+                lastToCacheRowIndex = Math.Min(lastToCacheRowIndex, maxRowIndex);
+            }
+
             RevisionGraphRevision[] orderedNodesCache = BuildOrderedNodesCache(currentRowIndex);
 
             BuildOrderedRowCache(orderedNodesCache, currentRowIndex, lastToCacheRowIndex);

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -481,16 +481,10 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 for (int currentIndex = startIndex; currentIndex <= lastStraightenIndex;)
                 {
                     goBackLimit = Math.Max(goBackLimit, currentIndex - _straightenLanesLookAhead);
-                    IRevisionGraphRow currentRow = localOrderedRowCache[currentIndex];
-                    if (currentRow.Segments.Count >= MaxLanes)
-                    {
-                        ++currentIndex;
-                        continue;
-                    }
-
                     bool moved = false;
+                    IRevisionGraphRow currentRow = localOrderedRowCache[currentIndex];
                     IRevisionGraphRow previousRow = localOrderedRowCache[currentIndex - 1];
-                    foreach (RevisionGraphSegment revisionGraphSegment in currentRow.Segments)
+                    foreach (RevisionGraphSegment revisionGraphSegment in currentRow.Segments.Take(MaxLanes))
                     {
                         Lane currentRowLane = currentRow.GetLaneForSegment(revisionGraphSegment);
                         if (currentRowLane.Sharing != LaneSharing.ExclusiveOrPrimary)

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -492,8 +492,14 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                     IRevisionGraphRow previousRow = localOrderedRowCache[currentIndex - 1];
                     foreach (RevisionGraphSegment revisionGraphSegment in currentRow.Segments)
                     {
+                        Lane currentRowLane = currentRow.GetLaneForSegment(revisionGraphSegment);
+                        if (currentRowLane.Sharing != LaneSharing.ExclusiveOrPrimary)
+                        {
+                            continue; // with next revisionGraphSegment
+                        }
+
+                        int currentLane = currentRowLane.Index;
                         int previousLane = previousRow.GetLaneForSegment(revisionGraphSegment).Index;
-                        int currentLane = currentRow.GetLaneForSegment(revisionGraphSegment).Index;
                         if (previousLane <= currentLane)
                         {
                             continue; // with next revisionGraphSegment

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -367,8 +367,11 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 List<RevisionGraphSegment> segments;
                 RevisionGraphSegment[] revisionStartSegments = revision.GetStartSegments();
 
+                RevisionGraphRow? previousRevisionGraphRow;
                 if (nextIndex == 0)
                 {
+                    previousRevisionGraphRow = null;
+
                     // This is the first row. Start with only the startsegments of this row
                     segments = new List<RevisionGraphSegment>(revisionStartSegments);
 
@@ -380,9 +383,9 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 else
                 {
                     // Copy lanes from last row
-                    RevisionGraphRow previousRevisionGraphRow = localOrderedRowCache[nextIndex - 1];
+                    previousRevisionGraphRow = localOrderedRowCache[nextIndex - 1];
 
-                    // Create segments list with te correct capacity
+                    // Create segments list with the correct capacity
                     segments = new List<RevisionGraphSegment>(previousRevisionGraphRow.Segments.Count + revisionStartSegments.Length);
 
                     // Loop through all segments that do not end in the previous row
@@ -433,7 +436,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                     }
                 }
 
-                localOrderedRowCache.Add(new RevisionGraphRow(revision, segments));
+                localOrderedRowCache.Add(new RevisionGraphRow(revision, segments, previousRevisionGraphRow));
             }
 
             // Straightening does not apply to the first and the last row. The single node there shall not be moved.
@@ -489,8 +492,8 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                     IRevisionGraphRow previousRow = localOrderedRowCache[currentIndex - 1];
                     foreach (RevisionGraphSegment revisionGraphSegment in currentRow.Segments)
                     {
-                        int previousLane = previousRow.GetLaneIndexForSegment(revisionGraphSegment);
-                        int currentLane = currentRow.GetLaneIndexForSegment(revisionGraphSegment);
+                        int previousLane = previousRow.GetLaneForSegment(revisionGraphSegment).Index;
+                        int currentLane = currentRow.GetLaneForSegment(revisionGraphSegment).Index;
                         if (previousLane <= currentLane)
                         {
                             continue; // with next revisionGraphSegment
@@ -500,7 +503,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                         int lookaheadLane = currentLane;
                         for (int lookaheadIndex = currentIndex + 1; lookaheadLane == currentLane && lookaheadIndex <= Math.Min(currentIndex + _straightenLanesLookAhead, lastLookaheadIndex); ++lookaheadIndex)
                         {
-                            lookaheadLane = localOrderedRowCache[lookaheadIndex].GetLaneIndexForSegment(revisionGraphSegment);
+                            lookaheadLane = localOrderedRowCache[lookaheadIndex].GetLaneForSegment(revisionGraphSegment).Index;
                             if ((lookaheadLane == straightenedCurrentLane) || (lookaheadLane > straightenedCurrentLane && previousLane == straightenedCurrentLane))
                             {
                                 for (int moveIndex = currentIndex; moveIndex < lookaheadIndex; ++moveIndex)

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -9,7 +9,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
         int GetCurrentRevisionLane();
         int GetLaneCount();
-        int GetLaneIndexForSegment(RevisionGraphSegment revisionGraphRevision);
+        Lane GetLaneForSegment(RevisionGraphSegment revisionGraphRevision);
         IEnumerable<RevisionGraphSegment> GetSegmentsForIndex(int index);
         void MoveLanesRight(int fromLane);
     }
@@ -20,20 +20,25 @@ namespace GitUI.UserControls.RevisionGrid.Graph
     // Therefore, a single lane can have multiple segments.
     public class RevisionGraphRow : IRevisionGraphRow
     {
-        public RevisionGraphRow(RevisionGraphRevision revision, IReadOnlyList<RevisionGraphSegment> segments)
+        private static readonly Lane _noLane = new(Index: -1, LaneSharing.ExclusiveOrPrimary);
+
+        public RevisionGraphRow(RevisionGraphRevision revision, IReadOnlyList<RevisionGraphSegment> segments, RevisionGraphRow previousRow)
         {
             Revision = revision;
             Segments = segments;
+            _previousRow = previousRow;
         }
 
         public RevisionGraphRevision Revision { get; }
 
         public IReadOnlyList<RevisionGraphSegment> Segments { get; }
 
+        private readonly RevisionGraphRow _previousRow;
+
         /// <summary>
         /// This dictionary contains a cached list of all segments and the lane index the segment is in for this row.
         /// </summary>
-        private Dictionary<RevisionGraphSegment, int>? _segmentLanes;
+        private Dictionary<RevisionGraphSegment, Lane>? _segmentLanes;
 
         /// <summary>
         /// Contains the gaps created by. <cref>MoveLanesRight</cref>
@@ -74,6 +79,8 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 _segmentLanes = new(capacity: Segments.Count);
                 _laneCount = 0;
                 _revisionLane = -1;
+                bool hasStart = false;
+                bool hasEnd = false;
 
                 foreach (RevisionGraphSegment segment in Segments)
                 {
@@ -87,50 +94,106 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
                 return;
 
-                int CreateOrReuseLane(RevisionGraphSegment segment)
+                Lane CreateOrReuseLane(RevisionGraphSegment segment)
                 {
-                    if (segment.Child == Revision || segment.Parent == Revision)
+                    // All segments that connect to the current revision are in the same lane.
+                    //              | | * |                               prev StartLane:   0                   1                   2               3
+                    //              | |/ /                                prev LaneSharing: ExclusiveOrPrimary, ExclusiveOrPrimary, DifferentStart, ExclusiveOrPrimary
+                    // start        * | |                                      StartLane:   0                   1                   1               2
+                    //              |/_/     <-- segment.Parent == Revision => LaneSharing: ExclusiveOrPrimary, DifferentStart,     Entire,         DifferentStart
+                    // center       *____    <-- this.Revision                 CenterLane:  _revisionLane                                           ^^^ impossible: would also be shared with lane 1
+                    //              |\ \ \   <-- segment.Child == Revision  => LaneSharing: ExclusiveOrPrimary, DifferentEnd, DifferentEnd, DifferentEnd (never entirely shared)
+                    // end          | | * |                                    EndLane:     0                   1             2             3
+
+                    if (segment.Child == Revision)
                     {
-                        // The current segment connects to the revision of this row. Store the revision lane.
+                        // The current segment starts at the revision of this row. Store the revision lane.
                         if (_revisionLane < 0)
                         {
                             _revisionLane = CreateLane();
                         }
 
-                        // All segments that connect to the current revision are in the same lane.
-                        return _revisionLane;
+                        LaneSharing laneSharing;
+                        if (!hasStart)
+                        {
+                            hasStart = true;
+                            laneSharing = LaneSharing.ExclusiveOrPrimary;
+                        }
+                        else
+                        {
+                            laneSharing = LaneSharing.DifferentEnd;
+                        }
+
+                        return new Lane(_revisionLane, laneSharing);
+                    }
+
+                    if (segment.Parent == Revision)
+                    {
+                        // The current segment ends at the revision of this row. Store the revision lane.
+                        if (_revisionLane < 0)
+                        {
+                            _revisionLane = CreateLane();
+                        }
+
+                        // prev start   | | *                                 prev StartLane:   0                   1                   2
+                        //              | |/                                  prev LaneSharing: ExclusiveOrPrimary, ExclusiveOrPrimary, DifferentStart
+                        // prev center  * |                                        StartLane:   0                   1                   1
+                        //              |/       <-- segment.Parent == Revision => LaneSharing: ExclusiveOrPrimary, DifferentStart,     Entire
+                        // prev end     *        <-- this.Revision                 CenterLane:  _revisionLane
+                        LaneSharing laneSharing;
+                        if (!hasEnd)
+                        {
+                            hasEnd = true;
+                            laneSharing = LaneSharing.ExclusiveOrPrimary;
+                        }
+                        else
+                        {
+                            laneSharing = GetSecondarySharingOfContinuedSegment();
+                        }
+
+                        return new Lane(_revisionLane, laneSharing);
                     }
 
                     // This is a crossing lane. We could not merge it in the lane with this row's revision.
 
                     // Try to detect this:
-                    // *
-                    // |
-                    // | *
-                    // | |
-                    // | |  <- this is the row we are processing
-                    // |/
-                    // *    <- same parent, not on current row
+                    // | * | |
+                    // | | | |
+                    // * | | |
+                    // | | | |
+                    // | | | | <-- this is the row we are processing
+                    // |/_/_/
+                    // *       <-- same parent, not on current row
                     //
                     // And change it into this, by merging the segments in a singe lane:
-                    // *
+                    // | * |
+                    // | |/    <-- LaneSharing: ExclusiveOrPrimary, ExclusiveOrPrimary, DifferentStart, Entire
+                    // * |     <-- (previous row: merge into a singe lane to simplify graph - added here just for LaneSharing value)
+                    // |/      <-- LaneSharing: ExclusiveOrPrimary, DifferentStart,     Entire,         Entire
+                    // |       <-- processed row: merge into a singe lane to simplify graph
                     // |
-                    // | *
-                    // |/
-                    // |    <- merge into a singe lane to simplify graph
-                    // |
                     // *
-                    foreach (var searchParent in _segmentLanes)
+                    foreach (KeyValuePair<RevisionGraphSegment, Lane> searchParent in _segmentLanes)
                     {
                         // If there is another segment with the same parent, and it is not this row's revision, merge into one lane.
-                        if (searchParent.Value != _revisionLane && searchParent.Key.Parent == segment.Parent)
+                        if (searchParent.Value.Index != _revisionLane && searchParent.Key.Parent == segment.Parent)
                         {
-                            return searchParent.Value;
+                            return new Lane(searchParent.Value.Index, GetSecondarySharingOfContinuedSegment());
                         }
                     }
 
                     // Segment has not been assigned a lane yet
-                    return CreateLane();
+                    return new Lane(CreateLane(), LaneSharing.ExclusiveOrPrimary);
+
+                    LaneSharing GetSecondarySharingOfContinuedSegment()
+                    {
+                        return _previousRow.GetLaneForSegment(segment).Sharing switch
+                        {
+                            LaneSharing.ExclusiveOrPrimary or LaneSharing.DifferentEnd => LaneSharing.DifferentStart,
+                            LaneSharing.Entire or LaneSharing.DifferentStart => LaneSharing.Entire,
+                            _ => throw new NotImplementedException()
+                        };
+                    }
                 }
 
                 int CreateLane()
@@ -155,24 +218,24 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         public IEnumerable<RevisionGraphSegment> GetSegmentsForIndex(int index)
         {
             BuildSegmentLanes();
-            foreach (var keyValue in _segmentLanes!)
+            foreach (KeyValuePair<RevisionGraphSegment, Lane> keyValue in _segmentLanes!)
             {
-                if (keyValue.Value == index)
+                if (keyValue.Value.Index == index)
                 {
                     yield return keyValue.Key;
                 }
             }
         }
 
-        public int GetLaneIndexForSegment(RevisionGraphSegment revisionGraphRevision)
+        public Lane GetLaneForSegment(RevisionGraphSegment revisionGraphRevision)
         {
             BuildSegmentLanes();
-            if (_segmentLanes!.TryGetValue(revisionGraphRevision, out int index))
+            if (_segmentLanes!.TryGetValue(revisionGraphRevision, out Lane lane))
             {
-                return index;
+                return lane;
             }
 
-            return -1;
+            return _noLane;
         }
 
         public void MoveLanesRight(int fromLane)
@@ -185,7 +248,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             }
 
             Validates.NotNull(_segmentLanes);
-            RevisionGraphSegment[] segmentsToBeMoved = _segmentLanes.Where(keyValue => keyValue.Value >= fromLane && keyValue.Value < nextGap)
+            RevisionGraphSegment[] segmentsToBeMoved = _segmentLanes.Where(keyValue => keyValue.Value.Index >= fromLane && keyValue.Value.Index < nextGap)
                                                                     .Select(keyValue => keyValue.Key)
                                                                     .ToArray();
             if (!segmentsToBeMoved.Any())
@@ -206,7 +269,8 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
             foreach (RevisionGraphSegment segment in segmentsToBeMoved)
             {
-                ++_segmentLanes[segment];
+                Lane lane = _segmentLanes[segment];
+                _segmentLanes[segment] = new Lane(lane.Index + 1, lane.Sharing);
             }
         }
     }

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphRowTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphRowTests.cs
@@ -15,7 +15,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         public void MoveLanesRight_should_do_nothing_if_empty([Values(-1, 0, 1)] int fromLane)
         {
             List<RevisionGraphSegment> segments = new();
-            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments);
+            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, previousRow: null);
             revisionGraphRow.GetLaneCount().Should().Be(1);
 
             revisionGraphRow.MoveLanesRight(fromLane);
@@ -31,13 +31,13 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         public void MoveLanesRight_should_move_single_segment(int fromLane, int expectedLane)
         {
             List<RevisionGraphSegment> segments = new() { _segment };
-            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments);
+            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, previousRow: null);
             revisionGraphRow.GetLaneCount().Should().Be(segments.Count);
 
             revisionGraphRow.MoveLanesRight(fromLane);
 
             revisionGraphRow.GetLaneCount().Should().Be(fromLane >= segments.Count ? segments.Count : segments.Count + 1);
-            revisionGraphRow.GetLaneIndexForSegment(_segment).Should().Be(expectedLane);
+            revisionGraphRow.GetLaneForSegment(_segment).Index.Should().Be(expectedLane);
         }
 
         [TestCase(-1, 1, 2, 3)]
@@ -49,15 +49,15 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         public void MoveLanesRight_should_move_segments(int fromLane, int expectedLane, int expectedLane1, int expectedLane2)
         {
             List<RevisionGraphSegment> segments = new() { _segment, _segment1, _segment2 };
-            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments);
+            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, previousRow: null);
             revisionGraphRow.GetLaneCount().Should().Be(3);
 
             revisionGraphRow.MoveLanesRight(fromLane);
 
             revisionGraphRow.GetLaneCount().Should().Be(fromLane >= segments.Count ? segments.Count : segments.Count + 1);
-            revisionGraphRow.GetLaneIndexForSegment(_segment).Should().Be(expectedLane);
-            revisionGraphRow.GetLaneIndexForSegment(_segment1).Should().Be(expectedLane1);
-            revisionGraphRow.GetLaneIndexForSegment(_segment2).Should().Be(expectedLane2);
+            revisionGraphRow.GetLaneForSegment(_segment).Index.Should().Be(expectedLane);
+            revisionGraphRow.GetLaneForSegment(_segment1).Index.Should().Be(expectedLane1);
+            revisionGraphRow.GetLaneForSegment(_segment2).Index.Should().Be(expectedLane2);
         }
 
         [TestCase(-1, 4, 1, 2, 3)]
@@ -83,16 +83,16 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         public void MoveLanesRight_should_move_segments_twice(int fromLane1, int fromLane2, int expectedLane, int expectedLane1, int expectedLane2)
         {
             List<RevisionGraphSegment> segments = new() { _segment, _segment1, _segment2 };
-            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments);
+            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, previousRow: null);
             revisionGraphRow.GetLaneCount().Should().Be(3);
 
             revisionGraphRow.MoveLanesRight(fromLane1);
             revisionGraphRow.MoveLanesRight(fromLane2);
 
             revisionGraphRow.GetLaneCount().Should().Be(expectedLane2 + 1);
-            revisionGraphRow.GetLaneIndexForSegment(_segment).Should().Be(expectedLane);
-            revisionGraphRow.GetLaneIndexForSegment(_segment1).Should().Be(expectedLane1);
-            revisionGraphRow.GetLaneIndexForSegment(_segment2).Should().Be(expectedLane2);
+            revisionGraphRow.GetLaneForSegment(_segment).Index.Should().Be(expectedLane);
+            revisionGraphRow.GetLaneForSegment(_segment1).Index.Should().Be(expectedLane1);
+            revisionGraphRow.GetLaneForSegment(_segment2).Index.Should().Be(expectedLane2);
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/gitextensions/gitextensions/pull/10778#discussion_r1155193582

## Proposed changes

- Do not straighten re-used graph lanes

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before | After

![image](https://user-images.githubusercontent.com/36601201/230556549-45d9954e-13b0-4808-ad44-2796e508d87f.png)   ![image](https://user-images.githubusercontent.com/36601201/230556742-f4d358a9-1855-4966-8062-239953c2552c.png)

![image](https://user-images.githubusercontent.com/36601201/230557520-af9c2145-54a0-4dd9-8bed-415fb54e90c3.png)   ![image](https://user-images.githubusercontent.com/36601201/230557609-2b8b6865-ec07-437f-bff3-818c13a52149.png) above commit `1a6d9175b626d89bd710ee35a87fe1e2a5d85641`


## Test methodology <!-- How did you ensure quality? -->

- 

## Please do **not squash** merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).