### PR TITLE
Reset from command line

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1370,18 +1370,6 @@ namespace GitCommands
             _gitExecutable.RunCommand(GitCommandHelpers.ResetCmd(mode, commit: null, file));
         }
 
-        public string ResetFile(string file)
-        {
-            return _gitExecutable.GetOutput(
-                new GitArgumentBuilder("checkout-index")
-            {
-                "--index",
-                "--force",
-                "--",
-                file.ToPosixPath().Quote()
-            });
-        }
-
         public string ResetFiles(IReadOnlyList<string> files)
         {
             if (files is null || files.Count == 0)

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1334,9 +1334,40 @@ namespace GitCommands
             return _gitExecutable.GetOutput(args);
         }
 
+        /// <summary>
+        /// Reset all changes to HEAD
+        /// </summary>
+        /// <param name="clean">Clean non ignored files.</param>
+        /// <param name="onlyWorkTree">Reset only WorkTree files.</param>
+        /// <returns><see langword="true"/> if executed.</returns>
+        public bool ResetAllChanges(bool clean, bool onlyWorkTree = false)
+        {
+            if (onlyWorkTree)
+            {
+                GitArgumentBuilder args = new("checkout")
+                    {
+                        "--",
+                        "."
+                    };
+                GitExecutable.GetOutput(args);
+            }
+            else
+            {
+                // Reset all changes.
+                Reset(ResetMode.Hard);
+            }
+
+            if (clean)
+            {
+                Clean(CleanMode.OnlyNonIgnored, directories: true);
+            }
+
+            return true;
+        }
+
         public void Reset(ResetMode mode, string? file = null)
         {
-            _gitExecutable.RunCommand(GitCommandHelpers.ResetCmd(mode, null, file));
+            _gitExecutable.RunCommand(GitCommandHelpers.ResetCmd(mode, commit: null, file));
         }
 
         public string ResetFile(string file)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1352,7 +1352,7 @@ namespace GitUI.CommandsDialogs
 
         private void ResetToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            UICommands.StartResetChangesDialog(this);
+            UICommands.StartResetChangesDialog(this, Module.GetWorkTreeFiles(), onlyWorkTree: false);
             RefreshGitStatusMonitor();
             revisionDiff.RefreshArtificial();
         }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -3123,15 +3123,7 @@ namespace GitUI.CommandsDialogs
             foreach (var item in unstagedFiles.Where(it => it.IsSubmodule))
             {
                 GitModule module = Module.GetSubmodule(item.Name);
-
-                // Reset all changes.
-                module.Reset(ResetMode.Hard);
-
-                // Also delete new files, if requested.
-                if (resetType == FormResetChanges.ActionEnum.ResetAndDelete)
-                {
-                    module.Clean(CleanMode.OnlyNonIgnored, directories: true);
-                }
+                module.ResetAllChanges(clean: resetType == FormResetChanges.ActionEnum.ResetAndDelete);
             }
 
             Initialize();

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2120,74 +2120,18 @@ namespace GitUI.CommandsDialogs
                     return;
                 }
 
-                // Unstage file first, then reset
-                List<GitItemStatus> selectedFiles = Staged.SelectedItems.Items().ToList();
-                toolStripProgressBar1.Visible = true;
-                toolStripProgressBar1.Maximum = selectedFiles.Count;
-                toolStripProgressBar1.Value = 0;
-                Module.BatchUnstageFiles(selectedFiles, (eventArgs) =>
-                {
-                    toolStripProgressBar1.Value = Math.Min(toolStripProgressBar1.Maximum - 1, toolStripProgressBar1.Value + eventArgs.ProcessedCount);
-                });
-
                 // remember max selected index
                 _currentFilesList.StoreNextIndexToSelect();
 
-                bool deleteNewFiles = _currentFilesList.SelectedItems.Any(item => DeletableItem(item)) && (resetType == FormResetChanges.ActionEnum.ResetAndDelete);
-                List<string> filesInUse = new();
-                List<string> filesToReset = new();
-                List<string> conflictsToReset = new();
-                StringBuilder output = new();
-                foreach (var item in _currentFilesList.SelectedItems)
-                {
-                    if (DeletableItem(item))
-                    {
-                        if (deleteNewFiles)
-                        {
-                            try
-                            {
-                                string? path = _fullPathResolver.Resolve(item.Item.Name);
-                                if (File.Exists(path))
-                                {
-                                    File.Delete(path);
-                                }
-                                else if (Directory.Exists(path))
-                                {
-                                    Directory.Delete(path, recursive: true);
-                                }
-                            }
-                            catch (IOException)
-                            {
-                                filesInUse.Add(item.Item.Name);
-                            }
-                            catch (UnauthorizedAccessException)
-                            {
-                            }
-                        }
-                    }
+                IReadOnlyList<GitItemStatus> selectedItems = _currentFilesList.SelectedItems.Items().ToList();
+                toolStripProgressBar1.Visible = true;
+                toolStripProgressBar1.Maximum = selectedItems.Count(item => item.Staged == StagedStatus.Index);
+                toolStripProgressBar1.Value = 0;
 
-                    if (item.Item.IsRenamed)
-                    {
-                        filesToReset.Add(item.Item.OldName);
-                    }
-                    else if (item.Item.IsConflict)
-                    {
-                        conflictsToReset.Add(item.Item.Name);
-                    }
-                    else if (!item.Item.IsNew)
-                    {
-                        filesToReset.Add(item.Item.Name);
-                    }
-                }
-
-                output.Append(Module.ResetFiles(filesToReset));
-                if (conflictsToReset.Count > 0)
+                Module.ResetChanges(selectedItems, resetAndDelete: resetType == FormResetChanges.ActionEnum.ResetAndDelete, _fullPathResolver, out List<string> filesInUse, out StringBuilder output, (eventArgs) =>
                 {
-                    // Special handling for conflicted files, shown in worktree (with the raw diff).
-                    // Must be reset to HEAD as Index is just a status marker.
-                    ObjectId headId = Module.RevParse("HEAD");
-                    Module.CheckoutFiles(conflictsToReset, headId, force: false);
-                }
+                    toolStripProgressBar1.Value = Math.Min(toolStripProgressBar1.Maximum - 1, toolStripProgressBar1.Value + eventArgs.ProcessedCount);
+                });
 
                 toolStripProgressBar1.Value = toolStripProgressBar1.Maximum;
                 toolStripProgressBar1.Visible = false;

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -1309,15 +1309,7 @@ namespace GitUI.CommandsDialogs
             foreach (var name in submodules)
             {
                 GitModule module = Module.GetSubmodule(name);
-
-                // Reset all changes.
-                module.Reset(ResetMode.Hard);
-
-                // Also delete new files, if requested.
-                if (resetType == FormResetChanges.ActionEnum.ResetAndDelete)
-                {
-                    module.Clean(CleanMode.OnlyNonIgnored, directories: true);
-                }
+                module.ResetAllChanges(clean: resetType == FormResetChanges.ActionEnum.ResetAndDelete);
             }
 
             RequestRefresh();
@@ -1449,13 +1441,13 @@ namespace GitUI.CommandsDialogs
                 : $"{_firstRevision.Text}{DescribeRevision(items.FirstRevs().ToList())}";
             string confirmationMessage = string.Format(_resetSelectedChangesText.Text, revDescription);
 
-            FormResetChanges.ActionEnum resetAction = FormResetChanges.ShowResetDialog(ParentForm, hasExistingFiles, hasNewFiles, confirmationMessage);
-            if (resetAction == FormResetChanges.ActionEnum.Cancel)
+            FormResetChanges.ActionEnum resetType = FormResetChanges.ShowResetDialog(ParentForm, hasExistingFiles, hasNewFiles, confirmationMessage);
+            if (resetType == FormResetChanges.ActionEnum.Cancel)
             {
                 return;
             }
 
-            bool deleteUncommittedAddedItems = resetAction == FormResetChanges.ActionEnum.ResetAndDelete;
+            bool deleteUncommittedAddedItems = resetType == FormResetChanges.ActionEnum.ResetAndDelete;
             ResetSelectedItemsTo(resetToSelected, deleteUncommittedAddedItems);
         }
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -701,56 +701,30 @@ namespace GitUI
             return DoActionOnRepo(owner, Action, changesRepo: false);
         }
 
-        public bool StartResetChangesDialog(IWin32Window? owner = null)
-        {
-            var workTreeFiles = Module.GetWorkTreeFiles();
-            return StartResetChangesDialog(owner, workTreeFiles, false);
-        }
-
         public bool StartResetChangesDialog(IWin32Window? owner, IReadOnlyCollection<GitItemStatus> workTreeFiles, bool onlyWorkTree)
         {
             // Show a form asking the user if they want to reset the changes.
-            FormResetChanges.ActionEnum resetAction = FormResetChanges.ShowResetDialog(owner, workTreeFiles.Any(item => !item.IsNew), workTreeFiles.Any(item => item.IsNew));
+            FormResetChanges.ActionEnum resetType = FormResetChanges.ShowResetDialog(owner, hasExistingFiles: workTreeFiles.Any(item => !item.IsNew), hasNewFiles: workTreeFiles.Any(item => item.IsNew));
 
-            if (resetAction == FormResetChanges.ActionEnum.Cancel)
+            if (resetType == FormResetChanges.ActionEnum.Cancel)
             {
                 return false;
             }
 
+            return DoActionOnRepo(owner, Action);
+
             bool Action()
             {
-                if (onlyWorkTree)
-                {
-                    GitArgumentBuilder args = new("checkout")
-                    {
-                        "--",
-                        "."
-                    };
-                    Module.GitExecutable.GetOutput(args);
-                }
-                else
-                {
-                    // Reset all changes.
-                    Module.Reset(ResetMode.Hard);
-                }
-
-                if (resetAction == FormResetChanges.ActionEnum.ResetAndDelete)
-                {
-                    Module.Clean(CleanMode.OnlyNonIgnored, directories: true);
-                }
-
-                return true;
+                return Module.ResetAllChanges(clean: resetType == FormResetChanges.ActionEnum.ResetAndDelete, onlyWorkTree);
             }
-
-            return DoActionOnRepo(owner, Action);
         }
 
         private bool StartResetChangesDialog(string fileName)
         {
             // Show a form asking the user if they want to reset the changes.
-            FormResetChanges.ActionEnum resetAction = FormResetChanges.ShowResetDialog(null, true, false);
+            FormResetChanges.ActionEnum resetType = FormResetChanges.ShowResetDialog(null, hasExistingFiles: true, hasNewFiles: false);
 
-            if (resetAction == FormResetChanges.ActionEnum.Cancel)
+            if (resetType == FormResetChanges.ActionEnum.Cancel)
             {
                 return false;
             }
@@ -761,7 +735,7 @@ namespace GitUI
                 Module.ResetFile(fileName);
 
                 // Also delete new files, if requested.
-                if (resetAction == FormResetChanges.ActionEnum.ResetAndDelete)
+                if (resetType == FormResetChanges.ActionEnum.ResetAndDelete)
                 {
                     string? errorCaption = null;
                     string? errorMessage = null;

--- a/GitUI/LeftPanel/SubmoduleTree.cs
+++ b/GitUI/LeftPanel/SubmoduleTree.cs
@@ -376,15 +376,7 @@ namespace GitUI.LeftPanel
             }
 
             GitModule module = new(node.Info.Path);
-
-            // Reset all changes.
-            module.Reset(ResetMode.Hard);
-
-            // Also delete new files, if requested.
-            if (resetType == FormResetChanges.ActionEnum.ResetAndDelete)
-            {
-                module.Clean(CleanMode.OnlyNonIgnored, directories: true);
-            }
+            module.ResetAllChanges(clean: resetType == FormResetChanges.ActionEnum.ResetAndDelete);
         }
 
         public void StashSubmodule(IWin32Window owner, SubmoduleNode node)


### PR DESCRIPTION
Resolves #10899 
Resolves #10950 

## Proposed changes

Three parts:
* Refactoring to use common code to reset all changes (just git-reset is not sufficient to reset in all situations).
* Common code to reset file changes.
Note that FormCommit:ResetFilesClick() vs RevisionDiffControl:ResetSelectedItemsWithConfirmation() are not merged. They are slightly different (the first only handles reset to HEAD). They still may require alignment.
* GE command line reset [file] (and revert that really is an alias) raised warnings if new, renamed, conflicted files were selected and did not work at all if 'reset all changes' were used.

Note: This PR (together with #10956) should be included in a 4.1.1, it is one of the most common issues raised.
I thought this was fixed in other PRs, but this is a separate scenario.
(Most issues regarding this have very minimal description.)

Note: This PR does not change the behavior (except command line usage that is aligned to FormCommit). Several of my private test scenarios fail with this PR still. 
I will submit a separate PR to handle these scenarios, not necessarily for 4.1.x

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

- Rebase merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
