### PR TITLE
IDE0057 simplify substring

### DIFF
--- a/BugReporter/GitHubUrlBuilder.cs
+++ b/BugReporter/GitHubUrlBuilder.cs
@@ -46,7 +46,7 @@ namespace BugReporter
             if (subject.Length > 69)
             {
                 // if the subject is longer than 70 characters, trim it
-                subject = subject.Substring(0, 66) + "...";
+                subject = subject[..66] + "...";
             }
 
             string urlEncodedError = _errorReportUrlBuilder.Build(exception, exceptionInfo, environmentInfo, additionalInfo);

--- a/Externals/NetSpell.SpellChecker/Dictionary/Affix/AffixUtility.cs
+++ b/Externals/NetSpell.SpellChecker/Dictionary/Affix/AffixUtility.cs
@@ -44,7 +44,7 @@ namespace NetSpell.SpellChecker.Dictionary.Affix
 
                     if (passCount == entry.ConditionCount)
                     {
-                        string tempWord = word.Substring(entry.StripCharacters.Length);
+                        string tempWord = word[entry.StripCharacters.Length..];
                         tempWord = entry.AddCharacters + tempWord;
                         return tempWord;
                     }
@@ -94,7 +94,7 @@ namespace NetSpell.SpellChecker.Dictionary.Affix
                     if (passCount == entry.ConditionCount)
                     {
                         int tempLen = word.Length - entry.StripCharacters.Length;
-                        string tempWord = word.Substring(0, tempLen);
+                        string tempWord = word[..tempLen];
                         tempWord += entry.AddCharacters;
                         return tempWord;
                     }
@@ -253,7 +253,7 @@ namespace NetSpell.SpellChecker.Dictionary.Affix
                 && word.StartsWith(entry.AddCharacters))
             {
                 // word with out affix
-                string tempWord = word.Substring(entry.AddCharacters.Length);
+                string tempWord = word[entry.AddCharacters.Length..];
 
                 // add back strip chars
                 tempWord = entry.StripCharacters + tempWord;
@@ -305,7 +305,7 @@ namespace NetSpell.SpellChecker.Dictionary.Affix
                 && word.EndsWith(entry.AddCharacters))
             {
                 // word with out affix
-                string tempWord = word.Substring(0, tempLength);
+                string tempWord = word[..tempLength];
 
                 // add back strip chars
                 tempWord += entry.StripCharacters;

--- a/Externals/NetSpell.SpellChecker/Dictionary/WordDictionary.cs
+++ b/Externals/NetSpell.SpellChecker/Dictionary/WordDictionary.cs
@@ -582,7 +582,7 @@ namespace NetSpell.SpellChecker.Dictionary
                         {
                             if (rule.ReplaceMode)
                             {
-                                tempWord = rule.ReplaceString + tempWord.Substring(rule.ConditionCount - rule.ConsumeCount);
+                                tempWord = rule.ReplaceString + tempWord[(rule.ConditionCount - rule.ConsumeCount)..];
                             }
                             else
                             {
@@ -591,7 +591,7 @@ namespace NetSpell.SpellChecker.Dictionary
                                     code.Append(rule.ReplaceString);
                                 }
 
-                                tempWord = tempWord.Substring(rule.ConditionCount - rule.ConsumeCount);
+                                tempWord = tempWord[(rule.ConditionCount - rule.ConsumeCount)..];
                             }
 
                             break;
@@ -602,7 +602,7 @@ namespace NetSpell.SpellChecker.Dictionary
                 // if no match consume one char
                 if (prevWord.Length == tempWord.Length)
                 {
-                    tempWord = tempWord.Substring(1);
+                    tempWord = tempWord[1..];
                 }
             }
 

--- a/Externals/NetSpell.SpellChecker/Spelling.cs
+++ b/Externals/NetSpell.SpellChecker/Spelling.cs
@@ -293,9 +293,7 @@ namespace NetSpell.SpellChecker
                 int pos = CurrentWord.IndexOf(key, StringComparison.InvariantCulture);
                 while (pos > -1)
                 {
-                    string tempWord = CurrentWord[..pos];
-                    tempWord += replacement;
-                    tempWord += CurrentWord[(pos + key.Length)..];
+                    string tempWord = $"{CurrentWord[..pos]}{replacement}{CurrentWord[(pos + key.Length)..]}";
 
                     if (FindWord(ref tempWord))
                     {
@@ -747,8 +745,7 @@ namespace NetSpell.SpellChecker
             // if first letter upper case, match case for replacement word
             if (char.IsUpper(_words[replacedIndex].ToString(), 0))
             {
-                _replacementWord = _replacementWord[..1].ToUpper(CultureInfo.CurrentUICulture)
-                    + _replacementWord[1..];
+                _replacementWord = $"{char.ToUpper(_replacementWord[0], CultureInfo.CurrentUICulture)}{_replacementWord[1..]}";
             }
 
             _text.Insert(index, _replacementWord);

--- a/Externals/NetSpell.SpellChecker/Spelling.cs
+++ b/Externals/NetSpell.SpellChecker/Spelling.cs
@@ -287,15 +287,15 @@ namespace NetSpell.SpellChecker
             for (int i = 0; i < replacementChars.Count; i++)
             {
                 int split = replacementChars[i].IndexOf(' ');
-                string key = replacementChars[i].Substring(0, split);
-                string replacement = replacementChars[i].Substring(split + 1);
+                string key = replacementChars[i][..split];
+                string replacement = replacementChars[i][(split + 1)..];
 
                 int pos = CurrentWord.IndexOf(key, StringComparison.InvariantCulture);
                 while (pos > -1)
                 {
-                    string tempWord = CurrentWord.Substring(0, pos);
+                    string tempWord = CurrentWord[..pos];
                     tempWord += replacement;
-                    tempWord += CurrentWord.Substring(pos + key.Length);
+                    tempWord += CurrentWord[(pos + key.Length)..];
 
                     if (FindWord(ref tempWord))
                     {
@@ -403,8 +403,8 @@ namespace NetSpell.SpellChecker
         {
             for (int i = 1; i < CurrentWord.Length - 1; i++)
             {
-                string firstWord = CurrentWord.Substring(0, i);
-                string secondWord = CurrentWord.Substring(i);
+                string firstWord = CurrentWord[..i];
+                string secondWord = CurrentWord[i..];
 
                 if (FindWord(ref firstWord) && FindWord(ref secondWord))
                 {
@@ -747,8 +747,8 @@ namespace NetSpell.SpellChecker
             // if first letter upper case, match case for replacement word
             if (char.IsUpper(_words[replacedIndex].ToString(), 0))
             {
-                _replacementWord = _replacementWord.Substring(0, 1).ToUpper(CultureInfo.CurrentUICulture)
-                    + _replacementWord.Substring(1);
+                _replacementWord = _replacementWord[..1].ToUpper(CultureInfo.CurrentUICulture)
+                    + _replacementWord[1..];
             }
 
             _text.Insert(index, _replacementWord);

--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -107,8 +107,8 @@ namespace GitCommands.Config
         {
             var keyIndex = FindAndCheckKeyIndex(setting);
 
-            var configSectionName = setting.Substring(0, keyIndex);
-            var keyName = setting.Substring(keyIndex + 1);
+            var configSectionName = setting[..keyIndex];
+            var keyName = setting[(keyIndex + 1)..];
 
             FindOrCreateConfigSection(configSectionName).SetValue(keyName, value);
         }
@@ -149,8 +149,8 @@ namespace GitCommands.Config
 
             var keyIndex = FindAndCheckKeyIndex(setting);
 
-            var configSectionName = setting.Substring(0, keyIndex);
-            var keyName = setting.Substring(keyIndex + 1);
+            var configSectionName = setting[..keyIndex];
+            var keyName = setting[(keyIndex + 1)..];
 
             var configSection = FindConfigSection(configSectionName);
 
@@ -171,8 +171,8 @@ namespace GitCommands.Config
         {
             var keyIndex = FindAndCheckKeyIndex(setting);
 
-            var configSectionName = setting.Substring(0, keyIndex);
-            var keyName = setting.Substring(keyIndex + 1);
+            var configSectionName = setting[..keyIndex];
+            var keyName = setting[(keyIndex + 1)..];
 
             var configSection = FindConfigSection(configSectionName);
 

--- a/GitCommands/Config/ConfigSection.cs
+++ b/GitCommands/Config/ConfigSection.cs
@@ -26,7 +26,7 @@ namespace GitCommands.Config
             if (slashIndex != -1)
             {
                 // [section "subsection"] case sensitive
-                SectionName = name.Substring(0, slashIndex).Trim();
+                SectionName = name[..slashIndex].Trim();
                 SubSection = name.Substring(slashIndex + 1, name.LastIndexOf('\"') - slashIndex - 1);
                 SubSectionCaseSensitive = true;
             }
@@ -46,8 +46,8 @@ namespace GitCommands.Config
                     throw new Exception("Invalid section name: " + name);
                 }
 
-                SectionName = name.Substring(0, subSectionIndex).Trim();
-                SubSection = name.Substring(subSectionIndex + 1).Trim();
+                SectionName = name[..subSectionIndex].Trim();
+                SubSection = name[(subSectionIndex + 1)..].Trim();
                 SubSectionCaseSensitive = false;
             }
 

--- a/GitCommands/CustomDiffMergeToolCache.cs
+++ b/GitCommands/CustomDiffMergeToolCache.cs
@@ -116,7 +116,7 @@ namespace GitCommands
                 // two tabs, then tool name, cmd (if split in 3) in second
                 // cmd is unreliable for diff and not needed but could be used for mergetool special handling
                 string[] delimit = { " ", ".cmd" };
-                var tool = l.Substring(2).Split(delimit, 2, StringSplitOptions.None);
+                var tool = l[2..].Split(delimit, 2, StringSplitOptions.None);
                 if (tool.Length == 0)
                 {
                     continue;

--- a/GitCommands/Git/GitBranchNameNormaliser.cs
+++ b/GitCommands/Git/GitBranchNameNormaliser.cs
@@ -193,12 +193,12 @@ namespace GitCommands.Git
             branchName = Regex.Replace(branchName, @"(\/{2,})", "/");
             if (branchName.StartsWith("/"))
             {
-                branchName = branchName.Substring(1);
+                branchName = branchName[1..];
             }
 
             if (branchName.EndsWith("/"))
             {
-                branchName = branchName.Substring(0, branchName.Length - 1);
+                branchName = branchName[..^1];
             }
 
             return branchName;

--- a/GitCommands/Git/GitDescribeProvider.cs
+++ b/GitCommands/Git/GitDescribeProvider.cs
@@ -38,21 +38,21 @@ namespace GitCommands.Git
                 return (description, string.Empty);
             }
 
-            string commitHash = description.Substring(commitHashPos + 2);
+            string commitHash = description[(commitHashPos + 2)..];
             if (commitHash.Length == 0 || !revision.Equals(commitHash))
             {
                 return (description, string.Empty);
             }
 
-            description = description.Substring(0, commitHashPos);
+            description = description[..commitHashPos];
             int commitCountPos = description.LastIndexOf("-", StringComparison.Ordinal);
             if (commitCountPos == -1)
             {
                 return (description, string.Empty);
             }
 
-            string commitCount = description.Substring(commitCountPos + 1);
-            description = description.Substring(0, commitCountPos);
+            string commitCount = description[(commitCountPos + 1)..];
+            description = description[..commitCountPos];
             return (description, commitCount);
 
             IGitModule GetModule()

--- a/GitCommands/Git/GitDirectoryResolver.cs
+++ b/GitCommands/Git/GitDirectoryResolver.cs
@@ -79,7 +79,7 @@ namespace GitCommands.Git
                 var line = _fileSystem.File.ReadLines(gitPath).FirstOrDefault(l => l.StartsWith(gitdir));
                 if (line is not null)
                 {
-                    string path = line.Substring(gitdir.Length).Trim().ToNativePath();
+                    string path = line[gitdir.Length..].Trim().ToNativePath();
                     if (Path.IsPathRooted(path))
                     {
                         return path.EnsureTrailingPathSeparator();

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -117,11 +117,11 @@ namespace GitCommands
 
                         if (line.StartsWith(gitdir))
                         {
-                            string gitPath = line.Substring(gitdir.Length).Trim();
+                            string gitPath = line[gitdir.Length..].Trim();
                             int pos = gitPath.IndexOf("/.git/modules/", StringComparison.Ordinal);
                             if (pos != -1)
                             {
-                                gitPath = gitPath.Substring(0, pos + 1).Replace('/', '\\');
+                                gitPath = gitPath[..(pos + 1)].Replace('/', '\\');
                                 gitPath = Path.GetFullPath(Path.Combine(WorkingDir, gitPath));
                                 if (HasGitModulesFile(gitPath))
                                 {
@@ -134,7 +134,7 @@ namespace GitCommands
 
                 if (!string.IsNullOrEmpty(superprojectPath) && currentPath.ToPosixPath().StartsWith(superprojectPath.ToPosixPath()))
                 {
-                    var submodulePath = currentPath.Substring(superprojectPath.Length).ToPosixPath();
+                    var submodulePath = currentPath[superprojectPath.Length..].ToPosixPath();
                     ConfigFile configFile = new(Path.Combine(superprojectPath, ".gitmodules"));
 
                     foreach (var configSection in configFile.ConfigSections)
@@ -750,16 +750,16 @@ namespace GitCommands
             foreach (var line in unmerged)
             {
                 int findSecondWhitespace = line.IndexOfAny(new[] { ' ', '\t' });
-                string fileStage = findSecondWhitespace >= 0 ? line.Substring(findSecondWhitespace).Trim() : "";
+                string fileStage = findSecondWhitespace >= 0 ? line[findSecondWhitespace..].Trim() : "";
 
                 findSecondWhitespace = fileStage.IndexOfAny(new[] { ' ', '\t' });
 
-                string hash = findSecondWhitespace >= 0 ? fileStage.Substring(0, findSecondWhitespace).Trim() : "";
-                fileStage = findSecondWhitespace >= 0 ? fileStage.Substring(findSecondWhitespace).Trim() : "";
+                string hash = findSecondWhitespace >= 0 ? fileStage[..findSecondWhitespace].Trim() : "";
+                fileStage = findSecondWhitespace >= 0 ? fileStage[findSecondWhitespace..].Trim() : "";
 
                 if (fileStage.Length > 2 && int.TryParse(fileStage[0].ToString(), out var stage) && stage is (>= 1 and <= 3))
                 {
-                    var itemName = fileStage.Substring(2);
+                    var itemName = fileStage[2..];
                     if (prevItemName != itemName && prevItemName is not null)
                     {
                         list.Add(new ConflictData(item[0], item[1], item[2]));
@@ -1013,7 +1013,7 @@ namespace GitCommands
                 ReadOnlySpan<char> span = (body ?? "").AsSpan();
                 int endSubjectIndex = span.IndexOf('\n');
                 revision.Subject = endSubjectIndex >= 0
-                    ? span.Slice(0, endSubjectIndex).TrimEnd().ToString()
+                    ? span[..endSubjectIndex].TrimEnd().ToString()
                     : body ?? "";
             }
 
@@ -1203,7 +1203,7 @@ namespace GitCommands
             Debug.Assert(WorkingDir.StartsWith(SuperprojectModule.WorkingDir), "Submodule working dir should start with super-project's working dir");
 
             return Path.GetDirectoryName(
-                WorkingDir.Substring(SuperprojectModule.WorkingDir.Length)).ToPosixPath();
+                WorkingDir[SuperprojectModule.WorkingDir.Length..]).ToPosixPath();
         }
 
         public string GetSubmoduleFullPath(string? localPath)
@@ -2239,7 +2239,7 @@ namespace GitCommands
                                     if (value.IndexOf('<') > 0 && value.IndexOf('<') < value.Length)
                                     {
                                         var author = RFC2047Decoder.Parse(value);
-                                        patchFile.Author = author.Substring(0, author.IndexOf('<')).Trim();
+                                        patchFile.Author = author[..author.IndexOf('<')].Trim();
                                     }
                                     else
                                     {
@@ -2250,7 +2250,7 @@ namespace GitCommands
                                 case "Date":
                                     if (value.IndexOf('+') > 0 && value.IndexOf('<') < value.Length)
                                     {
-                                        patchFile.Date = value.Substring(0, value.IndexOf('+')).Trim();
+                                        patchFile.Date = value[..value.IndexOf('+')].Trim();
                                     }
                                     else
                                     {
@@ -2299,7 +2299,7 @@ namespace GitCommands
                 }
 
                 Debug.Assert(m1.Groups[1].Value == m2.Groups[1].Value, "m1.Groups[1].Value == m2.Groups[1].Value");
-                return str1.Substring(0, str1.Length - 2) + m2.Groups[2].Value + "?=";
+                return str1[..^2] + m2.Groups[2].Value + "?=";
             }
         }
 
@@ -3081,7 +3081,7 @@ namespace GitCommands
                 return string.Empty;
             }
 
-            return headFileContents.Substring(prefix.Length).TrimEnd();
+            return headFileContents[prefix.Length..].TrimEnd();
         }
 
         /// <summary>
@@ -3324,7 +3324,7 @@ namespace GitCommands
                     int idx = item.IndexOf(" ->", StringComparison.Ordinal);
                     if (idx >= 0)
                     {
-                        item = item.Substring(0, idx);
+                        item = item[..idx];
                     }
                 }
 
@@ -3578,7 +3578,7 @@ namespace GitCommands
                 else if (line.StartsWith("\t"))
                 {
                     // The contents of the actual line is output after the above header, prefixed by a TAB. This is to allow adding more header elements later.
-                    var text = ReEncodeStringFromLossless(line.Substring(1), encoding);
+                    var text = ReEncodeStringFromLossless(line[1..], encoding);
 
                     GitBlameCommit commit;
                     if (hasCommitHeader)
@@ -3636,52 +3636,52 @@ namespace GitCommands
                 }
                 else if (line.StartsWith("author "))
                 {
-                    author = ReEncodeStringFromLossless(line.Substring("author ".Length));
+                    author = ReEncodeStringFromLossless(line["author ".Length..]);
                     hasCommitHeader = true;
                 }
                 else if (line.StartsWith("author-mail "))
                 {
-                    authorMail = ReEncodeStringFromLossless(line.Substring("author-mail ".Length));
+                    authorMail = ReEncodeStringFromLossless(line["author-mail ".Length..]);
                     hasCommitHeader = true;
                 }
                 else if (line.StartsWith("author-time "))
                 {
-                    authorTime = DateTimeUtils.ParseUnixTime(line.Substring("author-time ".Length));
+                    authorTime = DateTimeUtils.ParseUnixTime(line["author-time ".Length..]);
                     hasCommitHeader = true;
                 }
                 else if (line.StartsWith("author-tz "))
                 {
-                    authorTimeZone = line.Substring("author-tz ".Length);
+                    authorTimeZone = line["author-tz ".Length..];
                     hasCommitHeader = true;
                 }
                 else if (line.StartsWith("committer "))
                 {
-                    committer = ReEncodeStringFromLossless(line.Substring("committer ".Length));
+                    committer = ReEncodeStringFromLossless(line["committer ".Length..]);
                     hasCommitHeader = true;
                 }
                 else if (line.StartsWith("committer-mail "))
                 {
-                    committerMail = line.Substring("committer-mail ".Length);
+                    committerMail = line["committer-mail ".Length..];
                     hasCommitHeader = true;
                 }
                 else if (line.StartsWith("committer-time "))
                 {
-                    committerTime = DateTimeUtils.ParseUnixTime(line.Substring("committer-time ".Length));
+                    committerTime = DateTimeUtils.ParseUnixTime(line["committer-time ".Length..]);
                     hasCommitHeader = true;
                 }
                 else if (line.StartsWith("committer-tz "))
                 {
-                    committerTimeZone = line.Substring("committer-tz ".Length);
+                    committerTimeZone = line["committer-tz ".Length..];
                     hasCommitHeader = true;
                 }
                 else if (line.StartsWith("summary "))
                 {
-                    summary = ReEncodeStringFromLossless(line.Substring("summary ".Length));
+                    summary = ReEncodeStringFromLossless(line["summary ".Length..]);
                     hasCommitHeader = true;
                 }
                 else if (line.StartsWith("filename "))
                 {
-                    filename = ReEncodeFileNameFromLossless(line.Substring("filename ".Length));
+                    filename = ReEncodeFileNameFromLossless(line["filename ".Length..]);
                     hasCommitHeader = true;
                 }
             }
@@ -4195,8 +4195,8 @@ namespace GitCommands
             string diff;
             if (p > 0)
             {
-                header = s.Substring(0, p);
-                diff = s.Substring(p);
+                header = s[..p];
+                diff = s[p..];
             }
             else
             {
@@ -4207,8 +4207,8 @@ namespace GitCommands
             p = diff.IndexOf("@@");
             if (p > 0)
             {
-                diffHeader = diff.Substring(0, p);
-                diffContent = diff.Substring(p);
+                diffHeader = diff[..p];
+                diffContent = diff[p..];
             }
             else
             {
@@ -4229,7 +4229,7 @@ namespace GitCommands
 
         public string? GetLocalTrackingBranchName(string remoteName, string branch)
         {
-            var branchName = remoteName.Length > 0 ? branch.Substring(remoteName.Length + 1) : branch;
+            var branchName = remoteName.Length > 0 ? branch[(remoteName.Length + 1)..] : branch;
             foreach (var section in LocalConfigFile.GetConfigSections())
             {
                 if (section.SectionName == "branch" && section.GetValue("remote") == remoteName)

--- a/GitCommands/Git/GitRef.cs
+++ b/GitCommands/Git/GitRef.cs
@@ -123,7 +123,7 @@ namespace GitCommands
 
         public bool IsOther => !IsHead && !IsRemote && !IsTag;
 
-        public string LocalName => IsRemote && Name.StartsWith($"{Remote}/") ? Name.Substring(Remote.Length + 1) : Name;
+        public string LocalName => IsRemote && Name.StartsWith($"{Remote}/") ? Name[(Remote.Length + 1)..] : Name;
 
         public string Remote { get; }
 

--- a/GitCommands/Git/GitRefName.cs
+++ b/GitCommands/Git/GitRefName.cs
@@ -89,7 +89,7 @@ namespace GitCommands
                 return string.Empty;
             }
 
-            return refName.Substring(1 + startBranch);
+            return refName[(1 + startBranch)..];
         }
 
         [Pure]

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -89,7 +89,7 @@ namespace GitCommands
 
                 if (version.StartsWith(Prefix))
                 {
-                    return version.Substring(Prefix.Length).Trim();
+                    return version[Prefix.Length..].Trim();
                 }
 
                 return version.Trim();

--- a/GitCommands/Git/SubmoduleHelpers.cs
+++ b/GitCommands/Git/SubmoduleHelpers.cs
@@ -94,7 +94,7 @@ namespace GitCommands.Git
                     int pos = line.IndexOf(commitStr);
                     if (pos >= 0)
                     {
-                        hash = line.Substring(pos + commitStr.Length);
+                        hash = line[(pos + commitStr.Length)..];
                     }
 
                     bool endsWithDirty = hash.EndsWith("-dirty");

--- a/GitCommands/Patches/PatchManager.cs
+++ b/GitCommands/Patches/PatchManager.cs
@@ -67,7 +67,7 @@ namespace GitCommands.Patches
             {
                 if (line.StartsWith("+++"))
                 {
-                    pppLine = "---" + line.Substring(3);
+                    pppLine = "---" + line[3..];
                 }
             }
 
@@ -219,8 +219,8 @@ namespace GitCommands.Patches
                 return null;
             }
 
-            header = text.Substring(0, patchPos);
-            string diff = text.Substring(patchPos - 1);
+            header = text[..patchPos];
+            string diff = text[(patchPos - 1)..];
 
             string[] chunks = diff.Split(new[] { "\n@@" }, StringSplitOptions.RemoveEmptyEntries);
             List<Chunk> selectedChunks = new();
@@ -318,7 +318,7 @@ namespace GitCommands.Patches
 
         public void SetOperation(string operationMark)
         {
-            Text = operationMark + Text.Substring(1);
+            Text = operationMark + Text[1..];
         }
     }
 
@@ -363,11 +363,11 @@ namespace GitCommands.Patches
                 {
                     if (inPostPart)
                     {
-                        removePart = removePart.Combine("\n", " " + removedLine.Text.Substring(1));
+                        removePart = removePart.Combine("\n", " " + removedLine.Text[1..]);
                     }
                     else
                     {
-                        prePart = prePart.Combine("\n", " " + removedLine.Text.Substring(1));
+                        prePart = prePart.Combine("\n", " " + removedLine.Text[1..]);
                     }
 
                     addedCount++;
@@ -389,11 +389,11 @@ namespace GitCommands.Patches
                 {
                     if (inPostPart)
                     {
-                        postPart = postPart.Combine("\n", " " + addedLine.Text.Substring(1));
+                        postPart = postPart.Combine("\n", " " + addedLine.Text[1..]);
                     }
                     else
                     {
-                        prePart = prePart.Combine("\n", " " + addedLine.Text.Substring(1));
+                        prePart = prePart.Combine("\n", " " + addedLine.Text[1..]);
                     }
 
                     addedCount++;
@@ -449,7 +449,7 @@ namespace GitCommands.Patches
                 {
                     wereSelectedLines = true;
                     inPostPart = true;
-                    addPart = addPart.Combine("\n", "+" + removedLine.Text.Substring(1));
+                    addPart = addPart.Combine("\n", "+" + removedLine.Text[1..]);
                     addedCount++;
                 }
             }
@@ -460,18 +460,18 @@ namespace GitCommands.Patches
                 {
                     wereSelectedLines = true;
                     inPostPart = true;
-                    removePart = removePart.Combine("\n", "-" + addedLine.Text.Substring(1));
+                    removePart = removePart.Combine("\n", "-" + addedLine.Text[1..]);
                     removedCount++;
                 }
                 else
                 {
                     if (inPostPart)
                     {
-                        postPart = postPart.Combine("\n", " " + addedLine.Text.Substring(1));
+                        postPart = postPart.Combine("\n", " " + addedLine.Text[1..]);
                     }
                     else
                     {
-                        prePart = prePart.Combine("\n", " " + addedLine.Text.Substring(1));
+                        prePart = prePart.Combine("\n", " " + addedLine.Text[1..]);
                     }
 
                     addedCount++;

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -76,7 +76,7 @@ namespace GitCommands
                 (dirPath[^1] == NativeDirectorySeparatorChar ||
                  dirPath[^1] == PosixDirectorySeparatorChar))
             {
-                return dirPath.Substring(0, dirPath.Length - 1);
+                return dirPath[..^1];
             }
 
             return dirPath;
@@ -124,7 +124,7 @@ namespace GitCommands
             var pos = fileName.LastIndexOfAny(pathSeparators);
             if (pos != -1)
             {
-                fileName = fileName.Substring(pos + 1);
+                fileName = fileName[(pos + 1)..];
             }
 
             return fileName;
@@ -338,12 +338,12 @@ namespace GitCommands
 
                 if (path.EndsWith(standardRepositorySuffix))
                 {
-                    path = path.Substring(0, path.Length - standardRepositorySuffix.Length);
+                    path = path[..^standardRepositorySuffix.Length];
                 }
 
                 if (path.Contains("\\") || path.Contains("/"))
                 {
-                    name = path.Substring(path.LastIndexOfAny(new[] { '\\', '/' }) + 1);
+                    name = path[(path.LastIndexOfAny(new[] { '\\', '/' }) + 1)..];
                 }
             }
 

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -218,10 +218,10 @@ namespace GitCommands
             ReadOnlySpan<byte> array = chunk.AsSpan();
 
             // The first 40 bytes are the revision ID and the tree ID back to back
-            if (!ObjectId.TryParseAsciiHexReadOnlySpan(array.Slice(0, ObjectId.Sha1CharCount), out var objectId) ||
+            if (!ObjectId.TryParseAsciiHexReadOnlySpan(array[..ObjectId.Sha1CharCount], out var objectId) ||
                 !ObjectId.TryParseAsciiHexReadOnlySpan(array.Slice(ObjectId.Sha1CharCount, ObjectId.Sha1CharCount), out var treeId))
             {
-                ParseAssert($"Log parse error, object id: {chunk.Count}({array.Slice(0, ObjectId.Sha1CharCount).ToString()}");
+                ParseAssert($"Log parse error, object id: {chunk.Count}({array[..ObjectId.Sha1CharCount].ToString()}");
                 revision = default;
                 return false;
             }
@@ -421,7 +421,7 @@ namespace GitCommands
                 int lengthSubject = bodySlice.IndexOf('\n');
                 bool hasMultiLineMessage = lengthSubject >= 0;
                 string subject = hasMultiLineMessage
-                    ? bodySlice.Slice(0, lengthSubject).TrimEnd().ToString()
+                    ? bodySlice[..lengthSubject].TrimEnd().ToString()
                     : bodySlice.ToString();
 
                 // See caller for reasoning when message body can be omitted

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -223,11 +223,11 @@ namespace GitCommands
             int len = debugPath.Length;
             if (gitExtDir.Length > len)
             {
-                var path = gitExtDir.Substring(gitExtDir.Length - len);
+                var path = gitExtDir[^len..];
 
                 if (debugPath.ToPosixPath() == path.ToPosixPath())
                 {
-                    string projectPath = gitExtDir.Substring(0, gitExtDir.Length - len);
+                    string projectPath = gitExtDir[..^len];
                     return Path.Combine(projectPath, "Bin");
                 }
             }

--- a/GitCommands/StringExtensions.cs
+++ b/GitCommands/StringExtensions.cs
@@ -19,7 +19,7 @@ namespace System
         public static string RemovePrefix(this string str, string prefix, StringComparison comparison = StringComparison.Ordinal)
         {
             return str.StartsWith(prefix, comparison)
-                ? str.Substring(prefix.Length)
+                ? str[prefix.Length..]
                 : str;
         }
 
@@ -31,7 +31,7 @@ namespace System
         public static string RemoveSuffix(this string str, string suffix, StringComparison comparison = StringComparison.Ordinal)
         {
             return str.EndsWith(suffix, comparison)
-                ? str.Substring(0, str.Length - suffix.Length)
+                ? str[..^suffix.Length]
                 : str;
         }
 
@@ -46,7 +46,7 @@ namespace System
             var index = str.IndexOf(c);
 
             return index != -1
-                ? str.Substring(0, index)
+                ? str[..index]
                 : str;
         }
 
@@ -61,7 +61,7 @@ namespace System
             var index = str.LastIndexOf(c);
 
             return index != -1
-                ? str.Substring(0, index)
+                ? str[..index]
                 : str;
         }
 
@@ -76,7 +76,7 @@ namespace System
             var index = str.IndexOf(c);
 
             return index != -1
-                ? str.Substring(index + 1)
+                ? str[(index + 1)..]
                 : str;
         }
 
@@ -91,7 +91,7 @@ namespace System
             var index = str.IndexOf(s, comparison);
 
             return index != -1
-                ? str.Substring(index + s.Length)
+                ? str[(index + s.Length)..]
                 : str;
         }
 
@@ -106,7 +106,7 @@ namespace System
             var index = str.LastIndexOf(c);
 
             return index != -1
-                ? str.Substring(index + 1)
+                ? str[(index + 1)..]
                 : str;
         }
 
@@ -121,7 +121,7 @@ namespace System
             var index = str.LastIndexOf(s, comparison);
 
             return index != -1
-                ? str.Substring(index + s.Length)
+                ? str[(index + s.Length)..]
                 : str;
         }
 
@@ -139,7 +139,7 @@ namespace System
             {
                 if (s.Length <= prefixLength || s[prefixLength] != c)
                 {
-                    return s.Substring(0, prefixLength);
+                    return s[..prefixLength];
                 }
 
                 prefixLength++;
@@ -221,7 +221,7 @@ namespace System
 
             if (value[^1] == '\n')
             {
-                value = value.Substring(0, value.Length - 1);
+                value = value[..^1];
             }
 
             StringBuilder sb = new(capacity: value.Length);
@@ -255,10 +255,10 @@ namespace System
 
             if (maxLength < 3)
             {
-                return str.Substring(0, maxLength);
+                return str[..maxLength];
             }
 
-            return str.Substring(0, maxLength - 3) + "...";
+            return str[..(maxLength - 3)] + "...";
         }
 
         /// <summary>

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -218,7 +218,7 @@ namespace GitCommands.Submodules
 
             var superWorkDir = currentModule.SuperprojectModule?.WorkingDir;
             var currentWorkDir = currentModule.WorkingDir;
-            var localPath = currentWorkDir.Substring(topProject.WorkingDir.Length);
+            var localPath = currentWorkDir[topProject.WorkingDir.Length..];
             if (string.IsNullOrWhiteSpace(localPath))
             {
                 localPath = ".";

--- a/GitCommands/UserRepositoryHistory/RecentRepoInfo.cs
+++ b/GitCommands/UserRepositoryHistory/RecentRepoInfo.cs
@@ -153,7 +153,7 @@
             // if there is no short name for a repo, then try to find unique caption extending short directory path
             if (shortenPath && repoInfo.DirInfo is not null)
             {
-                string s = repoInfo.DirName.Substring(repoInfo.DirInfo.FullName.Length);
+                string s = repoInfo.DirName[repoInfo.DirInfo.FullName.Length..];
                 if (!string.IsNullOrEmpty(s))
                 {
                     s = s.Trim(Path.DirectorySeparatorChar);
@@ -279,12 +279,12 @@
 
                     if (company?.Length > skipCount)
                     {
-                        c = company.Substring(0, company.Length - skipCount);
+                        c = company[..^skipCount];
                     }
 
                     if (repository?.Length > skipCount)
                     {
-                        r = repository.Substring(skipCount, repository.Length - skipCount);
+                        r = repository[skipCount..];
                     }
 
                     repoInfo.Caption = MakePath(root, c!);
@@ -315,7 +315,7 @@
                         }
                         else
                         {
-                            repoInfo.Caption = path.Substring(0, leftEnd) + ".." + path.Substring(rightStart, path.Length - rightStart);
+                            repoInfo.Caption = path[..leftEnd] + ".." + path[rightStart..];
                         }
 
                         return true;

--- a/GitCommands/Utils/RFC2047Decoder.cs
+++ b/GitCommands/Utils/RFC2047Decoder.cs
@@ -86,7 +86,7 @@ namespace GitCommands
             }
 
             // Get the name of the encoding but skip the leading =?
-            string encodingName = input.Substring(2, input.IndexOf("?", 2, StringComparison.Ordinal) - 2);
+            string encodingName = input[2..input.IndexOf("?", 2, StringComparison.Ordinal)];
             Encoding enc = Encoding.ASCII;
             if (!string.IsNullOrEmpty(encodingName))
             {

--- a/GitExtUtils/LazyStringSplit.cs
+++ b/GitExtUtils/LazyStringSplit.cs
@@ -60,7 +60,7 @@ namespace GitExtUtils
 
                     if (delimiterIndex == -1)
                     {
-                        Current = _input.Substring(_index);
+                        Current = _input[_index..];
                         _index = _input.Length + 1;
                         return true;
                     }

--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -139,8 +139,8 @@ namespace GitUI.AutoCompletion
             foreach (var line in autoCompleteRegexes)
             {
                 var i = line.IndexOf('=');
-                var extensionStr = line.Substring(0, i);
-                var regexStr = line.Substring(i + 1).Trim();
+                var extensionStr = line[..i];
+                var regexStr = line[(i + 1)..].Trim();
 
                 var extensions = extensionStr.LazySplit(',').Select(s => s.Trim()).Distinct();
                 Regex regex = new(regexStr, RegexOptions.Compiled);

--- a/GitUI/Avatars/CustomAvatarProvider.cs
+++ b/GitUI/Avatars/CustomAvatarProvider.cs
@@ -79,7 +79,7 @@ namespace GitUI.Avatars
             // and try to parse it as an AvatarProvider enum.
             if (providerTemplate.StartsWith("<") && providerTemplate.EndsWith(">"))
             {
-                var providerName = providerTemplate.Substring(1, providerTemplate.Length - 2);
+                var providerName = providerTemplate[1..^1];
 
                 if (Enum.TryParse<AvatarProvider>(providerName, true, out var provider)
                     && provider != AvatarProvider.Custom)

--- a/GitUI/Avatars/TemplateFormatter.cs
+++ b/GitUI/Avatars/TemplateFormatter.cs
@@ -26,7 +26,7 @@ namespace GitUI.Avatars
                 var variableStartIndex = template.IndexOf('{', position);
                 var fixIndex = variableStartIndex < 0 ? template.Length : variableStartIndex;
 
-                var fixValue = template.Substring(position, fixIndex - position);
+                var fixValue = template[position..fixIndex];
                 formatParts.Add((sb, _) => sb.Append(fixValue));
 
                 if (variableStartIndex < 0)

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -492,7 +492,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                     break;
                 }
 
-                text = text.Substring(0, text.Length - 1);
+                text = text[..^1];
             }
 
             return text + ellipsis;

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -460,7 +460,7 @@ namespace GitUI.CommandsDialogs
             {
                 _remoteName = GitRefName.GetRemoteName(branch, Module.GetRemoteNames());
                 _localBranchName = Module.GetLocalTrackingBranchName(_remoteName, branch) ?? "";
-                var remoteBranchName = _remoteName.Length > 0 ? branch.Substring(_remoteName.Length + 1) : branch;
+                var remoteBranchName = _remoteName.Length > 0 ? branch[(_remoteName.Length + 1)..] : branch;
                 _newLocalBranchName = string.Concat(_remoteName, "_", remoteBranchName);
                 int i = 2;
                 while (LocalBranchExists(_newLocalBranchName))

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2330,7 +2330,7 @@ namespace GitUI.CommandsDialogs
 
                 if (newlineIndex != -1)
                 {
-                    label = label.Substring(0, newlineIndex);
+                    label = label[..newlineIndex];
                 }
 
                 if (label.Length > maxLabelLength)
@@ -2403,8 +2403,8 @@ namespace GitUI.CommandsDialogs
                 string diff = Module.GitExecutable.GetOutput(args);
                 var lines = diff.Split(Delimiters.LineFeed, StringSplitOptions.RemoveEmptyEntries);
                 const string subprojectCommit = "Subproject commit ";
-                var from = lines.Single(s => s.StartsWith("-" + subprojectCommit)).Substring(subprojectCommit.Length + 1);
-                var to = lines.Single(s => s.StartsWith("+" + subprojectCommit)).Substring(subprojectCommit.Length + 1);
+                var from = lines.Single(s => s.StartsWith("-" + subprojectCommit))[(subprojectCommit.Length + 1)..];
+                var to = lines.Single(s => s.StartsWith("+" + subprojectCommit))[(subprojectCommit.Length + 1)..];
                 if (!string.IsNullOrEmpty(from) && !string.IsNullOrEmpty(to))
                 {
                     sb.AppendLine("Submodule " + path + ":");
@@ -2424,7 +2424,7 @@ namespace GitUI.CommandsDialogs
                     }
                     else
                     {
-                        sb.AppendLine("    * Revision changed to " + to.Substring(0, 7));
+                        sb.AppendLine("    * Revision changed to " + to[..7]);
                     }
 
                     sb.AppendLine();

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -1016,7 +1016,7 @@ namespace GitUI.CommandsDialogs
                 return firstTabIdx == 40
                     ? processOutput
                     : firstTabIdx > 40
-                        ? processOutput.Substring(firstTabIdx - 40)
+                        ? processOutput[(firstTabIdx - 40)..]
                         : string.Empty;
             }
 

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -667,8 +667,8 @@ namespace GitUI.CommandsDialogs
                     int idx = _mergetoolCmd.IndexOf(executablePattern);
                     if (idx >= 0)
                     {
-                        _mergetoolPath = _mergetoolCmd.Substring(0, idx + executablePattern.Length + 1).Trim('\"', ' ');
-                        _mergetoolCmd = _mergetoolCmd.Substring(idx + executablePattern.Length + 1);
+                        _mergetoolPath = _mergetoolCmd[..(idx + executablePattern.Length + 1)].Trim('\"', ' ');
+                        _mergetoolCmd = _mergetoolCmd[(idx + executablePattern.Length + 1)..];
                     }
                 }
 

--- a/GitUI/CommandsDialogs/FormVerify.LostObject.cs
+++ b/GitUI/CommandsDialogs/FormVerify.LostObject.cs
@@ -134,7 +134,7 @@ namespace GitUI.CommandsDialogs
                 else if (objectType == LostObjectType.Blob)
                 {
                     var hash = objectId.ToString();
-                    var blobPath = Path.Combine(module.WorkingDirGitDir, "objects", hash.Substring(0, 2), hash.Substring(2, ObjectId.Sha1CharCount - 2));
+                    var blobPath = Path.Combine(module.WorkingDirGitDir, "objects", hash[..2], hash[2..ObjectId.Sha1CharCount]);
                     result.Date = new FileInfo(blobPath).CreationTime;
                 }
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -960,7 +960,7 @@ See the changes in the commit form.");
                 return false;
             }
 
-            return _revisionFileTreeController.SelectFileOrFolder(tvGitTree, filePath.Substring(Module.WorkingDir.Length));
+            return _revisionFileTreeController.SelectFileOrFolder(tvGitTree, filePath[Module.WorkingDir.Length..]);
         }
 
         internal void RegisterGitHostingPluginInBlameControl()

--- a/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
+++ b/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
@@ -104,7 +104,7 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
                         .Select(head =>
                         {
                             int branchIndex = head.IndexOf(GitRefName.RefsHeadsPrefix);
-                            return branchIndex == -1 ? null : head.Substring(branchIndex + GitRefName.RefsHeadsPrefix.Length);
+                            return branchIndex == -1 ? null : head[(branchIndex + GitRefName.RefsHeadsPrefix.Length)..];
                         })
                         .WhereNotNull()
                         .ToImmutableList();

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -77,7 +77,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
                 var strings = line.Split(' ');
                 if (strings[0] == "worktree")
                 {
-                    currentWorktree = new WorkTree { Path = Module.GetWindowsPath(line.Substring(9)) };
+                    currentWorktree = new WorkTree { Path = Module.GetWindowsPath(line[9..]) };
                     currentWorktree.IsDeleted = !Directory.Exists(currentWorktree.Path);
                     _worktrees.Add(currentWorktree);
                 }
@@ -99,7 +99,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
                             currentWorktree.Branch = CleanBranchName(strings[1]);
 
                             string? CleanBranchName(string? branch)
-                                => branch != null && branch.StartsWith(GitRefName.RefsHeadsPrefix) ? branch.Substring(GitRefName.RefsHeadsPrefix.Length) : branch;
+                                => branch != null && branch.StartsWith(GitRefName.RefsHeadsPrefix) ? branch[GitRefName.RefsHeadsPrefix.Length..] : branch;
 
                             break;
                         case "detached":

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -244,7 +244,7 @@ namespace GitUI.CommitInfo
             int warningPos = tree.IndexOf("warning:");
             if (warningPos >= 0)
             {
-                throw new RefsWarningException(tree.Substring(warningPos).LazySplit('\n', StringSplitOptions.RemoveEmptyEntries).First());
+                throw new RefsWarningException(tree[warningPos..].LazySplit('\n', StringSplitOptions.RemoveEmptyEntries).First());
             }
 
             int i = 0;

--- a/GitUI/CommitInfo/RefsFormatter.cs
+++ b/GitUI/CommitInfo/RefsFormatter.cs
@@ -86,7 +86,7 @@ namespace GitUI.CommitInfo
                     branchIsLocal = !branch.StartsWith(remotesPrefix);
                     if (!branchIsLocal)
                     {
-                        noPrefixBranch = branch.Substring(remotesPrefix.Length);
+                        noPrefixBranch = branch[remotesPrefix.Length..];
                     }
                 }
                 else

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -809,7 +809,7 @@ namespace GitUI.Editor
                 if (hpos <= pos)
                 {
                     char[] specials = { ' ', '-', '+' };
-                    lines = lines.Select(s => s.Length > 0 && specials.Any(c => c == s[0]) ? s.Substring(1) : s);
+                    lines = lines.Select(s => s.Length > 0 && specials.Any(c => c == s[0]) ? s[1..] : s);
                 }
 
                 code = string.Join("\n", lines);
@@ -1727,7 +1727,7 @@ namespace GitUI.Editor
 
                 foreach (var special in specials.Where(line.StartsWith))
                 {
-                    return line.Substring(special.Length);
+                    return line[special.Length..];
                 }
 
                 return line;

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -690,13 +690,13 @@ namespace GitUI.Editor.RichTextBoxExtension
                 for (int i = 0; i < colFormat.Count; i++)
                 {
                     var (pos, markup) = colFormat[i];
-                    strHTML.Append(WebUtility.HtmlEncode(strT.Substring(nAcum, pos - nAcum)) + markup);
+                    strHTML.Append(WebUtility.HtmlEncode(strT[nAcum..pos]) + markup);
                     nAcum = pos;
                 }
 
                 if (nAcum < strT.Length)
                 {
-                    strHTML.Append(strT.Substring(nAcum));
+                    strHTML.Append(strT[nAcum..]);
                 }
             }
             catch (Exception /*ex*/)
@@ -1157,8 +1157,8 @@ namespace GitUI.Editor.RichTextBoxExtension
 
                 // prior to net47 links were created via hidden text, and had the following format: "text#link"
                 // extract the link portion only
-                string linkOldFormat = text.Substring(from, to - from);
-                return linkOldFormat.Substring(linkOldFormat.IndexOf(LinkSeparator) + LinkSeparator.Length);
+                string linkOldFormat = text[from..to];
+                return linkOldFormat[(linkOldFormat.IndexOf(LinkSeparator) + LinkSeparator.Length)..];
             }
             catch
             {
@@ -1464,7 +1464,7 @@ namespace GitUI.Editor.RichTextBoxExtension
                                 string text = reader.Value;
                                 if (text.StartsWith("#"))
                                 {
-                                    string strCr = text.Substring(1);
+                                    string strCr = text[1..];
                                     int nCr = Convert.ToInt32(strCr, 16);
                                     Color color = Color.FromArgb(nCr);
                                     crFont = GetCOLORREF(color);
@@ -1532,8 +1532,8 @@ namespace GitUI.Editor.RichTextBoxExtension
                             int idx = rtfText.LastIndexOf('}');
                             if (idx != -1)
                             {
-                                string head = rtfText.Substring(0, idx);
-                                string tail = rtfText.Substring(idx);
+                                string head = rtfText[..idx];
+                                string tail = rtfText[idx..];
                                 RtbSetSelectedRtf(rtb, $@"{head}\v {LinkSeparator}{cs.hyperlink}\v0{tail}");
                                 length = rtb.TextLength - cs.hyperlinkStart;
                             }

--- a/GitUI/FindFilePredicateProvider.cs
+++ b/GitUI/FindFilePredicateProvider.cs
@@ -30,7 +30,7 @@ namespace GitUI
 
             if (pattern.StartsWith(dir, StringComparison.OrdinalIgnoreCase))
             {
-                pattern = pattern.Substring(dir.Length).TrimStart('/');
+                pattern = pattern[dir.Length..].TrimStart('/');
                 return fileName => fileName?.StartsWith(pattern, StringComparison.OrdinalIgnoreCase) is true;
             }
 

--- a/GitUI/LeftPanel/RemoteBranchNode.cs
+++ b/GitUI/LeftPanel/RemoteBranchNode.cs
@@ -41,7 +41,7 @@ namespace GitUI.LeftPanel
         private RemoteBranchInfo GetRemoteBranchInfo()
         {
             var remote = FullPath.LazySplit('/').First();
-            var branch = FullPath.Substring(remote.Length + 1);
+            var branch = FullPath[(remote.Length + 1)..];
             return new RemoteBranchInfo(remote, branch);
         }
 

--- a/GitUI/LeftPanel/SubmoduleTree.cs
+++ b/GitUI/LeftPanel/SubmoduleTree.cs
@@ -219,7 +219,7 @@ namespace GitUI.LeftPanel
                     continue;
                 }
 
-                string localPath = Path.GetDirectoryName(submoduleInfo.Path.Substring(superPath.Length)).ToPosixPath();
+                string localPath = Path.GetDirectoryName(submoduleInfo.Path[superPath.Length..]).ToPosixPath();
 
                 var isCurrent = submoduleInfo.Bold;
 

--- a/GitUI/Script/ScriptOptionsParser.cs
+++ b/GitUI/Script/ScriptOptionsParser.cs
@@ -537,7 +537,7 @@ namespace GitUI.Script
             int firstSlashIndex = remoteBranchName.IndexOf('/');
             if (firstSlashIndex >= 0)
             {
-                return remoteBranchName.Substring(firstSlashIndex + 1);
+                return remoteBranchName[(firstSlashIndex + 1)..];
             }
 
             return remoteBranchName;

--- a/GitUI/Theming/ThemeCssUrlResolver.cs
+++ b/GitUI/Theming/ThemeCssUrlResolver.cs
@@ -21,11 +21,11 @@ namespace GitUI.Theming
         {
             if (url.EndsWith(_themePathProvider.ThemeExtension, StringComparison.OrdinalIgnoreCase))
             {
-                url = url.Substring(0, url.Length - _themePathProvider.ThemeExtension.Length);
+                url = url[..^_themePathProvider.ThemeExtension.Length];
             }
 
             ThemeId id = url.StartsWith(CssVariableUserThemesDirectory)
-                ? new ThemeId(url.Substring(CssVariableUserThemesDirectory.Length), isBuiltin: false)
+                ? new ThemeId(url[CssVariableUserThemesDirectory.Length..], isBuiltin: false)
                 : new ThemeId(url, isBuiltin: true);
 
             try

--- a/GitUI/Theming/ThemeLoader.cs
+++ b/GitUI/Theming/ThemeLoader.cs
@@ -118,9 +118,7 @@ namespace GitUI.Theming
                 throw StyleRuleThemeException(rule, themeFileName);
             }
 
-            return selectorText
-                .Substring(ClassSelector.Length)
-                .Split(new[] { ClassSelector }, StringSplitOptions.RemoveEmptyEntries);
+            return selectorText[ClassSelector.Length..].Split(new[] { ClassSelector }, StringSplitOptions.RemoveEmptyEntries);
         }
 
         private static Color GetColor(string themeFileName, StyleRule rule)

--- a/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
+++ b/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
@@ -158,7 +158,7 @@ namespace GitUI.UserControls
                     return null;
                 }
 
-                string rest = outputChunk.Substring(_commandLineCharsInOutput);
+                string rest = outputChunk[_commandLineCharsInOutput..];
                 _commandLineCharsInOutput = 0;
                 return rest;
             }

--- a/GitUI/UserControls/PathFormatter.cs
+++ b/GitUI/UserControls/PathFormatter.cs
@@ -144,7 +144,7 @@ namespace GitUI
 
                 if (truncatePathMethod == TruncatePathMethod.TrimStart)
                 {
-                    return "..." + path.Substring(path.Length - length);
+                    return "..." + path[^length..];
                 }
 
                 return path;
@@ -166,8 +166,8 @@ namespace GitUI
             int slashIndex = name.TrimEnd(PathUtil.PosixDirectorySeparatorChar).LastIndexOf(PathUtil.PosixDirectorySeparatorChar);
             if (slashIndex >= 0 && slashIndex < name.Length)
             {
-                string path = name.Substring(0, slashIndex + 1);
-                string fileName = name.Substring(slashIndex + 1);
+                string path = name[..(slashIndex + 1)];
+                string fileName = name[(slashIndex + 1)..];
                 return (path, fileName);
             }
 

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -87,7 +87,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                     e.State.HasFlag(DataGridViewElementStates.Selected),
                     style.NormalFont,
                     ref offset,
-                    revision.ReflogSelector.Substring(5),
+                    revision.ReflogSelector[5..],
                     AppColor.OtherTag.GetThemeColor(),
                     RefArrowType.None,
                     messageBounds,

--- a/GitUI/UserControls/RevisionGrid/FormQuickItemSelector.cs
+++ b/GitUI/UserControls/RevisionGrid/FormQuickItemSelector.cs
@@ -43,7 +43,7 @@
 
                     // assume that the branch names or tags are never longer than MaxRefLength symbols long
                     // if they are (sanity!) - don't resize past beyond certain limit
-                    var label = item.Label.Length > MaxRefLength ? item.Label.Substring(0, MaxRefLength) : item.Label;
+                    var label = item.Label.Length > MaxRefLength ? item.Label[..MaxRefLength] : item.Label;
                     longestItemWidth = Math.Max(longestItemWidth, graphics.MeasureString(label, lbxRefs.Font).Width);
                 }
             }

--- a/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
@@ -61,7 +61,7 @@ namespace GitUI
                 // backspace
                 RestartQuickSearchTimer();
 
-                _quickSearchString = _quickSearchString.Substring(0, _quickSearchString.Length - 1);
+                _quickSearchString = _quickSearchString[..^1];
 
                 FindNextMatch(curIndex, _quickSearchString, false);
                 _lastQuickSearchString = _quickSearchString;

--- a/Plugins/Bitbucket/GetPullRequest.cs
+++ b/Plugins/Bitbucket/GetPullRequest.cs
@@ -22,7 +22,7 @@ namespace GitExtensions.Plugins.Bitbucket
                 DestProjectKey = json["toRef"]["repository"]["project"]["key"].ToString(),
                 DestRepo = json["toRef"]["repository"]["name"].ToString(),
                 DestBranch = json["toRef"]["displayId"].ToString(),
-                CreatedDate = Convert.ToDouble(json["createdDate"].ToString().Substring(0, 10))
+                CreatedDate = Convert.ToDouble(json["createdDate"].ToString()[..10])
             };
             var reviewers = json["reviewers"];
             var participants = json["participants"];

--- a/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
+++ b/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
@@ -587,7 +587,7 @@ namespace JenkinsIntegration
                     buildTree = post;
                 }
 
-                restServicePath = restServicePath.Substring(0, postIndex);
+                restServicePath = restServicePath[..postIndex];
             }
             else
             {

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
@@ -568,16 +568,16 @@ namespace TeamCityIntegration
 
         private static DateTime DecodeJsonDateTime(string dateTimeString)
         {
-            var dateTime = new DateTime(
-                    int.Parse(dateTimeString[..4]),
-                    int.Parse(dateTimeString.Substring(4, 2)),
-                    int.Parse(dateTimeString.Substring(6, 2)),
-                    int.Parse(dateTimeString.Substring(9, 2)),
-                    int.Parse(dateTimeString.Substring(11, 2)),
-                    int.Parse(dateTimeString.Substring(13, 2)),
+            DateTime dateTime = new DateTime(
+                    int.Parse(dateTimeString.AsSpan(0, 4)),
+                    int.Parse(dateTimeString.AsSpan(4, 2)),
+                    int.Parse(dateTimeString.AsSpan(6, 2)),
+                    int.Parse(dateTimeString.AsSpan(9, 2)),
+                    int.Parse(dateTimeString.AsSpan(11, 2)),
+                    int.Parse(dateTimeString.AsSpan(13, 2)),
                     DateTimeKind.Utc)
-                .AddHours(int.Parse(dateTimeString.Substring(15, 3)))
-                .AddMinutes(int.Parse(dateTimeString.Substring(15, 1) + dateTimeString.Substring(18, 2)));
+                .AddHours(int.Parse(dateTimeString.AsSpan(15, 3)))
+                .AddMinutes(int.Parse(string.Concat(dateTimeString.AsSpan(15, 1), dateTimeString.AsSpan(18, 2))));
 
             return dateTime;
         }

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
@@ -569,7 +569,7 @@ namespace TeamCityIntegration
         private static DateTime DecodeJsonDateTime(string dateTimeString)
         {
             var dateTime = new DateTime(
-                    int.Parse(dateTimeString.Substring(0, 4)),
+                    int.Parse(dateTimeString[..4]),
                     int.Parse(dateTimeString.Substring(4, 2)),
                     int.Parse(dateTimeString.Substring(6, 2)),
                     int.Parse(dateTimeString.Substring(9, 2)),

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -193,7 +193,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
                         GitArgumentBuilder args = new("push")
                         {
                             remoteName,
-                            $":{remoteBranch.Name.Substring(remoteBranchNameOffset)}"
+                            $":{remoteBranch.Name[remoteBranchNameOffset..]}"
                         };
                         _gitCommands.GitExecutable.GetOutput(args);
                     }

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -113,7 +113,7 @@ namespace GitExtensions.Plugins.GitFlow
                 if (currentRef.StartsWith(startRef))
                 {
                     branchType = branch.ToString();
-                    branchName = currentRef.Substring(startRef.Length);
+                    branchName = currentRef[startRef.Length..];
                     return true;
                 }
             }

--- a/Plugins/ReleaseNotesGenerator/HtmlFragment.cs
+++ b/Plugins/ReleaseNotesGenerator/HtmlFragment.cs
@@ -85,7 +85,7 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
 
                         int endHtml = int.Parse(val);
 
-                        Context = rawClipboardText.Substring(startHtml, endHtml - startHtml);
+                        Context = rawClipboardText[startHtml..endHtml];
                         break;
 
                     // Byte count from the beginning of the clipboard to the start of the fragment.
@@ -106,7 +106,7 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
                         }
 
                         int endFragment = int.Parse(val);
-                        Fragment = rawClipboardText.Substring(startFragment, endFragment - startFragment);
+                        Fragment = rawClipboardText[startFragment..endFragment];
                         break;
 
                     // Optional Source URL, used for resolving relative links.

--- a/Plugins/Statistics/GitImpact/ImpactLoader.cs
+++ b/Plugins/Statistics/GitImpact/ImpactLoader.cs
@@ -163,7 +163,7 @@ namespace GitExtensions.Plugins.GitImpact
                 }
 
                 // Strip "--- "
-                line = line.Substring(4);
+                line = line[4..];
 
                 // Split date and author
                 string[] header = line.Split(new[] { " --- " }, 2, StringSplitOptions.RemoveEmptyEntries);

--- a/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
+++ b/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
@@ -175,7 +175,7 @@ namespace ResourceManager.CommitDataRenders
             }
 
             ++ind;
-            return author.Substring(ind, author.LastIndexOf(">", StringComparison.Ordinal) - ind);
+            return author[ind..author.LastIndexOf(">", StringComparison.Ordinal)];
         }
 
         private string RenderObjectIds(IEnumerable<ObjectId> objectIds, bool showRevisionsAsLinks)

--- a/ResourceManager/LinkFactory.cs
+++ b/ResourceManager/LinkFactory.cs
@@ -156,7 +156,7 @@ namespace ResourceManager
                     break;
                 }
 
-                uriCandidate = uriCandidate.Substring(idx + 1);
+                uriCandidate = uriCandidate[(idx + 1)..];
             }
 
             return false;

--- a/ResourceManager/Translator.cs
+++ b/ResourceManager/Translator.cs
@@ -25,7 +25,7 @@ namespace ResourceManager
                     var result = Directory.EnumerateFiles(translationsDir, translationName + "*.xlf");
                     foreach (var file in result)
                     {
-                        var name = Path.GetFileNameWithoutExtension(file).Substring(translationName.Length);
+                        var name = Path.GetFileNameWithoutExtension(file)[translationName.Length..];
                         var t = TranslationSerializer.Deserialize(file) ??
                                 new TranslationFile();
                         t.SourceLanguage = t.TranslationCategories.FirstOrDefault()?.SourceLanguage;

--- a/UnitTests/GitCommands.Tests/AppTitleGeneratorTests.cs
+++ b/UnitTests/GitCommands.Tests/AppTitleGeneratorTests.cs
@@ -109,7 +109,7 @@ namespace GitCommandsTests
             AppTitleGenerator.Initialise(buildSha, buildBranch);
             string title = _appTitleGenerator.Generate("a", true, null, defaultBranchName: _defaultBranchName);
 
-            title.Should().Be($"{MockRepositoryDescriptionProvider.ShortName} ({_defaultBranchName}) - {AppSettings.ApplicationName} {buildSha.Substring(0, 8)} ({buildBranch})");
+            title.Should().Be($"{MockRepositoryDescriptionProvider.ShortName} ({_defaultBranchName}) - {AppSettings.ApplicationName} {buildSha[..8]} ({buildBranch})");
         }
 #endif
     }

--- a/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
@@ -282,7 +282,7 @@ namespace GitCommandsTests.Git
 
             for (var length = 0; length < ObjectId.Sha1CharCount; length++)
             {
-                Assert.AreEqual(s.Substring(0, length), id.ToShortString(length));
+                Assert.AreEqual(s[..length], id.ToShortString(length));
             }
 
             Assert.Throws<ArgumentOutOfRangeException>(() => id.ToShortString(-1));

--- a/UnitTests/GitUI.Tests/CommandsDialogs/FormOpenDirectoryTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/FormOpenDirectoryTests.cs
@@ -54,7 +54,7 @@ namespace GitUITests.CommandsDialogs
             path[^1].Should().Be(Path.DirectorySeparatorChar);
 
             // ensure absence of the trailing slash isn't a problem
-            path = path.Substring(0, path.Length - 1);
+            path = path[..^1];
             Assert.DoesNotThrow(() => FormOpenDirectory.TestAccessor.OpenGitRepository(path, _localRepositoryManager));
         }
 

--- a/UnitTests/GitUI.Tests/UserControls/ConsoleEmulatorOutputControlFixture.cs
+++ b/UnitTests/GitUI.Tests/UserControls/ConsoleEmulatorOutputControlFixture.cs
@@ -21,8 +21,8 @@ namespace GitUITests.UserControls
 
             ConsoleCommandLineOutputProcessor filter = new(cmd.Length, FireDataReceived);
 
-            string chunk1 = cmd.Substring(0, 10);
-            string chunk2 = cmd.Substring(10, cmd.Length - 10) + Environment.NewLine + outputData;
+            string chunk1 = cmd[..10];
+            string chunk2 = cmd[10..] + Environment.NewLine + outputData;
             filter.AnsiStreamChunkReceived(null, new AnsiStreamChunkEventArgs(GitModule.SystemEncoding.GetBytes(chunk1)));
             filter.AnsiStreamChunkReceived(null, new AnsiStreamChunkEventArgs(GitModule.SystemEncoding.GetBytes(chunk2)));
 
@@ -43,8 +43,8 @@ namespace GitUITests.UserControls
 
             ConsoleCommandLineOutputProcessor filter = new(cmd.Length, FireDataReceived);
 
-            string chunk1 = cmd.Substring(0, 10);
-            string chunk2 = cmd.Substring(10, cmd.Length - 10) + Environment.NewLine + outputData;
+            string chunk1 = cmd[..10];
+            string chunk2 = cmd[10..] + Environment.NewLine + outputData;
             filter.AnsiStreamChunkReceived(null, new AnsiStreamChunkEventArgs(GitModule.SystemEncoding.GetBytes(chunk1)));
             filter.AnsiStreamChunkReceived(null, new AnsiStreamChunkEventArgs(GitModule.SystemEncoding.GetBytes(chunk2)));
             filter.Flush();


### PR DESCRIPTION
## Proposed changes

VS suggested change, simplifies displayed code using range operator.
(Should be no change to runtime execution.)

https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0057

Typical like

```
diff --git a/BugReporter/GitHubUrlBuilder.cs b/BugReporter/GitHubUrlBuilder.cs
index 8377b..5b8b8 100644
--- a/BugReporter/GitHubUrlBuilder.cs
+++ b/BugReporter/GitHubUrlBuilder.cs
@@ -46,7 +46,7 @@ public GitHubUrlBuilder(IErrorReportUrlBuilder errorReportUrlBuilder)
             if (subject.Length > 69)
             {
                 // if the subject is longer than 70 characters, trim it
-                subject = subject.Substring(0, 66) + "...";
+                subject = subject[..66] + "...";
             }
 
             string urlEncodedError = _errorReportUrlBuilder.Build(exception, exceptionInfo, environmentInfo, additionalInfo);
```

## Test methodology <!-- How did you ensure quality? -->

Refactoring

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
