### PR TITLE
Improve commit selection for 'Find file' feature

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1960,6 +1960,14 @@ namespace GitUI.CommandsDialogs
 
         private void FindFileInSelectedCommit()
         {
+            IReadOnlyList<GitRevision> selectedRevisions = RevisionGrid.GetSelectedRevisions();
+            if (selectedRevisions.Count > 1 || (selectedRevisions.Count == 1 && selectedRevisions[0].IsArtificial))
+            {
+                GitRevision potentialRevision = selectedRevisions[0];
+                ObjectId? targetCommit = potentialRevision.IsArtificial ? RevisionGrid.CurrentCheckout : potentialRevision.ObjectId;
+                RevisionGrid.SetSelectedRevision(targetCommit);
+            }
+
             CommitInfoTabControl.SelectedTab = TreeTabPage;
 
             AppSettings.ShowSplitViewLayout = true;


### PR DESCRIPTION
before launching the search by
* selecting the last selected when multiple commits are selected (otherwise we don't know on which commit we search)
* selecting HEAD if the selected commit is artificial

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

We can't launch the feature, start searching and discover that we end up nowhere
![original_find_file](https://user-images.githubusercontent.com/460196/232067247-4222f1b7-7e00-42ed-8c15-298a3ac7cb03.gif)

### After

If on artificial commit, it switch to HEAD before searching
![improve_find_file](https://user-images.githubusercontent.com/460196/232067290-86d411dd-fc3e-479b-a4b8-ceb7afa7157b.gif)

When multiselect, only the commit we are searching in stay selected so that we know which one is really used:
![multiselect_find_file](https://user-images.githubusercontent.com/460196/232068043-a81cfe37-52fe-4faf-9c8f-db4be1150598.gif)




## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 9855deffe1093125ee7f6b1980fc88c667dc6ab8
- Git 2.40.0.windows.1
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.15
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.4 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
