### PR TITLE
Improve exception reporting

### DIFF
--- a/BugReporter/BugReportForm.cs
+++ b/BugReporter/BugReportForm.cs
@@ -26,11 +26,11 @@ namespace BugReporter
 
 Because of this, make sure to fill in all the fields in the report template please.
 
-Send report anyway?");
+Send report?");
         private readonly TranslationString _toolTipCopy = new("Copy the issue details into clipboard");
         private readonly TranslationString _toolTipSendQuit = new("Report the issue to GitHub and quit application.\r\nA valid GitHub account is required");
         private readonly TranslationString _toolTipQuit = new("Quit application without reporting the issue");
-        private readonly TranslationString _noReproStepsSuppliedErrorMessage = new(@"Please provide as much as information as possible to help the developers solve this issue.");
+        private readonly TranslationString _noReproStepsSuppliedErrorMessage = new("Please provide as much as information as possible to help the developers solve this issue.");
 
         private static readonly IErrorReportUrlBuilder ErrorReportBodyBuilder;
         private static readonly GitHubUrlBuilder UrlBuilder;
@@ -103,11 +103,13 @@ Send report anyway?");
             if (focusDetails)
             {
                 mainTabs.SelectedTab = exceptionTabPage;
+
+                // Hold back users from reporting UserExternalOperationExceptions directly
+                sendAndQuitButton.Enabled = false;
             }
 
             ControlBox = canIgnore;
-            showIgnore &= canIgnore;
-            IgnoreButton.Visible = showIgnore;
+            IgnoreButton.Enabled = showIgnore && canIgnore;
             IgnoreButton.Visible = showIgnore;
 
             DialogResult = DialogResult.None;

--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -151,12 +151,13 @@ namespace GitCommands
                             if (_throwOnErrorExit && exitCode != 0)
                             {
                                 string errorOutput = _process.StandardError.ReadToEnd().Trim();
+                                string errorMessage = errorOutput.Length > 0 ? errorOutput : "External program returned non-zero exit code.";
                                 Exception ex
                                     = new ExternalOperationException(command: _process.StartInfo.FileName,
                                             _process.StartInfo.Arguments,
                                             _process.StartInfo.WorkingDirectory,
                                             exitCode,
-                                            new Exception(errorOutput));
+                                            new Exception(errorMessage));
                                 if (exitCode == NativeMethods.STATUS_CONTROL_C_EXIT)
                                 {
                                     ex = new OperationCanceledException("Ctrl+C pressed or console closed", ex);

--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -151,12 +151,17 @@ namespace GitCommands
                             if (_throwOnErrorExit && exitCode != 0)
                             {
                                 string errorOutput = _process.StandardError.ReadToEnd().Trim();
-                                ExternalOperationException ex
-                                    = new(command: _process.StartInfo.FileName,
+                                Exception ex
+                                    = new ExternalOperationException(command: _process.StartInfo.FileName,
                                             _process.StartInfo.Arguments,
                                             _process.StartInfo.WorkingDirectory,
                                             exitCode,
                                             new Exception(errorOutput));
+                                if (exitCode == NativeMethods.STATUS_CONTROL_C_EXIT)
+                                {
+                                    ex = new OperationCanceledException("Ctrl+C pressed or console closed", ex);
+                                }
+
                                 _logOperation.LogProcessEnd(ex);
                                 _exitTaskCompletionSource.TrySetException(ex);
                             }

--- a/GitCommands/Git/Status.cs
+++ b/GitCommands/Git/Status.cs
@@ -1,0 +1,7 @@
+﻿namespace System
+{
+    internal static partial class NativeMethods
+    {
+        internal const int STATUS_CONTROL_C_EXIT = -1073741510; // 0xC000013A
+    }
+}

--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -149,7 +149,7 @@ namespace GitUI.NBugReports
 
             TaskDialogPage page = new()
             {
-                Icon = TaskDialogIcon.Error,
+                Icon = isExternalOperation ? TaskDialogIcon.Warning : TaskDialogIcon.Error,
                 Caption = TranslatedStrings.Error,
                 Heading = rootError,
                 AllowCancel = true,
@@ -159,18 +159,19 @@ namespace GitUI.NBugReports
             // prefer to ignore failed external operations
             if (isExternalOperation)
             {
-                AddIgnoreOrCloseButton();
+                AddIgnoreOrCloseButton(TranslatedStrings.ExternalErrorDescription);
             }
-
-            // no bug reports for user configured operations
-            if (!isUserExternalOperation)
+            else
             {
                 // directions and button to raise a bug
                 text.AppendLine().AppendLine(TranslatedStrings.ReportBug);
             }
 
-            string buttonText = isUserExternalOperation ? TranslatedStrings.ButtonViewDetails : TranslatedStrings.ButtonReportBug;
-            TaskDialogCommandLinkButton taskDialogCommandLink = new(buttonText);
+            // no bug reports for user configured operations
+            TaskDialogCommandLinkButton taskDialogCommandLink
+                = isUserExternalOperation ? new(TranslatedStrings.ButtonViewDetails)
+                    : isExternalOperation ? new(TranslatedStrings.ReportIssue, TranslatedStrings.ReportIssueDescription)
+                    : new(TranslatedStrings.ButtonReportBug);
             taskDialogCommandLink.Click += (s, e) =>
             {
                 ShowNBug(OwnerForm, exception, isExternalOperation, isTerminating);
@@ -187,10 +188,10 @@ namespace GitUI.NBugReports
             TaskDialog.ShowDialog(OwnerFormHandle, page);
             return;
 
-            void AddIgnoreOrCloseButton()
+            void AddIgnoreOrCloseButton(string descriptionText = null)
             {
                 string buttonText = isTerminating ? TranslatedStrings.ButtonCloseApp : TranslatedStrings.ButtonIgnore;
-                TaskDialogCommandLinkButton taskDialogCommandLink = new(buttonText);
+                TaskDialogCommandLinkButton taskDialogCommandLink = new(buttonText, descriptionText);
                 page.Buttons.Add(taskDialogCommandLink);
             }
         }

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -106,6 +106,8 @@ the last selected commit.");
         private readonly TranslationString _exitCodeText = new("Exit code");
         private readonly TranslationString _workingDirectoryText = new("Working directory");
         private readonly TranslationString _reportBugText = new("If you think this was caused by Git Extensions, you can report a bug for the team to investigate.");
+        private readonly TranslationString _reportIssueDescription = new($"for the team to investigate - if you think this was caused by {AppSettings.ApplicationName}");
+        private readonly TranslationString _externalErrorDescription = new("error from git or from other external application");
 
         private readonly TranslationString _filterFileInGrid = new("Filter file in &grid");
 
@@ -294,6 +296,8 @@ following command.
         public static string ExitCode => _instance.Value._exitCodeText.Text;
         public static string WorkingDirectory => _instance.Value._workingDirectoryText.Text;
         public static string ReportBug => _instance.Value._reportBugText.Text;
+        public static string ReportIssueDescription => _instance.Value._reportIssueDescription.Text;
+        public static string ExternalErrorDescription => _instance.Value._externalErrorDescription.Text;
 
         public static string RemoteInError => _instance.Value._remoteInError.Text;
         public static string NoChanges => _instance.Value._noChanges.Text;

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -168,11 +168,11 @@ following command.
         private readonly TranslationString _seeErrorMessage = new("See error message...");
         private readonly TranslationString _hideErrorMessage = new("Hide error message...");
         private readonly TranslationString _reportIssue = new("Report the issue");
-        private readonly TranslationString _reportIssueDescription = new("If you can consistently reproduce the issue, please report it.");
+        private readonly TranslationString _reportReproducedIssueDescription = new("If you can consistently reproduce the issue, please report it.");
         private readonly TranslationString _restartApplication = new($"Restart {AppSettings.ApplicationName}");
         private readonly TranslationString _restartApplicationDescription = new("Usually restarting the application solves the issue.\r\nSometimes Windows may need to be restarted too.");
         private readonly TranslationString _failedToLoadAnAssembly = new("Failed to load an assembly");
-        private readonly TranslationString _failedToLoadFileOrAssemblyFormat = new("Could not load file or assembly '{0}'");
+        private readonly TranslationString _failedToLoadFileOrAssemblyFormat = new("Could not load file or assembly '{0}'.");
         private readonly TranslationString _failedToLoadFileOrAssemblyText = new("Most of the times the error is temporary, likely caused by Windows Update.");
 
         // public only because of FormTranslate
@@ -350,7 +350,7 @@ following command.
         public static string SeeErrorMessage => _instance.Value._seeErrorMessage.Text;
         public static string HideErrorMessage => _instance.Value._hideErrorMessage.Text;
         public static string ReportIssue => _instance.Value._reportIssue.Text;
-        public static string ReportIssueDescription => _instance.Value._reportIssueDescription.Text;
+        public static string ReportReproducedIssueDescription => _instance.Value._reportReproducedIssueDescription.Text;
         public static string RestartApplication => _instance.Value._restartApplication.Text;
         public static string RestartApplicationDescription => _instance.Value._restartApplicationDescription.Text;
         public static string FailedToLoadAnAssembly => _instance.Value._failedToLoadAnAssembly.Text;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -10093,7 +10093,7 @@ Select this commit to populate the full message.</source>
         <target />
       </trans-unit>
       <trans-unit id="_failedToLoadFileOrAssemblyFormat.Text">
-        <source>Could not load file or assembly '{0}'</source>
+        <source>Could not load file or assembly '{0}'.</source>
         <target />
       </trans-unit>
       <trans-unit id="_failedToLoadFileOrAssemblyText.Text">
@@ -10315,7 +10315,7 @@ Remote: {1}</source>
         <source>Report the issue</source>
         <target />
       </trans-unit>
-      <trans-unit id="_reportIssueDescription.Text">
+      <trans-unit id="_reportReproducedIssueDescription.Text">
         <source>If you can consistently reproduce the issue, please report it.</source>
         <target />
       </trans-unit>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -441,7 +441,7 @@ Click this info icon for more details.</source>
 
 Because of this, make sure to fill in all the fields in the report template please.
 
-Send report anyway?</source>
+Send report?</source>
         <target />
       </trans-unit>
       <trans-unit id="_title.Text">
@@ -10088,6 +10088,10 @@ Select this commit to populate the full message.</source>
         <source>Exit code</source>
         <target />
       </trans-unit>
+      <trans-unit id="_externalErrorDescription.Text">
+        <source>error from git or from other external application</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_failedToLoadAnAssembly.Text">
         <source>Failed to load an assembly</source>
         <target />
@@ -10313,6 +10317,10 @@ Remote: {1}</source>
       </trans-unit>
       <trans-unit id="_reportIssue.Text">
         <source>Report the issue</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_reportIssueDescription.Text">
+        <source>for the team to investigate - if you think this was caused by Git Extensions</source>
         <target />
       </trans-unit>
       <trans-unit id="_reportReproducedIssueDescription.Text">


### PR DESCRIPTION
Fixes #10543
Fixes #11165
Fixes https://github.com/gitextensions/gitextensions/pull/11074#issuecomment-1688928982

## Proposed changes

- Throw `OperationCanceledException` instead of plain `ExternalOperationException` on `Ctrl+C` exit code from external process in order to avoid (bug report) popup
- Fixup `ReportFailedToLoadAnAssembly`:
  - only if the `FileNotFoundException` message starts with the specific "Could not load file or assembly"
  - remove lengthy version info from displayed message
  - handle `isTerminating`
  - simplify (like other usages)
  - use warning icon
- Add descriptions to `Ignore` / `Report` buttons and use warning icon in case of `ExternalOperationException`
- Disable `Send and quit` for `UserExternalOperationException` (The `Copy` button can be used.)
- Add exception text "External program returned non-zero exit code." in case of empty StandardError output

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/4403806/9ff0edde-ebd1-4cf0-bd9a-598ec977e087)

for other exceptions: direct invocation of BugReporter

### After

![image](https://github.com/gitextensions/gitextensions/assets/36601201/09659b0a-1073-4af8-bafa-c0707844fe87)

![image](https://github.com/gitextensions/gitextensions/assets/36601201/721a60cc-ecc2-4379-90d8-8e04d0b9899e)   ![image](https://github.com/gitextensions/gitextensions/assets/36601201/a67bd1f6-bc34-4901-bb40-9dc8f41021a9)

![image](https://github.com/gitextensions/gitextensions/assets/36601201/a8075135-a2a3-499a-b466-1bd84d4462af)   ![image](https://github.com/gitextensions/gitextensions/assets/36601201/891815bd-729b-4a47-90bf-4485abafe41a)

![image](https://github.com/gitextensions/gitextensions/assets/36601201/69363472-7a85-48ca-872b-ea7b854546a2)   ![image](https://github.com/gitextensions/gitextensions/assets/36601201/71711dcf-ab09-4923-8135-794f58b7a7b4)

![image](https://github.com/gitextensions/gitextensions/assets/36601201/0ba6f7c8-289e-43f5-8a5f-2b69e049e839)   ![image](https://github.com/gitextensions/gitextensions/assets/36601201/5163cdc3-17af-4fcc-a10e-3c2a01d9fa66)

![image](https://github.com/gitextensions/gitextensions/assets/36601201/be2574cc-6f3c-4940-a8ca-9442d76fea71)   ![image](https://github.com/gitextensions/gitextensions/assets/36601201/827248e4-94ad-4ff7-b582-47b3d27922a0)

![image](https://github.com/gitextensions/gitextensions/assets/36601201/c84aafd9-5fde-46e7-9705-ed7512b23e7d)   ![image](https://github.com/gitextensions/gitextensions/assets/36601201/328fb020-1e53-4d2a-9228-f2272927c0d7)

### BEFORE

![image](https://github.com/gitextensions/gitextensions/assets/36601201/de200673-4415-4817-ab45-1da57ea404e3)   ![image](https://github.com/gitextensions/gitextensions/assets/36601201/01d526e2-6f8e-47e6-a418-ddde2740b028)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).