### PR TITLE
Change ShowMergeCommits to HideMergeCommits

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1190,7 +1190,7 @@ namespace GitCommands
         }
 
         // Note: The meaning of this value is changed in the GUI, setting name is kept for compatibility
-        public static bool NoMergeCommits
+        public static bool HideMergeCommits
         {
             get => !GetBool("showmergecommits", true);
             set => SetBool("showmergecommits", !value);

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -833,7 +833,7 @@ namespace GitCommands
 
         public static bool SimplifyMergesInFileHistory
         {
-            get => GetBool("simplifymergesinfileHistory", true);
+            get => GetBool("simplifymergesinfileHistory", false);
             set => SetBool("simplifymergesinfileHistory", value);
         }
 
@@ -1189,10 +1189,11 @@ namespace GitCommands
             set => SetBool("showannotatedtagsmessages", value);
         }
 
-        public static bool ShowMergeCommits
+        // Note: The meaning of this value is changed in the GUI, setting name is kept for compatibility
+        public static bool NoMergeCommits
         {
-            get => GetBool("showmergecommits", true);
-            set => SetBool("showmergecommits", value);
+            get => !GetBool("showmergecommits", true);
+            set => SetBool("showmergecommits", !value);
         }
 
         public static bool ShowTags

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -349,7 +349,7 @@ namespace GitUI.Hotkey
                     Hk(RevisionGridControl.Command.ToggleOrderRevisionsByDate, Keys.None),
                     Hk(RevisionGridControl.Command.ToggleRevisionGraph, Keys.None),
                     Hk(RevisionGridControl.Command.ToggleShowGitNotes, Keys.None),
-                    Hk(RevisionGridControl.Command.ToggleNoMergeCommits, Keys.Control | Keys.Shift | Keys.M),
+                    Hk(RevisionGridControl.Command.ToggleHideMergeCommits, Keys.Control | Keys.Shift | Keys.M),
                     Hk(RevisionGridControl.Command.ToggleShowRelativeDate, Keys.None),
                     Hk(RevisionGridControl.Command.ToggleShowTags, Keys.Control | Keys.Alt | Keys.T)),
                 new HotkeySettings(

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -349,7 +349,7 @@ namespace GitUI.Hotkey
                     Hk(RevisionGridControl.Command.ToggleOrderRevisionsByDate, Keys.None),
                     Hk(RevisionGridControl.Command.ToggleRevisionGraph, Keys.None),
                     Hk(RevisionGridControl.Command.ToggleShowGitNotes, Keys.None),
-                    Hk(RevisionGridControl.Command.ToggleShowMergeCommits, Keys.Control | Keys.Shift | Keys.M),
+                    Hk(RevisionGridControl.Command.ToggleNoMergeCommits, Keys.Control | Keys.Shift | Keys.M),
                     Hk(RevisionGridControl.Command.ToggleShowRelativeDate, Keys.None),
                     Hk(RevisionGridControl.Command.ToggleShowTags, Keys.Control | Keys.Alt | Keys.T)),
                 new HotkeySettings(

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7005,8 +7005,8 @@ Do you want to use this custom merge script?</source>
         <source>&amp;Ignore case</source>
         <target />
       </trans-unit>
-      <trans-unit id="MergeCommitsCheck.Text">
-        <source>Merge commi&amp;ts</source>
+      <trans-unit id="NoMergeCommitsCheck.Text">
+        <source>No merge commi&amp;ts</source>
         <target />
       </trans-unit>
       <trans-unit id="Ok.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7005,8 +7005,8 @@ Do you want to use this custom merge script?</source>
         <source>&amp;Ignore case</source>
         <target />
       </trans-unit>
-      <trans-unit id="NoMergeCommitsCheck.Text">
-        <source>No merge commi&amp;ts</source>
+      <trans-unit id="HideMergeCommitsCheck.Text">
+        <source>Hide merge commi&amp;ts</source>
         <target />
       </trans-unit>
       <trans-unit id="Ok.Text">
@@ -9222,7 +9222,7 @@ See the changes in the commit form.</source>
         <source>Message</source>
         <target />
       </trans-unit>
-      <trans-unit id="_noMergeBaseCommit.Text">
+      <trans-unit id="_hideMergeBaseCommit.Text">
         <source>There is no common ancestor for the selected commits.</source>
         <target />
       </trans-unit>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -7001,12 +7001,12 @@ Do you want to use this custom merge script?</source>
         <source>Full &amp;history</source>
         <target />
       </trans-unit>
-      <trans-unit id="IgnoreCase.Text">
-        <source>&amp;Ignore case</source>
-        <target />
-      </trans-unit>
       <trans-unit id="HideMergeCommitsCheck.Text">
         <source>Hide merge commi&amp;ts</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="IgnoreCase.Text">
+        <source>&amp;Ignore case</source>
         <target />
       </trans-unit>
       <trans-unit id="Ok.Text">
@@ -7014,7 +7014,7 @@ Do you want to use this custom merge script?</source>
         <target />
       </trans-unit>
       <trans-unit id="OnlyFirstParentCheck.Text">
-        <source>Only &amp;first parent</source>
+        <source>Show only &amp;first parent</source>
         <target />
       </trans-unit>
       <trans-unit id="ReflogCheck.Text">
@@ -9210,6 +9210,10 @@ See the changes in the commit form.</source>
         <source>For you own protection dropping more than 10 patch files at once is blocked!</source>
         <target />
       </trans-unit>
+      <trans-unit id="_hideMergeBaseCommit.Text">
+        <source>There is no common ancestor for the selected commits.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_invalidDiffContainsFilter.Text">
         <source>Filter text '{0}' not valid for "Diff contains" filter.</source>
         <target />
@@ -9220,10 +9224,6 @@ See the changes in the commit form.</source>
       </trans-unit>
       <trans-unit id="_maximizedColumn.HeaderText">
         <source>Message</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_hideMergeBaseCommit.Text">
-        <source>There is no common ancestor for the selected commits.</source>
         <target />
       </trans-unit>
       <trans-unit id="_noRevisionFoundError.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9210,10 +9210,6 @@ See the changes in the commit form.</source>
         <source>For you own protection dropping more than 10 patch files at once is blocked!</source>
         <target />
       </trans-unit>
-      <trans-unit id="_hideMergeBaseCommit.Text">
-        <source>There is no common ancestor for the selected commits.</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_invalidDiffContainsFilter.Text">
         <source>Filter text '{0}' not valid for "Diff contains" filter.</source>
         <target />
@@ -9224,6 +9220,10 @@ See the changes in the commit form.</source>
       </trans-unit>
       <trans-unit id="_maximizedColumn.HeaderText">
         <source>Message</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_noMergeBaseCommit.Text">
+        <source>There is no common ancestor for the selected commits.</source>
         <target />
       </trans-unit>
       <trans-unit id="_noRevisionFoundError.Text">

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -149,10 +149,10 @@ namespace GitUI.UserControls.RevisionGrid
             set => AppSettings.ShowSimplifyByDecoration = value;
         }
 
-        public bool NoMergeCommits
+        public bool HideMergeCommits
         {
-            get => AppSettings.NoMergeCommits;
-            set => AppSettings.NoMergeCommits = value;
+            get => AppSettings.HideMergeCommits;
+            set => AppSettings.HideMergeCommits = value;
         }
 
         public bool ShowFullHistory
@@ -191,7 +191,7 @@ namespace GitUI.UserControls.RevisionGrid
                 || ByMessage
                 || ByDiffContent
                 || !string.IsNullOrWhiteSpace(PathFilter)
-                || NoMergeCommits
+                || HideMergeCommits
                 || ShowSimplifyByDecoration;
         }
 
@@ -211,7 +211,7 @@ namespace GitUI.UserControls.RevisionGrid
             ByPathFilter = false;
             ByBranchFilter = false;
             ShowOnlyFirstParent = false;
-            NoMergeCommits = false;
+            HideMergeCommits = false;
             ShowSimplifyByDecoration = false;
         }
 
@@ -349,7 +349,7 @@ namespace GitUI.UserControls.RevisionGrid
         /// <param name="filter">ArgumentBuilder arg</param>
         private void GetLimitingRevisionFilter(ArgumentBuilder filter)
         {
-            if (NoMergeCommits)
+            if (HideMergeCommits)
             {
                 filter.Add("--no-merges");
             }
@@ -532,7 +532,7 @@ namespace GitUI.UserControls.RevisionGrid
         /// <param name="filter">StringBuilder arg</param>
         private void GetLimitingFilterSummary(StringBuilder filter)
         {
-            // Ignore IgnoreCase, NoMergeCommits, FullHistoryInFileHistory/SimplifyMergesInFileHistory (when history filtered)
+            // Ignore IgnoreCase, HideMergeCommits, FullHistoryInFileHistory/SimplifyMergesInFileHistory (when history filtered)
 
             if (ByPathFilter)
             {

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -108,16 +108,6 @@ namespace GitUI.UserControls.RevisionGrid
             set => _branchFilter = value ?? string.Empty;
         }
 
-        public void SetBranchFilter(string filter)
-        {
-            // Set filtered branches if there is a filter, handled as all branches otherwise
-            ShowCurrentBranchOnly = false;
-
-            string newFilter = filter?.Trim() ?? string.Empty;
-            ByBranchFilter = !string.IsNullOrWhiteSpace(newFilter);
-            BranchFilter = newFilter;
-        }
-
         public bool IsShowAllBranchesChecked => !ByBranchFilter && !ShowCurrentBranchOnly;
 
         public bool IsShowCurrentBranchOnlyChecked => ShowCurrentBranchOnly;
@@ -178,7 +168,12 @@ namespace GitUI.UserControls.RevisionGrid
                 || ByDateFrom
                 || ByDateTo
                 || ShowOnlyFirstParent
-                || !string.IsNullOrWhiteSpace(BranchFilter);
+                || !string.IsNullOrWhiteSpace(BranchFilter)
+                || ByCommitsLimit
+                || ShowCurrentBranchOnly
+                || ShowReflogReferences
+                || ShowFullHistory
+                || ShowSimplifyMerges;
         }
 
         /// <summary>
@@ -607,6 +602,16 @@ namespace GitUI.UserControls.RevisionGrid
             }
 
             return condition ? valueTrue : valueFalse;
+        }
+
+        public void SetBranchFilter(string filter)
+        {
+            // Set filtered branches if there is a filter, handled as all branches otherwise
+            ShowCurrentBranchOnly = false;
+
+            string newFilter = filter?.Trim() ?? string.Empty;
+            ByBranchFilter = !string.IsNullOrWhiteSpace(newFilter);
+            BranchFilter = newFilter;
         }
     }
 }

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -108,6 +108,16 @@ namespace GitUI.UserControls.RevisionGrid
             set => _branchFilter = value ?? string.Empty;
         }
 
+        public void SetBranchFilter(string filter)
+        {
+            // Set filtered branches if there is a filter, handled as all branches otherwise
+            ShowCurrentBranchOnly = false;
+
+            string newFilter = filter?.Trim() ?? string.Empty;
+            ByBranchFilter = !string.IsNullOrWhiteSpace(newFilter);
+            BranchFilter = newFilter;
+        }
+
         public bool IsShowAllBranchesChecked => !ByBranchFilter && !ShowCurrentBranchOnly;
 
         public bool IsShowCurrentBranchOnlyChecked => ShowCurrentBranchOnly;
@@ -168,12 +178,7 @@ namespace GitUI.UserControls.RevisionGrid
                 || ByDateFrom
                 || ByDateTo
                 || ShowOnlyFirstParent
-                || !string.IsNullOrWhiteSpace(BranchFilter)
-                || ByCommitsLimit
-                || ShowCurrentBranchOnly
-                || ShowReflogReferences
-                || ShowFullHistory
-                || ShowSimplifyMerges;
+                || !string.IsNullOrWhiteSpace(BranchFilter);
         }
 
         /// <summary>
@@ -602,16 +607,6 @@ namespace GitUI.UserControls.RevisionGrid
             }
 
             return condition ? valueTrue : valueFalse;
-        }
-
-        public void SetBranchFilter(string filter)
-        {
-            // Set filtered branches if there is a filter, handled as all branches otherwise
-            ShowCurrentBranchOnly = false;
-
-            string newFilter = filter?.Trim() ?? string.Empty;
-            ByBranchFilter = !string.IsNullOrWhiteSpace(newFilter);
-            BranchFilter = newFilter;
         }
     }
 }

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -149,10 +149,10 @@ namespace GitUI.UserControls.RevisionGrid
             set => AppSettings.ShowSimplifyByDecoration = value;
         }
 
-        public bool ShowMergeCommits
+        public bool NoMergeCommits
         {
-            get => AppSettings.ShowMergeCommits;
-            set => AppSettings.ShowMergeCommits = value;
+            get => AppSettings.NoMergeCommits;
+            set => AppSettings.NoMergeCommits = value;
         }
 
         public bool ShowFullHistory
@@ -191,7 +191,7 @@ namespace GitUI.UserControls.RevisionGrid
                 || ByMessage
                 || ByDiffContent
                 || !string.IsNullOrWhiteSpace(PathFilter)
-                || !ShowMergeCommits
+                || NoMergeCommits
                 || ShowSimplifyByDecoration;
         }
 
@@ -211,7 +211,7 @@ namespace GitUI.UserControls.RevisionGrid
             ByPathFilter = false;
             ByBranchFilter = false;
             ShowOnlyFirstParent = false;
-            ShowMergeCommits = true;
+            NoMergeCommits = false;
             ShowSimplifyByDecoration = false;
         }
 
@@ -349,7 +349,7 @@ namespace GitUI.UserControls.RevisionGrid
         /// <param name="filter">ArgumentBuilder arg</param>
         private void GetLimitingRevisionFilter(ArgumentBuilder filter)
         {
-            if (!ShowMergeCommits)
+            if (NoMergeCommits)
             {
                 filter.Add("--no-merges");
             }
@@ -532,7 +532,7 @@ namespace GitUI.UserControls.RevisionGrid
         /// <param name="filter">StringBuilder arg</param>
         private void GetLimitingFilterSummary(StringBuilder filter)
         {
-            // Ignore IgnoreCase, ShowMergeCommits, FullHistoryInFileHistory/SimplifyMergesInFileHistory (when history filtered)
+            // Ignore IgnoreCase, NoMergeCommits, FullHistoryInFileHistory/SimplifyMergesInFileHistory (when history filtered)
 
             if (ByPathFilter)
             {

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
@@ -29,7 +29,8 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.Ok = new System.Windows.Forms.Button();
+            this.btnOk = new System.Windows.Forms.Button();
+            this.btnResetDefault = new System.Windows.Forms.Button();
             this._NO_TRANSLATE_lblSince = new System.Windows.Forms.Label();
             this.Since = new System.Windows.Forms.DateTimePicker();
             this.SinceCheck = new System.Windows.Forms.CheckBox();
@@ -80,20 +81,34 @@
             // 
             // ControlsPanel
             // 
-            this.ControlsPanel.Controls.Add(this.Ok);
+            this.ControlsPanel.Controls.Add(this.btnOk);
             this.ControlsPanel.Location = new System.Drawing.Point(0, 483);
             this.ControlsPanel.Size = new System.Drawing.Size(408, 39);
+            this.ControlsPanel.Controls.Add(this.btnResetDefault);
             // 
-            // Ok
+            // btnOk
             // 
-            this.Ok.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.Ok.Location = new System.Drawing.Point(320, 8);
-            this.Ok.Name = "Ok";
-            this.Ok.Size = new System.Drawing.Size(75, 23);
-            this.Ok.TabIndex = 0;
-            this.Ok.Text = "OK";
-            this.Ok.UseVisualStyleBackColor = true;
-            this.Ok.Click += new System.EventHandler(this.OkClick);
+            this.btnOk.AutoSize = true;
+            this.btnOk.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.btnOk.Location = new System.Drawing.Point(320, 8);
+            this.btnOk.MinimumSize = new System.Drawing.Size(75, 25);
+            this.btnOk.Name = "Ok";
+            this.btnOk.Size = new System.Drawing.Size(75, 25);
+            this.btnOk.TabIndex = 0;
+            this.btnOk.Text = "OK";
+            this.btnOk.UseVisualStyleBackColor = true;
+            this.btnOk.Click += new System.EventHandler(this.btnOk_Click);
+            // 
+            // btnResetDefault
+            // 
+            this.btnResetDefault.AutoSize = true;
+            this.btnResetDefault.Location = new Point(210, 8);
+            this.btnResetDefault.Name = "btnResetDefault";
+            this.btnResetDefault.Size = new Size(104, 25);
+            this.btnResetDefault.TabIndex = 1;
+            this.btnResetDefault.Text = "Reset to &defaults";
+            this.btnResetDefault.UseVisualStyleBackColor = true;
+            this.btnResetDefault.Visible = false;
             // 
             // _NO_TRANSLATE_lblSince
             // 
@@ -548,7 +563,7 @@
             // 
             // FormRevisionFilter
             // 
-            this.AcceptButton = this.Ok;
+            this.AcceptButton = this.btnOk;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(408, 527);
@@ -570,7 +585,7 @@
 
         #endregion
 
-        private System.Windows.Forms.Button Ok;
+        private System.Windows.Forms.Button btnOk;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Label _NO_TRANSLATE_lblSince;
         private System.Windows.Forms.CheckBox SinceCheck;
@@ -608,5 +623,6 @@
         private System.Windows.Forms.CheckBox FullHistoryCheck;
         private System.Windows.Forms.CheckBox SimplifyMergesCheck;
         private System.Windows.Forms.ToolTip toolTip;
+        private System.Windows.Forms.Button btnResetDefault;
     }
 }

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
@@ -61,7 +61,7 @@
             this.CurrentBranchOnlyCheck = new System.Windows.Forms.CheckBox();
             this.ReflogCheck = new System.Windows.Forms.CheckBox();
             this.OnlyFirstParentCheck = new System.Windows.Forms.CheckBox();
-            this.NoMergeCommitsCheck = new System.Windows.Forms.CheckBox();
+            this.HideMergeCommitsCheck = new System.Windows.Forms.CheckBox();
             this.SimplifyByDecorationCheck = new System.Windows.Forms.CheckBox();
             this.FullHistoryCheck = new System.Windows.Forms.CheckBox();
             this.SimplifyMergesCheck = new System.Windows.Forms.CheckBox();
@@ -430,16 +430,16 @@
             // 
             // MergeCommitsCheck
             // 
-            this.NoMergeCommitsCheck.AutoSize = true;
-            this.tableLayoutPanel1.SetColumnSpan(this.NoMergeCommitsCheck, 2);
-            this.NoMergeCommitsCheck.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.NoMergeCommitsCheck.Location = new System.Drawing.Point(76, 359);
-            this.NoMergeCommitsCheck.Name = "MergeCommitsCheck";
-            this.NoMergeCommitsCheck.Size = new System.Drawing.Size(305, 19);
-            this.NoMergeCommitsCheck.TabIndex = 31;
-            this.NoMergeCommitsCheck.Text = "No merge commi&ts";
-            this.NoMergeCommitsCheck.UseVisualStyleBackColor = true;
-            this.NoMergeCommitsCheck.CheckedChanged += new System.EventHandler(this.option_CheckedChanged);
+            this.HideMergeCommitsCheck.AutoSize = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.HideMergeCommitsCheck, 2);
+            this.HideMergeCommitsCheck.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.HideMergeCommitsCheck.Location = new System.Drawing.Point(76, 359);
+            this.HideMergeCommitsCheck.Name = "MergeCommitsCheck";
+            this.HideMergeCommitsCheck.Size = new System.Drawing.Size(305, 19);
+            this.HideMergeCommitsCheck.TabIndex = 31;
+            this.HideMergeCommitsCheck.Text = "Hide merge commi&ts";
+            this.HideMergeCommitsCheck.UseVisualStyleBackColor = true;
+            this.HideMergeCommitsCheck.CheckedChanged += new System.EventHandler(this.option_CheckedChanged);
             // 
             // SimplifyByDecorationCheck
             // 
@@ -517,7 +517,7 @@
             this.tableLayoutPanel1.Controls.Add(this.CurrentBranchOnlyCheck, 1, 10);
             this.tableLayoutPanel1.Controls.Add(this.ReflogCheck, 1, 11);
             this.tableLayoutPanel1.Controls.Add(this.OnlyFirstParentCheck, 1, 12);
-            this.tableLayoutPanel1.Controls.Add(this.NoMergeCommitsCheck, 1, 13);
+            this.tableLayoutPanel1.Controls.Add(this.HideMergeCommitsCheck, 1, 13);
             this.tableLayoutPanel1.Controls.Add(this.SimplifyByDecorationCheck, 1, 14);
             this.tableLayoutPanel1.Controls.Add(this.FullHistoryCheck, 1, 15);
             this.tableLayoutPanel1.Controls.Add(this.SimplifyMergesCheck, 1, 16);
@@ -603,7 +603,7 @@
         private System.Windows.Forms.CheckBox CurrentBranchOnlyCheck;
         private System.Windows.Forms.CheckBox ReflogCheck;
         private System.Windows.Forms.CheckBox OnlyFirstParentCheck;
-        private System.Windows.Forms.CheckBox NoMergeCommitsCheck;
+        private System.Windows.Forms.CheckBox HideMergeCommitsCheck;
         private System.Windows.Forms.CheckBox SimplifyByDecorationCheck;
         private System.Windows.Forms.CheckBox FullHistoryCheck;
         private System.Windows.Forms.CheckBox SimplifyMergesCheck;

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
@@ -424,7 +424,7 @@
             this.OnlyFirstParentCheck.Name = "OnlyFirstParentCheck";
             this.OnlyFirstParentCheck.Size = new System.Drawing.Size(305, 19);
             this.OnlyFirstParentCheck.TabIndex = 30;
-            this.OnlyFirstParentCheck.Text = "Only &first parent";
+            this.OnlyFirstParentCheck.Text = "Show only &first parent";
             this.OnlyFirstParentCheck.UseVisualStyleBackColor = true;
             this.OnlyFirstParentCheck.CheckedChanged += new System.EventHandler(this.option_CheckedChanged);
             // 

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
@@ -61,7 +61,7 @@
             this.CurrentBranchOnlyCheck = new System.Windows.Forms.CheckBox();
             this.ReflogCheck = new System.Windows.Forms.CheckBox();
             this.OnlyFirstParentCheck = new System.Windows.Forms.CheckBox();
-            this.MergeCommitsCheck = new System.Windows.Forms.CheckBox();
+            this.NoMergeCommitsCheck = new System.Windows.Forms.CheckBox();
             this.SimplifyByDecorationCheck = new System.Windows.Forms.CheckBox();
             this.FullHistoryCheck = new System.Windows.Forms.CheckBox();
             this.SimplifyMergesCheck = new System.Windows.Forms.CheckBox();
@@ -430,16 +430,16 @@
             // 
             // MergeCommitsCheck
             // 
-            this.MergeCommitsCheck.AutoSize = true;
-            this.tableLayoutPanel1.SetColumnSpan(this.MergeCommitsCheck, 2);
-            this.MergeCommitsCheck.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.MergeCommitsCheck.Location = new System.Drawing.Point(76, 359);
-            this.MergeCommitsCheck.Name = "MergeCommitsCheck";
-            this.MergeCommitsCheck.Size = new System.Drawing.Size(305, 19);
-            this.MergeCommitsCheck.TabIndex = 31;
-            this.MergeCommitsCheck.Text = "Merge commi&ts";
-            this.MergeCommitsCheck.UseVisualStyleBackColor = true;
-            this.MergeCommitsCheck.CheckedChanged += new System.EventHandler(this.option_CheckedChanged);
+            this.NoMergeCommitsCheck.AutoSize = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.NoMergeCommitsCheck, 2);
+            this.NoMergeCommitsCheck.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.NoMergeCommitsCheck.Location = new System.Drawing.Point(76, 359);
+            this.NoMergeCommitsCheck.Name = "MergeCommitsCheck";
+            this.NoMergeCommitsCheck.Size = new System.Drawing.Size(305, 19);
+            this.NoMergeCommitsCheck.TabIndex = 31;
+            this.NoMergeCommitsCheck.Text = "No merge commi&ts";
+            this.NoMergeCommitsCheck.UseVisualStyleBackColor = true;
+            this.NoMergeCommitsCheck.CheckedChanged += new System.EventHandler(this.option_CheckedChanged);
             // 
             // SimplifyByDecorationCheck
             // 
@@ -517,7 +517,7 @@
             this.tableLayoutPanel1.Controls.Add(this.CurrentBranchOnlyCheck, 1, 10);
             this.tableLayoutPanel1.Controls.Add(this.ReflogCheck, 1, 11);
             this.tableLayoutPanel1.Controls.Add(this.OnlyFirstParentCheck, 1, 12);
-            this.tableLayoutPanel1.Controls.Add(this.MergeCommitsCheck, 1, 13);
+            this.tableLayoutPanel1.Controls.Add(this.NoMergeCommitsCheck, 1, 13);
             this.tableLayoutPanel1.Controls.Add(this.SimplifyByDecorationCheck, 1, 14);
             this.tableLayoutPanel1.Controls.Add(this.FullHistoryCheck, 1, 15);
             this.tableLayoutPanel1.Controls.Add(this.SimplifyMergesCheck, 1, 16);
@@ -603,7 +603,7 @@
         private System.Windows.Forms.CheckBox CurrentBranchOnlyCheck;
         private System.Windows.Forms.CheckBox ReflogCheck;
         private System.Windows.Forms.CheckBox OnlyFirstParentCheck;
-        private System.Windows.Forms.CheckBox MergeCommitsCheck;
+        private System.Windows.Forms.CheckBox NoMergeCommitsCheck;
         private System.Windows.Forms.CheckBox SimplifyByDecorationCheck;
         private System.Windows.Forms.CheckBox FullHistoryCheck;
         private System.Windows.Forms.CheckBox SimplifyMergesCheck;

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.Designer.cs
@@ -29,8 +29,7 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.btnOk = new System.Windows.Forms.Button();
-            this.btnResetDefault = new System.Windows.Forms.Button();
+            this.Ok = new System.Windows.Forms.Button();
             this._NO_TRANSLATE_lblSince = new System.Windows.Forms.Label();
             this.Since = new System.Windows.Forms.DateTimePicker();
             this.SinceCheck = new System.Windows.Forms.CheckBox();
@@ -81,34 +80,20 @@
             // 
             // ControlsPanel
             // 
-            this.ControlsPanel.Controls.Add(this.btnOk);
+            this.ControlsPanel.Controls.Add(this.Ok);
             this.ControlsPanel.Location = new System.Drawing.Point(0, 483);
             this.ControlsPanel.Size = new System.Drawing.Size(408, 39);
-            this.ControlsPanel.Controls.Add(this.btnResetDefault);
             // 
-            // btnOk
+            // Ok
             // 
-            this.btnOk.AutoSize = true;
-            this.btnOk.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.btnOk.Location = new System.Drawing.Point(320, 8);
-            this.btnOk.MinimumSize = new System.Drawing.Size(75, 25);
-            this.btnOk.Name = "Ok";
-            this.btnOk.Size = new System.Drawing.Size(75, 25);
-            this.btnOk.TabIndex = 0;
-            this.btnOk.Text = "OK";
-            this.btnOk.UseVisualStyleBackColor = true;
-            this.btnOk.Click += new System.EventHandler(this.btnOk_Click);
-            // 
-            // btnResetDefault
-            // 
-            this.btnResetDefault.AutoSize = true;
-            this.btnResetDefault.Location = new Point(210, 8);
-            this.btnResetDefault.Name = "btnResetDefault";
-            this.btnResetDefault.Size = new Size(104, 25);
-            this.btnResetDefault.TabIndex = 1;
-            this.btnResetDefault.Text = "Reset to &defaults";
-            this.btnResetDefault.UseVisualStyleBackColor = true;
-            this.btnResetDefault.Visible = false;
+            this.Ok.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.Ok.Location = new System.Drawing.Point(320, 8);
+            this.Ok.Name = "Ok";
+            this.Ok.Size = new System.Drawing.Size(75, 23);
+            this.Ok.TabIndex = 0;
+            this.Ok.Text = "OK";
+            this.Ok.UseVisualStyleBackColor = true;
+            this.Ok.Click += new System.EventHandler(this.OkClick);
             // 
             // _NO_TRANSLATE_lblSince
             // 
@@ -563,7 +548,7 @@
             // 
             // FormRevisionFilter
             // 
-            this.AcceptButton = this.btnOk;
+            this.AcceptButton = this.Ok;
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(408, 527);
@@ -585,7 +570,7 @@
 
         #endregion
 
-        private System.Windows.Forms.Button btnOk;
+        private System.Windows.Forms.Button Ok;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Label _NO_TRANSLATE_lblSince;
         private System.Windows.Forms.CheckBox SinceCheck;
@@ -623,6 +608,5 @@
         private System.Windows.Forms.CheckBox FullHistoryCheck;
         private System.Windows.Forms.CheckBox SimplifyMergesCheck;
         private System.Windows.Forms.ToolTip toolTip;
-        private System.Windows.Forms.Button btnResetDefault;
     }
 }

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -45,6 +45,13 @@ namespace GitUI.UserControls.RevisionGrid
             _filterInfo = filterInfo;
         }
 
+        private void CheckIfChanged()
+        {
+            FilterInfo tempFilter = new();
+            UpdateFilterInfoFromUI(tempFilter);
+            btnResetDefault.Visible = tempFilter.HasFilter;
+        }
+
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
@@ -82,17 +89,6 @@ namespace GitUI.UserControls.RevisionGrid
             UpdateFilters();
         }
 
-        private void option_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateFilters();
-
-            // If CommitsLimitCheck was changed, the displayed value may need to be updated too
-            if (sender == CommitsLimitCheck && !CommitsLimitCheck.Checked)
-            {
-                _NO_TRANSLATE_CommitsLimit.Value = _filterInfo.CommitsLimitDefault;
-            }
-        }
-
         private void UpdateFilters()
         {
             Since.Enabled = SinceCheck.Checked;
@@ -110,36 +106,56 @@ namespace GitUI.UserControls.RevisionGrid
             BranchFilter.Enabled = BranchFilterCheck.Checked;
         }
 
-        private void OkClick(object sender, EventArgs e)
+        private void UpdateFilterInfoFromUI(FilterInfo filterInfo)
         {
             // Note: There is no validation that information (like branch filters) are valid
 
-            _filterInfo.ByDateFrom = SinceCheck.Checked;
-            _filterInfo.DateFrom = Since.Value;
-            _filterInfo.ByDateTo = CheckUntil.Checked;
-            _filterInfo.DateTo = Until.Value;
-            _filterInfo.ByAuthor = AuthorCheck.Checked;
-            _filterInfo.Author = Author.Text.Trim();
-            _filterInfo.ByCommitter = CommitterCheck.Checked;
-            _filterInfo.Committer = Committer.Text.Trim();
-            _filterInfo.ByMessage = MessageCheck.Checked;
-            _filterInfo.Message = Message.Text.Trim();
-            _filterInfo.ByDiffContent = DiffContentCheck.Checked;
-            _filterInfo.DiffContent = DiffContent.Text.Trim();
-            _filterInfo.IgnoreCase = IgnoreCase.Checked;
-            _filterInfo.ByCommitsLimit = CommitsLimitCheck.Checked;
-            _filterInfo.CommitsLimit = (int)_NO_TRANSLATE_CommitsLimit.Value;
-            _filterInfo.ByPathFilter = PathFilterCheck.Checked;
-            _filterInfo.PathFilter = PathFilter.Text;
-            _filterInfo.ByBranchFilter = BranchFilterCheck.Checked;
-            _filterInfo.BranchFilter = BranchFilter.Text;
-            _filterInfo.ShowCurrentBranchOnly = CurrentBranchOnlyCheck.Checked;
-            _filterInfo.ShowReflogReferences = ReflogCheck.Checked;
-            _filterInfo.ShowOnlyFirstParent = OnlyFirstParentCheck.Checked;
-            _filterInfo.NoMergeCommits = NoMergeCommitsCheck.Checked;
-            _filterInfo.ShowSimplifyByDecoration = SimplifyByDecorationCheck.Checked;
-            _filterInfo.ShowFullHistory = FullHistoryCheck.Checked;
-            _filterInfo.ShowSimplifyMerges = SimplifyMergesCheck.Checked;
+            filterInfo.ByDateFrom = SinceCheck.Checked;
+            filterInfo.DateFrom = Since.Value;
+            filterInfo.ByDateTo = CheckUntil.Checked;
+            filterInfo.DateTo = Until.Value;
+            filterInfo.ByAuthor = AuthorCheck.Checked;
+            filterInfo.Author = Author.Text.Trim();
+            filterInfo.ByCommitter = CommitterCheck.Checked;
+            filterInfo.Committer = Committer.Text.Trim();
+            filterInfo.ByMessage = MessageCheck.Checked;
+            filterInfo.Message = Message.Text.Trim();
+            filterInfo.ByDiffContent = DiffContentCheck.Checked;
+            filterInfo.DiffContent = DiffContent.Text.Trim();
+            filterInfo.IgnoreCase = IgnoreCase.Checked;
+            filterInfo.ByCommitsLimit = CommitsLimitCheck.Checked;
+            filterInfo.CommitsLimit = (int)_NO_TRANSLATE_CommitsLimit.Value;
+            filterInfo.ByPathFilter = PathFilterCheck.Checked;
+            filterInfo.PathFilter = PathFilter.Text;
+            filterInfo.ByBranchFilter = BranchFilterCheck.Checked;
+            filterInfo.BranchFilter = BranchFilter.Text;
+            filterInfo.ShowCurrentBranchOnly = CurrentBranchOnlyCheck.Checked;
+            filterInfo.ShowReflogReferences = ReflogCheck.Checked;
+            filterInfo.ShowOnlyFirstParent = OnlyFirstParentCheck.Checked;
+            filterInfo.NoMergeCommits = NoMergeCommitsCheck.Checked;
+            filterInfo.ShowSimplifyByDecoration = SimplifyByDecorationCheck.Checked;
+            filterInfo.ShowFullHistory = FullHistoryCheck.Checked;
+            filterInfo.ShowSimplifyMerges = SimplifyMergesCheck.Checked;
+        }
+
+        private void btnOk_Click(object sender, EventArgs e)
+        {
+            // Note: There is no validation that information (like branch filters) are valid
+
+            UpdateFilterInfoFromUI(_filterInfo);
+        }
+
+        private void option_CheckedChanged(object sender, EventArgs e)
+        {
+            UpdateFilters();
+
+            // If CommitsLimitCheck was changed, the displayed value may need to be updated too
+            if (sender == CommitsLimitCheck && !CommitsLimitCheck.Checked)
+            {
+                _NO_TRANSLATE_CommitsLimit.Value = _filterInfo.CommitsLimitDefault;
+            }
+
+            CheckIfChanged();
         }
     }
 }

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -74,7 +74,7 @@ namespace GitUI.UserControls.RevisionGrid
             CurrentBranchOnlyCheck.Checked = rawFilterInfo.ShowCurrentBranchOnly;
             ReflogCheck.Checked = rawFilterInfo.ShowReflogReferences;
             OnlyFirstParentCheck.Checked = rawFilterInfo.ShowOnlyFirstParent;
-            MergeCommitsCheck.Checked = rawFilterInfo.ShowMergeCommits;
+            NoMergeCommitsCheck.Checked = rawFilterInfo.NoMergeCommits;
             SimplifyByDecorationCheck.Checked = rawFilterInfo.ShowSimplifyByDecoration;
             FullHistoryCheck.Checked = rawFilterInfo.ShowFullHistory;
             SimplifyMergesCheck.Checked = rawFilterInfo.ShowSimplifyMerges;
@@ -136,7 +136,7 @@ namespace GitUI.UserControls.RevisionGrid
             _filterInfo.ShowCurrentBranchOnly = CurrentBranchOnlyCheck.Checked;
             _filterInfo.ShowReflogReferences = ReflogCheck.Checked;
             _filterInfo.ShowOnlyFirstParent = OnlyFirstParentCheck.Checked;
-            _filterInfo.ShowMergeCommits = MergeCommitsCheck.Checked;
+            _filterInfo.NoMergeCommits = NoMergeCommitsCheck.Checked;
             _filterInfo.ShowSimplifyByDecoration = SimplifyByDecorationCheck.Checked;
             _filterInfo.ShowFullHistory = FullHistoryCheck.Checked;
             _filterInfo.ShowSimplifyMerges = SimplifyMergesCheck.Checked;

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -45,13 +45,6 @@ namespace GitUI.UserControls.RevisionGrid
             _filterInfo = filterInfo;
         }
 
-        private void CheckIfChanged()
-        {
-            FilterInfo tempFilter = new();
-            UpdateFilterInfoFromUI(tempFilter);
-            btnResetDefault.Visible = tempFilter.HasFilter;
-        }
-
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
@@ -89,6 +82,17 @@ namespace GitUI.UserControls.RevisionGrid
             UpdateFilters();
         }
 
+        private void option_CheckedChanged(object sender, EventArgs e)
+        {
+            UpdateFilters();
+
+            // If CommitsLimitCheck was changed, the displayed value may need to be updated too
+            if (sender == CommitsLimitCheck && !CommitsLimitCheck.Checked)
+            {
+                _NO_TRANSLATE_CommitsLimit.Value = _filterInfo.CommitsLimitDefault;
+            }
+        }
+
         private void UpdateFilters()
         {
             Since.Enabled = SinceCheck.Checked;
@@ -106,56 +110,36 @@ namespace GitUI.UserControls.RevisionGrid
             BranchFilter.Enabled = BranchFilterCheck.Checked;
         }
 
-        private void UpdateFilterInfoFromUI(FilterInfo filterInfo)
+        private void OkClick(object sender, EventArgs e)
         {
             // Note: There is no validation that information (like branch filters) are valid
 
-            filterInfo.ByDateFrom = SinceCheck.Checked;
-            filterInfo.DateFrom = Since.Value;
-            filterInfo.ByDateTo = CheckUntil.Checked;
-            filterInfo.DateTo = Until.Value;
-            filterInfo.ByAuthor = AuthorCheck.Checked;
-            filterInfo.Author = Author.Text.Trim();
-            filterInfo.ByCommitter = CommitterCheck.Checked;
-            filterInfo.Committer = Committer.Text.Trim();
-            filterInfo.ByMessage = MessageCheck.Checked;
-            filterInfo.Message = Message.Text.Trim();
-            filterInfo.ByDiffContent = DiffContentCheck.Checked;
-            filterInfo.DiffContent = DiffContent.Text.Trim();
-            filterInfo.IgnoreCase = IgnoreCase.Checked;
-            filterInfo.ByCommitsLimit = CommitsLimitCheck.Checked;
-            filterInfo.CommitsLimit = (int)_NO_TRANSLATE_CommitsLimit.Value;
-            filterInfo.ByPathFilter = PathFilterCheck.Checked;
-            filterInfo.PathFilter = PathFilter.Text;
-            filterInfo.ByBranchFilter = BranchFilterCheck.Checked;
-            filterInfo.BranchFilter = BranchFilter.Text;
-            filterInfo.ShowCurrentBranchOnly = CurrentBranchOnlyCheck.Checked;
-            filterInfo.ShowReflogReferences = ReflogCheck.Checked;
-            filterInfo.ShowOnlyFirstParent = OnlyFirstParentCheck.Checked;
-            filterInfo.NoMergeCommits = NoMergeCommitsCheck.Checked;
-            filterInfo.ShowSimplifyByDecoration = SimplifyByDecorationCheck.Checked;
-            filterInfo.ShowFullHistory = FullHistoryCheck.Checked;
-            filterInfo.ShowSimplifyMerges = SimplifyMergesCheck.Checked;
-        }
-
-        private void btnOk_Click(object sender, EventArgs e)
-        {
-            // Note: There is no validation that information (like branch filters) are valid
-
-            UpdateFilterInfoFromUI(_filterInfo);
-        }
-
-        private void option_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateFilters();
-
-            // If CommitsLimitCheck was changed, the displayed value may need to be updated too
-            if (sender == CommitsLimitCheck && !CommitsLimitCheck.Checked)
-            {
-                _NO_TRANSLATE_CommitsLimit.Value = _filterInfo.CommitsLimitDefault;
-            }
-
-            CheckIfChanged();
+            _filterInfo.ByDateFrom = SinceCheck.Checked;
+            _filterInfo.DateFrom = Since.Value;
+            _filterInfo.ByDateTo = CheckUntil.Checked;
+            _filterInfo.DateTo = Until.Value;
+            _filterInfo.ByAuthor = AuthorCheck.Checked;
+            _filterInfo.Author = Author.Text.Trim();
+            _filterInfo.ByCommitter = CommitterCheck.Checked;
+            _filterInfo.Committer = Committer.Text.Trim();
+            _filterInfo.ByMessage = MessageCheck.Checked;
+            _filterInfo.Message = Message.Text.Trim();
+            _filterInfo.ByDiffContent = DiffContentCheck.Checked;
+            _filterInfo.DiffContent = DiffContent.Text.Trim();
+            _filterInfo.IgnoreCase = IgnoreCase.Checked;
+            _filterInfo.ByCommitsLimit = CommitsLimitCheck.Checked;
+            _filterInfo.CommitsLimit = (int)_NO_TRANSLATE_CommitsLimit.Value;
+            _filterInfo.ByPathFilter = PathFilterCheck.Checked;
+            _filterInfo.PathFilter = PathFilter.Text;
+            _filterInfo.ByBranchFilter = BranchFilterCheck.Checked;
+            _filterInfo.BranchFilter = BranchFilter.Text;
+            _filterInfo.ShowCurrentBranchOnly = CurrentBranchOnlyCheck.Checked;
+            _filterInfo.ShowReflogReferences = ReflogCheck.Checked;
+            _filterInfo.ShowOnlyFirstParent = OnlyFirstParentCheck.Checked;
+            _filterInfo.NoMergeCommits = NoMergeCommitsCheck.Checked;
+            _filterInfo.ShowSimplifyByDecoration = SimplifyByDecorationCheck.Checked;
+            _filterInfo.ShowFullHistory = FullHistoryCheck.Checked;
+            _filterInfo.ShowSimplifyMerges = SimplifyMergesCheck.Checked;
         }
     }
 }

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -74,7 +74,7 @@ namespace GitUI.UserControls.RevisionGrid
             CurrentBranchOnlyCheck.Checked = rawFilterInfo.ShowCurrentBranchOnly;
             ReflogCheck.Checked = rawFilterInfo.ShowReflogReferences;
             OnlyFirstParentCheck.Checked = rawFilterInfo.ShowOnlyFirstParent;
-            NoMergeCommitsCheck.Checked = rawFilterInfo.NoMergeCommits;
+            HideMergeCommitsCheck.Checked = rawFilterInfo.HideMergeCommits;
             SimplifyByDecorationCheck.Checked = rawFilterInfo.ShowSimplifyByDecoration;
             FullHistoryCheck.Checked = rawFilterInfo.ShowFullHistory;
             SimplifyMergesCheck.Checked = rawFilterInfo.ShowSimplifyMerges;
@@ -136,7 +136,7 @@ namespace GitUI.UserControls.RevisionGrid
             _filterInfo.ShowCurrentBranchOnly = CurrentBranchOnlyCheck.Checked;
             _filterInfo.ShowReflogReferences = ReflogCheck.Checked;
             _filterInfo.ShowOnlyFirstParent = OnlyFirstParentCheck.Checked;
-            _filterInfo.NoMergeCommits = NoMergeCommitsCheck.Checked;
+            _filterInfo.HideMergeCommits = HideMergeCommitsCheck.Checked;
             _filterInfo.ShowSimplifyByDecoration = SimplifyByDecorationCheck.Checked;
             _filterInfo.ShowFullHistory = FullHistoryCheck.Checked;
             _filterInfo.ShowSimplifyMerges = SimplifyMergesCheck.Checked;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Command.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Command.cs
@@ -12,7 +12,7 @@
             ToggleDrawNonRelativesGray = 5,
             ToggleShowGitNotes = 6,
             //// <snip>
-            ToggleShowMergeCommits = 8,
+            ToggleNoMergeCommits = 8,
             ShowAllBranches = 9,
             ShowCurrentBranchOnly = 10,
             ShowFilteredBranches = 11,

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Command.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Command.cs
@@ -12,7 +12,7 @@
             ToggleDrawNonRelativesGray = 5,
             ToggleShowGitNotes = 6,
             //// <snip>
-            ToggleNoMergeCommits = 8,
+            ToggleHideMergeCommits = 8,
             ShowAllBranches = 9,
             ShowCurrentBranchOnly = 10,
             ShowFilteredBranches = 11,

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2463,9 +2463,9 @@ namespace GitUI
             PerformRefreshRevisions();
         }
 
-        internal void ToggleShowMergeCommits()
+        internal void ToggleNoMergeCommits()
         {
-            AppSettings.ShowMergeCommits = !AppSettings.ShowMergeCommits;
+            AppSettings.NoMergeCommits = !AppSettings.NoMergeCommits;
             PerformRefreshRevisions();
         }
 
@@ -3021,7 +3021,7 @@ namespace GitUI
                 case Command.ToggleShowRelativeDate: ToggleShowRelativeDate(EventArgs.Empty); break;
                 case Command.ToggleDrawNonRelativesGray: ToggleDrawNonRelativesGray(); break;
                 case Command.ToggleShowGitNotes: ToggleShowGitNotes(); break;
-                case Command.ToggleShowMergeCommits: ToggleShowMergeCommits(); break;
+                case Command.ToggleNoMergeCommits: ToggleNoMergeCommits(); break;
                 case Command.ToggleShowTags: ToggleShowTags(); break;
                 case Command.ShowAllBranches: ShowAllBranches(); break;
                 case Command.ShowCurrentBranchOnly: ShowCurrentBranchOnly(); break;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -86,7 +86,7 @@ namespace GitUI
         private readonly TranslationString _rebaseBranchInteractive = new("Rebase branch interactively.");
         private readonly TranslationString _areYouSureRebase = new("Are you sure you want to rebase? This action will rewrite commit history.");
         private readonly TranslationString _dontShowAgain = new("Don't show me this message again.");
-        private readonly TranslationString _noMergeBaseCommit = new("There is no common ancestor for the selected commits.");
+        private readonly TranslationString _hideMergeBaseCommit = new("There is no common ancestor for the selected commits.");
         private readonly TranslationString _invalidDiffContainsFilter = new("Filter text '{0}' not valid for \"Diff contains\" filter.");
 
         private readonly FilterInfo _filterInfo = new();
@@ -2463,9 +2463,9 @@ namespace GitUI
             PerformRefreshRevisions();
         }
 
-        internal void ToggleNoMergeCommits()
+        internal void ToggleHideMergeCommits()
         {
-            AppSettings.NoMergeCommits = !AppSettings.NoMergeCommits;
+            AppSettings.HideMergeCommits = !AppSettings.HideMergeCommits;
             PerformRefreshRevisions();
         }
 
@@ -2705,7 +2705,7 @@ namespace GitUI
             var mergeBaseCommitId = UICommands.GitModule.GitExecutable.GetOutput(args).TrimEnd('\n');
             if (string.IsNullOrWhiteSpace(mergeBaseCommitId))
             {
-                MessageBox.Show(_noMergeBaseCommit.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(_hideMergeBaseCommit.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -3021,7 +3021,7 @@ namespace GitUI
                 case Command.ToggleShowRelativeDate: ToggleShowRelativeDate(EventArgs.Empty); break;
                 case Command.ToggleDrawNonRelativesGray: ToggleDrawNonRelativesGray(); break;
                 case Command.ToggleShowGitNotes: ToggleShowGitNotes(); break;
-                case Command.ToggleNoMergeCommits: ToggleNoMergeCommits(); break;
+                case Command.ToggleHideMergeCommits: ToggleHideMergeCommits(); break;
                 case Command.ToggleShowTags: ToggleShowTags(); break;
                 case Command.ShowAllBranches: ShowAllBranches(); break;
                 case Command.ShowCurrentBranchOnly: ShowCurrentBranchOnly(); break;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -86,7 +86,7 @@ namespace GitUI
         private readonly TranslationString _rebaseBranchInteractive = new("Rebase branch interactively.");
         private readonly TranslationString _areYouSureRebase = new("Are you sure you want to rebase? This action will rewrite commit history.");
         private readonly TranslationString _dontShowAgain = new("Don't show me this message again.");
-        private readonly TranslationString _hideMergeBaseCommit = new("There is no common ancestor for the selected commits.");
+        private readonly TranslationString _noMergeBaseCommit = new("There is no common ancestor for the selected commits.");
         private readonly TranslationString _invalidDiffContainsFilter = new("Filter text '{0}' not valid for \"Diff contains\" filter.");
 
         private readonly FilterInfo _filterInfo = new();
@@ -2705,7 +2705,7 @@ namespace GitUI
             var mergeBaseCommitId = UICommands.GitModule.GitExecutable.GetOutput(args).TrimEnd('\n');
             if (string.IsNullOrWhiteSpace(mergeBaseCommitId))
             {
-                MessageBox.Show(_hideMergeBaseCommit.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(_noMergeBaseCommit.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -257,7 +257,7 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.RelativeDate)], true, false, false);
                 yield return (properties[nameof(AppSettings.ShowGitNotes)], false, false, false);
                 yield return (properties[nameof(AppSettings.ShowAnnotatedTagsMessages)], true, false, false);
-                yield return (properties[nameof(AppSettings.NoMergeCommits)], false, false, false);
+                yield return (properties[nameof(AppSettings.HideMergeCommits)], false, false, false);
                 yield return (properties[nameof(AppSettings.ShowTags)], true, false, false);
                 yield return (properties[nameof(AppSettings.ShowRevisionGridGraphColumn)], true, false, false);
                 yield return (properties[nameof(AppSettings.ShowAuthorAvatarColumn)], true, false, false);

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -205,7 +205,7 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.FollowRenamesInFileHistory)], true, false, false);
                 yield return (properties[nameof(AppSettings.FollowRenamesInFileHistoryExactOnly)], false, false, false);
                 yield return (properties[nameof(AppSettings.FullHistoryInFileHistory)], false, false, false);
-                yield return (properties[nameof(AppSettings.SimplifyMergesInFileHistory)], true, false, false);
+                yield return (properties[nameof(AppSettings.SimplifyMergesInFileHistory)], false, false, false);
                 yield return (properties[nameof(AppSettings.LoadFileHistoryOnShow)], true, false, false);
                 yield return (properties[nameof(AppSettings.LoadBlameOnShow)], true, false, false);
                 yield return (properties[nameof(AppSettings.DetectCopyInFileOnBlame)], true, false, false);
@@ -257,7 +257,7 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.RelativeDate)], true, false, false);
                 yield return (properties[nameof(AppSettings.ShowGitNotes)], false, false, false);
                 yield return (properties[nameof(AppSettings.ShowAnnotatedTagsMessages)], true, false, false);
-                yield return (properties[nameof(AppSettings.ShowMergeCommits)], true, false, false);
+                yield return (properties[nameof(AppSettings.NoMergeCommits)], false, false, false);
                 yield return (properties[nameof(AppSettings.ShowTags)], true, false, false);
                 yield return (properties[nameof(AppSettings.ShowRevisionGridGraphColumn)], true, false, false);
                 yield return (properties[nameof(AppSettings.ShowAuthorAvatarColumn)], true, false, false);

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.FilterInfo_ctor_expected.verified.txt
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.FilterInfo_ctor_expected.verified.txt
@@ -26,7 +26,7 @@
   ShowOnlyFirstParent: false,
   ShowReflogReferences: false,
   ShowSimplifyByDecoration: false,
-  ShowMergeCommits: true,
+  NoMergeCommits: false,
   ShowFullHistory: false,
   ShowSimplifyMerges: false,
   HasFilter: false,

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.FilterInfo_ctor_expected.verified.txt
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.FilterInfo_ctor_expected.verified.txt
@@ -26,7 +26,7 @@
   ShowOnlyFirstParent: false,
   ShowReflogReferences: false,
   ShowSimplifyByDecoration: false,
-  NoMergeCommits: false,
+  HideMergeCommits: false,
   ShowFullHistory: false,
   ShowSimplifyMerges: false,
   HasFilter: false,

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.FilterInfo_ctor_with_Raw_expected.verified.txt
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.FilterInfo_ctor_with_Raw_expected.verified.txt
@@ -26,7 +26,7 @@
   ShowOnlyFirstParent: false,
   ShowReflogReferences: false,
   ShowSimplifyByDecoration: false,
-  ShowMergeCommits: true,
+  NoMergeCommits: false,
   ShowFullHistory: false,
   ShowSimplifyMerges: false,
   HasFilter: false,

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.FilterInfo_ctor_with_Raw_expected.verified.txt
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.FilterInfo_ctor_with_Raw_expected.verified.txt
@@ -26,7 +26,7 @@
   ShowOnlyFirstParent: false,
   ShowReflogReferences: false,
   ShowSimplifyByDecoration: false,
-  NoMergeCommits: false,
+  HideMergeCommits: false,
   ShowFullHistory: false,
   ShowSimplifyMerges: false,
   HasFilter: false,

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
@@ -17,7 +17,7 @@ namespace GitUITests.UserControls
         public void SetUp()
         {
             AppSettings.ShowGitNotes = false;
-            AppSettings.NoMergeCommits = false;
+            AppSettings.HideMergeCommits = false;
             AppSettings.ShowOnlyFirstParent = false;
             AppSettings.ShowSimplifyByDecoration = false;
             AppSettings.SimplifyMergesInFileHistory = false;
@@ -819,7 +819,7 @@ namespace GitUITests.UserControls
                                     {
                                         foreach (bool showSimplifyByDecoration in new[] { false, true })
                                         {
-                                            foreach (bool noMergeCommits in new[] { false, true })
+                                            foreach (bool hideMergeCommits in new[] { false, true })
                                             {
                                                 foreach (string pathFilter in new[] { "file1", "", null })
                                                 {
@@ -829,7 +829,7 @@ namespace GitUITests.UserControls
                                                         {
                                                             foreach (string branchFilter in new[] { "branch1", "", null })
                                                             {
-                                                                yield return new TestCaseData(byDateFrom, byDateTo, byAuthor, byCommitter, byMessage, byDiffContent, showSimplifyByDecoration, noMergeCommits, pathFilter, showCurrentBranchOnly, showReflogReferences, branchFilter);
+                                                                yield return new TestCaseData(byDateFrom, byDateTo, byAuthor, byCommitter, byMessage, byDiffContent, showSimplifyByDecoration, hideMergeCommits, pathFilter, showCurrentBranchOnly, showReflogReferences, branchFilter);
                                                             }
                                                         }
                                                     }
@@ -846,7 +846,7 @@ namespace GitUITests.UserControls
         }
 
         [TestCaseSource(nameof(FilterInfo_HasFilterTestCases))]
-        public void FilterInfo_HasFilter_expected(bool byDateFrom, bool byDateTo, bool byAuthor, bool byCommitter, bool byMessage, bool byDiffContent, bool showSimplifyByDecoration, bool noMergeCommits, string pathFilter, bool showCurrentBranchOnly, bool showReflogReferences, string branchFilter)
+        public void FilterInfo_HasFilter_expected(bool byDateFrom, bool byDateTo, bool byAuthor, bool byCommitter, bool byMessage, bool byDiffContent, bool showSimplifyByDecoration, bool hideMergeCommits, string pathFilter, bool showCurrentBranchOnly, bool showReflogReferences, string branchFilter)
         {
             FilterInfo filterInfo = new()
             {
@@ -857,7 +857,7 @@ namespace GitUITests.UserControls
                 ByMessage = byMessage,
                 ByDiffContent = byDiffContent,
                 ShowSimplifyByDecoration = showSimplifyByDecoration,
-                NoMergeCommits = noMergeCommits,
+                HideMergeCommits = hideMergeCommits,
                 ByPathFilter = true,
                 PathFilter = pathFilter,
                 ShowCurrentBranchOnly = showCurrentBranchOnly,
@@ -866,11 +866,11 @@ namespace GitUITests.UserControls
                 BranchFilter = branchFilter
             };
 
-            filterInfo.HasFilter.Should().Be(byDateFrom || byDateTo || byAuthor || byCommitter || byMessage || byDiffContent || showSimplifyByDecoration || noMergeCommits || !string.IsNullOrWhiteSpace(pathFilter) || !string.IsNullOrWhiteSpace(branchFilter));
+            filterInfo.HasFilter.Should().Be(byDateFrom || byDateTo || byAuthor || byCommitter || byMessage || byDiffContent || showSimplifyByDecoration || hideMergeCommits || !string.IsNullOrWhiteSpace(pathFilter) || !string.IsNullOrWhiteSpace(branchFilter));
         }
 
         [TestCaseSource(nameof(FilterInfo_HasFilterTestCases))]
-        public void FilterInfo_ResetAllFilters_expected(bool byDateFrom, bool byDateTo, bool byAuthor, bool byCommitter, bool byMessage, bool byDiffContent, bool showSimplifyByDecoration, bool noMergeCommits, string pathFilter, bool showCurrentBranchOnly, bool showReflogReferences, string branchFilter)
+        public void FilterInfo_ResetAllFilters_expected(bool byDateFrom, bool byDateTo, bool byAuthor, bool byCommitter, bool byMessage, bool byDiffContent, bool showSimplifyByDecoration, bool hideMergeCommits, string pathFilter, bool showCurrentBranchOnly, bool showReflogReferences, string branchFilter)
         {
             FilterInfo filterInfo = new()
             {
@@ -881,7 +881,7 @@ namespace GitUITests.UserControls
                 ByMessage = byMessage,
                 ByDiffContent = byDiffContent,
                 ShowSimplifyByDecoration = showSimplifyByDecoration,
-                NoMergeCommits = noMergeCommits,
+                HideMergeCommits = hideMergeCommits,
                 ByPathFilter = true,
                 PathFilter = pathFilter,
                 ShowCurrentBranchOnly = showCurrentBranchOnly,
@@ -899,7 +899,7 @@ namespace GitUITests.UserControls
             filterInfo.ByMessage.Should().BeFalse();
             filterInfo.ByDiffContent.Should().BeFalse();
             filterInfo.ShowSimplifyByDecoration.Should().BeFalse();
-            filterInfo.NoMergeCommits.Should().BeFalse();
+            filterInfo.HideMergeCommits.Should().BeFalse();
             filterInfo.ByPathFilter.Should().BeFalse();
             filterInfo.ByBranchFilter.Should().BeFalse();
 
@@ -910,7 +910,7 @@ namespace GitUITests.UserControls
         [TestCase("author1", "committer2", "message3", "diffContent4", true, true, "pathFilter7", false, false, "branchFilter8",
             "Since: 10/1/2021 1:30:34 AM\r\nUntil: 11/1/2021 1:30:34 AM\r\nPath filter: pathFilter7\r\nAuthor: author1\r\nCommitter: committer2\r\nSimplify by decoration\r\nMessage: message3\r\nDiff contains: diffContent4\r\nBranches: branchFilter8\r\n",
             @"--max-count=100000 --since=""2021-10-01 01:30:34"" --until=""2021-11-01 01:30:34"" --no-merges --simplify-by-decoration --author=""author1"" --committer=""committer2"" --regexp-ignore-case -G""diffContent4"" --grep=""message3"" --parents --glob=refs/stas[h] branchFilter8")]
-        public void FilterInfo_GetRevisionFilter(string author, string committer, string message, string diffContent, bool showSimplifyByDecoration, bool noMergeCommits, string pathFilter, bool showReflog, bool showCurrentBranchOnly, string branchFilter, string expectedSummary, string expectedArgs)
+        public void FilterInfo_GetRevisionFilter(string author, string committer, string message, string diffContent, bool showSimplifyByDecoration, bool hideMergeCommits, string pathFilter, bool showReflog, bool showCurrentBranchOnly, string branchFilter, string expectedSummary, string expectedArgs)
         {
             AppSettings.MaxRevisionGraphCommits = 100000;
             DateTime dateFrom = new(2021, 10, 1, 1, 30, 34, DateTimeKind.Local);
@@ -930,7 +930,7 @@ namespace GitUITests.UserControls
                 DiffContent = diffContent,
                 ByDiffContent = !string.IsNullOrEmpty(message),
                 ShowSimplifyByDecoration = showSimplifyByDecoration,
-                NoMergeCommits = noMergeCommits,
+                HideMergeCommits = hideMergeCommits,
                 PathFilter = pathFilter,
                 ByPathFilter = !string.IsNullOrEmpty(pathFilter),
                 ShowReflogReferences = showReflog,
@@ -1055,11 +1055,11 @@ namespace GitUITests.UserControls
 
         [TestCase(false)]
         [TestCase(true)]
-        public void FilterInfo_NoMerges(bool expected)
+        public void FilterInfo_HideMerges(bool expected)
         {
             FilterInfo filterInfo = new()
             {
-                NoMergeCommits = expected
+                HideMergeCommits = expected
             };
 
             string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId?>(() => ObjectId.Random()));

--- a/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/FilterInfoTests.cs
@@ -17,7 +17,7 @@ namespace GitUITests.UserControls
         public void SetUp()
         {
             AppSettings.ShowGitNotes = false;
-            AppSettings.ShowMergeCommits = true;
+            AppSettings.NoMergeCommits = false;
             AppSettings.ShowOnlyFirstParent = false;
             AppSettings.ShowSimplifyByDecoration = false;
             AppSettings.SimplifyMergesInFileHistory = false;
@@ -819,7 +819,7 @@ namespace GitUITests.UserControls
                                     {
                                         foreach (bool showSimplifyByDecoration in new[] { false, true })
                                         {
-                                            foreach (bool showMergeCommits in new[] { false, true })
+                                            foreach (bool noMergeCommits in new[] { false, true })
                                             {
                                                 foreach (string pathFilter in new[] { "file1", "", null })
                                                 {
@@ -829,7 +829,7 @@ namespace GitUITests.UserControls
                                                         {
                                                             foreach (string branchFilter in new[] { "branch1", "", null })
                                                             {
-                                                                yield return new TestCaseData(byDateFrom, byDateTo, byAuthor, byCommitter, byMessage, byDiffContent, showSimplifyByDecoration, showMergeCommits, pathFilter, showCurrentBranchOnly, showReflogReferences, branchFilter);
+                                                                yield return new TestCaseData(byDateFrom, byDateTo, byAuthor, byCommitter, byMessage, byDiffContent, showSimplifyByDecoration, noMergeCommits, pathFilter, showCurrentBranchOnly, showReflogReferences, branchFilter);
                                                             }
                                                         }
                                                     }
@@ -846,7 +846,7 @@ namespace GitUITests.UserControls
         }
 
         [TestCaseSource(nameof(FilterInfo_HasFilterTestCases))]
-        public void FilterInfo_HasFilter_expected(bool byDateFrom, bool byDateTo, bool byAuthor, bool byCommitter, bool byMessage, bool byDiffContent, bool showSimplifyByDecoration, bool showMergeCommits, string pathFilter, bool showCurrentBranchOnly, bool showReflogReferences, string branchFilter)
+        public void FilterInfo_HasFilter_expected(bool byDateFrom, bool byDateTo, bool byAuthor, bool byCommitter, bool byMessage, bool byDiffContent, bool showSimplifyByDecoration, bool noMergeCommits, string pathFilter, bool showCurrentBranchOnly, bool showReflogReferences, string branchFilter)
         {
             FilterInfo filterInfo = new()
             {
@@ -857,7 +857,7 @@ namespace GitUITests.UserControls
                 ByMessage = byMessage,
                 ByDiffContent = byDiffContent,
                 ShowSimplifyByDecoration = showSimplifyByDecoration,
-                ShowMergeCommits = showMergeCommits,
+                NoMergeCommits = noMergeCommits,
                 ByPathFilter = true,
                 PathFilter = pathFilter,
                 ShowCurrentBranchOnly = showCurrentBranchOnly,
@@ -866,11 +866,11 @@ namespace GitUITests.UserControls
                 BranchFilter = branchFilter
             };
 
-            filterInfo.HasFilter.Should().Be(byDateFrom || byDateTo || byAuthor || byCommitter || byMessage || byDiffContent || showSimplifyByDecoration || !showMergeCommits || !string.IsNullOrWhiteSpace(pathFilter) || !string.IsNullOrWhiteSpace(branchFilter));
+            filterInfo.HasFilter.Should().Be(byDateFrom || byDateTo || byAuthor || byCommitter || byMessage || byDiffContent || showSimplifyByDecoration || noMergeCommits || !string.IsNullOrWhiteSpace(pathFilter) || !string.IsNullOrWhiteSpace(branchFilter));
         }
 
         [TestCaseSource(nameof(FilterInfo_HasFilterTestCases))]
-        public void FilterInfo_ResetAllFilters_expected(bool byDateFrom, bool byDateTo, bool byAuthor, bool byCommitter, bool byMessage, bool byDiffContent, bool showSimplifyByDecoration, bool showMergeCommits, string pathFilter, bool showCurrentBranchOnly, bool showReflogReferences, string branchFilter)
+        public void FilterInfo_ResetAllFilters_expected(bool byDateFrom, bool byDateTo, bool byAuthor, bool byCommitter, bool byMessage, bool byDiffContent, bool showSimplifyByDecoration, bool noMergeCommits, string pathFilter, bool showCurrentBranchOnly, bool showReflogReferences, string branchFilter)
         {
             FilterInfo filterInfo = new()
             {
@@ -881,7 +881,7 @@ namespace GitUITests.UserControls
                 ByMessage = byMessage,
                 ByDiffContent = byDiffContent,
                 ShowSimplifyByDecoration = showSimplifyByDecoration,
-                ShowMergeCommits = showMergeCommits,
+                NoMergeCommits = noMergeCommits,
                 ByPathFilter = true,
                 PathFilter = pathFilter,
                 ShowCurrentBranchOnly = showCurrentBranchOnly,
@@ -899,7 +899,7 @@ namespace GitUITests.UserControls
             filterInfo.ByMessage.Should().BeFalse();
             filterInfo.ByDiffContent.Should().BeFalse();
             filterInfo.ShowSimplifyByDecoration.Should().BeFalse();
-            filterInfo.ShowMergeCommits.Should().BeTrue();
+            filterInfo.NoMergeCommits.Should().BeFalse();
             filterInfo.ByPathFilter.Should().BeFalse();
             filterInfo.ByBranchFilter.Should().BeFalse();
 
@@ -907,10 +907,10 @@ namespace GitUITests.UserControls
             filterInfo.ShowReflogReferences.Should().Be(showReflogReferences);
         }
 
-        [TestCase("author1", "committer2", "message3", "diffContent4", true, false, "pathFilter7", false, false, "branchFilter8",
+        [TestCase("author1", "committer2", "message3", "diffContent4", true, true, "pathFilter7", false, false, "branchFilter8",
             "Since: 10/1/2021 1:30:34 AM\r\nUntil: 11/1/2021 1:30:34 AM\r\nPath filter: pathFilter7\r\nAuthor: author1\r\nCommitter: committer2\r\nSimplify by decoration\r\nMessage: message3\r\nDiff contains: diffContent4\r\nBranches: branchFilter8\r\n",
             @"--max-count=100000 --since=""2021-10-01 01:30:34"" --until=""2021-11-01 01:30:34"" --no-merges --simplify-by-decoration --author=""author1"" --committer=""committer2"" --regexp-ignore-case -G""diffContent4"" --grep=""message3"" --parents --glob=refs/stas[h] branchFilter8")]
-        public void FilterInfo_GetRevisionFilter(string author, string committer, string message, string diffContent, bool showSimplifyByDecoration, bool showMergeCommits, string pathFilter, bool showReflog, bool showCurrentBranchOnly, string branchFilter, string expectedSummary, string expectedArgs)
+        public void FilterInfo_GetRevisionFilter(string author, string committer, string message, string diffContent, bool showSimplifyByDecoration, bool noMergeCommits, string pathFilter, bool showReflog, bool showCurrentBranchOnly, string branchFilter, string expectedSummary, string expectedArgs)
         {
             AppSettings.MaxRevisionGraphCommits = 100000;
             DateTime dateFrom = new(2021, 10, 1, 1, 30, 34, DateTimeKind.Local);
@@ -930,7 +930,7 @@ namespace GitUITests.UserControls
                 DiffContent = diffContent,
                 ByDiffContent = !string.IsNullOrEmpty(message),
                 ShowSimplifyByDecoration = showSimplifyByDecoration,
-                ShowMergeCommits = showMergeCommits,
+                NoMergeCommits = noMergeCommits,
                 PathFilter = pathFilter,
                 ByPathFilter = !string.IsNullOrEmpty(pathFilter),
                 ShowReflogReferences = showReflog,
@@ -1059,12 +1059,12 @@ namespace GitUITests.UserControls
         {
             FilterInfo filterInfo = new()
             {
-                ShowMergeCommits = expected
+                NoMergeCommits = expected
             };
 
             string args = filterInfo.GetRevisionFilter(new Lazy<ObjectId?>(() => ObjectId.Random()));
 
-            if (!expected)
+            if (expected)
             {
                 args.ToString().Should().MatchRegex(@"(^|\s)--no-merges($|\s)");
             }


### PR DESCRIPTION
Follow up to #11065 

## Proposed changes

This better reflects the Git defaults and changes the only option ticked by default, that adds filter by selection.
Supposedly, this was a confusion in #11065

Change default for --simplify-merges to false to match defaults. Anyway, the value is not used by default as --full-history is false and --simplify-merges depends on --full-history.

--

This handles a setting with negation in the name, which can be confusing. The cange could be done in the user facing part only.
However, it is normally easier if the code and UI matches. This also remove the special handlig for the setting, negating by default.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/6248932/d2b563e2-85e7-45b6-9e3b-f9733330d6f3)

### After

![image](https://github.com/gitextensions/gitextensions/assets/6248932/36cfd23c-d225-445c-947a-2fd249d89844)

## Test methodology <!-- How did you ensure quality? -->

Tests updated

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
