### PR TITLE
Cancel loading custom diff/merge tools when the control is diposed

### DIFF
--- a/GitCommands/CustomDiffMergeToolCache.cs
+++ b/GitCommands/CustomDiffMergeToolCache.cs
@@ -48,6 +48,8 @@ namespace GitCommands
                 return _tools;
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
+
             // The command will compete with other resources, avoid delaying startup
             // Do not bother with cancel tokens
             await Task.Delay(delay, cancellationToken);
@@ -64,6 +66,8 @@ namespace GitCommands
                     var toolKey = _isDiff ? SettingKeyString.DiffToolKey : SettingKeyString.MergeToolKey;
                     var defaultTool = module.GetEffectiveSetting(toolKey);
                     string output = module.GetCustomDiffMergeTools(_isDiff, cancellationToken);
+
+                    cancellationToken.ThrowIfCancellationRequested();
                     _tools = ParseCustomDiffMergeTool(output, defaultTool);
                 }
             }

--- a/GitUI/CustomDiffMergeToolProvider.cs
+++ b/GitUI/CustomDiffMergeToolProvider.cs
@@ -46,6 +46,8 @@ namespace GitUI
 
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 // get the tools, possibly with a delay as requesting requires considerable time
                 // cache is shared
                 List<string> tools = (await (isDiff ? CustomDiffMergeToolCache.DiffToolCache : CustomDiffMergeToolCache.MergeToolCache)
@@ -58,13 +60,18 @@ namespace GitUI
                     return;
                 }
 
+                cancellationToken.ThrowIfCancellationRequested();
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
                 foreach (var menu in menus)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     menu.MenuItem.DropDown = new ContextMenuStrip(components);
                     foreach (var tool in tools)
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
+
                         ToolStripMenuItem item = new(tool) { Tag = tool };
 
                         item.Click += menu.Click;
@@ -85,6 +92,8 @@ namespace GitUI
 
                     if (isDiff)
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
+
                         // Allow disabling for difftools
                         menu.MenuItem.DropDown.Items.Add(new ToolStripSeparator());
                         ToolStripMenuItem disableItem = new()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

I observed test hags in https://ci.appveyor.com/project/gitextensions/gitextensions/builds/47950171
![image](https://github.com/gitextensions/gitextensions/assets/4403806/4a7779f0-eb8c-4aae-9bdb-3aa9e60c8507)



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
