### PR TITLE
Diff window: Avoid duplicate diff group

### DIFF
--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -151,14 +151,7 @@ namespace GitUI.CommandsDialogs
             else
             {
                 Validates.NotNull(_firstRevision);
-                if (_mergeBase is null)
-                {
-                    revisions = new[] { _secondRevision, _firstRevision };
-                }
-                else
-                {
-                    revisions = new[] { _secondRevision, _mergeBase, _firstRevision };
-                }
+                revisions = new[] { _secondRevision, _firstRevision };
             }
 
             ThreadHelper.JoinableTaskFactory.RunAsync(async () =>


### PR DESCRIPTION
Fixes #11200

## Proposed changes

- FormDiff: Let DiffFiles decide about the diff groups in order to be consistent with other FileStatusLists

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/36601201/ff819cfc-34bf-41b9-ac92-47f3c5323bc9)

### After

![image](https://github.com/gitextensions/gitextensions/assets/36601201/084856e0-3a6f-480d-9cb5-cfcb759f4331)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).