### PR TITLE
IDE0056 index operator

### DIFF
--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -364,7 +364,7 @@ namespace GitCommands.Config
                 {
                     case '\n':
                         // check for line continuation
-                        if (_token.Length > 0 && _token[_token.Length - 1] == '\\')
+                        if (_token.Length > 0 && _token[^1] == '\\')
                         {
                             _token.Remove(_token.Length - 1, 1);
                             return ReadComment;

--- a/GitCommands/Config/ConfigSection.cs
+++ b/GitCommands/Config/ConfigSection.cs
@@ -99,7 +99,7 @@ namespace GitCommands.Config
             {
                 if (list.Count > 0)
                 {
-                    return list[list.Count - 1];
+                    return list[^1];
                 }
             }
 

--- a/GitCommands/Git/GitConvert.cs
+++ b/GitCommands/Git/GitConvert.cs
@@ -163,7 +163,7 @@ namespace GitCommands
 
                 if (buf.Length >= 1)
                 {
-                    if (buf[buf.Length - 1] == 0x1A)
+                    if (buf[^1] == 0x1A)
                     {
                         cntNonPrintable--;
                     }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2415,12 +2415,12 @@ namespace GitCommands
 
                     if (remoteMatch.Groups["direction"].Value == "push")
                     {
-                        if (remotes.Count <= 0 || name != remotes[remotes.Count - 1].Name)
+                        if (remotes.Count <= 0 || name != remotes[^1].Name)
                         {
                             throw new Exception("Unable to update remote pushurl for command output: " + remoteLine);
                         }
 
-                        remotes[remotes.Count - 1].PushUrls.Add(remoteUrl);
+                        remotes[^1].PushUrls.Add(remoteUrl);
                         continue;
                     }
 
@@ -2610,7 +2610,7 @@ namespace GitCommands
             }
 
             return patches.Count != 0
-                ? patches[patches.Count - 1]
+                ? patches[^1]
                 : null;
         }
 

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -73,8 +73,8 @@ namespace GitCommands
         public static string? RemoveTrailingPathSeparator(this string? dirPath)
         {
             if (dirPath?.Length > 0 &&
-                (dirPath[dirPath.Length - 1] == NativeDirectorySeparatorChar ||
-                 dirPath[dirPath.Length - 1] == PosixDirectorySeparatorChar))
+                (dirPath[^1] == NativeDirectorySeparatorChar ||
+                 dirPath[^1] == PosixDirectorySeparatorChar))
             {
                 return dirPath.Substring(0, dirPath.Length - 1);
             }
@@ -92,8 +92,8 @@ namespace GitCommands
         public static string? EnsureTrailingPathSeparator(this string? dirPath)
         {
             if (!string.IsNullOrEmpty(dirPath) &&
-                dirPath[dirPath.Length - 1] != NativeDirectorySeparatorChar &&
-                dirPath[dirPath.Length - 1] != PosixDirectorySeparatorChar)
+                dirPath[^1] != NativeDirectorySeparatorChar &&
+                dirPath[^1] != PosixDirectorySeparatorChar)
             {
                 dirPath += NativeDirectorySeparatorChar;
             }

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -219,7 +219,7 @@ namespace System
                 return value;
             }
 
-            if (value[value.Length - 1] == '\n')
+            if (value[^1] == '\n')
             {
                 value = value.Substring(0, value.Length - 1);
             }

--- a/GitExtUtils/GitUI/ListViewExtensions.cs
+++ b/GitExtUtils/GitUI/ListViewExtensions.cs
@@ -51,7 +51,7 @@ namespace GitUI
                 return null;
             }
 
-            return listView.SelectedItems[listView.SelectedItems.Count - 1];
+            return listView.SelectedItems[^1];
         }
 
         /// <summary>

--- a/GitExtUtils/StringBuilderExtensions.cs
+++ b/GitExtUtils/StringBuilderExtensions.cs
@@ -33,7 +33,7 @@ namespace GitExtUtils
                     return false;
                 }
 
-                if (s.Length > 1 && s[0] == '"' && s[s.Length - 1] == '"')
+                if (s.Length > 1 && s[0] == '"' && s[^1] == '"')
                 {
                     // String is already quoted
                     return false;

--- a/GitUI/Avatars/InitialsAvatarProvider.cs
+++ b/GitUI/Avatars/InitialsAvatarProvider.cs
@@ -115,7 +115,7 @@ namespace GitUI.Avatars
                 char[] upperChars = name.Where(char.IsUpper).ToArray();
                 if (upperChars.Length > 1)
                 {
-                    return $"{upperChars[0]}{upperChars[upperChars.Length - 1]}";
+                    return $"{upperChars[0]}{upperChars[^1]}";
                 }
 
                 // return first letter upper-case and second letter original/lower case.
@@ -123,7 +123,7 @@ namespace GitUI.Avatars
             }
 
             // Return initials from first and last name-element as uppercase
-            return $"{name[0]}{names[names.Length - 1][0]}".ToUpper();
+            return $"{name[0]}{names[^1][0]}".ToUpper();
         }
 
         private readonly Graphics _graphics = Graphics.FromImage(new Bitmap(1, 1));

--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -32,9 +32,9 @@ namespace GitUI.CommandsDialogs
                 // PathFilter is a free text field and may contain wildcards, quoting is optional.
                 // This is will adjust the string at least for paths added from context menus.
                 string? path = e.PathFilter;
-                if (path?.Length is > 1 && path[0] == '"' && path[path.Length - 1] == '"')
+                if (path?.Length is > 1 && path[0] == '"' && path[^1] == '"')
                 {
-                    path = path[1..(path.Length - 1)];
+                    path = path[1..^1];
                 }
 
                 revisionDiff.FallbackFollowedFile = path;

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -598,7 +598,7 @@ See the changes in the commit form.");
                 nodes = selectedNode.Nodes;
             }
 
-            var lastItem = _revisionFileTreeController.Find(nodes, items[items.Length - 1]);
+            var lastItem = _revisionFileTreeController.Find(nodes, items[^1]);
             if (lastItem is not null)
             {
                 tvGitTree.SelectedNode = lastItem;

--- a/GitUI/LeftPanel/BaseRevisionNode.cs
+++ b/GitUI/LeftPanel/BaseRevisionNode.cs
@@ -20,7 +20,7 @@ namespace GitUI.LeftPanel
             }
 
             string[] dirs = fullPath.Split(PathSeparator);
-            Name = dirs[dirs.Length - 1];
+            Name = dirs[^1];
             ParentPath = dirs.Take(dirs.Length - 1).Join(PathSeparator.ToString());
             Visible = visible;
         }

--- a/GitUI/LeftPanel/Nodes.cs
+++ b/GitUI/LeftPanel/Nodes.cs
@@ -106,6 +106,6 @@
 
         public int Count => _nodesList.Count;
 
-        public Node? LastNode => _nodesList.Count > 0 ? _nodesList[_nodesList.Count - 1] : null;
+        public Node? LastNode => _nodesList.Count > 0 ? _nodesList[^1] : null;
     }
 }

--- a/GitUI/LeftPanel/SubmoduleNode.cs
+++ b/GitUI/LeftPanel/SubmoduleNode.cs
@@ -85,7 +85,7 @@ namespace GitUI.LeftPanel
                 // Get the current (most likely) selections from the grid
                 IReadOnlyList<GitRevision>? revs = UICommands.GetSelectedRevisions() ?? new List<GitRevision>();
                 selected = revs.Count > 0 ? revs[0].ObjectId : null;
-                first = revs.Count > 1 ? revs[revs.Count - 1].ObjectId : null;
+                first = revs.Count > 1 ? revs[^1].ObjectId : null;
             }
             else
             {

--- a/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
+++ b/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
@@ -186,7 +186,7 @@ namespace GitUI.UserControls
 
             string[] outputLines = Regex.Split(output, @"(?<=[\n\r])");
             int lineCount = outputLines.Length;
-            if (string.IsNullOrEmpty(outputLines[lineCount - 1]))
+            if (string.IsNullOrEmpty(outputLines[^1]))
             {
                 lineCount--;
             }
@@ -198,8 +198,8 @@ namespace GitUI.UserControls
                 if (isTheLastLine)
                 {
                     bool isLineCompleted = outputLine.Length > 0 &&
-                        ((outputLine[outputLine.Length - 1] == '\n') ||
-                        outputLine[outputLine.Length - 1] == '\r');
+                        ((outputLine[^1] == '\n') ||
+                        outputLine[^1] == '\r');
                     if (!isLineCompleted)
                     {
                         _lineChunk = outputLine;

--- a/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
@@ -44,7 +44,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             {
                 var i = Array.FindIndex(widthByLength, w => w > Column.Width);
 
-                if (i == -1 && Column.Width > widthByLength[widthByLength.Length - 1])
+                if (i == -1 && Column.Width > widthByLength[^1])
                 {
                     _grid.DrawColumnText(e, revision.ObjectId.ToString(), monospaceFont, style.ForeColor, e.CellBounds, useEllipsis: false);
                 }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2658,7 +2658,7 @@ namespace GitUI
                 return;
             }
 
-            GitRevision revision = revisions[revisions.Count - 1];
+            GitRevision revision = revisions[^1];
             while (revision.IsArtificial)
             {
                 revision = GetRevision(revision.FirstParentId);

--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -222,7 +222,7 @@ namespace GitExtensions.Plugins.GitImpact
                 }
 
                 // Draw black border around selected author
-                string selectedAuthor = _authorStack[_authorStack.Count - 1];
+                string selectedAuthor = _authorStack[^1];
                 if (_brushes.ContainsKey(selectedAuthor) && _paths.TryGetValue(selectedAuthor, out GraphicsPath? selectedAuthorPath))
                 {
                     e.Graphics.DrawPath(new Pen(SystemColors.WindowText, 2), selectedAuthorPath);
@@ -406,7 +406,7 @@ namespace GitExtensions.Plugins.GitImpact
                         }
                     }
 
-                    var (lastRect, _) = points[points.Count - 1];
+                    var (lastRect, _) = points[^1];
 
                     // Right border
                     _paths[author].AddLine(lastRect.Right,

--- a/Plugins/Statistics/GitStatistics/PieChart/Quadrilateral.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/Quadrilateral.cs
@@ -126,7 +126,7 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
                 }
             }
 
-            if (DoesIntersects(point, cornerPoints[cornerPoints.Length - 1], cornerPoints[0]))
+            if (DoesIntersects(point, cornerPoints[^1], cornerPoints[0]))
             {
                 ++intersections;
             }

--- a/UnitTests/GitUI.Tests/CommandsDialogs/FormOpenDirectoryTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/FormOpenDirectoryTests.cs
@@ -40,7 +40,7 @@ namespace GitUITests.CommandsDialogs
         {
             // Path.GetTempPath returns a path with the trailing slash
             string path = Path.GetTempPath();
-            path[path.Length - 1].Should().Be(Path.DirectorySeparatorChar);
+            path[^1].Should().Be(Path.DirectorySeparatorChar);
 
             FormOpenDirectory.TestAccessor.OpenGitRepository(path, _localRepositoryManager).Should().BeNull();
             _localRepositoryManager.DidNotReceive().AddAsMostRecentAsync(Arg.Any<string>());
@@ -51,7 +51,7 @@ namespace GitUITests.CommandsDialogs
         {
             // Path.GetTempPath returns a path with the trailing slash
             string path = Path.GetTempPath();
-            path[path.Length - 1].Should().Be(Path.DirectorySeparatorChar);
+            path[^1].Should().Be(Path.DirectorySeparatorChar);
 
             // ensure absence of the trailing slash isn't a problem
             path = path.Substring(0, path.Length - 1);
@@ -63,7 +63,7 @@ namespace GitUITests.CommandsDialogs
         {
             // Path.GetTempPath returns a path with the trailing slash
             string path = Path.GetTempPath();
-            path[path.Length - 1].Should().Be(Path.DirectorySeparatorChar);
+            path[^1].Should().Be(Path.DirectorySeparatorChar);
 
             var module = FormOpenDirectory.TestAccessor.OpenGitRepository(_referenceRepository.Module.WorkingDir, _localRepositoryManager);
 

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RevisionFileTreeControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RevisionFileTreeControllerTests.cs
@@ -201,7 +201,7 @@ namespace GitUITests.CommandsDialogs
         {
             var parts = filePathToAdd.Split(Path.DirectorySeparatorChar);
             var folders = parts.Take(parts.Length - 1);
-            var fileName = parts[parts.Length - 1];
+            var fileName = parts[^1];
             var nodes = treeView.Nodes;
             foreach (var folder in folders)
             {


### PR DESCRIPTION
## Proposed changes

Use C# 8.0 from-end-operator for index access.
Shorter code, easier to review (when you know about the feature).

https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/member-access-operators#index-from-end-operator-

```patch
diff --git a/GitCommands/Config/ConfigSection.cs b/GitCommands/Config/ConfigSection.cs
index 91a0e..7ee77e 100644
--- a/GitCommands/Config/ConfigSection.cs
+++ b/GitCommands/Config/ConfigSection.cs
@@ -99,7 +99,7 @@ public string GetValue(string key, string defaultValue)
             {
                 if (list.Count > 0)
                 {
-                    return list[list.Count - 1];
+                    return list[^1];
                 }
             }
```

## Test methodology <!-- How did you ensure quality? -->

Code review, refactoring

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
