### PR TITLE
 Sort references by version

### DIFF
--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -129,10 +129,14 @@ namespace GitCommands.Git.Commands
                     return string.Empty;
                 }
 
+                // special handling for GitRefsSortBy.versionRefname as enum string is not the same as git sort key
+                // also, colon cannot be included in the deref sort key at all
+                const string gitRefsSortByVersion = "version:refname";
+                string sortKey = sortBy == GitRefsSortBy.versionRefname ? gitRefsSortByVersion : sortBy.ToString();
                 string order = sortOrder == GitRefsSortOrder.Ascending ? string.Empty : "-";
                 if (!needTags)
                 {
-                    return $@"--sort=""{order}{sortBy}""";
+                    return $@"--sort=""{order}{sortKey}""";
                 }
 
                 // Sort by dereferenced data
@@ -144,7 +148,8 @@ namespace GitCommands.Git.Commands
                 // ref ordering (i.e. local and remote branches), and this is generally a significantly
                 // greater of two evils.
                 // Refer to https://github.com/gitextensions/gitextensions/issues/8621 for more info.
-                return $@"--sort=""{order}*{sortBy}"" --sort=""{order}{sortBy}""";
+                string derefSortKey = (sortBy == GitRefsSortBy.versionRefname ? GitRefsSortBy.refname : sortBy).ToString();
+                return $@"--sort=""{order}*{derefSortKey}"" --sort=""{order}{sortKey}""";
             }
 
             static ArgumentString GitRefsFormat(bool needTags)

--- a/Plugins/GitUIPluginInterfaces/GitRefsOrder.cs
+++ b/Plugins/GitUIPluginInterfaces/GitRefsOrder.cs
@@ -2,7 +2,8 @@
 
 namespace GitUIPluginInterfaces
 {
-    // NB: The values are fed directly into git commands, casing is important!
+    // NB: The values are fed directly into 'git for-each-ref --sort==', casing is important!
+    // Special handling for Default and Version.
     public enum GitRefsSortBy
     {
         [Description("Git default")]
@@ -22,6 +23,10 @@ namespace GitUIPluginInterfaces
 
         [Description("Alpha-numeric")]
         refname,
+
+        // NB: sort key is version:refname
+        [Description("Version")]
+        versionRefname,
 
         [Description("Object size")]
         objectsize,

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -676,9 +676,13 @@ namespace GitCommandsTests.Git.Commands
                         }
                         else
                         {
-                            string prefix = sortOrder == GitRefsSortOrder.Ascending ? string.Empty : "-";
-                            sortCondition = $@" --sort=""{prefix}{sortBy}""";
-                            sortConditionRef = $@" --sort=""{prefix}*{sortBy}""";
+                            const string gitRefsSortByVersion = "version:refname";
+                            string sortKey = sortBy == GitRefsSortBy.versionRefname ? gitRefsSortByVersion : sortBy.ToString();
+                            string derefSortKey = (sortBy == GitRefsSortBy.versionRefname ? GitRefsSortBy.refname : sortBy).ToString();
+
+                            string order = sortOrder == GitRefsSortOrder.Ascending ? string.Empty : "-";
+                            sortCondition = $@" --sort=""{order}{sortKey}""";
+                            sortConditionRef = $@" --sort=""{order}*{derefSortKey}""";
                         }
 
                         yield return new TestCaseData(RefsFilter.Tags | RefsFilter.Heads | RefsFilter.Remotes, /* noLocks */ false, sortBy, sortOrder, 0,


### PR DESCRIPTION
Fixes #11028

## Proposed changes

Sort references (tags, branches) by 'version:refname'.

## Screenshots <!-- Remove this section if PR does not change UI -->

### After

Version added, also in Settings

![image](https://github.com/gitextensions/gitextensions/assets/6248932/178aa1a8-d4a8-4a34-b43d-688eb8c24cda)

## Test methodology <!-- How did you ensure quality? -->

Tests are adapted

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
