### PR TITLE
Replace more LINQ First/Last with indexer

### DIFF
--- a/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -116,7 +116,7 @@ namespace GitUI.CommandsDialogs
             void SaveMultipleFiles(List<FileStatusItem> selectedFiles)
             {
                 // Derive the folder from the first selected file.
-                string firstItemFullName = _fullPathResolver.Resolve(selectedFiles.First().Item.Name);
+                string firstItemFullName = _fullPathResolver.Resolve(selectedFiles[0].Item.Name);
                 string baseSourceDirectory = Path.GetDirectoryName(firstItemFullName).EnsureTrailingPathSeparator();
 
                 string selectedPath = userSelection(baseSourceDirectory);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
@@ -123,7 +123,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 return null;
             }
 
-            var defaultProjectName = Module.WorkingDir.Split(Delimiters.PathSeparators, StringSplitOptions.RemoveEmptyEntries).Last();
+            var defaultProjectName = Module.WorkingDir.Split(Delimiters.PathSeparators, StringSplitOptions.RemoveEmptyEntries)[^1];
 
             var exports = ManagedExtensibility.GetExports<IBuildServerSettingsUserControl, IBuildServerTypeMetadata>();
             var selectedExport = exports.SingleOrDefault(export => export.Metadata.BuildServerType == GetSelectedBuildServerType());

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
@@ -175,7 +175,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             _externalLinksManager.AddRange(externalLinkDefinitions);
 
             ReloadCategories();
-            _NO_TRANSLATE_Categories.SelectedItem = externalLinkDefinitions.First();
+            _NO_TRANSLATE_Categories.SelectedItem = externalLinkDefinitions[0];
             CategoryChanged();
         }
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1336,7 +1336,7 @@ namespace GitUI
             }
             else if (relevantHosts.Count == 1)
             {
-                StartCreatePullRequest(owner, relevantHosts.First());
+                StartCreatePullRequest(owner, relevantHosts[0]);
             }
             else
             {

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -550,7 +550,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                     _orderedNodesCache = localOrderedNodesCache;
                     if (localOrderedNodesCache.Length > 0)
                     {
-                        _orderedUntilScore = localOrderedNodesCache.Last().Score;
+                        _orderedUntilScore = localOrderedNodesCache[^1].Score;
                     }
 
                     return localOrderedNodesCache;

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -363,7 +363,7 @@ namespace AppVeyorIntegration
             }
 
             var buildData = buildDetailsParsed["build"];
-            var buildDescription = buildData["jobs"].Last();
+            var buildDescription = buildData["jobs"][^1];
 
             var status = buildDescription["status"].ToObject<string>();
             buildDetails.Status = ParseBuildStatus(status);

--- a/Plugins/GitUIPluginInterfaces/Settings/ChoiceSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/ChoiceSetting.cs
@@ -15,7 +15,7 @@
             Values = values;
             if (DefaultValue is null && values.Any())
             {
-                DefaultValue = values.First();
+                DefaultValue = values[0];
             }
         }
 

--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -493,7 +493,7 @@ namespace GitExtensions.Plugins.GitImpact
 
             lock (_dataLock)
             {
-                return _authorStack.Last();
+                return _authorStack[^1];
             }
         }
 

--- a/UnitTests/GitUI.Tests/Editor/Diff/LinePrefixHelperFixture.cs
+++ b/UnitTests/GitUI.Tests/Editor/Diff/LinePrefixHelperFixture.cs
@@ -117,8 +117,8 @@ namespace GitUITests.Editor.Diff
                 }
                 else
                 {
-                    var lastSeg = lineSegments.Last();
-                    seg.Offset = lastSeg.Offset + lastSeg.Length + 1;
+                    ISegment lastSegment = lineSegments[^1];
+                    seg.Offset = lastSegment.Offset + lastSegment.Length + 1;
                 }
 
                 lineSegments.Add(seg);

--- a/UnitTests/GitUI.Tests/Editor/FindAndReplaceFormTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/FindAndReplaceFormTests.cs
@@ -193,7 +193,7 @@ namespace GitUITests.Editor
                 return true;
             }
 
-            Arrange(texts.First(), searchPhrase, scanRegion: scanRegion, fileLoader: FileLoader);
+            Arrange(texts[0], searchPhrase, scanRegion: scanRegion, fileLoader: FileLoader);
 
             foreach (TextRange expectedRange in expectedRanges)
             {


### PR DESCRIPTION
addendum to #11131

## Proposed changes

- Replace more LINQ `First()` / `Last()` with indexer

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).