### PR TITLE
CA1826: Use property instead of Linq

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1420,7 +1420,7 @@ namespace GitCommands
                     {
                         filesToUnstage.Add(item);
                     }
-                    else if (initialStatus.Value.Where(i => i.Name == item.Name && i.Staged == StagedStatus.Index).FirstOrDefault() is GitItemStatus gitStatus)
+                    else if (initialStatus.Value.FirstOrDefault(i => i.Name == item.Name && i.Staged == StagedStatus.Index) is GitItemStatus gitStatus)
                     {
                         filesToUnstage.Add(gitStatus);
                     }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
@@ -53,7 +53,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             {
                 if (MessageBox.Show(this, _bisectStart.Text, Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
                 {
-                    BisectRange(revisions.First().ObjectId, revisions.Last().ObjectId);
+                    BisectRange(revisions[0].ObjectId, revisions[^1].ObjectId);
                     Close();
                 }
             }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1485,12 +1485,8 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            GitRevision mainRevision = revisions.First();
-            GitRevision? diffRevision = null;
-            if (revisions.Count == 2)
-            {
-                diffRevision = revisions.Last();
-            }
+            GitRevision mainRevision = revisions[0];
+            GitRevision? diffRevision = revisions.Count == 2 ? revisions[1] : null;
 
             UICommands.StartArchiveDialog(this, mainRevision, diffRevision);
         }
@@ -1530,19 +1526,19 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
+            string onto = revisions[0].ObjectId.ToString(); // 2nd selected commit
             if (revisions.Count == 2)
             {
                 // Set defaults in rebase form to rebase commits defined by the range *from* first selected commit *to* HEAD
                 // *onto* 2nd selected commit
-                string? from = revisions[1].ObjectId.ToShortString(); // 1st selected commit (excluded from rebase)
-                string? to = RevisionGrid.CurrentBranch.Value; // current branch checked out (HEAD)
-                string? onto = revisions[0].ObjectId.ToString(); // 2nd selected commit
+                string from = revisions[1].ObjectId.ToShortString(); // 1st selected commit (excluded from rebase)
+                string to = RevisionGrid.CurrentBranch.Value; // current branch checked out (HEAD)
 
                 UICommands.StartRebaseDialog(this, from, to, onto, interactive: false, startRebaseImmediately: false);
             }
             else
             {
-                UICommands.StartRebaseDialog(this, revisions.First().Guid);
+                UICommands.StartRebaseDialog(this, onto);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -662,7 +662,7 @@ namespace GitUI.CommandsDialogs
         private void RefreshSelection()
         {
             var selectedRevisions = RevisionGrid.GetSelectedRevisions();
-            var selectedRevision = selectedRevisions.FirstOrDefault();
+            GitRevision? selectedRevision = selectedRevisions.Count > 0 ? selectedRevisions[0] : null;
 
             FillFileTree(selectedRevision);
             FillDiff(selectedRevisions);
@@ -1944,13 +1944,12 @@ namespace GitUI.CommandsDialogs
 
         private void AddNotes()
         {
-            IReadOnlyList<GitRevision> selectedRevisions = RevisionGrid.GetSelectedRevisions();
-            if (selectedRevisions.Count == 0 || selectedRevisions[0].ObjectId.IsArtificial)
+            GitRevision? revision = RevisionGrid.GetSelectedRevisionOrDefault();
+            if (revision?.IsArtificial is not false)
             {
                 return;
             }
 
-            GitRevision revision = selectedRevisions[0];
             Module.EditNotes(revision.ObjectId);
             FillCommitInfo(revision);
         }

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -122,7 +122,7 @@ namespace GitUI.CommandsDialogs
                         }
                         else
                         {
-                            currentBranchRemote = remotes.FirstOrDefault();
+                            currentBranchRemote = remotes.Count > 0 ? remotes[0] : null;
                         }
                     }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1710,7 +1710,7 @@ namespace GitUI.CommandsDialogs
             {
                 _currentFilesList = Unstaged;
                 _skipUpdate = false;
-                if (!e.ByMouse && Unstaged.AllItems.Count() != 0 && Unstaged.SelectedIndex == -1)
+                if (!e.ByMouse && Unstaged.AllItems.Any() && Unstaged.SelectedIndex == -1)
                 {
                     Unstaged.SelectedIndex = 0;
                 }
@@ -1969,7 +1969,7 @@ namespace GitUI.CommandsDialogs
             {
                 _currentFilesList = Staged;
                 _skipUpdate = false;
-                if (!e.ByMouse && Staged.AllItems.Count() != 0 && Staged.SelectedIndex == -1)
+                if (!e.ByMouse && Staged.AllItems.Any() && Staged.SelectedIndex == -1)
                 {
                     Staged.SelectedIndex = 0;
                 }

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -72,7 +72,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     var repositoryHistory = await RepositoryHistoryManager.Locals.LoadRecentHistoryAsync();
 
                     await this.SwitchToMainThreadAsync();
-                    var lastRepo = repositoryHistory.FirstOrDefault();
+                    Repository? lastRepo = repositoryHistory.Count > 0 ? repositoryHistory[0] : null;
                     if (!string.IsNullOrEmpty(lastRepo?.Path))
                     {
                         string p = lastRepo.Path.Trim('/', '\\');

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -454,7 +454,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
                 if (multipleProtocols && updateProtocols)
                 {
-                    var currentSelection = (GitProtocol)(ProtocolDropdownList.SelectedItem ?? repo.SupportedCloneProtocols.First());
+                    GitProtocol currentSelection = (GitProtocol)(ProtocolDropdownList.SelectedItem ?? repo.SupportedCloneProtocols[0]);
                     ProtocolDropdownList.DataSource = repo.SupportedCloneProtocols;
                     if (repo.SupportedCloneProtocols.Contains(currentSelection))
                     {

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -376,7 +376,7 @@ namespace GitUI.CommandsDialogs
         {
             return parents.Count switch
             {
-                1 => DescribeRevision(parents.FirstOrDefault()?.ObjectId, 50),
+                1 => DescribeRevision(parents[0]?.ObjectId, 50),
                 > 1 => _multipleDescription.Text,
                 _ => null
             };
@@ -420,7 +420,7 @@ namespace GitUI.CommandsDialogs
 
             // Some items are not supported if more than one revision is selected
             var revisions = selectedItems.SecondRevs().ToList();
-            var selectedRev = revisions.Count != 1 ? null : revisions.FirstOrDefault();
+            GitRevision? selectedRev = revisions.Count == 1 ? revisions[0] : null;
 
             // First (A) is parent if one revision selected or if parent, then selected
             var parentIds = selectedItems.FirstIds().ToList();

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -428,7 +428,7 @@ namespace GitUI.CommandsDialogs
             // Combined diff, range diff etc are for display only, no manipulations
             bool isStatusOnly = selectedItems.Any(item => item.Item.IsRangeDiff || item.Item.IsStatusOnly);
             bool isDisplayOnlyDiff = parentIds.Contains(ObjectId.CombinedDiffId) || isStatusOnly;
-            int selectedGitItemCount = selectedItems.Count();
+            int selectedGitItemCount = selectedItems.Count;
 
             // No changes to files in bare repos
             bool isBareRepository = Module.IsBareRepository();
@@ -1053,10 +1053,10 @@ namespace GitUI.CommandsDialogs
         private ContextMenuDiffToolInfo GetContextMenuDiffToolInfo()
         {
             // Some items are not supported if more than one revision is selected
-            var revisions = DiffFiles.SelectedItems.SecondRevs().ToList();
-            var selectedRev = revisions.Count() != 1 ? null : revisions.FirstOrDefault();
+            List<GitRevision> revisions = DiffFiles.SelectedItems.SecondRevs().ToList();
+            GitRevision? selectedRev = revisions.Count == 1 ? revisions[0] : null;
 
-            var parentIds = DiffFiles.SelectedItems.FirstIds().ToList();
+            List<ObjectId> parentIds = DiffFiles.SelectedItems.FirstIds().ToList();
             bool firstIsParent = _gitRevisionTester.AllFirstAreParentsToSelected(parentIds, selectedRev);
             bool localExists = _gitRevisionTester.AnyLocalFileExists(DiffFiles.SelectedItems.Select(i => i.Item));
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
@@ -145,7 +145,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private static Remote FindRemoteByPreference(IList<Remote> remotes)
         {
-            if (remotes is null)
+            if (remotes?.Count is not > 0)
             {
                 return default;
             }
@@ -160,7 +160,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 }
             }
 
-            return remotes.FirstOrDefault();
+            return remotes[0];
         }
 
         private void ExtractExternalLinkDefinitions(ICloudProviderExternalLinkDefinitionExtractor externalLinkDefinitionExtractor)

--- a/GitUI/LeftPanel/RepoObjectsTree.SettingsContextMenu.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.SettingsContextMenu.cs
@@ -60,7 +60,7 @@ namespace GitUI.LeftPanel
                 swapIndex = up ? swapIndex - 1 : swapIndex + 1;
 
                 // If there are no visible nodes to swap with, we're done
-                if (swapIndex < 0 || swapIndex >= treeToIndex.Count())
+                if (swapIndex < 0 || swapIndex >= treeToIndex.Count)
                 {
                     return;
                 }

--- a/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -296,12 +296,19 @@ namespace GitUI.LeftPanel
 
             var cancellationToken = _selectionCancellationTokenSequence.Next();
 
-            GitRevision selectedRevision = selectedRevisions.FirstOrDefault();
-            string? selectedGuid = selectedRevision is null
-                ? null
-                : selectedRevision.IsArtificial
-                    ? "HEAD"
-                    : selectedRevision.Guid;
+            GitRevision? selectedRevision;
+            string? selectedGuid;
+            if (selectedRevisions.Count == 0)
+            {
+                selectedRevision = null;
+                selectedGuid = null;
+            }
+            else
+            {
+                selectedRevision = selectedRevisions[0];
+                selectedGuid = selectedRevision.IsArtificial ? "HEAD" : selectedRevision.Guid;
+            }
+
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -488,14 +495,12 @@ namespace GitUI.LeftPanel
 
             TreeNode? GetNextSearchResult()
             {
-                var first = _searchResult?.FirstOrDefault();
-
-                if (first is null)
+                if (_searchResult?.Count is not > 0 || _searchResult[0] is not TreeNode first)
                 {
                     return null;
                 }
 
-                _searchResult!.RemoveAt(0);
+                _searchResult.RemoveAt(0);
                 _searchResult.Add(first);
                 return first;
             }

--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -34,16 +34,14 @@ namespace GitUI
             _fileStatusDiffCalculatorInfo.HeadId = headId;
             _fileStatusDiffCalculatorInfo.AllowMultiDiff = allowMultiDiff;
 
-            var selectedRev = revisions.FirstOrDefault();
-            if (selectedRev is null)
+            if (revisions?.Count is not > 0 || revisions[0] is not GitRevision selectedRev)
             {
                 return Array.Empty<FileStatusWithDescription>();
             }
 
             GitModule module = GetModule();
-
             List<FileStatusWithDescription> fileStatusDescs = new();
-            if (revisions!.Count == 1)
+            if (revisions.Count == 1)
             {
                 // If the grid is filtered, parents may be rewritten
                 GitRevision actualRev = GetActualRevisionForRevision(selectedRev);
@@ -103,7 +101,7 @@ namespace GitUI
             // the first item is therefore the second selected
             var firstRev = AppSettings.ShowDiffForAllParents && revisions.Count == maxMultiCompare
                 ? revisions[2]
-                : revisions.Last();
+                : revisions[^1];
 
             fileStatusDescs.Add(new FileStatusWithDescription(
                 firstRev: firstRev,

--- a/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
@@ -140,12 +140,12 @@ namespace GitUI.UserControls.RevisionGrid
             }
 
             // Add other items
-            int count = revisions.Count();
+            int count = revisions.Count;
             AddItem(ResourceManager.TranslatedStrings.GetCommitHash(count), r => r.Guid, Images.CommitId, 'C');
             AddItem(ResourceManager.TranslatedStrings.GetMessage(count), r => r.Body ?? r.Subject, Images.Message, 'M');
             AddItem(ResourceManager.TranslatedStrings.GetAuthor(count), r => $"{r.Author} <{r.AuthorEmail}>", Images.Author, 'A');
 
-            if (count == 1 && revisions.First().AuthorDate == revisions.First().CommitDate)
+            if (count == 1 && revisions[0].AuthorDate == revisions[0].CommitDate)
             {
                 AddItem(ResourceManager.TranslatedStrings.Date, r => r.AuthorDate.ToString(), Images.Date, 'D');
             }

--- a/GitUI/UserControls/RevisionGrid/Graph/LaneNodeLocator.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneNodeLocator.cs
@@ -37,7 +37,7 @@
             }
 
             var segmentsForLane = row.GetSegmentsForIndex(lane);
-            if (segmentsForLane.Count() > 0)
+            if (segmentsForLane.Any())
             {
                 var firstParent = segmentsForLane.First().Parent;
 #if DEBUG

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -695,6 +695,25 @@ namespace GitUI
         }
 
         /// <summary>
+        /// Get the (last) selected revision in the grid.
+        /// </summary>
+        /// <returns>The selected revisions or <see langword="null"/> if none selected.</returns>
+        public GitRevision? GetSelectedRevisionOrDefault()
+        {
+            int rowCount = _gridView.RowCount;
+            foreach (DataGridViewRow row in _gridView.SelectedRows)
+            {
+                if (row.Index < rowCount
+                    && GetRevision(row.Index) is GitRevision revision)
+                {
+                    return revision;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Get the selected revisions in the grid.
         /// Note that the parents may be rewritten if a filter is applied.
         /// </summary>
@@ -1647,7 +1666,7 @@ namespace GitUI
                 return;
             }
 
-            DoubleClickRevision?.Invoke(this, new DoubleClickRevisionEventArgs(GetSelectedRevisions().FirstOrDefault()));
+            DoubleClickRevision?.Invoke(this, new DoubleClickRevisionEventArgs(GetSelectedRevisionOrDefault()));
 
             if (!DoubleClickDoesNotOpenCommitInfo)
             {
@@ -2601,7 +2620,7 @@ namespace GitUI
 
         private void HighlightSelectedBranch()
         {
-            GitRevision revision = GetSelectedRevisions().FirstOrDefault();
+            GitRevision? revision = GetSelectedRevisionOrDefault();
             if (revision is null)
             {
                 return;
@@ -2789,7 +2808,7 @@ namespace GitUI
 
         private void CompareToBranchToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var headCommit = GetSelectedRevisions().FirstOrDefault();
+            GitRevision? headCommit = GetSelectedRevisionOrDefault();
             if (headCommit is null)
             {
                 return;
@@ -2813,7 +2832,7 @@ namespace GitUI
                 return;
             }
 
-            var baseCommit = GetSelectedRevisions().FirstOrDefault();
+            GitRevision? baseCommit = GetSelectedRevisionOrDefault();
             if (baseCommit is null)
             {
                 return;
@@ -2824,7 +2843,7 @@ namespace GitUI
 
         private void selectAsBaseToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            _baseCommitToCompare = GetSelectedRevisions().FirstOrDefault();
+            _baseCommitToCompare = GetSelectedRevisionOrDefault();
             compareToBaseToolStripMenuItem.Enabled = _baseCommitToCompare is not null;
         }
 
@@ -2836,7 +2855,7 @@ namespace GitUI
                 return;
             }
 
-            var headCommit = GetSelectedRevisions().FirstOrDefault();
+            GitRevision? headCommit = GetSelectedRevisionOrDefault();
             if (headCommit is null)
             {
                 return;
@@ -2847,7 +2866,7 @@ namespace GitUI
 
         private void compareToWorkingDirectoryMenuItem_Click(object sender, EventArgs e)
         {
-            var baseCommit = GetSelectedRevisions().FirstOrDefault();
+            GitRevision? baseCommit = GetSelectedRevisionOrDefault();
             if (baseCommit is null)
             {
                 return;
@@ -2907,22 +2926,24 @@ namespace GitUI
 
         private void openBuildReportToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var revision = GetSelectedRevisions().FirstOrDefault();
-
-            if (revision is not null && !string.IsNullOrWhiteSpace(revision.BuildStatus?.Url))
+            GitRevision? revision = GetSelectedRevisionOrDefault();
+            if (string.IsNullOrWhiteSpace(revision?.BuildStatus?.Url))
             {
-                OsShellUtil.OpenUrlInDefaultBrowser(revision.BuildStatus.Url);
+                return;
             }
+
+            OsShellUtil.OpenUrlInDefaultBrowser(revision.BuildStatus.Url);
         }
 
         private void openPullRequestPageStripMenuItem_Click(object sender, EventArgs e)
         {
-            var revision = GetSelectedRevisions().FirstOrDefault();
-
-            if (revision is not null && !string.IsNullOrWhiteSpace(revision.BuildStatus?.PullRequestUrl))
+            GitRevision? revision = GetSelectedRevisionOrDefault();
+            if (string.IsNullOrWhiteSpace(revision?.BuildStatus?.PullRequestUrl))
             {
-                OsShellUtil.OpenUrlInDefaultBrowser(revision.BuildStatus.PullRequestUrl);
+                return;
             }
+
+            OsShellUtil.OpenUrlInDefaultBrowser(revision.BuildStatus.PullRequestUrl);
         }
 
         private void editCommitToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2182,18 +2182,14 @@ namespace GitUI
         private void ArchiveRevisionToolStripMenuItemClick(object sender, EventArgs e)
         {
             var selectedRevisions = GetSelectedRevisions();
-            if (selectedRevisions.Count > 2)
+            if (selectedRevisions.Count is > 2)
             {
                 MessageBox.Show(this, "Select only one or two revisions. Abort.", "Archive revision", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            GitRevision mainRevision = selectedRevisions.FirstOrDefault();
-            GitRevision? diffRevision = null;
-            if (selectedRevisions.Count == 2)
-            {
-                diffRevision = selectedRevisions.Last();
-            }
+            GitRevision? mainRevision = selectedRevisions.Count > 0 ? selectedRevisions[0] : null;
+            GitRevision? diffRevision = selectedRevisions.Count == 2 ? selectedRevisions[1] : null;
 
             UICommands.StartArchiveDialog(ParentForm, mainRevision, diffRevision);
         }

--- a/Plugins/GitUIPluginInterfaces/GitRevision.cs
+++ b/Plugins/GitUIPluginInterfaces/GitRevision.cs
@@ -117,7 +117,7 @@ namespace GitUIPluginInterfaces
 
         public bool HasParent => ParentIds?.Count > 0;
 
-        public ObjectId? FirstParentId => ParentIds?.FirstOrDefault();
+        public ObjectId? FirstParentId => HasParent ? ParentIds[0] : null;
 
         #region INotifyPropertyChanged
 

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -166,11 +166,11 @@ namespace GitExtensions.Plugins.JiraCommitHintPlugin
                 ThreadHelper.JoinableTaskFactory.RunAsync(
                     async () =>
                     {
-                        var message = await GetMessageToCommitAsync(localJira, localQuery, localStringTemplate);
+                        JiraTaskDTO[] message = await GetMessageToCommitAsync(localJira, localQuery, localStringTemplate);
                         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                        var preview = message.FirstOrDefault();
+                        string previewText = message.Length > 0 ? message[0].Text : EmptyQueryResultMessage.Text;
 
-                        MessageBox.Show(null, preview is null ? EmptyQueryResultMessage.Text : preview.Text, EmptyQueryResultCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                        MessageBox.Show(null, previewText, EmptyQueryResultCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
                         _btnPreview.Enabled = true;
                     });

--- a/UnitTests/GitCommands.Tests/ExternalLinks/ExternalLinkRevisionParserTests.cs
+++ b/UnitTests/GitCommands.Tests/ExternalLinks/ExternalLinkRevisionParserTests.cs
@@ -21,7 +21,7 @@ namespace GitCommandsTests.ExternalLinks
         [SetUp]
         public void Setup()
         {
-            _linkDef = Parse(GetGitHubIssuesXmlDef()).First();
+            _linkDef = Parse(GetGitHubIssuesXmlDef())[0];
 
             _revision = new GitRevision(ObjectId.Random());
 
@@ -93,7 +93,7 @@ namespace GitCommandsTests.ExternalLinks
         [Test]
         public void ParseLinkWithEmptyRemotePart()
         {
-            _linkDef = Parse(GetEmptyRemotePartXmlDef()).First();
+            _linkDef = Parse(GetEmptyRemotePartXmlDef())[0];
             _revision.Body = "Merge pull request #3657 from RussKie/tweak_FormRemotes_tooltips";
             var expectedLinks = new[]
             {

--- a/UnitTests/GitCommands.Tests/ExternalLinks/ExternalLinksManagerIntegrationTests.cs
+++ b/UnitTests/GitCommands.Tests/ExternalLinks/ExternalLinksManagerIntegrationTests.cs
@@ -156,7 +156,7 @@ namespace GitCommandsTests.ExternalLinks
             // 1 comes from the local
             effective.Count.Should().Be(5);
 
-            manager.Remove(effective.Last());
+            manager.Remove(effective[^1]);
 
             manager.Save();
 

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -80,8 +80,8 @@ namespace GitCommandsTests
             Assert.AreSame(result.Lines[0].Commit, result.Lines[1].Commit);
             Assert.AreSame(result.Lines[0].Commit, result.Lines[6].Commit);
 
-            Assert.AreEqual(ObjectId.Parse("e3268019c66da7534414e9562ececdee5d455b1b"), result.Lines.Last().Commit.ObjectId);
-            Assert.AreEqual("", result.Lines.Last().Text);
+            Assert.AreEqual(ObjectId.Parse("e3268019c66da7534414e9562ececdee5d455b1b"), result.Lines[^1].Commit.ObjectId);
+            Assert.AreEqual("", result.Lines[^1].Text);
         }
 
         [TestCase(null, null)]

--- a/UnitTests/GitUI.Tests/LeftPanel/GitRefMenuItemsTest.cs
+++ b/UnitTests/GitUI.Tests/LeftPanel/GitRefMenuItemsTest.cs
@@ -65,7 +65,7 @@ namespace GitUITests.LeftPanel
             // Act
             var menuItems = group.ToArray();
             Assert.IsEmpty(_factoryQueue);
-            Assert.AreEqual(menuItems.Count(), expectedTotal);
+            Assert.AreEqual(menuItems.Length, expectedTotal);
             int testIndex = 0;
             AssertItem(menuItems[testIndex++], nameof(TestBranchNode.Checkout));
             AssertItem(menuItems[testIndex++], nameof(TestBranchNode.Merge));
@@ -87,7 +87,7 @@ namespace GitUITests.LeftPanel
             const int expectedEnabled = 2; // create branch, rename
             int expectedDisabled = expectedTotal - expectedEnabled;
             var disabledItems = generator.Where(t => !LocalBranchMenuItems<TestBranchNode>.CurrentBranchItemKeys.Contains(t.Key)).ToArray();
-            Assert.AreEqual(disabledItems.Count(), expectedDisabled);
+            Assert.AreEqual(disabledItems.Length, expectedDisabled);
             int testIndex = 0;
             AssertItem(disabledItems[testIndex++], nameof(TestBranchNode.Checkout));
             AssertItem(disabledItems[testIndex++], nameof(TestBranchNode.Merge));


### PR DESCRIPTION
## Proposed changes

Use direct indexed access instead of LINQ access methods for efficiency.
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1826

A few of the accesses are done quite often, I doubt that this is measurable though.
(Compare to using foreach() instead of LINQ, which is often requested in code reviews.)
The Visual Studio suggestion is handled by this, so it is not ignored where it could be relevant.

This PR has two commits, review by commit:
* First are changes mostly automated, simply changing `.First()` tp `[0]`. This should be simple to review, if incorrect access before, same now.

```patch
diff --git a/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs b/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
index 7b06a..66ddb 100644
--- a/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
@@ -53,7 +53,7 @@ private void Start_Click(object sender, EventArgs e)
             {
                 if (MessageBox.Show(this, _bisectStart.Text, Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
                 {
-                    BisectRange(revisions.First().ObjectId, revisions.Last().ObjectId);
+                    BisectRange(revisions[0].ObjectId, revisions[^1].ObjectId);
                     Close();
                 }
             }
```

* Change `FirstOrDefault()` etc ti index operators, normally requires some rewriting.
`RevisionGridControl.GetSelectedRevisionOrDefault()` added as a helper function for a common case.

```patch
diff --git a/GitUI/CommandsDialogs/FormClone.cs b/GitUI/CommandsDialogs/FormClone.cs
index f368b..b971 100644
--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -122,7 +122,7 @@ protected override void OnRuntimeLoad(EventArgs e)
                         }
                         else
                         {
-                            currentBranchRemote = remotes.FirstOrDefault();
+                            currentBranchRemote = remotes.Count > 0 ? remotes[0] : null;
                         }
                     }
 
```

Related to #11130 as there may be merge conflicts (will likely want to merge this after).
(This adds some ^1 index accesses too).

## Test methodology <!-- How did you ensure quality? -->

Code review

## Merge strategy

Probably rebase merge (PR submitter must change the commit message for the last commit).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
