### PR TITLE
Make all exceptions serializable

### DIFF
--- a/GitCommands/Config/GitConfigurationException.cs
+++ b/GitCommands/Config/GitConfigurationException.cs
@@ -1,5 +1,8 @@
-﻿namespace GitCommands.Config
+﻿using System.Runtime.Serialization;
+
+namespace GitCommands.Config
 {
+    [Serializable]
     public class GitConfigurationException : Exception
     {
         public GitConfigurationException(string configPath, Exception? innerException)
@@ -16,6 +19,11 @@
             }
 
             ConfigPath = configPath;
+        }
+
+        protected GitConfigurationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
 
         public string ConfigPath { get; }

--- a/GitCommands/Git/FileDeleteException.cs
+++ b/GitCommands/Git/FileDeleteException.cs
@@ -1,11 +1,19 @@
+using System.Runtime.Serialization;
+
 namespace GitCommands.Git
 {
+    [Serializable]
     public class FileDeleteException : Exception
     {
         public FileDeleteException(string fileName, Exception inner)
             : base(inner.Message, inner)
         {
             FileName = fileName;
+        }
+
+        protected FileDeleteException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
 
         /// <summary>

--- a/GitCommands/Git/GitException.cs
+++ b/GitCommands/Git/GitException.cs
@@ -1,5 +1,8 @@
+using System.Runtime.Serialization;
+
 namespace GitCommands.Git
 {
+    [Serializable]
     public class GitException : Exception
     {
         public GitException(string message)
@@ -9,6 +12,11 @@ namespace GitCommands.Git
 
         public GitException(string message, Exception? inner)
             : base(message, inner)
+        {
+        }
+
+        protected GitException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/GitCommands/Git/RefsWarningException.cs
+++ b/GitCommands/Git/RefsWarningException.cs
@@ -1,5 +1,8 @@
+using System.Runtime.Serialization;
+
 namespace GitCommands.Git
 {
+    [Serializable]
     public class RefsWarningException : GitException
     {
         public RefsWarningException(string message)
@@ -9,6 +12,11 @@ namespace GitCommands.Git
 
         public RefsWarningException(string message, Exception? inner)
             : base(message, inner)
+        {
+        }
+
+        protected RefsWarningException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/GitCommands/Settings/SaveSettingsException.cs
+++ b/GitCommands/Settings/SaveSettingsException.cs
@@ -1,9 +1,17 @@
-﻿namespace GitCommands.Settings
+﻿using System.Runtime.Serialization;
+
+namespace GitCommands.Settings
 {
+    [Serializable]
     public class SaveSettingsException : Exception
     {
         public SaveSettingsException(Exception? innerException)
             : base(message: null, innerException)
+        {
+        }
+
+        protected SaveSettingsException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/GitExtUtils/ExternalOperationException.cs
+++ b/GitExtUtils/ExternalOperationException.cs
@@ -1,9 +1,12 @@
-﻿namespace GitExtUtils
+﻿using System.Runtime.Serialization;
+
+namespace GitExtUtils
 {
     /// <summary>
     /// Represents errors that occur during execution of an external operation,
     /// e.g. running a git operation or launching an external process.
     /// </summary>
+    [Serializable]
     public class ExternalOperationException : Exception
     {
         /// <summary>
@@ -27,6 +30,11 @@
             Arguments = arguments;
             WorkingDirectory = workingDirectory;
             ExitCode = exitCode;
+        }
+
+        protected ExternalOperationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
 
         /// <summary>

--- a/GitUI/NBugReports/UserExternalOperationException.cs
+++ b/GitUI/NBugReports/UserExternalOperationException.cs
@@ -1,10 +1,12 @@
-﻿using GitExtUtils;
+﻿using System.Runtime.Serialization;
+using GitExtUtils;
 
 namespace GitUI.NBugReports
 {
     /// <summary>
     /// Represents errors that occur during execution of user-configured operation, e.g. a script.
     /// </summary>
+    [Serializable]
     public class UserExternalOperationException : ExternalOperationException
     {
         /// <summary>
@@ -26,6 +28,11 @@ namespace GitUI.NBugReports
         /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public UserExternalOperationException(Exception innerException)
             : base(innerException: innerException)
+        {
+        }
+
+        protected UserExternalOperationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
 

--- a/GitUI/Theming/ThemeCssUrlResolverException.cs
+++ b/GitUI/Theming/ThemeCssUrlResolverException.cs
@@ -1,9 +1,17 @@
-﻿namespace GitUI.Theming
+﻿using System.Runtime.Serialization;
+
+namespace GitUI.Theming
 {
+    [Serializable]
     public class ThemeCssUrlResolverException : ThemeException
     {
         public ThemeCssUrlResolverException(string message, Exception innerException)
             : base(message, innerException)
+        {
+        }
+
+        protected ThemeCssUrlResolverException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/GitUI/Theming/ThemeException.cs
+++ b/GitUI/Theming/ThemeException.cs
@@ -1,5 +1,8 @@
-﻿namespace GitUI.Theming
+﻿using System.Runtime.Serialization;
+
+namespace GitUI.Theming
 {
+    [Serializable]
     public class ThemeException : Exception
     {
         public ThemeException()
@@ -13,6 +16,11 @@
 
         public ThemeException(string message, string path, Exception? innerException = null)
             : base($"Failed to load {path}: {message}", innerException)
+        {
+        }
+
+        protected ThemeException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }


### PR DESCRIPTION
Might fix some of the silent crashes (where exceptions do not make it to the `BugReportInvoker`, which creates serializable clones of the exceptions)

## Proposed changes

Apply the generally recommended template to all self-defined exception classes
- Add attribute `[Serializable]`
- Add protected deserialization ctor

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).