### PR TITLE
Write info async on Commit dialog close

### DIFF
--- a/GitUI/CommandsDialogs/FormRevertCommit.cs
+++ b/GitUI/CommandsDialogs/FormRevertCommit.cs
@@ -3,6 +3,7 @@ using GitCommands.Git.Commands;
 using GitExtUtils;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Threading;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs
@@ -96,6 +97,8 @@ namespace GitUI.CommandsDialogs
                 {
                     try
                     {
+                        await TaskScheduler.Default;
+
                         string message = await commitMessageManager.GetMergeOrCommitMessageAsync();
                         string newCommitMessageContent = $"{existingCommitMessage}\n\n{message}";
                         await commitMessageManager.WriteCommitMessageToFileAsync(newCommitMessageContent, CommitMessageType.Merge,


### PR DESCRIPTION
Addendum to #10930

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
