### PR TITLE
Better report test hangs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -131,6 +131,11 @@ on_failure:
         Push-AppveyorArtifact "$_"
     }
 - ps: |
+   Get-ChildItem -Recurse artifacts\Release\**\*.dgml -ErrorAction SilentlyContinue `
+    | ForEach-Object {
+        Push-AppveyorArtifact "$_"
+    }
+- ps: |
     Get-ChildItem -recurse artifacts\Release\TestsResults\*.trx | `
         ForEach-Object {
             $file = $_.FullName.Replace('[', '``[').Replace(']', '``]')


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

Save the `HangReporter` [dgml reports](https://learn.microsoft.com/visualstudio/modeling/directed-graph-markup-language-dgml-reference) so that those can be opened in VS for further investigations.
![image](https://github.com/gitextensions/gitextensions/assets/4403806/3d2cd325-9201-48ab-b7f2-b7596db00273)
https://ci.appveyor.com/project/gitextensions/gitextensions/builds/47948910/artifacts

For example,
![image](https://github.com/gitextensions/gitextensions/assets/4403806/e89cc206-2ff7-4af1-957c-2dccacff1bff)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
