### PR TITLE
Reenable lost rebase onto feature from revision grid

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1522,24 +1522,13 @@ namespace GitUI.CommandsDialogs
 
             if (revisions.Count == 2)
             {
-                string? to = null;
-                string? from = null;
+                // Set defaults in rebase form to rebase commits defined by the range *from* first selected commit *to* HEAD
+                // *onto* 2nd selected commit
+                string? from = revisions[1].ObjectId.ToShortString(); // 1st selected commit (excluded from rebase)
+                string? to = RevisionGrid.CurrentBranch.Value; // current branch checked out (HEAD)
+                string? onto = revisions[0].ObjectId.ToString(); // 2nd selected commit
 
-                string currentBranch = RevisionGrid.CurrentBranch.Value;
-                var currentCheckout = RevisionGrid.CurrentCheckout;
-
-                if (revisions[0].ObjectId == currentCheckout)
-                {
-                    from = revisions[1].ObjectId.ToShortString();
-                    to = currentBranch;
-                }
-                else if (revisions[1].ObjectId == currentCheckout)
-                {
-                    from = revisions[0].ObjectId.ToShortString();
-                    to = currentBranch;
-                }
-
-                UICommands.StartRebaseDialog(this, from, to, null, interactive: false, startRebaseImmediately: false);
+                UICommands.StartRebaseDialog(this, from, to, onto, interactive: false, startRebaseImmediately: false);
             }
             else
             {
@@ -2246,12 +2235,13 @@ namespace GitUI.CommandsDialogs
             branchToolStripMenuItem.Enabled =
             deleteBranchToolStripMenuItem.Enabled =
             mergeBranchToolStripMenuItem.Enabled =
-            rebaseToolStripMenuItem.Enabled =
             checkoutBranchToolStripMenuItem.Enabled =
             cherryPickToolStripMenuItem.Enabled =
             checkoutToolStripMenuItem.Enabled =
             bisectToolStripMenuItem.Enabled =
                 singleNormalCommit && !Module.IsBareRepository();
+
+            rebaseToolStripMenuItem.Enabled = selectedRevisions.Count is (1 or 2) && selectedRevisions.All(r => !r.IsArtificial) && !Module.IsBareRepository();
 
             tagToolStripMenuItem.Enabled =
             deleteTagToolStripMenuItem.Enabled =

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -88,6 +88,7 @@ namespace GitUI.CommandsDialogs
             chkInteractive.Checked = interactive;
             chkAutosquash.Enabled = interactive;
             _startRebaseImmediately = startRebaseImmediately;
+            chkSpecificRange.Checked = !string.IsNullOrEmpty(from);
         }
 
         protected override void OnShown(EventArgs e)

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1039,9 +1039,9 @@ namespace GitUI
                 interactive: true, startRebaseImmediately: true);
         }
 
-        public bool StartRebaseDialogWithAdvOptions(IWin32Window? owner, string onto)
+        public bool StartRebaseDialogWithAdvOptions(IWin32Window? owner, string onto, string from = "")
         {
-            return StartRebaseDialog(owner, from: "", to: null, onto, interactive: false, startRebaseImmediately: false);
+            return StartRebaseDialog(owner, from: from, to: null, onto, interactive: false, startRebaseImmediately: false);
         }
 
         public bool StartRebaseDialog(IWin32Window? owner, string? onto)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -259,6 +259,7 @@ namespace GitUI
             this.rebaseOnToolStripMenuItem.Name = "rebaseOnToolStripMenuItem";
             this.rebaseOnToolStripMenuItem.Size = new System.Drawing.Size(270, 22);
             this.rebaseOnToolStripMenuItem.Text = "&Rebase current branch on";
+            this.rebaseOnToolStripMenuItem.DropDownOpening += RebaseOnToolStripMenuItem_DropDownOpening;
             // 
             // resetCurrentBranchToHereToolStripMenuItem
             // 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2053,6 +2053,17 @@ namespace GitUI
                 : gitRef.Name;
         }
 
+        private void RebaseOnToolStripMenuItem_DropDownOpening(object sender, EventArgs e)
+        {
+            IReadOnlyList<GitRevision> selectedRevisions = GetSelectedRevisions();
+            rebaseToolStripMenuItem.Enabled
+                = rebaseInteractivelyToolStripMenuItem.Enabled
+                = _rebaseOnTopOf is not null && selectedRevisions.Count == 1;
+            rebaseWithAdvOptionsToolStripMenuItem.Enabled = _rebaseOnTopOf is not null
+                && (selectedRevisions.Count == 1
+                    || (selectedRevisions.Count == 2 && selectedRevisions.All(r => !r.IsArtificial)));
+        }
+
         private void ToolStripItemClickRebaseBranch(object sender, EventArgs e)
         {
             if (_rebaseOnTopOf is null)
@@ -2137,7 +2148,19 @@ namespace GitUI
         {
             if (_rebaseOnTopOf is not null)
             {
-                UICommands.StartRebaseDialogWithAdvOptions(ParentForm, _rebaseOnTopOf);
+                IReadOnlyList<GitRevision> selectedRevisions = GetSelectedRevisions();
+                string from;
+                if (selectedRevisions.Count == 2)
+                {
+                    // Rebase onto: define the lower boundary of commits range that will be rebased
+                    from = selectedRevisions[1].ObjectId.ToShortString();
+                }
+                else
+                {
+                    from = string.Empty;
+                }
+
+                UICommands.StartRebaseDialogWithAdvOptions(ParentForm, _rebaseOnTopOf, from);
             }
         }
 


### PR DESCRIPTION
introduced in v2.44: 324be3750df39ac60febcfb3904079d30bc907df
lost in v3.0: a9b79574c11b038b6d1eed9df45e337d709999d8

but with some improvements:
* Allow rebase only when one commit is selected
* Allow rebase onto when 2 commits are selected but only through "advanced options..."
* Automatically check "Specific range" checkbox when rebase onto
* Improved logic when using "rebase onto" from the "Commands" menu
	* 1st commit selected is the "from" parameter (that determine the range of commits that will be rebased)
	* 2nd commit selected is the "onto" parameter (on which commit it will be rebased)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

When more than one commit selected, we can' rebase (even if some dead code was there to handle it)
![image](https://user-images.githubusercontent.com/460196/232070079-6b2876f6-96b2-43b2-9af8-13dd098e423f.png)


### After

We can do a rebase onto from menu:

![image](https://user-images.githubusercontent.com/460196/232070447-96c0f36c-d425-4c40-bb26-dd4398c39dfa.png)

or from contextual menu:

![rebase_onto](https://user-images.githubusercontent.com/460196/232069760-c8724223-84b7-460c-9d81-65ddb888e85e.gif)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 38e120c355ad07e23d8cb82db33ae0d79963d6a3
- Git 2.40.0.windows.1
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.15
- DPI 96dpi (no scaling)
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.4 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
