### PR TITLE
FileStatusList: Always show diff groups if multiple groups although empty

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -994,7 +994,8 @@ namespace GitUI
 
         private void UpdateFileStatusListView(bool updateCausedByFilter = false)
         {
-            if (!GitItemStatuses.Any())
+            bool hasChangesOrMultipleGroups = GitItemStatusesWithDescription.Count > 1 || GitItemStatusesWithDescription.Any(x => x.Statuses.Count > 0);
+            if (!hasChangesOrMultipleGroups)
             {
                 HandleVisibility_NoFilesLabel_FilterComboBox(filesPresent: false);
             }
@@ -1020,8 +1021,6 @@ namespace GitUI
             FileStatusListView.Groups.Clear();
             FileStatusListView.Items.Clear();
 
-            bool hasChanges = GitItemStatusesWithDescription.Any(x => x.Statuses.Count > 0);
-
             List<ListViewItem> list = new();
             foreach (var i in GitItemStatusesWithDescription)
             {
@@ -1039,7 +1038,7 @@ namespace GitUI
                 FileStatusListView.Groups.Add(group);
 
                 IReadOnlyList<GitItemStatus> itemStatuses;
-                if (hasChanges && i.Statuses.Count == 0)
+                if (hasChangesOrMultipleGroups && i.Statuses.Count == 0)
                 {
                     itemStatuses = _noItemStatuses;
                     if (group is not null)


### PR DESCRIPTION
Contributes to #10991

## Proposed changes

- FileStatusList: Always show diff groups if multiple groups although empty 

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/36601201/586ce4b8-20bc-46b5-b164-cc2b3fad65dd)

### After

![image](https://github.com/gitextensions/gitextensions/assets/36601201/3baa50d3-ce77-420a-a228-0d222223d949)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).