### PR TITLE
Fixup / simplify use of JoinableTaskFactory.Run

### DIFF
--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -230,10 +230,7 @@ namespace GitCommands
             public Task<int> WaitForExitAsync(CancellationToken token) => WaitForExitAsync().WithCancellation(token);
 
             /// <inheritdoc />
-            public int WaitForExit()
-            {
-                return ThreadHelper.JoinableTaskFactory.Run(() => WaitForExitAsync());
-            }
+            public int WaitForExit() => ThreadHelper.JoinableTaskFactory.Run(WaitForExitAsync);
 
             /// <inheritdoc />
             public void Dispose()

--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -349,11 +349,13 @@ namespace GitUI.BuildServerIntegration
                         () =>
                         {
                             // To run the `StartSettingsDialog()` in the UI Thread
-                            _revisionGrid.Invoke((Action)(() =>
-                            {
-                                _revisionGrid.UICommands.StartSettingsDialog(typeof(BuildServerIntegrationSettingsPage));
-                            }));
-                        }, objectId => _revisionGridInfo.GetRevision(objectId) is not null);
+                            ThreadHelper.JoinableTaskFactory.Run(async () =>
+                                {
+                                    await _revisionGrid.SwitchToMainThreadAsync();
+                                    _revisionGrid.UICommands.StartSettingsDialog(typeof(BuildServerIntegrationSettingsPage));
+                                });
+                        },
+                        objectId => _revisionGridInfo.GetRevision(objectId) is not null);
                     return buildServerAdapter;
                 }
                 catch (InvalidOperationException ex)

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -811,19 +811,9 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             RepositoryContextAction(sender as ToolStripMenuItem, selectedRepositoryItem =>
             {
                 ThreadHelper.JoinableTaskFactory.Run(() =>
-                {
-                    Task task;
-                    if (selectedRepositoryItem.IsFavourite)
-                    {
-                        task = RepositoryHistoryManager.Locals.RemoveFavouriteAsync(selectedRepositoryItem.Repository.Path);
-                    }
-                    else
-                    {
-                        task = RepositoryHistoryManager.Locals.RemoveRecentAsync(selectedRepositoryItem.Repository.Path);
-                    }
-
-                    return task;
-                });
+                    selectedRepositoryItem.IsFavourite
+                        ? RepositoryHistoryManager.Locals.RemoveFavouriteAsync(selectedRepositoryItem.Repository.Path)
+                        : RepositoryHistoryManager.Locals.RemoveRecentAsync(selectedRepositoryItem.Repository.Path));
                 ShowRecentRepositories();
             });
         }

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
@@ -80,12 +80,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 SortPinnedRepos = AppSettings.SortPinnedRepos
             };
 
-            _allRecentRepositories ??= ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.LoadRecentHistoryAsync());
+            _allRecentRepositories ??= ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync);
             var repositories = Filter(_allRecentRepositories, pattern);
             splitter.SplitRecentRepos(repositories, pinnedRepos, allRecentRepos);
             var recentRepositories = pinnedRepos.Union(allRecentRepos).ToList();
 
-            _allFavoriteRepositories ??= ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.LoadFavouriteHistoryAsync());
+            _allFavoriteRepositories ??= ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadFavouriteHistoryAsync);
             repositories = Filter(_allFavoriteRepositories, pattern);
             pinnedRepos.Clear();
             allRecentRepos.Clear();

--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
@@ -13,19 +13,16 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         public FormOpenDirectory(GitModule? currentModule)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             InitializeComponent();
             InitializeComplete();
 
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
-            {
-                var repositoryHistory = await RepositoryHistoryManager.Locals.LoadRecentHistoryAsync();
-
-                await this.SwitchToMainThreadAsync();
-                _NO_TRANSLATE_Directory.DataSource = GetDirectories(currentModule, repositoryHistory);
-                Load.Select();
-                _NO_TRANSLATE_Directory.Focus();
-                _NO_TRANSLATE_Directory.Select();
-            });
+            IList<Repository> repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync);
+            _NO_TRANSLATE_Directory.DataSource = GetDirectories(currentModule, repositoryHistory);
+            Load.Select();
+            _NO_TRANSLATE_Directory.Focus();
+            _NO_TRANSLATE_Directory.Select();
         }
 
         protected override void OnRuntimeLoad(EventArgs e)

--- a/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
@@ -15,17 +15,14 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         public FormRecentReposSettings()
             : base(true)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             InitializeComponent();
             InitializeComplete();
 
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
-            {
-                _repositoryHistory = await RepositoryHistoryManager.Locals.LoadRecentHistoryAsync();
-
-                await this.SwitchToMainThreadAsync();
-                LoadSettings();
-                RefreshRepos();
-            });
+            _repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync);
+            LoadSettings();
+            RefreshRepos();
         }
 
         private void LoadSettings()
@@ -343,6 +340,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void removeRecentToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (!GetSelectedRepos(sender, out List<RecentRepoInfo?> repos))
             {
                 return;
@@ -354,10 +353,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 {
                     _repositoryHistory = await RepositoryHistoryManager.Locals.RemoveRecentAsync(repo.Repo.Path);
                 }
-
-                await this.SwitchToMainThreadAsync();
-                RefreshRepos();
             });
+            RefreshRepos();
         }
 
         private void listView_DrawItem(object sender, DrawListViewItemEventArgs e)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -608,7 +608,11 @@ namespace GitUI.CommandsDialogs
             // It can also be called from background tasks, e.g. from BackgroundFetchPlugin.
             if (!ThreadHelper.JoinableTaskContext.IsOnMainThread)
             {
-                Invoke(() => RefreshRevisions(e.GetRefs));
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
+                    {
+                        await this.SwitchToMainThreadAsync();
+                        RefreshRevisions(e.GetRefs);
+                    });
                 return;
             }
 

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -50,11 +50,6 @@ namespace GitUI.CommandsDialogs
             _url = url;
             _defaultBranchItems = new[] { _branchDefaultRemoteHead.Text, _branchNone.Text };
             _NO_TRANSLATE_Branches.DataSource = _defaultBranchItems;
-
-            IList<Repository> repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync);
-            ThreadHelper.AssertOnUIThread();
-            _NO_TRANSLATE_To.DataSource = repositoryHistory;
-            _NO_TRANSLATE_To.DisplayMember = nameof(Repository.Path);
         }
 
         protected override void OnRuntimeLoad(EventArgs e)

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -247,11 +247,10 @@ namespace GitUI.CommandsDialogs
                     }
                 }
 
-                ThreadHelper.JoinableTaskFactory.Run(() =>
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
-                    RepositoryHistoryManager.Remotes.AddAsMostRecentAsync(sourceRepo);
-                    RepositoryHistoryManager.Locals.AddAsMostRecentAsync(dirTo);
-                    return Task.CompletedTask;
+                    await RepositoryHistoryManager.Remotes.AddAsMostRecentAsync(sourceRepo);
+                    await RepositoryHistoryManager.Locals.AddAsMostRecentAsync(dirTo);
                 });
 
                 if (!string.IsNullOrEmpty(_puttySshKey))

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -51,28 +51,21 @@ namespace GitUI.CommandsDialogs
             _defaultBranchItems = new[] { _branchDefaultRemoteHead.Text, _branchNone.Text };
             _NO_TRANSLATE_Branches.DataSource = _defaultBranchItems;
 
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
-            {
-                var repositoryHistory = await RepositoryHistoryManager.Locals.LoadRecentHistoryAsync();
-
-                await this.SwitchToMainThreadAsync();
-                _NO_TRANSLATE_To.DataSource = repositoryHistory;
-                _NO_TRANSLATE_To.DisplayMember = nameof(Repository.Path);
-            });
+            IList<Repository> repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync);
+            ThreadHelper.AssertOnUIThread();
+            _NO_TRANSLATE_To.DataSource = repositoryHistory;
+            _NO_TRANSLATE_To.DisplayMember = nameof(Repository.Path);
         }
 
         protected override void OnRuntimeLoad(EventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             base.OnRuntimeLoad(e);
 
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
-            {
-                var repositoryHistory = await RepositoryHistoryManager.Remotes.LoadRecentHistoryAsync();
-
-                await this.SwitchToMainThreadAsync();
-                _NO_TRANSLATE_From.DataSource = repositoryHistory;
-                _NO_TRANSLATE_From.DisplayMember = nameof(Repository.Path);
-            });
+            IList<Repository> repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Remotes.LoadRecentHistoryAsync);
+            _NO_TRANSLATE_From.DataSource = repositoryHistory;
+            _NO_TRANSLATE_From.DisplayMember = nameof(Repository.Path);
 
             _NO_TRANSLATE_To.Text = AppSettings.DefaultCloneDestinationPath;
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2058,9 +2058,7 @@ namespace GitUI.CommandsDialogs
                             }
 
                             GitSubmoduleStatus? gitSubmoduleStatus = ThreadHelper.JoinableTaskFactory.Run(() =>
-                            {
-                                return item.GetSubmoduleStatusAsync() ?? Task.FromResult<GitSubmoduleStatus?>(null);
-                            });
+                                item.GetSubmoduleStatusAsync() ?? Task.FromResult<GitSubmoduleStatus?>(null));
 
                             if (gitSubmoduleStatus is null || !gitSubmoduleStatus.IsDirty)
                             {

--- a/GitUI/CommandsDialogs/FormInit.cs
+++ b/GitUI/CommandsDialogs/FormInit.cs
@@ -24,20 +24,16 @@ namespace GitUI.CommandsDialogs
         public FormInit(string dir, EventHandler<GitModuleEventArgs>? gitModuleChanged)
             : base(commands: null, enablePositionRestore: true)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             _gitModuleChanged = gitModuleChanged;
             InitializeComponent();
 
             InitializeComplete();
 
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
-            {
-                var repositoryHistory = await RepositoryHistoryManager.Locals.LoadRecentHistoryAsync();
-
-                await this.SwitchToMainThreadAsync();
-                _NO_TRANSLATE_Directory.DataSource = repositoryHistory;
-                _NO_TRANSLATE_Directory.DisplayMember = nameof(Repository.Path);
-            });
-
+            IList<Repository> repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync);
+            _NO_TRANSLATE_Directory.DataSource = repositoryHistory;
+            _NO_TRANSLATE_Directory.DisplayMember = nameof(Repository.Path);
             _NO_TRANSLATE_Directory.SelectedIndex = -1;
             _NO_TRANSLATE_Directory.Text = string.IsNullOrEmpty(dir) ? AppSettings.DefaultCloneDestinationPath : dir;
         }

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -980,6 +980,8 @@ namespace GitUI.CommandsDialogs
 
         private void PullFromUrlCheckedChanged(object sender, EventArgs e)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (!PullFromUrl.Checked)
             {
                 return;
@@ -996,16 +998,11 @@ namespace GitUI.CommandsDialogs
             Merge.Enabled = true;
             Rebase.Enabled = true;
 
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
-            {
-                var repositoryHistory = await RepositoryHistoryManager.Remotes.LoadRecentHistoryAsync();
-
-                await this.SwitchToMainThreadAsync();
-                string prevUrl = comboBoxPullSource.Text;
-                comboBoxPullSource.DataSource = repositoryHistory;
-                comboBoxPullSource.DisplayMember = nameof(Repository.Path);
-                comboBoxPullSource.Text = prevUrl;
-            });
+            IList<Repository> repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Remotes.LoadRecentHistoryAsync);
+            string prevUrl = comboBoxPullSource.Text;
+            comboBoxPullSource.DataSource = repositoryHistory;
+            comboBoxPullSource.DisplayMember = nameof(Repository.Path);
+            comboBoxPullSource.Text = prevUrl;
         }
 
         private void AddRemoteClick(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormRevertCommit.cs
+++ b/GitUI/CommandsDialogs/FormRevertCommit.cs
@@ -83,7 +83,7 @@ namespace GitUI.CommandsDialogs
 
             CommitMessageManager commitMessageManager = new(this, Module.WorkingDirGitDir, Module.CommitEncoding);
 
-            string existingCommitMessage = ThreadHelper.JoinableTaskFactory.Run(async () => await commitMessageManager.GetMergeOrCommitMessageAsync());
+            string existingCommitMessage = ThreadHelper.JoinableTaskFactory.Run(() => commitMessageManager.GetMergeOrCommitMessageAsync());
 
             ArgumentString command = GitCommandHelpers.RevertCmd(Revision.ObjectId, AutoCommit.Checked, parentIndex);
 

--- a/GitUI/CommandsDialogs/InvalidRepositoryRemover.cs
+++ b/GitUI/CommandsDialogs/InvalidRepositoryRemover.cs
@@ -19,7 +19,7 @@ namespace GitUI.CommandsDialogs
         /// <inheritdoc/>
         public bool ShowDeleteInvalidRepositoryDialog(string repositoryPath)
         {
-            int invalidPathCount = ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.LoadRecentHistoryAsync())
+            int invalidPathCount = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync)
                                                                    .Count(repo => !GitModule.IsValidGitWorkingDir(repo.Path));
 
             TaskDialogPage page = new()

--- a/GitUI/CommandsDialogs/Menus/CopyPathsToolStripMenuItem.cs
+++ b/GitUI/CommandsDialogs/Menus/CopyPathsToolStripMenuItem.cs
@@ -24,7 +24,7 @@ namespace GitUI.CommandsDialogs.Menus
         private void CopyPathsToClipboard(string prefixDir, Func<string, string> convertPath)
         {
             IEnumerable<string?> selectedFilePaths
-                = (_getSelectedFilePaths ?? throw new InvalidOperationException("The menu is not initialized.")).Invoke();
+                = (_getSelectedFilePaths ?? throw new InvalidOperationException("The menu is not initialized."))();
             string filePaths = GetFilePaths(selectedFilePaths, prefixDir, convertPath);
             if (!string.IsNullOrWhiteSpace(filePaths))
             {

--- a/GitUI/CommandsDialogs/Menus/StartToolStripMenuItem.cs
+++ b/GitUI/CommandsDialogs/Menus/StartToolStripMenuItem.cs
@@ -101,14 +101,9 @@ namespace GitUI.CommandsDialogs.Menus
 
         private void tsmiRecentRepositoriesClear_Click(object sender, EventArgs e)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
-            {
-                var repositoryHistory = Array.Empty<Repository>();
-                await RepositoryHistoryManager.Locals.SaveRecentHistoryAsync(repositoryHistory);
-
-                await this.SwitchToMainThreadAsync();
-                RecentRepositoriesCleared?.Invoke(sender, e);
-            });
+            ThreadHelper.ThrowIfNotOnUIThread();
+            ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.SaveRecentHistoryAsync(Array.Empty<Repository>()));
+            RecentRepositoriesCleared?.Invoke(sender, e);
         }
     }
 }

--- a/GitUI/CommandsDialogs/Menus/ToolStripMenuItemEx.cs
+++ b/GitUI/CommandsDialogs/Menus/ToolStripMenuItemEx.cs
@@ -12,7 +12,7 @@ namespace GitUI.CommandsDialogs.Menus
         ///  Gets the current instance of the UI commands.
         /// </summary>
         protected GitUICommands UICommands
-            => (_getUICommands ?? throw new InvalidOperationException("The button is not initialized")).Invoke();
+            => (_getUICommands ?? throw new InvalidOperationException("The button is not initialized"))();
 
         /// <summary>
         ///  Gets the current instance of the git module.

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -61,24 +61,20 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
         private void Init()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             if (!string.IsNullOrEmpty(AppSettings.DefaultCloneDestinationPath))
             {
                 destinationTB.Text = AppSettings.DefaultCloneDestinationPath;
             }
             else
             {
-                ThreadHelper.JoinableTaskFactory.Run(async () =>
+                IList<Repository> repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync);
+                Repository? lastRepo = repositoryHistory.Count > 0 ? repositoryHistory[0] : null;
+                if (!string.IsNullOrEmpty(lastRepo?.Path))
                 {
-                    var repositoryHistory = await RepositoryHistoryManager.Locals.LoadRecentHistoryAsync();
-
-                    await this.SwitchToMainThreadAsync();
-                    Repository? lastRepo = repositoryHistory.Count > 0 ? repositoryHistory[0] : null;
-                    if (!string.IsNullOrEmpty(lastRepo?.Path))
-                    {
-                        string p = lastRepo.Path.Trim('/', '\\');
-                        destinationTB.Text = Path.GetDirectoryName(p);
-                    }
-                });
+                    string p = lastRepo.Path.Trim('/', '\\');
+                    destinationTB.Text = Path.GetDirectoryName(p);
+                }
             }
 
             Text = $"{_gitHoster.Name}: {Text}";

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -206,8 +206,8 @@ namespace GitUI.CommandsDialogs.RepoHosting
             // In this case we fallback to the first remote in the list.
             // Currently, local git repo with no remote will show error message and can not open this dialog.
             // So there will always be at least 1 remote when this dialog is open
-            _cloneGitProtocol = ThreadHelper.JoinableTaskFactory.Run(async () => (await Module.GetRemotesAsync())
-                .First(r => string.IsNullOrEmpty(currentRemote) || r.Name == currentRemote).FetchUrl.IsUrlUsingHttp() ? GitProtocol.Https : GitProtocol.Ssh);
+            _cloneGitProtocol = ThreadHelper.JoinableTaskFactory.Run(Module.GetRemotesAsync)
+                .First(r => string.IsNullOrEmpty(currentRemote) || r.Name == currentRemote).FetchUrl.IsUrlUsingHttp() ? GitProtocol.Https : GitProtocol.Ssh;
             var hostedRemote = _selectHostedRepoCB.Items.
                 Cast<IHostedRemote>().
                 FirstOrDefault(remote => string.Equals(remote.Name, currentRemote, StringComparison.OrdinalIgnoreCase));

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
@@ -168,10 +168,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Validates.NotNull(Module);
             Validates.NotNull(_externalLinksManager);
 
-            var remotes = ThreadHelper.JoinableTaskFactory.Run(async () => await Module.GetRemotesAsync()).ToList();
-            var selectedRemote = FindRemoteByPreference(remotes.Where(r => externalLinkDefinitionExtractor.IsValidRemoteUrl(r.FetchUrl)).ToList());
+            IReadOnlyList<Remote> remotes = ThreadHelper.JoinableTaskFactory.Run(Module.GetRemotesAsync).ToList();
+            Remote selectedRemote = FindRemoteByPreference(remotes.Where(r => externalLinkDefinitionExtractor.IsValidRemoteUrl(r.FetchUrl)).ToList());
 
-            var externalLinkDefinitions = externalLinkDefinitionExtractor.GetDefinitions(selectedRemote.FetchUrl);
+            IList<ExternalLinkDefinition> externalLinkDefinitions = externalLinkDefinitionExtractor.GetDefinitions(selectedRemote.FetchUrl);
             _externalLinksManager.AddRange(externalLinkDefinitions);
 
             ReloadCategories();

--- a/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
+++ b/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
@@ -23,19 +23,16 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
         public FormAddSubmodule(GitUICommands commands)
             : base(commands)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             InitializeComponent();
             InitializeComplete();
 
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
-            {
-                var repositoryHistory = await RepositoryHistoryManager.Remotes.LoadRecentHistoryAsync();
-
-                await this.SwitchToMainThreadAsync();
-                Directory.DataSource = repositoryHistory;
-                Directory.DisplayMember = nameof(Repository.Path);
-                Directory.Text = "";
-                LocalPath.Text = "";
-            });
+            IList<Repository> repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Remotes.LoadRecentHistoryAsync);
+            Directory.DataSource = repositoryHistory;
+            Directory.DisplayMember = nameof(Repository.Path);
+            Directory.Text = "";
+            LocalPath.Text = "";
         }
 
         private void BrowseClick(object sender, EventArgs e)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -678,7 +678,7 @@ namespace GitUI.Editor
 
         public void Clear()
         {
-            ThreadHelper.JoinableTaskFactory.Run(() => ClearAsync());
+            ThreadHelper.JoinableTaskFactory.Run(ClearAsync);
         }
 
         /// <summary>
@@ -1060,10 +1060,7 @@ namespace GitUI.Editor
             {
                 return _async.LoadAsync(
                     getSubmoduleText,
-                    text =>
-                    {
-                        ThreadHelper.JoinableTaskFactory.Run(() => ViewTextAsync(fileName, text, item, line: null, openWithDifftool));
-                    });
+                    text => ThreadHelper.JoinableTaskFactory.Run(() => ViewTextAsync(fileName, text, item, line: null, openWithDifftool)));
             }
             else if (FileHelper.IsImage(fileName))
             {
@@ -1105,8 +1102,7 @@ namespace GitUI.Editor
             {
                 return _async.LoadAsync(
                     getFileText,
-                    text => ThreadHelper.JoinableTaskFactory.Run(
-                        () => ViewTextAsync(fileName, text, item, line, openWithDifftool, checkGitAttributes: true)));
+                    text => ThreadHelper.JoinableTaskFactory.Run(() => ViewTextAsync(fileName, text, item, line, openWithDifftool, checkGitAttributes: true)));
             }
         }
 

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -193,7 +193,7 @@ namespace GitUI.Editor
         {
             if (searchForwardOrOpenWithDifftool && OpenWithDifftool is not null && string.IsNullOrEmpty(_findAndReplaceForm.LookFor))
             {
-                OpenWithDifftool.Invoke();
+                OpenWithDifftool();
                 return;
             }
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -525,6 +525,8 @@ namespace GitUI
 
             bool Action()
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 // Commit dialog can be opened on its own without the main form
                 // If it is opened by itself, we need to ensure plugins are loaded because some of them
                 // may have hooks into the commit flow
@@ -537,12 +539,8 @@ namespace GitUI
                     // if the dialog is loaded on its own, plugins need to be loaded before we load the form
                     if (!werePluginsRegistered)
                     {
-                        ThreadHelper.JoinableTaskFactory.Run(async () =>
-                        {
-                            PluginRegistry.Initialize();
-                            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                            PluginRegistry.Register(this);
-                        });
+                        PluginRegistry.Initialize();
+                        PluginRegistry.Register(this);
                     }
 
                     using FormCommit form = new(this, commitMessage: commitMessage);

--- a/GitUI/LeftPanel/RemoteBranchTree.cs
+++ b/GitUI/LeftPanel/RemoteBranchTree.cs
@@ -26,7 +26,7 @@ namespace GitUI.LeftPanel
             IDictionary<string, AheadBehindData>? aheadBehindData = _aheadBehindDataProvider?.GetData()?.DistinctBy(r => r.Value.RemoteRef).ToDictionary(r => r.Value.RemoteRef, r => r.Value);
 
             List<RemoteRepoNode> enabledRemoteRepoNodes = new();
-            Dictionary<string, Remote> remoteByName = ThreadHelper.JoinableTaskFactory.Run(async () => (await Module.GetRemotesAsync()).ToDictionary(r => r.Name));
+            Dictionary<string, Remote> remoteByName = ThreadHelper.JoinableTaskFactory.Run(Module.GetRemotesAsync).ToDictionary(r => r.Name);
 
             ConfigFileRemoteSettingsManager remotesManager = new(() => Module);
 

--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -342,7 +342,11 @@ namespace GitUI.NBugReports
             {
                 if (ownerForm is FormBrowse formBrowse)
                 {
-                    formBrowse.Invoke(() => formBrowse.SetWorkingDir(workingDir));
+                    ThreadHelper.JoinableTaskFactory.Run(async () =>
+                        {
+                            await formBrowse.SwitchToMainThreadAsync();
+                            formBrowse.SetWorkingDir(workingDir);
+                        });
                 }
             }
         }

--- a/GitUI/RepositoryHistoryUIService.cs
+++ b/GitUI/RepositoryHistoryUIService.cs
@@ -80,7 +80,7 @@ namespace GitUI
 
         public void PopulateFavouriteRepositoriesMenu(ToolStripDropDownItem container)
         {
-            var repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.LoadFavouriteHistoryAsync());
+            IList<Repository> repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadFavouriteHistoryAsync);
             if (repositoryHistory.Count < 1)
             {
                 return;
@@ -138,7 +138,7 @@ namespace GitUI
             List<RecentRepoInfo> pinnedRepos = new();
             List<RecentRepoInfo> allRecentRepos = new();
 
-            var repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.LoadRecentHistoryAsync());
+            IList<Repository> repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync);
             if (repositoryHistory.Count < 1)
             {
                 return;

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -388,9 +388,7 @@ namespace GitUI.Blame
                             }
                             else
                             {
-                                var avatar = ThreadHelper.JoinableTaskFactory.Run(() =>
-                                    AvatarService.DefaultProvider.GetAvatarAsync(authorEmail, line.Commit.Author,
-                                        avatarSize));
+                                Image avatar = ThreadHelper.JoinableTaskFactory.Run(() => AvatarService.DefaultProvider.GetAvatarAsync(authorEmail, line.Commit.Author, avatarSize));
                                 cacheAvatars.Add(authorEmail, avatar);
                                 gitBlameDisplays[index].Avatar = avatar;
                             }

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/AzureDevOpsAdapter.cs
@@ -242,7 +242,7 @@ Detail of the error:");
                     {
                         _projectOnErrorKey = null;
                         Validates.NotNull(_openSettings);
-                        _openSettings.Invoke();
+                        _openSettings();
                     }
                 }
             }

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -118,7 +118,7 @@ namespace CommonTestUtils
 
             public int WaitForExit()
             {
-                return ThreadHelper.JoinableTaskFactory.Run(() => WaitForExitAsync());
+                return ThreadHelper.JoinableTaskFactory.Run(WaitForExitAsync);
             }
 
             public Task<int> WaitForExitAsync()


### PR DESCRIPTION
## Proposed changes

- `FormClone`: Fixup usage of `JoinableTaskFactory.Run()`: add missing `await`
- Replace `GitUIExtensions.InvokeSync()` and `Control.Invoke()` with `JoinableTaskFactory.Run()` and `SwitchToMainThreadAsync()`
- Simplify use of `JoinableTaskFactory.Run()`: omit `async` or lambda at all if applicable
- Replace superfluous `.Invoke()` with direct call

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).