### PR TITLE
Perf (and bugfix) avatars handling

### DIFF
--- a/GitUI/Avatars/FileSystemAvatarCache.cs
+++ b/GitUI/Avatars/FileSystemAvatarCache.cs
@@ -29,7 +29,14 @@ namespace GitUI.Avatars
             string cacheDir = AppSettings.AvatarImageCachePath;
             string path = Path.Combine(cacheDir, $"{email}.{imageSize}px.png");
 
-            Image image = ReadImage() ?? await _inner.GetAvatarAsync(email, name, imageSize);
+            Image image = ReadImage();
+
+            if (image is not null)
+            {
+                return image;
+            }
+
+            image = await _inner.GetAvatarAsync(email, name, imageSize);
 
             if (image is not null)
             {


### PR DESCRIPTION
## Proposed changes

1. Avatar: prevent always rewrite of avatar file on disk (in FileSystemAvatarCache )

when the avatar has been loaded from file.
Consequences:
 * fix (old time) bug where the avatar is **never** refreshed
if we open the repository enough often (i.e. < avatar cache period)
because the last `LastWriteTime` that we use to check
 if the avatar has expired is always update when the avatar is written
 * better perfs

2. Display Avatar and revision grid (slightly?) more efficiently

* Do all the other drawing things before letting more chance to the Task that fetch the avatar to complete
(reducing the number of redraw) => less generic avatar displayed before displaying the good avatar.
* Invalidate only the avatar region to redraw instead of the whole grid when getting the avatar

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 6d1276457497896d7c4b5e06d6c8af5c9ceee634
- Git 2.40.0.windows.1
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.15
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.4 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer Rebase merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
