### PR TITLE
Refactor TaskManager.FileAndForget

### DIFF
--- a/GitExtUtils/GitUI/ThreadHelper.cs
+++ b/GitExtUtils/GitUI/ThreadHelper.cs
@@ -59,9 +59,27 @@ namespace GitUI
             }
         }
 
+        /// <summary>
+        /// Asynchronously run <paramref name="asyncAction"/> on a background thread and forward all exceptions to <see cref="Application.OnThreadException"/> except for <see cref="OperationCanceledException"/>, which is ignored.
+        /// </summary>
+        public static void FileAndForget(Func<Task> asyncAction)
+            => _taskManager.FileAndForget(asyncAction);
+
+        /// <summary>
+        /// Asynchronously run <paramref name="action"/> on a background thread and forward all exceptions to <see cref="Application.OnThreadException"/> except for <see cref="OperationCanceledException"/>, which is ignored.
+        /// </summary>
+        public static void FileAndForget(Action action)
+            => _taskManager.FileAndForget(action);
+
+        /// <summary>
+        /// Asynchronously run <paramref name="joinableTask"/> on a background thread and forward all exceptions to <see cref="Application.OnThreadException"/> except for <see cref="OperationCanceledException"/>, which is ignored.
+        /// </summary>
         public static void FileAndForget(this JoinableTask joinableTask)
             => _taskManager.FileAndForget(joinableTask.Task);
 
+        /// <summary>
+        /// Asynchronously run <paramref name="task"/> on a background thread and forward all exceptions to <see cref="Application.OnThreadException"/> except for <see cref="OperationCanceledException"/>, which is ignored.
+        /// </summary>
         public static void FileAndForget(this Task task)
             => _taskManager.FileAndForget(task);
 

--- a/GitExtUtils/GitUI/ThreadHelper.cs
+++ b/GitExtUtils/GitUI/ThreadHelper.cs
@@ -59,13 +59,11 @@ namespace GitUI
             }
         }
 
-        public static void FileAndForget(this JoinableTask joinableTask, Func<Exception, bool>? fileOnlyIf = null)
-        {
-            joinableTask.Task.FileAndForget(fileOnlyIf);
-        }
+        public static void FileAndForget(this JoinableTask joinableTask)
+            => _taskManager.FileAndForget(joinableTask.Task);
 
-        public static void FileAndForget(this Task task, Func<Exception, bool>? fileOnlyIf = null)
-            => _taskManager.FileAndForget(task, fileOnlyIf);
+        public static void FileAndForget(this Task task)
+            => _taskManager.FileAndForget(task);
 
         public static async Task JoinPendingOperationsAsync(CancellationToken cancellationToken)
             => await _taskManager.JoinPendingOperationsAsync(cancellationToken);

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -30,7 +30,7 @@ namespace GitUI.CommandsDialogs
         public FormDeleteRemoteBranch(GitUICommands commands, string defaultRemoteBranch)
             : base(commands, enablePositionRestore: false)
         {
-            _taskManager.RunAsyncAndForget(() => _mergedBranches = Module.GetMergedRemoteBranches().ToHashSet());
+            _taskManager.FileAndForget(() => _mergedBranches = Module.GetMergedRemoteBranches().ToHashSet());
 
             _defaultRemoteBranch = defaultRemoteBranch;
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1056,22 +1056,21 @@ namespace GitUI
                 {
                     await TaskScheduler.Default;
 
-                    RevisionReader reader = new(capturedModule, hasReflogSelector: false);
-                    string pathFilter = BuildPathFilter(_filterInfo.PathFilter);
-                    ParentsAreRewritten = _filterInfo.HasRevisionFilter;
-
-                    cancellationToken.ThrowIfCancellationRequested();
-                    reader.GetLog(
-                        observeRevisions,
-                        _filterInfo.GetRevisionFilter(currentCheckout),
-                        pathFilter,
-                        cancellationToken);
-                }).FileAndForget(
-                    ex =>
+                    TaskManager.HandleExceptions(() =>
                     {
-                        observeRevisions.OnError(ex);
-                        return false;
-                    });
+                        RevisionReader reader = new(capturedModule, hasReflogSelector: false);
+                        string pathFilter = BuildPathFilter(_filterInfo.PathFilter);
+                        ParentsAreRewritten = _filterInfo.HasRevisionFilter;
+
+                        cancellationToken.ThrowIfCancellationRequested();
+                        reader.GetLog(
+                            observeRevisions,
+                            _filterInfo.GetRevisionFilter(currentCheckout),
+                            pathFilter,
+                            cancellationToken);
+                    },
+                    ex => observeRevisions.OnError(ex));
+                });
 
                 // Initiate update left panel
                 RevisionsLoading?.Invoke(this, new RevisionLoadEventArgs(this, UICommands, getUnfilteredRefs, getStashRevs, forceRefresh));

--- a/UnitTests/GitUI.Tests/ThreadHelperTests.cs
+++ b/UnitTests/GitUI.Tests/ThreadHelperTests.cs
@@ -22,7 +22,6 @@ namespace GitUITests
         }
 
         [Test]
-        [Ignore("Hangs")]
         public async Task FileAndForgetReportsThreadException()
         {
             using ThreadExceptionHelper helper = new();
@@ -42,45 +41,6 @@ namespace GitUITests
             form.Dispose();
 
             YieldOntoControlMainThreadAsync(form).FileAndForget();
-
-            await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
-            Assert.Null(helper.Exception, helper.Message);
-        }
-
-        [Test]
-        [Ignore("Hangs")]
-        public async Task FileAndForgetFilterCanAllowExceptions()
-        {
-            using ThreadExceptionHelper helper = new();
-            Exception ex = new();
-
-            ThrowExceptionAsync(ex).FileAndForget(fileOnlyIf: e => e == ex);
-
-            await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
-            Assert.AreSame(ex, helper.Exception);
-        }
-
-        [Test]
-        [Ignore("Hangs")]
-        public async Task FileAndForgetFilterCanIgnoreExceptions()
-        {
-            using ThreadExceptionHelper helper = new();
-            Exception ex = new();
-
-            ThrowExceptionAsync(ex).FileAndForget(fileOnlyIf: e => e != ex);
-
-            await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
-            Assert.Null(helper.Exception, helper.Message);
-        }
-
-        [Test]
-        public async Task FileAndForgetFilterIgnoresCancellationExceptions()
-        {
-            using ThreadExceptionHelper helper = new();
-            Form form = new();
-            form.Dispose();
-
-            YieldOntoControlMainThreadAsync(form).FileAndForget(fileOnlyIf: ex => true);
 
             await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
             Assert.Null(helper.Exception, helper.Message);


### PR DESCRIPTION
## Proposed changes

- `TaskManager.FileAndForget()`: Remove argument `fileOnlyIf`, and replace its single usage
- Rename and refactor `TaskManager.FileAndForget()` to `RunAsyncAndForget()` in order to emphasize what it actually does,
  and save an unnecessary second call of `JoinableTaskFactory.RunAsync()` by `TaskManager.RunAsyncAndForget(asyncAction)`

In a follow-up PR, I am going to replace all `JTF.RunAsync()` and `FileAndForget()` with `RunAsyncAndForget()` (background thread) or `Control.InvokeAsync()` (UI thread), respectively.
Then I will sort the methods of `ThreadHelper` alphabetically.

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).