### PR TITLE
Replace sync CommitMessageManager API with async

### DIFF
--- a/GitCommands/CommitMessageManager.cs
+++ b/GitCommands/CommitMessageManager.cs
@@ -250,7 +250,7 @@ namespace GitCommands
             {
                 await _fileSystem.File.WriteAllTextAsync(filePath, content, encoding ?? Encoding.Default, cancellationToken);
             }
-            catch (Exception ex) when (ex is not OperationCanceledException && ex is not ObjectDisposedException)
+            catch (Exception ex) when (ex is not (OperationCanceledException or ObjectDisposedException))
             {
                 await _owner.SwitchToMainThreadAsync();
 

--- a/GitCommands/CommitMessageManager.cs
+++ b/GitCommands/CommitMessageManager.cs
@@ -255,7 +255,7 @@ namespace GitCommands
                 await _owner.SwitchToMainThreadAsync();
 
                 // No need to cancel the other operations in FormCommit - just let the user know that something went wrong
-                MessageBox.Show(null, string.Format(CannotAccessFile, ex.Message, filePath), errorTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                MessageBox.Show(_owner, string.Format(CannotAccessFile, ex.Message, filePath), errorTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
             }
         }
     }

--- a/GitCommands/CommitMessageManager.cs
+++ b/GitCommands/CommitMessageManager.cs
@@ -228,7 +228,7 @@ namespace GitCommands
 
                 return await _fileSystem.File.ReadAllTextAsync(filePath, encoding ?? Encoding.Default, cancellationToken);
             }
-            catch (Exception ex) when (ex is not OperationCanceledException && ex is not ObjectDisposedException)
+            catch (Exception ex) when (ex is not (OperationCanceledException or ObjectDisposedException))
             {
                 await _owner.SwitchToMainThreadAsync();
                 MessageBox.Show(_owner, string.Format(CannotAccessFile, ex.Message, filePath), errorTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);

--- a/GitCommands/CommitMessageManager.cs
+++ b/GitCommands/CommitMessageManager.cs
@@ -1,40 +1,52 @@
 ﻿using System.IO.Abstractions;
 using System.Text;
 using GitExtUtils;
+using GitUI;
+using Microsoft.VisualStudio.Threading;
 
 namespace GitCommands
 {
     public interface ICommitMessageManager
     {
         /// <summary>
-        /// Reads/stores whether the previous commit shall be amended (if AppSettings.RememberAmendCommitState).
-        /// </summary>
-        bool AmendState { get; set; }
-
-        /// <summary>
-        /// The path of .git/COMMITMESSAGE, where a prepared (non-merge) commit message is stored.
+        ///  The path of .git/COMMITMESSAGE, where a prepared (non-merge) commit message is stored.
         /// </summary>
         string CommitMessagePath { get; }
 
         /// <summary>
-        /// Returns whether .git/MERGE_MSG exists.
+        ///  Returns whether .git/MERGE_MSG exists.
         /// </summary>
         bool IsMergeCommit { get; }
 
         /// <summary>
-        /// The path of .git/MERGE_MSG, where a merge-commit message is stored.
+        ///  The path of .git/MERGE_MSG, where a merge-commit message is stored.
         /// </summary>
         string MergeMessagePath { get; }
 
         /// <summary>
-        /// Reads/stores the prepared commit message from/in .git/MERGE_MSG if it exists or else in .git/COMMITMESSAGE.
+        ///  Reads the indicator whether the previous commit shall be amended (if <see cref="AppSettings.RememberAmendCommitState"/>).
         /// </summary>
-        string MergeOrCommitMessage { get; set; }
+        Task<bool> GetAmendStateAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Deletes .git/COMMITMESSAGE and the file with the AmendState.
+        ///  Reads/stores the prepared commit message from/in .git/MERGE_MSG if it exists or else in .git/COMMITMESSAGE.
         /// </summary>
-        void ResetCommitMessage();
+        Task<string> GetMergeOrCommitMessageAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///  Deletes .git/COMMITMESSAGE and the file with the AmendState.
+        /// </summary>
+        Task ResetCommitMessageAsync();
+
+        /// <summary>
+        ///  Stores the indicator whether the previous commit shall be amended (if <see cref="AppSettings.RememberAmendCommitState"/>).
+        /// </summary>
+        Task SetAmendStateAsync(bool amendState, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///  Stores the prepared commit message from/in .git/MERGE_MSG if it exists or else in .git/COMMITMESSAGE.
+        /// </summary>
+        Task SetMergeOrCommitMessageAsync(string? message, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///  Writes the provided commit message to .git/COMMITMESSAGE.
@@ -44,7 +56,8 @@ namespace GitCommands
         /// <param name="messageType">The type of message to write out.</param>
         /// <param name="usingCommitTemplate">The indicator whether a commit template is used.</param>
         /// <param name="ensureCommitMessageSecondLineEmpty">The indicator whether empty second line is enforced.</param>
-        void WriteCommitMessageToFile(string commitMessage, CommitMessageType messageType, bool usingCommitTemplate, bool ensureCommitMessageSecondLineEmpty);
+        Task WriteCommitMessageToFileAsync(string commitMessage, CommitMessageType messageType, bool usingCommitTemplate,
+                                           bool ensureCommitMessageSecondLineEmpty, CancellationToken cancellationToken = default);
     }
 
     public sealed class CommitMessageManager : ICommitMessageManager
@@ -58,6 +71,7 @@ namespace GitCommands
         private readonly string _amendSaveStatePath;
 
         private readonly IFileSystem _fileSystem;
+        private readonly Control _owner;
 
         // Commit messages are UTF-8 by default unless otherwise in the config file.
         // The git manual states:
@@ -69,13 +83,16 @@ namespace GitCommands
 
         private string? _overriddenCommitMessage;
 
-        public CommitMessageManager(string workingDirGitDir, Encoding commitEncoding, string? overriddenCommitMessage = null)
-            : this(workingDirGitDir, commitEncoding, new FileSystem(), overriddenCommitMessage)
+        public CommitMessageManager(Control owner, string workingDirGitDir, Encoding commitEncoding, string? overriddenCommitMessage = null)
+            : this(owner, workingDirGitDir, commitEncoding, new FileSystem(), overriddenCommitMessage)
         {
         }
 
-        internal CommitMessageManager(string workingDirGitDir, Encoding commitEncoding, IFileSystem fileSystem, string? overriddenCommitMessage = null)
+        internal CommitMessageManager(Control owner, string workingDirGitDir, Encoding commitEncoding, IFileSystem fileSystem, string? overriddenCommitMessage = null)
         {
+            ArgumentNullException.ThrowIfNull(nameof(owner));
+
+            _owner = owner;
             _fileSystem = fileSystem;
             _commitEncoding = commitEncoding;
             _amendSaveStatePath = GetFilePath(workingDirGitDir, "GitExtensions.amend");
@@ -84,83 +101,82 @@ namespace GitCommands
             _overriddenCommitMessage = overriddenCommitMessage;
         }
 
-        /// <inheritdoc/>
-        public bool AmendState
+        public async Task<bool> GetAmendStateAsync(CancellationToken cancellationToken = default)
         {
-            get
+            bool amendState = false;
+
+            if (AppSettings.RememberAmendCommitState)
             {
-                bool amendState = false;
-
-                if (AppSettings.RememberAmendCommitState)
-                {
-                    bool.TryParse(ReadFile(_amendSaveStatePath, CannotReadAmendState), out amendState);
-                }
-
-                return amendState;
+                string amendStateRawValue = await ReadFileAsync(_amendSaveStatePath, CannotReadAmendState, cancellationToken: cancellationToken);
+                _ = bool.TryParse(amendStateRawValue, out amendState);
             }
-            set
-            {
-                if (AppSettings.RememberAmendCommitState && value)
-                {
-                    WriteFile(_amendSaveStatePath, CannotSaveAmendState, true.ToString());
-                    return;
-                }
 
-                if (_fileSystem.File.Exists(_amendSaveStatePath))
-                {
-                    _fileSystem.File.Delete(_amendSaveStatePath);
-                }
+            return amendState;
+        }
+
+        public async Task SetAmendStateAsync(bool amendState, CancellationToken cancellationToken = default)
+        {
+            await TaskScheduler.Default;
+
+            if (AppSettings.RememberAmendCommitState && amendState)
+            {
+                await WriteFileAsync(_amendSaveStatePath, CannotSaveAmendState, true.ToString(), cancellationToken: cancellationToken);
+                return;
+            }
+
+            if (_fileSystem.File.Exists(_amendSaveStatePath))
+            {
+                _fileSystem.File.Delete(_amendSaveStatePath);
             }
         }
 
-        /// <inheritdoc/>
         public string CommitMessagePath { get; }
 
-        /// <inheritdoc/>
         public bool IsMergeCommit => _fileSystem.File.Exists(MergeMessagePath);
 
-        /// <inheritdoc/>
         public string MergeMessagePath { get; }
 
-        /// <inheritdoc/>
-        public string MergeOrCommitMessage
+        public async Task<string> GetMergeOrCommitMessageAsync(CancellationToken cancellationToken = default)
         {
-            get
+            if (_overriddenCommitMessage is not null)
             {
-                if (_overriddenCommitMessage is not null)
-                {
-                    return _overriddenCommitMessage;
-                }
-
-                return ReadFile(GetMergeOrCommitMessagePath(), CannotReadCommitMessage, _commitEncoding);
+                return _overriddenCommitMessage;
             }
-            set
-            {
-                var content = value ?? string.Empty;
 
-                // do not remember commit message when they have been specified by the command line
-                if (content != _overriddenCommitMessage)
-                {
-                    WriteFile(GetMergeOrCommitMessagePath(), CannotSaveCommitMessage, content, _commitEncoding);
-                }
-            }
+            return await ReadFileAsync(GetMergeOrCommitMessagePath(), CannotReadCommitMessage, _commitEncoding, cancellationToken);
         }
 
-        /// <inheritdoc/>
-        public void ResetCommitMessage()
+        public async Task ResetCommitMessageAsync()
         {
+            await TaskScheduler.Default;
+
             _overriddenCommitMessage = null;
             _fileSystem.File.Delete(CommitMessagePath);
             _fileSystem.File.Delete(_amendSaveStatePath);
         }
 
-        /// <inheritdoc/>
-        public void WriteCommitMessageToFile(string commitMessage, CommitMessageType messageType, bool usingCommitTemplate, bool ensureCommitMessageSecondLineEmpty)
+        public async Task SetMergeOrCommitMessageAsync(string? message, CancellationToken cancellationToken = default)
         {
-            var formattedCommitMessage = FormatCommitMessage(commitMessage, usingCommitTemplate, ensureCommitMessageSecondLineEmpty);
+            await TaskScheduler.Default;
+
+            string content = message ?? string.Empty;
+
+            // do not remember commit message when they have been specified by the command line
+            if (content != _overriddenCommitMessage)
+            {
+                await WriteFileAsync(GetMergeOrCommitMessagePath(), CannotSaveCommitMessage, content, _commitEncoding, cancellationToken);
+            }
+        }
+
+        public async Task WriteCommitMessageToFileAsync(string commitMessage, CommitMessageType messageType, bool usingCommitTemplate,
+                                                        bool ensureCommitMessageSecondLineEmpty, CancellationToken cancellationToken = default)
+        {
+            await TaskScheduler.Default;
+
+            string formattedCommitMessage = FormatCommitMessage(commitMessage, usingCommitTemplate, ensureCommitMessageSecondLineEmpty);
 
             string path = messageType == CommitMessageType.Normal ? CommitMessagePath : MergeMessagePath;
-            WriteFile(path, CannotSaveCommitMessage, formattedCommitMessage, _commitEncoding);
+            await WriteFileAsync(path, CannotSaveCommitMessage, formattedCommitMessage, _commitEncoding, cancellationToken);
         }
 
         internal static string FormatCommitMessage(string commitMessage, bool usingCommitTemplate, bool ensureCommitMessageSecondLineEmpty)
@@ -199,8 +215,10 @@ namespace GitCommands
 
         private string GetMergeOrCommitMessagePath() => IsMergeCommit ? MergeMessagePath : CommitMessagePath;
 
-        private string ReadFile(string filePath, string errorTitle, Encoding? encoding = null)
+        private async Task<string> ReadFileAsync(string filePath, string errorTitle, Encoding? encoding = null, CancellationToken cancellationToken = default)
         {
+            await TaskScheduler.Default;
+
             try
             {
                 if (!_fileSystem.File.Exists(filePath))
@@ -208,18 +226,20 @@ namespace GitCommands
                     return string.Empty;
                 }
 
-                return _fileSystem.File.ReadAllText(filePath, encoding ?? Encoding.Default);
+                return await _fileSystem.File.ReadAllTextAsync(filePath, encoding ?? Encoding.Default, cancellationToken);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not ObjectDisposedException)
             {
-                MessageBox.Show(null, string.Format(CannotAccessFile, ex.Message, filePath), errorTitle,
-                    MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                await _owner.SwitchToMainThreadAsync();
+                MessageBox.Show(_owner, string.Format(CannotAccessFile, ex.Message, filePath), errorTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                 return string.Empty;
             }
         }
 
-        private void WriteFile(string filePath, string errorTitle, string content, Encoding? encoding = null)
+        private async Task WriteFileAsync(string filePath, string errorTitle, string content, Encoding? encoding = null, CancellationToken cancellationToken = default)
         {
+            await TaskScheduler.Default;
+
             if (!_fileSystem.Directory.Exists(Path.GetDirectoryName(filePath)))
             {
                 // The repo no longer exists - ignore silently
@@ -228,13 +248,14 @@ namespace GitCommands
 
             try
             {
-                _fileSystem.File.WriteAllText(filePath, content, encoding ?? Encoding.Default);
+                await _fileSystem.File.WriteAllTextAsync(filePath, content, encoding ?? Encoding.Default, cancellationToken);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not ObjectDisposedException)
             {
+                await _owner.SwitchToMainThreadAsync();
+
                 // No need to cancel the other operations in FormCommit - just let the user know that something went wrong
-                MessageBox.Show(null, string.Format(CannotAccessFile, ex.Message, filePath), errorTitle,
-                    MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                MessageBox.Show(null, string.Format(CannotAccessFile, ex.Message, filePath), errorTitle, MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
             }
         }
     }

--- a/GitUI/Avatars/FileSystemAvatarCache.cs
+++ b/GitUI/Avatars/FileSystemAvatarCache.cs
@@ -95,7 +95,7 @@ namespace GitUI.Avatars
 
                 bool HasExpired()
                 {
-                    IFileInfo info = _fileSystem.FileInfo.FromFileName(path);
+                    IFileInfo info = _fileSystem.FileInfo.New(path);
 
                     if (!info.Exists)
                     {

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -477,7 +477,7 @@ namespace GitUI.CommandsDialogs
                 // a special meaning, and can be dangerous if used inappropriately.
                 if (CommitKind is (CommitKind.Normal or CommitKind.Amend))
                 {
-                    ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                    ThreadHelper.JoinableTaskFactory.Run(async () =>
                     {
                         await _commitMessageManager.SetMergeOrCommitMessageAsync(Message.Text);
                         await _commitMessageManager.SetAmendStateAsync(Amend.Checked);

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1378,7 +1378,7 @@ namespace GitUI.CommandsDialogs
                     {
                         // Save last commit message in settings. This way it can be used in multiple repositories.
                         AppSettings.LastCommitMessage = Message.Text;
-                        ThreadHelper.JoinableTaskFactory.RunAsync(
+                        ThreadHelper.JoinableTaskFactory.Run(
                             () => _commitMessageManager.WriteCommitMessageToFileAsync(Message.Text, CommitMessageType.Normal,
                                                                                       usingCommitTemplate: !string.IsNullOrEmpty(_commitTemplate),
                                                                                       ensureCommitMessageSecondLineEmpty: AppSettings.EnsureCommitMessageSecondLineEmpty));

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -103,7 +103,7 @@ namespace GitUI.CommandsDialogs
             {
                 // [!] Do not reset the last commit message stored in AppSettings.LastCommitMessage
 
-                ThreadHelper.JoinableTaskFactory.RunAsync(
+                ThreadHelper.JoinableTaskFactory.Run(
                     () => _commitMessageManager.WriteCommitMessageToFileAsync(mergeMessage.Text, CommitMessageType.Merge,
                                                                               usingCommitTemplate: false,
                                                                               ensureCommitMessageSecondLineEmpty: false));

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -35,7 +35,7 @@ namespace GitUI.CommandsDialogs
             helpImageDisplayUserControl1.Image2 = Properties.Images.HelpCommandMergeFastForward.AdaptLightness();
             InitializeComplete();
 
-            _commitMessageManager = new CommitMessageManager(Module.WorkingDirGitDir, Module.CommitEncoding);
+            _commitMessageManager = new CommitMessageManager(this, Module.WorkingDirGitDir, Module.CommitEncoding);
 
             currentBranchLabel.Font = new Font(currentBranchLabel.Font, FontStyle.Bold);
             noCommit.Checked = AppSettings.DontCommitMerge;
@@ -87,8 +87,7 @@ namespace GitUI.CommandsDialogs
 
         private void OkClick(object sender, EventArgs e)
         {
-            IDetachedSettings detachedSettings = Module.GetEffectiveSettings()
-                .Detached();
+            IDetachedSettings detachedSettings = Module.GetEffectiveSettings().Detached();
 
             detachedSettings.NoFastForwardMerge = noFastForward.Checked;
             AppSettings.DontCommitMerge = noCommit.Checked;
@@ -104,9 +103,10 @@ namespace GitUI.CommandsDialogs
             {
                 // [!] Do not reset the last commit message stored in AppSettings.LastCommitMessage
 
-                _commitMessageManager.WriteCommitMessageToFile(mergeMessage.Text, CommitMessageType.Merge,
-                                                               usingCommitTemplate: false,
-                                                               ensureCommitMessageSecondLineEmpty: false);
+                ThreadHelper.JoinableTaskFactory.RunAsync(
+                    () => _commitMessageManager.WriteCommitMessageToFileAsync(mergeMessage.Text, CommitMessageType.Merge,
+                                                                              usingCommitTemplate: false,
+                                                                              ensureCommitMessageSecondLineEmpty: false));
                 mergeMessagePath = _commitMessageManager.MergeMessagePath;
             }
 

--- a/Packages.props
+++ b/Packages.props
@@ -25,7 +25,7 @@
     <PackageReference Update="SmartFormat" Version="3.0.0" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.321" />
     <PackageReference Update="System.Collections.Immutable" Version="6.0.0" /> <!-- Required by GitExtensions.Plugins.AutoCompileSubmodules -->
-    <PackageReference Update="System.IO.Abstractions" Version="16.1.10" />
+    <PackageReference Update="System.IO.Abstractions" Version="19.2.18" />
     <PackageReference Update="System.Reactive" Version="5.0.0" />
     <PackageReference Update="System.Reactive.Linq" Version="5.0.0" />
     <PackageReference Update="System.Reactive.Interfaces" Version="5.0.0" />
@@ -46,7 +46,7 @@
     <PackageReference Update="NUnit.ConsoleRunner" Version="3.12.0" />
     <PackageReference Update="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Update="NUnit" Version="3.13.2" />
-    <PackageReference Update="System.IO.Abstractions.TestingHelpers" Version="16.1.10" />
+    <PackageReference Update="System.IO.Abstractions.TestingHelpers" Version="19.2.18" />
     <PackageReference Update="YamlDotNet" Version="11.2.1" />
 
   </ItemGroup>

--- a/UnitTests/CommonTestUtils/ReferenceRepository.cs
+++ b/UnitTests/CommonTestUtils/ReferenceRepository.cs
@@ -178,7 +178,11 @@ namespace CommonTestUtils
                 repository.Config.Set(SettingKeyString.UserEmail, "author@mail.com");
             }
 
-            new CommitMessageManager(Module.WorkingDirGitDir, Module.CommitEncoding).ResetCommitMessage();
+            // We don't expect any failures so that we won't be switching to the main thread or showing messages
+            CommitMessageManager commitMessageManager = new(owner: null!, Module.WorkingDirGitDir, Module.CommitEncoding);
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+            commitMessageManager.ResetCommitMessageAsync().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
         }
 
         public void Stash(string stashMessage, string content = null)

--- a/UnitTests/GitUI.Tests/Avatars/AvatarPersistentCacheTests.cs
+++ b/UnitTests/GitUI.Tests/Avatars/AvatarPersistentCacheTests.cs
@@ -31,7 +31,7 @@ namespace GitUITests.Avatars
             _fileInfo = Substitute.For<FileInfoBase>();
             _fileInfo.Exists.Returns(true);
             _fileInfoFactory = Substitute.For<IFileInfoFactory>();
-            _fileInfoFactory.FromFileName(Arg.Any<string>()).Returns(_fileInfo);
+            _fileInfoFactory.New(Arg.Any<string>()).Returns(_fileInfo);
             _fileSystem.FileInfo.Returns(_fileInfoFactory);
 
             AppSettings.AvatarProvider = AvatarProvider.Default;
@@ -71,7 +71,7 @@ namespace GitUITests.Avatars
         {
             _fileInfo.Exists.Returns(true);
             _fileInfo.LastWriteTime.Returns(new DateTime(2010, 1, 1));
-            _fileSystem.File.OpenWrite(Arg.Any<string>()).Returns(_ => new MemoryStream());
+            _fileSystem.File.OpenWrite(Arg.Any<string>()).Returns(_ => (Stream)new MemoryStream());
             _fileSystem.File.Delete(Arg.Any<string>());
 
             await MissAsync(_email1, _name1);


### PR DESCRIPTION
Resolves #10926

The use of sync API leads to observable delays and locking
the application when working with repos located in WSL.<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Test methodology <!-- How did you ensure quality? -->

- manual
- unit tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
