### PR TITLE
FormCommitTests: Disable AppSettings.ProvideAutocompletion

### DIFF
--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -19,6 +19,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         private ReferenceRepository _referenceRepository;
 
         // Track the original setting value
+        private bool _provideAutocompletion;
         private bool _showAvailableDiffTools;
 
         // Created once for each test
@@ -35,15 +36,18 @@ namespace GitExtensions.UITests.CommandsDialogs
         public void OneTimeSetUp()
         {
             // Remember the current setting...
+            _provideAutocompletion = AppSettings.ProvideAutocompletion;
             _showAvailableDiffTools = AppSettings.ShowAvailableDiffTools;
 
-            // ...and stop loading custom diff tools
+            // ...and stop loading auto completion and custom diff tools
+            AppSettings.ProvideAutocompletion = false;
             AppSettings.ShowAvailableDiffTools = false;
         }
 
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
+            AppSettings.ProvideAutocompletion = _provideAutocompletion;
             AppSettings.ShowAvailableDiffTools = _showAvailableDiffTools;
             _referenceRepository.Dispose();
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11156

## Proposed changes

- Disable `AppSettings.ProvideAutocompletion` for `FormCommitTests`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).