### PR TITLE
ShowCurrentBranchOnly: Filter also if no branch checkout

### DIFF
--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -430,15 +430,19 @@ namespace GitUI.UserControls.RevisionGrid
                 filter.Add("--reflog");
             }
 
-            if (IsShowCurrentBranchOnlyChecked && !string.IsNullOrWhiteSpace(currentBranch.Value))
+            if (IsShowCurrentBranchOnlyChecked)
             {
                 // Git default, no option by default (stashes is special).
 
-                AddFirstStashRef();
+                if (!string.IsNullOrWhiteSpace(currentBranch.Value))
+                {
+                    // Without any stash nothing will be shown with only --glob and no --branches
+                    AddFirstStashRef();
 
-                // Add as filter (even if Git default is current branch) as the branch (ref) must exist
-                // and the repo must contain commits, otherwise Git will exit with errors.
-                filter.Add($"--branches={GetFilterRefName(currentBranch.Value)}");
+                    // Add as filter (even if Git default is current branch) as the branch (ref) must exist
+                    // and the repo must contain commits, otherwise Git will exit with errors.
+                    filter.Add($"--branches={GetFilterRefName(currentBranch.Value)}");
+                }
             }
             else if (IsShowFilteredBranchesChecked && !string.IsNullOrWhiteSpace(BranchFilter))
             {

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -297,7 +297,7 @@ namespace GitUI.UserControls.RevisionGrid
             return searchParametersChanged;
         }
 
-        public ArgumentString GetRevisionFilter(Lazy<string> currentBranch)
+        public ArgumentString GetRevisionFilter(Lazy<ObjectId?> currentCheckout)
         {
             if (IsRaw)
             {
@@ -309,7 +309,7 @@ namespace GitUI.UserControls.RevisionGrid
             // Separate the filters in groups
             GetCommitRevisionFilter(filter);
             GetLimitingRevisionFilter(filter);
-            GetBranchRevisionFilter(filter, currentBranch);
+            GetBranchRevisionFilter(filter, currentCheckout);
 
             return filter;
         }
@@ -417,7 +417,8 @@ namespace GitUI.UserControls.RevisionGrid
         /// Branch revision filters, not affecting parent rewriting.
         /// </summary>
         /// <param name="filter">ArgumentBuilder arg</param>
-        private void GetBranchRevisionFilter(ArgumentBuilder filter, Lazy<string> currentBranch)
+        /// <param name="currentCheckout">Commit currently checked out</param>
+        private void GetBranchRevisionFilter(ArgumentBuilder filter, Lazy<ObjectId?> currentCheckout)
         {
             if (ShowOnlyFirstParent)
             {
@@ -432,16 +433,16 @@ namespace GitUI.UserControls.RevisionGrid
 
             if (IsShowCurrentBranchOnlyChecked)
             {
-                // Git default, no option by default (stashes is special).
+                // Git default with no options
 
-                if (!string.IsNullOrWhiteSpace(currentBranch.Value))
+                if (currentCheckout.Value is not null)
                 {
-                    // Without any stash nothing will be shown with only --glob and no --branches
+                    // Without any stash nothing will be shown with only --glob and no hash or --branches
                     AddFirstStashRef();
 
-                    // Add as filter (even if Git default is current branch) as the branch (ref) must exist
+                    // Add as filter (even if Git default is current branch) as commit must exist
                     // and the repo must contain commits, otherwise Git will exit with errors.
-                    filter.Add($"--branches={GetFilterRefName(currentBranch.Value)}");
+                    filter.Add(currentCheckout.Value);
                 }
             }
             else if (IsShowFilteredBranchesChecked && !string.IsNullOrWhiteSpace(BranchFilter))

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -431,19 +431,15 @@ namespace GitUI.UserControls.RevisionGrid
                 filter.Add("--reflog");
             }
 
-            if (IsShowCurrentBranchOnlyChecked)
+            if (IsShowCurrentBranchOnlyChecked && currentCheckout.Value is not null)
             {
                 // Git default with no options
 
-                if (currentCheckout.Value is not null)
-                {
-                    // Without any stash nothing will be shown with only --glob and no hash or --branches
-                    AddFirstStashRef();
+                AddFirstStashRef();
 
-                    // Add as filter (even if Git default is current branch) as commit must exist
-                    // and the repo must contain commits, otherwise Git will exit with errors.
-                    filter.Add(currentCheckout.Value);
-                }
+                // Add as filter or --all (even if Git default is current branch)
+                // as Git will exit with errors if there are no commits.
+                filter.Add(currentCheckout.Value);
             }
             else if (IsShowFilteredBranchesChecked && !string.IsNullOrWhiteSpace(BranchFilter))
             {

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -936,6 +936,8 @@ namespace GitUI
                 Lazy<ObjectId?> currentCheckout = new(() =>
                     headRef.Value?.ObjectId ?? capturedModule.GetCurrentCheckout());
 
+                ObjectId? previousCheckout = CurrentCheckout;
+
                 // Evaluate GitRefs and current commit
                 ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
@@ -944,12 +946,11 @@ namespace GitUI
 
                     // If the current checkout (HEAD) is changed, don't get the currently selected rows,
                     // select the new current checkout instead.
-                    if (currentCheckout.Value != CurrentCheckout && currentCheckout.Value is not null)
-                    {
-                        currentlySelectedObjectIds = new List<ObjectId> { currentCheckout.Value };
-                    }
-
                     CurrentCheckout = currentCheckout.Value;
+                    if (CurrentCheckout != previousCheckout && CurrentCheckout is not null)
+                    {
+                        currentlySelectedObjectIds = new List<ObjectId> { CurrentCheckout };
+                    }
 
                     // Exclude the 'stash' ref, it is specially handled when stashes are shown
                     refsByObjectId = (AppSettings.ShowStashes
@@ -958,7 +959,7 @@ namespace GitUI
                         .ToLookup(gitRef => gitRef.ObjectId);
                     ResetNavigationHistory();
                     UpdateSelectedRef(capturedModule, getUnfilteredRefs.Value, headRef.Value);
-                    _gridView.ToBeSelectedObjectIds = GetToBeSelectedRevisions(currentCheckout.Value, currentlySelectedObjectIds);
+                    _gridView.ToBeSelectedObjectIds = GetToBeSelectedRevisions(CurrentCheckout, currentlySelectedObjectIds);
 
                     _gridView._revisionGraph.OnlyFirstParent = _filterInfo.ShowOnlyFirstParent;
                     _gridView._revisionGraph.HeadId = CurrentCheckout;

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
@@ -1116,10 +1116,7 @@ namespace GitUITests.UserControls
                 BranchFilter = branchFilter
             };
             string args = filterInfo.GetRevisionFilter(new Lazy<string>(() => currentBranch));
-            bool showAll = (!showCurrentBranchOnly && string.IsNullOrWhiteSpace(branchFilter))
-                || (showCurrentBranchOnly && string.IsNullOrWhiteSpace(currentBranch));
-            bool showCurrent = showCurrentBranchOnly && !string.IsNullOrWhiteSpace(currentBranch);
-            bool showFiltredOrCurrent = showCurrent || (!showCurrentBranchOnly && !string.IsNullOrWhiteSpace(branchFilter));
+            bool showAll = !showCurrentBranchOnly && string.IsNullOrWhiteSpace(branchFilter);
 
             try
             {
@@ -1142,17 +1139,18 @@ namespace GitUITests.UserControls
                 }
 
                 string branch = Regex.Escape($"--branches={GetFilterRefName(currentBranch)}");
-                if (showCurrent)
+                if (showCurrentBranchOnly && !string.IsNullOrWhiteSpace(currentBranch))
                 {
                     args.ToString().Should().MatchRegex(@$"(^|\s){branch}($|\s)");
                 }
-                else if (!string.IsNullOrWhiteSpace(branch))
+                else
                 {
                     args.ToString().Should().NotMatchRegex(@$"(^|\s){branch}($|\s)");
                 }
 
                 string stash = Regex.Escape($"--glob={"refs/stas[h]"}");
-                if (showFiltredOrCurrent && showStash)
+                if (showStash && ((showCurrentBranchOnly && !string.IsNullOrWhiteSpace(currentBranch))
+                    || (!showCurrentBranchOnly && !string.IsNullOrWhiteSpace(branchFilter))))
                 {
                     args.ToString().Should().MatchRegex(@$"(^|\s){stash}($|\s)");
                 }


### PR DESCRIPTION
Fixes #10939

I rather not merge this and close #10939 as not planned

## Proposed changes

If no branch checkout, the branch filter was handling ShowCurrentBranchOnly as ALBranches.
This is changed to work similar to before, where ShowCurrentBranchOnly filtered on the current commit instead.
A consequence is that the first stash is not added to the grid if there is no branch checked out.

first stash could be visible in some situations if current commit was added instead (rather than HEAD that may not exist), but there will still be some checks needed and this is fgar too complicated as it is.

## Test methodology <!-- How did you ensure quality? -->

The 'parallel implementation' tests were updated,

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
