### PR TITLE
Added password text box to remote console window

### DIFF
--- a/GitCommands/Git/EnvironmentConfiguration.cs
+++ b/GitCommands/Git/EnvironmentConfiguration.cs
@@ -44,6 +44,12 @@ namespace GitCommands
             // to prevent from leaking processes see issue #1092 for details
             Env.SetEnvironmentVariable("TERM", "msys");
 
+            // Force a non-empty DISPLAY so ssh uses SSH_ASKPASS if it has no terminal
+            if (string.IsNullOrEmpty(Env.GetEnvironmentVariable("DISPLAY")))
+            {
+                Env.SetEnvironmentVariable("DISPLAY", ":");
+            }
+
             // SSH_ASKPASS variable
 
             if (EnvUtils.RunningOnWindows())

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1260,6 +1260,8 @@ namespace GitCommands
             set => SetBool("closeprocessdialog", value);
         }
 
+        public static ISetting<bool> ShowProcessDialogPasswordInput => Setting.Create(DetailedSettingsPath, nameof(ShowProcessDialogPasswordInput), true);
+
         public static bool ShowCurrentBranchOnly
         {
             get => GetBool("showcurrentbranchonly", false);

--- a/GitUI/HelperDialogs/FormRemoteProcess.cs
+++ b/GitUI/HelperDialogs/FormRemoteProcess.cs
@@ -68,6 +68,8 @@ Do you want to register the host's fingerprint and restart the process?");
         {
             _restart = false;
             Plink = GitSshHelpers.IsPlink;
+            ShowPassword.Visible = true;
+            PasswordPanel.Visible = ShowPassword.Checked;
             base.BeforeProcessStart();
         }
 

--- a/GitUI/HelperDialogs/FormStatus.Designer.cs
+++ b/GitUI/HelperDialogs/FormStatus.Designer.cs
@@ -18,10 +18,15 @@
             this.Ok = new System.Windows.Forms.Button();
             this.ProgressBar = new System.Windows.Forms.ProgressBar();
             this.KeepDialogOpen = new System.Windows.Forms.CheckBox();
+            this.ShowPassword = new System.Windows.Forms.CheckBox();
             this.Abort = new System.Windows.Forms.Button();
             this.pnlOutput = new System.Windows.Forms.Panel();
+            this.PasswordPanel = new System.Windows.Forms.Panel();
+            this.Password = new System.Windows.Forms.TextBox();
+            this.PasswordSend = new System.Windows.Forms.Button();
             this.MainPanel.SuspendLayout();
             this.ControlsPanel.SuspendLayout();
+            this.PasswordPanel.SuspendLayout();
             this.SuspendLayout();
             // 
             // MainPanel
@@ -30,12 +35,47 @@
             this.MainPanel.Padding = new System.Windows.Forms.Padding(0);
             this.MainPanel.Size = new System.Drawing.Size(549, 246);
             // 
+            // PasswordPanel
+            // 
+            this.PasswordPanel.Controls.Add(this.Password);
+            this.PasswordPanel.Controls.Add(this.PasswordSend);
+            this.PasswordPanel.Anchor = (AnchorStyles.Left | AnchorStyles.Right);
+            this.PasswordPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.PasswordPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.PasswordPanel.Padding = new System.Windows.Forms.Padding(8);
+            this.PasswordPanel.Size = new System.Drawing.Size(549, 39);
+            this.PasswordPanel.Location = new System.Drawing.Point(0, 249);
+            this.PasswordPanel.TabIndex = 2;
+            // 
+            // Password
+            // 
+            this.Password.UseSystemPasswordChar = true;
+            this.Password.TabIndex = 0;
+            this.Password.Anchor = (AnchorStyles.Left | AnchorStyles.Right);
+            this.Password.Margin = new System.Windows.Forms.Padding(0);
+            this.Password.Size = new System.Drawing.Size(443, 23);
+            this.Password.Location = new System.Drawing.Point(12, 8);
+            // 
+            // PasswordSend
+            // 
+            this.PasswordSend.Anchor = AnchorStyles.Right;
+            this.PasswordSend.Location = new System.Drawing.Point(461, 8);
+            this.PasswordSend.MinimumSize = new System.Drawing.Size(75, 23);
+            this.PasswordSend.Name = "PasswordSend";
+            this.PasswordSend.Size = new System.Drawing.Size(75, 23);
+            this.PasswordSend.TabIndex = 1;
+            this.PasswordSend.Text = "Send input";
+            this.PasswordSend.UseCompatibleTextRendering = true;
+            this.PasswordSend.UseVisualStyleBackColor = true;
+            this.PasswordSend.Click += new System.EventHandler(this.PasswordSend_Click);
+            // 
             // ControlsPanel
             // 
             this.ControlsPanel.Controls.Add(this.Abort);
             this.ControlsPanel.Controls.Add(this.Ok);
             this.ControlsPanel.Controls.Add(this.KeepDialogOpen);
-            this.ControlsPanel.Location = new System.Drawing.Point(0, 249);
+            this.ControlsPanel.Controls.Add(this.ShowPassword);
+            this.ControlsPanel.Location = new System.Drawing.Point(0, 288);
             this.ControlsPanel.Size = new System.Drawing.Size(549, 39);
             // 
             // Ok
@@ -64,14 +104,26 @@
             this.ProgressBar.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
             this.ProgressBar.TabIndex = 0;
             // 
+            // ShowPassword
+            // 
+            this.ShowPassword.AutoSize = true;
+            this.ShowPassword.Location = new System.Drawing.Point(134, 8);
+            this.ShowPassword.Name = "ShowPassword";
+            this.ShowPassword.Size = new System.Drawing.Size(120, 22);
+            this.ShowPassword.TabIndex = 2;
+            this.ShowPassword.Text = "Show &password input";
+            this.ShowPassword.UseCompatibleTextRendering = true;
+            this.ShowPassword.UseVisualStyleBackColor = true;
+            this.ShowPassword.CheckedChanged += new System.EventHandler(this.ShowPassword_CheckedChanged);
+            // 
             // KeepDialogOpen
             // 
             this.KeepDialogOpen.AutoSize = true;
             this.KeepDialogOpen.Location = new System.Drawing.Point(254, 8);
             this.KeepDialogOpen.Name = "KeepDialogOpen";
             this.KeepDialogOpen.Size = new System.Drawing.Size(120, 22);
-            this.KeepDialogOpen.TabIndex = 2;
-            this.KeepDialogOpen.Text = "Keep dialog open";
+            this.KeepDialogOpen.TabIndex = 3;
+            this.KeepDialogOpen.Text = "&Keep dialog open";
             this.KeepDialogOpen.UseCompatibleTextRendering = true;
             this.KeepDialogOpen.UseVisualStyleBackColor = true;
             this.KeepDialogOpen.CheckedChanged += new System.EventHandler(this.KeepDialogOpen_CheckedChanged);
@@ -106,8 +158,9 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.CancelButton = this.Abort;
-            this.ClientSize = new System.Drawing.Size(549, 288);
+            this.ClientSize = new System.Drawing.Size(549, 327);
             this.Controls.Add(this.ProgressBar);
+            this.Controls.Add(this.PasswordPanel);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.MinimumSize = new System.Drawing.Size(500, 200);
@@ -115,11 +168,14 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Process";
             this.Controls.SetChildIndex(this.ControlsPanel, 0);
+            this.Controls.SetChildIndex(this.PasswordPanel, 0);
             this.Controls.SetChildIndex(this.ProgressBar, 0);
             this.Controls.SetChildIndex(this.MainPanel, 0);
             this.MainPanel.ResumeLayout(false);
             this.ControlsPanel.ResumeLayout(false);
             this.ControlsPanel.PerformLayout();
+            this.PasswordPanel.ResumeLayout(false);
+            this.PasswordPanel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -128,8 +184,12 @@
         #endregion
 
         private System.Windows.Forms.ProgressBar ProgressBar;
+        protected System.Windows.Forms.Panel PasswordPanel;
+        protected System.Windows.Forms.TextBox Password;
+        protected System.Windows.Forms.Button PasswordSend;
         protected System.Windows.Forms.Button Ok;
         protected System.Windows.Forms.CheckBox KeepDialogOpen;
+        protected System.Windows.Forms.CheckBox ShowPassword;
         protected System.Windows.Forms.Button Abort;
         protected System.Windows.Forms.Panel pnlOutput;
     }

--- a/GitUI/HelperDialogs/FormStatus.cs
+++ b/GitUI/HelperDialogs/FormStatus.cs
@@ -39,6 +39,14 @@ namespace GitUI.HelperDialogs
             pnlOutput.Controls.Add(ConsoleOutput);
             ConsoleOutput.Dock = DockStyle.Fill;
 
+            Password.AllowDrop = true;
+            Password.DragDrop += Password_DragDrop;
+            Password.DragEnter += Password_DragEnter;
+            Password.DragOver += Password_DragEnter;
+            Password.GotFocus += Password_GotFocus;
+            Password.LostFocus += Password_LostFocus;
+            ShowPassword.Checked = AppSettings.ShowProcessDialogPasswordInput.Value;
+
             if (_useDialogSettings)
             {
                 KeepDialogOpen.Checked = !AppSettings.CloseProcessDialog;
@@ -119,6 +127,8 @@ namespace GitUI.HelperDialogs
 
             form.ProgressBar.Visible = false;
             form.KeepDialogOpen.Visible = false;
+            form.ShowPassword.Visible = false;
+            form.PasswordPanel.Visible = false;
             form.Abort.Visible = false;
 
             form.StartPosition = FormStartPosition.CenterParent;
@@ -160,6 +170,8 @@ namespace GitUI.HelperDialogs
             try
             {
                 AppendMessage("Done");
+                PasswordPanel.Visible = false;
+                ShowPassword.Visible = false;
                 ProgressBar.Visible = false;
                 Ok.Enabled = true;
                 Ok.Focus();
@@ -188,6 +200,8 @@ namespace GitUI.HelperDialogs
             SetIcon(Images.StatusBadgeWaiting);
             ConsoleOutput.Reset();
             OutputLog.Clear();
+            PasswordPanel.Visible = false;
+            ShowPassword.Visible = false;
             ProgressBar.Visible = true;
             Ok.Enabled = false;
             ActiveControl = null;
@@ -262,6 +276,61 @@ namespace GitUI.HelperDialogs
             if ((!KeepDialogOpen.Checked /* keep off */) && Ok.Enabled /* done */ && (!_errorOccurred /* and successful */))
             {
                 Close();
+            }
+        }
+
+        private void ShowPassword_CheckedChanged(object sender, EventArgs e)
+        {
+            AppSettings.ShowProcessDialogPasswordInput.Value = ShowPassword.Checked;
+            PasswordPanel.Visible = ShowPassword.Checked;
+        }
+
+        private void PasswordSend_Click(object sender, EventArgs e)
+        {
+            if (!Ok.Enabled)
+            {
+                ConsoleOutput.AppendInputFreeThreaded(Password.Text + "\n");
+                Password.Text = "";
+            }
+        }
+
+        private void Password_DragEnter(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.Text))
+            {
+                e.Effect = DragDropEffects.Copy;
+                Password.Focus();
+
+                // Workaround for a bug in GetCharIndexFromPosition: It cannot return the position after the last character
+                string original = Password.Text;
+                Password.Text = Password.Text + " ";
+                int pos = Password.GetCharIndexFromPosition(Password.PointToClient(new Point(e.X, e.Y)));
+                Password.Text = original;
+                Password.Select(pos, 0);
+            }
+        }
+
+        private void Password_DragDrop(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.Text))
+            {
+                Password.Paste(e.Data.GetData(DataFormats.Text).ToString());
+            }
+        }
+
+        private void Password_GotFocus(object sender, EventArgs e)
+        {
+            if (!Ok.Enabled)
+            {
+                AcceptButton = PasswordSend;
+            }
+        }
+
+        private void Password_LostFocus(object sender, EventArgs e)
+        {
+            if (AcceptButton == PasswordSend)
+            {
+                AcceptButton = null;
             }
         }
 

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6234,11 +6234,19 @@ Stash them before if you don't want to lose them.</source>
         <target />
       </trans-unit>
       <trans-unit id="KeepDialogOpen.Text">
-        <source>Keep dialog open</source>
+        <source>&amp;Keep dialog open</source>
         <target />
       </trans-unit>
       <trans-unit id="Ok.Text">
         <source>OK</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="PasswordSend.Text">
+        <source>Send input</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="ShowPassword.Text">
+        <source>Show &amp;password input</source>
         <target />
       </trans-unit>
       <trans-unit id="_fingerprintNotRegistredText.Text">
@@ -7238,11 +7246,19 @@ Therefore the Cancel button does NOT revert any changes made.</source>
         <target />
       </trans-unit>
       <trans-unit id="KeepDialogOpen.Text">
-        <source>Keep dialog open</source>
+        <source>&amp;Keep dialog open</source>
         <target />
       </trans-unit>
       <trans-unit id="Ok.Text">
         <source>OK</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="PasswordSend.Text">
+        <source>Send input</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="ShowPassword.Text">
+        <source>Show &amp;password input</source>
         <target />
       </trans-unit>
     </body>

--- a/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
+++ b/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
@@ -43,6 +43,12 @@ namespace GitUI.UserControls
             _terminal.RunningSession?.WriteOutputTextAsync(text);
         }
 
+        public override void AppendInputFreeThreaded(string text)
+        {
+            Validates.NotNull(_terminal);
+            _terminal.RunningSession?.WriteInputTextAsync(text);
+        }
+
         public override void KillProcess()
         {
             Validates.NotNull(_terminal);

--- a/GitUI/UserControls/ConsoleOutputControl.cs
+++ b/GitUI/UserControls/ConsoleOutputControl.cs
@@ -18,6 +18,8 @@ namespace GitUI.UserControls
 
         public abstract void AppendMessageFreeThreaded(string text);
 
+        public abstract void AppendInputFreeThreaded(string text);
+
         /// <summary>
         /// Creates the instance best fitting the current environment.
         /// </summary>

--- a/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
+++ b/GitUI/UserControls/EditboxBasedConsoleOutputControl.cs
@@ -20,6 +20,8 @@ namespace GitUI.UserControls
 
         private ProcessOutputThrottle? _outputThrottle;
 
+        private StreamWriter? _input;
+
         public EditboxBasedConsoleOutputControl()
         {
             _editbox = new RichTextBox
@@ -59,6 +61,11 @@ namespace GitUI.UserControls
             _outputThrottle?.Append(text);
         }
 
+        public override void AppendInputFreeThreaded(string text)
+        {
+            _input?.Write(text);
+        }
+
         public override void KillProcess()
         {
             if (InvokeRequired)
@@ -81,6 +88,7 @@ namespace GitUI.UserControls
             }
 
             _process = null;
+            _input = null;
             FireProcessExited();
         }
 
@@ -156,6 +164,7 @@ namespace GitUI.UserControls
                             _exitcode = _process.ExitCode;
                             operation.LogProcessEnd(_exitcode);
                             _process = null;
+                            _input = null;
                             _outputThrottle?.FlushOutput();
                             FireProcessExited();
                             _outputThrottle?.Stop(flush: true);
@@ -165,6 +174,7 @@ namespace GitUI.UserControls
                 process.Start();
                 operation.SetProcessId(process.Id);
                 _process = process;
+                _input = process.StandardInput;
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();
             }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

This adds a password input box below the console when running remote commands such as push/pull. This allows entering the password in a native control if one is required by the connection.

It is also usable for other input, like accepting server fingerprints, although the input is hidden regardless of the query.

## Screenshots <!-- Remove this section if PR does not change UI -->

![image](https://github.com/gitextensions/gitextensions/assets/5435495/fbfc1eaf-3d41-4cfd-b939-80f02dae6dad)

### Before

If using OpenSSH with the embedded console, direct typing and drag-and-drop may work, but the embedded console can corrupt input from auto-typers like KeePass. It also allows paste via Ctrl+V but not through right click/context menu.

If using OpenSSH with the emulated console, input isn't requested at all, and password input automatically fails.

If using Plink, password input automatically fails even in normal terminal. The only workaround is to use TortoisePlink which offers its own built-in password dialog.

### After

An additional password input box is available underneath the console. It is possible to type into it, auto-type into it, paste into it (with Ctrl+V or right click menu), or drag and drop text into it. Upon pressing Enter, the text is fed into the console (including line feed).

In OpenSSH with embedded console, SSH may not allow password input through a pipe, so extra measures are taken to ensure it uses `SSH_ASKPASS` instead.

Plink cannot be fixed. The only workaround is to use TortoisePlink.

## Test methodology <!-- How did you ensure quality? -->

- Made several pull requests to a password-protected SSH server, testing all possible combinations of SSH and console choice.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.41.0.windows.1
- Windows 10.0.19045

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
