### PR TITLE
Improve rebase onto commit selection

### DIFF
--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -386,7 +386,9 @@ namespace GitUI.CommandsDialogs
             try
             {
                 AppSettings.ShowStashes = false;
-                using FormChooseCommit chooseForm = new(UICommands, txtFrom.Text, showCurrentBranchOnly: true);
+                ObjectId firstParent = UICommands.GitModule.RevParse("HEAD~");
+                string preSelectedCommit = !string.IsNullOrWhiteSpace(txtFrom.Text) ? txtFrom.Text : firstParent?.ToString() ?? string.Empty;
+                using FormChooseCommit chooseForm = new(UICommands, preSelectedCommit, showCurrentBranchOnly: true);
                 if (chooseForm.ShowDialog(this) == DialogResult.OK && chooseForm.SelectedRevision is not null)
                 {
                     txtFrom.Text = chooseForm.SelectedRevision.ObjectId.ToShortString();

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -381,9 +381,11 @@ namespace GitUI.CommandsDialogs
             bool previousValueBranchFilterEnabled = AppSettings.BranchFilterEnabled;
             bool previousValueShowCurrentBranchOnly = AppSettings.ShowCurrentBranchOnly;
             bool previousValueShowReflogReferences = AppSettings.ShowReflogReferences;
+            bool previousValueShowStashes = AppSettings.ShowStashes;
 
             try
             {
+                AppSettings.ShowStashes = false;
                 using FormChooseCommit chooseForm = new(UICommands, txtFrom.Text, showCurrentBranchOnly: true);
                 if (chooseForm.ShowDialog(this) == DialogResult.OK && chooseForm.SelectedRevision is not null)
                 {
@@ -392,6 +394,7 @@ namespace GitUI.CommandsDialogs
             }
             finally
             {
+                AppSettings.ShowStashes = previousValueShowStashes;
                 AppSettings.BranchFilterEnabled = previousValueBranchFilterEnabled;
                 AppSettings.ShowCurrentBranchOnly = previousValueShowCurrentBranchOnly;
                 AppSettings.ShowReflogReferences = previousValueShowReflogReferences;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Improvement over #9686

## Proposed changes

- Hide stashes in revision grid when selecting commit range (now that we display all the stashes in the revision grid)
- Select first parent which is a better default selection. So if the user want to rebase only one commit (which is not so rare), he only has to validate the selection...


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

We see stashes and the selection is on the tip of the branch:
![image](https://user-images.githubusercontent.com/460196/231808248-7552607e-2c3d-40cb-a15a-c8951c1c8398.png)

### After

Stashes are not displayed and the 2nd commit of the branch is selected
![image](https://user-images.githubusercontent.com/460196/231809015-c77ec0b7-f569-4550-b9a6-31abd5b7a4bc.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 74ad45025d7877460d65b48ccfdab2fb8b779743
- Git 2.40.0.windows.1
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.15
- DPI 96dpi (no scaling)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

Rebase merge.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
