### PR TITLE
Fixup path to system git config

### DIFF
--- a/GitCommands/Git/EnvironmentConfiguration.cs
+++ b/GitCommands/Git/EnvironmentConfiguration.cs
@@ -21,18 +21,18 @@ namespace GitCommands
         {
             // PATH variable
 
-            if (!string.IsNullOrEmpty(AppSettings.GitBinDir))
+            if (!string.IsNullOrEmpty(AppSettings.LinuxToolsDir))
             {
-                // Ensure the git binary dir is on the path
+                // Ensure the GNU/Linux tools dir is on the path
                 string? path = Env.GetEnvironmentVariable("PATH");
 
                 if (path is null)
                 {
-                    Env.SetEnvironmentVariable("PATH", AppSettings.GitBinDir);
+                    Env.SetEnvironmentVariable("PATH", AppSettings.LinuxToolsDir);
                 }
-                else if (!path.Contains(AppSettings.GitBinDir))
+                else if (!path.Contains(AppSettings.LinuxToolsDir))
                 {
-                    Env.SetEnvironmentVariable("PATH", $"{path}{Path.PathSeparator}{AppSettings.GitBinDir}");
+                    Env.SetEnvironmentVariable("PATH", $"{path}{Path.PathSeparator}{AppSettings.LinuxToolsDir}");
                 }
             }
 

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3990,7 +3990,7 @@ namespace GitCommands
             }
 
             // Get processes by "ps" command.
-            var cmd = Path.Combine(AppSettings.GitBinDir, "ps");
+            string cmd = Path.Combine(AppSettings.LinuxToolsDir, "ps");
             string[] lines = new Executable(cmd).GetOutput("x").Split(Delimiters.LineFeed);
 
             if (lines.Length <= 2)

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -394,7 +394,7 @@ namespace GitCommands
                     return true;
                 }
 
-                shellPath = Path.Combine(AppSettings.GitBinDir, shell);
+                shellPath = Path.Combine(AppSettings.LinuxToolsDir, shell);
                 if (File.Exists(shellPath))
                 {
                     return true;

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -696,7 +696,7 @@ namespace GitCommands
             if (!string.IsNullOrEmpty(ssh))
             {
                 // OpenSSH uses empty path, compatibility with path set in 3.4
-                string path = new SshPathLocator().GetSshFromGitDir(GitBinDir);
+                string path = new SshPathLocator().GetSshFromGitDir(LinuxToolsDir);
                 if (path == ssh)
                 {
                     AppSettings.SshPath = "";
@@ -1313,22 +1313,15 @@ namespace GitCommands
             set => SetBool("ShowCommitBodyInRevisionGrid", value);
         }
 
-        /// <summary>Gets or sets the path to the git application executable.</summary>
-        public static string GitBinDir
+        /// <summary>Gets or sets the path to the GNU/Linux tools (bash, ps, sh, ssh, etc.), e.g. "C:\Program Files\Git\usr\bin\"</summary>
+        public static string LinuxToolsDir
         {
-            get => GetString("gitbindir", "");
+            // Migrate the setting value from the from the former "gitbindir"
+            get => GetString(nameof(LinuxToolsDir), defaultValue: null) ?? GetString("gitbindir", "");
             set
             {
-                var temp = value.EnsureTrailingPathSeparator();
-                SetString("gitbindir", temp);
-
-                ////if (string.IsNullOrEmpty(_gitBinDir))
-                ////   return;
-                ////
-                ////var path =
-                ////   Environment.GetEnvironmentVariable("path", EnvironmentVariableTarget.Process) + ";" +
-                ////   _gitBinDir;
-                ////Environment.SetEnvironmentVariable("path", path, EnvironmentVariableTarget.Process);
+                string linuxToolsDir = value.EnsureTrailingPathSeparator();
+                SetString(nameof(LinuxToolsDir), linuxToolsDir);
             }
         }
 

--- a/GitCommands/Settings/ConfigFileSettings.cs
+++ b/GitCommands/Settings/ConfigFileSettings.cs
@@ -56,7 +56,7 @@ namespace GitCommands.Settings
             if (!File.Exists(configPath))
             {
                 // Git 1.xx
-                configPath = Path.Combine(AppSettings.GitBinDir, "..", "etc", "gitconfig");
+                configPath = Path.Combine(AppSettings.GitCommand, "..", "..", "etc", "gitconfig");
                 if (!File.Exists(configPath))
                 {
                     return null;

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -47,11 +47,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             return true;
         }
 
-        public bool SolveLinuxToolsDir(string? possibleNewPath = null)
+        public static bool SolveLinuxToolsDir(string? possibleNewPath = null)
         {
             if (!EnvUtils.RunningOnWindows())
             {
-                AppSettings.GitBinDir = string.Empty;
+                AppSettings.LinuxToolsDir = string.Empty;
                 return true;
             }
 
@@ -69,18 +69,18 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
                 if (ContainsSh(linuxToolsPath))
                 {
-                    AppSettings.GitBinDir = linuxToolsPath;
+                    AppSettings.LinuxToolsDir = linuxToolsPath;
                     return true;
                 }
 
                 if (CheckIfFileIsInPath("sh.exe") || CheckIfFileIsInPath("sh"))
                 {
-                    if (ContainsSh(AppSettings.GitBinDir))
+                    if (ContainsSh(AppSettings.LinuxToolsDir))
                     {
                         return true;
                     }
 
-                    AppSettings.GitBinDir = string.Empty;
+                    AppSettings.LinuxToolsDir = string.Empty;
                     return true;
                 }
 
@@ -89,7 +89,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     linuxToolsPath = path + toolsPath;
                     if (ContainsSh(gitpath))
                     {
-                        AppSettings.GitBinDir = gitpath;
+                        AppSettings.LinuxToolsDir = gitpath;
                         return true;
                     }
                 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -200,8 +200,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 return;
             }
 
-            MessageBox.Show(this, string.Format(_shCanBeRun.Text, AppSettings.GitBinDir), _shCanBeRunCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
-            ////GitBinPath.Text = Settings.GitBinDir;
+            MessageBox.Show(this, string.Format(_shCanBeRun.Text, AppSettings.LinuxToolsDir), _shCanBeRunCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
             PageHost.LoadAll(); // apply settings to dialog controls (otherwise the later called SaveAndRescan_Click would overwrite settings again)
             SaveAndRescan_Click(this, EventArgs.Empty);
         }
@@ -396,7 +395,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private bool CheckGitExe()
         {
-            return RenderSettingSetUnset(() => !File.Exists(AppSettings.GitBinDir + "sh.exe") && !File.Exists(AppSettings.GitBinDir + "sh") &&
+            return RenderSettingSetUnset(() => !File.Exists(AppSettings.LinuxToolsDir + "sh.exe") && !File.Exists(AppSettings.LinuxToolsDir + "sh") &&
                                          !CheckSettingsLogic.CheckIfFileIsInPath("sh.exe") && !CheckSettingsLogic.CheckIfFileIsInPath("sh"),
                                    GitBinFound, GitBinFound_Fix,
                                    _linuxToolsSshNotFound.Text, _linuxToolsSshFound.Text);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.Designer.cs
@@ -39,8 +39,8 @@
             this.downloadGitForWindows = new System.Windows.Forms.LinkLabel();
             this.lblGitCommand = new System.Windows.Forms.Label();
             this.lblShPath = new System.Windows.Forms.Label();
-            this.BrowseGitBinPath = new System.Windows.Forms.Button();
-            this.GitBinPath = new System.Windows.Forms.TextBox();
+            this.BrowseLinuxToolsDir = new System.Windows.Forms.Button();
+            this.LinuxToolsDir = new System.Windows.Forms.TextBox();
             this.GitPath = new System.Windows.Forms.TextBox();
             this.BrowseGitPath = new System.Windows.Forms.Button();
             this.gbEnvironment = new System.Windows.Forms.GroupBox();
@@ -118,8 +118,8 @@
             tlpnlGitPaths.Controls.Add(this.downloadGitForWindows, 0, 3);
             tlpnlGitPaths.Controls.Add(this.lblGitCommand, 0, 1);
             tlpnlGitPaths.Controls.Add(this.lblShPath, 0, 2);
-            tlpnlGitPaths.Controls.Add(this.BrowseGitBinPath, 2, 2);
-            tlpnlGitPaths.Controls.Add(this.GitBinPath, 1, 2);
+            tlpnlGitPaths.Controls.Add(this.BrowseLinuxToolsDir, 2, 2);
+            tlpnlGitPaths.Controls.Add(this.LinuxToolsDir, 1, 2);
             tlpnlGitPaths.Controls.Add(this.GitPath, 1, 1);
             tlpnlGitPaths.Controls.Add(this.BrowseGitPath, 2, 1);
             tlpnlGitPaths.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -180,28 +180,28 @@
             this.lblShPath.Text = "Path to linux tools (sh). Leave empty when it is in the path.";
             this.lblShPath.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // BrowseGitBinPath
+            // BrowseLinuxToolsDir
             // 
-            this.BrowseGitBinPath.AutoSize = true;
-            this.BrowseGitBinPath.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.BrowseGitBinPath.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.BrowseGitBinPath.Location = new System.Drawing.Point(554, 45);
-            this.BrowseGitBinPath.Name = "BrowseGitBinPath";
-            this.BrowseGitBinPath.Size = new System.Drawing.Size(52, 23);
-            this.BrowseGitBinPath.TabIndex = 6;
-            this.BrowseGitBinPath.Text = "Browse";
-            this.BrowseGitBinPath.UseVisualStyleBackColor = true;
-            this.BrowseGitBinPath.Click += new System.EventHandler(this.BrowseGitBinPath_Click);
+            this.BrowseLinuxToolsDir.AutoSize = true;
+            this.BrowseLinuxToolsDir.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.BrowseLinuxToolsDir.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.BrowseLinuxToolsDir.Location = new System.Drawing.Point(554, 45);
+            this.BrowseLinuxToolsDir.Name = "BrowseLinuxToolsDir";
+            this.BrowseLinuxToolsDir.Size = new System.Drawing.Size(52, 23);
+            this.BrowseLinuxToolsDir.TabIndex = 6;
+            this.BrowseLinuxToolsDir.Text = "Browse";
+            this.BrowseLinuxToolsDir.UseVisualStyleBackColor = true;
+            this.BrowseLinuxToolsDir.Click += new System.EventHandler(this.BrowseLinuxToolsDir_Click);
             // 
-            // GitBinPath
+            // LinuxToolsDir
             // 
-            this.GitBinPath.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.GitBinPath.Location = new System.Drawing.Point(300, 45);
-            this.GitBinPath.MaxLength = 300;
-            this.GitBinPath.Name = "GitBinPath";
-            this.GitBinPath.Size = new System.Drawing.Size(248, 21);
-            this.GitBinPath.TabIndex = 5;
-            this.GitBinPath.TextChanged += new System.EventHandler(this.GitBinPath_TextChanged);
+            this.LinuxToolsDir.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.LinuxToolsDir.Location = new System.Drawing.Point(300, 45);
+            this.LinuxToolsDir.MaxLength = 300;
+            this.LinuxToolsDir.Name = "LinuxToolsDir";
+            this.LinuxToolsDir.Size = new System.Drawing.Size(248, 21);
+            this.LinuxToolsDir.TabIndex = 5;
+            this.LinuxToolsDir.TextChanged += new System.EventHandler(this.LinuxToolsDir_TextChanged);
             // 
             // GitPath
             // 
@@ -299,10 +299,10 @@
         private System.Windows.Forms.Button ChangeHomeButton;
         private System.Windows.Forms.GroupBox gbPaths;
         private System.Windows.Forms.LinkLabel downloadGitForWindows;
-        private System.Windows.Forms.Button BrowseGitBinPath;
+        private System.Windows.Forms.Button BrowseLinuxToolsDir;
         private System.Windows.Forms.TextBox GitPath;
         private System.Windows.Forms.Button BrowseGitPath;
-        private System.Windows.Forms.TextBox GitBinPath;
+        private System.Windows.Forms.TextBox LinuxToolsDir;
         private System.Windows.Forms.Label lblGlobalConfigPath;
         private System.Windows.Forms.Label lblGitCommand;
         private System.Windows.Forms.Label label50;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
@@ -22,7 +22,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         public override void OnPageShown()
         {
             GitPath.Text = AppSettings.GitCommandValue;
-            GitBinPath.Text = AppSettings.LinuxToolsDir;
+            LinuxToolsDir.Text = AppSettings.LinuxToolsDir;
         }
 
         protected override void SettingsToPage()
@@ -31,7 +31,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             homeIsSetToLabel.Text = string.Concat(_homeIsSetToString.Text, " ", EnvironmentConfiguration.GetHomeDir());
 
             GitPath.Text = AppSettings.GitCommandValue;
-            GitBinPath.Text = AppSettings.LinuxToolsDir;
+            LinuxToolsDir.Text = AppSettings.LinuxToolsDir;
 
             base.SettingsToPage();
         }
@@ -39,7 +39,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void PageToSettings()
         {
             AppSettings.GitCommandValue = GitPath.Text;
-            AppSettings.LinuxToolsDir = GitBinPath.Text;
+            AppSettings.LinuxToolsDir = LinuxToolsDir.Text;
 
             base.PageToSettings();
         }
@@ -59,15 +59,15 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             }
         }
 
-        private void BrowseGitBinPath_Click(object sender, EventArgs e)
+        private void BrowseLinuxToolsDir_Click(object sender, EventArgs e)
         {
-            CheckSettingsLogic.SolveLinuxToolsDir(GitBinPath.Text.Trim());
+            CheckSettingsLogic.SolveLinuxToolsDir(LinuxToolsDir.Text.Trim());
 
             string? userSelectedPath = OsShellUtil.PickFolder(this, AppSettings.LinuxToolsDir);
 
             if (userSelectedPath is not null)
             {
-                GitBinPath.Text = userSelectedPath;
+                LinuxToolsDir.Text = userSelectedPath;
             }
         }
 
@@ -77,10 +77,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             CheckSettingsLogic.SolveGitCommand(GitPath.Text.Trim());
         }
 
-        private void GitBinPath_TextChanged(object sender, EventArgs e)
+        private void LinuxToolsDir_TextChanged(object sender, EventArgs e)
         {
             // If user pastes text or types in the box be sure to validate and save in the settings.
-            CheckSettingsLogic.SolveLinuxToolsDir(GitBinPath.Text.Trim());
+            CheckSettingsLogic.SolveLinuxToolsDir(LinuxToolsDir.Text.Trim());
         }
 
         private void downloadGitForWindows_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
@@ -22,7 +22,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         public override void OnPageShown()
         {
             GitPath.Text = AppSettings.GitCommandValue;
-            GitBinPath.Text = AppSettings.GitBinDir;
+            GitBinPath.Text = AppSettings.LinuxToolsDir;
         }
 
         protected override void SettingsToPage()
@@ -31,7 +31,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             homeIsSetToLabel.Text = string.Concat(_homeIsSetToString.Text, " ", EnvironmentConfiguration.GetHomeDir());
 
             GitPath.Text = AppSettings.GitCommandValue;
-            GitBinPath.Text = AppSettings.GitBinDir;
+            GitBinPath.Text = AppSettings.LinuxToolsDir;
 
             base.SettingsToPage();
         }
@@ -39,7 +39,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void PageToSettings()
         {
             AppSettings.GitCommandValue = GitPath.Text;
-            AppSettings.GitBinDir = GitBinPath.Text;
+            AppSettings.LinuxToolsDir = GitBinPath.Text;
 
             base.PageToSettings();
         }
@@ -63,7 +63,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             CheckSettingsLogic.SolveLinuxToolsDir(GitBinPath.Text.Trim());
 
-            var userSelectedPath = OsShellUtil.PickFolder(this, AppSettings.GitBinDir);
+            string? userSelectedPath = OsShellUtil.PickFolder(this, AppSettings.LinuxToolsDir);
 
             if (userSelectedPath is not null)
             {

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7883,11 +7883,11 @@ Check if file is accessible.</source>
         <source>Paths</source>
         <target />
       </trans-unit>
-      <trans-unit id="BrowseGitBinPath.Text">
+      <trans-unit id="BrowseGitPath.Text">
         <source>Browse</source>
         <target />
       </trans-unit>
-      <trans-unit id="BrowseGitPath.Text">
+      <trans-unit id="BrowseLinuxToolsDir.Text">
         <source>Browse</source>
         <target />
       </trans-unit>


### PR DESCRIPTION
Relates to #10914

## Proposed changes

- `ConfigFileSettings.CreateSystemWide()`: use `AppSettings.GitCommand` instead of misleading `AppSettings.GitBinDir` 
- Rename `AppSettings.LinuxToolsDir` from `GitBinDir`
- Rename `GitSettingsPage.LinuxToolsDir` from `GitBinPath`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

##  Please do not squash merge!

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).