### PR TITLE
Check output of every git command when exit code is different than 0

### DIFF
--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -12,8 +12,6 @@ namespace GitUI.NBugReports
 {
     public static class BugReportInvoker
     {
-        private const string _dubiousOwnershipSecurityConfigString = "config --global --add safe.directory";
-
         private static Form? OwnerForm
             => Form.ActiveForm ?? (Application.OpenForms.Count > 0 ? Application.OpenForms[0] : null);
 
@@ -105,7 +103,7 @@ namespace GitUI.NBugReports
 
             ExternalOperationException externalOperationException = exception as ExternalOperationException;
 
-            if (externalOperationException?.InnerException?.Message?.Contains(_dubiousOwnershipSecurityConfigString) is true)
+            if (externalOperationException?.InnerException?.Message?.Contains(ExecutableExtensions.DubiousOwnershipSecurityConfigString) is true)
             {
                 ReportDubiousOwnership(externalOperationException.InnerException);
                 return;
@@ -202,9 +200,9 @@ namespace GitUI.NBugReports
                 AllowCancel = true,
                 SizeToContent = true,
             };
-            int startIndex = error.IndexOf(_dubiousOwnershipSecurityConfigString);
+            int startIndex = error.IndexOf(ExecutableExtensions.DubiousOwnershipSecurityConfigString);
             string gitConfigTrustRepoCommand = error[startIndex..];
-            string folderPath = error[(startIndex + _dubiousOwnershipSecurityConfigString.Length + 1)..];
+            string folderPath = error[(startIndex + ExecutableExtensions.DubiousOwnershipSecurityConfigString.Length + 1)..];
 
             TaskDialogCommandLinkButton openExplorerButton = new(TranslatedStrings.GitDubiousOwnershipOpenRepositoryFolder, allowCloseDialog: false);
             openExplorerButton.Click += (_, _) => OsShellUtil.OpenWithFileExplorer(PathUtil.ToNativePath(folderPath));
@@ -258,13 +256,13 @@ namespace GitUI.NBugReports
             {
                 TaskDialogCommandLinkButton button = new(buttonText, allowCloseDialog: false)
                 {
-                    DescriptionText = $"git {_dubiousOwnershipSecurityConfigString} *",
+                    DescriptionText = $"git {ExecutableExtensions.DubiousOwnershipSecurityConfigString} *",
                 };
 
                 button.Click += (_, _) =>
                 {
                     string tempFile = Path.GetTempFileName();
-                    File.WriteAllText(tempFile, $"{TranslatedStrings.GitDubiousOwnershipTrustAllInstruction}\r\n\r\ngit {_dubiousOwnershipSecurityConfigString} \"*\"");
+                    File.WriteAllText(tempFile, $"{TranslatedStrings.GitDubiousOwnershipTrustAllInstruction}\r\n\r\ngit {ExecutableExtensions.DubiousOwnershipSecurityConfigString} \"*\"");
 
                     using FormEditor formEditor = new(new GitUICommands(new GitModule(null)), tempFile, showWarning: false, readOnly: true);
                     formEditor.ShowDialog();


### PR DESCRIPTION
to check if it's not due to security issue

Fixes #10816, Fixes #10975, Fixes #11027, Fixes #11039

Improvement on security issue over what has been already done in #10436

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/92df4fa0-af29-4f9e-b9fc-647afecb74df)


### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/443d3097-72e7-4f0a-b36b-61e867f1be42)


## Test methodology <!-- How did you ensure quality? -->

- Manual (For FormCommit and FormPull)

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build bcbc3ddc814a2dd291a0ad200d240cb1f92198e7
- Git 2.40.0.windows.1 (recommended: 2.40.1 or later)
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.16
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.16 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.5 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
