### PR TITLE
No async when minimized

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -2042,7 +2042,7 @@ namespace GitCommands
 
         public static bool GitAsyncWhenMinimized
         {
-            get => GetBool("GitAsyncWhenMinimized", true);
+            get => GetBool("GitAsyncWhenMinimized", false);
         }
 
         private static IEnumerable<(string name, string value)> GetSettingsFromRegistry()


### PR DESCRIPTION
## Proposed changes

Do not run git-ls-files by default when in minimized to not interfere with restoring.
The setting was added in
cccfbc967ce835dfd64452a4c08db478936499b6 (#10847)
but required explicit configuration.

--
I have used this on/off for some days and get quite consistent the problem with the default implementation. 
The drawback with activating the setting is that "is conflicted" is not always detected.

The drawback of making this hack permanent is that the core problem will not be fixed.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
