### PR TITLE
Fixup test discovery in Visual Studio

### DIFF
--- a/UnitTests/CommonTestUtils/CommonTestUtils.csproj
+++ b/UnitTests/CommonTestUtils/CommonTestUtils.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\..\GitExtensionsTest.ruleset</CodeAnalysisRuleSet>
     
@@ -7,6 +8,10 @@
 
     <!-- To be removed when NRT annotations are complete -->
     <Nullable>annotations</Nullable>
+
+    <!-- Exclude this project from the list of tests project -->
+    <TestProject>false</TestProject>
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,6 +25,11 @@
     <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj" />
     <ProjectReference Include="..\..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
     <PackageReference Include="JetBrains.Annotations" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- This project takes depedency on nUnit that adds the TestContainer capability importing NUnit.props, but this is not a test project -->
+    <ProjectCapability Remove="TestContainer" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #10986
https://developercommunity.visualstudio.com/t/Test-discovery-fails-with-MicrosoftVis/10372682?port=1025&fsid=708954cf-6ea4-4ac6-8735-dbf396aaba02&ref=native&refTime=1684952393560&refUserId=2a9334e3-6c08-64a6-9b8f-60d221b1cbab

## Proposed changes

- Mark `CommonTestUtils` as "not a test project / container" as proposed by Microsoft Support

## Test methodology <!-- How did you ensure quality? -->

- Open Test Explorer

## Test environment(s) <!-- Remove any that don't apply -->

- VS 17.6.4.
- Windows 10

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).