### PR TITLE
FileStatusList: No group for diff to commit with untracked files of a stash

### DIFF
--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -65,10 +65,12 @@ namespace GitUI
                 else
                 {
                     // Get the parents for the selected revision
-                    var multipleParents = actualRev.ParentIds is null ? 0 : AppSettings.ShowDiffForAllParents ? actualRev.ParentIds.Count : 1;
+                    // Exclude the group with the diff to the orphan commit containing the untracked files of a stash
+                    int multipleParents = actualRev.ParentIds is null ? 0 : AppSettings.ShowDiffForAllParents ? actualRev.ParentIds.Count : 1;
                     fileStatusDescs.AddRange(actualRev
                         .ParentIds
                         .Take(multipleParents)
+                        .Where(parentId => DescribeRevision is null || !DescribeRevision(parentId).Contains(": untracked files on "))
                         .Select(parentId =>
                             new FileStatusWithDescription(
                                 firstRev: new GitRevision(parentId),

--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -65,12 +65,12 @@ namespace GitUI
                 else
                 {
                     // Get the parents for the selected revision
-                    // Exclude the group with the diff to the orphan commit containing the untracked files of a stash
+                    // Exclude the optional third group with the diff to the orphan commit containing the untracked files of a stash
                     int multipleParents = actualRev.ParentIds is null ? 0 : AppSettings.ShowDiffForAllParents ? actualRev.ParentIds.Count : 1;
                     fileStatusDescs.AddRange(actualRev
                         .ParentIds
                         .Take(multipleParents)
-                        .Where(parentId => DescribeRevision is null || !DescribeRevision(parentId).Contains(": untracked files on "))
+                        .Where(parentId => !(multipleParents == 3 && DescribeRevision?.Invoke(parentId).Contains(": untracked files on ") is true))
                         .Select(parentId =>
                             new FileStatusWithDescription(
                                 firstRev: new GitRevision(parentId),


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10991

## Proposed changes

- FileStatusList: Do not create a group for diff to stash untracked
  because it contains all(!) files of the repo as added files

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![grafik](https://github.com/gitextensions/gitextensions/assets/36601201/c1e73910-7a12-4477-adf6-86df21eee86a)  ![grafik](https://github.com/gitextensions/gitextensions/assets/36601201/88b84fc1-9aac-424a-8acf-73fa0f1673bb)

### After

with #11018
![image](https://github.com/gitextensions/gitextensions/assets/36601201/3baa50d3-ce77-420a-a228-0d222223d949)

### The omitted diff made visible by selecting both commits

![image](https://github.com/gitextensions/gitextensions/assets/36601201/64af71ea-8ffb-48ab-841c-992e44b9f231)
![image](https://github.com/gitextensions/gitextensions/assets/36601201/8158d691-65cd-4600-b84d-61e35bc11062)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).