### PR TITLE
GitHub: Check that PAT is filled before trying to add upsteam remote

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Drawing2D;
 using System.Globalization;
-using System.Text;
 using ConEmu.WinForms;
 using GitCommands;
 using GitCommands.Config;
@@ -1823,7 +1822,7 @@ namespace GitUI.CommandsDialogs
 
         private void _viewPullRequestsToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (!TryGetRepositoryHost(out var repoHost))
+            if (!TryGetRepositoryHost(out IRepositoryHostPlugin? repoHost))
             {
                 return;
             }
@@ -1833,7 +1832,7 @@ namespace GitUI.CommandsDialogs
 
         private void _createPullRequestToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (!TryGetRepositoryHost(out var repoHost))
+            if (!TryGetRepositoryHost(out IRepositoryHostPlugin? repoHost))
             {
                 return;
             }
@@ -1843,19 +1842,12 @@ namespace GitUI.CommandsDialogs
 
         private void _addUpstreamRemoteToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            if (!TryGetRepositoryHost(out IRepositoryHostPlugin? repoHost))
             {
-                if (!TryGetRepositoryHost(out var repoHost))
-                {
-                    return;
-                }
+                return;
+            }
 
-                var remoteName = await repoHost.AddUpstreamRemoteAsync();
-                if (!string.IsNullOrEmpty(remoteName))
-                {
-                    UICommands.StartPullDialogAndPullImmediately(this, null, remoteName, AppSettings.PullAction.Fetch);
-                }
-            }).FileAndForget();
+            UICommands.AddUpstreamRemote(this, repoHost);
         }
 
         private bool TryGetRepositoryHost([NotNullWhen(returnValue: true)] out IRepositoryHostPlugin? repoHost)

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1338,6 +1338,22 @@ namespace GitUI
                                 });
         }
 
+        internal void AddUpstreamRemote(IWin32Window? owner, IRepositoryHostPlugin gitHoster)
+        {
+            WrapRepoHostingCall(TranslatedStrings.AddUpstreamRemote, gitHoster,
+                                gh =>
+                                {
+                                    ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                                    {
+                                        string remoteName = await gh.AddUpstreamRemoteAsync();
+                                        if (!string.IsNullOrEmpty(remoteName))
+                                        {
+                                            StartPullDialogAndPullImmediately(owner, remoteBranch: null, remoteName, AppSettings.PullAction.Fetch);
+                                        }
+                                    }).FileAndForget();
+                                });
+        }
+
         public void StartCreatePullRequest(IWin32Window? owner)
         {
             List<IRepositoryHostPlugin> relevantHosts =

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -29,6 +29,7 @@ namespace GitUI
         private readonly TranslationString _containedInTagsText = new("Contained in tags:");
         private readonly TranslationString _containedInNoTagText = new("Contained in no tag");
         private readonly TranslationString _invisibleCommitText = new("'{0}' is not currently visible");
+        private readonly TranslationString _addUpstreamRemote = new("Add upstream remote");
         private readonly TranslationString _viewPullRequest = new("View pull requests");
         private readonly TranslationString _createPullRequest = new("Create pull request");
         private readonly TranslationString _forkCloneRepo = new("Fork or clone a repository");
@@ -210,6 +211,7 @@ following command.
         public static string CreatePullRequest => _instance.Value._createPullRequest.Text;
         public static string ForkCloneRepo => _instance.Value._forkCloneRepo.Text;
         public static string ViewPullRequest => _instance.Value._viewPullRequest.Text;
+        public static string AddUpstreamRemote => _instance.Value._addUpstreamRemote.Text;
 
         public static string Branch => _instance.Value._branchText.Text;
         public static string Branches => _instance.Value._branchesText.Text;

--- a/GitUI/Translation/English.Plugins.xlf
+++ b/GitUI/Translation/English.Plugins.xlf
@@ -739,6 +739,10 @@ Are you sure you want to continue?</source>
         <source>Manage GitHub personal access token</source>
         <target />
       </trans-unit>
+      <trans-unit id="_noteRestartNeeded.Text">
+        <source>Note: Git Extensions need to be restarted so that the token is taken into account.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_openLinkFailed.Text">
         <source>Fail to open the link. Reason: </source>
         <target />

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9853,6 +9853,10 @@ When OpenSSH is used, command line dialogs are shown!
   </file>
   <file datatype="plaintext" original="TranslatedStrings" source-language="en">
     <body>
+      <trans-unit id="_addUpstreamRemote.Text">
+        <source>Add upstream remote</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_areYouSure.Text">
         <source>Are you sure you want to drop the stash? This action cannot be undone.</source>
         <target />

--- a/Plugins/GitHub3/GitHub3Plugin.cs
+++ b/Plugins/GitHub3/GitHub3Plugin.cs
@@ -71,6 +71,7 @@ namespace GitExtensions.Plugins.GitHub3
         private readonly TranslationString _generateToken = new("Generate a GitHub personal access token");
         private readonly TranslationString _manageToken = new("Manage GitHub personal access token");
         private readonly TranslationString _openLinkFailed = new("Fail to open the link. Reason: ");
+        private readonly TranslationString _noteRestartNeeded = new("Note: Git Extensions need to be restarted so that the token is taken into account.");
 
         public static string GitHubAuthorizationRelativeUrl = "authorizations";
         public static string UpstreamConventionName = "upstream";
@@ -108,6 +109,8 @@ namespace GitExtensions.Plugins.GitHub3
             LinkLabel manageTokenLink = new() { Text = _manageToken.Text };
             manageTokenLink.Click += ManageTokenLink_Click;
             yield return new PseudoSetting(manageTokenLink);
+
+            yield return new PseudoSetting(_noteRestartNeeded.Text);
         }
 
         private void GenerateTokenLink_Click(object sender, EventArgs e)


### PR DESCRIPTION
like the other GitHub features
otherwise the user action is doing nothing
and the user can't understand why.

+ label in the settings saying that GitExtensions need to restart to take PAT into account.

## Test methodology <!-- How did you ensure quality? -->

- Manual. If the PAT is not filled, the GitHub plugin setting page is opened so that the user fill the PAT.
- 
## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build b8639a06a687113fd7eeb3318d56851be6c66bc9 (Dirty)
- Git 2.40.0.windows.1
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.15
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
