### PR TITLE
Run ROT git-branch on worker thread

### DIFF
--- a/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -12,6 +12,7 @@ using GitUI.Script;
 using GitUI.UserControls;
 using GitUI.UserControls.RevisionGrid;
 using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Threading;
 using ResourceManager;
 
 namespace GitUI.LeftPanel
@@ -304,6 +305,7 @@ namespace GitUI.LeftPanel
                     : selectedRevision.Guid;
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
+                await TaskScheduler.Default;
                 cancellationToken.ThrowIfCancellationRequested();
                 HashSet<string> mergedBranches = selectedGuid is null
                     ? new HashSet<string>()


### PR DESCRIPTION
See https://github.com/gitextensions/gitextensions/issues/9409#issuecomment-1559668880

## Proposed changes

The left panel runs git-branch in GetMergedBranchesAsync() to update the status for branches (show separate icon for merged branches).
This command runs on the main thread.
It normally takes some hundreds ms, could be longer.
In some scenarios the UI seem to "freeze", this command may be contributing.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
