### PR TITLE
Prevent a (not important) early git call breaks the ownership security issue handling done in GE

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -287,8 +287,17 @@ namespace GitUI.CommandsDialogs
                 PluginRegistry.Initialize();
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 RegisterPlugins();
-                revisionDiff.RegisterGitHostingPluginInBlameControl();
-                fileTree.RegisterGitHostingPluginInBlameControl();
+                try
+                {
+                    revisionDiff.RegisterGitHostingPluginInBlameControl();
+                    fileTree.RegisterGitHostingPluginInBlameControl();
+                }
+                catch (Exception)
+                {
+                    // Swallow crash due to potential ownership security issues
+                    // on a early git command that doesn't capture command output
+                    // and so let a subsequent git call crash
+                }
             }).FileAndForget();
 
             InitCountArtificial(out _gitStatusMonitor);


### PR DESCRIPTION

because this early git call doesn't capture the output so the repo ownership security issue handling can't detect that the crash is due to this reason and so display the crash popup instead of the user friendly ownership issue dialog.

Because these 2 actions are not very important and very unlikely to crash, swallowing the exceptions to let subsequent git calls crash if needed and handle the security issue well.

Fixes #11039 (and #10975 )

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/92df4fa0-af29-4f9e-b9fc-647afecb74df)


### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/443d3097-72e7-4f0a-b36b-61e867f1be42)

## Test methodology <!-- How did you ensure quality? -->

- Manual (on a repository where I changed the file owner using file explorer)

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 098c6f7f04b32a566a623b086cf4034f51d1b99c (Dirty)
- Git 2.40.0.windows.1 (recommended: 2.40.1 or later)
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.16
- DPI 96dpi (no scaling)
- Portable: False


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
