### PR TITLE
Fixup highlighted graph

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -17,9 +17,6 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         private readonly RevisionGraph _revisionGraph;
         private readonly GraphCache _graphCache = new();
 
-        private RevisionGraphDrawStyleEnum _revisionGraphDrawStyleCache;
-        private RevisionGraphDrawStyleEnum _revisionGraphDrawStyle;
-
         public RevisionGraphColumnProvider(RevisionGraph revisionGraph, IGitRevisionSummaryBuilder gitRevisionSummaryBuilder)
             : base("Graph")
         {
@@ -38,24 +35,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             };
         }
 
-        public RevisionGraphDrawStyleEnum RevisionGraphDrawStyle
-        {
-            get
-            {
-                if (_revisionGraphDrawStyle == RevisionGraphDrawStyleEnum.HighlightSelected)
-                {
-                    return RevisionGraphDrawStyleEnum.HighlightSelected;
-                }
-
-                if (AppSettings.RevisionGraphDrawNonRelativesGray)
-                {
-                    return RevisionGraphDrawStyleEnum.DrawNonRelativesGray;
-                }
-
-                return RevisionGraphDrawStyleEnum.Normal;
-            }
-            set { _revisionGraphDrawStyle = value; }
-        }
+        public RevisionGraphDrawStyle RevisionGraphDrawStyle { get; set; }
 
         public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {
@@ -166,9 +146,6 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
                 void DrawVisibleGraph()
                 {
-                    // Getting RevisionGraphDrawStyle results in call to AppSettings. This is not very cheap, cache.
-                    _revisionGraphDrawStyleCache = RevisionGraphDrawStyle;
-
                     for (int index = start; index < end; index++)
                     {
                         // Get the x,y value of the current item's upper left in the cache
@@ -208,7 +185,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
                 void DrawItem(int index)
                 {
-                    GraphRenderer.DrawItem(_graphCache.GraphBitmapGraphics, index, width, rowHeight, _revisionGraph.GetSegmentsForRow, _revisionGraphDrawStyleCache, _revisionGraph.HeadId);
+                    GraphRenderer.DrawItem(_graphCache.GraphBitmapGraphics, index, width, rowHeight, _revisionGraph.GetSegmentsForRow, RevisionGraphDrawStyle, _revisionGraph.HeadId);
                 }
             }
         }

--- a/GitUI/UserControls/RevisionGrid/Graph/Rendering/GraphRenderer.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/Rendering/GraphRenderer.cs
@@ -17,7 +17,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph.Rendering
 
         public static void DrawItem(Graphics g, int index, int width, int rowHeight,
             Func<int, IRevisionGraphRow?> getSegmentsForRow,
-            RevisionGraphDrawStyleEnum revisionGraphDrawStyle,
+            RevisionGraphDrawStyle revisionGraphDrawStyle,
             ObjectId headId)
         {
             SmoothingMode oldSmoothingMode = g.SmoothingMode;
@@ -202,11 +202,11 @@ namespace GitUI.UserControls.RevisionGrid.Graph.Rendering
             }
         }
 
-        private static Brush GetBrushForLaneInfo(LaneInfo? laneInfo, bool isRelative, RevisionGraphDrawStyleEnum revisionGraphDrawStyle)
+        private static Brush GetBrushForLaneInfo(LaneInfo? laneInfo, bool isRelative, RevisionGraphDrawStyle revisionGraphDrawStyle)
         {
             // laneInfo can be null for revisions without parents and children, especially when filtering, draw them gray, too
             if (laneInfo is null
-                || (!isRelative && (revisionGraphDrawStyle is RevisionGraphDrawStyleEnum.DrawNonRelativesGray or RevisionGraphDrawStyleEnum.HighlightSelected)))
+                || (!isRelative && (revisionGraphDrawStyle is RevisionGraphDrawStyle.DrawNonRelativesGray or RevisionGraphDrawStyle.HighlightSelected)))
             {
                 return RevisionGraphLaneColor.NonRelativeBrush;
             }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -32,7 +32,7 @@ using TaskDialogButton = System.Windows.Forms.TaskDialogButton;
 
 namespace GitUI
 {
-    public enum RevisionGraphDrawStyleEnum
+    public enum RevisionGraphDrawStyle
     {
         Normal,
         DrawNonRelativesGray,
@@ -665,7 +665,7 @@ namespace GitUI
 
         private void HighlightBranch(ObjectId id)
         {
-            _revisionGraphColumnProvider.RevisionGraphDrawStyle = RevisionGraphDrawStyleEnum.HighlightSelected;
+            _revisionGraphColumnProvider.RevisionGraphDrawStyle = RevisionGraphDrawStyle.HighlightSelected;
             _revisionGraphColumnProvider.HighlightBranch(id);
             _gridView.Update();
         }
@@ -888,7 +888,8 @@ namespace GitUI
 
             try
             {
-                _revisionGraphColumnProvider.RevisionGraphDrawStyle = RevisionGraphDrawStyleEnum.DrawNonRelativesGray;
+                _revisionGraphColumnProvider.RevisionGraphDrawStyle
+                    = AppSettings.RevisionGraphDrawNonRelativesGray ? RevisionGraphDrawStyle.DrawNonRelativesGray : RevisionGraphDrawStyle.Normal;
 
                 // Apply checkboxes changes also to FormBrowse main menu
                 MenuCommands.TriggerMenuChanged();


### PR DESCRIPTION
Fixes #11098
regressed in #10915

## Proposed changes

- Refactor: Simplify property `RevisionGraphColumnProvider.RevisionGraphDrawStyle`
- Avoid drawing the same graph curve twice only if unrelated branches are colored

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/36601201/857a18df-1ebe-4566-8167-a464c5a6f477)

### After

![image](https://github.com/gitextensions/gitextensions/assets/36601201/c386a9b5-28b8-4f1d-a318-cf7eb62463c2)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).