### PR TITLE
Allow configuring editor for local files

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1350,6 +1350,8 @@ namespace GitCommands
             set => SetInt("diffverticalrulerposition", value);
         }
 
+        public static ISetting<string> LocalFileEditor => Setting.Create(DetailedSettingsPath, nameof(LocalFileEditor), string.Empty);
+
         [MaybeNull]
         public static string RecentWorkingDir
         {

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2717,7 +2717,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            UICommands.StartFileEditorDialog(fileName);
+            UICommands.StartLocalFileEditorDialog(fileName);
 
             UnstagedSelectionChanged(this, EventArgs.Empty);
         }

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -994,7 +994,7 @@ namespace GitUI.CommandsDialogs
             }
 
             var fileName = _fullPathResolver.Resolve(DiffFiles.SelectedItem.Item.Name);
-            UICommands.StartFileEditorDialog(fileName);
+            UICommands.StartLocalFileEditorDialog(fileName);
             RequestRefresh();
         }
 

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -614,7 +614,7 @@ See the changes in the commit form.");
 
             var fileName = _fullPathResolver.Resolve(gitItem.FileName);
             Validates.NotNull(fileName);
-            UICommands.StartFileEditorDialog(fileName);
+            UICommands.StartLocalFileEditorDialog(fileName);
             _refreshGitStatus?.Invoke();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
@@ -29,6 +29,8 @@
         private void InitializeComponent()
         {
             this.tlpnlGeneral = new System.Windows.Forms.TableLayoutPanel();
+            this.lblEditor = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_cboEditor = new System.Windows.Forms.ComboBox();
             this.chkRememberIgnoreWhiteSpacePreference = new System.Windows.Forms.CheckBox();
             this.chkRememberShowNonPrintingCharsPreference = new System.Windows.Forms.CheckBox();
             this.chkRememberShowEntireFilePreference = new System.Windows.Forms.CheckBox();
@@ -55,8 +57,8 @@
             this.tlpnlGeneral.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.tlpnlGeneral.ColumnCount = 3;
             this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tlpnlGeneral.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpnlGeneral.Controls.Add(this.chkRememberIgnoreWhiteSpacePreference, 0, 0);
             this.tlpnlGeneral.Controls.Add(this.chkRememberShowNonPrintingCharsPreference, 0, 1);
             this.tlpnlGeneral.Controls.Add(this.chkRememberShowEntireFilePreference, 0, 2);
@@ -69,10 +71,13 @@
             this.tlpnlGeneral.Controls.Add(this.chkShowAllCustomDiffTools, 0, 9);
             this.tlpnlGeneral.Controls.Add(this.label1, 0, 10);
             this.tlpnlGeneral.Controls.Add(this.VerticalRulerPosition, 1, 10);
+            this.tlpnlGeneral.Controls.Add(this.lblEditor, 0, 11);
+            this.tlpnlGeneral.Controls.Add(this._NO_TRANSLATE_cboEditor, 1, 11);
             this.tlpnlGeneral.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tlpnlGeneral.Location = new System.Drawing.Point(8, 24);
             this.tlpnlGeneral.Name = "tlpnlGeneral";
-            this.tlpnlGeneral.RowCount = 11;
+            this.tlpnlGeneral.RowCount = 12;
+            this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpnlGeneral.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -216,6 +221,23 @@
             0,
             0});
             // 
+            // lblEditor
+            // 
+            this.lblEditor.AutoSize = true;
+            this.lblEditor.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblEditor.Location = new System.Drawing.Point(3, 275);
+            this.lblEditor.Name = "lblEditor";
+            this.lblEditor.Size = new System.Drawing.Size(325, 27);
+            this.lblEditor.Text = "Local file editor (Leave blank to use built-in editor)";
+            this.lblEditor.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // _NO_TRANSLATE_cboEditor
+            // 
+            this._NO_TRANSLATE_cboEditor.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._NO_TRANSLATE_cboEditor.Location = new System.Drawing.Point(334, 278);
+            this._NO_TRANSLATE_cboEditor.Name = "_NO_TRANSLATE_cboEditor";
+            this._NO_TRANSLATE_cboEditor.Size = new System.Drawing.Size(356, 21);
+            // 
             // tlpnlMain
             // 
             this.tlpnlMain.ColumnCount = 1;
@@ -278,6 +300,8 @@
         private UserControls.Settings.SettingsCheckBox chkShowAllCustomDiffTools;
         private System.Windows.Forms.NumericUpDown VerticalRulerPosition;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label lblEditor;
+        private System.Windows.Forms.ComboBox _NO_TRANSLATE_cboEditor;
         private System.Windows.Forms.TableLayoutPanel tlpnlMain;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
@@ -13,6 +13,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkShowDiffForAllParents.Text = TranslatedStrings.ShowDiffForAllParentsText;
             chkShowDiffForAllParents.ToolTipText = TranslatedStrings.ShowDiffForAllParentsTooltip;
             chkContScrollToNextFileOnlyWithAlt.Text = TranslatedStrings.ContScrollToNextFileOnlyWithAlt;
+
+            _NO_TRANSLATE_cboEditor.Items.Add(string.Empty);
+            _NO_TRANSLATE_cboEditor.Items.AddRange(EditorHelper.GetEditors());
         }
 
         protected override void SettingsToPage()
@@ -28,6 +31,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkShowDiffForAllParents.Checked = AppSettings.ShowDiffForAllParents;
             chkShowAllCustomDiffTools.Checked = AppSettings.ShowAvailableDiffTools;
             VerticalRulerPosition.Value = AppSettings.DiffVerticalRulerPosition;
+            _NO_TRANSLATE_cboEditor.Text = AppSettings.LocalFileEditor.Value;
 
             base.SettingsToPage();
         }
@@ -45,6 +49,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.ShowDiffForAllParents = chkShowDiffForAllParents.Checked;
             AppSettings.ShowAvailableDiffTools = chkShowAllCustomDiffTools.Checked;
             AppSettings.DiffVerticalRulerPosition = (int)VerticalRulerPosition.Value;
+            AppSettings.LocalFileEditor.Value = _NO_TRANSLATE_cboEditor.Text;
 
             base.PageToSettings();
         }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1396,6 +1396,10 @@ the last selected commit.</source>
         <source>Vertical ruler position [chars]</source>
         <target />
       </trans-unit>
+      <trans-unit id="lblEditor.Text">
+        <source>Local file editor (Leave blank to use built-in editor)</source>
+        <target />
+      </trans-unit>
     </body>
   </file>
   <file datatype="plaintext" original="EditNetSpell" source-language="en">


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8769

## Proposed changes

In Settings, General, adds an option "Local file editor" which allows configuring an alternative editor for F4 action. If left blank, the current behavior is applied.

Only applies to actions associated with the F4 button. Does **not** apply to custom editors, e.g. `.gitignore`, `.git/config`.

## Screenshots <!-- Remove this section if PR does not change UI -->

![image](https://github.com/gitextensions/gitextensions/assets/5435495/cdc8310e-a0bd-41c7-8259-b0fcc2a086f8)

### Before

When pressing F4 in diff list, file tree, or commit window, an built-in editor opens up.

### After

It is possible to configure a different editor. If left blank, the old behavior remains. If configured, the selected editor is executed instead.

## Test methodology <!-- How did you ensure quality? -->

- Configured an editor and tested
- Changed editor to blank, and tested that it runs the built-in editor
- Created a file with whitespaces in the name, and tested that it opens correctly
- Set editor to `"D:\Program Files\TortoiseHg\lib\kdiff3.exe" C:\temp\test.txt` to test running a program that contains spaces in its filename, while also applying command line arguments.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.41.0.windows.1
- Windows 10.0.19045

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
