### PR TITLE
Open VS Code in a new window

### DIFF
--- a/GitCommands/DiffMergeTools/VsCode.cs
+++ b/GitCommands/DiffMergeTools/VsCode.cs
@@ -5,13 +5,13 @@ namespace GitCommands.DiffMergeTools
         private static readonly string[] Folders = GetFolders();
 
         /// <inheritdoc />
-        public override string DiffCommand => "--wait --diff \"$LOCAL\" \"$REMOTE\"";
+        public override string DiffCommand => "--new-window --wait --diff \"$LOCAL\" \"$REMOTE\"";
 
         /// <inheritdoc />
         public override string ExeFileName => "Code.exe";
 
         /// <inheritdoc />
-        public override string MergeCommand => "--wait --merge \"$REMOTE\" \"$LOCAL\" \"$BASE\" \"$MERGED\"";
+        public override string MergeCommand => "--new-window --wait --merge \"$REMOTE\" \"$LOCAL\" \"$BASE\" \"$MERGED\"";
 
         /// <inheritdoc />
         public override string Name => "vscode";

--- a/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
@@ -28,7 +28,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private static string GetVsCode()
         {
-            return GetEditorCommandLine("Visual Studio Code", "code.exe", " --wait", "Microsoft VS Code");
+            return GetEditorCommandLine("Visual Studio Code", "code.exe", " --new-window --wait", "Microsoft VS Code");
         }
 
         private static string GetAtom()


### PR DESCRIPTION
Fixes #10942

## Proposed changes

- Add `--new-window` to Visual Studio Code command lines

## Screenshots

I wasn't able to build the repository on my current machine due to dependencies, and I don't have time this evening to set it up. If it's too late to get this in, I understand. 😄 

### Before

<!-- TODO -->

### After

<!-- TODO -->

## Test methodology <!-- How did you ensure quality? -->

- Manually added `--new-window` to existing commands to verify that VS Code accepts them. I tested the Edit command and the Diff command, but I didn't have a scenario handy to test the Merge command.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

Merge commit preferred

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
