### PR TITLE
Tweak repos dropdown

### DIFF
--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -15,7 +15,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
     public partial class UserRepositoriesList : GitExtensionsControl
     {
         private readonly TranslationString _groupRecentRepositories = new("Recent repositories");
-        private readonly TranslationString _repositorySearchPlaceholder = new("Search repositories");
+        private readonly TranslationString _repositorySearchPlaceholder = new("Search repositories...");
         private readonly TranslationString _groupActions = new("Actions");
         private readonly TranslationString _deleteCategoryCaption = new(
             "Delete Category");

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -33,7 +33,7 @@ namespace GitUI.CommandsDialogs
             commitInfoRightwardMenuItem = new ToolStripMenuItem();
             toolStripSeparator17 = new ToolStripSeparator();
             toolStripButtonLevelUp = new ToolStripSplitButton();
-            _NO_TRANSLATE_WorkingDir = new ToolStripSplitButton();
+            _NO_TRANSLATE_WorkingDir = new WorkingDirectoryToolStripSplitButton();
             branchSelect = new ToolStripSplitButton();
             toolStripSeparator1 = new ToolStripSeparator();
             toolStripSplitStash = new ToolStripSplitButton();
@@ -309,17 +309,9 @@ namespace GitUI.CommandsDialogs
             // 
             // _NO_TRANSLATE_WorkingDir
             // 
-            _NO_TRANSLATE_WorkingDir.Image = Properties.Resources.RepoOpen;
-            _NO_TRANSLATE_WorkingDir.ImageAlign = ContentAlignment.MiddleLeft;
-            _NO_TRANSLATE_WorkingDir.ImageTransparentColor = Color.Magenta;
-            _NO_TRANSLATE_WorkingDir.Name = "_NO_TRANSLATE_WorkingDir";
             _NO_TRANSLATE_WorkingDir.Size = new Size(83, 22);
             _NO_TRANSLATE_WorkingDir.Text = "WorkingDir";
-            _NO_TRANSLATE_WorkingDir.TextAlign = ContentAlignment.MiddleLeft;
             _NO_TRANSLATE_WorkingDir.ToolTipText = "Change working directory";
-            _NO_TRANSLATE_WorkingDir.ButtonClick += WorkingDirClick;
-            _NO_TRANSLATE_WorkingDir.DropDownOpening += WorkingDirDropDownOpening;
-            _NO_TRANSLATE_WorkingDir.MouseUp += _NO_TRANSLATE_WorkingDir_MouseUp;
             // 
             // branchSelect
             // 
@@ -1467,7 +1459,7 @@ namespace GitUI.CommandsDialogs
         private ToolStripEx ToolStripScripts;
 
         private ToolStripButton toolStripButtonCommit;
-        private ToolStripSplitButton _NO_TRANSLATE_WorkingDir;
+        private WorkingDirectoryToolStripSplitButton _NO_TRANSLATE_WorkingDir;
         private ToolStripSeparator toolStripSeparator0;
         private ToolStripSeparator toolStripSeparator1;
         private ToolStripSplitButton userShell;

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -184,8 +184,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _noReposHostPluginLoaded = new("No repository host plugin loaded.");
         private readonly TranslationString _noReposHostFound = new("Could not find any relevant repository hosts for the currently open repository.");
 
-        private readonly TranslationString _configureWorkingDirMenu = new("&Configure this menu...");
-
         private readonly TranslationString _updateCurrentSubmodule = new("Update current submodule");
 
         private readonly TranslationString _pullFetch = new("Fetch");
@@ -198,7 +196,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _buildReportTabCaption = new("Build Report");
         private readonly TranslationString _consoleTabCaption = new("Console");
 
-        private readonly TranslationString _noWorkingFolderText = new("No working directory");
         private readonly TranslationString _commitButtonText = new("Commit");
 
         private readonly TranslationString _undoLastCommitText = new("You will still be able to find all the commit's changes in the staging area\n\nDo you want to continue?");
@@ -261,6 +258,7 @@ namespace GitUI.CommandsDialogs
             fileToolStripMenuItem.Initialize(() => UICommands);
             helpToolStripMenuItem.Initialize(() => UICommands);
             toolsToolStripMenuItem.Initialize(() => UICommands);
+            _NO_TRANSLATE_WorkingDir.Initialize(() => UICommands, _repositoryHistoryUIService, fileToolStripMenuItem);
 
             _repositoryHistoryUIService.GitModuleChanged += SetGitModule;
 
@@ -992,7 +990,7 @@ namespace GitUI.CommandsDialogs
 
                 toolsToolStripMenuItem.RefreshState(bareRepository);
 
-                RefreshWorkingDirComboText();
+                _NO_TRANSLATE_WorkingDir.RefreshContent();
 
                 OnActivate();
 
@@ -1153,102 +1151,6 @@ namespace GitUI.CommandsDialogs
                 toolStripSplitStash.Text = string.Empty;
             }
         }
-
-        #region Working directory combo box
-
-        /// <summary>Updates the text shown on the combo button itself.</summary>
-        private void RefreshWorkingDirComboText()
-        {
-            string path = Module.WorkingDir;
-
-            // it appears at times Module.WorkingDir path is an empty string, this caused issues like #4874
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                _NO_TRANSLATE_WorkingDir.Text = _noWorkingFolderText.Text;
-                return;
-            }
-
-            IList<Repository> recentRepositoryHistory = ThreadHelper.JoinableTaskFactory.Run(
-                () => RepositoryHistoryManager.Locals.AddAsMostRecentAsync(path));
-
-            List<RecentRepoInfo> pinnedRepos = new();
-            RecentRepoSplitter splitter = new()
-            {
-                MeasureFont = _NO_TRANSLATE_WorkingDir.Font,
-            };
-
-            splitter.SplitRecentRepos(recentRepositoryHistory, pinnedRepos, pinnedRepos);
-
-            RecentRepoInfo ri = pinnedRepos.Find(e => e.Repo.Path.Equals(path, StringComparison.InvariantCultureIgnoreCase));
-
-            _NO_TRANSLATE_WorkingDir.Text = PathUtil.GetDisplayPath(ri?.Caption ?? path);
-
-            if (AppSettings.RecentReposComboMinWidth > 0)
-            {
-                _NO_TRANSLATE_WorkingDir.AutoSize = false;
-                int captionWidth = TextRenderer.MeasureText(_NO_TRANSLATE_WorkingDir.Text, _NO_TRANSLATE_WorkingDir.Font).Width;
-                captionWidth = captionWidth + _NO_TRANSLATE_WorkingDir.DropDownButtonWidth + 5;
-                _NO_TRANSLATE_WorkingDir.Width = Math.Max(AppSettings.RecentReposComboMinWidth, captionWidth);
-            }
-            else
-            {
-                _NO_TRANSLATE_WorkingDir.AutoSize = true;
-            }
-        }
-
-        private void WorkingDirDropDownOpening(object sender, EventArgs e)
-        {
-            _NO_TRANSLATE_WorkingDir.DropDown.SuspendLayout();
-            _NO_TRANSLATE_WorkingDir.DropDownItems.Clear();
-
-            ToolStripMenuItem tsmiCategorisedRepos = new(fileToolStripMenuItem.FavouriteRepositoriesMenuItem.Text, fileToolStripMenuItem.FavouriteRepositoriesMenuItem.Image);
-            _repositoryHistoryUIService.PopulateFavouriteRepositoriesMenu(tsmiCategorisedRepos);
-            if (tsmiCategorisedRepos.DropDownItems.Count > 0)
-            {
-                _NO_TRANSLATE_WorkingDir.DropDownItems.Add(tsmiCategorisedRepos);
-            }
-
-            _repositoryHistoryUIService.PopulateRecentRepositoriesMenu(_NO_TRANSLATE_WorkingDir);
-
-            _NO_TRANSLATE_WorkingDir.DropDownItems.Add(new ToolStripSeparator());
-
-            ToolStripMenuItem mnuOpenLocalRepository = new(fileToolStripMenuItem.OpenRepositoryMenuItem.Text, fileToolStripMenuItem.OpenRepositoryMenuItem.Image)
-            {
-                ShortcutKeyDisplayString = fileToolStripMenuItem.OpenRepositoryMenuItem.ShortcutKeyDisplayString
-            };
-            mnuOpenLocalRepository.Click += (s, e) => fileToolStripMenuItem.OpenRepositoryMenuItem.PerformClick();
-            _NO_TRANSLATE_WorkingDir.DropDownItems.Add(mnuOpenLocalRepository);
-
-            ToolStripMenuItem mnuRecentReposSettings = new(_configureWorkingDirMenu.Text);
-            mnuRecentReposSettings.Click += (hs, he) =>
-            {
-                using (FormRecentReposSettings frm = new())
-                {
-                    frm.ShowDialog(this);
-                }
-
-                RefreshWorkingDirComboText();
-            };
-
-            _NO_TRANSLATE_WorkingDir.DropDownItems.Add(mnuRecentReposSettings);
-
-            _NO_TRANSLATE_WorkingDir.DropDown.ResumeLayout();
-        }
-
-        private void WorkingDirClick(object sender, EventArgs e)
-        {
-            _NO_TRANSLATE_WorkingDir.ShowDropDown();
-        }
-
-        private void _NO_TRANSLATE_WorkingDir_MouseUp(object sender, MouseEventArgs e)
-        {
-            if (e.Button == MouseButtons.Right)
-            {
-                fileToolStripMenuItem.OpenRepositoryMenuItem.PerformClick();
-            }
-        }
-
-        #endregion
 
         private void FillFileTree(GitRevision revision)
         {

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -258,7 +258,7 @@ namespace GitUI.CommandsDialogs
             fileToolStripMenuItem.Initialize(() => UICommands);
             helpToolStripMenuItem.Initialize(() => UICommands);
             toolsToolStripMenuItem.Initialize(() => UICommands);
-            _NO_TRANSLATE_WorkingDir.Initialize(() => UICommands, _repositoryHistoryUIService, fileToolStripMenuItem);
+            _NO_TRANSLATE_WorkingDir.Initialize(() => UICommands, _repositoryHistoryUIService, fileToolStripMenuItem, closeToolStripMenuItem);
 
             _repositoryHistoryUIService.GitModuleChanged += SetGitModule;
 

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -258,8 +258,6 @@ namespace GitUI.CommandsDialogs
             fileToolStripMenuItem.Initialize(() => UICommands);
             helpToolStripMenuItem.Initialize(() => UICommands);
             toolsToolStripMenuItem.Initialize(() => UICommands);
-            _NO_TRANSLATE_WorkingDir.Initialize(() => UICommands, _repositoryHistoryUIService, fileToolStripMenuItem, closeToolStripMenuItem);
-
             _repositoryHistoryUIService.GitModuleChanged += SetGitModule;
 
             BackColor = OtherColors.BackgroundColor;
@@ -289,6 +287,10 @@ namespace GitUI.CommandsDialogs
             InitCommitDetails();
 
             InitializeComplete();
+
+            // The toolstrip and menu items must be initialised after InitializeComplete
+            // which invokes the translation logic and applies the current language to the components.
+            _NO_TRANSLATE_WorkingDir.Initialize(() => UICommands, _repositoryHistoryUIService, fileToolStripMenuItem, closeToolStripMenuItem);
 
             HotkeysEnabled = true;
             LoadHotkeys(HotkeySettingsName);

--- a/src/app/GitUI/CommandsDialogs/Menus/ToolStripMenuItemEx.cs
+++ b/src/app/GitUI/CommandsDialogs/Menus/ToolStripMenuItemEx.cs
@@ -10,12 +10,6 @@ namespace GitUI.CommandsDialogs.Menus
         private Func<GitUICommands>? _getUICommands;
 
         /// <summary>
-        ///  Gets the current instance of the UI commands.
-        /// </summary>
-        protected GitUICommands UICommands
-            => (_getUICommands ?? throw new InvalidOperationException("The button is not initialized"))();
-
-        /// <summary>
         ///  Gets the current instance of the git module.
         /// </summary>
         protected IGitModule Module => UICommands.Module;
@@ -25,6 +19,12 @@ namespace GitUI.CommandsDialogs.Menus
         /// </summary>
         protected static Form? OwnerForm
             => Form.ActiveForm ?? (Application.OpenForms.Count > 0 ? Application.OpenForms[0] : null);
+
+        /// <summary>
+        ///  Gets the current instance of the UI commands.
+        /// </summary>
+        protected GitUICommands UICommands
+            => (_getUICommands ?? throw new InvalidOperationException("The button is not initialized"))();
 
         /// <summary>
         ///  Initializes the menu item.

--- a/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
+++ b/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
@@ -1,0 +1,176 @@
+using GitCommands;
+using GitCommands.UserRepositoryHistory;
+using GitExtensions.Extensibility.Git;
+using GitExtensions.Extensibility.Translations;
+using GitUI.CommandsDialogs.BrowseDialog;
+using ResourceManager;
+
+namespace GitUI.CommandsDialogs.Menus
+{
+    /// <summary>
+    ///  Represents a split button that contains the recent repositories.
+    /// </summary>
+    internal class WorkingDirectoryToolStripSplitButton : ToolStripSplitButton, ITranslate
+    {
+        private readonly TranslationString _noWorkingFolderText = new("No working directory");
+        private readonly TranslationString _configureWorkingDirMenu = new("&Configure this menu");
+
+        private Func<GitUICommands>? _getUICommands;
+        private RepositoryHistoryUIService _dont_use_me_repositoryHistoryUIService;
+
+        // NOTE: This is pretty bad, but we want to share the same look and feel of the menu items defined in the Start menu.
+        private StartToolStripMenuItem _startToolStripMenuItem;
+
+        public WorkingDirectoryToolStripSplitButton()
+        {
+            Name = nameof(WorkingDirectoryToolStripSplitButton);
+
+            Image = Properties.Resources.RepoOpen;
+            ImageAlign = ContentAlignment.MiddleLeft;
+            ImageTransparentColor = Color.Magenta;
+            TextAlign = ContentAlignment.MiddleLeft;
+        }
+
+        /// <summary>
+        ///  Gets the current instance of the git module.
+        /// </summary>
+        protected IGitModule Module => UICommands.Module;
+
+        /// <summary>
+        ///  Gets the form that is displaying the menu item.
+        /// </summary>
+        protected static Form? OwnerForm
+            => Form.ActiveForm ?? (Application.OpenForms.Count > 0 ? Application.OpenForms[0] : null);
+
+        /// <summary>
+        ///  Gets the current instance of the <see cref="RepositoryHistoryUIService"/>.
+        /// </summary>
+        protected RepositoryHistoryUIService RepositoryHistoryUIService
+            => _dont_use_me_repositoryHistoryUIService ?? throw new InvalidOperationException("The button is not initialized");
+
+        /// <summary>
+        ///  Gets the current instance of the UI commands.
+        /// </summary>
+        protected GitUICommands UICommands
+            => (_getUICommands ?? throw new InvalidOperationException("The button is not initialized")).Invoke();
+
+        /// <summary>
+        ///  Initializes the menu item.
+        /// </summary>
+        /// <param name="getUICommands">The method that returns the current instance of UI commands.</param>
+        public void Initialize(Func<GitUICommands> getUICommands, RepositoryHistoryUIService repositoryHistoryUIService,
+                               StartToolStripMenuItem startToolStripMenuItem)
+        {
+            Translator.Translate(this, AppSettings.CurrentTranslation);
+
+            _getUICommands = getUICommands;
+            _dont_use_me_repositoryHistoryUIService = repositoryHistoryUIService;
+            _startToolStripMenuItem = startToolStripMenuItem;
+        }
+
+        protected override void OnButtonClick(EventArgs e)
+        {
+            base.OnButtonClick(e);
+            ShowDropDown();
+        }
+
+        protected override void OnDropDownShow(EventArgs e)
+        {
+            DropDown.SuspendLayout();
+            DropDownItems.Clear();
+
+            ToolStripMenuItem tsmiCategorisedRepos = new(_startToolStripMenuItem.FavouriteRepositoriesMenuItem.Text, _startToolStripMenuItem.FavouriteRepositoriesMenuItem.Image);
+            RepositoryHistoryUIService.PopulateFavouriteRepositoriesMenu(tsmiCategorisedRepos);
+            if (tsmiCategorisedRepos.DropDownItems.Count > 0)
+            {
+                DropDownItems.Add(tsmiCategorisedRepos);
+            }
+
+            RepositoryHistoryUIService.PopulateRecentRepositoriesMenu(this);
+
+            DropDownItems.Add(new ToolStripSeparator());
+
+            ToolStripMenuItem mnuOpenLocalRepository = new(_startToolStripMenuItem.OpenRepositoryMenuItem.Text, _startToolStripMenuItem.OpenRepositoryMenuItem.Image)
+            {
+                ShortcutKeys = _startToolStripMenuItem.OpenRepositoryMenuItem.ShortcutKeys
+            };
+            mnuOpenLocalRepository.Click += (s, e) => _startToolStripMenuItem.OpenRepositoryMenuItem.PerformClick();
+            DropDownItems.Add(mnuOpenLocalRepository);
+
+            ToolStripMenuItem mnuRecentReposSettings = new(_configureWorkingDirMenu.Text);
+            mnuRecentReposSettings.Click += (hs, he) =>
+            {
+                using (FormRecentReposSettings frm = new())
+                {
+                    frm.ShowDialog(OwnerForm);
+                }
+
+                RefreshContent();
+            };
+
+            DropDownItems.Add(mnuRecentReposSettings);
+
+            DropDown.ResumeLayout();
+        }
+
+        protected override void OnMouseUp(MouseEventArgs e)
+        {
+            base.OnMouseUp(e);
+
+            if (e.Button == MouseButtons.Right)
+            {
+                _startToolStripMenuItem.OpenRepositoryMenuItem.PerformClick();
+            }
+        }
+
+        /// <summary>Updates the text shown on the combo button itself.</summary>
+        public void RefreshContent()
+        {
+            string path = Module.WorkingDir;
+
+            // it appears at times Module.WorkingDir path is an empty string, this caused issues like #4874
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                Text = _noWorkingFolderText.Text;
+                return;
+            }
+
+            IList<Repository> recentRepositoryHistory = ThreadHelper.JoinableTaskFactory.Run(
+                () => RepositoryHistoryManager.Locals.AddAsMostRecentAsync(path));
+
+            List<RecentRepoInfo> pinnedRepos = new();
+            RecentRepoSplitter splitter = new()
+            {
+                MeasureFont = Font,
+            };
+
+            splitter.SplitRecentRepos(recentRepositoryHistory, pinnedRepos, pinnedRepos);
+
+            RecentRepoInfo ri = pinnedRepos.Find(e => e.Repo.Path.Equals(path, StringComparison.InvariantCultureIgnoreCase));
+
+            Text = PathUtil.GetDisplayPath(ri?.Caption ?? path);
+
+            if (AppSettings.RecentReposComboMinWidth > 0)
+            {
+                AutoSize = false;
+                int captionWidth = TextRenderer.MeasureText(Text, Font).Width;
+                captionWidth = captionWidth + DropDownButtonWidth + 5;
+                Width = Math.Max(AppSettings.RecentReposComboMinWidth, captionWidth);
+            }
+            else
+            {
+                AutoSize = true;
+            }
+        }
+
+        void ITranslate.AddTranslationItems(ITranslation translation)
+        {
+            TranslationUtils.AddTranslationItemsFromFields("FormBrowse", this, translation);
+        }
+
+        void ITranslate.TranslateItems(ITranslation translation)
+        {
+            TranslationUtils.TranslateItemsFromFields("FormBrowse", this, translation);
+        }
+    }
+}

--- a/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
+++ b/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
@@ -20,6 +20,7 @@ namespace GitUI.CommandsDialogs.Menus
 
         // NOTE: This is pretty bad, but we want to share the same look and feel of the menu items defined in the Start menu.
         private StartToolStripMenuItem _startToolStripMenuItem;
+        private ToolStripMenuItem _closeToolStripMenuItem;
 
         public WorkingDirectoryToolStripSplitButton()
         {
@@ -59,13 +60,14 @@ namespace GitUI.CommandsDialogs.Menus
         /// </summary>
         /// <param name="getUICommands">The method that returns the current instance of UI commands.</param>
         public void Initialize(Func<GitUICommands> getUICommands, RepositoryHistoryUIService repositoryHistoryUIService,
-                               StartToolStripMenuItem startToolStripMenuItem)
+                               StartToolStripMenuItem startToolStripMenuItem, ToolStripMenuItem closeToolStripMenuItem)
         {
             Translator.Translate(this, AppSettings.CurrentTranslation);
 
             _getUICommands = getUICommands;
             _dont_use_me_repositoryHistoryUIService = repositoryHistoryUIService;
             _startToolStripMenuItem = startToolStripMenuItem;
+            _closeToolStripMenuItem = closeToolStripMenuItem;
         }
 
         protected override void OnButtonClick(EventArgs e)
@@ -96,6 +98,12 @@ namespace GitUI.CommandsDialogs.Menus
             };
             mnuOpenLocalRepository.Click += (s, e) => _startToolStripMenuItem.OpenRepositoryMenuItem.PerformClick();
             DropDownItems.Add(mnuOpenLocalRepository);
+
+            ToolStripMenuItem mnuCloseRepo = new(_closeToolStripMenuItem.Text);
+            mnuCloseRepo.Click += (hs, he) => _closeToolStripMenuItem.PerformClick();
+            DropDownItems.Add(mnuCloseRepo);
+
+            DropDownItems.Add(new ToolStripSeparator());
 
             ToolStripMenuItem mnuRecentReposSettings = new(_configureWorkingDirMenu.Text);
             mnuRecentReposSettings.Click += (hs, he) =>

--- a/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
+++ b/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
@@ -228,6 +228,7 @@ namespace GitUI.CommandsDialogs.Menus
         {
             DropDown.SuspendLayout();
             DropDownItems.Clear();
+            _tsmiCategorisedRepos.DropDownItems.Clear();
 
             _txtFilter.Text = string.Empty;
 

--- a/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
+++ b/src/app/GitUI/CommandsDialogs/Menus/WorkingDirectoryToolStripSplitButton.cs
@@ -84,12 +84,6 @@ namespace GitUI.CommandsDialogs.Menus
 
                 try
                 {
-                    if (_moveMouseWhenFiltering)
-                    {
-                        Cursor.Position = owner.RectangleToScreen(DropDownButtonBounds).Location;
-                        _moveMouseWhenFiltering = false;
-                    }
-
                     DropDown.SuspendLayout();
 
                     if (string.IsNullOrWhiteSpace(filterTextbox.Text))
@@ -115,6 +109,17 @@ namespace GitUI.CommandsDialogs.Menus
                 finally
                 {
                     DropDown.ResumeLayout();
+                    if (string.IsNullOrWhiteSpace(filterTextbox.Text))
+                    {
+                        EnableMousePositionHack();
+                    }
+                }
+
+                if (_moveMouseWhenFiltering)
+                {
+                    Point newPosition = filterTextbox.PointToScreen(Point.Empty) + new Size(0, filterTextbox.Size.Height);
+                    Cursor.Position = newPosition;
+                    _moveMouseWhenFiltering = false;
                 }
             };
         }
@@ -198,10 +203,8 @@ namespace GitUI.CommandsDialogs.Menus
             ShowDropDown();
         }
 
-        protected override void OnDropDownOpened(EventArgs e)
+        private void EnableMousePositionHack()
         {
-            base.OnDropDownOpened(e);
-
             if (Owner is not { } owner)
             {
                 return;
@@ -213,6 +216,12 @@ namespace GitUI.CommandsDialogs.Menus
             //       toolbar items as that would cause the DropDown to be closed immediately.
             Rectangle rect = owner.RectangleToScreen(DropDownButtonBounds);
             _moveMouseWhenFiltering = (rect.Top + rect.Height) > DropDown.Top;
+        }
+
+        protected override void OnDropDownOpened(EventArgs e)
+        {
+            base.OnDropDownOpened(e);
+            EnableMousePositionHack();
         }
 
         protected override void OnDropDownShow(EventArgs e)

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -2432,6 +2432,10 @@ compare with first:</source>
         <source>(Repository hosts)</source>
         <target />
       </trans-unit>
+      <trans-unit id="_repositorySearchPlaceholder.Text">
+        <source>Search repositories...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_superprojectModuleFormat.Text">
         <source>Superproject: {0}</source>
         <target />
@@ -10779,7 +10783,7 @@ The action cannot be undone.</source>
         <target />
       </trans-unit>
       <trans-unit id="_repositorySearchPlaceholder.Text">
-        <source>Search repositories</source>
+        <source>Search repositories...</source>
         <target />
       </trans-unit>
       <trans-unit id="clmhdrBranch.Text">


### PR DESCRIPTION
Resolves #10810

## Proposed changes

- Extract the working directory / recent repositories dropdown as a standalone component
- Add "Close (go to Dashboard) to repos dropdown
- Allow to filter the recent repositories dropdown

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/226240129-934b9ba7-8f99-4a70-b356-fe649b9d9b32.png)


### After

* In action:

    https://user-images.githubusercontent.com/4403806/233787474-81dcc157-9aa1-42f0-b586-124557bc2ee0.mp4

* Translations:
![image](https://user-images.githubusercontent.com/4403806/233787605-6c969234-211f-43f8-b4d9-73035404a62c.png)


## Test methodology <!-- How did you ensure quality? -->

- manual
- automated TBD

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
