### PR TITLE
Fix "Commit info position" tooltip containing &

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2805,7 +2805,7 @@ namespace GitUI.CommandsDialogs
             int commitInfoPositionNumber = (int)AppSettings.CommitInfoPosition;
             var selectedMenuItem = menuCommitInfoPosition.DropDownItems[commitInfoPositionNumber];
             menuCommitInfoPosition.Image = selectedMenuItem.Image;
-            menuCommitInfoPosition.ToolTipText = selectedMenuItem.Text;
+            menuCommitInfoPosition.ToolTipText = selectedMenuItem.Text?.Replace("&", string.Empty);
         }
 
         private void LayoutRevisionInfo()


### PR DESCRIPTION
Fixes #10888

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

See issue
### After
![image](https://user-images.githubusercontent.com/460196/232489446-62082f7b-87e8-4cdb-9d03-afab28e09e20.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 4b51d89ffa985c6c6eff61b8083a3b7c6062b1b6
- Git 2.40.0.windows.1
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.16
- DPI 96dpi (no scaling)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
