### PR TITLE
Remove impossible result from OpenWithDifftool

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3830,12 +3830,12 @@ namespace GitCommands
             return result.StandardOutput;
         }
 
-        public string OpenWithDifftoolDirDiff(string? firstRevision, string? secondRevision, string? customTool = null)
+        public void OpenWithDifftoolDirDiff(string? firstRevision, string? secondRevision, string? customTool = null)
         {
-            return OpenWithDifftool(null, firstRevision: firstRevision, secondRevision: secondRevision, extraDiffArguments: "--dir-diff", customTool: customTool);
+            OpenWithDifftool(null, firstRevision: firstRevision, secondRevision: secondRevision, extraDiffArguments: "--dir-diff", customTool: customTool);
         }
 
-        public string OpenWithDifftool(string? filename, string? oldFileName = "", string? firstRevision = GitRevision.IndexGuid, string? secondRevision = GitRevision.WorkTreeGuid, string? extraDiffArguments = null, bool isTracked = true, string? customTool = null)
+        public void OpenWithDifftool(string? filename, string? oldFileName = "", string? firstRevision = GitRevision.IndexGuid, string? secondRevision = GitRevision.WorkTreeGuid, string? extraDiffArguments = null, bool isTracked = true, string? customTool = null)
         {
             // Use Windows Git if custom tool is selected as the list is native to the application.
             (string.IsNullOrWhiteSpace(customTool) ? _gitCommandRunner : _gitWindowsCommandRunner)
@@ -3848,23 +3848,19 @@ namespace GitCommands
                 extraDiffArguments,
                 _revisionDiffProvider.Get(firstRevision, secondRevision, filename, oldFileName, isTracked)
             });
-
-            // This method is supposed to return an error message, but the detached process is untracked
-            // TODO track the process somehow, so errors can be reported
-            return "";
         }
 
         /// <summary>
         /// Compare two Git commitish; blob or rev:path.
+        /// Does nothing if either input is null or empty.
         /// </summary>
         /// <param name="firstGitCommit">commitish.</param>
         /// <param name="secondGitCommit">commitish.</param>
-        /// <returns>empty string, or null if either input is null.</returns>
-        public string? OpenFilesWithDifftool(string? firstGitCommit, string? secondGitCommit, string? customTool = null)
+        public void OpenFilesWithDifftool(string? firstGitCommit, string? secondGitCommit, string? customTool = null)
         {
             if (string.IsNullOrWhiteSpace(firstGitCommit) || string.IsNullOrWhiteSpace(secondGitCommit))
             {
-                return null;
+                return;
             }
 
             // Use Windows Git if custom tool is selected as the list is native to the application.
@@ -3878,8 +3874,6 @@ namespace GitCommands
                 firstGitCommit.QuoteNE(),
                 secondGitCommit.QuoteNE()
             });
-
-            return "";
         }
 
         public ObjectId? RevParse(string? revisionExpression)

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1152,11 +1152,7 @@ namespace GitUI
             }
             else
             {
-                string output = Module.OpenWithDifftool(fileName, oldFileName, firstRevision, secondRevision, isTracked: isTracked, customTool: customTool);
-                if (!string.IsNullOrEmpty(output))
-                {
-                    MessageBox.Show(owner, output, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
+                Module.OpenWithDifftool(fileName, oldFileName, firstRevision, secondRevision, isTracked: isTracked, customTool: customTool);
             }
         }
 
@@ -1441,7 +1437,16 @@ namespace GitUI
                 case "commit":      // [--quiet]
                     return Commit(arguments);
                 case "difftool":    // filename
-                    return Module.OpenWithDifftool(args[2]) == "";
+                    try
+                    {
+                        Module.OpenWithDifftool(args[2]);
+                        return true;
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+
                 case BlameHistoryCommand:
                 case FileHistoryCommand:
                     // filename [revision [--filter-by-revision]]

--- a/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
@@ -158,10 +158,10 @@ namespace GitUITests.GitUICommandsTests
             => RunCommandBasedOnArgument<FormCommit>(new string[] { "ge.exe", "commit" });
 
         [Test]
-        public void RunCommandBasedOnArgument_difftool_throws()
+        public void RunCommandBasedOnArgument_difftool_returns_false_on_missing_argument()
         {
-            ((Action)(() => _commands.GetTestAccessor().RunCommandBasedOnArgument(new string[] { "ge.exe", "difftool" })))
-                .Should().Throw<ArgumentOutOfRangeException>();
+            _commands.GetTestAccessor().RunCommandBasedOnArgument(new string[] { "ge.exe", "difftool" })
+                .Should().BeFalse();
         }
 
         [Test]


### PR DESCRIPTION
## Proposed changes

- Remove mostly unused and basically impossible result (due to detached execution) from all variants of OpenWithDifftool 

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- adapted existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).