### PR TITLE
Handle all message filters starting with -- as git-log options

### DIFF
--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -19,12 +19,6 @@ namespace GitUI.UserControls.RevisionGrid
         private int _commitsLimit = -1;
 
         /// <summary>
-        /// Prefix to "Message" filters that forces the text to be interpreted as Git options.
-        /// This enables use of options not available in the GUI.
-        /// </summary>
-        private readonly string[] _messageAsGitOptions = new[] { "--not ", "--exclude=" };
-
-        /// <summary>
         ///  Gets whether all properties will unconditionally return the underlying data.
         ///  Otherwise return values will depend on the respective filter, e.g. "get => ByXyz ? Xyz : default".
         /// </summary>
@@ -388,8 +382,9 @@ namespace GitUI.UserControls.RevisionGrid
 
             if (ByMessage && !string.IsNullOrWhiteSpace(Message))
             {
-                if (Message.StartsWithAny(_messageAsGitOptions))
+                if (Message.StartsWith("--"))
                 {
+                    // Add as git-log options
                     filter.Add(Message);
                 }
                 else
@@ -560,7 +555,7 @@ namespace GitUI.UserControls.RevisionGrid
 
             if (ByMessage && !string.IsNullOrEmpty(Message))
             {
-                if (Message.StartsWithAny(_messageAsGitOptions))
+                if (Message.StartsWith("--"))
                 {
                     filter.AppendLine(Message);
                 }

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
@@ -1183,10 +1183,10 @@ namespace GitUITests.UserControls
 
         [TestCase("message1", true)]
         [TestCase("message1 --not", true)]
-        [TestCase("--not=message1", true)]
+        [TestCase("--not=message1", false)]
         [TestCase("--not message1", false)]
         [TestCase(" --not message1", true)]
-        [TestCase("--exclude message1", true)]
+        [TestCase("--exclude message1", false)]
         [TestCase("--exclude= message1", false)]
         [TestCase("--exclude= message1 ", false)]
         [TestCase("\t--exclude= message1", true)]


### PR DESCRIPTION
Similar handling as #10832 for branch box

## Proposed changes

#10240 handles "--not ", "--exclude=" as options, this aligns with #10832

To be considered for 4.1

## Test methodology <!-- How did you ensure quality? -->

Tests updated.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
