### PR TITLE
More user friendly handling for "Could not load file or assembly" exceptions

### DIFF
--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -217,16 +217,18 @@ namespace GitUI.NBugReports
             {
                 Icon = TaskDialogIcon.Error,
                 Caption = TranslatedStrings.FailedToLoadAnAssembly,
-                Heading = TranslatedStrings.FailedToLoadAnAssemblyHeader,
-                Text = TranslatedStrings.FailedToLoadAnAssemblyExplanation,
+                Heading = string.Format(TranslatedStrings.FailedToLoadFileOrAssemblyFormat, exception.FileName),
+                Text = TranslatedStrings.FailedToLoadFileOrAssemblyText,
                 AllowCancel = false,
                 SizeToContent = true,
             };
 
-            TaskDialogCommandLinkButton relaunchButton = new(TranslatedStrings.RelaunchGitExtensions);
+            TaskDialogCommandLinkButton relaunchButton = new(TranslatedStrings.RestartApplication);
+            relaunchButton.DescriptionText = TranslatedStrings.RestartApplicationDescription;
             pageFailToLoadAssembly.Buttons.Add(relaunchButton);
 
-            TaskDialogCommandLinkButton reportButton = new(TranslatedStrings.ReportTheIssue);
+            TaskDialogCommandLinkButton reportButton = new(TranslatedStrings.ReportIssue);
+            reportButton.DescriptionText = TranslatedStrings.ReportIssueDescription;
             pageFailToLoadAssembly.Buttons.Add(reportButton);
 
             pageFailToLoadAssembly.Expander = new TaskDialogExpander

--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -117,6 +117,11 @@ namespace GitUI.NBugReports
                 Process.Start(pi);
                 Environment.Exit(0);
             }
+            else
+            {
+                ShowNBug(OwnerForm, exception, false, isTerminating);
+                return;
+            }
 
             ExternalOperationException externalOperationException = exception as ExternalOperationException;
 

--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -18,6 +18,12 @@ namespace GitUI.NBugReports
         private static IntPtr OwnerFormHandle
             => OwnerForm?.Handle ?? IntPtr.Zero;
 
+        private enum UserAction
+        {
+            ReportIssue,
+            RestartApplication
+        }
+
         /// <summary>
         /// Gets the root error.
         /// </summary>
@@ -99,6 +105,17 @@ namespace GitUI.NBugReports
             if (AppSettings.WriteErrorLog)
             {
                 LogError(exception, isTerminating);
+            }
+
+            if (exception is FileNotFoundException fileNotFoundException
+                && ReportFailToLoadAnAssembly(fileNotFoundException) == UserAction.RestartApplication)
+            {
+                // Skipping the 1st parameter that, starting from .net core, contains the path to application dll (instead of exe)
+                string arguments = string.Join(" ", Environment.GetCommandLineArgs().Skip(1));
+                ProcessStartInfo pi = new(Environment.ProcessPath, arguments);
+                pi.WorkingDirectory = Environment.CurrentDirectory;
+                Process.Start(pi);
+                Environment.Exit(0);
             }
 
             ExternalOperationException externalOperationException = exception as ExternalOperationException;
@@ -186,6 +203,38 @@ namespace GitUI.NBugReports
                 TaskDialogCommandLinkButton taskDialogCommandLink = new(buttonText);
                 page.Buttons.Add(taskDialogCommandLink);
             }
+        }
+
+        private static UserAction ReportFailToLoadAnAssembly(FileNotFoundException exception)
+        {
+            string error = exception.Message;
+            TaskDialogPage pageFailToLoadAssembly = new()
+            {
+                Icon = TaskDialogIcon.Error,
+                Caption = TranslatedStrings.FailedToLoadAnAssembly,
+                Heading = TranslatedStrings.FailedToLoadAnAssemblyHeader,
+                Text = TranslatedStrings.FailedToLoadAnAssemblyExplanation,
+                AllowCancel = false,
+                SizeToContent = true,
+            };
+
+            TaskDialogCommandLinkButton relaunchButton = new(TranslatedStrings.RelaunchGitExtensions);
+            pageFailToLoadAssembly.Buttons.Add(relaunchButton);
+
+            TaskDialogCommandLinkButton reportButton = new(TranslatedStrings.ReportTheIssue);
+            pageFailToLoadAssembly.Buttons.Add(reportButton);
+
+            pageFailToLoadAssembly.Expander = new TaskDialogExpander
+            {
+                CollapsedButtonText = TranslatedStrings.SeeErrorMessage,
+                ExpandedButtonText = TranslatedStrings.HideErrorMessage,
+                Position = TaskDialogExpanderPosition.AfterFootnote,
+                Text = error,
+            };
+
+            return TaskDialog.ShowDialog(OwnerFormHandle, pageFailToLoadAssembly) == relaunchButton
+                ? UserAction.RestartApplication
+                : UserAction.ReportIssue;
         }
 
         private static void ReportDubiousOwnership(Exception exception)

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -165,6 +165,16 @@ following command.
 
 !!! THIS CAN BE DANGEROUS !!!");
 
+        private readonly TranslationString _seeErrorMessage = new("See error message...");
+        private readonly TranslationString _hideErrorMessage = new("Hide error message...");
+        private readonly TranslationString _reportTheIssue = new("Report the issue");
+        private readonly TranslationString _restartGitExtensions = new("Restart " + AppSettings.ApplicationName);
+        private readonly TranslationString _failedToLoadAnAssembly = new("Failed to load an assembly");
+        private readonly TranslationString _failedToLoadAnAssemblyHeader = new(AppSettings.ApplicationName + " encountered a problem while trying to load an assembly.");
+        private readonly TranslationString _failedToLoadAnAssemblyExplanation = new(@"The error is believed to be caused by Windows Update and restarting the application should solve the issue.
+
+If it is not the first time it happens, and you can consistently reproduce the issue, please report it.");
+
         // public only because of FormTranslate
         public TranslatedStrings()
         {
@@ -336,5 +346,13 @@ following command.
         public static string GitDubiousOwnershipSeeGitCommandOutput => _instance.Value._gitDubiousOwnershipSeeGitCommandOutput.Text;
         public static string GitDubiousOwnershipHideGitCommandOutput => _instance.Value._gitDubiousOwnershipHideGitCommandOutput.Text;
         public static string GitDubiousOwnershipTrustAllInstruction => _instance.Value._gitDubiousOwnershipTrustAllInstruction.Text;
+
+        public static string SeeErrorMessage => _instance.Value._seeErrorMessage.Text;
+        public static string HideErrorMessage => _instance.Value._hideErrorMessage.Text;
+        public static string ReportTheIssue => _instance.Value._reportTheIssue.Text;
+        public static string RelaunchGitExtensions => _instance.Value._restartGitExtensions.Text;
+        public static string FailedToLoadAnAssembly => _instance.Value._failedToLoadAnAssembly.Text;
+        public static string FailedToLoadAnAssemblyHeader => _instance.Value._failedToLoadAnAssemblyHeader.Text;
+        public static string FailedToLoadAnAssemblyExplanation => _instance.Value._failedToLoadAnAssemblyExplanation.Text;
     }
 }

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -167,13 +167,13 @@ following command.
 
         private readonly TranslationString _seeErrorMessage = new("See error message...");
         private readonly TranslationString _hideErrorMessage = new("Hide error message...");
-        private readonly TranslationString _reportTheIssue = new("Report the issue");
-        private readonly TranslationString _restartGitExtensions = new("Restart " + AppSettings.ApplicationName);
+        private readonly TranslationString _reportIssue = new("Report the issue");
+        private readonly TranslationString _reportIssueDescription = new("If you can consistently reproduce the issue, please report it.");
+        private readonly TranslationString _restartApplication = new($"Restart {AppSettings.ApplicationName}");
+        private readonly TranslationString _restartApplicationDescription = new("Usually restarting the application solves the issue.\r\nSometimes Windows may need to be restarted too.");
         private readonly TranslationString _failedToLoadAnAssembly = new("Failed to load an assembly");
-        private readonly TranslationString _failedToLoadAnAssemblyHeader = new(AppSettings.ApplicationName + " encountered a problem while trying to load an assembly.");
-        private readonly TranslationString _failedToLoadAnAssemblyExplanation = new(@"The error is believed to be caused by Windows Update and restarting the application should solve the issue.
-
-If it is not the first time it happens, and you can consistently reproduce the issue, please report it.");
+        private readonly TranslationString _failedToLoadFileOrAssemblyFormat = new("Could not load file or assembly '{0}'");
+        private readonly TranslationString _failedToLoadFileOrAssemblyText = new("Most of the times the error is temporary, likely caused by Windows Update.");
 
         // public only because of FormTranslate
         public TranslatedStrings()
@@ -349,10 +349,12 @@ If it is not the first time it happens, and you can consistently reproduce the i
 
         public static string SeeErrorMessage => _instance.Value._seeErrorMessage.Text;
         public static string HideErrorMessage => _instance.Value._hideErrorMessage.Text;
-        public static string ReportTheIssue => _instance.Value._reportTheIssue.Text;
-        public static string RelaunchGitExtensions => _instance.Value._restartGitExtensions.Text;
+        public static string ReportIssue => _instance.Value._reportIssue.Text;
+        public static string ReportIssueDescription => _instance.Value._reportIssueDescription.Text;
+        public static string RestartApplication => _instance.Value._restartApplication.Text;
+        public static string RestartApplicationDescription => _instance.Value._restartApplicationDescription.Text;
         public static string FailedToLoadAnAssembly => _instance.Value._failedToLoadAnAssembly.Text;
-        public static string FailedToLoadAnAssemblyHeader => _instance.Value._failedToLoadAnAssemblyHeader.Text;
-        public static string FailedToLoadAnAssemblyExplanation => _instance.Value._failedToLoadAnAssemblyExplanation.Text;
+        public static string FailedToLoadFileOrAssemblyFormat => _instance.Value._failedToLoadFileOrAssemblyFormat.Text;
+        public static string FailedToLoadFileOrAssemblyText => _instance.Value._failedToLoadFileOrAssemblyText.Text;
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -10080,14 +10080,12 @@ Select this commit to populate the full message.</source>
         <source>Failed to load an assembly</source>
         <target />
       </trans-unit>
-      <trans-unit id="_failedToLoadAnAssemblyExplanation.Text">
-        <source>The error is believed to be caused by Windows Update and restarting the application should solve the issue.
-
-If it is not the first time it happens, and you can consistently reproduce the issue, please report it.</source>
+      <trans-unit id="_failedToLoadFileOrAssemblyFormat.Text">
+        <source>Could not load file or assembly '{0}'</source>
         <target />
       </trans-unit>
-      <trans-unit id="_failedToLoadAnAssemblyHeader.Text">
-        <source>Git Extensions encountered a problem while trying to load an assembly.</source>
+      <trans-unit id="_failedToLoadFileOrAssemblyText.Text">
+        <source>Most of the times the error is temporary, likely caused by Windows Update.</source>
         <target />
       </trans-unit>
       <trans-unit id="_filterFileInGrid.Text">
@@ -10301,8 +10299,12 @@ Remote: {1}</source>
         <source>If you think this was caused by Git Extensions, you can report a bug for the team to investigate.</source>
         <target />
       </trans-unit>
-      <trans-unit id="_reportTheIssue.Text">
+      <trans-unit id="_reportIssue.Text">
         <source>Report the issue</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_reportIssueDescription.Text">
+        <source>If you can consistently reproduce the issue, please report it.</source>
         <target />
       </trans-unit>
       <trans-unit id="_resetChangesCaption.Text">
@@ -10317,8 +10319,13 @@ Remote: {1}</source>
         <source>Are you sure you want to reset the changes to the selected lines?</source>
         <target />
       </trans-unit>
-      <trans-unit id="_restartGitExtensions.Text">
+      <trans-unit id="_restartApplication.Text">
         <source>Restart Git Extensions</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_restartApplicationDescription.Text">
+        <source>Usually restarting the application solves the issue.
+Sometimes Windows may need to be restarted too.</source>
         <target />
       </trans-unit>
       <trans-unit id="_rotInactive.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -10076,6 +10076,20 @@ Select this commit to populate the full message.</source>
         <source>Exit code</source>
         <target />
       </trans-unit>
+      <trans-unit id="_failedToLoadAnAssembly.Text">
+        <source>Failed to load an assembly</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_failedToLoadAnAssemblyExplanation.Text">
+        <source>The error is believed to be caused by Windows Update and restarting the application should solve the issue.
+
+If it is not the first time it happens, and you can consistently reproduce the issue, please report it.</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_failedToLoadAnAssemblyHeader.Text">
+        <source>Git Extensions encountered a problem while trying to load an assembly.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_filterFileInGrid.Text">
         <source>Filter file in &amp;grid</source>
         <target />
@@ -10147,6 +10161,10 @@ following command.
       </trans-unit>
       <trans-unit id="_gitSecurityError.Text">
         <source>Git security error</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_hideErrorMessage.Text">
+        <source>Hide error message...</source>
         <target />
       </trans-unit>
       <trans-unit id="_hoursAgo.Text">
@@ -10283,6 +10301,10 @@ Remote: {1}</source>
         <source>If you think this was caused by Git Extensions, you can report a bug for the team to investigate.</source>
         <target />
       </trans-unit>
+      <trans-unit id="_reportTheIssue.Text">
+        <source>Report the issue</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_resetChangesCaption.Text">
         <source>Reset changes</source>
         <target />
@@ -10293,6 +10315,10 @@ Remote: {1}</source>
       </trans-unit>
       <trans-unit id="_resetSelectedLinesConfirmation.Text">
         <source>Are you sure you want to reset the changes to the selected lines?</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_restartGitExtensions.Text">
+        <source>Restart Git Extensions</source>
         <target />
       </trans-unit>
       <trans-unit id="_rotInactive.Text">
@@ -10329,6 +10355,10 @@ Remote: {1}</source>
       </trans-unit>
       <trans-unit id="_secondsAgo.Text">
         <source>{0} {1:second|seconds} ago</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_seeErrorMessage.Text">
+        <source>See error message...</source>
         <target />
       </trans-unit>
       <trans-unit id="_settingsTypeToFind.Text">


### PR DESCRIPTION
due to a Windows update

Workaround for #10367, #10368, #10376, #10381, #10392, #10412, #10413, #10528, #10551, #10624, #10625, #10734, #10738, #10771, #10772, #10803, #10804, #10813, #10874, #10875, #10876, #11047, #11047, #11066 (and possibly others).


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

User get the report tool popup
![image](https://github.com/gitextensions/gitextensions/assets/460196/ce18d98d-0d98-42a3-a9b5-0157461e943e)

### After

User get an error popup explaining the problem and encouraging them to restart instead of reporting the issue
![image](https://github.com/gitextensions/gitextensions/assets/460196/8f46f38e-53fe-4850-8145-36cd0eec83b7)

## Test methodology <!-- How did you ensure quality? -->

- Manually (I have not been able to reproduce the exception so I throw the exception myself -- that does not 100% satisfy me but I hope it's enough--)

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
