### PR TITLE
Remove reset and delete from commit working dir menu

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -87,11 +87,6 @@ namespace GitUI.CommandsDialogs
             this.showSkipWorktreeFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showAssumeUnchangedFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showUntrackedFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-            this.deleteSelectedFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resetSelectedFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resetUnstagedChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resetAllTrackedChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.editGitIgnoreToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editLocallyIgnoredFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -745,11 +740,6 @@ namespace GitUI.CommandsDialogs
             this.showSkipWorktreeFilesToolStripMenuItem,
             this.showAssumeUnchangedFilesToolStripMenuItem,
             this.showUntrackedFilesToolStripMenuItem,
-            this.toolStripSeparator3,
-            this.deleteSelectedFilesToolStripMenuItem,
-            this.resetSelectedFilesToolStripMenuItem,
-            this.resetUnstagedChangesToolStripMenuItem,
-            this.resetAllTrackedChangesToolStripMenuItem,
             this.toolStripSeparator1,
             this.editGitIgnoreToolStripMenuItem,
             this.editLocallyIgnoredFilesToolStripMenuItem,
@@ -790,41 +780,6 @@ namespace GitUI.CommandsDialogs
             this.showUntrackedFilesToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
             this.showUntrackedFilesToolStripMenuItem.Text = "Show untracked files";
             this.showUntrackedFilesToolStripMenuItem.Click += new System.EventHandler(this.ShowUntrackedFilesToolStripMenuItemClick);
-            // 
-            // toolStripSeparator3
-            // 
-            this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(239, 6);
-            // 
-            // deleteSelectedFilesToolStripMenuItem
-            // 
-            this.deleteSelectedFilesToolStripMenuItem.Name = "deleteSelectedFilesToolStripMenuItem";
-            this.deleteSelectedFilesToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
-            this.deleteSelectedFilesToolStripMenuItem.Text = "Delete selected files";
-            this.deleteSelectedFilesToolStripMenuItem.Click += new System.EventHandler(this.DeleteSelectedFilesToolStripMenuItemClick);
-            // 
-            // resetSelectedFilesToolStripMenuItem
-            // 
-            this.resetSelectedFilesToolStripMenuItem.Name = "resetSelectedFilesToolStripMenuItem";
-            this.resetSelectedFilesToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
-            this.resetSelectedFilesToolStripMenuItem.Text = "Reset selected files";
-            this.resetSelectedFilesToolStripMenuItem.Click += new System.EventHandler(this.ResetSelectedFilesToolStripMenuItemClick);
-            // 
-            // resetUnstagedChangesToolStripMenuItem
-            // 
-            this.resetUnstagedChangesToolStripMenuItem.Image = global::GitUI.Properties.Images.ResetWorkingDirChanges;
-            this.resetUnstagedChangesToolStripMenuItem.Name = "resetUnstagedChangesToolStripMenuItem";
-            this.resetUnstagedChangesToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
-            this.resetUnstagedChangesToolStripMenuItem.Text = "Reset unstaged changes";
-            this.resetUnstagedChangesToolStripMenuItem.Click += new System.EventHandler(this.resetUnstagedChangesToolStripMenuItem_Click);
-            // 
-            // resetAllTrackedChangesToolStripMenuItem
-            // 
-            this.resetAllTrackedChangesToolStripMenuItem.Image = global::GitUI.Properties.Images.ResetWorkingDirChanges;
-            this.resetAllTrackedChangesToolStripMenuItem.Name = "resetAllTrackedChangesToolStripMenuItem";
-            this.resetAllTrackedChangesToolStripMenuItem.Size = new System.Drawing.Size(242, 22);
-            this.resetAllTrackedChangesToolStripMenuItem.Text = "Reset all (tracked) changes";
-            this.resetAllTrackedChangesToolStripMenuItem.Click += new System.EventHandler(this.ResetAllTrackedChangesToolStripMenuItemClick);
             // 
             // toolStripSeparator1
             // 
@@ -1643,10 +1598,6 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem showAssumeUnchangedFilesToolStripMenuItem;
         private ToolStripMenuItem showSkipWorktreeFilesToolStripMenuItem;
         private ToolStripMenuItem showUntrackedFilesToolStripMenuItem;
-        private ToolStripSeparator toolStripSeparator3;
-        private ToolStripMenuItem deleteSelectedFilesToolStripMenuItem;
-        private ToolStripMenuItem resetSelectedFilesToolStripMenuItem;
-        private ToolStripMenuItem resetAllTrackedChangesToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator1;
         private ToolStripMenuItem editGitIgnoreToolStripMenuItem;
         private ToolStripMenuItem editLocallyIgnoredFilesToolStripMenuItem;
@@ -1728,7 +1679,6 @@ namespace GitUI.CommandsDialogs
         private CheckBox ResetAuthor;
         private CheckBox StageInSuperproject;
         private Button ResetUnStaged;
-        private ToolStripMenuItem resetUnstagedChangesToolStripMenuItem;
         private ToolStripMenuItem noVerifyToolStripMenuItem;
         private ToolStripButton createBranchToolStripButton;
         private ToolStripStatusLabel toolStripStatusBranchIcon;

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2288,55 +2288,6 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void DeleteSelectedFilesToolStripMenuItemClick(object sender, EventArgs e)
-        {
-            if (MessageBox.Show(this, _deleteSelectedFiles.Text, _deleteSelectedFilesCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) !=
-                DialogResult.Yes)
-            {
-                return;
-            }
-
-            try
-            {
-                foreach (var gitItemStatus in Unstaged.SelectedItems)
-                {
-                    File.Delete(_fullPathResolver.Resolve(gitItemStatus.Item.Name));
-                }
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(this, _deleteFailed.Text + Environment.NewLine + ex, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-
-            Initialize();
-        }
-
-        private void ResetSelectedFilesToolStripMenuItemClick(object sender, EventArgs e)
-        {
-            if (MessageBox.Show(this, _resetSelectedChangesText.Text, TranslatedStrings.ResetChangesCaption, MessageBoxButtons.YesNo, MessageBoxIcon.Question) !=
-                DialogResult.Yes)
-            {
-                return;
-            }
-
-            foreach (var gitItemStatus in Unstaged.SelectedItems)
-            {
-                Module.ResetFile(gitItemStatus.Item.Name);
-            }
-
-            Initialize();
-        }
-
-        private void ResetAllTrackedChangesToolStripMenuItemClick(object sender, EventArgs e)
-        {
-            ResetClick(this, EventArgs.Empty);
-        }
-
-        private void resetUnstagedChangesToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            ResetUnStagedClick(this, EventArgs.Empty);
-        }
-
         private void EditGitIgnoreToolStripMenuItemClick(object sender, EventArgs e)
         {
             UICommands.StartEditGitIgnoreDialog(this, localExcludes: false);

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3817,10 +3817,6 @@ You can unset the template:
         <source>Delete file</source>
         <target />
       </trans-unit>
-      <trans-unit id="deleteSelectedFilesToolStripMenuItem.Text">
-        <source>Delete selected files</source>
-        <target />
-      </trans-unit>
       <trans-unit id="doNotAssumeUnchangedToolStripMenuItem.Text">
         <source>Do not assume unchanged</source>
         <target />
@@ -3889,10 +3885,6 @@ You can unset the template:
         <source>(Remote name)</source>
         <target />
       </trans-unit>
-      <trans-unit id="resetAllTrackedChangesToolStripMenuItem.Text">
-        <source>Reset all (tracked) changes</source>
-        <target />
-      </trans-unit>
       <trans-unit id="resetChanges.Text">
         <source>Reset file or directory changes</source>
         <target />
@@ -3901,16 +3893,8 @@ You can unset the template:
         <source>Reset chunk of file</source>
         <target />
       </trans-unit>
-      <trans-unit id="resetSelectedFilesToolStripMenuItem.Text">
-        <source>Reset selected files</source>
-        <target />
-      </trans-unit>
       <trans-unit id="resetSubmoduleChanges.Text">
         <source>Reset submodule changes</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="resetUnstagedChangesToolStripMenuItem.Text">
-        <source>Reset unstaged changes</source>
         <target />
       </trans-unit>
       <trans-unit id="selectionFilterToolStripMenuItem.Text">


### PR DESCRIPTION
## Proposed changes

Commands are available in the context menu and buttons, where the user is expected to look for them.
The commands were not working correctly for renamed and conflicted files.

- For selected files (delete/rest) the context menu is the natural way to reset
- For Reset all/unstaged, the buttons make the same actions, and the visible/enable is set correctly

A number of similar issues have been reported in 4.0 (after Git errors were no longer ignored).
There are no report for this problem what I see, but some reported issues will build on this (remove a function).

This affects translations (removing strings), but I would like to include it in a 4.1.1 or so.

## Screenshots <!-- Remove this section if PR does not change UI -->

Buttons unchanged
![image](https://github.com/gitextensions/gitextensions/assets/6248932/85b588ba-260f-4893-b1d6-facf53396d69)

### Before

![image](https://github.com/gitextensions/gitextensions/assets/6248932/a5bc6655-9e1a-4bd1-9007-1ec0d9172f50)

### After

![image](https://github.com/gitextensions/gitextensions/assets/6248932/c85b5b0a-f12c-47fa-9d4f-55413570405e)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
