### PR TITLE
CI: more meaningful icon instead of displaying a circle

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Drawing.Drawing2D;
 using GitCommands;
 using GitCommands.Settings;
 using GitExtUtils.GitUI;
@@ -79,36 +78,10 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                 return;
             }
 
-            Size size;
+            string text = (AppSettings.ShowBuildStatusIconColumn ? revision.BuildStatus.StatusSymbol : string.Empty)
+                + (AppSettings.ShowBuildStatusTextColumn ? (string)e.FormattedValue : string.Empty);
 
-            if (AppSettings.ShowBuildStatusIconColumn)
-            {
-                size = DpiUtil.Scale(new Size(8, 8));
-
-                Point location = new(
-                    e.CellBounds.Left + (size.Width / 2),
-                    e.CellBounds.Top + ((e.CellBounds.Height - size.Height) / 2));
-
-                GraphicsContainer container = e.Graphics.BeginContainer();
-                e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;
-                using Brush brush = CreateCircleBrush();
-                e.Graphics.FillEllipse(brush, new Rectangle(location, size));
-                e.Graphics.EndContainer(container);
-            }
-            else
-            {
-                size = default;
-            }
-
-            if (AppSettings.ShowBuildStatusTextColumn)
-            {
-                _grid.DrawColumnText(
-                    e,
-                    (string)e.FormattedValue,
-                    style.NormalFont,
-                    GetColor(style.ForeColor),
-                    bounds: e.CellBounds.ReduceLeft(size.Width * 2));
-            }
+            _grid.DrawColumnText(e, text, style.NormalFont, GetColor(style.ForeColor), bounds: e.CellBounds);
 
             Color GetColor(Color foreColor)
             {
@@ -133,42 +106,12 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                         customColor = Color.OrangeRed;
                         break;
                     case BuildInfo.BuildStatus.Stopped:
+                    default:
                         customColor = isSelected ? Color.LightGray : Color.Gray;
                         break;
-
-                    default:
-                        throw new InvalidOperationException("Unsupported build status enum value.");
                 }
 
                 return customColor.AdaptTextColor();
-            }
-
-            Brush CreateCircleBrush()
-            {
-                Color color;
-                switch (revision.BuildStatus.Status)
-                {
-                    case BuildInfo.BuildStatus.Success:
-                        color = Color.LightGreen;
-                        break;
-                    case BuildInfo.BuildStatus.Failure:
-                        color = Color.Red;
-                        break;
-                    case BuildInfo.BuildStatus.InProgress:
-                        color = _lightBlue;
-                        break;
-                    case BuildInfo.BuildStatus.Unstable:
-                        color = Color.DarkOrange;
-                        break;
-                    case BuildInfo.BuildStatus.Stopped:
-                    case BuildInfo.BuildStatus.Unknown:
-                        color = Color.Gray;
-                        break;
-                    default:
-                        throw new InvalidOperationException("Unsupported build status enum value.");
-                }
-
-                return new SolidBrush(color.AdaptBackColor());
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
@@ -19,6 +19,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
         // Increase contrast to selected rows
         private readonly Color _lightBlue = Color.FromArgb(130, 180, 240);
+        private Font? _fontWithUnicodeCache = null;
 
         public BuildStatusColumnProvider(RevisionGridControl grid, RevisionDataGridView gridView, Func<IGitModule> module)
             : base("Build Status")
@@ -81,7 +82,12 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             string text = (AppSettings.ShowBuildStatusIconColumn ? revision.BuildStatus.StatusSymbol : string.Empty)
                 + (AppSettings.ShowBuildStatusTextColumn ? (string)e.FormattedValue : string.Empty);
 
-            _grid.DrawColumnText(e, text, style.NormalFont, GetColor(style.ForeColor), bounds: e.CellBounds);
+            if (_fontWithUnicodeCache?.Size != style.NormalFont.Size)
+            {
+                _fontWithUnicodeCache = new Font(FontFamily.GenericMonospace, style.NormalFont.Size);
+            }
+
+            _grid.DrawColumnText(e, text, _fontWithUnicodeCache, GetColor(style.ForeColor), bounds: e.CellBounds);
 
             Color GetColor(Color foreColor)
             {

--- a/Plugins/GitUIPluginInterfaces/BuildServerIntegration/BuildInfo.cs
+++ b/Plugins/GitUIPluginInterfaces/BuildServerIntegration/BuildInfo.cs
@@ -1,4 +1,4 @@
-namespace GitUIPluginInterfaces.BuildServerIntegration
+﻿namespace GitUIPluginInterfaces.BuildServerIntegration
 {
     public class BuildInfo
     {
@@ -22,5 +22,15 @@ namespace GitUIPluginInterfaces.BuildServerIntegration
         public bool ShowInBuildReportTab { get; set; } = true;
         public string? Tooltip { get; set; }
         public string? PullRequestUrl { get; set; }
+
+        public string StatusSymbol => Status switch
+        {
+            BuildStatus.Success => "✔",
+            BuildStatus.Failure => "❌",
+            BuildStatus.InProgress => "▶️",
+            BuildStatus.Stopped => "⏹️",
+            BuildStatus.Unstable => "❗",
+            _ => "❓",
+        };
     }
 }

--- a/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegration.Tests/ApprovedFiles/AppVeyorAdapterTests.Should_return_a_build_Info_When_Json_content_is_the_one_of_a_master_build.verified.txt
+++ b/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegration.Tests/ApprovedFiles/AppVeyorAdapterTests.Should_return_a_build_Info_When_Json_content_is_the_one_of_a_master_build.verified.txt
@@ -19,3 +19,4 @@
   ShowInBuildReportTab: true
   Tooltip: 
   PullRequestUrl: 
+  StatusSymbol: ✔

--- a/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegration.Tests/ApprovedFiles/AppVeyorAdapterTests.Should_return_a_build_Info_When_Json_content_is_the_one_of_a_pull_request_build.verified.txt
+++ b/UnitTests/Plugins/BuildServerIntegration/AppVeyorIntegration.Tests/ApprovedFiles/AppVeyorAdapterTests.Should_return_a_build_Info_When_Json_content_is_the_one_of_a_pull_request_build.verified.txt
@@ -19,3 +19,4 @@
   ShowInBuildReportTab: true
   Tooltip: 
   PullRequestUrl: https://github.com/gitextensions/gitextensions/pull/6326
+  StatusSymbol: ✔


### PR DESCRIPTION

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Unknown and stopped are both grey
![image](https://user-images.githubusercontent.com/460196/232754300-576835ce-1720-4009-a033-c552b47efba8.png)


### After

Status: Failure, Success, Unstable, Stopped, In progress, Unknown
![image](https://user-images.githubusercontent.com/460196/232753258-ba4084bc-330b-43b2-87fe-f19132ad03fa.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 2bc70dbb9e9d797be7aa8c9a96cf5453786b38cf (Dirty)
- Git 2.40.0.windows.1
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.16
- DPI 96dpi (no scaling)



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
