### PR TITLE
Register git hosters after repo opened

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -287,8 +287,6 @@ namespace GitUI.CommandsDialogs
                 PluginRegistry.Initialize();
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 RegisterPlugins();
-                revisionDiff.RegisterGitHostingPluginInBlameControl();
-                fileTree.RegisterGitHostingPluginInBlameControl();
             }).FileAndForget();
 
             InitCountArtificial(out _gitStatusMonitor);
@@ -1720,6 +1718,9 @@ namespace GitUI.CommandsDialogs
             }
 
             RegisterPlugins();
+
+            revisionDiff.RegisterGitHostingPluginInBlameControl();
+            fileTree.RegisterGitHostingPluginInBlameControl();
         }
 
         private void FileExplorerToolStripMenuItemClick(object sender, EventArgs e)


### PR DESCRIPTION
Previously git hosters would only get registered once when the main form was created. This caused two issues:

1. The hosters would attempt to run git commands before the main form was fully setup and all its handlers wired. This led to situations where the hoster would fail (e.g., with git dubious ownership issue) but the main form's error handler was yet to be wired, thus crashing the app.

2. The git hosters would not get updated whenever a new repo was opened.

Fixes #10816
Fixes #10975
Fixes #11027
Fixes #11039


----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
