### PR TITLE
FileStatusList: Avoid blocking check for Visual Studio

### DIFF
--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -108,8 +108,6 @@ the last selected commit.");
         private readonly TranslationString _reportBugText = new("If you think this was caused by Git Extensions, you can report a bug for the team to investigate.");
 
         private readonly TranslationString _filterFileInGrid = new("Filter file in &grid");
-        private readonly TranslationString _openInVisualStudioFailureText = new("Could not find this file in any open solution. Ensure you have a project containing this file open before trying again.");
-        private readonly TranslationString _openInVisualStudioFailureCaption = new("Unable to open file");
 
         private readonly TranslationString _remoteInError = new("{0}\n\nRemote: {1}");
 
@@ -287,8 +285,6 @@ following command.
         public static string WorkingDirectory => _instance.Value._workingDirectoryText.Text;
         public static string ReportBug => _instance.Value._reportBugText.Text;
 
-        public static string OpenInVisualStudioFailureText => _instance.Value._openInVisualStudioFailureText.Text;
-        public static string OpenInVisualStudioFailureCaption => _instance.Value._openInVisualStudioFailureCaption.Text;
         public static string RemoteInError => _instance.Value._remoteInError.Text;
         public static string NoChanges => _instance.Value._noChanges.Text;
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -10253,14 +10253,6 @@ following command.
         <source>Open in &amp;Visual Studio</source>
         <target />
       </trans-unit>
-      <trans-unit id="_openInVisualStudioFailureCaption.Text">
-        <source>Unable to open file</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_openInVisualStudioFailureText.Text">
-        <source>Could not find this file in any open solution. Ensure you have a project containing this file open before trying again.</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_openReport.Text">
         <source>Open report</source>
         <target />

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -102,6 +102,8 @@ namespace GitUI
 
             base.Enter += FileStatusList_Enter;
 
+            VisualStudioIntegration.Init();
+
             return;
 
             ImageList CreateImageList()
@@ -199,14 +201,10 @@ namespace GitUI
                 };
                 item.Click += (_, _) =>
                 {
-                    var itemName = SelectedItemAbsolutePath;
-                    if (itemName != null && !VisualStudioIntegration.TryOpenFile(itemName))
+                    string? itemName = SelectedItemAbsolutePath;
+                    if (itemName is not null)
                     {
-                        MessageBox.Show(
-                            TranslatedStrings.OpenInVisualStudioFailureText,
-                            TranslatedStrings.OpenInVisualStudioFailureCaption,
-                            MessageBoxButtons.OK,
-                            MessageBoxIcon.Warning);
+                        VisualStudioIntegration.OpenFile(itemName);
                     }
                 };
                 return item;
@@ -1409,10 +1407,10 @@ namespace GitUI
                 cm.Items.Add(_NO_TRANSLATE_openInVisualStudioMenuItem);
             }
 
-            bool fileExists = File.Exists(SelectedItemAbsolutePath);
-            _NO_TRANSLATE_openInVisualStudioMenuItem.Enabled = fileExists;
-            _NO_TRANSLATE_openInVisualStudioMenuItem.Visible = fileExists;
-            _openInVisualStudioSeparator.Visible = fileExists;
+            bool canOpenInVisualStudio = File.Exists(SelectedItemAbsolutePath) && VisualStudioIntegration.IsVisualStudioInstalled;
+            _NO_TRANSLATE_openInVisualStudioMenuItem.Enabled = canOpenInVisualStudio;
+            _NO_TRANSLATE_openInVisualStudioMenuItem.Visible = canOpenInVisualStudio;
+            _openInVisualStudioSeparator.Visible = canOpenInVisualStudio;
 
             if (!cm.Items.Find(_sortByContextMenu.Name, true).Any())
             {

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -1409,8 +1409,10 @@ namespace GitUI
                 cm.Items.Add(_NO_TRANSLATE_openInVisualStudioMenuItem);
             }
 
-            _NO_TRANSLATE_openInVisualStudioMenuItem.Visible = _openInVisualStudioSeparator.Visible = VisualStudioIntegration.IsVisualStudioRunning;
-            _NO_TRANSLATE_openInVisualStudioMenuItem.Enabled = File.Exists(SelectedItemAbsolutePath);
+            bool fileExists = File.Exists(SelectedItemAbsolutePath);
+            _NO_TRANSLATE_openInVisualStudioMenuItem.Enabled = fileExists;
+            _NO_TRANSLATE_openInVisualStudioMenuItem.Visible = fileExists;
+            _openInVisualStudioSeparator.Visible = fileExists;
 
             if (!cm.Items.Find(_sortByContextMenu.Name, true).Any())
             {

--- a/GitUI/VisualStudioIntegration.cs
+++ b/GitUI/VisualStudioIntegration.cs
@@ -15,7 +15,14 @@ namespace GitUI
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await TaskScheduler.Default;
-                Executable executable = new($@"{Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)}\Microsoft Visual Studio\Installer\vswhere.exe");
+
+                string vswhere = $@"{Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)}\Microsoft Visual Studio\Installer\vswhere.exe";
+                if (!File.Exists(vswhere))
+                {
+                    return;
+                }
+
+                Executable executable = new(vswhere);
                 ArgumentBuilder arguments = new()
                 {
                     "-latest",


### PR DESCRIPTION
Fixes #10856

## Proposed changes

- Do not check for a running Visual Studio on every open of the FileStatusList context menu
- Check for installed MSVS on startup in background
- Open a new instance if no running instance has opened a project with this file instead of error popup

## Screenshot

unchanged

![image](https://user-images.githubusercontent.com/36601201/232327811-f7e3e5c2-01c7-492f-8419-0ecfcbe12a9d.png)

removed

![image](https://user-images.githubusercontent.com/36601201/232328216-71d966d8-a7c7-48df-a124-34959e6fc58d.png)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).