### PR TITLE
Fixup 3-revision diff with artificial

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -104,7 +104,7 @@ namespace GitUI.CommandsDialogs
                 {
                     DiffFiles.SelectStoredNextIndex();
                 }
-            });
+            }).FileAndForget();
         }
 
         #region Hotkey commands
@@ -243,7 +243,7 @@ namespace GitUI.CommandsDialogs
                 {
                     DiffFiles.SelectFirstVisibleItem();
                 }
-            });
+            }).FileAndForget();
         }
 
         /// <summary>

--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -124,15 +124,16 @@ namespace GitUI
             }
             else
             {
-                // check that the middle commit is base to the first/second
+                // Check whether the middle commit is base to the first/second
                 // Allow commits earlier to the actual base commit
-                ObjectId? testBaseRevId = GetMergeBase(firstRevHead, revisions[1].ObjectId);
-                if (testBaseRevId == revisions[1].ObjectId)
+                GitRevision middleRev = revisions[1];
+                if (!middleRev.IsArtificial)
                 {
-                    testBaseRevId = GetMergeBase(selectedRevHead, revisions[1].ObjectId);
-                    if (testBaseRevId == revisions[1].ObjectId)
+                    ObjectId middleId = middleRev.ObjectId;
+                    if (GetMergeBase(firstRevHead, middleId) == middleId
+                        && GetMergeBase(selectedRevHead, middleId) == middleId)
                     {
-                        baseRevId = testBaseRevId;
+                        baseRevId = middleId;
                     }
                 }
             }

--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -126,15 +126,12 @@ namespace GitUI
             {
                 // Check whether the middle commit is base to the first/second
                 // Allow commits earlier to the actual base commit
-                GitRevision middleRev = revisions[1];
-                if (!middleRev.IsArtificial)
+                ObjectId middleId = revisions[1].ObjectId;
+                if (!middleId.IsArtificial
+                    && GetMergeBase(firstRevHead, middleId) == middleId
+                    && GetMergeBase(selectedRevHead, middleId) == middleId)
                 {
-                    ObjectId middleId = middleRev.ObjectId;
-                    if (GetMergeBase(firstRevHead, middleId) == middleId
-                        && GetMergeBase(selectedRevHead, middleId) == middleId)
-                    {
-                        baseRevId = middleId;
-                    }
+                    baseRevId = middleId;
                 }
             }
 


### PR DESCRIPTION
## Proposed changes

- FileStatusDiffCalculator: Do not attempt to detect artificial commit as base commit
- RevisionDiffControl: Fixup silent exceptions from `SetDiffsAsync`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/36601201/28be26e3-7be9-4ed1-86e6-daaf6a895be9)

### After

![image](https://github.com/gitextensions/gitextensions/assets/36601201/2a3abcd0-b16a-4e15-bc2b-89ec5c3bbc74)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).