### PR TITLE
Select the good (or better) line when blaming from context menu

### DIFF
--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -109,8 +109,7 @@ namespace GitUI.Blame
                 return;
             }
 
-            int line = _clickedBlameLine is not null && _clickedBlameLine.Commit.ObjectId == objectId
-                ? _clickedBlameLine.OriginLineNumber
+            int line = _clickedBlameLine is not null ? _clickedBlameLine.OriginLineNumber
                 : initialLine ?? (fileName == _fileName ? BlameFile.CurrentFileLine : 1);
             _revGrid = revGrid;
             _fileName = fileName;
@@ -314,7 +313,7 @@ namespace GitUI.Blame
                 () => BlameFile.ViewTextAsync(_fileName, body));
             cancellationToken.ThrowIfCancellationRequested();
 
-            BlameFile.GoToLine(lineNumber);
+            BlameFile.GoToLine(Math.Min(lineNumber, _blame.Lines.Count));
             _clickedBlameLine = null;
 
             _blameId = revision.ObjectId;
@@ -643,6 +642,7 @@ namespace GitUI.Blame
             // Try get actual parent revision, get popup if it does not exist.
             // (The menu should be disabled if previous is not in grid).
             GitRevision? revision = _revGrid?.GetActualRevision(blameInfo.selectedRevision);
+            _clickedBlameLine = _lastBlameLine;
             BlameRevision(revision?.FirstParentId, blameInfo.filename);
         }
 

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -628,6 +628,8 @@ namespace GitUI.Blame
                 return;
             }
 
+            _clickedBlameLine = _lastBlameLine;
+
             BlameRevision(blameInfo.selectedRevision.ObjectId, blameInfo.filename);
         }
 


### PR DESCRIPTION
## Proposed changes

- select original line when blaming for "Blame this revision" to get the exact same behavior than when blaming a commit by double clicking on the line.
- try to select a better line (than the current behavior that return to the top) when using "Blame previous revision" by selecting the original line even if it is not the one of the commit we will blame because the probability that the lines are around is high.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Blame **this** revision:
#### Before

It returns to the top of the file :(
![blame_broken](https://github.com/gitextensions/gitextensions/assets/460196/16ce7af9-cf25-4184-b05f-195f609369dd)

#### After

It is located at the good line
![blame_fixed](https://github.com/gitextensions/gitextensions/assets/460196/d36711ce-4cac-4eba-8234-6bf9ec020792)
### Blame **previous** revision:
#### Before

It returns to the top of the file :(
![blame_previous_before](https://github.com/gitextensions/gitextensions/assets/460196/033dd2ca-b253-432f-835a-d1432a479a03)

#### After

It is located at a line that has a higher probability to be where the user want to end up
![blame_previous_after](https://github.com/gitextensions/gitextensions/assets/460196/0a9e5991-eb13-49bc-9395-001518785bca)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 33.33.33
- Build 37e812b77ba9b406b4b7e58cbe8db0d099c976cb
- Git 2.40.0.windows.1 (recommended: 2.40.1 or later)
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.16
- DPI 96dpi (no scaling)
- Portable: False


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
