### PR TITLE
Remove SettingsCache entry when setting empty value

### DIFF
--- a/GitCommands/Settings/SettingsCache.cs
+++ b/GitCommands/Settings/SettingsCache.cs
@@ -130,7 +130,14 @@ namespace GitCommands
 
                 SettingsChanged();
 
-                _byNameMap.AddOrUpdate(name, value, (key, oldValue) => value);
+                if (string.IsNullOrEmpty(value))
+                {
+                    _byNameMap.TryRemove(name, out _);
+                }
+                else
+                {
+                    _byNameMap.AddOrUpdate(name, value, (key, oldValue) => value);
+                }
             });
         }
 

--- a/UnitTests/GitCommands.Tests/Settings/ConfigSectionTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/ConfigSectionTests.cs
@@ -1,0 +1,48 @@
+﻿using FluentAssertions;
+using GitCommands.Config;
+using NUnit.Framework;
+
+namespace GitCommandsTests.Settings
+{
+    [TestFixture]
+    internal sealed class ConfigSectionTests
+    {
+        private static readonly string _keyName = Guid.NewGuid().ToString();
+        private static readonly string _sectionName = Guid.NewGuid().ToString();
+
+        private static ConfigSection _configSection;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _configSection = new ConfigSection(_sectionName, forceCaseSensitive: true);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _configSection = null;
+        }
+
+        [Test]
+        public void should_remove_setting([Values(null, "")] string noValue)
+        {
+            string value = Guid.NewGuid().ToString();
+            string defaultValue = Guid.NewGuid().ToString();
+            _configSection.HasValue(_keyName).Should().BeFalse();
+            _configSection.SetValue(_keyName, value);
+            _configSection.HasValue(_keyName).Should().BeTrue();
+            _configSection.GetValue(_keyName, defaultValue).Should().Be(value);
+
+            string invalidKey = "foobar";
+            _configSection.GetValue(invalidKey, defaultValue).Should().Be(defaultValue);
+            _configSection.HasValue(invalidKey).Should().BeFalse();
+
+            _configSection.HasValue(_keyName).Should().BeTrue();
+            _configSection.SetValue(_keyName, noValue);
+            _configSection.HasValue(_keyName).Should().BeFalse();
+            _configSection.GetValue(_keyName, defaultValue).Should().Be(defaultValue);
+            _configSection.HasValue(_keyName).Should().BeFalse();
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10917

## Proposed changes

- Remove `SettingsCache` entry when setting empty or `null` value 

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- added unit test

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).