### PR TITLE
Avoid and cope with exceptions on graph reload

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -305,9 +305,9 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
             if (!updateParents)
             {
-                // The rows may already be cached, invalidate and request reload of "some" rows
+                // The rows may already be cached, invalidate and update but do not reload rows in this context
                 _reorder = true;
-                CacheTo(0, 99);
+                Updated?.Invoke();
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.BackgroundUpdater.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.BackgroundUpdater.cs
@@ -40,23 +40,28 @@
 
             private async Task WrappedOperationAsync()
             {
-                await _operation();
-
-                if (_rerunRequested)
+                try
                 {
-                    await Task.Delay(_cooldownMilliseconds);
+                    await _operation();
                 }
-
-                lock (_sync)
+                finally
                 {
                     if (_rerunRequested)
                     {
-                        Task.Run(WrappedOperationAsync);
-                        _rerunRequested = false;
+                        await Task.Delay(_cooldownMilliseconds);
                     }
-                    else
+
+                    lock (_sync)
                     {
-                        _executing = false;
+                        if (_rerunRequested)
+                        {
+                            Task.Run(WrappedOperationAsync);
+                            _rerunRequested = false;
+                        }
+                        else
+                        {
+                            _executing = false;
+                        }
                     }
                 }
             }

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -715,7 +715,7 @@ namespace GitUI.UserControls.RevisionGrid
 
             async Task UpdateGraphAsync(int fromIndex, int toIndex)
             {
-                // Cache the next item
+                // Cache the next item; build the cache in limited chunks in order to update intermittently
                 _revisionGraph.CacheTo(currentRowIndex: toIndex, lastToCacheRowIndex: Math.Min(fromIndex + 1500, toIndex));
 
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();


### PR DESCRIPTION
Fixes #11166
Might fix #10957

## Proposed changes

- `BackgroundUpdater.WrappedOperationAsync()`: Avoid getting stuck on exception by adding `try finally`
- `RevisionGraph.IsRowCacheDirty()`: Safer detection by adding an additional check; rename for clarity
- Call `RevisionGraph.CacheTo()` from single context only

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- extensive runs of existing tests

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).