### PR TITLE
Improved context menu detection when using keyboard

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2801,8 +2801,6 @@ namespace GitUI.CommandsDialogs
                 ExecuteCommitCommand();
                 e.Handled = true;
             }
-
-            Message.SpellCheckContextMenuTrigger = ToolStripMenuTrigger.Keyboard;
         }
 
         private void Message_TextChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2801,6 +2801,8 @@ namespace GitUI.CommandsDialogs
                 ExecuteCommitCommand();
                 e.Handled = true;
             }
+
+            Message.SpellCheckContextMenuTrigger = ToolStripMenuTrigger.Keyboard;
         }
 
         private void Message_TextChanged(object sender, EventArgs e)

--- a/GitUI/SpellChecker/EditNetSpell.Designer.cs
+++ b/GitUI/SpellChecker/EditNetSpell.Designer.cs
@@ -64,6 +64,7 @@
             this.TextBox.Leave += new System.EventHandler(this.TextBoxLeave);
             this.TextBox.GotFocus += TextBox_GotFocus;
             this.TextBox.LostFocus += TextBox_LostFocus;
+            this.TextBox.MouseDown += new System.Windows.Forms.MouseEventHandler(this.TextBox_MouseDown);
             // 
             // AutoComplete
             // 

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -1128,9 +1128,12 @@ namespace GitUI.SpellChecker
             base.Dispose(disposing);
         }
 
-        private void TextBox_MouseDown(object sender, EventArgs e)
+        private void TextBox_MouseDown(object sender, MouseEventArgs e)
         {
-            TextBox.SelectionStart = TextBox.GetCharIndexFromPosition(TextBox.PointToClient(MousePosition));
+            if (e.Button == MouseButtons.Right)
+            {
+                TextBox.SelectionStart = TextBox.GetCharIndexFromPosition(e.Location);
+            }
         }
     }
 }

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -56,6 +56,8 @@ namespace GitUI.SpellChecker
 
         public bool IsUndoInProgress;
 
+        public ToolStripMenuTrigger SpellCheckContextMenuTrigger;
+
         public EditNetSpell()
         {
             InitializeComponent();
@@ -511,7 +513,7 @@ namespace GitUI.SpellChecker
         private void SpellCheckContextMenuOpening(object sender, CancelEventArgs e)
         {
             TextBox.Focus();
-            var pos = TextBox.GetCharIndexFromPosition(TextBox.PointToClient(MousePosition));
+            var pos = SpellCheckContextMenuTrigger == ToolStripMenuTrigger.Keyboard ? this.TextBox.SelectionStart : TextBox.GetCharIndexFromPosition(TextBox.PointToClient(MousePosition));
             if (pos < 0)
             {
                 e.Cancel = true;
@@ -550,6 +552,8 @@ namespace GitUI.SpellChecker
                 ToggleAutoCompletion();
             };
             SpellCheckContextMenu.Items.Add(mi);
+
+            SpellCheckContextMenuTrigger = ToolStripMenuTrigger.RestoreTriggerValue;
         }
 
         private void RemoveWordClick(object sender, EventArgs e)
@@ -1127,5 +1131,11 @@ namespace GitUI.SpellChecker
 
             base.Dispose(disposing);
         }
+    }
+
+    public enum ToolStripMenuTrigger
+    {
+        RestoreTriggerValue,
+        Keyboard
     }
 }

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -513,7 +513,7 @@ namespace GitUI.SpellChecker
         private void SpellCheckContextMenuOpening(object sender, CancelEventArgs e)
         {
             TextBox.Focus();
-            var pos = SpellCheckContextMenuTrigger == ToolStripMenuTrigger.Keyboard ? this.TextBox.SelectionStart : TextBox.GetCharIndexFromPosition(TextBox.PointToClient(MousePosition));
+            var pos = SpellCheckContextMenuTrigger == ToolStripMenuTrigger.Keyboard ? TextBox.SelectionStart : TextBox.GetCharIndexFromPosition(TextBox.PointToClient(MousePosition));
             if (pos < 0)
             {
                 e.Cancel = true;

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -56,8 +56,6 @@ namespace GitUI.SpellChecker
 
         public bool IsUndoInProgress;
 
-        public ToolStripMenuTrigger SpellCheckContextMenuTrigger;
-
         public EditNetSpell()
         {
             InitializeComponent();
@@ -513,7 +511,7 @@ namespace GitUI.SpellChecker
         private void SpellCheckContextMenuOpening(object sender, CancelEventArgs e)
         {
             TextBox.Focus();
-            var pos = SpellCheckContextMenuTrigger == ToolStripMenuTrigger.Keyboard ? TextBox.SelectionStart : TextBox.GetCharIndexFromPosition(TextBox.PointToClient(MousePosition));
+            var pos = TextBox.SelectionStart;
             if (pos < 0)
             {
                 e.Cancel = true;
@@ -552,8 +550,6 @@ namespace GitUI.SpellChecker
                 ToggleAutoCompletion();
             };
             SpellCheckContextMenu.Items.Add(mi);
-
-            SpellCheckContextMenuTrigger = ToolStripMenuTrigger.RestoreTriggerValue;
         }
 
         private void RemoveWordClick(object sender, EventArgs e)
@@ -1131,11 +1127,10 @@ namespace GitUI.SpellChecker
 
             base.Dispose(disposing);
         }
-    }
 
-    public enum ToolStripMenuTrigger
-    {
-        RestoreTriggerValue,
-        Keyboard
+        private void TextBox_MouseDown(object sender, EventArgs e)
+        {
+            TextBox.SelectionStart = TextBox.GetCharIndexFromPosition(TextBox.PointToClient(MousePosition));
+        }
     }
 }


### PR DESCRIPTION
Fixes [#11072](https://github.com/gitextensions/gitextensions/issues/11072)

## Proposed changes

- Pressing the menu key on the keyboard, will display the context menu with word-suggestions for the word where a caret is positioned (if the spelling is incorrect).

## Test methodology

- Manual with GE repo

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 5fc8e6d
- Git 2.30.0.windows.2 (recommended: 2.41.0 or later)
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.14
- DPI 120dpi (125% scaling)

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
