### PR TITLE
Fixed padding of the revision grid in the file history window

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.Designer.cs
@@ -98,6 +98,7 @@ namespace GitUI.CommandsDialogs
             this.RevisionGrid.Name = "FileChanges";
             this.RevisionGrid.Size = new System.Drawing.Size(748, 101);
             this.RevisionGrid.TabIndex = 2;
+            this.RevisionGrid.Padding = new Padding(0, 22, 0, 0);
             this.RevisionGrid.DoubleClick += new System.EventHandler(this.FileChangesDoubleClick);
             // 
             // FileHistoryContextMenu


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11071 File History window: last commit is hidden under action bar

## Proposed changes

- Added padding to the revision grid in the the file history window. Now the latest commit is not under the action bar.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The File History window **without** checkbox `Show file history in the main window`:
![image](https://github.com/gitextensions/gitextensions/assets/5438647/f9d50aa6-9770-4731-aaa0-3db8b4793e30)

### After

The File History window **without** checkbox `Show file history in the main window`:
![image](https://github.com/gitextensions/gitextensions/assets/5438647/1525abe1-652e-4181-96d1-8cc5fbac181c)

The File History window **with** checkbox `Show file history in the main window` (was not changed):
![image](https://github.com/gitextensions/gitextensions/assets/5438647/a3b3de0f-11a0-46dc-87e4-3d3065c9a9ee)

## Test methodology <!-- How did you ensure quality? -->

- Test this changes with checkbox `Show file history in the main window` and without that.
- Test that winforms designer of form `FormFileHistory` still works correct.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT version 2.41.0.windows.1
- Windows 10 Pro

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
