### PR TITLE
Allow forced reload of revisions

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -640,7 +640,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            RevisionGrid.PerformRefreshRevisions(getRefs, forceRefresh: true);
+            RevisionGrid.PerformRefreshRevisions(getRefs, forceRefreshRefs: true);
 
             InternalInitialize();
             ToolStripFilters.RefreshRevisionFunction(getRefs);

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1661,39 +1661,45 @@ namespace GitUI.CommandsDialogs
             if (Module.IsValidGitWorkingDir())
             {
                 RevisionGrid.SuspendRefreshRevisions();
-                string path = Module.WorkingDir;
-                ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.AddAsMostRecentAsync(path));
-                AppSettings.RecentWorkingDir = path;
-
-                HideDashboard();
-
-                if (!string.Equals(originalWorkingDir, Module.WorkingDir, StringComparison.Ordinal))
+                try
                 {
-                    ChangeTerminalActiveFolder(Module.WorkingDir);
+                    string path = Module.WorkingDir;
+                    ThreadHelper.JoinableTaskFactory.Run(() => RepositoryHistoryManager.Locals.AddAsMostRecentAsync(path));
+                    AppSettings.RecentWorkingDir = path;
+
+                    HideDashboard();
+
+                    if (!string.Equals(originalWorkingDir, Module.WorkingDir, StringComparison.Ordinal))
+                    {
+                        ChangeTerminalActiveFolder(Module.WorkingDir);
 
 #if DEBUG
-                    // Current encodings
-                    Debug.WriteLine($"Encodings for {Module.WorkingDir}");
-                    Debug.WriteLine($"Files content encoding: {Module.FilesEncoding.EncodingName}");
-                    Debug.WriteLine($"Commit encoding: {Module.CommitEncoding.EncodingName}");
-                    if (Module.LogOutputEncoding.CodePage != Module.CommitEncoding.CodePage)
-                    {
-                        Debug.WriteLine($"Log output encoding: {Module.LogOutputEncoding.EncodingName}");
-                    }
+                        // Current encodings
+                        Debug.WriteLine($"Encodings for {Module.WorkingDir}");
+                        Debug.WriteLine($"Files content encoding: {Module.FilesEncoding.EncodingName}");
+                        Debug.WriteLine($"Commit encoding: {Module.CommitEncoding.EncodingName}");
+                        if (Module.LogOutputEncoding.CodePage != Module.CommitEncoding.CodePage)
+                        {
+                            Debug.WriteLine($"Log output encoding: {Module.LogOutputEncoding.EncodingName}");
+                        }
 #endif
 
-                    // Reset the filter when switching repos
+                        // Reset the filter when switching repos
 
-                    // If we're applying custom branch or revision filters - reset them
-                    RevisionGrid.ResetAllFilters();
-                    ToolStripFilters.ClearQuickFilters();
-                    revisionDiff.RepositoryChanged();
+                        // If we're applying custom branch or revision filters - reset them
+                        RevisionGrid.ResetAllFilters();
+                        ToolStripFilters.ClearQuickFilters();
+                        revisionDiff.RepositoryChanged();
+                    }
+
+                    RevisionInfo.SetRevisionWithChildren(revision: null, children: Array.Empty<ObjectId>());
                 }
+                finally
+                {
+                    RevisionGrid.ResumeRefreshRevisions();
 
-                RevisionInfo.SetRevisionWithChildren(revision: null, children: Array.Empty<ObjectId>());
-                RevisionGrid.ResumeRefreshRevisions();
-
-                RefreshRevisions();
+                    RefreshRevisions();
+                }
             }
             else
             {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9418
Fixes  #11453
And it makes `View` | `Sorting` options not being ignored sometimes.

## Proposed changes

RevisionGridControl:
- `PerformRefreshRevisions`: Allow forced reload
- Remove `!_isRefreshingRevisions` from `CanRefresh`
- Ignore `OperationCanceledException` in `OnRevisionRead`, which killed the app

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

need to wait until loading of previous revisions has finished and to manually refresh when e.g. switching repo
 
### After

![image](https://github.com/gitextensions/gitextensions/assets/36601201/6ed13e7d-e740-4b62-b20c-f2d03db9f40e)

## Test methodology <!-- How did you ensure quality? -->

- existing tests
- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).