### PR TITLE
Use the correct interface of JContainer for indexer

### DIFF
--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -356,16 +356,17 @@ namespace AppVeyorIntegration
 
         private void UpdateDescription(AppVeyorBuildInfo buildDetails, CancellationToken cancellationToken)
         {
-            var buildDetailsParsed = ThreadHelper.JoinableTaskFactory.Run(() => FetchBuildDetailsManagingVersionUpdateAsync(buildDetails, cancellationToken));
+            JObject buildDetailsParsed = ThreadHelper.JoinableTaskFactory.Run(() => FetchBuildDetailsManagingVersionUpdateAsync(buildDetails, cancellationToken));
             if (buildDetailsParsed is null)
             {
                 return;
             }
 
-            var buildData = buildDetailsParsed["build"];
-            var buildDescription = buildData["jobs"][^1];
+            JToken buildData = buildDetailsParsed["build"];
+            IList<JToken> buildJobs = (JContainer)buildData["jobs"];
+            JToken buildDescription = buildJobs[^1];
 
-            var status = buildDescription["status"].ToObject<string>();
+            string status = buildDescription["status"].ToObject<string>();
             buildDetails.Status = ParseBuildStatus(status);
 
             buildDetails.ChangeProgressCounter();


### PR DESCRIPTION
Fixes regression from #11141: `System.ArgumentException: 'Accessed JArray values with invalid key value: ^1. Int32 array index expected.'`

## Proposed changes

- Use the correct interface `IList` implemented by `JContainer` in order to be able to use the new style of array indexing "[^1]"

## Screenshots <!-- Remove this section if PR does not change UI -->

more than one build result in grid again

## Test methodology <!-- How did you ensure quality? -->

- manually

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).