### PR TITLE
Decode url-encoded repository folder's name

### DIFF
--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -310,7 +310,10 @@ namespace GitCommands
             if (repositoryUrl is not null)
             {
                 const string standardRepositorySuffix = ".git";
-                string path = repositoryUrl.TrimEnd('\\', '/');
+                string path = (Uri.IsWellFormedUriString(repositoryUrl, UriKind.Absolute) || repositoryUrl.StartsWith("git@", StringComparison.OrdinalIgnoreCase)
+                    ? System.Net.WebUtility.UrlDecode(repositoryUrl)
+                    : repositoryUrl)
+                    .TrimEnd('\\', '/');
 
                 if (path.EndsWith(standardRepositorySuffix))
                 {

--- a/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
@@ -161,17 +161,23 @@ namespace GitCommandsTests.Helpers
             Assert.AreEqual(PathUtil.GetRepositoryName("ssh://john-abraham.doe@mygitserver/git/MyAwesomeRepo.git"), "MyAwesomeRepo");
             Assert.AreEqual(PathUtil.GetRepositoryName("git@anotherserver.mysubnet.com:project/somerepo.git"), "somerepo");
             Assert.AreEqual(PathUtil.GetRepositoryName("http://anotherserver.mysubnet.com/project/somerepo.git"), "somerepo");
+            Assert.AreEqual(PathUtil.GetRepositoryName("http://anotherserver.mysubnet.com/project/Hello+G%C3%BCnter.git"), "Hello Günter");
+            Assert.AreEqual(PathUtil.GetRepositoryName("ssh://anotherserver.mysubnet.com/project/Hello+G%C3%BCnter.git"), "Hello Günter");
+            Assert.AreEqual(PathUtil.GetRepositoryName("git://anotherserver.mysubnet.com/project/Hello+G%C3%BCnter.git"), "Hello Günter");
+            Assert.AreEqual(PathUtil.GetRepositoryName("git@anotherserver.mysubnet.com:project/Hello+G%C3%BCnter.git"), "Hello Günter");
 
             Assert.AreEqual(PathUtil.GetRepositoryName(""), "");
             Assert.AreEqual(PathUtil.GetRepositoryName(null), "");
             if (Path.DirectorySeparatorChar == '\\')
             {
                 Assert.AreEqual(PathUtil.GetRepositoryName(@"C:\dev\my_repo"), "my_repo");
+                Assert.AreEqual(PathUtil.GetRepositoryName(@"C:\dev\Hello+G%C3%BCnter"), "Hello+G%C3%BCnter");
                 Assert.AreEqual(PathUtil.GetRepositoryName(@"\\networkshare\folder1\folder2\gitextensions"), "gitextensions");
             }
             else
             {
                 Assert.AreEqual(PathUtil.GetRepositoryName(@"/dev/my_repo"), "my_repo");
+                Assert.AreEqual(PathUtil.GetRepositoryName(@"/dev/Hello+G%C3%BCnter"), "Hello+G%C3%BCnter");
                 Assert.AreEqual(PathUtil.GetRepositoryName(@"//networkshare/folder1/folder2/gitextensions"), "gitextensions");
             }
         }

--- a/contributors.txt
+++ b/contributors.txt
@@ -190,3 +190,4 @@ YYYY/MM/DD, github id, Full name, email
 2023/03/03, pedrolamas, Pedro Lamas, pedrolamas@gmail.com
 2023/03/07, o-kloster, Oddvar Kloster, okloster(at)gmail.com
 2023/03/08, RemiGaudin, Rémi Gaudin, remi.gaudin(at)gmail.com
+2023/04/27, montoner0, Alex Bogush, inmate66+gitext(@t)gmail.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10919

## Proposed changes

- Decode the part with the repository name for URLs but not local paths. Not quite sure though if `ssh://` and `git@` links are considered as URL-encoded (can't find info).

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/13542804/234972761-595346d7-b67c-41a3-b797-42bd7f5bf8f2.png)

### After

![image](https://user-images.githubusercontent.com/13542804/234973838-25b09391-feb2-47c1-ab7f-c93a93dd19ce.png)

## Test methodology <!-- How did you ensure quality? -->

- Additional cases to the [unit test for PathUtil.GetRepositoryName](https://github.com/gitextensions/gitextensions/blob/d454fc79f668a59188d098ff9ff7fccc4ca2b7d2/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs#L154)

## Test environment(s) <!-- Remove any that don't apply -->

- Git 2.40.1.windows.1
- Microsoft Windows NT 10.0.19045.0

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
