### PR TITLE
Replace JTF.RunAsync() with exception-safe wrappers

### DIFF
--- a/GitExtUtils/GitUI/ThreadHelper.cs
+++ b/GitExtUtils/GitUI/ThreadHelper.cs
@@ -86,6 +86,18 @@ namespace GitUI
         public static void FileAndForget(this Task task)
             => _taskManager.FileAndForget(task);
 
+        /// <summary>
+        /// Asynchronously run <paramref name="asyncAction"/> on the UI thread and forward all exceptions to <see cref="Application.OnThreadException"/> except for <see cref="OperationCanceledException"/>, which is ignored.
+        /// </summary>
+        public static void InvokeAndForget(this Control control, Func<Task> asyncAction, TaskManager? taskManager = null, CancellationToken cancellationToken = default)
+            => (taskManager ?? _taskManager).InvokeAndForget(control, asyncAction, cancellationToken);
+
+        /// <summary>
+        /// Asynchronously run <paramref name="action"/> on the UI thread and forward all exceptions to <see cref="Application.OnThreadException"/> except for <see cref="OperationCanceledException"/>, which is ignored.
+        /// </summary>
+        public static void InvokeAndForget(this Control control, Action action, TaskManager? taskManager = null, CancellationToken cancellationToken = default)
+            => InvokeAndForget(control, TaskManager.AsyncAction(action), taskManager, cancellationToken);
+
         public static async Task JoinPendingOperationsAsync(CancellationToken cancellationToken)
             => await _taskManager.JoinPendingOperationsAsync(cancellationToken);
 

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -330,9 +330,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                     };
                     listView1.Items.Add(item);
 
-                    ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                    ThreadHelper.FileAndForget(async () =>
                     {
-                        await TaskScheduler.Default;
                         bool isValidGitDir = _controller.IsValidGitWorkingDir(recent.Repo.Path);
                         string branchName = isValidGitDir ? _controller.GetCurrentBranchName(recent.Repo.Path) : "";
                         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -346,7 +345,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                             item.ImageIndex = 1;
                             _hasInvalidRepos = true;
                         }
-                    }).FileAndForget();
+                    });
                 }
             }
         }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGitCommandLog.cs
@@ -50,22 +50,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             void OnGitCommandLogChanged()
             {
-                ThreadHelper.JoinableTaskFactory.RunAsync(
-                    async () =>
-                    {
-                        await this.SwitchToMainThreadAsync();
-                        RefreshLogItems();
-                    });
+                this.InvokeAndForget(RefreshLogItems);
             }
 
             void OnCachedCommandsLogChanged(object sender, EventArgs e)
             {
-                ThreadHelper.JoinableTaskFactory.RunAsync(
-                    async () =>
-                    {
-                        await this.SwitchToMainThreadAsync();
-                        RefreshCommandCacheItems();
-                    });
+                this.InvokeAndForget(RefreshCommandCacheItems);
             }
         }
 

--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -97,8 +97,9 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             }
             catch (Exception ex)
             {
-                this.InvokeSync(() =>
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
                     {
+                        await this.SwitchToMainThreadAsync();
                         if (Visible)
                         {
                             ExceptionUtils.ShowException(this, ex, string.Empty, true);
@@ -130,8 +131,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void Done()
         {
-            this.InvokeSync(() =>
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
+                await this.SwitchToMainThreadAsync();
+
                 progressBar1.Visible = false;
 
                 if (UpdateFound)

--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -173,14 +173,14 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void btnUpdateNow_Click(object sender, EventArgs e)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-            {
-                linkChangeLog.Visible = false;
-                progressBar1.Visible = true;
-                btnUpdateNow.Enabled = false;
-                UpdateLabel.Text = _downloadingUpdate.Text;
-                string fileName = Path.GetFileName(UpdateUrl);
+            linkChangeLog.Visible = false;
+            progressBar1.Visible = true;
+            btnUpdateNow.Enabled = false;
+            UpdateLabel.Text = _downloadingUpdate.Text;
 
+            ThreadHelper.FileAndForget(async () =>
+            {
+                string fileName = Path.GetFileName(UpdateUrl);
                 try
                 {
 #pragma warning disable SYSLIB0014 // 'WebClient' is obsolete
@@ -202,6 +202,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                     process.StartInfo.Arguments = string.Format("/i \"{0}\\{1}\" /qb LAUNCH=1", Environment.GetEnvironmentVariable("TEMP"), fileName);
                     process.Start();
 
+                    await this.SwitchToMainThreadAsync();
                     progressBar1.Visible = false;
                     Close();
                     Application.Exit();
@@ -209,7 +210,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 catch (Win32Exception)
                 {
                 }
-            }).FileAndForget();
+            });
         }
 
         private void linkDirectDownload_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -471,13 +471,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 _isFirstPostRepoChanged = false;
             }
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                    async () =>
+            ThreadHelper.FileAndForget(async () =>
                     {
                         try
                         {
                             GitExtUtils.ArgumentString cmd = GitCommandHelpers.GetAllChangedFilesCmd(excludeIgnoredFiles: true, UntrackedFilesMode.Default, noLocks: noLocks);
-                            ExecutionResult result = await module.GitExecutable.ExecuteAsync(cmd, cancellationToken: cancelToken).ConfigureAwait(continueOnCapturedContext: false);
+                            ExecutionResult result = await module.GitExecutable.ExecuteAsync(cmd, cancellationToken: cancelToken);
 
                             if (result.ExitedSuccessfully && !ModuleHasChanged())
                             {
@@ -539,8 +538,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                                 }
                             }
                         }
-                    })
-                .FileAndForget();
+                    });
 
             return;
 

--- a/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
+++ b/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
@@ -185,8 +185,7 @@ namespace GitUI.CommandsDialogs
 
             if (favIconUrl is not null)
             {
-                ThreadHelper.JoinableTaskFactory.RunAsync(
-                    async () =>
+                ThreadHelper.FileAndForget(async () =>
                     {
                         using var imageStream = await DownloadRemoteImageFileAsync(favIconUrl);
                         if (imageStream is not null)

--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -13,14 +13,10 @@ namespace GitUI.CommandsDialogs
             RevisionGrid.IndexWatcher.Changed += (_, args) =>
             {
                 bool indexChanged = args.IsIndexChanged;
-                this.InvokeAsync(
-                        () =>
-                        {
-                            RefreshButton.Image = indexChanged && AppSettings.ShowGitStatusInBrowseToolbar && Module.IsValidGitWorkingDir()
-                                ? Images.ReloadRevisionsDirty
-                                : Images.ReloadRevisions;
-                        })
-                    .FileAndForget();
+                this.InvokeAndForget(() =>
+                    RefreshButton.Image = indexChanged && AppSettings.ShowGitStatusInBrowseToolbar && Module.IsValidGitWorkingDir()
+                        ? Images.ReloadRevisionsDirty
+                        : Images.ReloadRevisions);
             };
 
             RevisionGrid.MenuCommands.MenuChanged += (sender, e) => _formBrowseMenus.OnMenuCommandsPropertyChanged();

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -500,7 +500,7 @@ namespace GitUI.CommandsDialogs
                         new WindowsThumbnailToolbarButton(_closeAll.Text, Images.DeleteFile, (s, e) => NativeMethods.PostMessageW(NativeMethods.HWND_BROADCAST, _closeAllMessage))));
             }
 
-            this.InvokeAsync(OnActivate).FileAndForget();
+            this.InvokeAndForget(OnActivate);
             base.OnActivated(e);
         }
 

--- a/GitUI/CommandsDialogs/FormBrowseController.cs
+++ b/GitUI/CommandsDialogs/FormBrowseController.cs
@@ -1,6 +1,7 @@
 ﻿using GitCommands;
 using GitCommands.Gpg;
 using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Threading;
 
 namespace GitUI.CommandsDialogs
 {
@@ -25,12 +26,13 @@ namespace GitUI.CommandsDialogs
                 return null;
             }
 
-            var getCommitSignature = _gitGpgController.GetRevisionCommitSignatureStatusAsync(revision);
-            var getTagSignature = _gitGpgController.GetRevisionTagSignatureStatusAsync(revision);
+            await TaskScheduler.Default;
+            Task<CommitStatus> getCommitSignature = _gitGpgController.GetRevisionCommitSignatureStatusAsync(revision);
+            Task<TagStatus> getTagSignature = _gitGpgController.GetRevisionTagSignatureStatusAsync(revision);
             await Task.WhenAll(getCommitSignature, getTagSignature);
 
-            var commitStatus = await getCommitSignature;
-            var tagStatus = await getTagSignature;
+            CommitStatus commitStatus = getCommitSignature.CompletedResult();
+            TagStatus tagStatus = getTagSignature.CompletedResult();
 
             // Absence of Commit sign and Tag sign
             if (commitStatus == CommitStatus.NoSignature && tagStatus == TagStatus.NoTag)

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -482,11 +482,8 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-                ThreadHelper.JoinableTaskFactory.RunAsync(
-                    async () =>
+                ThreadHelper.FileAndForget(async () =>
                     {
-                        await TaskScheduler.Default;
-
                         var currentCheckout = Module.GetCurrentCheckout();
 
                         Validates.NotNull(currentCheckout);

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -154,10 +154,7 @@ namespace GitUI.CommandsDialogs
                 revisions = new[] { _secondRevision, _firstRevision };
             }
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-            {
-                await DiffFiles.SetDiffsAsync(revisions, _currentHead.Value, _viewChangesSequence.Next());
-            }).FileAndForget();
+            DiffFiles.InvokeAndForget(() => DiffFiles.SetDiffsAsync(revisions, _currentHead.Value, _viewChangesSequence.Next()));
         }
 
         private void ShowSelectedFileDiff()

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -211,13 +211,14 @@ namespace GitUI.CommandsDialogs
 
             // workaround to prevent GitIgnoreFileLoaded event handling (it causes wrong _originalGitIgnoreFileContent update)
             // TODO: implement in FileViewer separate events for loading text from file and for setting text directly via ViewText
-            _NO_TRANSLATE_GitIgnoreEdit.TextLoaded -= GitIgnoreFileLoaded;
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                () => _NO_TRANSLATE_GitIgnoreEdit.ViewTextAsync(
-                    ExcludeFile,
-                    currentFileContent + Environment.NewLine +
-                    string.Join(Environment.NewLine, patternsToAdd) + Environment.NewLine + string.Empty));
-            _NO_TRANSLATE_GitIgnoreEdit.TextLoaded += GitIgnoreFileLoaded;
+            _NO_TRANSLATE_GitIgnoreEdit.InvokeAndForget(async () =>
+                {
+                    _NO_TRANSLATE_GitIgnoreEdit.TextLoaded -= GitIgnoreFileLoaded;
+                    await _NO_TRANSLATE_GitIgnoreEdit.ViewTextAsync(
+                        ExcludeFile,
+                        $"{currentFileContent}{Environment.NewLine}{string.Join(Environment.NewLine, patternsToAdd)}{Environment.NewLine}");
+                    _NO_TRANSLATE_GitIgnoreEdit.TextLoaded += GitIgnoreFileLoaded;
+                });
         }
 
         private void AddPattern_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -515,11 +515,8 @@ Inactive remote is completely invisible to git.");
 
         private void TestConnectionClick(object sender, EventArgs e)
         {
-            var url = Url.Text;
-
-            ThreadHelper.JoinableTaskFactory
-                .RunAsync(() => new Plink().ConnectAsync(url))
-                .FileAndForget();
+            string url = Url.Text;
+            ThreadHelper.FileAndForget(() => new Plink().ConnectAsync(url));
         }
 
         private void RemoteBranchesDataError(object sender, DataGridViewDataErrorEventArgs e)

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -232,20 +232,15 @@ namespace GitUI.CommandsDialogs
 
             _previewedItem = CurrentItem;
 
-            var content = Module.ShowObject(_previewedItem.ObjectId) ?? "";
+            string content = Module.ShowObject(_previewedItem.ObjectId) ?? "";
             if (_previewedItem.ObjectType == LostObjectType.Commit)
             {
-                ThreadHelper.JoinableTaskFactory.RunAsync(() =>
-                    fileViewer.ViewFixedPatchAsync("commit.patch", content, null))
-                .FileAndForget();
+                fileViewer.InvokeAndForget(() => fileViewer.ViewFixedPatchAsync("commit.patch", content, openWithDifftool: null));
             }
             else
             {
-                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-                {
-                    var filename = GuessFileTypeWithContent(content);
-                    await fileViewer.ViewTextAsync(filename, content, null);
-                }).FileAndForget();
+                string filename = GuessFileTypeWithContent(content);
+                fileViewer.InvokeAndForget(() => fileViewer.ViewTextAsync(filename, content, openWithDifftool: null));
             }
         }
 

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -131,11 +131,8 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
         private void PopulateBranchesComboAndEnableCreateButton(IHostedRemote remote, ComboBox comboBox)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                    async () =>
+            ThreadHelper.FileAndForget(async () =>
                     {
-                        await TaskScheduler.Default;
-
                         try
                         {
                             IHostedRepository hostedRepository = remote.GetHostedRepository();
@@ -175,8 +172,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                                     SizeToContent = true
                                 });
                         }
-                    })
-                .FileAndForget();
+                    });
         }
 
         private void _yourBranchCB_SelectedIndexChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -88,13 +88,10 @@ namespace GitUI.CommandsDialogs.RepoHosting
             myReposLV.Items.Clear();
             myReposLV.Items.Add(new ListViewItem { Text = _strLoading.Text });
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                async () =>
+            ThreadHelper.FileAndForget(async () =>
                 {
                     try
                     {
-                        await TaskScheduler.Default;
-
                         var repos = _gitHoster.GetMyRepos();
 
                         await this.SwitchToMainThreadAsync();
@@ -126,8 +123,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                         helpTextLbl.Text = string.Format(_strFailedToGetRepos.Text, _gitHoster.Name) +
                                             "\r\n\r\nException: " + ex.Message + "\r\n\r\n" + helpTextLbl.Text;
                     }
-                })
-                .FileAndForget();
+                });
         }
 
         private const int ResizeOnContent = -1;
@@ -151,13 +147,10 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
             PrepareSearch(sender, e);
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                async () =>
+            ThreadHelper.FileAndForget(async () =>
                 {
                     try
                     {
-                        await TaskScheduler.Default;
-
                         var repositories = _gitHoster.SearchForRepository(search);
 
                         await this.SwitchToMainThreadAsync();
@@ -171,8 +164,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                         MessageBox.Show(this, _strSearchFailed.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         searchBtn.Enabled = true;
                     }
-                })
-                .FileAndForget();
+                });
         }
 
         private void _getFromUserBtn_Click(object sender, EventArgs e)
@@ -185,13 +177,10 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
             PrepareSearch(sender, e);
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                async () =>
+            ThreadHelper.FileAndForget(async () =>
                 {
                     try
                     {
-                        await TaskScheduler.Default;
-
                         var repositories = _gitHoster.GetRepositoriesOfUser(search.Trim());
 
                         await this.SwitchToMainThreadAsync();
@@ -214,8 +203,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
                         searchBtn.Enabled = true;
                     }
-                })
-                .FileAndForget();
+                });
         }
 
         private void PrepareSearch(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -130,13 +130,10 @@ namespace GitUI.CommandsDialogs.RepoHosting
             _selectHostedRepoCB.Enabled = false;
             ResetAllAndShowLoadingPullRequests();
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                async () =>
+            ThreadHelper.FileAndForget(async () =>
                 {
                     try
                     {
-                        await TaskScheduler.Default;
-
                         var pullRequests = hostedRepo.GetPullRequests();
 
                         await this.SwitchToMainThreadAsync();
@@ -148,8 +145,9 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     {
                         MessageBox.Show(this, _strFailedToFetchPullData.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
-                })
-                .FileAndForget();
+                });
+
+            return;
 
             void SelectNextHostedRepositoryIfFirstLoad()
             {
@@ -324,13 +322,10 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
         private void LoadDiscussion()
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                async () =>
+            ThreadHelper.FileAndForget(async () =>
                 {
                     try
                     {
-                        await TaskScheduler.Default;
-
                         // TODO make this operation async (requires change to Git.hub submodule)
                         Validates.NotNull(_currentPullRequestInfo);
                         var discussion = _currentPullRequestInfo.GetDiscussion();
@@ -344,8 +339,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                         MessageBox.Show(this, _strCouldNotLoadDiscussion.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         LoadDiscussion(null);
                     }
-                })
-                .FileAndForget();
+                });
         }
 
         private void LoadDiscussion(IPullRequestDiscussion? discussion)
@@ -366,8 +360,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
         private void LoadDiffPatch()
         {
             Validates.NotNull(_currentPullRequestInfo);
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                async () =>
+            ThreadHelper.FileAndForget(async () =>
                 {
                     try
                     {
@@ -381,8 +374,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     {
                         MessageBox.Show(this, _strFailedToLoadDiffData.Text + Environment.NewLine + ex.Message, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
-                })
-                .FileAndForget();
+                });
         }
 
         private void SplitAndLoadDiff(string diffData, string baseSha, string secondSha)

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -151,7 +151,7 @@ See the changes in the commit form.");
                 tvGitTree.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(tvGitTree_AfterSelect);
                 tvGitTree.SelectedNode.EnsureVisible();
 
-                ThreadHelper.JoinableTaskFactory.RunAsync(() => ShowGitItemAsync(gitItem, line));
+                this.InvokeAndForget(() => ShowGitItemAsync(gitItem, line));
             }
             else
             {
@@ -413,7 +413,9 @@ See the changes in the commit form.");
 
         private void tvGitTree_AfterSelect(object sender, TreeViewEventArgs e)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(ViewItem);
+            this.InvokeAndForget(ViewItem);
+
+            return;
 
             Task ViewItem()
             {
@@ -533,7 +535,7 @@ See the changes in the commit form.");
             int? line = FileText.Visible ? FileText.CurrentFileLine : BlameControl.CurrentFileLine;
             blameToolStripMenuItem1.Checked = !blameToolStripMenuItem1.Checked;
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(() => ShowGitItemAsync(gitItem, line));
+            this.InvokeAndForget(() => ShowGitItemAsync(gitItem, line));
         }
 
         private bool TryGetSelectedName([NotNullWhen(returnValue: true)] out string? name)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
@@ -54,8 +54,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         protected override void SettingsToPage()
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                async () =>
+            ThreadHelper.FileAndForget(async () =>
                 {
                     Validates.NotNull(_populateBuildServerTypeTask);
 

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -41,7 +41,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
                 var selectedBranch = UICommands.GitModule.GetSelectedBranch();
                 ExistingBranches = Module.GetRefs(RefsFilter.Heads);
                 comboBoxBranches.Text = TranslatedStrings.LoadingData;
-                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                ThreadHelper.FileAndForget(async () =>
                 {
                     await _branchesLoader.LoadAsync(
                         () => ExistingBranches.Where(r => r.Name != selectedBranch).ToList(),

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -92,13 +92,13 @@ namespace GitUI.CommitInfo
 
             UICommandsSourceSet += delegate
             {
-                this.InvokeAsync(() =>
+                this.InvokeAndForget(() =>
                 {
                     UICommandsSource.UICommandsChanged += delegate { RefreshSortedTags(); };
 
                     // call this event handler also now (necessary for "Contained in branches/tags")
                     RefreshSortedTags();
-                }).FileAndForget();
+                });
             };
 
             _commitDataManager = new CommitDataManager(() => Module);

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -53,7 +53,7 @@ namespace GitUI.CommitInfo
 
         public void ShowCommitInfo(GitRevision revision, IReadOnlyList<ObjectId>? children)
         {
-            this.InvokeAsync(() =>
+            this.InvokeAndForget(() =>
             {
                 var data = _commitDataManager.CreateFromRevision(revision, children);
                 var header = _commitDataHeaderRenderer.Render(data, showRevisionsAsLinks: CommandClicked is not null);
@@ -69,7 +69,7 @@ namespace GitUI.CommitInfo
                 rtbRevisionHeader.ResumeLayout(true);
 
                 LoadAuthorImage(revision);
-            }).FileAndForget();
+            });
         }
 
         public string GetPlainText()

--- a/GitUI/CustomDiffMergeToolProvider.cs
+++ b/GitUI/CustomDiffMergeToolProvider.cs
@@ -44,7 +44,7 @@ namespace GitUI
                 return;
             }
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            ThreadHelper.FileAndForget(async () =>
             {
                 // get the tools, possibly with a delay as requesting requires considerable time
                 // cache is shared
@@ -103,7 +103,7 @@ namespace GitUI
                         menu.MenuItem.DropDown.Items.Add(disableItem);
                     }
                 }
-            }).FileAndForget();
+            });
             return;
 
             static void InitMenus(IList<CustomDiffMergeTool> menus)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -997,6 +997,8 @@ namespace GitUI.Editor
         /// <param name="text">Metadata for linepatching.</param>
         private void ResetView(ViewMode viewMode, string? fileName, FileStatusItem? item = null, string? text = null)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             _viewMode = viewMode;
             _viewItem = item;
             if (_viewMode == ViewMode.Text
@@ -1232,11 +1234,7 @@ namespace GitUI.Editor
 
         private void UICommands_PostSettings(object sender, GitUIPostActionEventArgs? e)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-            {
-                await internalFileViewer.SwitchToMainThreadAsync();
-                internalFileViewer.VRulerPosition = AppSettings.DiffVerticalRulerPosition;
-            }).FileAndForget();
+            internalFileViewer.InvokeAndForget(() => internalFileViewer.VRulerPosition = AppSettings.DiffVerticalRulerPosition);
         }
 
         private void IgnoreWhitespaceAtEolToolStripMenuItem_Click(object sender, EventArgs e)
@@ -1959,8 +1957,8 @@ namespace GitUI.Editor
             switch (command)
             {
                 case Command.Find: internalFileViewer.Find(); break;
-                case Command.FindNextOrOpenWithDifftool: ThreadHelper.JoinableTaskFactory.RunAsync(() => internalFileViewer.FindNextAsync(searchForwardOrOpenWithDifftool: true)); break;
-                case Command.FindPrevious: ThreadHelper.JoinableTaskFactory.RunAsync(() => internalFileViewer.FindNextAsync(searchForwardOrOpenWithDifftool: false)); break;
+                case Command.FindNextOrOpenWithDifftool: internalFileViewer.InvokeAndForget(() => internalFileViewer.FindNextAsync(searchForwardOrOpenWithDifftool: true)); break;
+                case Command.FindPrevious: internalFileViewer.InvokeAndForget(() => internalFileViewer.FindNextAsync(searchForwardOrOpenWithDifftool: false)); break;
                 case Command.GoToLine: goToLineToolStripMenuItem.PerformClick(); break;
                 case Command.IncreaseNumberOfVisibleLines: increaseNumberOfLinesToolStripMenuItem.PerformClick(); break;
                 case Command.DecreaseNumberOfVisibleLines: decreaseNumberOfLinesToolStripMenuItem.PerformClick(); break;

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -258,7 +258,7 @@ namespace GitUI.Editor
             {
                 _encoding = value;
 
-                this.InvokeAsync(() =>
+                this.InvokeAndForget(() =>
                 {
                     if (_encoding is not null)
                     {
@@ -268,7 +268,7 @@ namespace GitUI.Editor
                     {
                         encodingToolStripComboBox.SelectedIndex = -1;
                     }
-                }).FileAndForget();
+                });
             }
         }
 

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -231,6 +231,8 @@ namespace GitUI.Editor
 
         public void SetText(string text, Action? openWithDifftool, bool isDiff, bool isRangeDiff)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             _currentViewPositionCache.Capture();
 
             OpenWithDifftool = openWithDifftool;

--- a/GitUI/Editor/FindAndReplaceForm.cs
+++ b/GitUI/Editor/FindAndReplaceForm.cs
@@ -119,18 +119,14 @@ namespace GitUI
 
         private void btnFindPrevious_Click(object sender, EventArgs e)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-            {
-                await FindNextAsync(false, true, _textNotFoundString.Text);
-            }).FileAndForget();
+            Validates.NotNull(_editor);
+            _editor.InvokeAndForget(() => FindNextAsync(viaF3: false, searchBackward: true, _textNotFoundString.Text));
         }
 
         private void btnFindNext_Click(object sender, EventArgs e)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-            {
-                await FindNextAsync(false, false, _textNotFoundString.Text);
-            }).FileAndForget();
+            Validates.NotNull(_editor);
+            _editor.InvokeAndForget(() => FindNextAsync(viaF3: false, searchBackward: false, _textNotFoundString.Text));
         }
 
         public async Task<TextRange?> FindNextAsync(bool viaF3, bool searchBackward, string? messageIfNotFound)
@@ -307,7 +303,7 @@ namespace GitUI
         {
             Validates.NotNull(_editor);
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            _editor.InvokeAndForget(async () =>
             {
                 SelectionManager sm = _editor.ActiveTextAreaControl.SelectionManager;
                 if (string.Equals(sm.SelectedText, txtLookFor.Text, StringComparison.OrdinalIgnoreCase))
@@ -316,7 +312,7 @@ namespace GitUI
                 }
 
                 await FindNextAsync(false, _lastSearchWasBackward, _textNotFoundString.Text);
-            }).FileAndForget();
+            });
         }
 
         private void btnReplaceAll_Click(object sender, EventArgs e)

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -233,35 +233,6 @@ namespace GitUI
             }
         }
 
-        public static async Task InvokeAsync(this Control control, Action action, CancellationToken token = default)
-        {
-            await control.SwitchToMainThreadAsync(token);
-            action();
-        }
-
-        public static async Task InvokeAsync<T>(this Control control, Action<T> action, T state, CancellationToken token = default)
-        {
-            await control.SwitchToMainThreadAsync(token);
-            action(state);
-        }
-
-        public static void InvokeSync(this Control control, Action action)
-        {
-            ThreadHelper.JoinableTaskFactory.Run(
-                async () =>
-                {
-                    try
-                    {
-                        await InvokeAsync(control, action);
-                    }
-                    catch (Exception e)
-                    {
-                        e.Data["StackTrace" + e.Data.Count] = e.StackTrace;
-                        throw;
-                    }
-                });
-        }
-
         public static Control FindFocusedControl(this ContainerControl container)
         {
             while (true)

--- a/GitUI/HelperDialogs/FormEdit.cs
+++ b/GitUI/HelperDialogs/FormEdit.cs
@@ -13,8 +13,7 @@
         {
             InitializeComponent();
             InitializeComplete();
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                () => Viewer.ViewTextAsync("", text));
+            Viewer.InvokeAndForget(() => Viewer.ViewTextAsync("", text));
             Viewer.IsReadOnly = false;
         }
 

--- a/GitUI/HelperDialogs/FormProcess.cs
+++ b/GitUI/HelperDialogs/FormProcess.cs
@@ -197,7 +197,7 @@ namespace GitUI.HelperDialogs
         {
             if (e.Text.Contains("%") || e.Text.Contains("remote: Counting objects"))
             {
-                ThreadHelper.JoinableTaskFactory.RunAsync(() => SetProgressAsync(e.Text)).FileAndForget();
+                this.InvokeAndForget(() => SetProgressAsync(e.Text));
             }
             else
             {

--- a/GitUI/HelperDialogs/FormProcess.cs
+++ b/GitUI/HelperDialogs/FormProcess.cs
@@ -168,7 +168,7 @@ namespace GitUI.HelperDialogs
 
         private void OnExit(int exitcode)
         {
-            this.InvokeAsync(() =>
+            this.InvokeAndForget(() =>
             {
                 bool isError;
                 try
@@ -186,7 +186,7 @@ namespace GitUI.HelperDialogs
                 }
 
                 Done(!isError);
-            }).FileAndForget();
+            });
         }
 
         protected virtual void DataReceived(object sender, TextEventArgs e)

--- a/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -309,7 +309,7 @@ namespace GitUI.LeftPanel
                 selectedGuid = selectedRevision.IsArtificial ? "HEAD" : selectedRevision.Guid;
             }
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            ThreadHelper.FileAndForget(async () =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 HashSet<string> mergedBranches = selectedGuid is null
@@ -318,7 +318,7 @@ namespace GitUI.LeftPanel
 
                 selectedRevision?.Refs.ForEach(gitRef => mergedBranches.Remove(gitRef.CompleteName));
 
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                await treeMain.SwitchToMainThreadAsync(cancellationToken);
 
                 try
                 {
@@ -332,7 +332,7 @@ namespace GitUI.LeftPanel
                 {
                     treeMain.EndUpdate();
                 }
-            }).FileAndForget();
+            });
 
             static ObjectId? GetSelectedNodeObjectId(TreeNode treeNode)
             {

--- a/GitUI/LeftPanel/SubmoduleTree.cs
+++ b/GitUI/LeftPanel/SubmoduleTree.cs
@@ -36,7 +36,7 @@ namespace GitUI.LeftPanel
 
         private void OnStatusUpdated(SubmoduleStatusEventArgs e)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            TreeViewNode.TreeView.InvokeAndForget(async () =>
             {
                 CancellationTokenSource? cts = null;
                 Task<Nodes>? loadNodesTask = null;
@@ -111,7 +111,7 @@ namespace GitUI.LeftPanel
                 }
 
                 Interlocked.CompareExchange(ref _currentSubmoduleInfo, null, e);
-            }).FileAndForget();
+            });
         }
 
         private async Task<Nodes> LoadNodesAsync(SubmoduleInfoResult info, CancellationToken token)

--- a/GitUI/RepositoryHistoryUIService.cs
+++ b/GitUI/RepositoryHistoryUIService.cs
@@ -46,13 +46,12 @@ namespace GitUI
                 item.ToolTipText = repo.Path;
             }
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            ThreadHelper.FileAndForget(async () =>
             {
-                await TaskScheduler.Default;
                 string branchName = _repositoryCurrentBranchNameProvider.GetCurrentBranchName(repo.Path);
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 item.ShortcutKeyDisplayString = branchName;
-            }).FileAndForget();
+            });
         }
 
         private void ChangeWorkingDir(string path)

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -387,8 +387,7 @@ namespace GitUI.SpellChecker
             Validates.NotNull(_autoCompleteListTask);
             Validates.NotNull(_spelling);
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                async () =>
+            ThreadHelper.FileAndForget(async () =>
                 {
                     IEnumerable<AutoCompleteWord> words = await _autoCompleteListTask.GetValueAsync(cancellationToken);
                     await this.SwitchToMainThreadAsync(cancellationToken);

--- a/GitUI/UserControls/AvatarControl.cs
+++ b/GitUI/UserControls/AvatarControl.cs
@@ -61,15 +61,12 @@ namespace GitUI
 
         public void ClearCache()
         {
-            ThreadHelper.JoinableTaskFactory
-                .RunAsync(
-                    async () =>
+            this.InvokeAndForget(async () =>
                     {
                         AvatarService.UpdateAvatarProvider();
                         await _avatarCacheCleaner.ClearCacheAsync().ConfigureAwait(true);
                         await UpdateAvatarAsync().ConfigureAwait(false);
-                    })
-                .FileAndForget();
+                    });
         }
 
         /// <summary>
@@ -103,7 +100,7 @@ namespace GitUI
 
             Email = email;
             AuthorName = name;
-            ThreadHelper.JoinableTaskFactory.RunAsync(() => UpdateAvatarAsync()).FileAndForget();
+            ThreadHelper.FileAndForget(UpdateAvatarAsync);
         }
 
         private void RefreshImage(Image? image)

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -309,11 +309,9 @@ namespace GitUI.Blame
 
             Validates.NotNull(_fileName);
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                () => BlameAuthor.ViewTextAsync("committer.txt", gutter));
+            BlameAuthor.InvokeAndForget(() => BlameAuthor.ViewTextAsync("committer.txt", gutter));
             cancellationToken.ThrowIfCancellationRequested();
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                () => BlameFile.ViewTextAsync(_fileName, body));
+            BlameFile.InvokeAndForget(() => BlameFile.ViewTextAsync(_fileName, body));
             cancellationToken.ThrowIfCancellationRequested();
 
             BlameFile.GoToLine(Math.Min(lineNumber, _blame.Lines.Count));

--- a/GitUI/UserControls/BranchSelector.cs
+++ b/GitUI/UserControls/BranchSelector.cs
@@ -118,10 +118,8 @@ namespace GitUI.UserControls
                     return;
                 }
 
-                ThreadHelper.JoinableTaskFactory.RunAsync(
-                    async () =>
+                ThreadHelper.FileAndForget(async () =>
                     {
-                        await TaskScheduler.Default.SwitchTo(alwaysYield: true);
                         var text = Module.GetCommitCountString(currentCheckout.ToString(), branchName);
                         await this.SwitchToMainThreadAsync();
                         lbChanges.Text = text;

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -82,24 +82,17 @@ namespace GitUI.UserControls
 
         private void DiffFiles_SelectedIndexChanged(object sender, EventArgs e)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-            {
-                await ViewSelectedDiffAsync();
-            }).FileAndForget();
+            ViewSelectedDiff();
         }
 
         private void DiffText_ExtraDiffArgumentsChanged(object sender, EventArgs e)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-            {
-                await ViewSelectedDiffAsync();
-            }).FileAndForget();
+            ViewSelectedDiff();
         }
 
-        private async Task ViewSelectedDiffAsync()
+        private void ViewSelectedDiff()
         {
-            await DiffText.ViewChangesAsync(DiffFiles.SelectedItem,
-                cancellationToken: _viewChangesSequence.Next());
+            DiffText.InvokeAndForget(() => DiffText.ViewChangesAsync(DiffFiles.SelectedItem, cancellationToken: _viewChangesSequence.Next()));
         }
     }
 }

--- a/GitUI/UserControls/CommitPickerSmallControl.cs
+++ b/GitUI/UserControls/CommitPickerSmallControl.cs
@@ -52,11 +52,8 @@ namespace GitUI.UserControls
             else
             {
                 textBoxCommitHash.Text = SelectedObjectId.ToShortString();
-                ThreadHelper.JoinableTaskFactory.RunAsync(
-                    async () =>
+                ThreadHelper.FileAndForget(async () =>
                     {
-                        await TaskScheduler.Default.SwitchTo(alwaysYield: true);
-
                         var currentCheckout = Module.GetCurrentCheckout();
 
                         Validates.NotNull(currentCheckout);

--- a/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -131,7 +131,7 @@ namespace GitUI.UserControls
                 process.ErrorDataReceived += (sender, args) => FireDataReceived(new TextEventArgs((args.Data ?? "") + '\n'));
                 process.Exited += delegate
                 {
-                    this.InvokeAsync(
+                    this.InvokeAndForget(
                         () =>
                         {
                             if (_process is null)
@@ -159,7 +159,7 @@ namespace GitUI.UserControls
                             _outputThrottle?.FlushOutput();
                             FireProcessExited();
                             _outputThrottle?.Stop(flush: true);
-                        }).FileAndForget();
+                        });
                 };
 
                 process.Start();

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -185,7 +185,7 @@ namespace GitUI
                     Text = TranslatedStrings.OpenWithGitExtensions,
                     Image = Images.GitExtensionsLogo16
                 };
-                item.Click += (_, _) => { ThreadHelper.JoinableTaskFactory.RunAsync(OpenSubmoduleAsync); };
+                item.Click += (_, _) => this.InvokeAndForget(OpenSubmoduleAsync);
                 return item;
             }
 
@@ -1072,7 +1072,7 @@ namespace GitUI
                     {
                         var capturedItem = item;
 
-                        ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                        ThreadHelper.FileAndForget(async () =>
                         {
 #pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
                             await task;
@@ -1443,9 +1443,8 @@ namespace GitUI
                 {
                     AppSettings.ShowDiffForAllParents = showAllDiferencesItem.Checked;
                     FileStatusListLoading();
-                    ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                    ThreadHelper.FileAndForget(async () =>
                     {
-                        await TaskScheduler.Default;
                         IReadOnlyList<FileStatusWithDescription> gitItemStatusesWithDescription = _diffCalculator.Reload();
 
                         await this.SwitchToMainThreadAsync();
@@ -1478,7 +1477,7 @@ namespace GitUI
 
                 if (AppSettings.OpenSubmoduleDiffInSeparateWindow && SelectedItem.Item.IsSubmodule)
                 {
-                    ThreadHelper.JoinableTaskFactory.RunAsync(OpenSubmoduleAsync);
+                    this.InvokeAndForget(OpenSubmoduleAsync);
                 }
                 else
                 {

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -281,10 +281,8 @@ namespace GitUI.UserControls
             }
 
             Enabled = true;
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            ThreadHelper.FileAndForget(async () =>
             {
-                await TaskScheduler.Default;
-
                 if (_getRefs is null)
                 {
                     Debug.Fail("getRefs is unexpectedly null");
@@ -297,7 +295,7 @@ namespace GitUI.UserControls
 
                 await this.SwitchToMainThreadAsync();
                 BindBranches(branches);
-            }).FileAndForget();
+            });
 
             return;
 

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -435,10 +435,8 @@ namespace GitUI.UserControls.RevisionGrid
             else
             {
                 // Rows have not been selected yet
-                ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                this.InvokeAndForget(async () =>
                 {
-                    await this.SwitchToMainThreadAsync();
-
                     SetRowCountAndSelectRowsIfReady();
 
                     if (_toBeSelectedGraphIndexesCache.Value.Count == 0)
@@ -477,8 +475,7 @@ namespace GitUI.UserControls.RevisionGrid
                     }
 
                     MarkAsDataLoadingComplete();
-                })
-                .FileAndForget();
+                });
             }
 
             foreach (ColumnProvider columnProvider in _columnProviders)

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -118,7 +118,7 @@ namespace GitUI.UserControls.RevisionGrid
             {
                 // We have to post this since the thread owns a lock on GraphData that we'll
                 // need in order to re-draw the graph.
-                this.InvokeAsync(() =>
+                this.InvokeAndForget(() =>
                     {
                         Debug.Assert(_rowHeight != 0, "_rowHeight != 0");
 
@@ -129,8 +129,7 @@ namespace GitUI.UserControls.RevisionGrid
                         }
 
                         Invalidate();
-                    })
-                    .FileAndForget();
+                    });
             };
 
             VirtualMode = true;
@@ -704,7 +703,8 @@ namespace GitUI.UserControls.RevisionGrid
                         }
                     }
 
-                    await this.InvokeAsync(NotifyProvidersVisibleRowRangeChanged);
+                    await this.SwitchToMainThreadAsync();
+                    NotifyProvidersVisibleRowRangeChanged();
                 }
             }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1212,7 +1212,7 @@ namespace GitUI
                 if (!firstRevisionReceived)
                 {
                     // Wait for refs,CurrentCheckout and stashes as second step
-                    this.InvokeAsync(() => { ShowLoading(showSpinner: false); }).FileAndForget();
+                    this.InvokeAndForget(() => ShowLoading(showSpinner: false));
                     semaphoreUpdateGrid.Wait(cancellationToken);
                     semaphoreUpdateGrid.Wait(cancellationToken);
                     firstRevisionReceived = true;
@@ -1317,13 +1317,11 @@ namespace GitUI
                 _refreshRevisionsSequence.CancelCurrent();
 
                 _gridView.MarkAsDataLoadingComplete();
-                this.InvokeAsync(() => SetPage(new ErrorControl()))
-                    .FileAndForget();
+                this.InvokeAndForget(() => SetPage(new ErrorControl()));
                 _isRefreshingRevisions = false;
 
                 // Rethrow the exception on the UI thread
-                this.InvokeAsync(() => throw exception)
-                    .FileAndForget();
+                ThreadHelper.FileAndForget(() => throw exception);
             }
 
             void OnRevisionReadCompleted()

--- a/GitUI/VisualStudioIntegration.cs
+++ b/GitUI/VisualStudioIntegration.cs
@@ -12,10 +12,8 @@ namespace GitUI
     {
         static VisualStudioIntegration()
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            ThreadHelper.FileAndForget(async () =>
             {
-                await TaskScheduler.Default;
-
                 string vswhere = $@"{Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86)}\Microsoft Visual Studio\Installer\vswhere.exe";
                 if (!File.Exists(vswhere))
                 {
@@ -29,7 +27,7 @@ namespace GitUI
                     "-property productPath"
                 };
                 _devEnvPath = await executable.GetOutputAsync(arguments);
-            }).FileAndForget();
+            });
         }
 
         public static void Init()
@@ -39,9 +37,8 @@ namespace GitUI
 
         public static void OpenFile(string filePath)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            ThreadHelper.FileAndForget(async () =>
             {
-                await TaskScheduler.Default;
                 if (!await TryOpenFileInRunningInstanceAsync(filePath))
                 {
                     if (_devEnvPath is not null)
@@ -49,7 +46,7 @@ namespace GitUI
                         using IProcess process = new Executable(_devEnvPath).Start(filePath);
                     }
                 }
-            }).FileAndForget();
+            });
         }
 
         public static async Task<bool> TryOpenFileInRunningInstanceAsync(string filePath)

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -67,9 +67,8 @@ namespace GitExtensions.Plugins.Bitbucket
                 return;
             }
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            ThreadHelper.FileAndForget(async () =>
             {
-                await TaskScheduler.Default;
                 var repositories = await GetRepositoriesAsync();
 
                 await this.SwitchToMainThreadAsync();
@@ -77,7 +76,7 @@ namespace GitExtensions.Plugins.Bitbucket
                 ddlRepositoryTarget.DataSource = repositories.ToList();
                 ddlRepositorySource.Enabled = true;
                 ddlRepositoryTarget.Enabled = true;
-            }).FileAndForget();
+            });
 
             async Task<List<Repository>> GetRepositoriesAsync()
             {
@@ -104,15 +103,14 @@ namespace GitExtensions.Plugins.Bitbucket
                 return;
             }
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            ThreadHelper.FileAndForget(async () =>
             {
-                await TaskScheduler.Default;
                 var pullRequests = await GetPullRequestsAsync();
 
                 await this.SwitchToMainThreadAsync();
                 lbxPullRequests.DataSource = pullRequests;
                 lbxPullRequests.DisplayMember = nameof(PullRequest.DisplayName);
-            }).FileAndForget();
+            });
 
             async Task<List<PullRequest>> GetPullRequestsAsync()
             {

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/SettingsUserControl.cs
@@ -128,7 +128,7 @@ namespace AzureDevOpsIntegration.Settings
 
         private void ExtractLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            this.InvokeAndForget(async () =>
             {
                 var buildUrl = Clipboard.ContainsText() ? Clipboard.GetText() : "";
                 var (success, projectUrl, buildId) = ProjectUrlHelper.TryParseBuildUrl(buildUrl);
@@ -164,7 +164,7 @@ namespace AzureDevOpsIntegration.Settings
                 {
                     MessageBox.Show(_failToExtractDataFromClipboardMessage.Text, _failToExtractDataFromClipboardCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
-            }).FileAndForget();
+            });
         }
     }
 }

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -83,7 +83,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
             checkBoxHeaderCell.CheckBoxClicked += CheckBoxHeader_OnCheckBoxClicked;
             _NO_TRANSLATE_deleteDataGridViewCheckBoxColumn.HeaderText = string.Empty;
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(() => RefreshObsoleteBranchesAsync());
+            this.InvokeAndForget(RefreshObsoleteBranchesAsync);
 
             BranchesGrid.DataSource = _branches;
         }
@@ -181,9 +181,8 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
             SetWorkingState(isWorking: true);
             lblStatus.Text = _deletingBranches.Text;
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            ThreadHelper.FileAndForget(async () =>
             {
-                await TaskScheduler.Default.SwitchTo(alwaysYield: true);
                 try
                 {
                     foreach (var remoteBranch in remoteBranches)
@@ -260,7 +259,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
 
         private void Refresh_Click(object sender, EventArgs e)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(() => RefreshObsoleteBranchesAsync());
+            this.InvokeAndForget(RefreshObsoleteBranchesAsync);
         }
 
         private void CheckBoxHeader_OnCheckBoxClicked(object sender, CheckBoxHeaderCellEventArgs e)

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -71,8 +71,7 @@ namespace GitExtensions.Plugins.JiraCommitHintPlugin
                 return false;
             }
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                async () =>
+            ThreadHelper.FileAndForget(async () =>
                 {
                     var message = await GetMessageToCommitAsync(_jira, _query, _stringTemplate);
                     await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -163,11 +162,10 @@ namespace GitExtensions.Plugins.JiraCommitHintPlugin
                 var localQuery = _jqlQuerySettings.CustomControl.Text;
                 var localStringTemplate = _stringTemplateSetting.CustomControl.Text;
 
-                ThreadHelper.JoinableTaskFactory.RunAsync(
-                    async () =>
+                ThreadHelper.FileAndForget(async () =>
                     {
                         JiraTaskDTO[] message = await GetMessageToCommitAsync(localJira, localQuery, localStringTemplate);
-                        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        await _btnPreview.SwitchToMainThreadAsync();
                         string previewText = message.Length > 0 ? message[0].Text : EmptyQueryResultMessage.Text;
 
                         MessageBox.Show(null, previewText, EmptyQueryResultCaption.Text, MessageBoxButtons.OK, MessageBoxIcon.Information);
@@ -295,7 +293,7 @@ namespace GitExtensions.Plugins.JiraCommitHintPlugin
                 return;
             }
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            ThreadHelper.FileAndForget(async () =>
             {
                 var currentMessages = await GetMessageToCommitAsync(_jira, _query, _stringTemplate);
 

--- a/Plugins/Statistics/GitImpact/ImpactLoader.cs
+++ b/Plugins/Statistics/GitImpact/ImpactLoader.cs
@@ -78,7 +78,7 @@ namespace GitExtensions.Plugins.GitImpact
 
             var tasks = GetTasks(token);
 
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            ThreadHelper.FileAndForget(async () =>
             {
                 try
                 {

--- a/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
+++ b/Plugins/Statistics/GitStatistics/FormGitStatistics.cs
@@ -92,11 +92,8 @@ namespace GitExtensions.Plugins.GitStatistics
 
         private void InitializeCommitCount()
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(
-                async () =>
+            ThreadHelper.FileAndForget(async () =>
                 {
-                    await TaskScheduler.Default.SwitchTo(alwaysYield: true);
-
                     var (totalCommits, commitsPerUser) = _module.GetCommitsByContributor();
 
                     await this.SwitchToMainThreadAsync();
@@ -217,11 +214,7 @@ namespace GitExtensions.Plugins.GitStatistics
             }
 
             // Sync rest to UI thread
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-            {
-                await this.SwitchToMainThreadAsync();
-                UpdateUI(_lineCounter, linesOfCodePerLanguageText.ToString(), extensionValues, extensionLabels);
-            }).FileAndForget();
+            this.InvokeAndForget(() => UpdateUI(_lineCounter, linesOfCodePerLanguageText.ToString(), extensionValues, extensionLabels));
         }
 
         private void UpdateUI(LineCounter lineCounter, string linesOfCodePerLanguageText, decimal[] extensionValues,


### PR DESCRIPTION
Follow-up to #11136 (and https://github.com/gitextensions/gitextensions/pull/11137#discussion_r1293391852)
inspired by d5b8f33de75f04606948ccd632259b9d388eb234

## Proposed changes

- Replace `JoinableTaskFactory.RunAsync()` with exception-safe wrappers `FileAndForget` or `InvokeAndForget`, respectively
- Replace and remove `GitUIExtensions.InvokeSync()` and `GitUIExtensions.InvokeAsync()`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- exisiting tests


## Please do not squash merge ❗

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).