### PR TITLE
Fix bad condition when handling "Could not load file or assembly" exception

### DIFF
--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -107,20 +107,22 @@ namespace GitUI.NBugReports
                 LogError(exception, isTerminating);
             }
 
-            if (exception is FileNotFoundException fileNotFoundException
-                && ReportFailToLoadAnAssembly(fileNotFoundException) == UserAction.RestartApplication)
+            if (exception is FileNotFoundException fileNotFoundException)
             {
-                // Skipping the 1st parameter that, starting from .net core, contains the path to application dll (instead of exe)
-                string arguments = string.Join(" ", Environment.GetCommandLineArgs().Skip(1));
-                ProcessStartInfo pi = new(Environment.ProcessPath, arguments);
-                pi.WorkingDirectory = Environment.CurrentDirectory;
-                Process.Start(pi);
-                Environment.Exit(0);
-            }
-            else
-            {
-                ShowNBug(OwnerForm, exception, false, isTerminating);
-                return;
+                if (ReportFailToLoadAnAssembly(fileNotFoundException) == UserAction.RestartApplication)
+                {
+                    // Skipping the 1st parameter that, starting from .net core, contains the path to application dll (instead of exe)
+                    string arguments = string.Join(" ", Environment.GetCommandLineArgs().Skip(1));
+                    ProcessStartInfo pi = new(Environment.ProcessPath, arguments);
+                    pi.WorkingDirectory = Environment.CurrentDirectory;
+                    Process.Start(pi);
+                    Environment.Exit(0);
+                }
+                else
+                {
+                    ShowNBug(OwnerForm, exception, false, isTerminating);
+                    return;
+                }
             }
 
             ExternalOperationException externalOperationException = exception as ExternalOperationException;


### PR DESCRIPTION

Followup of #11074

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/gitextensions/gitextensions/pull/11074#issuecomment-1688928982

## Proposed changes

- Special handling should be done **only** for FileNotFound Exception

## Test methodology <!-- How did you ensure quality? -->

- Manual (and done well now that the issue has been identified 😓 )

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 80b40b23725c9f82e588765bb37f31996c5997b6 (Dirty)
- Git 2.40.0.windows.1 (recommended: 2.41.0 or later)
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.16
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.16 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.5 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
