### PR TITLE
Improve revision grid scrolling

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -890,13 +890,12 @@ namespace GitUI.UserControls.RevisionGrid
                 int totalWheelDelta = (scrollLines * e.Delta) + _mouseWheelDeltaRemainder;
                 int wheelDeltaPerRow = SystemInformation.MouseWheelScrollDelta;
 
-                if (Math.Abs(totalWheelDelta) >= wheelDeltaPerRow)
+                // The total wheel delta is consumed in multiples of wheelDeltaPerRow.
+                // Save the remainder and credit it to the total wheel delta during the next MouseWheel event.
+                _mouseWheelDeltaRemainder = totalWheelDelta % wheelDeltaPerRow;
+                int rowDelta = -(totalWheelDelta - _mouseWheelDeltaRemainder) / wheelDeltaPerRow;
+                if (rowDelta != 0)
                 {
-                    // The total wheel delta is consumed in multiples of wheelDeltaPerRow.
-                    // Save the remainder and credit it to the total wheel delta during the next MouseWheel event.
-                    _mouseWheelDeltaRemainder = totalWheelDelta % wheelDeltaPerRow;
-                    int rowDelta = -(totalWheelDelta - _mouseWheelDeltaRemainder) / wheelDeltaPerRow;
-
                     int toRowIndex = Math.Clamp(FirstDisplayedScrollingRowIndex + rowDelta, 0, maxRowIndex);
 
                     // This will raise the Scroll event.

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -894,13 +894,15 @@ namespace GitUI.UserControls.RevisionGrid
 
                 // The wheel might be configured to scroll more than one row at once.
                 // Respect this by scaling MouseEventArgs.Delta accordingly.
-                int scrollLines = SystemInformation.MouseWheelScrollLines switch
+                int scrollLines = SystemInformation.MouseWheelScrollLines;
+
+                // Value of -1 indicates the "One screen at a time" mouse option.
+                if (scrollLines == -1)
                 {
-                    // Value of -1 indicates the "One screen at a time" mouse option.
-                    -1 => visibleCompleteRowsCount > 0 ? visibleCompleteRowsCount : 1,
-                    > 0 => SystemInformation.MouseWheelScrollLines,
-                    _ => 1
-                };
+                    scrollLines = visibleCompleteRowsCount;
+                }
+
+                scrollLines = Math.Max(1, scrollLines);
 
                 // Calculate the total wheel delta, which corresponds to the intended scrolling distance, from
                 // MouseEventArgs.Delta, which is usually a multiple of SystemInformation.MouseWheelScrollDelta

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -932,7 +932,7 @@ namespace GitUI.UserControls.RevisionGrid
                     }
                     catch (ArgumentOutOfRangeException)
                     {
-                        // Tried to scroll to nonexistant row.
+                        // Tried to scroll to nonexistent row.
                     }
                 }
             }

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -17,6 +17,7 @@ namespace GitUI.UserControls.RevisionGrid
     public sealed partial class RevisionDataGridView : DataGridView
     {
         private const int BackgroundThreadUpdatePeriod = 25;
+        private const int MouseWheelDeltaTimeout = 1500; // Mouse wheel idle time in milliseconds after which unconsumed wheel delta will be dropped.
         private static readonly AccessibleDataGridViewTextBoxCell _accessibleDataGridViewTextBoxCell = new();
 
         private readonly SolidBrush _alternatingRowBackgroundBrush;
@@ -880,7 +881,7 @@ namespace GitUI.UserControls.RevisionGrid
                 //   for scrolling one row is never reached on the first wheel rotation.
                 // - When using a precision scrolling device, the unconsumed delta will offset the first scroll,
                 //   which makes the user experience a subtle "lag" or "leap" at beginning of a scroll.
-                if (_lastMouseWheel.ElapsedMilliseconds > 1500)
+                if (_lastMouseWheel.ElapsedMilliseconds > MouseWheelDeltaTimeout)
                 {
                     _mouseWheelDeltaRemainder = 0;
                 }

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -921,7 +921,7 @@ namespace GitUI.UserControls.RevisionGrid
 
                     // Drop unconsumed wheel delta when reaching the upper or lower bound of the grid
                     // to prevent the grid being stuck there for a moment.
-                    if (toRowIndex == 0 || toRowIndex >= maxRowIndex - visibleCompleteRowsCount + 1)
+                    if (toRowIndex == 0 || toRowIndex + visibleCompleteRowsCount > maxRowIndex)
                     {
                         _mouseWheelDeltaRemainder = 0;
                     }

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -889,10 +889,13 @@ namespace GitUI.UserControls.RevisionGrid
                     int consumedWheelDelta = _mouseWheelDelta - (_mouseWheelDelta % wheelDeltaPerRow);
                     _mouseWheelDelta -= consumedWheelDelta;
                     int rowDelta = -consumedWheelDelta / wheelDeltaPerRow;
-                    int toIndex = Math.Clamp(FirstDisplayedScrollingRowIndex + rowDelta, 0, _revisionGraph.Count - 1);
+                    if (_revisionGraph.Count > 0)
+                    {
+                        int toRowIndex = Math.Clamp(FirstDisplayedScrollingRowIndex + rowDelta, 0, _revisionGraph.Count - 1);
 
-                    // This will raise the Scroll event.
-                    FirstDisplayedScrollingRowIndex = toIndex;
+                        // This will raise the Scroll event.
+                        FirstDisplayedScrollingRowIndex = toRowIndex;
+                    }
                 }
 
                 _lastMouseWheel.Restart();

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -853,6 +853,12 @@ namespace GitUI.UserControls.RevisionGrid
 
         protected override void OnMouseWheel(MouseEventArgs e)
         {
+            int maxRowIndex = _revisionGraph.Count - 1;
+            if (maxRowIndex < 0)
+            {
+                return;
+            }
+
             if (ModifierKeys.HasFlag(Keys.Shift))
             {
                 int currentIndex = HorizontalScrollingOffset;
@@ -890,12 +896,6 @@ namespace GitUI.UserControls.RevisionGrid
                     // Save the remainder and credit it to the total wheel delta during the next MouseWheel event.
                     _mouseWheelDeltaRemainder = totalWheelDelta % wheelDeltaPerRow;
                     int rowDelta = -(totalWheelDelta - _mouseWheelDeltaRemainder) / wheelDeltaPerRow;
-
-                    int maxRowIndex = _revisionGraph.Count - 1;
-                    if (maxRowIndex < 0)
-                    {
-                        return;
-                    }
 
                     int toRowIndex = Math.Clamp(FirstDisplayedScrollingRowIndex + rowDelta, 0, maxRowIndex);
 

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -854,7 +854,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         protected override void OnMouseWheel(MouseEventArgs e)
         {
-            int maxRowIndex = _revisionGraph.Count - 1;
+            int maxRowIndex = RowCount - 1;
             if (maxRowIndex < 0)
             {
                 return;
@@ -925,8 +925,15 @@ namespace GitUI.UserControls.RevisionGrid
                         _mouseWheelDeltaRemainder = 0;
                     }
 
-                    // This will raise the Scroll event.
-                    FirstDisplayedScrollingRowIndex = toRowIndex;
+                    try
+                    {
+                        // This will raise the Scroll event.
+                        FirstDisplayedScrollingRowIndex = toRowIndex;
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        // Tried to scroll to nonexistant row.
+                    }
                 }
             }
         }

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -37,7 +37,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         private int _backgroundScrollTo;
         private int _rowHeight; // Height of elements in the cache. Is equal to the control's row height.
-        private int _mouseWheelDelta;
+        private int _mouseWheelDeltaRemainder; // Corresponds to unconsumed scroll distance while scrolling via mouse wheel, see OnMouseWheel().
 
         private VisibleRowRange _visibleRowRange;
 
@@ -869,7 +869,7 @@ namespace GitUI.UserControls.RevisionGrid
             {
                 if (_lastMouseWheel.ElapsedMilliseconds > 1500)
                 {
-                    _mouseWheelDelta = 0;
+                    _mouseWheelDeltaRemainder = 0;
                 }
 
                 int scrollLines = SystemInformation.MouseWheelScrollLines switch
@@ -880,15 +880,14 @@ namespace GitUI.UserControls.RevisionGrid
                     _ => 1
                 };
 
-                _mouseWheelDelta += scrollLines * e.Delta;
+                int totalWheelDelta = (scrollLines * e.Delta) + _mouseWheelDeltaRemainder;
 
                 const int wheelDeltaPerRow = 120;
 
-                if (Math.Abs(_mouseWheelDelta) >= wheelDeltaPerRow)
+                if (Math.Abs(totalWheelDelta) >= wheelDeltaPerRow)
                 {
-                    int consumedWheelDelta = _mouseWheelDelta - (_mouseWheelDelta % wheelDeltaPerRow);
-                    _mouseWheelDelta -= consumedWheelDelta;
-                    int rowDelta = -consumedWheelDelta / wheelDeltaPerRow;
+                    _mouseWheelDeltaRemainder = totalWheelDelta % wheelDeltaPerRow;
+                    int rowDelta = -(totalWheelDelta - _mouseWheelDeltaRemainder) / wheelDeltaPerRow;
 
                     int maxRowIndex = _revisionGraph.Count - 1;
                     if (maxRowIndex < 0)

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -867,6 +867,7 @@ namespace GitUI.UserControls.RevisionGrid
             }
             else
             {
+                // Reset unconsumed wheel delta when the mouse wheel is idle.
                 if (_lastMouseWheel.ElapsedMilliseconds > 1500)
                 {
                     _mouseWheelDeltaRemainder = 0;
@@ -885,6 +886,8 @@ namespace GitUI.UserControls.RevisionGrid
 
                 if (Math.Abs(totalWheelDelta) >= wheelDeltaPerRow)
                 {
+                    // The total wheel delta is consumed in multiples of wheelDeltaPerRow.
+                    // Save the remainder and credit it to the total wheel delta during the next MouseWheel event.
                     _mouseWheelDeltaRemainder = totalWheelDelta % wheelDeltaPerRow;
                     int rowDelta = -(totalWheelDelta - _mouseWheelDeltaRemainder) / wheelDeltaPerRow;
 

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -889,13 +889,17 @@ namespace GitUI.UserControls.RevisionGrid
                     int consumedWheelDelta = _mouseWheelDelta - (_mouseWheelDelta % wheelDeltaPerRow);
                     _mouseWheelDelta -= consumedWheelDelta;
                     int rowDelta = -consumedWheelDelta / wheelDeltaPerRow;
-                    if (_revisionGraph.Count > 0)
-                    {
-                        int toRowIndex = Math.Clamp(FirstDisplayedScrollingRowIndex + rowDelta, 0, _revisionGraph.Count - 1);
 
-                        // This will raise the Scroll event.
-                        FirstDisplayedScrollingRowIndex = toRowIndex;
+                    int maxRowIndex = _revisionGraph.Count - 1;
+                    if (maxRowIndex < 0)
+                    {
+                        return;
                     }
+
+                    int toRowIndex = Math.Clamp(FirstDisplayedScrollingRowIndex + rowDelta, 0, maxRowIndex);
+
+                    // This will raise the Scroll event.
+                    FirstDisplayedScrollingRowIndex = toRowIndex;
                 }
 
                 _lastMouseWheel.Restart();

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -881,8 +881,7 @@ namespace GitUI.UserControls.RevisionGrid
                 };
 
                 int totalWheelDelta = (scrollLines * e.Delta) + _mouseWheelDeltaRemainder;
-
-                const int wheelDeltaPerRow = 120;
+                int wheelDeltaPerRow = SystemInformation.MouseWheelScrollDelta;
 
                 if (Math.Abs(totalWheelDelta) >= wheelDeltaPerRow)
                 {

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -36,10 +36,9 @@ namespace GitUI.UserControls.RevisionGrid
         private int _loadedToBeSelectedRevisionsCount = 0;
 
         private int _backgroundScrollTo;
-        private int _rowHeight; // Height of elements in the cache. Is equal to the control's row height.
-        private int _mouseWheelDeltaRemainder; // Corresponds to unconsumed scroll distance while scrolling via mouse wheel, see OnMouseWheel().
-
         private long _lastMouseWheelTickCount; // Timestamp of the last vertical scroll via mouse wheel.
+        private int _mouseWheelDeltaRemainder; // Corresponds to unconsumed scroll distance while scrolling via mouse wheel, see OnMouseWheel().
+        private int _rowHeight; // Height of elements in the cache. Is equal to the control's row height.
 
         private VisibleRowRange _visibleRowRange;
 

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -882,12 +882,13 @@ namespace GitUI.UserControls.RevisionGrid
 
                 _mouseWheelDelta += scrollLines * e.Delta;
 
-                // Wheel delta value of 120 corresponds to one row.
-                if (Math.Abs(_mouseWheelDelta) >= 120)
+                const int wheelDeltaPerRow = 120;
+
+                if (Math.Abs(_mouseWheelDelta) >= wheelDeltaPerRow)
                 {
-                    int consumedMouseWheelDelta = _mouseWheelDelta - (_mouseWheelDelta % 120);
-                    _mouseWheelDelta -= consumedMouseWheelDelta;
-                    int rowDelta = -consumedMouseWheelDelta / 120;
+                    int consumedWheelDelta = _mouseWheelDelta - (_mouseWheelDelta % wheelDeltaPerRow);
+                    _mouseWheelDelta -= consumedWheelDelta;
+                    int rowDelta = -consumedWheelDelta / wheelDeltaPerRow;
                     int toIndex = Math.Clamp(FirstDisplayedScrollingRowIndex + rowDelta, 0, _revisionGraph.Count - 1);
 
                     // This will raise the Scroll event.


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Utilize the OnMouseWheel() override to prevent the raising of redundant Scroll events and skip to the target row instantly while scrolling.

- Calculate the scrolling distance by adding up the mouse wheel Delta values, which leads to smoother scrolling with high-precision devices such as free-spinning mouse wheels or touchpads.

### Before

When rotating the mouse wheel by one unit, multiple Scroll events might be emitted simultaneously in accordance with SystemInformation.MouseWheelScrollLines. This leads to the revision grid being scrolled row by row with intermittent updates, which causes flickering and visual glitches.

### After

This reduces flickering and visual glitches when scrolling the revision grid via mouse wheel, and also improves scrolling with high-precision scrolling devices.

This also considerably reduces the noticeability of the BackgroundUpdater delay as discussed in #10680.

<!-- TODO -->

## Test methodology <!-- How did you ensure quality? -->

- Lots of scrolling with (1) a notched mouse wheel, (2) an app that simulates "smooth scrolling" and (3) a touchpad.
- Inserting Debug.WriteLine(...) at certain places in the code and observing the output window.
- Comparing different revisions of Git Extensions against each other.

## Test environment(s) <!-- Remove any that don't apply -->

- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.16
- DPI 134dpi (140% scaling)

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
