### PR TITLE
Ignore exceptions from cancelled loading of submodule details for left panel

### DIFF
--- a/GitUI/BranchTreePanel/SubmoduleTree.cs
+++ b/GitUI/BranchTreePanel/SubmoduleTree.cs
@@ -98,9 +98,15 @@ namespace GitUI.BranchTreePanel
 
                 if (_currentNodes is not null)
                 {
-                    var token = cts?.Token ?? e.Token;
-                    await LoadNodeDetailsAsync(_currentNodes, token).ConfigureAwaitRunInline();
-                    LoadNodeToolTips(_currentNodes, token);
+                    CancellationToken token = cts?.Token ?? e.Token;
+                    try
+                    {
+                        await LoadNodeDetailsAsync(_currentNodes, token).ConfigureAwaitRunInline();
+                        LoadNodeToolTips(_currentNodes, token);
+                    }
+                    catch (Exception) when (token.IsCancellationRequested)
+                    {
+                    }
                 }
 
                 Interlocked.CompareExchange(ref _currentSubmoduleInfo, null, e);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10883

## Proposed changes

- Ignore exceptions from cancelled loading of submodule details in left panel when `SubmoduleTree.OnStatusUpdated` calls
  - `LoadNodeDetailsAsync` 
  - `LoadNodeToolTips`  

## Test methodology <!-- How did you ensure quality? -->

- manual (on slow machine)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).