### PR TITLE
Left Panel: Fixup loading on early Dispose

### DIFF
--- a/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -43,7 +43,15 @@ namespace GitUI.LeftPanel
 
         public RepoObjectsTree()
         {
-            Disposed += (s, e) => _selectionCancellationTokenSequence.Dispose();
+            Disposed += (s, e) =>
+                {
+                    _selectionCancellationTokenSequence.Dispose();
+                    _branchesTree.Dispose();
+                    _remotesTree.Dispose();
+                    _tagTree.Dispose();
+                    _stashTree.Dispose();
+                    _submoduleTree.Dispose();
+                };
 
             InitializeComponent();
             InitImageList();


### PR DESCRIPTION
Should improve the stability of Left Panel tests and the loading of the stash tree

## Proposed changes

- Await `_updateSemaphore` with cancellation
- Ignore ObjectDisposedException on the final release of `_updateSemaphore`
- Dispose the Left Panel tree explicitly
- StashTree: Fixup too early release of `_updateSemaphore`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).