### PR TITLE
Auto-set GE as editor only in current environment

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -161,10 +161,10 @@ namespace GitExtensions
                         }
                     }
 
+                    GitUICommands uiCommands = new("");
+                    CommonLogic commonLogic = new(uiCommands.Module);
                     if (AppSettings.CheckSettings)
                     {
-                        GitUICommands uiCommands = new("");
-                        CommonLogic commonLogic = new(uiCommands.Module);
                         CheckSettingsLogic checkSettingsLogic = new(commonLogic);
                         SettingsPageHostMock fakePageHost = new(checkSettingsLogic);
                         using var checklistSettingsPage = SettingsPageBase.Create<ChecklistSettingsPage>(fakePageHost);
@@ -175,6 +175,10 @@ namespace GitExtensions
                                 uiCommands.StartSettingsDialog();
                             }
                         }
+                    }
+                    else
+                    {
+                        CheckSettingsLogic.SolveEditor(commonLogic);
                     }
                 }
             }

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -1,5 +1,4 @@
 ﻿using GitCommands;
-using GitCommands.Settings;
 using GitCommands.Utils;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;
 using Microsoft.Win32;
@@ -10,7 +9,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog
     {
         public readonly CommonLogic CommonLogic;
         private GitModule? Module => CommonLogic.Module;
-        private ConfigFileSettings GlobalConfigFileSettings => CommonLogic.ConfigFileSettingsSet.GlobalSettings;
 
         public CheckSettingsLogic(CommonLogic commonLogic)
         {
@@ -27,7 +25,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             bool valid = SolveGitCommand();
             valid = SolveLinuxToolsDir() && valid;
             valid = SolveGitExtensionsDir() && valid;
-            valid = SolveEditor() && valid;
+            valid = SolveEditor(CommonLogic) && valid;
 
             CommonLogic.ConfigFileSettingsSet.EffectiveSettings.Save();
             CommonLogic.DistributedSettingsSet.EffectiveSettings.Save();
@@ -35,13 +33,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog
             return valid;
         }
 
-        private bool SolveEditor()
+        public static bool SolveEditor(CommonLogic commonLogic)
         {
-            string? editor = CommonLogic.GetGlobalEditor();
+            string? editor = commonLogic.GetGlobalEditor();
 
             if (string.IsNullOrEmpty(editor))
             {
-                GlobalConfigFileSettings.SetPathValue("core.editor", EditorHelper.FileEditorCommand);
+                Environment.SetEnvironmentVariable(CommonLogic.AmbientGitEditorEnvVariableName, EditorHelper.FileEditorCommand);
             }
 
             return true;

--- a/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CommonLogic.cs
@@ -10,6 +10,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 {
     public sealed class CommonLogic : Translate
     {
+        internal const string PresetGitEditorEnvVariableName = "GIT_EDITOR";
+        internal const string AmbientGitEditorEnvVariableName = "EDITOR";
+
         private static readonly TranslationString _cantReadRegistry =
             new("Git Extensions has insufficient permissions to check the registry.");
 
@@ -95,10 +98,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
             IEnumerable<string> GetEditorOptions()
             {
-                yield return Environment.GetEnvironmentVariable("GIT_EDITOR");
+                yield return Environment.GetEnvironmentVariable(PresetGitEditorEnvVariableName);
                 yield return ConfigFileSettingsSet.GlobalSettings.GetValue("core.editor");
                 yield return Environment.GetEnvironmentVariable("VISUAL");
-                yield return Environment.GetEnvironmentVariable("EDITOR");
+                yield return Environment.GetEnvironmentVariable(AmbientGitEditorEnvVariableName);
             }
         }
 


### PR DESCRIPTION
Fixes #11045

## Proposed changes

- Auto-set GE as editor only in the environment of the current process (and its children)
  and not in the global git config if unset

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/36601201/bfe15680-a8c4-41d2-9b08-13ae7adf8293)

### After

![image](https://github.com/gitextensions/gitextensions/assets/36601201/3050201c-4871-442d-9741-943613d32b18)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).