### PR TITLE
Update GetEffectiveGitSetting to provide status and value

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2488,30 +2488,15 @@ namespace GitCommands
                 throw new ExternalOperationException("git config", args.ToString(), WorkingDir, result.ExitCode, new InvalidOperationException("Exit code had no value"));
             }
 
-            string standard = result.StandardOutput?.Trim();
-            string value = string.IsNullOrEmpty(standard) ? "\0\0" : standard; // Replace with nulls to still be able to split 3 empty fields.
-
-            // Scope, file, value split by null.
-
-            ReadOnlySpan<char> settingValueSpan = value.AsSpan();
-            ReadOnlySpan<char> delimiter = Delimiters.Null.AsSpan();
-
-            int nullIndex = settingValueSpan.IndexOf(delimiter);
-            ReadOnlySpan<char> scope = settingValueSpan.Slice(0, nullIndex);
-            settingValueSpan = settingValueSpan.Slice(nullIndex + 1);
-
-            nullIndex = settingValueSpan.IndexOf(delimiter);
-            ReadOnlySpan<char> filename = settingValueSpan.Slice(0, nullIndex);
-            settingValueSpan = settingValueSpan.Slice(nullIndex + 1);
-
-            ReadOnlySpan<char> actualValue = settingValueSpan;
+            ReadOnlySpan<char> scope, filename, actualValue;
+            GetConfigResult(result, out scope, out filename, out actualValue);
 
             int resultCode = result.ExitCode.Value;
 
             GitConfigGetResult output = (
                 Enum.IsDefined(typeof(GitConfigStatus), resultCode) ? (GitConfigStatus)resultCode : (GitConfigStatus?)null,
                 setting,
-                settingValueSpan.ToString(),
+                actualValue.ToString(),
                 DateTimeOffset.Now,
                 scope.ToString(),
                 filename.ToString()?.Replace("file:", "").ToNativePath(),
@@ -2525,6 +2510,27 @@ namespace GitCommands
                 default:
                     throw new ExternalOperationException("git config", args.ToString(), WorkingDir, result.ExitCode, new InvalidOperationException(output.ErrorMessage));
             }
+        }
+
+        private static void GetConfigResult(ExecutionResult result, out ReadOnlySpan<char> scope, out ReadOnlySpan<char> filename, out ReadOnlySpan<char> actualValue)
+        {
+            string standard = result.StandardOutput?.Trim();
+            string value = string.IsNullOrEmpty(standard) ? "\0\0" : standard; // Replace with nulls to still be able to split 3 empty fields.
+
+            // Scope, file, value split by null.
+
+            ReadOnlySpan<char> settingValueSpan = value.AsSpan();
+            ReadOnlySpan<char> delimiter = Delimiters.Null.AsSpan();
+
+            int nullIndex = settingValueSpan.IndexOf(delimiter);
+            scope = settingValueSpan.Slice(0, nullIndex);
+            settingValueSpan = settingValueSpan.Slice(nullIndex + 1);
+
+            nullIndex = settingValueSpan.IndexOf(delimiter);
+            filename = settingValueSpan.Slice(0, nullIndex);
+            settingValueSpan = settingValueSpan.Slice(nullIndex + 1);
+
+            actualValue = settingValueSpan;
         }
 
         public void UnsetSetting(string setting)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2744,8 +2744,8 @@ namespace GitUI.CommandsDialogs
                     await TaskScheduler.Default;
 
                     // Do not cache results in order to update the info on FormActivate
-                    string userName = Module.GetEffectiveGitSetting(SettingKeyString.UserName, cache: false);
-                    string userEmail = Module.GetEffectiveGitSetting(SettingKeyString.UserEmail, cache: false);
+                    string userName = Module.GetEffectiveGitSetting(SettingKeyString.UserName, cache: false).Value;
+                    string userEmail = Module.GetEffectiveGitSetting(SettingKeyString.UserEmail, cache: false).Value;
                     string committer = $"{_commitCommitterInfo.Text} {userName} <{userEmail}>";
 
                     await this.SwitchToMainThreadAsync();

--- a/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
@@ -376,7 +376,7 @@ namespace GitUITests.GitUICommandsTests
                 .OrderBy(s => s.Name)
                 .ToArray();
             settings.Should().NotContainNulls();
-
+#if DEBUG
             foreach (var g in settings.GroupBy(s => s.Status))
             {
                 Console.WriteLine(g.Key?.ToString() ?? "NULL");
@@ -385,6 +385,7 @@ namespace GitUITests.GitUICommandsTests
                     Console.WriteLine($"\t{s}");
                 }
             }
+#endif
         }
 
         private static void ClickButton(Form form, string buttonName)

--- a/Plugins/GitUIPluginInterfaces/GitConfigResult.cs
+++ b/Plugins/GitUIPluginInterfaces/GitConfigResult.cs
@@ -1,0 +1,11 @@
+namespace GitUIPluginInterfaces
+{
+    public readonly record struct GitConfigGetResult(GitConfigStatus? Status, string Name, string Value, DateTimeOffset Retrieved, string Scope, string File, string ErrorMessage)
+    {
+        public static implicit operator (GitConfigStatus? status, string name, string value, DateTimeOffset retrieved, string scope, string file, string errorMessage)(GitConfigGetResult value) =>
+            (value.Status, value.Name, value.Value, value.Retrieved, value.Scope, value.File, value.ErrorMessage);
+
+        public static implicit operator GitConfigGetResult((GitConfigStatus? status, string name, string value, DateTimeOffset retrieved, string scope, string file, string error) value) =>
+            new(value.status, value.name, value.value, value.retrieved, value.scope, value.file, value.error);
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/GitConfigStatus.cs
+++ b/Plugins/GitUIPluginInterfaces/GitConfigStatus.cs
@@ -4,21 +4,28 @@ namespace GitUIPluginInterfaces
     ///  Status of running git config https://git-scm.com/docs/git-config#_description.
     ///  This command will fail with non-zero status upon error.Some exit codes are:
     ///  <code>
-    ///   The section or key is invalid (ret= 1) this is returned when the key is not set also.
-    ///   No section or name was provided (ret= 2).
-    ///   The config file is invalid (ret=3).
-    ///   The config file cannot be written (ret=4).
-    ///   You try to unset an option which does not exist or you try to unset/set an option for which multiple lines match (ret = 5).
-    ///   You try to use an invalid regexp (ret = 6).
-    ///   On success, the command returns the exit code 0.
+    ///   return code 0: success, the command returns the exit code 0.
+    ///   return code 1: The section or key is invalid; this is returned when the key is not set also.
+    ///   return code 2: No section or name was provided.
+    ///   return code 3: The config file is invalid.
+    ///   return code 4: The config file cannot be written.
+    ///   return code 5: You try to unset an option which does not exist or you try to unset/set an option for which multiple lines match.
+    ///   return code 6: You try to use an invalid regexp.
     ///  </code>
     /// </summary>
     /// <remarks>
-    /// See https://github.com/git/git/blob/fac96dfbb1c24369ba7d37a5affd8adfe6c650fd/config.h#L26C1-L36C1 and find latest version in master of those values.
-    /// See https://github.com/git/git/blob/fac96dfbb1c24369ba7d37a5affd8adfe6c650fd/builtin/config.c#L927 for the flow of getting a config value.
-    /// See https://github.com/git/git/blob/fac96dfbb1c24369ba7d37a5affd8adfe6c650fd/builtin/config.c#L893 for the flow of setting a config value.
-    /// Following those flows, 0,1, and 7 are returned from a get call.
-    /// 6 is only returned when doing --get-rexexp
+    ///  <para>
+    ///   See https://github.com/git/git/blob/fac96dfbb1c24369ba7d37a5affd8adfe6c650fd/config.h#L26C1-L36C1 and find latest version in master of those values.
+    ///  </para>
+    ///  <para>
+    ///   See https://github.com/git/git/blob/fac96dfbb1c24369ba7d37a5affd8adfe6c650fd/builtin/config.c#L927 for the flow of getting a config value.
+    ///  </para>
+    ///  <para>
+    ///   See https://github.com/git/git/blob/fac96dfbb1c24369ba7d37a5affd8adfe6c650fd/builtin/config.c#L893 for the flow of setting a config value.
+    ///  </para>
+    ///  <para>
+    ///   Following those flows, 0, 1, and 7 are returned from a get call. 6 is only returned when doing --get-rexexp
+    ///  </para>
     /// </remarks>
     public enum GitConfigStatus
     {

--- a/Plugins/GitUIPluginInterfaces/GitConfigStatus.cs
+++ b/Plugins/GitUIPluginInterfaces/GitConfigStatus.cs
@@ -1,0 +1,70 @@
+namespace GitUIPluginInterfaces
+{
+    /// <summary>
+    ///  Status of running git config https://git-scm.com/docs/git-config#_description.
+    ///  This command will fail with non-zero status upon error.Some exit codes are:
+    ///  <code>
+    ///   The section or key is invalid (ret= 1) this is returned when the key is not set also.
+    ///   No section or name was provided (ret= 2).
+    ///   The config file is invalid (ret=3).
+    ///   The config file cannot be written (ret=4).
+    ///   You try to unset an option which does not exist or you try to unset/set an option for which multiple lines match (ret = 5).
+    ///   You try to use an invalid regexp (ret = 6).
+    ///   On success, the command returns the exit code 0.
+    ///  </code>
+    /// </summary>
+    /// <remarks>
+    /// See https://github.com/git/git/blob/fac96dfbb1c24369ba7d37a5affd8adfe6c650fd/config.h#L26C1-L36C1 and find latest version in master of those values.
+    /// See https://github.com/git/git/blob/fac96dfbb1c24369ba7d37a5affd8adfe6c650fd/builtin/config.c#L927 for the flow of getting a config value.
+    /// See https://github.com/git/git/blob/fac96dfbb1c24369ba7d37a5affd8adfe6c650fd/builtin/config.c#L893 for the flow of setting a config value.
+    /// Following those flows, 0,1, and 7 are returned from a get call.
+    /// 6 is only returned when doing --get-rexexp
+    /// </remarks>
+    public enum GitConfigStatus
+    {
+        /// <summary>
+        /// Cannot lock config file for writing.
+        /// </summary>
+        CannotLockConfigFile = -1,
+
+        /// <summary>
+        /// Retrieved the value successfully. The setting was set.
+        /// </summary>
+        Success = 0,
+
+        /// <summary>
+        /// Retrieved a blank value. The config value is not set or config key is invalid.
+        /// </summary>
+        ConfigKeyInvalidOrNotSet = 1,
+
+        /// <summary>
+        /// git config was provided no config key.
+        /// </summary>
+        NoConfigKeyGiven = 2,
+
+        /// <summary>
+        /// Invalid config file. Failed to open file or config file is corrupted.
+        /// </summary>
+        InvalidConfigFile = 3,
+
+        /// <summary>
+        /// Cannot write to config file.  File is read-only or permmisions do not allow write or file is corrupted.
+        /// </summary>
+        CannotWriteToConfigFile = 4,
+
+        /// <summary>
+        /// Trying to unset a value that is not set or current config already has too many values set and cannot replace multi values with a single value.
+        /// </summary>
+        CannotUnsetOrSet = 5,
+
+        /// <summary>
+        /// The key used to filter config keys while using --get-rexexp is invalid.
+        /// </summary>
+        InvalidRegexp = 6,
+
+        /// <summary>
+        /// Unknown error. Git did not provide a specific error.
+        /// </summary>
+        GenericError = 7
+    }
+}

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -125,7 +125,7 @@ namespace GitUIPluginInterfaces
 
         string GetSetting(string setting);
         string GetEffectiveSetting(string setting);
-        string GetEffectiveGitSetting(string setting, bool cache = true);
+        GitConfigGetResult GetEffectiveGitSetting(string setting, bool cache = true);
 
         /// <summary>Gets the current branch; or "(no branch)" if HEAD is detached.</summary>
         string GetSelectedBranch();


### PR DESCRIPTION
Updates the method to return not only the value of the config but also the status based on the ExitCodes from git config documentation. This allows for deciding what to do if config key doesn't exist by the user of GetEffectiveGitSetting

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11145 

## Proposed changes

- Don't treat exit codes as failures when running git config command



## Test methodology <!-- How did you ensure quality? -->

- No exceptions in clean machine when I wrote code to retrieve gpg.program and commit.gpgSign and such settings

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
