### PR TITLE
AutoComplete: Run git-status without locks

### DIFF
--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -158,7 +158,7 @@ namespace GitUI.AutoCompletion
         {
             if (file.IsTracked)
             {
-                var changes = await module.GetCurrentChangesAsync(file.Name, file.OldName, file.Staged == StagedStatus.Index, "-U1000000")
+                GitCommands.Patches.Patch changes = await module.GetCurrentChangesAsync(file.Name, file.OldName, file.Staged == StagedStatus.Index, "-U1000000", noLocks: true)
                 .ConfigureAwait(false);
 
                 if (changes is not null)
@@ -166,7 +166,7 @@ namespace GitUI.AutoCompletion
                     return changes.Text;
                 }
 
-                var content = await module.GetFileContentsAsync(file).ConfigureAwaitRunInline();
+                string? content = await module.GetFileContentsAsync(file).ConfigureAwaitRunInline();
                 if (content is not null)
                 {
                     return content;


### PR DESCRIPTION
Fixes #11029
Fixes #10499 

## Proposed changes

AutoComplete: Run git-status without locks
index can be locked by other Git clients, failing to get a lock should not be an exception in this case.

Other possible improvements:
* Try git-status a second time if locks fail
* Cache git-status - not much point in rerunning for each file (some handling due to index/worktree required).

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
