### PR TITLE
Force OpenSSH to use SSH_ASKPASS if a password is requested

### DIFF
--- a/GitCommands/Git/EnvironmentConfiguration.cs
+++ b/GitCommands/Git/EnvironmentConfiguration.cs
@@ -44,6 +44,12 @@ namespace GitCommands
             // to prevent from leaking processes see issue #1092 for details
             Env.SetEnvironmentVariable("TERM", "msys");
 
+            // Force a non-empty DISPLAY so ssh uses SSH_ASKPASS if it has no terminal
+            if (string.IsNullOrEmpty(Env.GetEnvironmentVariable("DISPLAY")))
+            {
+                Env.SetEnvironmentVariable("DISPLAY", ":");
+            }
+
             // SSH_ASKPASS variable
 
             if (EnvUtils.RunningOnWindows())
@@ -58,6 +64,11 @@ namespace GitCommands
             else if (string.IsNullOrEmpty(Env.GetEnvironmentVariable("SSH_ASKPASS")))
             {
                 Env.SetEnvironmentVariable("SSH_ASKPASS", "ssh-askpass");
+            }
+
+            if (!string.IsNullOrEmpty(Env.GetEnvironmentVariable("SSH_ASKPASS")))
+            {
+                Env.SetEnvironmentVariable("SSH_ASKPASS_REQUIRE", "force");
             }
 
             return;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

Minimalist alternative to #11182. This adds an environment variable that forces SSH_ASKPASS to be used even if a terminal is available. Requires OpenSSH 8.4 or higher. Has no effect on older versions of OpenSSH.

(The version that comes with Windows 10 is, unfortunately, 8.1. However, 9.2 is available via winget)

### Before

Inputting a password is done via the console emulator.

### After

Inputting a password is done via the `GitExtSshAskPass.exe` popup.

## Test methodology <!-- How did you ensure quality? -->

- Performed fetch from a remote server
- Inputted the password in the popup

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.41.0.windows.1
- Windows 10.0.19045

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
