### PR TITLE
Make ExecuteAsync cancellable and kill canceled processes

### DIFF
--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -34,7 +34,7 @@ namespace GitCommands
                               Encoding? outputEncoding = null,
                               bool useShellExecute = false,
                               bool throwOnErrorExit = true,
-                              CancellationToken? cancellationToken = null)
+                              CancellationToken cancellationToken = default)
         {
             // TODO should we set these on the child process only?
             EnvironmentConfiguration.SetEnvironmentVariables();
@@ -58,7 +58,7 @@ namespace GitCommands
             // TODO should this use TaskCreationOptions.RunContinuationsAsynchronously
             private readonly TaskCompletionSource<int> _exitTaskCompletionSource = new();
 
-            private readonly CancellationToken? _cancellationToken;
+            private readonly CancellationToken _cancellationToken;
             private readonly ProcessOperation _logOperation;
             private readonly Process _process;
             private readonly bool _redirectInput;
@@ -79,7 +79,7 @@ namespace GitCommands
                                   Encoding? outputEncoding,
                                   bool useShellExecute,
                                   bool throwOnErrorExit,
-                                  CancellationToken? cancellationToken)
+                                  CancellationToken cancellationToken)
             {
                 Debug.Assert(redirectOutput == (outputEncoding is not null), "redirectOutput == (outputEncoding is not null)");
                 _redirectInput = redirectInput;
@@ -261,7 +261,7 @@ namespace GitCommands
                             {
                                 HandleProcessExit();
                             }
-                            else if (_cancellationToken?.IsCancellationRequested is true)
+                            else if (_cancellationToken.IsCancellationRequested)
                             {
                                 // Directly kill the process because Ctrl+C does not reach the git process how we start it
                                 _process.Kill();

--- a/GitCommands/Git/Executable.cs
+++ b/GitCommands/Git/Executable.cs
@@ -27,14 +27,14 @@ namespace GitCommands
             _prefixArguments = prefixArguments;
         }
 
-        /// <inheritdoc />
         public IProcess Start(ArgumentString arguments = default,
                               bool createWindow = false,
                               bool redirectInput = false,
                               bool redirectOutput = false,
                               Encoding? outputEncoding = null,
                               bool useShellExecute = false,
-                              bool throwOnErrorExit = true)
+                              bool throwOnErrorExit = true,
+                              CancellationToken? cancellationToken = null)
         {
             // TODO should we set these on the child process only?
             EnvironmentConfiguration.SetEnvironmentVariables();
@@ -43,7 +43,7 @@ namespace GitCommands
 
             var fileName = _fileNameProvider();
 
-            return new ProcessWrapper(fileName, _prefixArguments, args, _workingDir, createWindow, redirectInput, redirectOutput, outputEncoding, useShellExecute, throwOnErrorExit);
+            return new ProcessWrapper(fileName, _prefixArguments, args, _workingDir, createWindow, redirectInput, redirectOutput, outputEncoding, useShellExecute, throwOnErrorExit, cancellationToken);
         }
 
         #region ProcessWrapper
@@ -58,14 +58,16 @@ namespace GitCommands
             // TODO should this use TaskCreationOptions.RunContinuationsAsynchronously
             private readonly TaskCompletionSource<int> _exitTaskCompletionSource = new();
 
-            private readonly object _syncRoot = new();
-            private readonly Process _process;
+            private readonly CancellationToken? _cancellationToken;
             private readonly ProcessOperation _logOperation;
+            private readonly Process _process;
             private readonly bool _redirectInput;
             private readonly bool _redirectOutput;
+            private readonly object _syncRoot = new();
             private readonly bool _throwOnErrorExit;
 
             private bool _disposed;
+            private bool _exitHandlerRemoved;
 
             public ProcessWrapper(string fileName,
                                   string prefixArguments,
@@ -76,12 +78,14 @@ namespace GitCommands
                                   bool redirectOutput,
                                   Encoding? outputEncoding,
                                   bool useShellExecute,
-                                  bool throwOnErrorExit)
+                                  bool throwOnErrorExit,
+                                  CancellationToken? cancellationToken)
             {
                 Debug.Assert(redirectOutput == (outputEncoding is not null), "redirectOutput == (outputEncoding is not null)");
                 _redirectInput = redirectInput;
                 _redirectOutput = redirectOutput;
                 _throwOnErrorExit = throwOnErrorExit;
+                _cancellationToken = cancellationToken;
 
                 Encoding errorEncoding = outputEncoding;
                 if (throwOnErrorExit)
@@ -135,50 +139,56 @@ namespace GitCommands
                 }
             }
 
+            private void HandleProcessExit()
+            {
+                try
+                {
+                    int exitCode = _process.ExitCode;
+                    _logOperation.LogProcessEnd(exitCode);
+
+                    if (_throwOnErrorExit && exitCode != 0)
+                    {
+                        string errorOutput = _process.StandardError.ReadToEnd().Trim();
+                        string errorMessage = errorOutput.Length > 0 ? errorOutput : "External program returned non-zero exit code.";
+                        Exception ex
+                            = new ExternalOperationException(command: _process.StartInfo.FileName,
+                                    _process.StartInfo.Arguments,
+                                    _process.StartInfo.WorkingDirectory,
+                                    exitCode,
+                                    new Exception(errorMessage));
+                        if (exitCode == NativeMethods.STATUS_CONTROL_C_EXIT)
+                        {
+                            ex = new OperationCanceledException("Ctrl+C pressed or console closed", ex);
+                        }
+
+                        _logOperation.LogProcessEnd(ex);
+                        _exitTaskCompletionSource.TrySetException(ex);
+                    }
+
+                    _exitTaskCompletionSource.TrySetResult(exitCode);
+                }
+                catch (Exception ex)
+                {
+                    _logOperation.LogProcessEnd(ex);
+                    _exitTaskCompletionSource.TrySetException(ex);
+                }
+            }
+
             private void OnProcessExit(object sender, EventArgs eventArgs)
             {
                 lock (_syncRoot)
                 {
                     // The Exited event can be raised after the process is disposed, however
                     // if the Process is disposed then reading ExitCode will throw.
-                    if (!_disposed)
+                    if (!_disposed && !_exitHandlerRemoved)
                     {
-                        try
-                        {
-                            int exitCode = _process.ExitCode;
-                            _logOperation.LogProcessEnd(exitCode);
-
-                            if (_throwOnErrorExit && exitCode != 0)
-                            {
-                                string errorOutput = _process.StandardError.ReadToEnd().Trim();
-                                string errorMessage = errorOutput.Length > 0 ? errorOutput : "External program returned non-zero exit code.";
-                                Exception ex
-                                    = new ExternalOperationException(command: _process.StartInfo.FileName,
-                                            _process.StartInfo.Arguments,
-                                            _process.StartInfo.WorkingDirectory,
-                                            exitCode,
-                                            new Exception(errorMessage));
-                                if (exitCode == NativeMethods.STATUS_CONTROL_C_EXIT)
-                                {
-                                    ex = new OperationCanceledException("Ctrl+C pressed or console closed", ex);
-                                }
-
-                                _logOperation.LogProcessEnd(ex);
-                                _exitTaskCompletionSource.TrySetException(ex);
-                            }
-
-                            _exitTaskCompletionSource.TrySetResult(exitCode);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logOperation.LogProcessEnd(ex);
-                            _exitTaskCompletionSource.TrySetException(ex);
-                        }
+                        _process.Exited -= OnProcessExit;
+                        _exitHandlerRemoved = true;
+                        HandleProcessExit();
                     }
                 }
             }
 
-            /// <inheritdoc />
             public StreamWriter StandardInput
             {
                 get
@@ -192,7 +202,6 @@ namespace GitCommands
                 }
             }
 
-            /// <inheritdoc />
             public StreamReader StandardOutput
             {
                 get
@@ -206,7 +215,6 @@ namespace GitCommands
                 }
             }
 
-            /// <inheritdoc />
             public StreamReader StandardError
             {
                 get
@@ -220,19 +228,16 @@ namespace GitCommands
                 }
             }
 
-            /// <inheritdoc />
+            public void Kill(bool entireProcessTree) => _process.Kill(entireProcessTree);
+
             public void WaitForInputIdle() => _process.WaitForInputIdle();
 
-            /// <inheritdoc />
             public Task<int> WaitForExitAsync() => _exitTaskCompletionSource.Task;
 
-            /// <inheritdoc />
             public Task<int> WaitForExitAsync(CancellationToken token) => WaitForExitAsync().WithCancellation(token);
 
-            /// <inheritdoc />
             public int WaitForExit() => ThreadHelper.JoinableTaskFactory.Run(WaitForExitAsync);
 
-            /// <inheritdoc />
             public void Dispose()
             {
                 lock (_syncRoot)
@@ -243,11 +248,39 @@ namespace GitCommands
                     }
 
                     _disposed = true;
+
+                    if (!_exitHandlerRemoved)
+                    {
+                        // HandleProcessExit directly, do not rely on event execution
+                        _process.Exited -= OnProcessExit;
+                        _exitHandlerRemoved = true;
+
+                        try
+                        {
+                            if (_process.HasExited)
+                            {
+                                HandleProcessExit();
+                            }
+                            else if (_cancellationToken?.IsCancellationRequested is true)
+                            {
+                                // Directly kill the process because Ctrl+C does not reach the git process how we start it
+                                _process.Kill();
+
+                                OperationCanceledException ex = new("Process killed");
+                                _logOperation.LogProcessEnd(ex);
+                                _exitTaskCompletionSource.TrySetException(ex);
+                            }
+                            else
+                            {
+                                _exitTaskCompletionSource.TrySetCanceled();
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Trace.WriteLine(ex);
+                        }
+                    }
                 }
-
-                _process.Exited -= OnProcessExit;
-
-                _exitTaskCompletionSource.TrySetCanceled();
 
                 _process.Dispose();
 

--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -296,11 +296,13 @@ namespace GitCommands
                     exitCode: 0);
             }
 
-            using IProcess process = executable.Start(arguments, createWindow: false, redirectInput: writeInput is not null, redirectOutput: true, outputEncoding, throwOnErrorExit: throwOnErrorExit);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using IProcess process = executable.Start(arguments, createWindow: false, redirectInput: writeInput is not null, redirectOutput: true, outputEncoding, throwOnErrorExit: throwOnErrorExit, cancellationToken: cancellationToken);
             MemoryStream outputBuffer = new();
             MemoryStream errorBuffer = new();
-            var outputTask = process.StandardOutput.BaseStream.CopyToAsync(outputBuffer);
-            var errorTask = process.StandardError.BaseStream.CopyToAsync(errorBuffer);
+            Task outputTask = process.StandardOutput.BaseStream.CopyToAsync(outputBuffer, cancellationToken);
+            Task errorTask = process.StandardError.BaseStream.CopyToAsync(errorBuffer, cancellationToken);
 
             if (writeInput is not null)
             {
@@ -324,10 +326,12 @@ namespace GitCommands
 #endif
 
             // Wait for the process to exit (or be cancelled) and for the output
-            Task<int> exitTask = process.WaitForExitAsync(cancellationToken);
+            int exitCode;
             try
             {
-                await Task.WhenAll(outputTask, errorTask, exitTask);
+                exitCode = await process.WaitForExitAsync(cancellationToken);
+                await Task.WhenAll(outputTask, errorTask);
+                cancellationToken.ThrowIfCancellationRequested();
             }
             catch (ExternalOperationException ex)
             {
@@ -349,9 +353,8 @@ namespace GitCommands
                 throw;
             }
 
-            var output = outputEncoding.GetString(outputBuffer.GetBuffer(), 0, (int)outputBuffer.Length);
-            var error = outputEncoding.GetString(errorBuffer.GetBuffer(), 0, (int)errorBuffer.Length);
-            int exitCode = await exitTask;
+            string output = outputEncoding.GetString(outputBuffer.GetBuffer(), 0, (int)outputBuffer.Length);
+            string error = outputEncoding.GetString(errorBuffer.GetBuffer(), 0, (int)errorBuffer.Length);
 
             if (cache is not null && exitCode == 0)
             {

--- a/GitCommands/Git/GitCommandRunner.cs
+++ b/GitCommands/Git/GitCommandRunner.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using GitExtUtils;
+using GitUI;
 using GitUIPluginInterfaces;
 
 namespace GitCommands
@@ -16,6 +17,7 @@ namespace GitCommands
         }
 
         public IProcess RunDetached(
+            CancellationToken cancellationToken,
             ArgumentString arguments = default,
             bool createWindow = false,
             bool redirectInput = false,
@@ -27,7 +29,21 @@ namespace GitCommands
                 outputEncoding = _defaultEncoding();
             }
 
-            return _gitExecutable.Start(arguments, createWindow, redirectInput, redirectOutput, outputEncoding);
+            return _gitExecutable.Start(arguments, createWindow, redirectInput, redirectOutput, outputEncoding, cancellationToken: cancellationToken);
+        }
+
+        public void RunDetached(
+            ArgumentString arguments = default,
+            bool createWindow = false,
+            bool redirectInput = false,
+            bool redirectOutput = false,
+            Encoding? outputEncoding = null)
+        {
+            ThreadHelper.FileAndForget(async () =>
+                {
+                    using IProcess process = RunDetached(CancellationToken.None, arguments, createWindow, redirectInput, redirectOutput, outputEncoding);
+                    await process.WaitForExitAsync();
+                });
         }
     }
 }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3778,10 +3778,9 @@ namespace GitCommands
                     "blob",
                     blob
                 };
-                using var process = _gitCommandRunner.RunDetached(args, redirectOutput: true);
+                using IProcess process = _gitCommandRunner.RunDetached(CancellationToken.None, args, redirectOutput: true);
                 MemoryStream stream = new();
                 process.StandardOutput.BaseStream.CopyTo(stream);
-                process.WaitForExit();
                 stream.Position = 0;
                 return stream;
             }

--- a/Plugins/GitUIPluginInterfaces/IExecutable.cs
+++ b/Plugins/GitUIPluginInterfaces/IExecutable.cs
@@ -33,6 +33,6 @@ namespace GitUIPluginInterfaces
                        Encoding? outputEncoding = null,
                        bool useShellExecute = false,
                        bool throwOnErrorExit = true,
-                       CancellationToken? cancellationToken = null);
+                       CancellationToken cancellationToken = default);
     }
 }

--- a/Plugins/GitUIPluginInterfaces/IExecutable.cs
+++ b/Plugins/GitUIPluginInterfaces/IExecutable.cs
@@ -32,6 +32,7 @@ namespace GitUIPluginInterfaces
                        bool redirectOutput = false,
                        Encoding? outputEncoding = null,
                        bool useShellExecute = false,
-                       bool throwOnErrorExit = true);
+                       bool throwOnErrorExit = true,
+                       CancellationToken? cancellationToken = null);
     }
 }

--- a/Plugins/GitUIPluginInterfaces/IGitCommandRunner.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitCommandRunner.cs
@@ -5,7 +5,23 @@ namespace GitUIPluginInterfaces
 {
     public interface IGitCommandRunner
     {
+        /// <summary>
+        /// Starts git with the given arguments in the background cancellably.
+        /// The process exit is awaited on dispose of the IProcess instance.
+        /// </summary>
         IProcess RunDetached(
+            CancellationToken cancellationToken,
+            ArgumentString arguments = default,
+            bool createWindow = false,
+            bool redirectInput = false,
+            bool redirectOutput = false,
+            Encoding? outputEncoding = null);
+
+        /// <summary>
+        /// Starts git with the given arguments in the background.
+        /// The process exit or exceptions are awaited in the background.
+        /// </summary>
+        void RunDetached(
             ArgumentString arguments = default,
             bool createWindow = false,
             bool redirectInput = false,

--- a/Plugins/GitUIPluginInterfaces/IProcess.cs
+++ b/Plugins/GitUIPluginInterfaces/IProcess.cs
@@ -41,6 +41,12 @@ namespace GitUIPluginInterfaces
         StreamReader StandardError { get; }
 
         /// <summary>
+        /// Kill the process at once.
+        /// </summary>
+        /// <param name="entireProcessTree">Specifies whether to kill all child processes, too.</param>
+        void Kill(bool entireProcessTree = false);
+
+        /// <summary>
         /// Blocks the calling thread until the process exits, or when this object is disposed.
         /// </summary>
         /// <returns>The process's exit code, or <c>null</c> if this object was disposed before the process exited.</returns>

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -65,7 +65,15 @@ namespace CommonTestUtils
             }
         }
 
-        public IProcess Start(ArgumentString arguments, bool createWindow, bool redirectInput, bool redirectOutput, Encoding outputEncoding, bool useShellExecute = false, bool throwOnErrorExit = true)
+        public IProcess Start(
+            ArgumentString arguments,
+            bool createWindow,
+            bool redirectInput,
+            bool redirectOutput,
+            Encoding outputEncoding,
+            bool useShellExecute = false,
+            bool throwOnErrorExit = true,
+            CancellationToken? cancellationToken = null)
         {
             System.Diagnostics.Debug.WriteLine($"mock-git {arguments}");
 
@@ -115,6 +123,10 @@ namespace CommonTestUtils
             public StreamWriter StandardInput { get; }
             public StreamReader StandardOutput { get; }
             public StreamReader StandardError { get; }
+
+            public void Kill(bool entireProcessTree)
+            {
+            }
 
             public int WaitForExit()
             {

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -73,7 +73,7 @@ namespace CommonTestUtils
             Encoding outputEncoding,
             bool useShellExecute = false,
             bool throwOnErrorExit = true,
-            CancellationToken? cancellationToken = null)
+            CancellationToken cancellationToken = default)
         {
             System.Diagnostics.Debug.WriteLine($"mock-git {arguments}");
 

--- a/UnitTests/GitCommands.Tests/ExecutableTests.cs
+++ b/UnitTests/GitCommands.Tests/ExecutableTests.cs
@@ -1,0 +1,136 @@
+﻿using System.Text;
+using FluentAssertions;
+using GitCommands;
+using GitCommands.Logging;
+using GitUI;
+using GitUIPluginInterfaces;
+using Microsoft.VisualStudio.Threading;
+
+namespace GitCommandsTests
+{
+    public sealed class ExecutableTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+        }
+
+        [Test]
+        public async Task Process_shall_be_killed_on_cancellation()
+        {
+            TimeSpan cancelDelay = TimeSpan.FromSeconds(1);
+
+            await TaskScheduler.Default;
+
+            using CancellationTokenSource cts = new();
+
+            // start a process running for seconds
+            IExecutable executable = new Executable("ping.exe");
+            IProcess process = executable.Start($"-n {cancelDelay.TotalSeconds + 60} 127.0.0.1", cancellationToken: cts.Token);
+            DateTime startedAt = DateTime.Now;
+
+            // cancel after delay
+            await Task.Delay(cancelDelay);
+            cts.Cancel();
+
+            // the process is killed on dispose but not before
+            using (CancellationTokenSource ctsWaitExit = new())
+            {
+                try
+                {
+                    ctsWaitExit.CancelAfter(cancelDelay);
+                    int exitCode = await process.WaitForExitAsync(ctsWaitExit.Token);
+                    Assert.Fail("should not have exited", exitCode);
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            }
+
+            process.Dispose();
+
+            TimeSpan durationWaitTimeout = DateTime.Now - startedAt;
+            durationWaitTimeout.Should().BeGreaterThan(1.5 * cancelDelay).And.BeLessThan(2.5 * cancelDelay);
+
+            CommandLogEntry? cmd = CommandLog.Commands.LastOrDefault();
+            (cmd?.Exception?.Message).Should().Be("Process killed");
+        }
+
+        [Test]
+        public async Task WaitForProcessExitAsync_shall_return_latest_after_timeout()
+        {
+            TimeSpan halfRuntime = TimeSpan.FromSeconds(3);
+
+            await TaskScheduler.Default;
+
+            // start a process running for seconds
+            IExecutable executable = new Executable("ping.exe");
+            using IProcess process = executable.Start($"-n {(halfRuntime.TotalSeconds * 2) + 1} 127.0.0.1");
+
+            // wait for process exit, but cancel the wait while the process is still running
+            using CancellationTokenSource cts = new();
+            DateTime startedAt = DateTime.Now;
+            cts.CancelAfter(halfRuntime);
+            try
+            {
+                await process.WaitForExitAsync(cts.Token); // may or may not throw on cancel
+            }
+            catch (OperationCanceledException)
+            {
+                // ignore
+            }
+
+            TimeSpan durationWaitTimeout = DateTime.Now - startedAt;
+            durationWaitTimeout.Should().BeGreaterThan(0.5 * halfRuntime).And.BeLessThan(1.5 * halfRuntime);
+
+            // wait for process exit without cancellation
+            await process.WaitForExitAsync(CancellationToken.None);
+
+            TimeSpan durationExit = DateTime.Now - startedAt;
+            durationExit.Should().BeGreaterThan(1.5 * halfRuntime).And.BeLessThan(2.5 * halfRuntime);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_shall_return_latest_after_timeout([Values("cmd.exe", "ping.exe")] string exeFile)
+        {
+            const int cancelDelay = 1000;
+            const int exitDelay = cancelDelay;
+            const int minRuntime = cancelDelay + exitDelay;
+            string arguments = exeFile.Contains("ping") ? $"-n {(minRuntime / 1000) + 2} 127.0.0.1" : "";
+
+            using CancellationTokenSource cancellationTokenSource = new();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+            IExecutable executable = new Executable(exeFile);
+
+            Exception exception = null;
+            ExecutionResult? executionResult = null;
+            async Task ExecuteAsync()
+            {
+                try
+                {
+                    await TaskScheduler.Default.SwitchTo(alwaysYield: true);
+                    executionResult = await executable.ExecuteAsync(arguments, outputEncoding: Encoding.Default, cancellationToken: cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+            }
+
+            _ = ThreadHelper.JoinableTaskFactory.RunAsync(ExecuteAsync, JoinableTaskCreationOptions.LongRunning);
+
+            await Task.Delay(cancelDelay);
+            cancellationTokenSource.Cancel();
+            await Task.Delay(exitDelay);
+
+            exception.Should().NotBeNull();
+            exception.GetType().Should().Be<OperationCanceledException>();
+            executionResult.Should().BeNull();
+        }
+    }
+}

--- a/UnitTests/GitCommands.Tests/Git/AheadBehindDataProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/AheadBehindDataProviderTests.cs
@@ -31,7 +31,7 @@ namespace GitCommandsTests.Git
             _process.StandardError.Returns(x => _errorStreamReader);
 
             _executable = Substitute.For<IExecutable>();
-            _executable.Start(Arg.Any<ArgumentString>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<Encoding>(), Arg.Any<bool>(), Arg.Any<bool>()).Returns(x => _process);
+            _executable.Start(Arg.Any<ArgumentString>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<Encoding>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(x => _process);
 
             _provider = new AheadBehindDataProvider(() => _executable);
         }


### PR DESCRIPTION
Fixes #9818
Preparation for #9418

## Proposed changes

- `Executable`:
  - Kill the process on disposal if cancellation was requested
  - Factor out `HandleProcessExit` from `OnProcessExit`
- `GitCommandRunner`:
  - `RunDetached` with and without cancellation
  - log exit code
- Make cancellation of `ExecuteAsync(this IExecutable executable, ...)` work: await exit first, then await the output with cancellation
- `RevisionReader`: Start processes with cancellation

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- add tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).