### PR TITLE
Present git-diff errors in diffViewer

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2554,7 +2554,7 @@ namespace GitCommands
                 throwOnErrorExit: false);
             if (!result.ExitedSuccessfully)
             {
-                return (patch: null, errorMessage: $"{result.StandardError}{Environment.NewLine}Git command: {args} ({result.ExitCode}){Environment.NewLine}");
+                return (patch: null, errorMessage: $"{result.StandardError}{Environment.NewLine}Git command (exit code: {result.ExitCode}): {args}{Environment.NewLine}");
             }
 
             string patch = result.StandardOutput;

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2516,7 +2516,7 @@ namespace GitCommands
             return stashes;
         }
 
-        public async Task<(Patch? patch, string? errMsg)> GetSingleDiffAsync(
+        public async Task<(Patch? patch, string? errorMessage)> GetSingleDiffAsync(
             ObjectId? firstId, ObjectId? secondId,
             string? fileName, string? oldFileName,
             string extraDiffArguments, Encoding encoding,
@@ -2554,13 +2554,13 @@ namespace GitCommands
                 throwOnErrorExit: false);
             if (!result.ExitedSuccessfully)
             {
-                return (patch: null, errMsg: $"{result.StandardError}{Environment.NewLine}Git command: {args} ({result.ExitCode}){Environment.NewLine}");
+                return (patch: null, errorMessage: $"{result.StandardError}{Environment.NewLine}Git command: {args} ({result.ExitCode}){Environment.NewLine}");
             }
 
             string patch = result.StandardOutput;
             IReadOnlyList<Patch> patches = PatchProcessor.CreatePatchesFromString(patch, new Lazy<Encoding>(() => encoding)).ToList();
 
-            return (patch: GetPatch(patches, fileName, oldFileName), errMsg: null);
+            return (patch: GetPatch(patches, fileName, oldFileName), errorMessage: null);
         }
 
         public async Task<string> GetRangeDiffAsync(

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2516,7 +2516,7 @@ namespace GitCommands
             return stashes;
         }
 
-        public async Task<Patch?> GetSingleDiffAsync(
+        public async Task<(Patch? patch, string? errMsg)> GetSingleDiffAsync(
             ObjectId? firstId, ObjectId? secondId,
             string? fileName, string? oldFileName,
             string extraDiffArguments, Encoding encoding,
@@ -2547,17 +2547,20 @@ namespace GitCommands
                 ? GitCommandCache
                 : null;
 
-            bool nonZeroGitExitCode = firstId == ObjectId.WorkTreeId && secondId is not null && !isTracked;
             ExecutionResult result = await _gitExecutable.ExecuteAsync(
                 args,
                 cache: cache,
                 outputEncoding: LosslessEncoding,
-                throwOnErrorExit: !nonZeroGitExitCode);
+                throwOnErrorExit: false);
+            if (!result.ExitedSuccessfully)
+            {
+                return (patch: null, errMsg: $"{result.StandardError}{Environment.NewLine}Git command: {args} ({result.ExitCode}){Environment.NewLine}");
+            }
 
             string patch = result.StandardOutput;
             IReadOnlyList<Patch> patches = PatchProcessor.CreatePatchesFromString(patch, new Lazy<Encoding>(() => encoding)).ToList();
 
-            return GetPatch(patches, fileName, oldFileName);
+            return (patch: GetPatch(patches, fileName, oldFileName), errMsg: null);
         }
 
         public async Task<string> GetRangeDiffAsync(

--- a/GitCommands/Git/SubmoduleHelpers.cs
+++ b/GitCommands/Git/SubmoduleHelpers.cs
@@ -10,8 +10,10 @@ namespace GitCommands.Git
     {
         public static async Task<GitSubmoduleStatus?> GetCurrentSubmoduleChangesAsync(GitModule module, string? fileName, string? oldFileName, ObjectId? firstId, ObjectId? secondId)
         {
-            Patch? patch = await module.GetSingleDiffAsync(firstId, secondId, fileName, oldFileName, "", GitModule.SystemEncoding, cacheResult: true).ConfigureAwait(false);
-            return ParseSubmodulePatchStatus(patch, module, fileName);
+            (Patch? patch, string? errMsg) = await module.GetSingleDiffAsync(firstId, secondId, fileName, oldFileName, "", GitModule.SystemEncoding, cacheResult: true).ConfigureAwait(false);
+            return patch is null
+                ? new GitSubmoduleStatus(errMsg ?? "", null, false, null, null, null, null)
+                : ParseSubmodulePatchStatus(patch, module, fileName);
         }
 
         public static async Task<GitSubmoduleStatus?> GetCurrentSubmoduleChangesAsync(GitModule module, string? fileName, string? oldFileName, bool staged, bool noLocks = false)

--- a/GitCommands/Git/SubmoduleHelpers.cs
+++ b/GitCommands/Git/SubmoduleHelpers.cs
@@ -10,9 +10,9 @@ namespace GitCommands.Git
     {
         public static async Task<GitSubmoduleStatus?> GetCurrentSubmoduleChangesAsync(GitModule module, string? fileName, string? oldFileName, ObjectId? firstId, ObjectId? secondId)
         {
-            (Patch? patch, string? errMsg) = await module.GetSingleDiffAsync(firstId, secondId, fileName, oldFileName, "", GitModule.SystemEncoding, cacheResult: true).ConfigureAwait(false);
+            (Patch? patch, string? errorMessage) = await module.GetSingleDiffAsync(firstId, secondId, fileName, oldFileName, "", GitModule.SystemEncoding, cacheResult: true).ConfigureAwait(false);
             return patch is null
-                ? new GitSubmoduleStatus(errMsg ?? "", null, false, null, null, null, null)
+                ? new GitSubmoduleStatus(errorMessage ?? "", null, false, null, null, null, null)
                 : ParseSubmodulePatchStatus(patch, module, fileName);
         }
 

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -145,15 +145,15 @@ namespace GitUI
                         : $"Failed to get status for submodule \"{file.Name}\"";
                 }
 
-                (Patch? patch, string? errorMessage)? result = await GetItemPatchAsync(fileViewer.Module, file, firstId, selectedId,
+                (Patch? patch, string? errorMessage) = await GetItemPatchAsync(fileViewer.Module, file, firstId, selectedId,
                     fileViewer.GetExtraDiffArguments(), fileViewer.Encoding);
 
                 cancellationToken.ThrowIfCancellationRequested();
                 return file.IsSubmodule
-                    ? LocalizationHelpers.ProcessSubmodulePatch(fileViewer.Module, file.Name, result.Value.patch)
-                    : result.Value.patch?.Text ?? result.Value.errorMessage;
+                    ? LocalizationHelpers.ProcessSubmodulePatch(fileViewer.Module, file.Name, patch)
+                    : patch?.Text ?? errorMessage;
 
-                static async Task<(Patch? patch, string? errorMessage)?> GetItemPatchAsync(
+                static async Task<(Patch? patch, string? errorMessage)> GetItemPatchAsync(
                     GitModule module,
                     GitItemStatus file,
                     ObjectId? firstId,

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -145,15 +145,15 @@ namespace GitUI
                         : $"Failed to get status for submodule \"{file.Name}\"";
                 }
 
-                var patch = await GetItemPatchAsync(fileViewer.Module, file, firstId, selectedId,
+                (Patch? patch, string? errMsg)? result = await GetItemPatchAsync(fileViewer.Module, file, firstId, selectedId,
                     fileViewer.GetExtraDiffArguments(), fileViewer.Encoding);
 
                 cancellationToken.ThrowIfCancellationRequested();
                 return file.IsSubmodule
-                    ? LocalizationHelpers.ProcessSubmodulePatch(fileViewer.Module, file.Name, patch)
-                    : patch?.Text;
+                    ? LocalizationHelpers.ProcessSubmodulePatch(fileViewer.Module, file.Name, result.Value.patch)
+                    : result.Value.patch?.Text ?? result.Value.errMsg;
 
-                static async Task<Patch?> GetItemPatchAsync(
+                static async Task<(Patch? patch, string? errMsg)?> GetItemPatchAsync(
                     GitModule module,
                     GitItemStatus file,
                     ObjectId? firstId,
@@ -162,7 +162,7 @@ namespace GitUI
                     Encoding encoding)
                 {
                     // Files with tree guid should be presented with normal diff
-                    var isTracked = file.IsTracked || (file.TreeGuid is not null && secondId is not null);
+                    bool isTracked = file.IsTracked || (file.TreeGuid is not null && secondId is not null);
 
                     return await module.GetSingleDiffAsync(firstId, secondId, file.Name, file.OldName, diffArgs, encoding, true, isTracked);
                 }

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -145,15 +145,15 @@ namespace GitUI
                         : $"Failed to get status for submodule \"{file.Name}\"";
                 }
 
-                (Patch? patch, string? errMsg)? result = await GetItemPatchAsync(fileViewer.Module, file, firstId, selectedId,
+                (Patch? patch, string? errorMessage)? result = await GetItemPatchAsync(fileViewer.Module, file, firstId, selectedId,
                     fileViewer.GetExtraDiffArguments(), fileViewer.Encoding);
 
                 cancellationToken.ThrowIfCancellationRequested();
                 return file.IsSubmodule
                     ? LocalizationHelpers.ProcessSubmodulePatch(fileViewer.Module, file.Name, result.Value.patch)
-                    : result.Value.patch?.Text ?? result.Value.errMsg;
+                    : result.Value.patch?.Text ?? result.Value.errorMessage;
 
-                static async Task<(Patch? patch, string? errMsg)?> GetItemPatchAsync(
+                static async Task<(Patch? patch, string? errorMessage)?> GetItemPatchAsync(
                     GitModule module,
                     GitItemStatus file,
                     ObjectId? firstId,


### PR DESCRIPTION
Fixes #11164 (and probably a few more)

## Proposed changes

Present the error output from git-diff that fail in the diff viewer instead of starting NBug.

git-diff is expected to be Git or user error, no need to show NBug in this scenario.
The error is not suppressed, it can still be reported manually (this could still be a GE issue, as in my error insertion).

This is a hack, especially for the submodule status.

## Screenshots <!-- Remove this section if PR does not change UI -->

Inserted error by editing the code

### Before

NBug popup

### After

![image](https://github.com/gitextensions/gitextensions/assets/6248932/f60d1f8a-05f7-4dd0-a3a5-40b974179650)

![image](https://github.com/gitextensions/gitextensions/assets/6248932/41a30a05-aee8-4843-963e-10e2f150e544)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
