### PR TITLE
Present vertical tab as return in commit message

### DIFF
--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -66,18 +66,10 @@ namespace GitCommands
             }
             else
             {
-                // $ git log --pretty="format:%B%nNotes:%n%-N" -1
-                // Remove redundant parameter
-                //
-                // The sha1 parameter must match CommitData.Guid.
-                // There's no point passing it. It only creates opportunity for bugs.
-                //
-                // Notes:
-
-                var lines = data.Split(Delimiters.LineFeed);
+                string[] lines = data.Split(Delimiters.LineFeed);
 
                 // Commit message is not re-encoded by Git when format is given
-                commitData.Body = GetModule().ReEncodeCommitMessage(ProcessDiffNotes(startIndex: 0, lines));
+                commitData.Body = GetModule().ReEncodeCommitMessage(ProcessDiffNotes(startIndex: 0, lines)).Replace('\v', '\n');
             }
         }
 
@@ -142,7 +134,7 @@ namespace GitCommands
             var message = ProcessDiffNotes(startIndex: 7, lines);
 
             // commit message is not re-encoded by git when format is given
-            var body = module.ReEncodeCommitMessage(message);
+            var body = module.ReEncodeCommitMessage(message).Replace('\v', '\n');
 
             Validates.NotNull(author);
             Validates.NotNull(committer);

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -993,10 +993,9 @@ namespace GitCommands
                 Committer = ReEncodeStringFromLossless(lines[6]),
                 CommitterEmail = ReEncodeStringFromLossless(lines[7]),
                 AuthorUnixTime = long.Parse(lines[5]),
-                CommitUnixTime = long.Parse(lines[8])
+                CommitUnixTime = long.Parse(lines[8]),
+                HasNotes = !shortFormat
             };
-
-            revision.HasNotes = !shortFormat;
             if (shortFormat)
             {
                 revision.Subject = ReEncodeCommitMessage(lines[9]) ?? "";
@@ -1007,14 +1006,15 @@ namespace GitCommands
 
                 // commit message is not re-encoded by git when format is given
                 // See also RevisionReader for parsing commit body
-                string body = ReEncodeCommitMessage(message);
-                revision.Body = body;
+                string body = ReEncodeCommitMessage(message).Replace('\v', '\n');
 
                 ReadOnlySpan<char> span = (body ?? "").AsSpan();
                 int endSubjectIndex = span.IndexOf('\n');
-                revision.Subject = endSubjectIndex >= 0
+                revision.HasMultiLineMessage = endSubjectIndex >= 0;
+                revision.Subject = revision.HasMultiLineMessage
                     ? span[..endSubjectIndex].TrimEnd().ToString()
                     : body ?? "";
+                revision.Body = revision.HasMultiLineMessage ? body : null;
             }
 
             if (loadRefs)

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1007,6 +1007,7 @@ namespace GitCommands
                 // commit message is not re-encoded by git when format is given
                 // See also RevisionReader for parsing commit body
                 string body = ReEncodeCommitMessage(message ?? "").Replace('\v', '\n');
+                revision.Body = body;
 
                 ReadOnlySpan<char> span = body.AsSpan();
                 int endSubjectIndex = span.IndexOf('\n');
@@ -1014,7 +1015,6 @@ namespace GitCommands
                 revision.Subject = revision.HasMultiLineMessage
                     ? span[..endSubjectIndex].TrimEnd().ToString()
                     : body;
-                revision.Body = revision.HasMultiLineMessage ? body : null;
             }
 
             if (loadRefs)

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1006,14 +1006,14 @@ namespace GitCommands
 
                 // commit message is not re-encoded by git when format is given
                 // See also RevisionReader for parsing commit body
-                string body = ReEncodeCommitMessage(message).Replace('\v', '\n');
+                string body = ReEncodeCommitMessage(message ?? "").Replace('\v', '\n');
 
-                ReadOnlySpan<char> span = (body ?? "").AsSpan();
+                ReadOnlySpan<char> span = body.AsSpan();
                 int endSubjectIndex = span.IndexOf('\n');
                 revision.HasMultiLineMessage = endSubjectIndex >= 0;
                 revision.Subject = revision.HasMultiLineMessage
                     ? span[..endSubjectIndex].TrimEnd().ToString()
-                    : body ?? "";
+                    : body;
                 revision.Body = revision.HasMultiLineMessage ? body : null;
             }
 


### PR DESCRIPTION
Follow up to #11020

## Proposed changes

Shift-return adds vertical tab in the message which may be rendered as an unknown char instead of as s return.

#11020 presented vertical tab for messages newer than six months (body is not saved for older). The vertical tab was not presented as a return for older commits, fetched when needed.
(#11020 also handles \vas \n when entering text.)

Seen when working with #11170 

## Screenshots <!-- Remove this section if PR does not change UI -->

As I have not found a commit with \v older than six months, this is a dummy commit and a a change to not save the commit body for older commits.
\t were not shown in CommitInfo

https://github.com/gerhardol/gitextensions/pull/new/tmp/i11020-vertical-tab-return

![image](https://github.com/gitextensions/gitextensions/assets/6248932/707a9464-a2f9-4d68-aba7-c7bf9e0b159c)

### After

![image](https://github.com/gitextensions/gitextensions/assets/6248932/907e1c9c-8b9e-4adb-9a44-1d23b0b51c7c)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).