### PR TITLE
Cancel pending GitStatusMonitor operations on form dispose

### DIFF
--- a/IntegrationTests/UI.IntegrationTests/UITest.cs
+++ b/IntegrationTests/UI.IntegrationTests/UITest.cs
@@ -98,7 +98,7 @@ namespace GitExtensions.UITests
             {
                 if (debug)
                 {
-                    Console.WriteLine($"{DateTime.Now.TimeOfDay} {message}");
+                    Trace.WriteLine($"{DateTime.Now.TimeOfDay} {message}");
                 }
             }
         }


### PR DESCRIPTION
I'm unable to run the LeftPanel-related tests (e.g., `RepoObjectTree_moving_first_up_and_last_down_does_nothing`) locally, they just lock up after the dialog is closed. My investigations suggest that there are outstanding async operations in `GitStatusMonitor`.

The sequence of event is something like the following:
- The form is closed disposing itself and `GitStatusMonitor` monitor (`FormBrowse.Dispose`).
- Despite of that `GitStatusMonitor` continues to execute `Update` operation, which continues making git calls and reschedules itself.

I was able to make the tests to pass to completion with the added early exits by checking the cancelled token and adding a `disposed` flag.