### PR TITLE
Remove DotnetRuntimeBootstrapper

### DIFF
--- a/GitExtensions/GitExtensions.csproj
+++ b/GitExtensions/GitExtensions.csproj
@@ -21,10 +21,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotnetRuntimeBootstrapper">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="GitInfo">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Packages.props
+++ b/Packages.props
@@ -7,7 +7,6 @@
     <PackageReference Update="AppInsights.WindowsDesktop" Version="2.18.1" />
     <PackageReference Update="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Update="ConEmu.Core" Version="22.12.18" />
-    <PackageReference Update="DotnetRuntimeBootstrapper" Version="2.3.1" />
     <PackageReference Update="EnvDTE" Version="17.0.32112.339" />
     <PackageReference Update="ExCSS" Version="4.1.3" />
     <PackageReference Update="GitInfo" Version="2.2.0" />


### PR DESCRIPTION
We have no use for it.

Closes #10425.