### PR TITLE
Correctly calculate number of visible grid rows

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -663,6 +663,7 @@ namespace GitUI.UserControls.RevisionGrid
         private async Task UpdateVisibleRowRangeInternalAsync()
         {
             int fromIndex = Math.Max(0, FirstDisplayedScrollingRowIndex);
+            // Rounding up integer division: (a+b-1)/b = ceil(a/b)
             int visibleRowCount = _rowHeight <= 0 ? 0 : (Height + _rowHeight - 1) / _rowHeight;
 
             visibleRowCount = Math.Min(_revisionGraph.Count - fromIndex, visibleRowCount);

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -663,8 +663,7 @@ namespace GitUI.UserControls.RevisionGrid
         private async Task UpdateVisibleRowRangeInternalAsync()
         {
             int fromIndex = Math.Max(0, FirstDisplayedScrollingRowIndex);
-            // Rounding up integer division: (a+b-1)/b = ceil(a/b)
-            int visibleRowCount = _rowHeight <= 0 ? 0 : (Height + _rowHeight - 1) / _rowHeight;
+            int visibleRowCount = _rowHeight <= 0 ? 0 : (Height + _rowHeight - 1) / _rowHeight; // Rounding up integer division: (a+b-1)/b = ceil(a/b)
 
             visibleRowCount = Math.Min(_revisionGraph.Count - fromIndex, visibleRowCount);
 

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -663,7 +663,7 @@ namespace GitUI.UserControls.RevisionGrid
         private async Task UpdateVisibleRowRangeInternalAsync()
         {
             int fromIndex = Math.Max(0, FirstDisplayedScrollingRowIndex);
-            int visibleRowCount = _rowHeight <= 0 ? 0 : (Height / _rowHeight) + 2 /*Add 2 for rounding*/;
+            int visibleRowCount = _rowHeight <= 0 ? 0 : (Height + _rowHeight - 1) / _rowHeight;
 
             visibleRowCount = Math.Min(_revisionGraph.Count - fromIndex, visibleRowCount);
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

Calculate visibleRowCount correctly, considering partially visible rows at the bottom of the revision grid visible. This will make the way in which the grid adapts to the graph at the top and at the bottom consistent.

### Before

Empty space between revision graph and text. The revision graph adapts to a row below the visible region, because visibleRowCount is set too high:

<div style="float: left">
<img src="https://github.com/gitextensions/gitextensions/assets/39014485/3d0204fd-5228-481c-8ea4-ef2d9a057274" align="top" alt="">
<img src="https://github.com/gitextensions/gitextensions/assets/39014485/0e246d59-42bd-4955-bcdf-634eea2d2d7c" align="top" alt="">
<img src="https://github.com/gitextensions/gitextensions/assets/39014485/98b587e9-b7b7-44e0-be03-66c7789eb761" align="top" alt="">
<img src="https://github.com/gitextensions/gitextensions/assets/39014485/b2baba52-0930-4463-9a5f-190ee3088268" align="top" alt="">
</div>

### After

The revision graph adapts only to visible rows:

<div style="float: left">
<img src="https://github.com/gitextensions/gitextensions/assets/39014485/838fc27f-9bc5-4172-a23c-0de38fe0de5c" align="top" alt="">
<img src="https://github.com/gitextensions/gitextensions/assets/39014485/76fa49d8-a842-4088-b8b3-a5e04980311d" align="top" alt="">
<img src="https://github.com/gitextensions/gitextensions/assets/39014485/2dd8be45-1769-40f2-b8bd-efa30e3b030e" align="top" alt="">
<img src="https://github.com/gitextensions/gitextensions/assets/39014485/d7044f01-3e88-4bad-a43e-16205db7882c" align="top" alt="">
</div>

## Test methodology <!-- How did you ensure quality? -->

- Scrolling and resizing the grid.

## Test environment(s) <!-- Remove any that don't apply -->

- Git 2.38.1.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.16
- DPI 134dpi (140% scaling)

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
