### PR TITLE
Remove use of git:// protocol in GitHub plugin

### DIFF
--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -387,9 +387,9 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
             GitUICommands uiCommands = new(new GitModule(null));
 
-            string repoSrc = PathUtil.IsLocalFile(repo.CloneReadWriteUrl)
-                ? uiCommands.Module.GetGitExecPath(repo.CloneReadWriteUrl)
-                : repo.CloneReadWriteUrl;
+            string repoSrc = PathUtil.IsLocalFile(repo.CloneUrl)
+                ? uiCommands.Module.GetGitExecPath(repo.CloneUrl)
+                : repo.CloneUrl;
 
             var cmd = GitCommandHelpers.CloneCmd(repoSrc, uiCommands.Module.GetGitExecPath(targetDir), depth: GetDepth());
 
@@ -407,9 +407,9 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
             GitModule module = new(targetDir);
 
-            if (addUpstreamRemoteAsCB.Text.Trim().Length > 0 && !string.IsNullOrEmpty(repo.ParentReadOnlyUrl))
+            if (addUpstreamRemoteAsCB.Text.Trim().Length > 0 && !string.IsNullOrEmpty(repo.ParentUrl))
             {
-                var error = module.AddRemote(addUpstreamRemoteAsCB.Text.Trim(), repo.ParentReadOnlyUrl);
+                var error = module.AddRemote(addUpstreamRemoteAsCB.Text.Trim(), repo.ParentUrl);
                 if (!string.IsNullOrEmpty(error))
                 {
                     MessageBox.Show(this, error, _strCouldNotAddRemote.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -503,11 +503,11 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
             if (tabControl.SelectedTab == searchReposPage)
             {
-                cloneInfoText.Text = string.Format(_strWillCloneInfo.Text, repo.CloneReadWriteUrl, GetTargetDir(), moreInfo);
+                cloneInfoText.Text = string.Format(_strWillCloneInfo.Text, repo.CloneUrl, GetTargetDir(), moreInfo);
             }
             else if (tabControl.SelectedTab == myReposPage)
             {
-                cloneInfoText.Text = string.Format(_strWillCloneWithPushAccess.Text, repo.CloneReadWriteUrl, GetTargetDir(), moreInfo);
+                cloneInfoText.Text = string.Format(_strWillCloneWithPushAccess.Text, repo.CloneUrl, GetTargetDir(), moreInfo);
             }
         }
 

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -435,7 +435,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             }
 
             var cmd = string.Format("fetch --no-tags --progress {0} {1}:{2}",
-                _currentPullRequestInfo.HeadRepo.CloneReadOnlyUrl, _currentPullRequestInfo.HeadRef, _currentPullRequestInfo.FetchBranch);
+                _currentPullRequestInfo.HeadRepo.CloneUrl, _currentPullRequestInfo.HeadRef, _currentPullRequestInfo.FetchBranch);
             var success = FormProcess.ShowDialog(this, arguments: cmd, Module.WorkingDir, input: null, useDialogSettings: true);
             if (!success)
             {
@@ -458,7 +458,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
             try
             {
                 var remoteName = _currentPullRequestInfo.Owner;
-                var remoteUrl = _currentPullRequestInfo.HeadRepo.CloneReadOnlyUrl;
+                var remoteUrl = _currentPullRequestInfo.HeadRepo.CloneUrl;
                 var remoteRef = _currentPullRequestInfo.HeadRef;
 
                 var existingRepo = _hostedRemotes.FirstOrDefault(el => el.Name == remoteName);
@@ -466,9 +466,9 @@ namespace GitUI.CommandsDialogs.RepoHosting
                 {
                     var hostedRepository = existingRepo.GetHostedRepository();
                     hostedRepository.CloneProtocol = _cloneGitProtocol;
-                    if (hostedRepository.CloneReadOnlyUrl != remoteUrl)
+                    if (hostedRepository.CloneUrl != remoteUrl)
                     {
-                        MessageBox.Show(this, string.Format(_strRemoteAlreadyExist.Text, remoteName, hostedRepository.CloneReadOnlyUrl, remoteUrl),
+                        MessageBox.Show(this, string.Format(_strRemoteAlreadyExist.Text, remoteName, hostedRepository.CloneUrl, remoteUrl),
                             TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         return;
                     }

--- a/Plugins/GitHub3/GitHub3Plugin.cs
+++ b/Plugins/GitHub3/GitHub3Plugin.cs
@@ -201,12 +201,12 @@ namespace GitExtensions.Plugins.GitHub3
                 return null;
             }
 
-            if ((await gitModule.GetRemotesAsync()).Any(r => r.Name == UpstreamConventionName || r.FetchUrl == hostedRepository.ParentReadOnlyUrl))
+            if ((await gitModule.GetRemotesAsync()).Any(r => r.Name == UpstreamConventionName || r.FetchUrl == hostedRepository.ParentUrl))
             {
                 return null;
             }
 
-            gitModule.AddRemote(UpstreamConventionName, hostedRepository.ParentReadOnlyUrl);
+            gitModule.AddRemote(UpstreamConventionName, hostedRepository.ParentUrl);
             return UpstreamConventionName;
         }
 

--- a/Plugins/GitHub3/GitHubRepo.cs
+++ b/Plugins/GitHub3/GitHubRepo.cs
@@ -21,7 +21,7 @@ namespace GitExtensions.Plugins.GitHub3
         public int Forks => _repo.Forks;
         public string Homepage => _repo.Homepage;
 
-        public string? ParentReadOnlyUrl
+        public string? ParentUrl
         {
             get
             {
@@ -40,7 +40,7 @@ namespace GitExtensions.Plugins.GitHub3
                     _repo = GitHub3Plugin.GitHub.getRepository(Owner, Name);
                 }
 
-                return CloneProtocol == GitProtocol.Ssh ? _repo.Parent?.GitUrl : _repo.Parent?.CloneUrl;
+                return CloneProtocol == GitProtocol.Ssh ? _repo.Parent?.SshUrl : _repo.Parent?.CloneUrl;
             }
         }
 
@@ -67,9 +67,7 @@ namespace GitExtensions.Plugins.GitHub3
             }
         }
 
-        public string CloneReadWriteUrl => CloneProtocol == GitProtocol.Ssh ? _repo.SshUrl : _repo.CloneUrl;
-
-        public string CloneReadOnlyUrl => CloneProtocol == GitProtocol.Ssh ? _repo.GitUrl : _repo.CloneUrl;
+        public string CloneUrl => CloneProtocol == GitProtocol.Ssh ? _repo.SshUrl : _repo.CloneUrl;
 
         public IReadOnlyList<IHostedBranch> GetBranches()
         {

--- a/Plugins/GitUIPluginInterfaces/RepositoryHosts/IHostedRepository.cs
+++ b/Plugins/GitUIPluginInterfaces/RepositoryHosts/IHostedRepository.cs
@@ -12,11 +12,10 @@
 
         string Homepage { get; }
 
-        string? ParentReadOnlyUrl { get; }
+        string? ParentUrl { get; }
         string? ParentOwner { get; }
 
-        string CloneReadWriteUrl { get; }
-        string CloneReadOnlyUrl { get; }
+        string CloneUrl { get; }
 
         /// <summary>
         /// Requests details of branches from the GitHub remote repository.


### PR DESCRIPTION
as it is no more supported by GitHub

https://github.blog/2021-09-01-improving-git-protocol-security-github/#when-are-these-changes-effective

Use ssh instead...

Fixes #10867

Depends on https://github.com/gitextensions/Git.hub/pull/21

## Test methodology <!-- How did you ensure quality? -->

- Not tested 😢 (as I don't use ssh). Hope that @djc5166 will be able to test it...

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 7dc4416813cc2d37cbdfab7b3dca932b8e61fae2 (Dirty)
- Git 2.40.0.windows.1
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.15
- DPI 96dpi (no scaling)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
