### PR TITLE
RevDiff: popup for failed reset

### DIFF
--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -195,10 +195,12 @@ namespace GitCommands
             foreach (BatchArgumentItem item in batchArguments)
             {
                 ExecutionResult itemResult = executable.Execute(item.Argument, writeInput);
-                result = result is null ? itemResult : new ExecutionResult(
-                    result?.StandardOutput + itemResult.StandardOutput,
-                    result?.StandardError + itemResult.StandardError,
-                    result?.ExitCode > 0 ? result?.ExitCode : itemResult.ExitCode);
+                result = result is null
+                    ? itemResult
+                    : new ExecutionResult(
+                        result?.StandardOutput + itemResult.StandardOutput,
+                        result?.StandardError + itemResult.StandardError,
+                        result?.ExitCode > 0 ? result?.ExitCode : itemResult.ExitCode);
 
                 // Invoke batch progress callback
                 action?.Invoke(new BatchProgressEventArgs(item.BatchItemsCount, result?.ExitedSuccessfully ?? false));

--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -200,7 +200,7 @@ namespace GitCommands
                     : new ExecutionResult(
                         result?.StandardOutput + itemResult.StandardOutput,
                         result?.StandardError + itemResult.StandardError,
-                        result?.ExitCode > 0 ? result?.ExitCode : itemResult.ExitCode);
+                        result?.ExitCode is (> 0 or < 0) ? result?.ExitCode : itemResult.ExitCode);
 
                 // Invoke batch progress callback
                 action?.Invoke(new BatchProgressEventArgs(item.BatchItemsCount, result?.ExitedSuccessfully ?? false));

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -1487,14 +1488,18 @@ namespace GitCommands
 
             output.Append(CheckoutIndexFiles(filesToReset));
             output.Append(CheckoutFiles(filesToCheckout, resetId, force: false));
+
+            const char bullet = '\u2022';
+            const char noBreakSpace = '\u00a0';
+            string separator = $"{Environment.NewLine}{bullet}{noBreakSpace}";
             if (filesInUse.Count > 0)
             {
-                output.Append($"The following files are currently in use and will not be reset: {Environment.NewLine}\u2022 " + string.Join($"{Environment.NewLine}\u2022 ", filesInUse));
+                output.Append($"The following files are currently in use and will not be reset:{separator}{string.Join(separator, filesInUse)}");
             }
 
             if (filesCannotCheckout.Count > 0)
             {
-                output.Append($"The following files are unmerged and will not be reset: {Environment.NewLine}\u2022 " + string.Join($"{Environment.NewLine}\u2022 ", filesCannotCheckout));
+                output.Append($"The following files are unmerged and will not be reset:{separator}{string.Join(separator, filesCannotCheckout)}");
             }
 
             return true;
@@ -1562,7 +1567,8 @@ namespace GitCommands
                     revStr,
                     "--"
                 }
-                .BuildBatchArgumentsForFiles(files))?.StandardOutput ?? "";
+                .BuildBatchArgumentsForFiles(files))
+                ?.StandardOutput ?? "";
         }
 
         public string RemoveFiles(IReadOnlyList<string> files, bool force)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2128,7 +2128,7 @@ namespace GitUI.CommandsDialogs
                 toolStripProgressBar1.Maximum = selectedItems.Count(item => item.Staged == StagedStatus.Index);
                 toolStripProgressBar1.Value = 0;
 
-                Module.ResetChanges(resetId: null, selectedItems, resetAndDelete: resetType == FormResetChanges.ActionEnum.ResetAndDelete, _fullPathResolver, out List<string> filesInUse, out StringBuilder output, progressAction: (eventArgs) =>
+                Module.ResetChanges(resetId: null, selectedItems, resetAndDelete: resetType == FormResetChanges.ActionEnum.ResetAndDelete, _fullPathResolver, out StringBuilder output, progressAction: (eventArgs) =>
                 {
                     toolStripProgressBar1.Value = Math.Max(0, Math.Min(toolStripProgressBar1.Maximum - 1, toolStripProgressBar1.Value + eventArgs.ProcessedCount));
                 });
@@ -2139,11 +2139,6 @@ namespace GitUI.CommandsDialogs
                 if (AppSettings.RevisionGraphShowArtificialCommits)
                 {
                     UICommands.RepoChangedNotifier.Notify();
-                }
-
-                if (filesInUse.Count > 0)
-                {
-                    MessageBox.Show(this, "The following files are currently in use and will not be reset:" + Environment.NewLine + "\u2022 " + string.Join(Environment.NewLine + "\u2022 ", filesInUse), "Files In Use", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 }
 
                 if (!string.IsNullOrEmpty(output.ToString()))

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text;
 using GitCommands;
 using GitCommands.Git;
 using GitCommands.Git.Commands;
@@ -512,7 +513,12 @@ namespace GitUI.CommandsDialogs
 
                     IReadOnlyList<GitItemStatus> resetItems = (resetToParent ? selectedItems.Items()
                         : selectedItems.Items().Select(item => item.InvertStatus())).ToList();
-                    Module.ResetChanges(id, resetItems, resetAndDelete: resetAndDelete, _fullPathResolver, filesInUse: out _, output: out _);
+                    Module.ResetChanges(id, resetItems, resetAndDelete: resetAndDelete, _fullPathResolver, out StringBuilder output);
+
+                    if (!string.IsNullOrEmpty(output.ToString()))
+                    {
+                        MessageBox.Show(this, output.ToString(), TranslatedStrings.ResetChangesCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
                 }
             }
             finally

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -515,7 +515,7 @@ namespace GitUI.CommandsDialogs
                         : selectedItems.Items().Select(item => item.InvertStatus())).ToList();
                     Module.ResetChanges(id, resetItems, resetAndDelete: resetAndDelete, _fullPathResolver, out StringBuilder output);
 
-                    if (!string.IsNullOrEmpty(output.ToString()))
+                    if (output.Length > 0)
                     {
                         MessageBox.Show(this, output.ToString(), TranslatedStrings.ResetChangesCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -745,7 +745,7 @@ namespace GitUI
                     return false;
                 }
 
-                Module.ResetChanges(resetId: null, selectedItems, resetAndDelete: resetType == FormResetChanges.ActionEnum.ResetAndDelete, _fullPathResolver, out List<string> filesInUse, out StringBuilder output);
+                Module.ResetChanges(resetId: null, selectedItems, resetAndDelete: resetType == FormResetChanges.ActionEnum.ResetAndDelete, _fullPathResolver, out StringBuilder output);
                 if (output.Length > 0)
                 {
                     MessageBox.Show(null, output.ToString(), TranslatedStrings.ResetChangesCaption, MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
@@ -86,31 +86,33 @@ namespace GitCommandsTests.Git
         }
 
         // Process argument upper bound is actually (short.MaxValue - 1)
-        [TestCase(32766, 32766, 32767, 2, true, new int[] { 1, 1 })]
-        [TestCase(32764, 1, 32767, 1, true, new int[] { 2 })]
+        [TestCase(32766, 32766, 32767, 2, new int[] { 1, 1 })]
+        [TestCase(32764, 1, 32767, 1, new int[] { 2 })]
         public void RunBatchCommand_can_handle_max_length_arguments(int arg1Len, int arg2Len,
-            int maxLength, int argCount, bool expectedResult, int[] expectedProcessedCounts)
+            int maxLength, int argCount, int[] expectedProcessedCounts)
         {
             // 3: double quotes + ' '
             // 9: 'reset -- '
             // 1: ' ' added after second Add in ArgumentBuilder
-            var appLength = _appPath.Length + 3;
+            int appLength = _appPath.Length + 3;
             ArgumentBuilder builder = new() { "reset --" };
-            var len = builder.ToString().Length;
-            var args = builder.BuildBatchArguments(new string[]
+            int len = builder.ToString().Length;
+            List<BatchArgumentItem> args = builder.BuildBatchArguments(new string[]
             {
                 GenerateStringByLength(Math.Max(1, arg1Len - appLength - len - 1)),
                 GenerateStringByLength(Math.Max(1, arg2Len - appLength - len - 1))
             }, appLength, maxLength);
 
             Assert.AreEqual(argCount, args.Count);
-            var index = 0;
-            Assert.AreEqual(expectedResult, _gitExecutable.RunBatchCommand(args, (eventArgs) =>
+            int index = 0;
+            ExecutionResult? result = _gitExecutable.RunBatchCommand(args, (eventArgs) =>
             {
                 Assert.IsTrue(eventArgs.ExecutionResult);
                 Assert.AreEqual(expectedProcessedCounts[index], eventArgs.ProcessedCount);
                 index++;
-            }));
+            });
+            Assert.IsTrue(result.Value.ExitedSuccessfully);
+            Assert.IsTrue(result.Value.StandardOutput.StartsWith("Unstaged changes after reset:"));
         }
 
         [TestCase(32766 - 8, 32766 - 8, int.MaxValue)]

--- a/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
@@ -111,7 +111,7 @@ namespace GitCommandsTests.Git
                 Assert.AreEqual(expectedProcessedCounts[index], eventArgs.ProcessedCount);
                 index++;
             });
-            Assert.IsTrue(result.Value.ExitedSuccessfully);
+            Assert.AreEqual(result.Value.ExitCode, 0);
             Assert.IsTrue(result.Value.StandardOutput.StartsWith("Unstaged changes after reset:"));
         }
 

--- a/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
@@ -104,6 +104,8 @@ namespace GitCommandsTests.Git
             }, appLength, maxLength);
 
             Assert.AreEqual(argCount, args.Count);
+
+            // The reset command runs in the GE repo dir, so the result depends on workTree contents
             int index = 0;
             ExecutionResult? result = _gitExecutable.RunBatchCommand(args, (eventArgs) =>
             {
@@ -111,8 +113,6 @@ namespace GitCommandsTests.Git
                 Assert.AreEqual(expectedProcessedCounts[index], eventArgs.ProcessedCount);
                 index++;
             });
-            Assert.AreEqual(result.Value.ExitCode, 0);
-            Assert.IsTrue(result.Value.StandardOutput.StartsWith("Unstaged changes after reset:"));
         }
 
         [TestCase(32766 - 8, 32766 - 8, int.MaxValue)]


### PR DESCRIPTION
~~Depends on #10980~~
~~First two commits are not to be removed in this PR~~

## Proposed changes

Return RunBatchCommand from RunBatchCommand(),
so CheckoutFiles() can return a combined error output.

Handle the error popup contents in GitModule.

## Screenshots

Existed in FormCommit before, now also in RevDiff.
I do not get 'file in use' exceptions right now though.

Reset to Index in RevDiff:
![image](https://github.com/gitextensions/gitextensions/assets/6248932/67283e4d-c9dc-45e2-8e5e-95a976b87055)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
