### PR TITLE
Wrap RevisionGrid access in IRevisionGrid/IRevisionGridUpdate

### DIFF
--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -9,6 +9,7 @@ using GitCommands;
 using GitCommands.Config;
 using GitCommands.Remotes;
 using GitCommands.Settings;
+using GitUI.CommandDialogs;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;
 using GitUI.HelperDialogs;
 using GitUI.UserControls;
@@ -28,6 +29,7 @@ namespace GitUI.BuildServerIntegration
         private readonly object _buildServerCredentialsLock = new();
         private readonly RevisionGridControl _revisionGrid;
         private readonly RevisionDataGridView _revisionGridView;
+        private readonly IRevisionGridInfo _revisionGridInfo;
         private readonly Func<GitModule> _module;
         private readonly IRepoNameExtractor _repoNameExtractor;
         private IDisposable? _buildStatusCancellationToken;
@@ -36,10 +38,11 @@ namespace GitUI.BuildServerIntegration
 
         internal BuildStatusColumnProvider ColumnProvider { get; }
 
-        public BuildServerWatcher(RevisionGridControl revisionGrid, RevisionDataGridView revisionGridView, Func<GitModule> module)
+        public BuildServerWatcher(RevisionGridControl revisionGrid, RevisionDataGridView revisionGridView, IRevisionGridInfo revisionGridInfo, Func<GitModule> module)
         {
             _revisionGrid = revisionGrid;
             _revisionGridView = revisionGridView;
+            _revisionGridInfo = revisionGridInfo;
             _module = module;
 
             _repoNameExtractor = new RepoNameExtractor(_module);
@@ -350,7 +353,7 @@ namespace GitUI.BuildServerIntegration
                             {
                                 _revisionGrid.UICommands.StartSettingsDialog(typeof(BuildServerIntegrationSettingsPage));
                             }));
-                        }, objectId => _revisionGrid.GetRevision(objectId) is not null);
+                        }, objectId => _revisionGridInfo.GetRevision(objectId) is not null);
                     return buildServerAdapter;
                 }
                 catch (InvalidOperationException ex)

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
@@ -1,5 +1,6 @@
 ﻿using GitCommands.Git;
 using GitCommands.Git.Commands;
+using GitUI.CommandDialogs;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -12,7 +13,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         private readonly TranslationString _bisectStart =
             new("Mark selected revisions as start bisect range?");
 
-        private readonly RevisionGridControl _revisionGrid;
+        private readonly IRevisionGridInfo _revisionGridInfo;
 
         [Obsolete("For VS designer and translation test only. Do not remove.")]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -25,7 +26,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         public FormBisect(RevisionGridControl revisionGrid)
             : base(revisionGrid.UICommands)
         {
-            _revisionGrid = revisionGrid;
+            _revisionGridInfo = revisionGrid;
             InitializeComponent();
             InitializeComplete();
             UpdateButtonsState();
@@ -47,7 +48,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             UpdateButtonsState();
 
-            var revisions = _revisionGrid.GetSelectedRevisions();
+            var revisions = _revisionGridInfo.GetSelectedRevisions();
             if (revisions.Count > 1)
             {
                 if (MessageBox.Show(this, _bisectStart.Text, Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)

--- a/GitUI/CommandsDialogs/FormBlame.cs
+++ b/GitUI/CommandsDialogs/FormBlame.cs
@@ -33,7 +33,7 @@ namespace GitUI.CommandsDialogs
 
             FileName = fileName;
 
-            _ = blameControl1.LoadBlameAsync(revision ?? Module.GetRevision(), null, fileName, null, null, Module.FilesEncoding, initialLine);
+            _ = blameControl1.LoadBlameAsync(revision ?? Module.GetRevision(), children: null, fileName, revisionGridInfo: null, revisionGridUpdate: null, controlToMask: null, Module.FilesEncoding, initialLine);
             blameControl1.ConfigureRepositoryHostPlugin(PluginRegistry.TryGetGitHosterForModule(Module));
         }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -327,11 +327,11 @@ namespace GitUI.CommandsDialogs
 
             _aheadBehindDataProvider = new AheadBehindDataProvider(() => Module.GitExecutable);
             toolStripButtonPush.Initialize(_aheadBehindDataProvider);
-            repoObjectsTree.Initialize(_aheadBehindDataProvider, filterRevisionGridBySpaceSeparatedRefs: ToolStripFilters.SetBranchFilter, RevisionGrid, RevisionGrid, RevisionGrid);
-            revisionDiff.Bind(RevisionGrid, fileTree, RefreshGitStatusMonitor);
+            repoObjectsTree.Initialize(_aheadBehindDataProvider, filterRevisionGridBySpaceSeparatedRefs: ToolStripFilters.SetBranchFilter, refsSource: RevisionGrid, revisionGridInfo: RevisionGrid, scriptRunner: RevisionGrid);
+            revisionDiff.Bind(revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, revisionFileTree: fileTree, filterInfo: RevisionGrid.CurrentFilter, RefreshGitStatusMonitor);
 
             // Show blame by default if not started from command line
-            fileTree.Bind(RevisionGrid, RefreshGitStatusMonitor, _isFileBlameHistory);
+            fileTree.Bind(revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, RefreshGitStatusMonitor, _isFileBlameHistory);
             RevisionGrid.ResumeRefreshRevisions();
 
             // Application is init, the repo related operations are triggered in OnLoad()

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -328,7 +328,7 @@ namespace GitUI.CommandsDialogs
             _aheadBehindDataProvider = new AheadBehindDataProvider(() => Module.GitExecutable);
             toolStripButtonPush.Initialize(_aheadBehindDataProvider);
             repoObjectsTree.Initialize(_aheadBehindDataProvider, filterRevisionGridBySpaceSeparatedRefs: ToolStripFilters.SetBranchFilter, refsSource: RevisionGrid, revisionGridInfo: RevisionGrid, scriptRunner: RevisionGrid);
-            revisionDiff.Bind(revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, revisionFileTree: fileTree, filterInfo: RevisionGrid.CurrentFilter, RefreshGitStatusMonitor);
+            revisionDiff.Bind(revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, revisionFileTree: fileTree, () => RevisionGrid.CurrentFilter.PathFilter, RefreshGitStatusMonitor);
 
             // Show blame by default if not started from command line
             fileTree.Bind(revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, RefreshGitStatusMonitor, _isFileBlameHistory);

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -333,7 +333,7 @@ namespace GitUI.CommandsDialogs
 
             if (tabControl1.SelectedTab == BlameTab)
             {
-                _ = Blame.LoadBlameAsync(revision, children, fileName, RevisionGrid, BlameTab, Diff.Encoding, force: force, cancellationToken: _viewChangesSequence.Next());
+                _ = Blame.LoadBlameAsync(revision, children, fileName, revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, controlToMask: BlameTab, Diff.Encoding, force: force, cancellationToken: _viewChangesSequence.Next());
             }
             else if (tabControl1.SelectedTab == ViewTab)
             {

--- a/GitUI/CommandsDialogs/IRevisionGridInfo.cs
+++ b/GitUI/CommandsDialogs/IRevisionGridInfo.cs
@@ -1,10 +1,17 @@
-﻿using GitUIPluginInterfaces;
+﻿using GitUI.UserControls.RevisionGrid;
+using GitUIPluginInterfaces;
 
 namespace GitUI.CommandDialogs
 {
     public interface IRevisionGridInfo
     {
+        ObjectId? CurrentCheckout { get; }
+        GitRevision GetRevision(ObjectId objectId);
+        GitRevision? GetActualRevision(ObjectId objectId);
+        GitRevision GetActualRevision(GitRevision revision);
         IReadOnlyList<GitRevision> GetSelectedRevisions();
+        string DescribeRevision(GitRevision revision, int maxLength = 0);
         string GetCurrentBranch();
+        ////FilterInfo CurrentFilter { get; }
     }
 }

--- a/GitUI/CommandsDialogs/IRevisionGridInfo.cs
+++ b/GitUI/CommandsDialogs/IRevisionGridInfo.cs
@@ -12,6 +12,5 @@ namespace GitUI.CommandDialogs
         IReadOnlyList<GitRevision> GetSelectedRevisions();
         string DescribeRevision(GitRevision revision, int maxLength = 0);
         string GetCurrentBranch();
-        ////FilterInfo CurrentFilter { get; }
     }
 }

--- a/GitUI/CommandsDialogs/IRevisionGridInfo.cs
+++ b/GitUI/CommandsDialogs/IRevisionGridInfo.cs
@@ -1,0 +1,10 @@
+﻿using GitUIPluginInterfaces;
+
+namespace GitUI.CommandDialogs
+{
+    public interface IRevisionGridInfo
+    {
+        IReadOnlyList<GitRevision> GetSelectedRevisions();
+        string GetCurrentBranch();
+    }
+}

--- a/GitUI/CommandsDialogs/IRevisionGridUpdate.cs
+++ b/GitUI/CommandsDialogs/IRevisionGridUpdate.cs
@@ -1,0 +1,9 @@
+﻿using GitUIPluginInterfaces;
+
+namespace GitUI.CommandDialogs
+{
+    public interface IRevisionGridUpdate
+    {
+        bool SetSelectedRevision(ObjectId? objectId, bool toggleSelection = false, bool updateNavigationHistory = true);
+    }
+}

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -575,6 +575,8 @@ namespace GitUI.CommandsDialogs
         /// <returns>a task</returns>
         private async Task ShowSelectedFileDiffAsync(bool ensureNoSwitchToFilter, int? line)
         {
+            Validates.NotNull(_pathFilter);
+
             BlameControl.Visible = false;
             DiffText.Visible = true;
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -32,7 +32,7 @@ namespace GitUI.CommandsDialogs
 
         private IRevisionGridInfo? _revisionGridInfo;
         private IRevisionGridUpdate? _revisionGridUpdate;
-        private FilterInfo? _filterInfo;
+        private Func<string>? _pathFilter;
         private RevisionFileTreeControl? _revisionFileTree;
         private readonly IRevisionDiffController _revisionDiffController = new RevisionDiffController();
         private readonly IFileStatusListContextMenuController _revisionDiffContextMenuController;
@@ -304,12 +304,12 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        public void Bind(IRevisionGridInfo revisionGridInfo, IRevisionGridUpdate revisionGridUpdate, RevisionFileTreeControl revisionFileTree, FilterInfo filterInfo, Action? refreshGitStatus)
+        public void Bind(IRevisionGridInfo revisionGridInfo, IRevisionGridUpdate revisionGridUpdate, RevisionFileTreeControl revisionFileTree, Func<string>? pathFilter, Action? refreshGitStatus)
         {
             _revisionGridInfo = revisionGridInfo;
             _revisionGridUpdate = revisionGridUpdate;
             _revisionFileTree = revisionFileTree;
-            _filterInfo = filterInfo;
+            _pathFilter = pathFilter;
             _refreshGitStatus = refreshGitStatus;
             DiffFiles.Bind(objectId => DescribeRevision(objectId), _revisionGridInfo.GetActualRevision);
         }
@@ -587,7 +587,7 @@ namespace GitUI.CommandsDialogs
             await DiffText.ViewChangesAsync(DiffFiles.SelectedItem,
                 line: line,
                 openWithDiffTool: () => firstToSelectedToolStripMenuItem.PerformClick(),
-                additionalCommandInfo: (DiffFiles.SelectedItem?.Item?.IsRangeDiff is true) && Module.GitVersion.SupportRangeDiffPath ? _filterInfo.PathFilter : "",
+                additionalCommandInfo: (DiffFiles.SelectedItem?.Item?.IsRangeDiff is true) && Module.GitVersion.SupportRangeDiffPath ? _pathFilter() : "",
                 cancellationToken: _viewChangesSequence.Next());
         }
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -4,6 +4,7 @@ using GitCommands;
 using GitCommands.Git;
 using GitExtUtils;
 using GitExtUtils.GitUI;
+using GitUI.CommandDialogs;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.Hotkey;
 using GitUI.Properties;
@@ -49,7 +50,8 @@ See the changes in the commit form.");
         private readonly RememberFileContextMenuController _rememberFileContextMenuController
             = RememberFileContextMenuController.Default;
         private Action? _refreshGitStatus;
-        private RevisionGridControl? _revisionGrid;
+        private IRevisionGridInfo? _revisionGridInfo;
+        private IRevisionGridUpdate? _revisionGridUpdate;
         private readonly CancellationTokenSequence _viewBlameSequence = new();
 
         public RevisionFileTreeControl()
@@ -67,9 +69,10 @@ See the changes in the commit form.");
             copyPathsToolStripMenuItem.Initialize(() => UICommands, () => new string[] { (tvGitTree.SelectedNode?.Tag as GitItem)?.FileName });
         }
 
-        public void Bind(RevisionGridControl revisionGrid, Action? refreshGitStatus, bool isBlame)
+        public void Bind(IRevisionGridInfo revisionGridInfo, IRevisionGridUpdate revisionGridUpdate, Action? refreshGitStatus, bool isBlame)
         {
-            _revisionGrid = revisionGrid;
+            _revisionGridInfo = revisionGridInfo;
+            _revisionGridUpdate = revisionGridUpdate;
             _refreshGitStatus = refreshGitStatus;
             blameToolStripMenuItem1.Checked = isBlame;
         }
@@ -440,7 +443,7 @@ See the changes in the commit form.");
 
                         FileText.Visible = false;
                         BlameControl.Visible = true;
-                        return BlameControl.LoadBlameAsync(_revision, children: null, gitItem.FileName, _revisionGrid, controlToMask: null, FileText.Encoding, line, cancellationToken: _viewBlameSequence.Next());
+                        return BlameControl.LoadBlameAsync(_revision, children: null, gitItem.FileName, _revisionGridInfo, _revisionGridUpdate, controlToMask: null, FileText.Encoding, line, cancellationToken: _viewBlameSequence.Next());
                     }
 
                 case GitObjectType.Commit:

--- a/GitUI/LeftPanel/LocalBranchTree.cs
+++ b/GitUI/LeftPanel/LocalBranchTree.cs
@@ -1,4 +1,5 @@
 ﻿using GitCommands.Git;
+using GitUI.CommandDialogs;
 using GitUI.Script;
 using GitUI.UserControls.RevisionGrid;
 using GitUIPluginInterfaces;
@@ -9,13 +10,13 @@ namespace GitUI.LeftPanel
     internal sealed class LocalBranchTree : BaseRefTree
     {
         private readonly IAheadBehindDataProvider? _aheadBehindDataProvider;
-        private readonly IScriptHostControl _scriptHost;
+        private readonly IRevisionGridInfo _revisionGridInfo;
 
-        public LocalBranchTree(TreeNode treeNode, IGitUICommandsSource uiCommands, IAheadBehindDataProvider? aheadBehindDataProvider, ICheckRefs refsSource, IScriptHostControl scriptHost)
+        public LocalBranchTree(TreeNode treeNode, IGitUICommandsSource uiCommands, IAheadBehindDataProvider? aheadBehindDataProvider, ICheckRefs refsSource, IRevisionGridInfo revisionGridInfo)
             : base(treeNode, uiCommands, refsSource, RefsFilter.Heads)
         {
             _aheadBehindDataProvider = aheadBehindDataProvider;
-            _scriptHost = scriptHost;
+            _revisionGridInfo = revisionGridInfo;
         }
 
         protected override Nodes FillTree(IReadOnlyList<IGitRef> branches, CancellationToken token)
@@ -52,7 +53,7 @@ namespace GitUI.LeftPanel
 
             Nodes nodes = new(this);
             var aheadBehindData = _aheadBehindDataProvider?.GetData();
-            string currentBranch = _scriptHost.GetCurrentBranch();
+            string currentBranch = _revisionGridInfo.GetCurrentBranch();
             Dictionary<string, BaseRevisionNode> pathToNode = new();
             foreach (IGitRef branch in PrioritizedBranches(branches))
             {

--- a/GitUI/LeftPanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.ContextActions.cs
@@ -122,7 +122,7 @@ namespace GitUI.LeftPanel
 
         private void RegisterContextActions()
         {
-            copyContextMenuItem.SetRevisionFunc(() => _scriptHost.GetSelectedRevisions());
+            copyContextMenuItem.SetRevisionFunc(() => _revisionGridInfo.GetSelectedRevisions());
 
             // Filter for selected
             filterForSelectedRefsMenuItem.ToolTipText = "Filter the revision grid to show selected (underlined) refs (branches and tags) only." +

--- a/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -5,6 +5,7 @@ using GitCommands;
 using GitCommands.Git;
 using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
+using GitUI.CommandDialogs;
 using GitUI.CommandsDialogs;
 using GitUI.Hotkey;
 using GitUI.Properties;
@@ -37,7 +38,7 @@ namespace GitUI.LeftPanel
         private IAheadBehindDataProvider? _aheadBehindDataProvider;
         private bool _searchCriteriaChanged;
         private ICheckRefs _refsSource;
-        private IScriptHostControl _scriptHost;
+        private IRevisionGridInfo _revisionGridInfo;
         private IRunScript _scriptRunner;
 
         public RepoObjectsTree()
@@ -222,12 +223,12 @@ namespace GitUI.LeftPanel
         }
 
         public void Initialize(IAheadBehindDataProvider? aheadBehindDataProvider, Action<string?> filterRevisionGridBySpaceSeparatedRefs,
-            ICheckRefs refsSource, IScriptHostControl scriptHost, IRunScript scriptRunner)
+            ICheckRefs refsSource, IRevisionGridInfo revisionGridInfo, IRunScript scriptRunner)
         {
             _aheadBehindDataProvider = aheadBehindDataProvider;
             _filterRevisionGridBySpaceSeparatedRefs = filterRevisionGridBySpaceSeparatedRefs;
             _refsSource = refsSource;
-            _scriptHost = scriptHost;
+            _revisionGridInfo = revisionGridInfo;
             _scriptRunner = scriptRunner;
 
             // This lazily sets the command source, invoking OnUICommandsSourceSet, which is required for setting up
@@ -366,7 +367,7 @@ namespace GitUI.LeftPanel
                 SelectedImageKey = nameof(Images.BranchLocalRoot)
             };
 
-            _branchesTree = new LocalBranchTree(rootNode, UICommandsSource, _aheadBehindDataProvider, _refsSource, _scriptHost);
+            _branchesTree = new LocalBranchTree(rootNode, UICommandsSource, _aheadBehindDataProvider, _refsSource, _revisionGridInfo);
         }
 
         private void CreateRemotes()

--- a/GitUI/Script/IScriptHostControl.cs
+++ b/GitUI/Script/IScriptHostControl.cs
@@ -4,10 +4,8 @@ namespace GitUI.Script
 {
     public interface IScriptHostControl
     {
-        GitRevision GetCurrentRevision();
         GitRevision? GetLatestSelectedRevision();
         IReadOnlyList<GitRevision> GetSelectedRevisions();
         Point GetQuickItemSelectorLocation();
-        string GetCurrentBranch();
     }
 }

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -5,6 +5,7 @@ using GitCommands;
 using GitExtUtils;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Avatars;
+using GitUI.CommandDialogs;
 using GitUI.Editor;
 using GitUI.HelperDialogs;
 using GitUI.Properties;
@@ -31,7 +32,8 @@ namespace GitUI.Blame
         private GitBlameLine? _clickedBlameLine;
         private GitBlameCommit? _highlightedCommit;
         private GitBlame? _blame;
-        private RevisionGridControl? _revGrid;
+        private IRevisionGridInfo? _revisionGridInfo;
+        private IRevisionGridUpdate? _revisionGridUpdate;
         private ObjectId? _blameId;
         private string? _fileName;
         private Encoding? _encoding;
@@ -94,12 +96,12 @@ namespace GitUI.Blame
             CommitInfo.CommandClicked -= commitInfo_CommandClicked;
         }
 
-        public async Task LoadBlameAsync(GitRevision revision, IReadOnlyList<ObjectId>? children, string fileName, RevisionGridControl? revGrid, Control? controlToMask, Encoding encoding, int? initialLine = null, bool force = false, CancellationToken cancellationToken = default)
+        public async Task LoadBlameAsync(GitRevision revision, IReadOnlyList<ObjectId>? children, string fileName, IRevisionGridInfo? revisionGridInfo, IRevisionGridUpdate? revisionGridUpdate, Control? controlToMask, Encoding encoding, int? initialLine = null, bool force = false, CancellationToken cancellationToken = default)
         {
             ObjectId objectId = revision.ObjectId;
 
             // refresh only when something changed
-            if (!force && objectId == _blameId && fileName == _fileName && revGrid == _revGrid && encoding == _encoding)
+            if (!force && objectId == _blameId && fileName == _fileName && revisionGridInfo == _revisionGridInfo && _revisionGridUpdate == revisionGridUpdate && encoding == _encoding)
             {
                 if (initialLine is not null)
                 {
@@ -111,7 +113,8 @@ namespace GitUI.Blame
 
             int line = _clickedBlameLine is not null ? _clickedBlameLine.OriginLineNumber
                 : initialLine ?? (fileName == _fileName ? BlameFile.CurrentFileLine : 1);
-            _revGrid = revGrid;
+            _revisionGridInfo = revisionGridInfo;
+            _revisionGridUpdate = revisionGridUpdate;
             _fileName = fileName;
             _encoding = encoding;
 
@@ -257,7 +260,7 @@ namespace GitUI.Blame
 
             _lastBlameLine = newBlameLine;
             ObjectId objectId = _lastBlameLine.Commit.ObjectId;
-            CommitInfo.Revision = _revGrid is null ? Module.GetRevision(objectId) : _revGrid.GetActualRevision(objectId);
+            CommitInfo.Revision = _revisionGridInfo is null ? Module.GetRevision(objectId) : _revisionGridInfo.GetActualRevision(objectId);
         }
 
         private void BlameAuthor_HScrollPositionChanged(object sender, EventArgs e)
@@ -507,7 +510,7 @@ namespace GitUI.Blame
             }
 
             ObjectId selectedId = _lastBlameLine.Commit.ObjectId;
-            if (_revGrid is null)
+            if (_revisionGridUpdate is null)
             {
                 using FormCommitDiff frm = new(UICommands, selectedId);
                 frm.ShowDialog(this);
@@ -515,7 +518,7 @@ namespace GitUI.Blame
             }
 
             _clickedBlameLine = _lastBlameLine;
-            if (!_revGrid.SetSelectedRevision(selectedId))
+            if (!_revisionGridUpdate.SetSelectedRevision(selectedId))
             {
                 MessageBoxes.RevisionFilteredInGrid(this, selectedId);
             }
@@ -562,8 +565,8 @@ namespace GitUI.Blame
             // The menu will be slightly slower in this situation.
             bool RevisionHasParent(GitRevision? selectedRevision)
             {
-                GitRevision actualRevision = _revGrid?.GetActualRevision(selectedRevision);
-                return (actualRevision?.HasParent ?? false) && (_revGrid?.GetRevision(actualRevision?.FirstParentId) is not null);
+                GitRevision actualRevision = _revisionGridInfo?.GetActualRevision(selectedRevision);
+                return (actualRevision?.HasParent ?? false) && (_revisionGridInfo?.GetRevision(actualRevision?.FirstParentId) is not null);
             }
         }
 
@@ -616,7 +619,7 @@ namespace GitUI.Blame
                 return false;
             }
 
-            blameInfo = (_revGrid?.GetRevision(blameCommit.ObjectId), blameCommit.FileName);
+            blameInfo = (_revisionGridInfo?.GetRevision(blameCommit.ObjectId), blameCommit.FileName);
             return blameInfo.selectedRevision is not null;
         }
 
@@ -641,7 +644,7 @@ namespace GitUI.Blame
 
             // Try get actual parent revision, get popup if it does not exist.
             // (The menu should be disabled if previous is not in grid).
-            GitRevision? revision = _revGrid?.GetActualRevision(blameInfo.selectedRevision);
+            GitRevision? revision = _revisionGridInfo?.GetActualRevision(blameInfo.selectedRevision);
             _clickedBlameLine = _lastBlameLine;
             BlameRevision(revision?.FirstParentId, blameInfo.filename);
         }
@@ -653,10 +656,10 @@ namespace GitUI.Blame
         /// <param name="filename">the relative path of the file to blame in this commit (because it could have been renamed)</param>
         private void BlameRevision(ObjectId? revisionId, string filename)
         {
-            if (_revGrid is not null)
+            if (_revisionGridUpdate is not null)
             {
                 PathToBlame = filename;
-                if (!_revGrid.SetSelectedRevision(revisionId))
+                if (!_revisionGridUpdate.SetSelectedRevision(revisionId))
                 {
                     MessageBoxes.RevisionFilteredInGrid(this, revisionId);
                 }

--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -20,17 +20,15 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         private static readonly int NodeDimension = DpiUtil.Scale(10);
 
         private readonly LaneInfoProvider _laneInfoProvider;
-        private readonly RevisionGridControl _grid;
         private readonly RevisionGraph _revisionGraph;
         private readonly GraphCache _graphCache = new();
 
         private RevisionGraphDrawStyleEnum _revisionGraphDrawStyleCache;
         private RevisionGraphDrawStyleEnum _revisionGraphDrawStyle;
 
-        public RevisionGraphColumnProvider(RevisionGridControl grid, RevisionGraph revisionGraph, IGitRevisionSummaryBuilder gitRevisionSummaryBuilder)
+        public RevisionGraphColumnProvider(RevisionGraph revisionGraph, IGitRevisionSummaryBuilder gitRevisionSummaryBuilder)
             : base("Graph")
         {
-            _grid = grid;
             _revisionGraph = revisionGraph;
             _laneInfoProvider = new LaneInfoProvider(new LaneNodeLocator(_revisionGraph), gitRevisionSummaryBuilder);
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -53,7 +53,7 @@ namespace GitUI
     }
 
     [DefaultEvent("DoubleClick")]
-    public sealed partial class RevisionGridControl : GitModuleControl, IScriptHostControl, ICheckRefs, IRunScript, IRevisionGridFilter, IRevisionGridInfo
+    public sealed partial class RevisionGridControl : GitModuleControl, IScriptHostControl, ICheckRefs, IRunScript, IRevisionGridFilter, IRevisionGridInfo, IRevisionGridUpdate
     {
         public event EventHandler<DoubleClickRevisionEventArgs>? DoubleClickRevision;
         public event EventHandler<FilterChangedEventArgs>? FilterChanged;
@@ -236,10 +236,10 @@ namespace GitUI
             _gridView.DragEnter += OnGridViewDragEnter;
             _gridView.DragDrop += OnGridViewDragDrop;
 
-            _buildServerWatcher = new BuildServerWatcher(this, _gridView, () => Module);
+            _buildServerWatcher = new BuildServerWatcher(revisionGrid: this, _gridView, revisionGridInfo: this, () => Module);
 
             GitRevisionSummaryBuilder gitRevisionSummaryBuilder = new();
-            _revisionGraphColumnProvider = new RevisionGraphColumnProvider(this, _gridView._revisionGraph, gitRevisionSummaryBuilder);
+            _revisionGraphColumnProvider = new RevisionGraphColumnProvider(_gridView._revisionGraph, gitRevisionSummaryBuilder);
             _gridView.AddColumn(_revisionGraphColumnProvider);
             _gridView.AddColumn(new MessageColumnProvider(this, gitRevisionSummaryBuilder));
             _gridView.AddColumn(new AvatarColumnProvider(_gridView, AvatarService.DefaultProvider, AvatarService.CacheCleaner));
@@ -3096,6 +3096,7 @@ namespace GitUI
         IReadOnlyList<GitRevision> IRevisionGridInfo.GetSelectedRevisions()
             => GetSelectedRevisions();
 
+        ObjectId? IRevisionGridInfo.CurrentCheckout => CurrentCheckout;
 
         string IRevisionGridInfo.GetCurrentBranch() => CurrentBranch.Value;
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -13,6 +13,7 @@ using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Avatars;
 using GitUI.BuildServerIntegration;
+using GitUI.CommandDialogs;
 using GitUI.CommandsDialogs;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.HelperDialogs;
@@ -52,7 +53,7 @@ namespace GitUI
     }
 
     [DefaultEvent("DoubleClick")]
-    public sealed partial class RevisionGridControl : GitModuleControl, IScriptHostControl, ICheckRefs, IRunScript, IRevisionGridFilter
+    public sealed partial class RevisionGridControl : GitModuleControl, IScriptHostControl, ICheckRefs, IRunScript, IRevisionGridFilter, IRevisionGridInfo
     {
         public event EventHandler<DoubleClickRevisionEventArgs>? DoubleClickRevision;
         public event EventHandler<FilterChangedEventArgs>? FilterChanged;
@@ -3074,12 +3075,10 @@ namespace GitUI
 
             return true;
         }
+
         #endregion
 
         #region IScriptHostControl
-
-        GitRevision IScriptHostControl.GetCurrentRevision()
-            => GetActualRevision(CurrentCheckout);
 
         GitRevision? IScriptHostControl.GetLatestSelectedRevision()
             => LatestSelectedRevision;
@@ -3090,7 +3089,16 @@ namespace GitUI
         Point IScriptHostControl.GetQuickItemSelectorLocation()
             => GetQuickItemSelectorLocation();
 
-        string IScriptHostControl.GetCurrentBranch() => CurrentBranch.Value;
+        #endregion
+
+        #region IRevisionGridInfo
+
+        IReadOnlyList<GitRevision> IRevisionGridInfo.GetSelectedRevisions()
+            => GetSelectedRevisions();
+
+
+        string IRevisionGridInfo.GetCurrentBranch() => CurrentBranch.Value;
+
         #endregion
 
         bool ICheckRefs.Contains(ObjectId objectId) => _gridView.Contains(objectId);

--- a/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
@@ -289,27 +289,27 @@ namespace GitUITests.UserControls
             GitRevision rev3 = new(ObjectId.Parse(_commit3));
             GitRevision rev2 = new(ObjectId.Parse(_commit2));
 
-            await _blameControl.LoadBlameAsync(rev3, null, _fileName1, null, null, null);
+            await _blameControl.LoadBlameAsync(rev3, null, _fileName1, null, null, null, null);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(1);
 
             _blameControl.GetTestAccessor().BlameFile.GoToLine(3);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(3);
-            await _blameControl.LoadBlameAsync(rev3, null, _fileName1, null, null, null);
+            await _blameControl.LoadBlameAsync(rev3, null, _fileName1, null, null, null, null);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(3);
 
             _blameControl.GetTestAccessor().BlameFile.GoToLine(2);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(2);
-            await _blameControl.LoadBlameAsync(rev3, null, _fileName1, null, null, Encoding.UTF8);
+            await _blameControl.LoadBlameAsync(rev3, null, _fileName1, null, null, null, Encoding.UTF8);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(2);
 
             _blameControl.GetTestAccessor().BlameFile.GoToLine(4);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(4);
-            await _blameControl.LoadBlameAsync(rev3, null, _fileName1, null, null, null);
+            await _blameControl.LoadBlameAsync(rev3, null, _fileName1, null, null, null, null);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(4);
 
             _blameControl.GetTestAccessor().BlameFile.GoToLine(3);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(3);
-            await _blameControl.LoadBlameAsync(rev2, null, _fileName1, null, null, null);
+            await _blameControl.LoadBlameAsync(rev2, null, _fileName1, null, null, null, null);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(3);
         }
 
@@ -319,27 +319,27 @@ namespace GitUITests.UserControls
             GitRevision rev3 = new(ObjectId.Parse(_commit3));
             GitRevision rev2 = new(ObjectId.Parse(_commit2));
 
-            await _blameControl.LoadBlameAsync(rev3, null, _fileName1, null, null, null);
+            await _blameControl.LoadBlameAsync(rev3, null, _fileName1, null, null, null, null);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(1);
 
             _blameControl.GetTestAccessor().BlameFile.GoToLine(3);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(3);
-            await _blameControl.LoadBlameAsync(rev3, null, _fileName2, null, null, null);
+            await _blameControl.LoadBlameAsync(rev3, null, _fileName2, null, null, null, null);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(1);
 
             _blameControl.GetTestAccessor().BlameFile.GoToLine(2);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(2);
-            await _blameControl.LoadBlameAsync(rev3, null, _fileName2, null, null, Encoding.UTF8);
+            await _blameControl.LoadBlameAsync(rev3, null, _fileName2, null, null, null, Encoding.UTF8);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(2);
 
             _blameControl.GetTestAccessor().BlameFile.GoToLine(4);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(4);
-            await _blameControl.LoadBlameAsync(rev3, null, _fileName1, null, null, null);
+            await _blameControl.LoadBlameAsync(rev3, null, _fileName1, null, null, null, null);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(1);
 
             _blameControl.GetTestAccessor().BlameFile.GoToLine(3);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(3);
-            await _blameControl.LoadBlameAsync(rev2, null, _fileName1, null, null, null);
+            await _blameControl.LoadBlameAsync(rev2, null, _fileName1, null, null, null, null);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(3);
         }
 
@@ -348,12 +348,12 @@ namespace GitUITests.UserControls
         {
             GitRevision rev1 = new(ObjectId.Parse(_referenceRepository.CommitHash));
 
-            await _blameControl.LoadBlameAsync(rev1, null, _fileName1, null, null, null);
+            await _blameControl.LoadBlameAsync(rev1, null, _fileName1, null, null, null, null);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(1);
 
             _blameControl.GetTestAccessor().BlameFile.GoToLine(3);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(3);
-            await _blameControl.LoadBlameAsync(rev1, null, _fileName1, null, null, null);
+            await _blameControl.LoadBlameAsync(rev1, null, _fileName1, null, null, null, null);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(3);
         }
 
@@ -362,13 +362,13 @@ namespace GitUITests.UserControls
         {
             GitRevision rev1 = new(ObjectId.Parse(_referenceRepository.CommitHash));
 
-            await _blameControl.LoadBlameAsync(rev1, null, _fileName1, null, null, null, initialLine: 4);
+            await _blameControl.LoadBlameAsync(rev1, null, _fileName1, null, null, null, null, initialLine: 4);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(4);
 
-            await _blameControl.LoadBlameAsync(rev1, null, _fileName1, null, null, null, initialLine: 7);
+            await _blameControl.LoadBlameAsync(rev1, null, _fileName1, null, null, null, null, initialLine: 7);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(7);
 
-            await _blameControl.LoadBlameAsync(rev1, null, _fileName2, null, null, null, initialLine: 5);
+            await _blameControl.LoadBlameAsync(rev1, null, _fileName2, null, null, null, null, initialLine: 5);
             _blameControl.GetTestAccessor().BlameFile.CurrentFileLine.Should().Be(5);
         }
     }


### PR DESCRIPTION
## Proposed changes

Refactoring

Separate IRevisionGridInfo from IScriptHostControl
Wrap RevisionGrid access in IRevisionGrid/IRevisionGridUpdate

For 'sibling' forms like Blame that accesses and occasionally updates the
revision grid, use an interface to limit possible methods.

--
Follow-up may spread use of IRevisionGridInfo to more forms, to avoid some Git call.
More information in RevisionGrid could be cached too. One example is use of getRefs() that can take seconds. The revGrid info froom the initial grid load is distributed in GitUIEventArgs. For further updates the Git command must run again, could use the revGrid as cache. 

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

- To be decided later.

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
