### PR TITLE
Treat vertical tab (Shift-Enter) as line feed

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -318,6 +318,7 @@ namespace GitCommands
 
             // Finally, decode the names, email, subject and body strings using the required text encoding
             // Handle '\v' (Shift-Enter) as '\n' for users that by habit avoid Enter to 'send'
+            // Handle '\v' (Shift-Enter) as '\n' for users that by habit avoid Enter to 'send'
             ReadOnlySpan<char> s = _logOutputEncoding.GetString(array[offset..]).Replace('\v', '\n').AsSpan();
             StringLineReader reader = new(in s);
 

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -317,7 +317,7 @@ namespace GitCommands
             #region Encoded string values (names, emails, subject, body)
 
             // Finally, decode the names, email, subject and body strings using the required text encoding
-            ReadOnlySpan<char> s = _logOutputEncoding.GetString(array[offset..]).AsSpan();
+            ReadOnlySpan<char> s = _logOutputEncoding.GetString(array[offset..]).Replace('\v', '\n').AsSpan();
             StringLineReader reader = new(in s);
 
             var author = reader.ReadLine();

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -317,6 +317,7 @@ namespace GitCommands
             #region Encoded string values (names, emails, subject, body)
 
             // Finally, decode the names, email, subject and body strings using the required text encoding
+            // Handle '\v' (Shift-Enter) as '\n' for users that by habit avoid Enter to 'send'
             ReadOnlySpan<char> s = _logOutputEncoding.GetString(array[offset..]).Replace('\v', '\n').AsSpan();
             StringLineReader reader = new(in s);
 

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -729,13 +729,23 @@ namespace GitUI.SpellChecker
                 return;
             }
 
+            // handle vertical tab (Shift + Enter)
+            if (e.Shift && e.KeyCode == Keys.Enter)
+            {
+                AddNewLine();
+                e.Handled = true;
+                return;
+            }
+
             OnKeyDown(e);
         }
 
         private void PasteTextFromClipboard()
         {
-            // insert only text
-            TextBox.Paste(DataFormats.GetFormat(DataFormats.UnicodeText));
+            // insert only text with replace vertical tab to line feed
+            string clipboardText = Clipboard.GetText().Replace('\v', '\n');
+
+            TextBox.SelectedText = clipboardText;
         }
 
         private void TextBox_KeyPress(object sender, KeyPressEventArgs e)
@@ -950,6 +960,11 @@ namespace GitUI.SpellChecker
             TextBox.Select(TextBox.SelectionStart - word.Length, word.Length);
             TextBox.SelectedText = completionWord.Word;
             CloseAutoComplete();
+        }
+
+        private void AddNewLine()
+        {
+            TextBox.SelectedText = "\n";
         }
 
         private void UpdateOrShowAutoComplete(bool calledByUser)

--- a/contributors.txt
+++ b/contributors.txt
@@ -193,3 +193,4 @@ YYYY/MM/DD, github id, Full name, email
 2023/03/08, RemiGaudin, Rémi Gaudin, remi.gaudin(at)gmail.com
 2023/04/27, montoner0, Alex Bogush, inmate66+gitext(@t)gmail.com
 2023/05/31, SimonCropp, Simon Cropp, simon.cropp@gmail.com
+2023/05/02, michalkress, Michał Kress, michal.kress@gmail.com


### PR DESCRIPTION
Shift Enter is replace to normal enter in revision list.

Fixes https://github.com/gitextensions/gitextensions/issues/10724

## Proposed changes

- When using Shift+Enter in a commit message instead of Enter, it causes garbled characters to be displayed in the list. The simple solution to this problem is to replace Shift+Enter with Enter, which allows for proper visual rendering without altering the commit history.

## Screenshots

### Before

![image](https://github.com/gitextensions/gitextensions/assets/19835872/319d0f82-11c3-4983-bac7-8533601caf67)

### After

![image](https://github.com/gitextensions/gitextensions/assets/19835872/2c73f39a-6855-4552-b7c2-4e817af7431a)

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
