### PR TITLE
RevDiff: Reset to HEAD for artificial

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -580,12 +580,11 @@ namespace GitUI.CommandsDialogs
         /// <returns><see langword="null"/> if not possible to reset to this revision.</returns>
         private ObjectId? GetResetId(ObjectId? resetId)
         {
-            return (resetId?.IsArtificial ?? true) ? null : resetId;
+            return (resetId?.IsArtificial is false) ? resetId : null;
         }
 
         /// <summary>
-        /// Return if this is a Index->WorkTree selection and reset to parent should be handled as Index
-        /// (artificial commits are normally handled as HEAD).
+        /// Return whether this is a Index->WorkTree selection and reset to parent should be handled as Index.
         /// </summary>
         /// <param name="selectedItems">The selected items.</param>
         /// <returns><see langword="true"/> if this is a Index->WorkTree selection.</returns>

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -569,20 +569,20 @@ namespace GitUI.CommandsDialogs
         }
 
         /// <summary>
-        /// Return if it is possible to reset to the commit, selected second.
+        /// Return if it is possible to reset to the first commit.
         /// </summary>
-        /// <param name="resetId">The selected commit it.</param>
-        /// <param name="selectedItems">The selected items.</param>
+        /// <param name="parentId">The parent commit id.</param>
+        /// <param name="selectedItems">The selected file status items.</param>
         /// <returns><see langword="true"/> if it is possible to reset to first id.</returns>
-        private bool CanResetToFirst(ObjectId? resetId, IEnumerable<FileStatusItem> selectedItems)
+        private bool CanResetToFirst(ObjectId? parentId, IEnumerable<FileStatusItem> selectedItems)
         {
-            return CanResetToSecond(resetId) || (selectedItems.SecondIds().All(i => i == ObjectId.WorkTreeId) && selectedItems.FirstIds().All(i => i == ObjectId.IndexId));
+            return CanResetToSecond(parentId) || (parentId == ObjectId.IndexId && selectedItems.SecondIds().All(i => i == ObjectId.WorkTreeId));
         }
 
         /// <summary>
-        /// Return if it is possible to reset to the commit, selected first.
+        /// Return if it is possible to reset to the second (selected) commit.
         /// </summary>
-        /// <param name="resetId">The selected commit it.</param>
+        /// <param name="resetId">The selected commit id.</param>
         /// <returns><see langword="true"/> if it is possible to reset to first id.</returns>
         private bool CanResetToSecond(ObjectId? resetId) => resetId?.IsArtificial is false;
 


### PR DESCRIPTION
## Proposed changes

First Index -> second WorkTree still reset to Index.
All other situations resetting to artificial commits will invisible menu items (and ignored).

Resetting from normal commit to Index does not mean anything
(files are already in Index).

Note: A previous version of this PR used HEAD instead of Index and WorkTreee/Combined reset to HEAD.
This introduced problems when resetting including files only in Index/Worktree, the added/removed status had to be evaluated a second time (possible but too complicated).

Related to #10960 (mentioned, separated to simplify review)
This will allow using common code in a follow up, to fix some reset issues that occur in 4.1 (so this is a candidate for 4.1.x)

Note 2: Resetting to Index is not handled correctly for Index files.
resetting in general is improved in #10980 (some more situations handled, common code). No other changes in this PR.

## Screenshots <!-- Remove this section if PR does not change UI -->

before|after
--|--
![worktree_before](https://github.com/gitextensions/gitextensions/assets/6248932/dc6ca82d-7d70-43bc-bc1b-ebc1b0e0ef2e)| same
![index_before](https://github.com/gitextensions/gitextensions/assets/6248932/7226807a-71d4-4e04-a77f-ecd5ef012fad) | ![image](https://github.com/gitextensions/gitextensions/assets/6248932/2fd0e19d-deb0-4c02-8497-1429cb4275fc)
![image](https://github.com/gitextensions/gitextensions/assets/6248932/3fda032e-9504-4e89-a3d4-26fa2577caa4) | ![image](https://github.com/gitextensions/gitextensions/assets/6248932/4d182b4d-6f99-4117-b8bc-6799e75dff2d)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
