### PR TITLE
Theme pragma SUPPORT_THEME_HOOKS

### DIFF
--- a/GitUI/Interops/LVGROUPW.cs
+++ b/GitUI/Interops/LVGROUPW.cs
@@ -2,6 +2,7 @@
 
 namespace System
 {
+#if SUPPORT_THEME_HOOKS
     internal static partial class NativeMethods
     {
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
@@ -19,4 +20,5 @@ namespace System
             public LVGA uAlign;
         }
     }
+#endif
 }

--- a/GitUI/Interops/LVHITTESTINFO.cs
+++ b/GitUI/Interops/LVHITTESTINFO.cs
@@ -2,6 +2,7 @@
 {
     internal static partial class NativeMethods
     {
+#if SUPPORT_THEME_HOOKS
         /// <summary>
         /// see http://msdn.microsoft.com/en-us/library/bb774754%28v=VS.85%29.aspx.
         /// </summary>
@@ -15,5 +16,6 @@
             // Vista/Win7+
             public int iGroup;
         }
+#endif
     }
 }

--- a/GitUI/Interops/ListViewGroupMask.cs
+++ b/GitUI/Interops/ListViewGroupMask.cs
@@ -2,6 +2,7 @@ namespace System
 {
     internal static partial class NativeMethods
     {
+#if SUPPORT_THEME_HOOKS
         public enum ListViewGroupMask : uint
         {
             None = 0x00000,
@@ -20,5 +21,6 @@ namespace System
             Subset = 0x08000,
             SubsetItems = 0x10000
         }
+#endif
     }
 }

--- a/GitUI/Interops/NMHDR.cs
+++ b/GitUI/Interops/NMHDR.cs
@@ -1,5 +1,6 @@
 ﻿namespace System
 {
+#if SUPPORT_THEME_HOOKS
     internal static partial class NativeMethods
     {
         public struct NMHDR
@@ -9,4 +10,5 @@
             public int code;
         }
     }
+ #endif
 }

--- a/GitUI/Theming/Renderers/ButtonRenderer.cs
+++ b/GitUI/Theming/Renderers/ButtonRenderer.cs
@@ -281,7 +281,8 @@ namespace GitUI.Theming
                 CBS_EXCLUDEDDISABLED = 20,
             }
 
-            public enum GroupBox
+ #if SUPPORT_THEME_HOOKS
+           public enum GroupBox
             {
                 GBS_NORMAL = 1,
                 GBS_DISABLED = 2,
@@ -295,6 +296,7 @@ namespace GitUI.Theming
                 CMDLGS_DISABLED = 4,
                 CMDLGS_DEFAULTED = 5,
             }
+#endif
         }
     }
 }

--- a/GitUI/Theming/Renderers/ButtonRenderer.cs
+++ b/GitUI/Theming/Renderers/ButtonRenderer.cs
@@ -282,7 +282,7 @@ namespace GitUI.Theming
             }
 
  #if SUPPORT_THEME_HOOKS
-           public enum GroupBox
+            public enum GroupBox
             {
                 GBS_NORMAL = 1,
                 GBS_DISABLED = 2,

--- a/GitUI/Theming/Renderers/ComboBoxRenderer.cs
+++ b/GitUI/Theming/Renderers/ComboBoxRenderer.cs
@@ -271,7 +271,7 @@ namespace GitUI.Theming
             }
 
  #if SUPPORT_THEME_HOOKS
-           public enum CueBanner
+            public enum CueBanner
             {
                 CBCB_NORMAL = 1,
                 CBCB_HOT = 2,

--- a/GitUI/Theming/Renderers/ComboBoxRenderer.cs
+++ b/GitUI/Theming/Renderers/ComboBoxRenderer.cs
@@ -228,6 +228,7 @@ namespace GitUI.Theming
                 CBXS_DISABLED = 4,
             }
 
+#if SUPPORT_THEME_HOOKS
             public enum DropDownRight
             {
                 CBXSR_NORMAL = 1,
@@ -251,6 +252,7 @@ namespace GitUI.Theming
                 CBTBS_DISABLED = 3,
                 CBTBS_FOCUSED = 4,
             }
+#endif
 
             public enum Border
             {
@@ -268,13 +270,15 @@ namespace GitUI.Theming
                 CBRO_DISABLED = 4,
             }
 
-            public enum CueBanner
+ #if SUPPORT_THEME_HOOKS
+           public enum CueBanner
             {
                 CBCB_NORMAL = 1,
                 CBCB_HOT = 2,
                 CBCB_PRESSED = 3,
                 CBCB_DISABLED = 4,
             }
+#endif
         }
     }
 }

--- a/GitUI/Theming/Renderers/EditRenderer.cs
+++ b/GitUI/Theming/Renderers/EditRenderer.cs
@@ -186,7 +186,7 @@ namespace GitUI.Theming
             }
 
  #if SUPPORT_THEME_HOOKS
-           public enum BackgroundWithBorder
+            public enum BackgroundWithBorder
             {
                 EBWBS_NORMAL = 1,
                 EBWBS_HOT = 2,

--- a/GitUI/Theming/Renderers/EditRenderer.cs
+++ b/GitUI/Theming/Renderers/EditRenderer.cs
@@ -185,13 +185,15 @@ namespace GitUI.Theming
                 EBS_ASSIST = 6,
             }
 
-            public enum BackgroundWithBorder
+ #if SUPPORT_THEME_HOOKS
+           public enum BackgroundWithBorder
             {
                 EBWBS_NORMAL = 1,
                 EBWBS_HOT = 2,
                 EBWBS_DISABLED = 3,
                 EBWBS_FOCUSED = 4,
             }
+#endif
 
             public enum BorderNoScroll
             {
@@ -201,6 +203,7 @@ namespace GitUI.Theming
                 EPSN_DISABLED = 4,
             }
 
+#if SUPPORT_THEME_HOOKS
             public enum BorderHScroll
             {
                 EPSH_NORMAL = 1,
@@ -224,6 +227,7 @@ namespace GitUI.Theming
                 EPSHV_FOCUSED = 3,
                 EPSHV_DISABLED = 4,
             }
+#endif
         }
     }
 }

--- a/GitUI/Theming/Renderers/HeaderRenderer.cs
+++ b/GitUI/Theming/Renderers/HeaderRenderer.cs
@@ -173,6 +173,7 @@ namespace GitUI.Theming
                 HIS_ICONSORTEDPRESSED = 12,
             }
 
+#if SUPPORT_THEME_HOOKS
             public enum ItemLeft
             {
                 HILS_NORMAL = 1,
@@ -206,6 +207,7 @@ namespace GitUI.Theming
                 HDDFS_SOFTHOT = 2,
                 HDDFS_HOT = 3
             }
+#endif
 
             public enum SortArrow
             {

--- a/GitUI/Theming/Renderers/ListViewRenderer.cs
+++ b/GitUI/Theming/Renderers/ListViewRenderer.cs
@@ -250,6 +250,7 @@ namespace GitUI.Theming
                 LVEB_PUSHED = 3,
             }
 
+#if SUPPORT_THEME_HOOKS
             public enum GroupHeader
             {
                 LVGH_OPEN = 1,
@@ -289,6 +290,7 @@ namespace GitUI.Theming
                 LVGHL_CLOSEMIXEDSELECTION = 15,
                 LVGHL_CLOSEMIXEDSELECTIONHOT = 16,
             }
+#endif
 
             public enum ListItem
             {

--- a/GitUI/Theming/Renderers/ScrollBarRenderer.cs
+++ b/GitUI/Theming/Renderers/ScrollBarRenderer.cs
@@ -305,6 +305,7 @@ namespace GitUI.Theming
                 ABS_RIGHTHOVER = 20,
             }
 
+#if SUPPORT_THEME_HOOKS
             public enum SizeBox
             {
                 SZB_HALFBOTTOMLEFTALIGN = 6,
@@ -316,6 +317,7 @@ namespace GitUI.Theming
                 SZB_TOPLEFTALIGN = 4,
                 SZB_TOPRIGHTALIGN = 3,
             }
+#endif
 
             public enum TrackThumb
             {

--- a/GitUI/Theming/Renderers/SpinRenderer.cs
+++ b/GitUI/Theming/Renderers/SpinRenderer.cs
@@ -139,7 +139,8 @@ namespace GitUI.Theming
                 DNS_DISABLED = 4,
             }
 
-            public enum UpHorizontal
+ #if SUPPORT_THEME_HOOKS
+           public enum UpHorizontal
             {
                 UPHZS_NORMAL = 1,
                 UPHZS_HOT = 2,
@@ -154,6 +155,7 @@ namespace GitUI.Theming
                 DNHZS_PRESSED = 3,
                 DNHZS_DISABLED = 4,
             }
+#endif
         }
     }
 }

--- a/GitUI/Theming/Renderers/SpinRenderer.cs
+++ b/GitUI/Theming/Renderers/SpinRenderer.cs
@@ -140,7 +140,7 @@ namespace GitUI.Theming
             }
 
  #if SUPPORT_THEME_HOOKS
-           public enum UpHorizontal
+            public enum UpHorizontal
             {
                 UPHZS_NORMAL = 1,
                 UPHZS_HOT = 2,

--- a/GitUI/Theming/Renderers/TooltipRenderer.cs
+++ b/GitUI/Theming/Renderers/TooltipRenderer.cs
@@ -55,6 +55,7 @@ namespace GitUI.Theming
             TTP_WRENCH = 7,
         }
 
+#if SUPPORT_THEME_HOOKS
         private class State
         {
             public enum Close
@@ -93,5 +94,6 @@ namespace GitUI.Theming
                 TTWS_PRESSED = 3,
             }
         }
+#endif
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/gitextensions/gitextensions/pull/11006
Credit to @SimonCropp , fork was removed though

## Proposed changes

Enclose unused classes and methods related to theming with the pragma SUPPORT_THEME_HOOKS

## Test methodology <!-- How did you ensure quality? -->

Build

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
