### PR TITLE
Update cherrypick dialog

### DIFF
--- a/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -247,6 +247,9 @@ namespace GitUI.CommandsDialogs
             AutoScaleMode = AutoScaleMode.Dpi;
             AutoSize = true;
             ClientSize = new Size(614, 420);
+            HelpButton = true;
+            ManualSectionAnchorName = "cherry-pick-commit";
+            ManualSectionSubfolder = "modify_history";
             MaximizeBox = false;
             MinimizeBox = false;
             MinimumSize = new Size(630, 370);

--- a/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -151,7 +151,7 @@ namespace GitUI.CommandsDialogs
             cbxAddReference.Location = new Point(3, 308);
             cbxAddReference.Name = "cbxAddReference";
             cbxAddReference.Size = new Size(584, 19);
-            cbxAddReference.TabIndex = 5;
+            cbxAddReference.TabIndex = 6;
             cbxAddReference.Text = "A&dd commit reference to commit message";
             cbxAddReference.UseVisualStyleBackColor = true;
             // 
@@ -162,7 +162,7 @@ namespace GitUI.CommandsDialogs
             cbxAutoCommit.Location = new Point(3, 333);
             cbxAutoCommit.Name = "cbxAutoCommit";
             cbxAutoCommit.Size = new Size(584, 19);
-            cbxAutoCommit.TabIndex = 6;
+            cbxAutoCommit.TabIndex = 5;
             cbxAutoCommit.Text = "&Automatically create a commit";
             cbxAutoCommit.UseVisualStyleBackColor = true;
             // 

--- a/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -45,6 +45,7 @@ namespace GitUI.CommandsDialogs
             commitSummaryUserControl1 = new UserControls.CommitSummaryUserControl();
             tlpnlMain = new TableLayoutPanel();
             flowLayoutPanel1 = new FlowLayoutPanel();
+            btnAbort = new Button();
             label2 = new Label();
             MainPanel.SuspendLayout();
             ControlsPanel.SuspendLayout();
@@ -60,6 +61,7 @@ namespace GitUI.CommandsDialogs
             // 
             // ControlsPanel
             // 
+            ControlsPanel.Controls.Add(btnAbort);
             ControlsPanel.Controls.Add(btnPick);
             ControlsPanel.Location = new Point(0, 379);
             ControlsPanel.Size = new Size(614, 41);
@@ -79,7 +81,7 @@ namespace GitUI.CommandsDialogs
             // btnPick
             // 
             btnPick.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            btnPick.Location = new Point(515, 8);
+            btnPick.Location = new Point(411, 8);
             btnPick.Name = "btnPick";
             btnPick.Size = new Size(109, 25);
             btnPick.TabIndex = 0;
@@ -227,6 +229,17 @@ namespace GitUI.CommandsDialogs
             flowLayoutPanel1.Size = new Size(584, 30);
             flowLayoutPanel1.TabIndex = 2;
             // 
+            // btnAbort
+            // 
+            btnAbort.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            btnAbort.Location = new Point(526, 8);
+            btnAbort.Name = "btnAbort";
+            btnAbort.Size = new Size(75, 25);
+            btnAbort.TabIndex = 1;
+            btnAbort.Text = "A&bort";
+            btnAbort.UseVisualStyleBackColor = true;
+            btnAbort.Click += btnAbort_Click;
+            // 
             // FormCherryPick
             // 
             AcceptButton = btnPick;
@@ -270,5 +283,6 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.Button btnChooseRevision;
         private System.Windows.Forms.TableLayoutPanel tlpnlMain;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private Button btnAbort;
     }
 }

--- a/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -30,9 +30,9 @@ namespace GitUI.CommandsDialogs
         /// </summary>
         private void InitializeComponent()
         {
+            Label label2;
             Pick = new Button();
             btnChooseRevision = new Button();
-            label2 = new Label();
             ParentsLabel = new Label();
             ParentsList = new UserControls.NativeListView();
             columnHeader1 = new ColumnHeader();
@@ -44,34 +44,40 @@ namespace GitUI.CommandsDialogs
             BranchInfo = new Label();
             commitSummaryUserControl1 = new UserControls.CommitSummaryUserControl();
             mainTableLayoutPanel = new TableLayoutPanel();
-            commitInformationPanel = new TableLayoutPanel();
             flowLayoutPanel1 = new FlowLayoutPanel();
-            tableLayoutPanel3 = new TableLayoutPanel();
-            panelParentsList = new TableLayoutPanel();
+            label2 = new Label();
             MainPanel.SuspendLayout();
             ControlsPanel.SuspendLayout();
             mainTableLayoutPanel.SuspendLayout();
-            commitInformationPanel.SuspendLayout();
             flowLayoutPanel1.SuspendLayout();
-            tableLayoutPanel3.SuspendLayout();
-            panelParentsList.SuspendLayout();
             SuspendLayout();
             // 
             // MainPanel
             // 
             MainPanel.Controls.Add(mainTableLayoutPanel);
-            MainPanel.Size = new Size(623, 323);
+            MainPanel.Size = new Size(637, 390);
             // 
             // ControlsPanel
             // 
             ControlsPanel.Controls.Add(Pick);
-            ControlsPanel.Location = new Point(0, 323);
-            ControlsPanel.Size = new Size(623, 41);
+            ControlsPanel.Location = new Point(0, 390);
+            ControlsPanel.Size = new Size(637, 41);
+            // 
+            // label2
+            // 
+            label2.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left;
+            label2.AutoSize = true;
+            label2.Location = new Point(435, 0);
+            label2.Name = "label2";
+            label2.Size = new Size(138, 30);
+            label2.TabIndex = 33;
+            label2.Text = "C&hoose another revision:";
+            label2.TextAlign = ContentAlignment.MiddleCenter;
             // 
             // Pick
             // 
             Pick.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            Pick.Location = new Point(501, 8);
+            Pick.Location = new Point(515, 8);
             Pick.Name = "Pick";
             Pick.Size = new Size(109, 25);
             Pick.TabIndex = 10;
@@ -83,43 +89,33 @@ namespace GitUI.CommandsDialogs
             // 
             btnChooseRevision.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             btnChooseRevision.Image = Properties.Images.SelectRevision;
-            btnChooseRevision.Location = new Point(69, 33);
+            btnChooseRevision.Location = new Point(579, 3);
             btnChooseRevision.Name = "btnChooseRevision";
             btnChooseRevision.Size = new Size(25, 24);
             btnChooseRevision.TabIndex = 34;
             btnChooseRevision.UseVisualStyleBackColor = true;
             btnChooseRevision.Click += btnChooseRevision_Click;
             // 
-            // label2
-            // 
-            label2.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            label2.AutoSize = true;
-            label2.Location = new Point(3, 0);
-            label2.Name = "label2";
-            label2.Size = new Size(91, 30);
-            label2.TabIndex = 33;
-            label2.Text = "C&hoose another\r\nrevision:";
-            // 
             // ParentsLabel
             // 
             ParentsLabel.AutoSize = true;
-            ParentsLabel.Location = new Point(3, 0);
+            ParentsLabel.Dock = DockStyle.Fill;
+            ParentsLabel.Location = new Point(3, 217);
             ParentsLabel.Name = "ParentsLabel";
-            ParentsLabel.Size = new Size(206, 15);
+            ParentsLabel.Size = new Size(607, 15);
             ParentsLabel.TabIndex = 12;
             ParentsLabel.Text = "This commit is a merge, select &parent:";
             // 
             // ParentsList
             // 
-            ParentsList.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
-            ParentsList.BorderStyle = BorderStyle.FixedSingle;
             ParentsList.Columns.AddRange(new ColumnHeader[] { columnHeader1, columnHeader2, columnHeader3, columnHeader4 });
+            ParentsList.Dock = DockStyle.Fill;
             ParentsList.FullRowSelect = true;
-            ParentsList.Location = new Point(0, 15);
-            ParentsList.Margin = new Padding(0);
+            ParentsList.Location = new Point(6, 238);
+            ParentsList.Margin = new Padding(6);
             ParentsList.MultiSelect = false;
             ParentsList.Name = "ParentsList";
-            ParentsList.Size = new Size(595, 41);
+            ParentsList.Size = new Size(601, 72);
             ParentsList.TabIndex = 13;
             ParentsList.UseCompatibleStateImageBehavior = false;
             ParentsList.View = View.Details;
@@ -146,22 +142,22 @@ namespace GitUI.CommandsDialogs
             // 
             // checkAddReference
             // 
-            checkAddReference.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
             checkAddReference.AutoSize = true;
-            checkAddReference.Location = new Point(3, 28);
+            checkAddReference.Dock = DockStyle.Fill;
+            checkAddReference.Location = new Point(3, 319);
             checkAddReference.Name = "checkAddReference";
-            checkAddReference.Size = new Size(253, 19);
+            checkAddReference.Size = new Size(607, 19);
             checkAddReference.TabIndex = 14;
             checkAddReference.Text = "A&dd commit reference to commit message";
             checkAddReference.UseVisualStyleBackColor = true;
             // 
             // AutoCommit
             // 
-            AutoCommit.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
             AutoCommit.AutoSize = true;
-            AutoCommit.Location = new Point(3, 3);
+            AutoCommit.Dock = DockStyle.Fill;
+            AutoCommit.Location = new Point(3, 344);
             AutoCommit.Name = "AutoCommit";
-            AutoCommit.Size = new Size(189, 19);
+            AutoCommit.Size = new Size(607, 19);
             AutoCommit.TabIndex = 11;
             AutoCommit.Text = "&Automatically create a commit";
             AutoCommit.UseVisualStyleBackColor = true;
@@ -169,23 +165,24 @@ namespace GitUI.CommandsDialogs
             // BranchInfo
             // 
             BranchInfo.AutoSize = true;
+            BranchInfo.Dock = DockStyle.Fill;
             BranchInfo.Location = new Point(3, 0);
             BranchInfo.Name = "BranchInfo";
-            BranchInfo.Size = new Size(137, 15);
+            BranchInfo.Size = new Size(607, 15);
             BranchInfo.TabIndex = 5;
             BranchInfo.Text = "Cherry pick this commit:";
             // 
             // commitSummaryUserControl1
             // 
-            commitSummaryUserControl1.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             commitSummaryUserControl1.AutoSize = true;
             commitSummaryUserControl1.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            commitSummaryUserControl1.Location = new Point(16, 3);
+            commitSummaryUserControl1.Dock = DockStyle.Fill;
+            commitSummaryUserControl1.Location = new Point(16, 18);
             commitSummaryUserControl1.Margin = new Padding(16, 3, 3, 3);
             commitSummaryUserControl1.MinimumSize = new Size(440, 160);
             commitSummaryUserControl1.Name = "commitSummaryUserControl1";
             commitSummaryUserControl1.Revision = null;
-            commitSummaryUserControl1.Size = new Size(475, 160);
+            commitSummaryUserControl1.Size = new Size(594, 160);
             commitSummaryUserControl1.TabIndex = 15;
             // 
             // mainTableLayoutPanel
@@ -194,85 +191,39 @@ namespace GitUI.CommandsDialogs
             mainTableLayoutPanel.ColumnCount = 1;
             mainTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
             mainTableLayoutPanel.Controls.Add(BranchInfo, 0, 0);
-            mainTableLayoutPanel.Controls.Add(commitInformationPanel, 0, 1);
-            mainTableLayoutPanel.Controls.Add(tableLayoutPanel3, 0, 3);
-            mainTableLayoutPanel.Controls.Add(panelParentsList, 0, 2);
+            mainTableLayoutPanel.Controls.Add(commitSummaryUserControl1, 0, 1);
+            mainTableLayoutPanel.Controls.Add(flowLayoutPanel1, 0, 2);
+            mainTableLayoutPanel.Controls.Add(ParentsLabel, 0, 3);
+            mainTableLayoutPanel.Controls.Add(ParentsList, 0, 4);
+            mainTableLayoutPanel.Controls.Add(checkAddReference, 0, 5);
+            mainTableLayoutPanel.Controls.Add(AutoCommit, 0, 6);
             mainTableLayoutPanel.Dock = DockStyle.Fill;
             mainTableLayoutPanel.Location = new Point(12, 12);
             mainTableLayoutPanel.Margin = new Padding(0);
             mainTableLayoutPanel.Name = "mainTableLayoutPanel";
-            mainTableLayoutPanel.RowCount = 4;
+            mainTableLayoutPanel.RowCount = 5;
+            mainTableLayoutPanel.RowStyles.Add(new RowStyle());
+            mainTableLayoutPanel.RowStyles.Add(new RowStyle());
             mainTableLayoutPanel.RowStyles.Add(new RowStyle());
             mainTableLayoutPanel.RowStyles.Add(new RowStyle());
             mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
             mainTableLayoutPanel.RowStyles.Add(new RowStyle());
-            mainTableLayoutPanel.Size = new Size(599, 299);
+            mainTableLayoutPanel.RowStyles.Add(new RowStyle());
+            mainTableLayoutPanel.Size = new Size(613, 366);
             mainTableLayoutPanel.TabIndex = 35;
-            // 
-            // commitInformationPanel
-            // 
-            commitInformationPanel.AutoSize = true;
-            commitInformationPanel.ColumnCount = 2;
-            commitInformationPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-            commitInformationPanel.ColumnStyles.Add(new ColumnStyle());
-            commitInformationPanel.Controls.Add(commitSummaryUserControl1, 0, 0);
-            commitInformationPanel.Controls.Add(flowLayoutPanel1, 1, 0);
-            commitInformationPanel.Dock = DockStyle.Fill;
-            commitInformationPanel.Location = new Point(2, 17);
-            commitInformationPanel.Margin = new Padding(2);
-            commitInformationPanel.Name = "commitInformationPanel";
-            commitInformationPanel.RowCount = 1;
-            commitInformationPanel.RowStyles.Add(new RowStyle());
-            commitInformationPanel.Size = new Size(595, 166);
-            commitInformationPanel.TabIndex = 6;
             // 
             // flowLayoutPanel1
             // 
             flowLayoutPanel1.AutoSize = true;
-            flowLayoutPanel1.Controls.Add(label2);
+            flowLayoutPanel1.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             flowLayoutPanel1.Controls.Add(btnChooseRevision);
+            flowLayoutPanel1.Controls.Add(label2);
             flowLayoutPanel1.Dock = DockStyle.Fill;
-            flowLayoutPanel1.FlowDirection = FlowDirection.TopDown;
-            flowLayoutPanel1.Location = new Point(496, 2);
-            flowLayoutPanel1.Margin = new Padding(2);
+            flowLayoutPanel1.FlowDirection = FlowDirection.RightToLeft;
+            flowLayoutPanel1.Location = new Point(3, 184);
             flowLayoutPanel1.Name = "flowLayoutPanel1";
-            flowLayoutPanel1.Size = new Size(97, 162);
+            flowLayoutPanel1.Size = new Size(607, 30);
             flowLayoutPanel1.TabIndex = 16;
-            // 
-            // tableLayoutPanel3
-            // 
-            tableLayoutPanel3.AutoSize = true;
-            tableLayoutPanel3.ColumnCount = 2;
-            tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-            tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle());
-            tableLayoutPanel3.Controls.Add(checkAddReference, 0, 1);
-            tableLayoutPanel3.Controls.Add(AutoCommit, 0, 0);
-            tableLayoutPanel3.Dock = DockStyle.Fill;
-            tableLayoutPanel3.Location = new Point(2, 247);
-            tableLayoutPanel3.Margin = new Padding(2);
-            tableLayoutPanel3.Name = "tableLayoutPanel3";
-            tableLayoutPanel3.RowCount = 2;
-            tableLayoutPanel3.RowStyles.Add(new RowStyle());
-            tableLayoutPanel3.RowStyles.Add(new RowStyle());
-            tableLayoutPanel3.RowStyles.Add(new RowStyle(SizeType.Absolute, 16F));
-            tableLayoutPanel3.Size = new Size(595, 50);
-            tableLayoutPanel3.TabIndex = 17;
-            // 
-            // panelParentsList
-            // 
-            panelParentsList.ColumnCount = 1;
-            panelParentsList.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-            panelParentsList.Controls.Add(ParentsLabel, 0, 0);
-            panelParentsList.Controls.Add(ParentsList, 0, 1);
-            panelParentsList.Dock = DockStyle.Fill;
-            panelParentsList.Location = new Point(2, 187);
-            panelParentsList.Margin = new Padding(2);
-            panelParentsList.Name = "panelParentsList";
-            panelParentsList.RowCount = 2;
-            panelParentsList.RowStyles.Add(new RowStyle());
-            panelParentsList.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-            panelParentsList.Size = new Size(595, 56);
-            panelParentsList.TabIndex = 18;
             // 
             // FormCherryPick
             // 
@@ -280,10 +231,10 @@ namespace GitUI.CommandsDialogs
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
             AutoSize = true;
-            ClientSize = new Size(623, 364);
+            ClientSize = new Size(637, 431);
             MaximizeBox = false;
             MinimizeBox = false;
-            MinimumSize = new Size(653, 350);
+            MinimumSize = new Size(653, 365);
             Name = "FormCherryPick";
             SizeGripStyle = SizeGripStyle.Hide;
             StartPosition = FormStartPosition.CenterParent;
@@ -295,14 +246,8 @@ namespace GitUI.CommandsDialogs
             ControlsPanel.ResumeLayout(false);
             mainTableLayoutPanel.ResumeLayout(false);
             mainTableLayoutPanel.PerformLayout();
-            commitInformationPanel.ResumeLayout(false);
-            commitInformationPanel.PerformLayout();
             flowLayoutPanel1.ResumeLayout(false);
             flowLayoutPanel1.PerformLayout();
-            tableLayoutPanel3.ResumeLayout(false);
-            tableLayoutPanel3.PerformLayout();
-            panelParentsList.ResumeLayout(false);
-            panelParentsList.PerformLayout();
             ResumeLayout(false);
             PerformLayout();
         }
@@ -321,11 +266,7 @@ namespace GitUI.CommandsDialogs
         private System.Windows.Forms.CheckBox checkAddReference;
         private GitUI.UserControls.CommitSummaryUserControl commitSummaryUserControl1;
         private System.Windows.Forms.Button btnChooseRevision;
-        private System.Windows.Forms.Label label2;
         private System.Windows.Forms.TableLayoutPanel mainTableLayoutPanel;
-        private System.Windows.Forms.TableLayoutPanel commitInformationPanel;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
-        private System.Windows.Forms.TableLayoutPanel panelParentsList;
     }
 }

--- a/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -55,21 +55,21 @@ namespace GitUI.CommandsDialogs
             // MainPanel
             // 
             MainPanel.Controls.Add(tlpnlMain);
-            MainPanel.Size = new Size(637, 390);
+            MainPanel.Size = new Size(614, 379);
             MainPanel.TabIndex = 0;
             // 
             // ControlsPanel
             // 
             ControlsPanel.Controls.Add(btnPick);
-            ControlsPanel.Location = new Point(0, 390);
-            ControlsPanel.Size = new Size(637, 41);
+            ControlsPanel.Location = new Point(0, 379);
+            ControlsPanel.Size = new Size(614, 41);
             ControlsPanel.TabIndex = 1;
             // 
             // label2
             // 
             label2.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left;
             label2.AutoSize = true;
-            label2.Location = new Point(435, 0);
+            label2.Location = new Point(412, 0);
             label2.Name = "label2";
             label2.Size = new Size(138, 30);
             label2.TabIndex = 0;
@@ -91,7 +91,7 @@ namespace GitUI.CommandsDialogs
             // 
             btnChooseRevision.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             btnChooseRevision.Image = Properties.Images.SelectRevision;
-            btnChooseRevision.Location = new Point(579, 3);
+            btnChooseRevision.Location = new Point(556, 3);
             btnChooseRevision.Name = "btnChooseRevision";
             btnChooseRevision.Size = new Size(25, 24);
             btnChooseRevision.TabIndex = 1;
@@ -104,7 +104,7 @@ namespace GitUI.CommandsDialogs
             lblParents.Dock = DockStyle.Fill;
             lblParents.Location = new Point(3, 217);
             lblParents.Name = "lblParents";
-            lblParents.Size = new Size(607, 15);
+            lblParents.Size = new Size(584, 15);
             lblParents.TabIndex = 3;
             lblParents.Text = "This commit is a merge, select &parent:";
             // 
@@ -116,8 +116,8 @@ namespace GitUI.CommandsDialogs
             lvParentsList.Location = new Point(6, 238);
             lvParentsList.Margin = new Padding(6);
             lvParentsList.MultiSelect = false;
-            lvParentsList.Size = new Size(601, 72);
             lvParentsList.Name = "lvParentsList";
+            lvParentsList.Size = new Size(578, 61);
             lvParentsList.TabIndex = 4;
             lvParentsList.UseCompatibleStateImageBehavior = false;
             lvParentsList.View = View.Details;
@@ -146,9 +146,9 @@ namespace GitUI.CommandsDialogs
             // 
             cbxAddReference.AutoSize = true;
             cbxAddReference.Dock = DockStyle.Fill;
-            cbxAddReference.Location = new Point(3, 319);
+            cbxAddReference.Location = new Point(3, 308);
             cbxAddReference.Name = "cbxAddReference";
-            cbxAddReference.Size = new Size(607, 19);
+            cbxAddReference.Size = new Size(584, 19);
             cbxAddReference.TabIndex = 5;
             cbxAddReference.Text = "A&dd commit reference to commit message";
             cbxAddReference.UseVisualStyleBackColor = true;
@@ -157,9 +157,9 @@ namespace GitUI.CommandsDialogs
             // 
             cbxAutoCommit.AutoSize = true;
             cbxAutoCommit.Dock = DockStyle.Fill;
-            cbxAutoCommit.Location = new Point(3, 344);
+            cbxAutoCommit.Location = new Point(3, 333);
             cbxAutoCommit.Name = "cbxAutoCommit";
-            cbxAutoCommit.Size = new Size(607, 19);
+            cbxAutoCommit.Size = new Size(584, 19);
             cbxAutoCommit.TabIndex = 6;
             cbxAutoCommit.Text = "&Automatically create a commit";
             cbxAutoCommit.UseVisualStyleBackColor = true;
@@ -170,7 +170,7 @@ namespace GitUI.CommandsDialogs
             lblBranchInfo.Dock = DockStyle.Fill;
             lblBranchInfo.Location = new Point(3, 0);
             lblBranchInfo.Name = "lblBranchInfo";
-            lblBranchInfo.Size = new Size(607, 15);
+            lblBranchInfo.Size = new Size(584, 15);
             lblBranchInfo.TabIndex = 0;
             lblBranchInfo.Text = "Cherry pick this commit:";
             // 
@@ -184,7 +184,7 @@ namespace GitUI.CommandsDialogs
             commitSummaryUserControl1.MinimumSize = new Size(440, 160);
             commitSummaryUserControl1.Name = "commitSummaryUserControl1";
             commitSummaryUserControl1.Revision = null;
-            commitSummaryUserControl1.Size = new Size(594, 160);
+            commitSummaryUserControl1.Size = new Size(571, 160);
             commitSummaryUserControl1.TabIndex = 1;
             // 
             // tlpnlMain
@@ -211,7 +211,7 @@ namespace GitUI.CommandsDialogs
             tlpnlMain.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
             tlpnlMain.RowStyles.Add(new RowStyle());
             tlpnlMain.RowStyles.Add(new RowStyle());
-            tlpnlMain.Size = new Size(613, 366);
+            tlpnlMain.Size = new Size(590, 355);
             tlpnlMain.TabIndex = 0;
             // 
             // flowLayoutPanel1
@@ -224,7 +224,7 @@ namespace GitUI.CommandsDialogs
             flowLayoutPanel1.FlowDirection = FlowDirection.RightToLeft;
             flowLayoutPanel1.Location = new Point(3, 184);
             flowLayoutPanel1.Name = "flowLayoutPanel1";
-            flowLayoutPanel1.Size = new Size(607, 30);
+            flowLayoutPanel1.Size = new Size(584, 30);
             flowLayoutPanel1.TabIndex = 2;
             // 
             // FormCherryPick
@@ -233,10 +233,10 @@ namespace GitUI.CommandsDialogs
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
             AutoSize = true;
-            ClientSize = new Size(637, 431);
+            ClientSize = new Size(614, 420);
             MaximizeBox = false;
             MinimizeBox = false;
-            MinimumSize = new Size(653, 365);
+            MinimumSize = new Size(630, 370);
             Name = "FormCherryPick";
             SizeGripStyle = SizeGripStyle.Hide;
             StartPosition = FormStartPosition.CenterParent;

--- a/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -48,6 +48,8 @@ namespace GitUI.CommandsDialogs
             flowLayoutPanel1 = new FlowLayoutPanel();
             tableLayoutPanel3 = new TableLayoutPanel();
             panelParentsList = new TableLayoutPanel();
+            MainPanel.SuspendLayout();
+            ControlsPanel.SuspendLayout();
             mainTableLayoutPanel.SuspendLayout();
             commitInformationPanel.SuspendLayout();
             flowLayoutPanel1.SuspendLayout();
@@ -55,12 +57,22 @@ namespace GitUI.CommandsDialogs
             panelParentsList.SuspendLayout();
             SuspendLayout();
             // 
+            // MainPanel
+            // 
+            MainPanel.Controls.Add(mainTableLayoutPanel);
+            MainPanel.Size = new Size(623, 323);
+            // 
+            // ControlsPanel
+            // 
+            ControlsPanel.Controls.Add(Pick);
+            ControlsPanel.Location = new Point(0, 323);
+            ControlsPanel.Size = new Size(623, 41);
+            // 
             // Pick
             // 
             Pick.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            Pick.Location = new Point(475, 22);
+            Pick.Location = new Point(501, 8);
             Pick.Name = "Pick";
-            tableLayoutPanel3.SetRowSpan(Pick, 2);
             Pick.Size = new Size(109, 25);
             Pick.TabIndex = 10;
             Pick.Text = "&Cherry pick";
@@ -107,7 +119,7 @@ namespace GitUI.CommandsDialogs
             ParentsList.Margin = new Padding(0);
             ParentsList.MultiSelect = false;
             ParentsList.Name = "ParentsList";
-            ParentsList.Size = new Size(587, 106);
+            ParentsList.Size = new Size(595, 41);
             ParentsList.TabIndex = 13;
             ParentsList.UseCompatibleStateImageBehavior = false;
             ParentsList.View = View.Details;
@@ -173,7 +185,7 @@ namespace GitUI.CommandsDialogs
             commitSummaryUserControl1.MinimumSize = new Size(440, 160);
             commitSummaryUserControl1.Name = "commitSummaryUserControl1";
             commitSummaryUserControl1.Revision = null;
-            commitSummaryUserControl1.Size = new Size(467, 160);
+            commitSummaryUserControl1.Size = new Size(475, 160);
             commitSummaryUserControl1.TabIndex = 15;
             // 
             // mainTableLayoutPanel
@@ -186,15 +198,15 @@ namespace GitUI.CommandsDialogs
             mainTableLayoutPanel.Controls.Add(tableLayoutPanel3, 0, 3);
             mainTableLayoutPanel.Controls.Add(panelParentsList, 0, 2);
             mainTableLayoutPanel.Dock = DockStyle.Fill;
-            mainTableLayoutPanel.Location = new Point(0, 0);
-            mainTableLayoutPanel.Margin = new Padding(2, 2, 2, 2);
+            mainTableLayoutPanel.Location = new Point(12, 12);
+            mainTableLayoutPanel.Margin = new Padding(0);
             mainTableLayoutPanel.Name = "mainTableLayoutPanel";
             mainTableLayoutPanel.RowCount = 4;
             mainTableLayoutPanel.RowStyles.Add(new RowStyle());
             mainTableLayoutPanel.RowStyles.Add(new RowStyle());
             mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
             mainTableLayoutPanel.RowStyles.Add(new RowStyle());
-            mainTableLayoutPanel.Size = new Size(591, 364);
+            mainTableLayoutPanel.Size = new Size(599, 299);
             mainTableLayoutPanel.TabIndex = 35;
             // 
             // commitInformationPanel
@@ -207,11 +219,11 @@ namespace GitUI.CommandsDialogs
             commitInformationPanel.Controls.Add(flowLayoutPanel1, 1, 0);
             commitInformationPanel.Dock = DockStyle.Fill;
             commitInformationPanel.Location = new Point(2, 17);
-            commitInformationPanel.Margin = new Padding(2, 2, 2, 2);
+            commitInformationPanel.Margin = new Padding(2);
             commitInformationPanel.Name = "commitInformationPanel";
             commitInformationPanel.RowCount = 1;
             commitInformationPanel.RowStyles.Add(new RowStyle());
-            commitInformationPanel.Size = new Size(587, 166);
+            commitInformationPanel.Size = new Size(595, 166);
             commitInformationPanel.TabIndex = 6;
             // 
             // flowLayoutPanel1
@@ -221,8 +233,8 @@ namespace GitUI.CommandsDialogs
             flowLayoutPanel1.Controls.Add(btnChooseRevision);
             flowLayoutPanel1.Dock = DockStyle.Fill;
             flowLayoutPanel1.FlowDirection = FlowDirection.TopDown;
-            flowLayoutPanel1.Location = new Point(488, 2);
-            flowLayoutPanel1.Margin = new Padding(2, 2, 2, 2);
+            flowLayoutPanel1.Location = new Point(496, 2);
+            flowLayoutPanel1.Margin = new Padding(2);
             flowLayoutPanel1.Name = "flowLayoutPanel1";
             flowLayoutPanel1.Size = new Size(97, 162);
             flowLayoutPanel1.TabIndex = 16;
@@ -233,18 +245,17 @@ namespace GitUI.CommandsDialogs
             tableLayoutPanel3.ColumnCount = 2;
             tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
             tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle());
-            tableLayoutPanel3.Controls.Add(Pick, 1, 0);
             tableLayoutPanel3.Controls.Add(checkAddReference, 0, 1);
             tableLayoutPanel3.Controls.Add(AutoCommit, 0, 0);
             tableLayoutPanel3.Dock = DockStyle.Fill;
-            tableLayoutPanel3.Location = new Point(2, 312);
-            tableLayoutPanel3.Margin = new Padding(2, 2, 2, 2);
+            tableLayoutPanel3.Location = new Point(2, 247);
+            tableLayoutPanel3.Margin = new Padding(2);
             tableLayoutPanel3.Name = "tableLayoutPanel3";
             tableLayoutPanel3.RowCount = 2;
             tableLayoutPanel3.RowStyles.Add(new RowStyle());
             tableLayoutPanel3.RowStyles.Add(new RowStyle());
             tableLayoutPanel3.RowStyles.Add(new RowStyle(SizeType.Absolute, 16F));
-            tableLayoutPanel3.Size = new Size(587, 50);
+            tableLayoutPanel3.Size = new Size(595, 50);
             tableLayoutPanel3.TabIndex = 17;
             // 
             // panelParentsList
@@ -255,12 +266,12 @@ namespace GitUI.CommandsDialogs
             panelParentsList.Controls.Add(ParentsList, 0, 1);
             panelParentsList.Dock = DockStyle.Fill;
             panelParentsList.Location = new Point(2, 187);
-            panelParentsList.Margin = new Padding(2, 2, 2, 2);
+            panelParentsList.Margin = new Padding(2);
             panelParentsList.Name = "panelParentsList";
             panelParentsList.RowCount = 2;
             panelParentsList.RowStyles.Add(new RowStyle());
             panelParentsList.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-            panelParentsList.Size = new Size(587, 121);
+            panelParentsList.Size = new Size(595, 56);
             panelParentsList.TabIndex = 18;
             // 
             // FormCherryPick
@@ -269,17 +280,19 @@ namespace GitUI.CommandsDialogs
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
             AutoSize = true;
-            ClientSize = new Size(591, 364);
-            Controls.Add(mainTableLayoutPanel);
+            ClientSize = new Size(623, 364);
             MaximizeBox = false;
             MinimizeBox = false;
-            MinimumSize = new Size(603, 296);
+            MinimumSize = new Size(653, 350);
             Name = "FormCherryPick";
             SizeGripStyle = SizeGripStyle.Hide;
             StartPosition = FormStartPosition.CenterParent;
             Text = "Cherry pick commit";
             FormClosing += Form_Closing;
             Load += Form_Load;
+            MainPanel.ResumeLayout(false);
+            MainPanel.PerformLayout();
+            ControlsPanel.ResumeLayout(false);
             mainTableLayoutPanel.ResumeLayout(false);
             mainTableLayoutPanel.PerformLayout();
             commitInformationPanel.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -199,8 +199,8 @@ namespace GitUI.CommandsDialogs
             tlpnlMain.Controls.Add(flowLayoutPanel1, 0, 2);
             tlpnlMain.Controls.Add(lblParents, 0, 3);
             tlpnlMain.Controls.Add(lvParentsList, 0, 4);
-            tlpnlMain.Controls.Add(cbxAddReference, 0, 5);
-            tlpnlMain.Controls.Add(cbxAutoCommit, 0, 6);
+            tlpnlMain.Controls.Add(cbxAutoCommit, 0, 5);
+            tlpnlMain.Controls.Add(cbxAddReference, 0, 6);
             tlpnlMain.Dock = DockStyle.Fill;
             tlpnlMain.Location = new Point(12, 12);
             tlpnlMain.Margin = new Padding(0);

--- a/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -56,12 +56,14 @@ namespace GitUI.CommandsDialogs
             // 
             MainPanel.Controls.Add(mainTableLayoutPanel);
             MainPanel.Size = new Size(637, 390);
+            MainPanel.TabIndex = 0;
             // 
             // ControlsPanel
             // 
             ControlsPanel.Controls.Add(Pick);
             ControlsPanel.Location = new Point(0, 390);
             ControlsPanel.Size = new Size(637, 41);
+            ControlsPanel.TabIndex = 1;
             // 
             // label2
             // 
@@ -70,7 +72,7 @@ namespace GitUI.CommandsDialogs
             label2.Location = new Point(435, 0);
             label2.Name = "label2";
             label2.Size = new Size(138, 30);
-            label2.TabIndex = 33;
+            label2.TabIndex = 0;
             label2.Text = "C&hoose another revision:";
             label2.TextAlign = ContentAlignment.MiddleCenter;
             // 
@@ -80,7 +82,7 @@ namespace GitUI.CommandsDialogs
             Pick.Location = new Point(515, 8);
             Pick.Name = "Pick";
             Pick.Size = new Size(109, 25);
-            Pick.TabIndex = 10;
+            Pick.TabIndex = 0;
             Pick.Text = "&Cherry pick";
             Pick.UseVisualStyleBackColor = true;
             Pick.Click += Revert_Click;
@@ -92,7 +94,7 @@ namespace GitUI.CommandsDialogs
             btnChooseRevision.Location = new Point(579, 3);
             btnChooseRevision.Name = "btnChooseRevision";
             btnChooseRevision.Size = new Size(25, 24);
-            btnChooseRevision.TabIndex = 34;
+            btnChooseRevision.TabIndex = 1;
             btnChooseRevision.UseVisualStyleBackColor = true;
             btnChooseRevision.Click += btnChooseRevision_Click;
             // 
@@ -103,7 +105,7 @@ namespace GitUI.CommandsDialogs
             ParentsLabel.Location = new Point(3, 217);
             ParentsLabel.Name = "ParentsLabel";
             ParentsLabel.Size = new Size(607, 15);
-            ParentsLabel.TabIndex = 12;
+            ParentsLabel.TabIndex = 3;
             ParentsLabel.Text = "This commit is a merge, select &parent:";
             // 
             // ParentsList
@@ -116,7 +118,7 @@ namespace GitUI.CommandsDialogs
             ParentsList.MultiSelect = false;
             ParentsList.Name = "ParentsList";
             ParentsList.Size = new Size(601, 72);
-            ParentsList.TabIndex = 13;
+            ParentsList.TabIndex = 4;
             ParentsList.UseCompatibleStateImageBehavior = false;
             ParentsList.View = View.Details;
             // 
@@ -147,7 +149,7 @@ namespace GitUI.CommandsDialogs
             checkAddReference.Location = new Point(3, 319);
             checkAddReference.Name = "checkAddReference";
             checkAddReference.Size = new Size(607, 19);
-            checkAddReference.TabIndex = 14;
+            checkAddReference.TabIndex = 5;
             checkAddReference.Text = "A&dd commit reference to commit message";
             checkAddReference.UseVisualStyleBackColor = true;
             // 
@@ -158,7 +160,7 @@ namespace GitUI.CommandsDialogs
             AutoCommit.Location = new Point(3, 344);
             AutoCommit.Name = "AutoCommit";
             AutoCommit.Size = new Size(607, 19);
-            AutoCommit.TabIndex = 11;
+            AutoCommit.TabIndex = 6;
             AutoCommit.Text = "&Automatically create a commit";
             AutoCommit.UseVisualStyleBackColor = true;
             // 
@@ -169,7 +171,7 @@ namespace GitUI.CommandsDialogs
             BranchInfo.Location = new Point(3, 0);
             BranchInfo.Name = "BranchInfo";
             BranchInfo.Size = new Size(607, 15);
-            BranchInfo.TabIndex = 5;
+            BranchInfo.TabIndex = 0;
             BranchInfo.Text = "Cherry pick this commit:";
             // 
             // commitSummaryUserControl1
@@ -183,7 +185,7 @@ namespace GitUI.CommandsDialogs
             commitSummaryUserControl1.Name = "commitSummaryUserControl1";
             commitSummaryUserControl1.Revision = null;
             commitSummaryUserControl1.Size = new Size(594, 160);
-            commitSummaryUserControl1.TabIndex = 15;
+            commitSummaryUserControl1.TabIndex = 1;
             // 
             // mainTableLayoutPanel
             // 
@@ -210,7 +212,7 @@ namespace GitUI.CommandsDialogs
             mainTableLayoutPanel.RowStyles.Add(new RowStyle());
             mainTableLayoutPanel.RowStyles.Add(new RowStyle());
             mainTableLayoutPanel.Size = new Size(613, 366);
-            mainTableLayoutPanel.TabIndex = 35;
+            mainTableLayoutPanel.TabIndex = 0;
             // 
             // flowLayoutPanel1
             // 
@@ -223,7 +225,7 @@ namespace GitUI.CommandsDialogs
             flowLayoutPanel1.Location = new Point(3, 184);
             flowLayoutPanel1.Name = "flowLayoutPanel1";
             flowLayoutPanel1.Size = new Size(607, 30);
-            flowLayoutPanel1.TabIndex = 16;
+            flowLayoutPanel1.TabIndex = 2;
             // 
             // FormCherryPick
             // 

--- a/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -30,279 +30,268 @@ namespace GitUI.CommandsDialogs
         /// </summary>
         private void InitializeComponent()
         {
-            this.Pick = new System.Windows.Forms.Button();
-            this.btnChooseRevision = new System.Windows.Forms.Button();
-            this.label2 = new System.Windows.Forms.Label();
-            this.ParentsLabel = new System.Windows.Forms.Label();
-            this.ParentsList = new UserControls.NativeListView();
-            this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.columnHeader3 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.checkAddReference = new System.Windows.Forms.CheckBox();
-            this.AutoCommit = new System.Windows.Forms.CheckBox();
-            this.BranchInfo = new System.Windows.Forms.Label();
-            this.commitSummaryUserControl1 = new GitUI.UserControls.CommitSummaryUserControl();
-            this.mainTableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
-            this.commitInformationPanel = new System.Windows.Forms.TableLayoutPanel();
-            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-            this.panelParentsList = new System.Windows.Forms.TableLayoutPanel();
-            this.mainTableLayoutPanel.SuspendLayout();
-            this.commitInformationPanel.SuspendLayout();
-            this.flowLayoutPanel1.SuspendLayout();
-            this.tableLayoutPanel3.SuspendLayout();
-            this.panelParentsList.SuspendLayout();
-            this.SuspendLayout();
+            Pick = new Button();
+            btnChooseRevision = new Button();
+            label2 = new Label();
+            ParentsLabel = new Label();
+            ParentsList = new UserControls.NativeListView();
+            columnHeader1 = new ColumnHeader();
+            columnHeader2 = new ColumnHeader();
+            columnHeader3 = new ColumnHeader();
+            columnHeader4 = new ColumnHeader();
+            checkAddReference = new CheckBox();
+            AutoCommit = new CheckBox();
+            BranchInfo = new Label();
+            commitSummaryUserControl1 = new UserControls.CommitSummaryUserControl();
+            mainTableLayoutPanel = new TableLayoutPanel();
+            commitInformationPanel = new TableLayoutPanel();
+            flowLayoutPanel1 = new FlowLayoutPanel();
+            tableLayoutPanel3 = new TableLayoutPanel();
+            panelParentsList = new TableLayoutPanel();
+            mainTableLayoutPanel.SuspendLayout();
+            commitInformationPanel.SuspendLayout();
+            flowLayoutPanel1.SuspendLayout();
+            tableLayoutPanel3.SuspendLayout();
+            panelParentsList.SuspendLayout();
+            SuspendLayout();
             // 
             // Pick
             // 
-            this.Pick.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.Pick.Location = new System.Drawing.Point(586, 35);
-            this.Pick.Margin = new System.Windows.Forms.Padding(4);
-            this.Pick.Name = "Pick";
-            this.tableLayoutPanel3.SetRowSpan(this.Pick, 2);
-            this.Pick.Size = new System.Drawing.Size(136, 31);
-            this.Pick.TabIndex = 10;
-            this.Pick.Text = "&Cherry pick";
-            this.Pick.UseVisualStyleBackColor = true;
-            this.Pick.Click += new System.EventHandler(this.Revert_Click);
+            Pick.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            Pick.Location = new Point(475, 22);
+            Pick.Name = "Pick";
+            tableLayoutPanel3.SetRowSpan(Pick, 2);
+            Pick.Size = new Size(109, 25);
+            Pick.TabIndex = 10;
+            Pick.Text = "&Cherry pick";
+            Pick.UseVisualStyleBackColor = true;
+            Pick.Click += Revert_Click;
             // 
             // btnChooseRevision
             // 
-            this.btnChooseRevision.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnChooseRevision.Image = global::GitUI.Properties.Images.SelectRevision;
-            this.btnChooseRevision.Location = new System.Drawing.Point(105, 50);
-            this.btnChooseRevision.Margin = new System.Windows.Forms.Padding(4);
-            this.btnChooseRevision.Name = "btnChooseRevision";
-            this.btnChooseRevision.Size = new System.Drawing.Size(31, 30);
-            this.btnChooseRevision.TabIndex = 34;
-            this.btnChooseRevision.UseVisualStyleBackColor = true;
-            this.btnChooseRevision.Click += new System.EventHandler(this.btnChooseRevision_Click);
+            btnChooseRevision.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            btnChooseRevision.Image = Properties.Images.SelectRevision;
+            btnChooseRevision.Location = new Point(69, 33);
+            btnChooseRevision.Name = "btnChooseRevision";
+            btnChooseRevision.Size = new Size(25, 24);
+            btnChooseRevision.TabIndex = 34;
+            btnChooseRevision.UseVisualStyleBackColor = true;
+            btnChooseRevision.Click += btnChooseRevision_Click;
             // 
             // label2
             // 
-            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(4, 0);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(132, 46);
-            this.label2.TabIndex = 33;
-            this.label2.Text = "C&hoose another\r\nrevision:";
+            label2.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            label2.AutoSize = true;
+            label2.Location = new Point(3, 0);
+            label2.Name = "label2";
+            label2.Size = new Size(91, 30);
+            label2.TabIndex = 33;
+            label2.Text = "C&hoose another\r\nrevision:";
             // 
             // ParentsLabel
             // 
-            this.ParentsLabel.AutoSize = true;
-            this.ParentsLabel.Location = new System.Drawing.Point(4, 0);
-            this.ParentsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.ParentsLabel.Name = "ParentsLabel";
-            this.ParentsLabel.Size = new System.Drawing.Size(298, 23);
-            this.ParentsLabel.TabIndex = 12;
-            this.ParentsLabel.Text = "This commit is a merge, select &parent:";
+            ParentsLabel.AutoSize = true;
+            ParentsLabel.Location = new Point(3, 0);
+            ParentsLabel.Name = "ParentsLabel";
+            ParentsLabel.Size = new Size(206, 15);
+            ParentsLabel.TabIndex = 12;
+            ParentsLabel.Text = "This commit is a merge, select &parent:";
             // 
             // ParentsList
             // 
-            this.ParentsList.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.ParentsList.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.ParentsList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.columnHeader1,
-            this.columnHeader2,
-            this.columnHeader3,
-            this.columnHeader4});
-            this.ParentsList.FullRowSelect = true;
-            this.ParentsList.HideSelection = false;
-            this.ParentsList.Location = new System.Drawing.Point(0, 23);
-            this.ParentsList.Margin = new System.Windows.Forms.Padding(0);
-            this.ParentsList.MultiSelect = false;
-            this.ParentsList.Name = "ParentsList";
-            this.ParentsList.Size = new System.Drawing.Size(726, 109);
-            this.ParentsList.TabIndex = 13;
-            this.ParentsList.UseCompatibleStateImageBehavior = false;
-            this.ParentsList.View = System.Windows.Forms.View.Details;
+            ParentsList.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            ParentsList.BorderStyle = BorderStyle.FixedSingle;
+            ParentsList.Columns.AddRange(new ColumnHeader[] { columnHeader1, columnHeader2, columnHeader3, columnHeader4 });
+            ParentsList.FullRowSelect = true;
+            ParentsList.Location = new Point(0, 15);
+            ParentsList.Margin = new Padding(0);
+            ParentsList.MultiSelect = false;
+            ParentsList.Name = "ParentsList";
+            ParentsList.Size = new Size(587, 106);
+            ParentsList.TabIndex = 13;
+            ParentsList.UseCompatibleStateImageBehavior = false;
+            ParentsList.View = View.Details;
             // 
             // columnHeader1
             // 
-            this.columnHeader1.Text = "No.";
-            this.columnHeader1.Width = 43;
+            columnHeader1.Text = "No.";
+            columnHeader1.Width = 43;
             // 
             // columnHeader2
             // 
-            this.columnHeader2.Text = "Message";
-            this.columnHeader2.Width = 291;
+            columnHeader2.Text = "Message";
+            columnHeader2.Width = 291;
             // 
             // columnHeader3
             // 
-            this.columnHeader3.Text = "Author";
-            this.columnHeader3.Width = 120;
+            columnHeader3.Text = "Author";
+            columnHeader3.Width = 120;
             // 
             // columnHeader4
             // 
-            this.columnHeader4.Text = "Date";
-            this.columnHeader4.Width = 80;
+            columnHeader4.Text = "Date";
+            columnHeader4.Width = 80;
             // 
             // checkAddReference
             // 
-            this.checkAddReference.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.checkAddReference.AutoSize = true;
-            this.checkAddReference.Location = new System.Drawing.Point(4, 39);
-            this.checkAddReference.Margin = new System.Windows.Forms.Padding(4);
-            this.checkAddReference.Name = "checkAddReference";
-            this.checkAddReference.Size = new System.Drawing.Size(357, 27);
-            this.checkAddReference.TabIndex = 14;
-            this.checkAddReference.Text = "A&dd commit reference to commit message";
-            this.checkAddReference.UseVisualStyleBackColor = true;
+            checkAddReference.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+            checkAddReference.AutoSize = true;
+            checkAddReference.Location = new Point(3, 28);
+            checkAddReference.Name = "checkAddReference";
+            checkAddReference.Size = new Size(253, 19);
+            checkAddReference.TabIndex = 14;
+            checkAddReference.Text = "A&dd commit reference to commit message";
+            checkAddReference.UseVisualStyleBackColor = true;
             // 
             // AutoCommit
             // 
-            this.AutoCommit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.AutoCommit.AutoSize = true;
-            this.AutoCommit.Location = new System.Drawing.Point(4, 4);
-            this.AutoCommit.Margin = new System.Windows.Forms.Padding(4);
-            this.AutoCommit.Name = "AutoCommit";
-            this.AutoCommit.Size = new System.Drawing.Size(265, 27);
-            this.AutoCommit.TabIndex = 11;
-            this.AutoCommit.Text = "&Automatically create a commit";
-            this.AutoCommit.UseVisualStyleBackColor = true;
+            AutoCommit.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+            AutoCommit.AutoSize = true;
+            AutoCommit.Location = new Point(3, 3);
+            AutoCommit.Name = "AutoCommit";
+            AutoCommit.Size = new Size(189, 19);
+            AutoCommit.TabIndex = 11;
+            AutoCommit.Text = "&Automatically create a commit";
+            AutoCommit.UseVisualStyleBackColor = true;
             // 
             // BranchInfo
             // 
-            this.BranchInfo.AutoSize = true;
-            this.BranchInfo.Location = new System.Drawing.Point(4, 0);
-            this.BranchInfo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.BranchInfo.Name = "BranchInfo";
-            this.BranchInfo.Size = new System.Drawing.Size(194, 23);
-            this.BranchInfo.TabIndex = 5;
-            this.BranchInfo.Text = "Cherry pick this commit:";
+            BranchInfo.AutoSize = true;
+            BranchInfo.Location = new Point(3, 0);
+            BranchInfo.Name = "BranchInfo";
+            BranchInfo.Size = new Size(137, 15);
+            BranchInfo.TabIndex = 5;
+            BranchInfo.Text = "Cherry pick this commit:";
             // 
             // commitSummaryUserControl1
             // 
-            this.commitSummaryUserControl1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.commitSummaryUserControl1.AutoSize = true;
-            this.commitSummaryUserControl1.Location = new System.Drawing.Point(20, 4);
-            this.commitSummaryUserControl1.Margin = new System.Windows.Forms.Padding(20, 4, 4, 4);
-            this.commitSummaryUserControl1.MinimumSize = new System.Drawing.Size(550, 200);
-            this.commitSummaryUserControl1.Name = "commitSummaryUserControl1";
-            this.commitSummaryUserControl1.Revision = null;
-            this.commitSummaryUserControl1.Size = new System.Drawing.Size(556, 200);
-            this.commitSummaryUserControl1.TabIndex = 15;
+            commitSummaryUserControl1.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            commitSummaryUserControl1.AutoSize = true;
+            commitSummaryUserControl1.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            commitSummaryUserControl1.Location = new Point(16, 3);
+            commitSummaryUserControl1.Margin = new Padding(16, 3, 3, 3);
+            commitSummaryUserControl1.MinimumSize = new Size(440, 160);
+            commitSummaryUserControl1.Name = "commitSummaryUserControl1";
+            commitSummaryUserControl1.Revision = null;
+            commitSummaryUserControl1.Size = new Size(467, 160);
+            commitSummaryUserControl1.TabIndex = 15;
             // 
             // mainTableLayoutPanel
             // 
-            this.mainTableLayoutPanel.AutoSize = true;
-            this.mainTableLayoutPanel.ColumnCount = 1;
-            this.mainTableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.mainTableLayoutPanel.Controls.Add(this.BranchInfo, 0, 0);
-            this.mainTableLayoutPanel.Controls.Add(this.commitInformationPanel, 0, 1);
-            this.mainTableLayoutPanel.Controls.Add(this.tableLayoutPanel3, 0, 3);
-            this.mainTableLayoutPanel.Controls.Add(this.panelParentsList, 0, 2);
-            this.mainTableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.mainTableLayoutPanel.Location = new System.Drawing.Point(0, 0);
-            this.mainTableLayoutPanel.Name = "mainTableLayoutPanel";
-            this.mainTableLayoutPanel.RowCount = 4;
-            this.mainTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.mainTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.mainTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.mainTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.mainTableLayoutPanel.Size = new System.Drawing.Size(732, 451);
-            this.mainTableLayoutPanel.TabIndex = 35;
+            mainTableLayoutPanel.AutoSize = true;
+            mainTableLayoutPanel.ColumnCount = 1;
+            mainTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            mainTableLayoutPanel.Controls.Add(BranchInfo, 0, 0);
+            mainTableLayoutPanel.Controls.Add(commitInformationPanel, 0, 1);
+            mainTableLayoutPanel.Controls.Add(tableLayoutPanel3, 0, 3);
+            mainTableLayoutPanel.Controls.Add(panelParentsList, 0, 2);
+            mainTableLayoutPanel.Dock = DockStyle.Fill;
+            mainTableLayoutPanel.Location = new Point(0, 0);
+            mainTableLayoutPanel.Margin = new Padding(2, 2, 2, 2);
+            mainTableLayoutPanel.Name = "mainTableLayoutPanel";
+            mainTableLayoutPanel.RowCount = 4;
+            mainTableLayoutPanel.RowStyles.Add(new RowStyle());
+            mainTableLayoutPanel.RowStyles.Add(new RowStyle());
+            mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            mainTableLayoutPanel.RowStyles.Add(new RowStyle());
+            mainTableLayoutPanel.Size = new Size(591, 364);
+            mainTableLayoutPanel.TabIndex = 35;
             // 
             // commitInformationPanel
             // 
-            this.commitInformationPanel.AutoSize = true;
-            this.commitInformationPanel.ColumnCount = 2;
-            this.commitInformationPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.commitInformationPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.commitInformationPanel.Controls.Add(this.commitSummaryUserControl1, 0, 0);
-            this.commitInformationPanel.Controls.Add(this.flowLayoutPanel1, 1, 0);
-            this.commitInformationPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.commitInformationPanel.Location = new System.Drawing.Point(3, 26);
-            this.commitInformationPanel.Name = "commitInformationPanel";
-            this.commitInformationPanel.RowCount = 1;
-            this.commitInformationPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.commitInformationPanel.Size = new System.Drawing.Size(726, 208);
-            this.commitInformationPanel.TabIndex = 6;
+            commitInformationPanel.AutoSize = true;
+            commitInformationPanel.ColumnCount = 2;
+            commitInformationPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            commitInformationPanel.ColumnStyles.Add(new ColumnStyle());
+            commitInformationPanel.Controls.Add(commitSummaryUserControl1, 0, 0);
+            commitInformationPanel.Controls.Add(flowLayoutPanel1, 1, 0);
+            commitInformationPanel.Dock = DockStyle.Fill;
+            commitInformationPanel.Location = new Point(2, 17);
+            commitInformationPanel.Margin = new Padding(2, 2, 2, 2);
+            commitInformationPanel.Name = "commitInformationPanel";
+            commitInformationPanel.RowCount = 1;
+            commitInformationPanel.RowStyles.Add(new RowStyle());
+            commitInformationPanel.Size = new Size(587, 166);
+            commitInformationPanel.TabIndex = 6;
             // 
             // flowLayoutPanel1
             // 
-            this.flowLayoutPanel1.AutoSize = true;
-            this.flowLayoutPanel1.Controls.Add(this.label2);
-            this.flowLayoutPanel1.Controls.Add(this.btnChooseRevision);
-            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(583, 3);
-            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(140, 202);
-            this.flowLayoutPanel1.TabIndex = 16;
+            flowLayoutPanel1.AutoSize = true;
+            flowLayoutPanel1.Controls.Add(label2);
+            flowLayoutPanel1.Controls.Add(btnChooseRevision);
+            flowLayoutPanel1.Dock = DockStyle.Fill;
+            flowLayoutPanel1.FlowDirection = FlowDirection.TopDown;
+            flowLayoutPanel1.Location = new Point(488, 2);
+            flowLayoutPanel1.Margin = new Padding(2, 2, 2, 2);
+            flowLayoutPanel1.Name = "flowLayoutPanel1";
+            flowLayoutPanel1.Size = new Size(97, 162);
+            flowLayoutPanel1.TabIndex = 16;
             // 
             // tableLayoutPanel3
             // 
-            this.tableLayoutPanel3.AutoSize = true;
-            this.tableLayoutPanel3.ColumnCount = 2;
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel3.Controls.Add(this.Pick, 1, 0);
-            this.tableLayoutPanel3.Controls.Add(this.checkAddReference, 0, 1);
-            this.tableLayoutPanel3.Controls.Add(this.AutoCommit, 0, 0);
-            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 378);
-            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.RowCount = 2;
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(726, 70);
-            this.tableLayoutPanel3.TabIndex = 17;
+            tableLayoutPanel3.AutoSize = true;
+            tableLayoutPanel3.ColumnCount = 2;
+            tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle());
+            tableLayoutPanel3.Controls.Add(Pick, 1, 0);
+            tableLayoutPanel3.Controls.Add(checkAddReference, 0, 1);
+            tableLayoutPanel3.Controls.Add(AutoCommit, 0, 0);
+            tableLayoutPanel3.Dock = DockStyle.Fill;
+            tableLayoutPanel3.Location = new Point(2, 312);
+            tableLayoutPanel3.Margin = new Padding(2, 2, 2, 2);
+            tableLayoutPanel3.Name = "tableLayoutPanel3";
+            tableLayoutPanel3.RowCount = 2;
+            tableLayoutPanel3.RowStyles.Add(new RowStyle());
+            tableLayoutPanel3.RowStyles.Add(new RowStyle());
+            tableLayoutPanel3.RowStyles.Add(new RowStyle(SizeType.Absolute, 16F));
+            tableLayoutPanel3.Size = new Size(587, 50);
+            tableLayoutPanel3.TabIndex = 17;
             // 
             // panelParentsList
             // 
-            this.panelParentsList.ColumnCount = 1;
-            this.panelParentsList.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.panelParentsList.Controls.Add(this.ParentsLabel, 0, 0);
-            this.panelParentsList.Controls.Add(this.ParentsList, 0, 1);
-            this.panelParentsList.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelParentsList.Location = new System.Drawing.Point(3, 240);
-            this.panelParentsList.Name = "panelParentsList";
-            this.panelParentsList.RowCount = 2;
-            this.panelParentsList.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.panelParentsList.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.panelParentsList.Size = new System.Drawing.Size(726, 132);
-            this.panelParentsList.TabIndex = 18;
+            panelParentsList.ColumnCount = 1;
+            panelParentsList.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            panelParentsList.Controls.Add(ParentsLabel, 0, 0);
+            panelParentsList.Controls.Add(ParentsList, 0, 1);
+            panelParentsList.Dock = DockStyle.Fill;
+            panelParentsList.Location = new Point(2, 187);
+            panelParentsList.Margin = new Padding(2, 2, 2, 2);
+            panelParentsList.Name = "panelParentsList";
+            panelParentsList.RowCount = 2;
+            panelParentsList.RowStyles.Add(new RowStyle());
+            panelParentsList.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            panelParentsList.Size = new Size(587, 121);
+            panelParentsList.TabIndex = 18;
             // 
             // FormCherryPick
             // 
-            this.AcceptButton = this.Pick;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(732, 451);
-            this.Controls.Add(this.mainTableLayoutPanel);
-            this.Margin = new System.Windows.Forms.Padding(4);
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(750, 360);
-            this.Name = "FormCherryPick";
-            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Cherry pick commit";
-            this.Load += new System.EventHandler(this.Form_Load);
-            this.FormClosing += new FormClosingEventHandler(this.Form_Closing);
-            this.mainTableLayoutPanel.ResumeLayout(false);
-            this.mainTableLayoutPanel.PerformLayout();
-            this.commitInformationPanel.ResumeLayout(false);
-            this.commitInformationPanel.PerformLayout();
-            this.flowLayoutPanel1.ResumeLayout(false);
-            this.flowLayoutPanel1.PerformLayout();
-            this.tableLayoutPanel3.ResumeLayout(false);
-            this.tableLayoutPanel3.PerformLayout();
-            this.panelParentsList.ResumeLayout(false);
-            this.panelParentsList.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AcceptButton = Pick;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
+            AutoSize = true;
+            ClientSize = new Size(591, 364);
+            Controls.Add(mainTableLayoutPanel);
+            MaximizeBox = false;
+            MinimizeBox = false;
+            MinimumSize = new Size(603, 296);
+            Name = "FormCherryPick";
+            SizeGripStyle = SizeGripStyle.Hide;
+            StartPosition = FormStartPosition.CenterParent;
+            Text = "Cherry pick commit";
+            FormClosing += Form_Closing;
+            Load += Form_Load;
+            mainTableLayoutPanel.ResumeLayout(false);
+            mainTableLayoutPanel.PerformLayout();
+            commitInformationPanel.ResumeLayout(false);
+            commitInformationPanel.PerformLayout();
+            flowLayoutPanel1.ResumeLayout(false);
+            flowLayoutPanel1.PerformLayout();
+            tableLayoutPanel3.ResumeLayout(false);
+            tableLayoutPanel3.PerformLayout();
+            panelParentsList.ResumeLayout(false);
+            panelParentsList.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion

--- a/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -31,36 +31,36 @@ namespace GitUI.CommandsDialogs
         private void InitializeComponent()
         {
             Label label2;
-            Pick = new Button();
+            btnPick = new Button();
             btnChooseRevision = new Button();
-            ParentsLabel = new Label();
-            ParentsList = new UserControls.NativeListView();
+            lblParents = new Label();
+            lvParentsList = new UserControls.NativeListView();
             columnHeader1 = new ColumnHeader();
             columnHeader2 = new ColumnHeader();
             columnHeader3 = new ColumnHeader();
             columnHeader4 = new ColumnHeader();
-            checkAddReference = new CheckBox();
-            AutoCommit = new CheckBox();
-            BranchInfo = new Label();
+            cbxAddReference = new CheckBox();
+            cbxAutoCommit = new CheckBox();
+            lblBranchInfo = new Label();
             commitSummaryUserControl1 = new UserControls.CommitSummaryUserControl();
-            mainTableLayoutPanel = new TableLayoutPanel();
+            tlpnlMain = new TableLayoutPanel();
             flowLayoutPanel1 = new FlowLayoutPanel();
             label2 = new Label();
             MainPanel.SuspendLayout();
             ControlsPanel.SuspendLayout();
-            mainTableLayoutPanel.SuspendLayout();
+            tlpnlMain.SuspendLayout();
             flowLayoutPanel1.SuspendLayout();
             SuspendLayout();
             // 
             // MainPanel
             // 
-            MainPanel.Controls.Add(mainTableLayoutPanel);
+            MainPanel.Controls.Add(tlpnlMain);
             MainPanel.Size = new Size(637, 390);
             MainPanel.TabIndex = 0;
             // 
             // ControlsPanel
             // 
-            ControlsPanel.Controls.Add(Pick);
+            ControlsPanel.Controls.Add(btnPick);
             ControlsPanel.Location = new Point(0, 390);
             ControlsPanel.Size = new Size(637, 41);
             ControlsPanel.TabIndex = 1;
@@ -76,16 +76,16 @@ namespace GitUI.CommandsDialogs
             label2.Text = "C&hoose another revision:";
             label2.TextAlign = ContentAlignment.MiddleCenter;
             // 
-            // Pick
+            // btnPick
             // 
-            Pick.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            Pick.Location = new Point(515, 8);
-            Pick.Name = "Pick";
-            Pick.Size = new Size(109, 25);
-            Pick.TabIndex = 0;
-            Pick.Text = "&Cherry pick";
-            Pick.UseVisualStyleBackColor = true;
-            Pick.Click += Revert_Click;
+            btnPick.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            btnPick.Location = new Point(515, 8);
+            btnPick.Name = "btnPick";
+            btnPick.Size = new Size(109, 25);
+            btnPick.TabIndex = 0;
+            btnPick.Text = "&Cherry pick";
+            btnPick.UseVisualStyleBackColor = true;
+            btnPick.Click += btnPick_Click;
             // 
             // btnChooseRevision
             // 
@@ -98,29 +98,29 @@ namespace GitUI.CommandsDialogs
             btnChooseRevision.UseVisualStyleBackColor = true;
             btnChooseRevision.Click += btnChooseRevision_Click;
             // 
-            // ParentsLabel
+            // lblParents
             // 
-            ParentsLabel.AutoSize = true;
-            ParentsLabel.Dock = DockStyle.Fill;
-            ParentsLabel.Location = new Point(3, 217);
-            ParentsLabel.Name = "ParentsLabel";
-            ParentsLabel.Size = new Size(607, 15);
-            ParentsLabel.TabIndex = 3;
-            ParentsLabel.Text = "This commit is a merge, select &parent:";
+            lblParents.AutoSize = true;
+            lblParents.Dock = DockStyle.Fill;
+            lblParents.Location = new Point(3, 217);
+            lblParents.Name = "lblParents";
+            lblParents.Size = new Size(607, 15);
+            lblParents.TabIndex = 3;
+            lblParents.Text = "This commit is a merge, select &parent:";
             // 
-            // ParentsList
+            // lvParentsList
             // 
-            ParentsList.Columns.AddRange(new ColumnHeader[] { columnHeader1, columnHeader2, columnHeader3, columnHeader4 });
-            ParentsList.Dock = DockStyle.Fill;
-            ParentsList.FullRowSelect = true;
-            ParentsList.Location = new Point(6, 238);
-            ParentsList.Margin = new Padding(6);
-            ParentsList.MultiSelect = false;
-            ParentsList.Name = "ParentsList";
-            ParentsList.Size = new Size(601, 72);
-            ParentsList.TabIndex = 4;
-            ParentsList.UseCompatibleStateImageBehavior = false;
-            ParentsList.View = View.Details;
+            lvParentsList.Columns.AddRange(new ColumnHeader[] { columnHeader1, columnHeader2, columnHeader3, columnHeader4 });
+            lvParentsList.Dock = DockStyle.Fill;
+            lvParentsList.FullRowSelect = true;
+            lvParentsList.Location = new Point(6, 238);
+            lvParentsList.Margin = new Padding(6);
+            lvParentsList.MultiSelect = false;
+            lvParentsList.Size = new Size(601, 72);
+            lvParentsList.Name = "lvParentsList";
+            lvParentsList.TabIndex = 4;
+            lvParentsList.UseCompatibleStateImageBehavior = false;
+            lvParentsList.View = View.Details;
             // 
             // columnHeader1
             // 
@@ -142,37 +142,37 @@ namespace GitUI.CommandsDialogs
             columnHeader4.Text = "Date";
             columnHeader4.Width = 80;
             // 
-            // checkAddReference
+            // cbxAddReference
             // 
-            checkAddReference.AutoSize = true;
-            checkAddReference.Dock = DockStyle.Fill;
-            checkAddReference.Location = new Point(3, 319);
-            checkAddReference.Name = "checkAddReference";
-            checkAddReference.Size = new Size(607, 19);
-            checkAddReference.TabIndex = 5;
-            checkAddReference.Text = "A&dd commit reference to commit message";
-            checkAddReference.UseVisualStyleBackColor = true;
+            cbxAddReference.AutoSize = true;
+            cbxAddReference.Dock = DockStyle.Fill;
+            cbxAddReference.Location = new Point(3, 319);
+            cbxAddReference.Name = "cbxAddReference";
+            cbxAddReference.Size = new Size(607, 19);
+            cbxAddReference.TabIndex = 5;
+            cbxAddReference.Text = "A&dd commit reference to commit message";
+            cbxAddReference.UseVisualStyleBackColor = true;
             // 
-            // AutoCommit
+            // cbxAutoCommit
             // 
-            AutoCommit.AutoSize = true;
-            AutoCommit.Dock = DockStyle.Fill;
-            AutoCommit.Location = new Point(3, 344);
-            AutoCommit.Name = "AutoCommit";
-            AutoCommit.Size = new Size(607, 19);
-            AutoCommit.TabIndex = 6;
-            AutoCommit.Text = "&Automatically create a commit";
-            AutoCommit.UseVisualStyleBackColor = true;
+            cbxAutoCommit.AutoSize = true;
+            cbxAutoCommit.Dock = DockStyle.Fill;
+            cbxAutoCommit.Location = new Point(3, 344);
+            cbxAutoCommit.Name = "cbxAutoCommit";
+            cbxAutoCommit.Size = new Size(607, 19);
+            cbxAutoCommit.TabIndex = 6;
+            cbxAutoCommit.Text = "&Automatically create a commit";
+            cbxAutoCommit.UseVisualStyleBackColor = true;
             // 
-            // BranchInfo
+            // lblBranchInfo
             // 
-            BranchInfo.AutoSize = true;
-            BranchInfo.Dock = DockStyle.Fill;
-            BranchInfo.Location = new Point(3, 0);
-            BranchInfo.Name = "BranchInfo";
-            BranchInfo.Size = new Size(607, 15);
-            BranchInfo.TabIndex = 0;
-            BranchInfo.Text = "Cherry pick this commit:";
+            lblBranchInfo.AutoSize = true;
+            lblBranchInfo.Dock = DockStyle.Fill;
+            lblBranchInfo.Location = new Point(3, 0);
+            lblBranchInfo.Name = "lblBranchInfo";
+            lblBranchInfo.Size = new Size(607, 15);
+            lblBranchInfo.TabIndex = 0;
+            lblBranchInfo.Text = "Cherry pick this commit:";
             // 
             // commitSummaryUserControl1
             // 
@@ -187,32 +187,32 @@ namespace GitUI.CommandsDialogs
             commitSummaryUserControl1.Size = new Size(594, 160);
             commitSummaryUserControl1.TabIndex = 1;
             // 
-            // mainTableLayoutPanel
+            // tlpnlMain
             // 
-            mainTableLayoutPanel.AutoSize = true;
-            mainTableLayoutPanel.ColumnCount = 1;
-            mainTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-            mainTableLayoutPanel.Controls.Add(BranchInfo, 0, 0);
-            mainTableLayoutPanel.Controls.Add(commitSummaryUserControl1, 0, 1);
-            mainTableLayoutPanel.Controls.Add(flowLayoutPanel1, 0, 2);
-            mainTableLayoutPanel.Controls.Add(ParentsLabel, 0, 3);
-            mainTableLayoutPanel.Controls.Add(ParentsList, 0, 4);
-            mainTableLayoutPanel.Controls.Add(checkAddReference, 0, 5);
-            mainTableLayoutPanel.Controls.Add(AutoCommit, 0, 6);
-            mainTableLayoutPanel.Dock = DockStyle.Fill;
-            mainTableLayoutPanel.Location = new Point(12, 12);
-            mainTableLayoutPanel.Margin = new Padding(0);
-            mainTableLayoutPanel.Name = "mainTableLayoutPanel";
-            mainTableLayoutPanel.RowCount = 5;
-            mainTableLayoutPanel.RowStyles.Add(new RowStyle());
-            mainTableLayoutPanel.RowStyles.Add(new RowStyle());
-            mainTableLayoutPanel.RowStyles.Add(new RowStyle());
-            mainTableLayoutPanel.RowStyles.Add(new RowStyle());
-            mainTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-            mainTableLayoutPanel.RowStyles.Add(new RowStyle());
-            mainTableLayoutPanel.RowStyles.Add(new RowStyle());
-            mainTableLayoutPanel.Size = new Size(613, 366);
-            mainTableLayoutPanel.TabIndex = 0;
+            tlpnlMain.AutoSize = true;
+            tlpnlMain.ColumnCount = 1;
+            tlpnlMain.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            tlpnlMain.Controls.Add(lblBranchInfo, 0, 0);
+            tlpnlMain.Controls.Add(commitSummaryUserControl1, 0, 1);
+            tlpnlMain.Controls.Add(flowLayoutPanel1, 0, 2);
+            tlpnlMain.Controls.Add(lblParents, 0, 3);
+            tlpnlMain.Controls.Add(lvParentsList, 0, 4);
+            tlpnlMain.Controls.Add(cbxAddReference, 0, 5);
+            tlpnlMain.Controls.Add(cbxAutoCommit, 0, 6);
+            tlpnlMain.Dock = DockStyle.Fill;
+            tlpnlMain.Location = new Point(12, 12);
+            tlpnlMain.Margin = new Padding(0);
+            tlpnlMain.Name = "tlpnlMain";
+            tlpnlMain.RowCount = 5;
+            tlpnlMain.RowStyles.Add(new RowStyle());
+            tlpnlMain.RowStyles.Add(new RowStyle());
+            tlpnlMain.RowStyles.Add(new RowStyle());
+            tlpnlMain.RowStyles.Add(new RowStyle());
+            tlpnlMain.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            tlpnlMain.RowStyles.Add(new RowStyle());
+            tlpnlMain.RowStyles.Add(new RowStyle());
+            tlpnlMain.Size = new Size(613, 366);
+            tlpnlMain.TabIndex = 0;
             // 
             // flowLayoutPanel1
             // 
@@ -229,7 +229,7 @@ namespace GitUI.CommandsDialogs
             // 
             // FormCherryPick
             // 
-            AcceptButton = Pick;
+            AcceptButton = btnPick;
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
             AutoSize = true;
@@ -246,8 +246,8 @@ namespace GitUI.CommandsDialogs
             MainPanel.ResumeLayout(false);
             MainPanel.PerformLayout();
             ControlsPanel.ResumeLayout(false);
-            mainTableLayoutPanel.ResumeLayout(false);
-            mainTableLayoutPanel.PerformLayout();
+            tlpnlMain.ResumeLayout(false);
+            tlpnlMain.PerformLayout();
             flowLayoutPanel1.ResumeLayout(false);
             flowLayoutPanel1.PerformLayout();
             ResumeLayout(false);
@@ -256,19 +256,19 @@ namespace GitUI.CommandsDialogs
 
         #endregion
 
-        private System.Windows.Forms.Label BranchInfo;
-        private System.Windows.Forms.Button Pick;
-        private System.Windows.Forms.CheckBox AutoCommit;
-        private UserControls.NativeListView ParentsList;
+        private System.Windows.Forms.Label lblBranchInfo;
+        private System.Windows.Forms.Button btnPick;
+        private System.Windows.Forms.CheckBox cbxAutoCommit;
+        private UserControls.NativeListView lvParentsList;
         private System.Windows.Forms.ColumnHeader columnHeader1;
         private System.Windows.Forms.ColumnHeader columnHeader2;
         private System.Windows.Forms.ColumnHeader columnHeader3;
         private System.Windows.Forms.ColumnHeader columnHeader4;
-        private System.Windows.Forms.Label ParentsLabel;
-        private System.Windows.Forms.CheckBox checkAddReference;
+        private System.Windows.Forms.Label lblParents;
+        private System.Windows.Forms.CheckBox cbxAddReference;
         private GitUI.UserControls.CommitSummaryUserControl commitSummaryUserControl1;
         private System.Windows.Forms.Button btnChooseRevision;
-        private System.Windows.Forms.TableLayoutPanel mainTableLayoutPanel;
+        private System.Windows.Forms.TableLayoutPanel tlpnlMain;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
     }
 }

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -7,7 +7,7 @@ using ResourceManager;
 
 namespace GitUI.CommandsDialogs
 {
-    public partial class FormCherryPick : GitModuleForm
+    public partial class FormCherryPick : GitExtensionsDialog
     {
         #region Translation
         private readonly TranslationString _noneParentSelectedText =
@@ -25,7 +25,7 @@ namespace GitUI.CommandsDialogs
         }
 
         public FormCherryPick(GitUICommands commands, GitRevision? revision)
-            : base(commands)
+            : base(commands, enablePositionRestore: false)
         {
             Revision = revision;
             InitializeComponent();

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -46,33 +46,33 @@ namespace GitUI.CommandsDialogs
 
         private void LoadSettings()
         {
-            AutoCommit.Checked = AppSettings.CommitAutomaticallyAfterCherryPick;
-            checkAddReference.Checked = AppSettings.AddCommitReferenceToCherryPick;
+            cbxAutoCommit.Checked = AppSettings.CommitAutomaticallyAfterCherryPick;
+            cbxAddReference.Checked = AppSettings.AddCommitReferenceToCherryPick;
         }
 
         private void SaveSettings()
         {
-            AppSettings.CommitAutomaticallyAfterCherryPick = AutoCommit.Checked;
-            AppSettings.AddCommitReferenceToCherryPick = checkAddReference.Checked;
+            AppSettings.CommitAutomaticallyAfterCherryPick = cbxAutoCommit.Checked;
+            AppSettings.AddCommitReferenceToCherryPick = cbxAddReference.Checked;
         }
 
         private void OnRevisionChanged()
         {
             try
             {
-                mainTableLayoutPanel.SuspendLayout();
+                tlpnlMain.SuspendLayout();
 
                 commitSummaryUserControl1.Revision = Revision;
 
-                ParentsList.Items.Clear();
+                lvParentsList.Items.Clear();
 
                 if (Revision is not null)
                 {
                     _isMerge = Module.IsMerge(Revision.ObjectId);
                 }
 
-                ParentsLabel.Visible = _isMerge;
-                ParentsList.Visible = _isMerge;
+                lblParents.Visible = _isMerge;
+                lvParentsList.Visible = _isMerge;
 
                 if (_isMerge && Revision is not null)
                 {
@@ -80,7 +80,7 @@ namespace GitUI.CommandsDialogs
 
                     for (int i = 0; i < parents.Count; i++)
                     {
-                        ParentsList.Items.Add(new ListViewItem((i + 1).ToString())
+                        lvParentsList.Items.Add(new ListViewItem((i + 1).ToString())
                         {
                             SubItems =
                         {
@@ -91,7 +91,7 @@ namespace GitUI.CommandsDialogs
                         });
                     }
 
-                    ParentsList.TopItem.Selected = true;
+                    lvParentsList.TopItem.Selected = true;
                     Size size = MinimumSize;
                     size.Height += 100;
                     MinimumSize = size;
@@ -99,42 +99,42 @@ namespace GitUI.CommandsDialogs
             }
             finally
             {
-                mainTableLayoutPanel.ResumeLayout(performLayout: true);
+                tlpnlMain.ResumeLayout(performLayout: true);
             }
         }
 
-        private void Revert_Click(object sender, EventArgs e)
+        private void btnPick_Click(object sender, EventArgs e)
         {
             ArgumentBuilder args = new();
             var canExecute = true;
 
             if (_isMerge)
             {
-                if (ParentsList.SelectedItems.Count == 0)
+                if (lvParentsList.SelectedItems.Count == 0)
                 {
                     MessageBox.Show(this, _noneParentSelectedText.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                     canExecute = false;
                 }
                 else
                 {
-                    args.Add("-m " + (ParentsList.SelectedItems[0].Index + 1));
+                    args.Add("-m " + (lvParentsList.SelectedItems[0].Index + 1));
                 }
             }
 
-            if (checkAddReference.Checked)
+            if (cbxAddReference.Checked)
             {
                 args.Add("-x");
             }
 
             if (canExecute && Revision is not null)
             {
-                var command = GitCommandHelpers.CherryPickCmd(Revision.ObjectId, AutoCommit.Checked, args.ToString());
+                var command = GitCommandHelpers.CherryPickCmd(Revision.ObjectId, cbxAutoCommit.Checked, args.ToString());
 
                 // Don't verify whether the command is successful.
                 // If it fails, likely there is a conflict that needs to be resolved.
                 FormProcess.ShowDialog(this, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
 
-                MergeConflictHandler.HandleMergeConflicts(UICommands, this, AutoCommit.Checked);
+                MergeConflictHandler.HandleMergeConflicts(UICommands, this, cbxAutoCommit.Checked);
                 DialogResult = DialogResult.OK;
                 Close();
             }
@@ -142,8 +142,8 @@ namespace GitUI.CommandsDialogs
 
         public void CopyOptions(FormCherryPick source)
         {
-            AutoCommit.Checked = source.AutoCommit.Checked;
-            checkAddReference.Checked = source.checkAddReference.Checked;
+            cbxAutoCommit.Checked = source.cbxAutoCommit.Checked;
+            cbxAddReference.Checked = source.cbxAddReference.Checked;
         }
 
         private void btnChooseRevision_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -52,8 +52,11 @@ namespace GitUI.CommandsDialogs
 
         private void SaveSettings()
         {
-            AppSettings.CommitAutomaticallyAfterCherryPick = cbxAutoCommit.Checked;
-            AppSettings.AddCommitReferenceToCherryPick = cbxAddReference.Checked;
+            if (DialogResult == DialogResult.OK)
+            {
+                AppSettings.CommitAutomaticallyAfterCherryPick = cbxAutoCommit.Checked;
+                AppSettings.AddCommitReferenceToCherryPick = cbxAddReference.Checked;
+            }
         }
 
         private void OnRevisionChanged()
@@ -101,6 +104,11 @@ namespace GitUI.CommandsDialogs
             {
                 tlpnlMain.ResumeLayout(performLayout: true);
             }
+        }
+
+        private void btnAbort_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Cancel;
         }
 
         private void btnPick_Click(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -29,6 +29,7 @@ namespace GitUI.CommandsDialogs
         {
             Revision = revision;
             InitializeComponent();
+            Size = MinimumSize;
             InitializeComplete();
         }
 
@@ -57,38 +58,48 @@ namespace GitUI.CommandsDialogs
 
         private void OnRevisionChanged()
         {
-            commitSummaryUserControl1.Revision = Revision;
-
-            ParentsList.Items.Clear();
-
-            if (Revision is not null)
+            try
             {
-                _isMerge = Module.IsMerge(Revision.ObjectId);
-            }
+                mainTableLayoutPanel.SuspendLayout();
 
-            panelParentsList.Visible = _isMerge;
+                commitSummaryUserControl1.Revision = Revision;
 
-            if (_isMerge && Revision is not null)
-            {
-                var parents = Module.GetParentRevisions(Revision.ObjectId);
+                ParentsList.Items.Clear();
 
-                for (int i = 0; i < parents.Count; i++)
+                if (Revision is not null)
                 {
-                    ParentsList.Items.Add(new ListViewItem((i + 1).ToString())
+                    _isMerge = Module.IsMerge(Revision.ObjectId);
+                }
+
+                ParentsLabel.Visible = _isMerge;
+                ParentsList.Visible = _isMerge;
+
+                if (_isMerge && Revision is not null)
+                {
+                    var parents = Module.GetParentRevisions(Revision.ObjectId);
+
+                    for (int i = 0; i < parents.Count; i++)
                     {
-                        SubItems =
+                        ParentsList.Items.Add(new ListViewItem((i + 1).ToString())
+                        {
+                            SubItems =
                         {
                             parents[i].Subject,
                             parents[i].Author,
                             parents[i].CommitDate.ToShortDateString()
                         }
-                    });
-                }
+                        });
+                    }
 
-                ParentsList.TopItem.Selected = true;
-                Size size = MinimumSize;
-                size.Height += 100;
-                MinimumSize = size;
+                    ParentsList.TopItem.Selected = true;
+                    Size size = MinimumSize;
+                    size.Height += 100;
+                    MinimumSize = size;
+                }
+            }
+            finally
+            {
+                mainTableLayoutPanel.ResumeLayout(performLayout: true);
             }
         }
 

--- a/GitUI/CommandsDialogs/FormCherryPick.resx
+++ b/GitUI/CommandsDialogs/FormCherryPick.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/GitUI/CommandsDialogs/FormCherryPick.resx
+++ b/GitUI/CommandsDialogs/FormCherryPick.resx
@@ -120,7 +120,4 @@
   <metadata name="label2.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
-  <metadata name="label2.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </metadata>
 </root>

--- a/GitUI/CommandsDialogs/FormCherryPick.resx
+++ b/GitUI/CommandsDialogs/FormCherryPick.resx
@@ -117,4 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="label2.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
+  <metadata name="label2.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
 </root>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3139,28 +3139,24 @@ Are you sure?</source>
         <source>Cherry pick commit</source>
         <target />
       </trans-unit>
-      <trans-unit id="AutoCommit.Text">
-        <source>&amp;Automatically create a commit</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="BranchInfo.Text">
-        <source>Cherry pick this commit:</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="ParentsLabel.Text">
-        <source>This commit is a merge, select &amp;parent:</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="Pick.Text">
-        <source>&amp;Cherry pick</source>
-        <target />
-      </trans-unit>
       <trans-unit id="_noneParentSelectedText.Text">
         <source>None parent is selected!</source>
         <target />
       </trans-unit>
-      <trans-unit id="checkAddReference.Text">
+      <trans-unit id="btnAbort.Text">
+        <source>A&amp;bort</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="btnPick.Text">
+        <source>&amp;Cherry pick</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="cbxAddReference.Text">
         <source>A&amp;dd commit reference to commit message</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="cbxAutoCommit.Text">
+        <source>&amp;Automatically create a commit</source>
         <target />
       </trans-unit>
       <trans-unit id="columnHeader1.Text">
@@ -3179,9 +3175,12 @@ Are you sure?</source>
         <source>Date</source>
         <target />
       </trans-unit>
-      <trans-unit id="label2.Text">
-        <source>C&amp;hoose another
-revision:</source>
+      <trans-unit id="lblBranchInfo.Text">
+        <source>Cherry pick this commit:</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="lblParents.Text">
+        <source>This commit is a merge, select &amp;parent:</source>
         <target />
       </trans-unit>
     </body>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Proposed changes

- Inherit from `GitExtensionsDialog` and update the layout.
- Rename controls and few other chores.
- Add "Abort" button that breaks the "cherry-pick many commits" sequence. It's possible to break the sequence by closing the dialog with the "X" button, but it's rather unintuitive.
- Add "Help" button which opens https://git-extensions-documentation.readthedocs.io/en/main/modify_history.html#cherry-pick-commit.

## Screenshots <!-- Remove this section if PR does not change UI -->

 Before | After
 -- | --
![image](https://github.com/gitextensions/gitextensions/assets/4403806/2a3d55e4-7a67-412a-a930-5cb1ccb459e9) | ![image](https://github.com/gitextensions/gitextensions/assets/4403806/b4b5ddc8-317f-4c49-aa51-38eabc310b70)
![image](https://github.com/gitextensions/gitextensions/assets/4403806/d4b1d140-6931-427f-b416-91be88f04e28) | ![image](https://github.com/gitextensions/gitextensions/assets/4403806/25b42ab1-2bf8-4139-8535-09e8c9d3adc7)

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
