### PR TITLE
Allow skipping file paths in recursive submodule directory clean

### DIFF
--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -551,7 +551,7 @@ namespace GitCommands.Git.Commands
         /// <param name="dryRun">Only show what would be deleted.</param>
         /// <param name="directories">Delete untracked directories too.</param>
         /// <param name="paths">Limit to specific paths.</param>
-        public static ArgumentString CleanSubmodules(CleanMode mode, bool dryRun, bool directories, string? paths = null)
+        public static ArgumentString CleanSubmodules(CleanMode mode, bool dryRun, bool directories, string? paths = null, string? excludes = null)
         {
             return new GitArgumentBuilder("submodule")
             {
@@ -559,7 +559,8 @@ namespace GitCommands.Git.Commands
                 mode,
                 { directories, "-d" },
                 { dryRun, "--dry-run", "-f" },
-                paths
+                paths,
+                { !string.IsNullOrEmpty(excludes), excludes }
             };
         }
 

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -63,7 +63,7 @@ namespace GitUI.CommandsDialogs
 
             if (CleanSubmodules.Checked)
             {
-                ArgumentString cleanSubmodulesCmd = GitCommandHelpers.CleanSubmodules(mode, dryRun, directories: RemoveDirectories.Checked, paths: includePathArgument);
+                ArgumentString cleanSubmodulesCmd = GitCommandHelpers.CleanSubmodules(mode, dryRun, directories: RemoveDirectories.Checked, paths: includePathArgument, excludes: excludePathArguments);
                 cmdOutput = FormProcess.ReadDialog(this, arguments: cleanSubmodulesCmd, Module.WorkingDir, input: null, useDialogSettings: true);
                 PreviewOutput.Text += EnvUtils.ReplaceLinuxNewLinesDependingOnPlatform(cmdOutput);
             }

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.Collections.Generic;
+using GitCommands;
 using GitCommands.Git.Commands;
 using GitCommands.Utils;
 using GitExtUtils;
@@ -172,9 +173,9 @@ namespace GitUI.CommandsDialogs
         private string MakePathRelativeToModule(string targetPath)
         {
             targetPath = targetPath.Replace(Module.WorkingDir, "").ToPosixPath();
-            List<string> submodulePaths = (List<string>)Module.GetSubmodulesLocalPaths();
+            IReadOnlyList<string> submodulePaths = Module.GetSubmodulesLocalPaths();
 
-            string nearestSubmodule = submodulePaths
+            string? nearestSubmodule = submodulePaths
                 .Where(submodulePath => targetPath.StartsWith(submodulePath))
                 .OrderByDescending(submodulePath => submodulePath.Length)
                 .FirstOrDefault();
@@ -184,7 +185,7 @@ namespace GitUI.CommandsDialogs
                 return targetPath;
             }
 
-            return targetPath.Substring(nearestSubmodule.Length + 1);
+            return targetPath[(nearestSubmodule.Length + 1)..];
         }
 
         private string? RequestUserFolderPath()

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -164,9 +164,27 @@ namespace GitUI.CommandsDialogs
 
             if (path is not null)
             {
-                path = path.Replace(Module.WorkingDir, "");
+                path = MakePathRelativeToModule(path);
                 textBoxExcludePaths.Text += path;
             }
+        }
+
+        private string MakePathRelativeToModule(string targetPath)
+        {
+            targetPath = targetPath.Replace(Module.WorkingDir, "").ToPosixPath();
+            List<string> submodulePaths = (List<string>)Module.GetSubmodulesLocalPaths();
+
+            string nearestSubmodule = submodulePaths
+                .Where(submodulePath => targetPath.StartsWith(submodulePath))
+                .OrderByDescending(submodulePath => submodulePath.Length)
+                .FirstOrDefault();
+
+            if (nearestSubmodule is null)
+            {
+                return targetPath;
+            }
+
+            return targetPath.Substring(nearestSubmodule.Length + 1);
         }
 
         private string? RequestUserFolderPath()

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -515,16 +515,21 @@ namespace GitCommandsTests.Git.Commands
             Assert.AreEqual(expected, GitCommandHelpers.CleanCmd(mode, dryRun, directories, paths, excludes).Arguments);
         }
 
-        [TestCase(CleanMode.OnlyNonIgnored, true, false, null, "clean --dry-run")]
-        [TestCase(CleanMode.OnlyNonIgnored, false, false, null, "clean -f")]
-        [TestCase(CleanMode.OnlyNonIgnored, false, true, null, "clean -d -f")]
-        [TestCase(CleanMode.OnlyNonIgnored, false, false, "paths", "clean -f paths")]
-        [TestCase(CleanMode.OnlyIgnored, false, false, null, "clean -X -f")]
-        [TestCase(CleanMode.All, false, false, null, "clean -x -f")]
-        public void CleanupSubmoduleCommand(CleanMode mode, bool dryRun, bool directories, string paths, string expected)
+        [TestCase(CleanMode.OnlyNonIgnored, true, false, null, null, "clean --dry-run")]
+        [TestCase(CleanMode.OnlyNonIgnored, false, false, null, null, "clean -f")]
+        [TestCase(CleanMode.OnlyNonIgnored, false, true, null, null, "clean -d -f")]
+        [TestCase(CleanMode.OnlyNonIgnored, false, false, "\"path1\"", null, "clean -f \"path1\"")]
+        [TestCase(CleanMode.OnlyNonIgnored, false, false, "\"path1\"", "--exclude=excludes", "clean -f \"path1\" --exclude=excludes")]
+        [TestCase(CleanMode.OnlyNonIgnored, false, false, null, "excludes", "clean -f excludes")]
+        [TestCase(CleanMode.OnlyNonIgnored, false, false, "\"path1\" \"path2\"", null, "clean -f \"path1\" \"path2\"")]
+        [TestCase(CleanMode.OnlyNonIgnored, false, false, "\"path1\" \"path2\"", "--exclude=exclude1 --exclude=exclude2", "clean -f \"path1\" \"path2\" --exclude=exclude1 --exclude=exclude2")]
+        [TestCase(CleanMode.OnlyNonIgnored, false, false, null, "--exclude=exclude1 --exclude=exclude2", "clean -f --exclude=exclude1 --exclude=exclude2")]
+        [TestCase(CleanMode.OnlyIgnored, false, false, null, null, "clean -X -f")]
+        [TestCase(CleanMode.All, false, false, null, null, "clean -x -f")]
+        public void CleanupSubmoduleCommand(CleanMode mode, bool dryRun, bool directories, string paths, string excludes, string expected)
         {
             string subExpected = "submodule foreach --recursive git " + expected;
-            Assert.AreEqual(subExpected, GitCommandHelpers.CleanSubmodules(mode, dryRun, directories, paths).Arguments);
+            Assert.AreEqual(subExpected, GitCommandHelpers.CleanSubmodules(mode, dryRun, directories, paths, excludes).Arguments);
         }
 
         [TestCase(null)]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->
Fixes https://github.com/gitextensions/gitextensions/issues/11099 (#11102)

## Proposed changes

- Skip certain file paths when cleaning submodules recursively

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->

## Test methodology <!-- How did you ensure quality? -->

- Added appropriate unit tests
- Verified in test repo

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).