### PR TITLE
#10992 noFastForward disabled in UI when Squash is checked

### DIFF
--- a/GitUI/CommandsDialogs/FormMergeBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.Designer.cs
@@ -198,7 +198,6 @@
             this.squash.TabIndex = 2;
             this.squash.Text = "Squash commits";
             this.squash.UseVisualStyleBackColor = true;
-            this.squash.CheckedChanged += new System.EventHandler(this.squash_CheckedChanged);
             // 
             // NonDefaultMergeStrategy
             // 

--- a/GitUI/CommandsDialogs/FormMergeBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.Designer.cs
@@ -198,6 +198,7 @@
             this.squash.TabIndex = 2;
             this.squash.Text = "Squash commits";
             this.squash.UseVisualStyleBackColor = true;
+            this.squash.CheckedChanged += new System.EventHandler(this.squash_CheckedChanged);
             // 
             // NonDefaultMergeStrategy
             // 

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -169,6 +169,12 @@ namespace GitUI.CommandsDialogs
         private void noFastForward_CheckedChanged(object sender, EventArgs e)
         {
             helpImageDisplayUserControl1.IsOnHoverShowImage2 = false;
+            squash.Enabled = !noFastForward.Checked;
+
+            if (noFastForward.Checked)
+            {
+                squash.Checked = false;
+            }
         }
 
         private void addMessages_CheckedChanged(object sender, EventArgs e)
@@ -192,13 +198,6 @@ namespace GitUI.CommandsDialogs
                 .Detailed();
 
             detailedSettings.MergeLogMessagesCount = Convert.ToInt32(nbMessages.Value);
-        }
-
-        private void squash_CheckedChanged(object sender, EventArgs e)
-        {
-            fastForward.Enabled = !fastForward.Enabled;
-            noFastForward.Enabled = !noFastForward.Enabled;
-            fastForward.Checked = true;
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -193,5 +193,12 @@ namespace GitUI.CommandsDialogs
 
             detailedSettings.MergeLogMessagesCount = Convert.ToInt32(nbMessages.Value);
         }
+
+        private void squash_CheckedChanged(object sender, EventArgs e)
+        {
+            fastForward.Enabled = !fastForward.Enabled;
+            noFastForward.Enabled = !noFastForward.Enabled;
+            fastForward.Checked = true;
+        }
     }
 }


### PR DESCRIPTION
Fixes [#10992](https://github.com/gitextensions/gitextensions/issues/10992)

## Proposed changes

- Selecting the `Always create a new merge commit` radio button in FormMergeBranch automatically disables the `Squash` checkbox.
- If the `Squash` checkbox is checked while disabling, it will be automatically unchecked.

## Test methodology

- Manual with GE repo

## Test environment(s)

- Git Extensions 33.33.33
- Build https://github.com/gitextensions/gitextensions/commit/f7e06a26f2959ac30f316ca576b9cc9640235c51
- Git 2.30.0.windows.2 (recommended: 2.41.0 or later)
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.14
- DPI 120dpi (125% scaling)

## Merge Strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
