### PR TITLE
#11108 Disabled hotkeys in scenarios where their usage was not intended

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1525,7 +1525,7 @@ namespace GitUI.CommandsDialogs
         {
             var revisions = RevisionGrid.GetSelectedRevisions();
 
-            if (revisions.Count == 0)
+            if (revisions.Count == 0 || revisions[0].IsArtificial)
             {
                 return;
             }
@@ -2069,28 +2069,10 @@ namespace GitUI.CommandsDialogs
                 case Command.GoToParent: RestoreFileStatusListFocus(() => RevisionGrid?.ExecuteCommand(RevisionGridControl.Command.GoToParent)); break;
                 case Command.PullOrFetch: DoPull(pullAction: AppSettings.FormPullAction, isSilent: false); break;
                 case Command.Push: UICommands.StartPushDialog(this, pushOnShow: ModifierKeys.HasFlag(Keys.Shift)); break;
-                case Command.CreateBranch:
-                    if (!Module.IsBareRepository() && RevisionGrid.GetSelectedRevisions().Count == 1 && !RevisionGrid.GetSelectedRevisions()[0].IsArtificial)
-                    {
-                        UICommands.StartCreateBranchDialog(this, RevisionGrid.LatestSelectedRevision?.ObjectId);
-                    }
-
-                    break;
+                case Command.CreateBranch: UICommands.StartCreateBranchDialog(this, RevisionGrid.LatestSelectedRevision?.ObjectId); break;
                 case Command.MergeBranches: UICommands.StartMergeBranchDialog(this, null); break;
-                case Command.CreateTag:
-                    if (RevisionGrid.GetSelectedRevisions().Count == 1 && !RevisionGrid.GetSelectedRevisions()[0].IsArtificial)
-                    {
-                        UICommands.StartCreateTagDialog(this, RevisionGrid.LatestSelectedRevision);
-                    }
-
-                    break;
-                case Command.Rebase:
-                    if (!RevisionGrid.GetSelectedRevisions()[0].IsArtificial)
-                    {
-                        rebaseToolStripMenuItem.PerformClick();
-                    }
-
-                    break;
+                case Command.CreateTag: UICommands.StartCreateTagDialog(this, RevisionGrid.LatestSelectedRevision); break;
+                case Command.Rebase: rebaseToolStripMenuItem.PerformClick(); break;
                 default: return base.ExecuteCommand(cmd);
             }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2069,10 +2069,28 @@ namespace GitUI.CommandsDialogs
                 case Command.GoToParent: RestoreFileStatusListFocus(() => RevisionGrid?.ExecuteCommand(RevisionGridControl.Command.GoToParent)); break;
                 case Command.PullOrFetch: DoPull(pullAction: AppSettings.FormPullAction, isSilent: false); break;
                 case Command.Push: UICommands.StartPushDialog(this, pushOnShow: ModifierKeys.HasFlag(Keys.Shift)); break;
-                case Command.CreateBranch: UICommands.StartCreateBranchDialog(this, RevisionGrid.LatestSelectedRevision?.ObjectId); break;
+                case Command.CreateBranch:
+                    if (!Module.IsBareRepository() && RevisionGrid.GetSelectedRevisions().Count == 1 && !RevisionGrid.GetSelectedRevisions()[0].IsArtificial)
+                    {
+                        UICommands.StartCreateBranchDialog(this, RevisionGrid.LatestSelectedRevision?.ObjectId);
+                    }
+
+                    break;
                 case Command.MergeBranches: UICommands.StartMergeBranchDialog(this, null); break;
-                case Command.CreateTag: UICommands.StartCreateTagDialog(this, RevisionGrid.LatestSelectedRevision); break;
-                case Command.Rebase: rebaseToolStripMenuItem.PerformClick(); break;
+                case Command.CreateTag:
+                    if (RevisionGrid.GetSelectedRevisions().Count == 1 && !RevisionGrid.GetSelectedRevisions()[0].IsArtificial)
+                    {
+                        UICommands.StartCreateTagDialog(this, RevisionGrid.LatestSelectedRevision);
+                    }
+
+                    break;
+                case Command.Rebase:
+                    if (!RevisionGrid.GetSelectedRevisions()[0].IsArtificial)
+                    {
+                        rebaseToolStripMenuItem.PerformClick();
+                    }
+
+                    break;
                 default: return base.ExecuteCommand(cmd);
             }
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -440,7 +440,7 @@ namespace GitUI
 
         public bool StartCreateBranchDialog(IWin32Window? owner = null, ObjectId? objectId = null, string? newBranchNamePrefix = null)
         {
-            if (Module.IsBareRepository() || (objectId is not null && objectId.IsArtificial))
+            if (Module.IsBareRepository() || objectId?.IsArtificial is true)
             {
                 return false;
             }
@@ -858,7 +858,7 @@ namespace GitUI
 
         public bool StartCreateTagDialog(IWin32Window? owner = null, GitRevision? revision = null)
         {
-            if (revision is not null && revision.IsArtificial)
+            if (revision?.IsArtificial is true)
             {
                  return false;
             }

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -440,6 +440,11 @@ namespace GitUI
 
         public bool StartCreateBranchDialog(IWin32Window? owner = null, ObjectId? objectId = null, string? newBranchNamePrefix = null)
         {
+            if (Module.IsBareRepository() || (objectId is not null && objectId.IsArtificial))
+            {
+                return false;
+            }
+
             bool Action()
             {
                 using FormCreateBranch form = new(this, objectId, newBranchNamePrefix);
@@ -853,6 +858,11 @@ namespace GitUI
 
         public bool StartCreateTagDialog(IWin32Window? owner = null, GitRevision? revision = null)
         {
+            if (revision is not null && revision.IsArtificial)
+            {
+                 return false;
+            }
+
             bool Action()
             {
                 using FormCreateTag form = new(this, revision?.ObjectId);


### PR DESCRIPTION
Fixes [#11108](https://github.com/gitextensions/gitextensions/issues/11108)

## Proposed changes

- Creating a new branch using hotkeys `Ctrl + B` does not prompt `FromCreateBranch` while in bare repository, neither when artificial commit is selected.
- While selecting multiple commits, hotkey for creating new branch is disabled
- Rebasing current branch using hotkeys `Ctrl + Shift + E` is disabled while artificial commit is selected
- Creating a new tag using hotkeys `Ctrl + T` is disabled while artificial commit is selected

## Test methodology

- Manual with GE repo

## Test environment(s)

- Git Extensions 33.33.33
- Build https://github.com/gitextensions/gitextensions/commit/8b5eab531dcc849d00110df6f9797a096e68b500
- Git 2.30.0.windows.2 (recommended: 2.40.1 or later)
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.14
- DPI 120dpi (125% scaling)
