### PR TITLE
Debug duplicate graph segments occurring in RevisionGraphMultiThreadingTests.ShouldReorderInTopoOrder

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -14,6 +14,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
     public class RevisionGraph : IRevisionGraphRowProvider
     {
         internal const int MaxLanes = 40;
+        private const int _loadNodesLookAhead = 1500;
         private const int _straightenLanesLookAhead = 20;
 
         // Some unordered collections with raw data
@@ -61,7 +62,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             _loadingCompleted = true;
         }
 
-        public int Count => _nodes.Count;
+        public int Count => _loadingCompleted ? _nodes.Count : Math.Max(0, _nodes.Count - _loadNodesLookAhead);
 
         public bool OnlyFirstParent { get; set; }
         public ObjectId HeadId { get; set; }
@@ -695,7 +696,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                     _reorder = false;
 
                     // Use a local variable, because the cached list can be reset.
-                    localOrderedNodesCache = _nodes.ToArray();
+                    localOrderedNodesCache = _loadingCompleted ? _nodes.ToArray() : _nodes.Take(_nodes.Count - _loadNodesLookAhead).ToArray();
                     Array.Sort(localOrderedNodesCache, (x, y) => x.Score.CompareTo(y.Score));
                     _orderedNodesCache = localOrderedNodesCache;
                     if (localOrderedNodesCache.Length > 0)

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -77,7 +77,8 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                     return;
                 }
 
-                _segmentLanes = new(capacity: Segments.Count);
+                int count = Segments.Count;
+                _segmentLanes = new(capacity: count);
                 _laneCount = 0;
                 _revisionLane = -1;
                 bool hasStart = false;
@@ -85,7 +86,19 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
                 foreach (RevisionGraphSegment segment in Segments)
                 {
-                    _segmentLanes.Add(segment, CreateOrReuseLane(segment));
+                    try
+                    {
+                        _segmentLanes.Add(segment, CreateOrReuseLane(segment));
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine(ex);
+                        Console.WriteLine($"Revision: {Revision?.Objectid} {Revision?.GitRevision?.Subject} has {count} or {Segments.Count} segments");
+                        foreach (RevisionGraphSegment seg in Segments)
+                        {
+                            Console.WriteLine($"Child: {seg?.Child?.Objectid} - Parent: {seg?.Parent?.Objectid}");
+                        }
+                    }
                 }
 
                 if (_revisionLane < 0)

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphMultiThreadingTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphMultiThreadingTests.cs
@@ -14,11 +14,11 @@ namespace GitUITests.UserControls.RevisionGrid
         // It is useful to repeat the threads, because it will make sure all threads are started at the same time.
         // Otherwise, the revision loading is long finished and the rendering is still running
         // Advice: set this number to 50 for thread safety test
-        private const int _numberOfRepeats = 10;
+        private const int _numberOfRepeats = 50;
 
         // Increase this number to create a larger test set.
         // Advice: set this number to 1000 for thread safety test
-        private const int _numberOfRevisionsAddedPerRun = 500;
+        private const int _numberOfRevisionsAddedPerRun = 1000;
         private readonly Random _random = new();
 
         private RevisionGraph _revisionGraph;
@@ -35,7 +35,7 @@ namespace GitUITests.UserControls.RevisionGrid
             _revisionGraph.Add(revision);
         }
 
-        [Test, Timeout(10 /*min*/ * 60 /*s*/ * 1000 /*ms*/), Repeat(300)]
+        [Test, Timeout(45 /*min*/ * 60 /*s*/ * 1000 /*ms*/), Repeat(25)]
         public void ShouldReorderInTopoOrder()
         {
             for (int i = 0; i < _numberOfRepeats; i++)
@@ -57,7 +57,9 @@ namespace GitUITests.UserControls.RevisionGrid
                 Task.WaitAll(loadRevisionsTask, buildCacheTask, renderTask);
 #pragma warning restore VSTHRD002
 
-                // One last 'cache to', in case the loading of the revisions was finished after building the cache (unlikely)
+                _revisionGraph.LoadingCompleted();
+
+                // One last 'cache to', because the loading of the revisions was finished after building the cache
                 _revisionGraph.CacheTo(_revisionGraph.Count, _revisionGraph.Count);
 
                 // Validate topo order
@@ -93,7 +95,7 @@ namespace GitUITests.UserControls.RevisionGrid
             for (int i = 0; i < _numberOfRevisionsAddedPerRun; i++)
             {
                 // Cache in chunks
-                _revisionGraph.CacheTo(_revisionGraph.GetCachedCount() + 30, _revisionGraph.GetCachedCount() + 10);
+                _revisionGraph.CacheTo(_revisionGraph.GetCachedCount() + 30, _revisionGraph.GetCachedCount() + 100);
             }
         }
 

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphMultiThreadingTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphMultiThreadingTests.cs
@@ -35,7 +35,7 @@ namespace GitUITests.UserControls.RevisionGrid
             _revisionGraph.Add(revision);
         }
 
-        [Test, Timeout(10 /*min*/ * 60 /*s*/ * 1000 /*ms*/)]
+        [Test, Timeout(10 /*min*/ * 60 /*s*/ * 1000 /*ms*/), Repeat(300)]
         public void ShouldReorderInTopoOrder()
         {
             for (int i = 0; i < _numberOfRepeats; i++)


### PR DESCRIPTION
## Proposed changes

- just for debugging: Print graph info in case of duplicate graph segments occuring in RevisionGraphMultiThreadingTests.ShouldReorderInTopoOrder
  seen in https://ci.appveyor.com/project/gitextensions/gitextensions/builds/47766875/tests

## Do not merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).