### PR TITLE
Hide build server status tab if not configured

### DIFF
--- a/Plugins/GitUIPluginInterfaces/BuildServerIntegration/IBuildServerSettings.cs
+++ b/Plugins/GitUIPluginInterfaces/BuildServerIntegration/IBuildServerSettings.cs
@@ -3,7 +3,7 @@
     public interface IBuildServerSettings
     {
         private const bool IntegrationEnabledDefault = false;
-        private const bool ShowBuildResultPageDefault = true;
+        private const bool ShowBuildResultPageDefault = false;
 
         /// <summary>
         ///  Gets or sets the type of the build server (e.g. AppVeyor, TeamCity, etc.).
@@ -26,7 +26,7 @@
         bool? ShowBuildResultPage { get; set; }
 
         /// <summary>
-        ///  If <see cref="ShowBuildResultPage"/> is configured - the configured value; otherwise the default <see langword="true"/>.
+        ///  If <see cref="ShowBuildResultPage"/> is configured - the configured value; otherwise the default <see langword="false"/>.
         /// </summary>
         bool ShowBuildResultPageOrDefault => ShowBuildResultPage.GetValueOrDefault(defaultValue: ShowBuildResultPageDefault);
 


### PR DESCRIPTION
## Proposed changes

The WebBrowser control uses IE11 and may give a bad experience. Disable it unless explicitly enabled.

![image](https://github.com/gitextensions/gitextensions/assets/6248932/830c33e1-10d0-41cc-bb95-72986820d47a)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
