### PR TITLE
Avoid always caught exception for unset settings

### DIFF
--- a/GitCommands/Settings/Setting.cs
+++ b/GitCommands/Settings/Setting.cs
@@ -171,6 +171,10 @@ namespace GitCommands.Settings
             private object? GetValue(string name)
             {
                 string? stringValue = SettingsSource.GetValue(name);
+                if (stringValue is null)
+                {
+                    return null;
+                }
 
                 Type type = typeof(T);
                 Type underlyingType = Nullable.GetUnderlyingType(type) ?? type;


### PR DESCRIPTION
## Proposed changes

- Do not try to invoke a `TypeConverter` for `null` in `Settings.GetValue()`
 
## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).