### PR TITLE
Optimize ObjectId parsing

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1163,12 +1163,12 @@ namespace GitCommands
             string submodule = lines[0];
 
             if (submodule.Length < ObjectId.Sha1CharCount + 3
-                || !ObjectId.TryParse(submodule, 1, out ObjectId objectId))
+                || !ObjectId.TryParse(submodule, 1, out ObjectId currentCommitId))
             {
                 return (' ', null);
             }
 
-            return (submodule[0], objectId);
+            return (submodule[0], currentCommitId);
         }
 
         public bool ExistsMergeCommit(string? startRev, string? endRev)

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1162,12 +1162,13 @@ namespace GitCommands
 
             string submodule = lines[0];
 
-            if (submodule.Length < 43)
+            if (submodule.Length < ObjectId.Sha1CharCount + 3
+                || !ObjectId.TryParse(submodule, 1, out ObjectId objectId))
             {
                 return (' ', null);
             }
 
-            return (submodule[0], ObjectId.Parse(submodule, 1));
+            return (submodule[0], objectId);
         }
 
         public bool ExistsMergeCommit(string? startRev, string? endRev)

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -218,8 +218,8 @@ namespace GitCommands
             ReadOnlySpan<byte> array = chunk.AsSpan();
 
             // The first 40 bytes are the revision ID and the tree ID back to back
-            if (!ObjectId.TryParseAsciiHexReadOnlySpan(array[..ObjectId.Sha1CharCount], out ObjectId? objectId) ||
-                !ObjectId.TryParseAsciiHexReadOnlySpan(array.Slice(ObjectId.Sha1CharCount, ObjectId.Sha1CharCount), out ObjectId? treeId))
+            if (!ObjectId.TryParse(array[..ObjectId.Sha1CharCount], out ObjectId? objectId) ||
+                !ObjectId.TryParse(array.Slice(ObjectId.Sha1CharCount, ObjectId.Sha1CharCount), out ObjectId? treeId))
             {
                 ParseAssert($"Log parse error, object id: {chunk.Count}({array[..ObjectId.Sha1CharCount].ToString()}");
                 revision = default;
@@ -274,7 +274,7 @@ namespace GitCommands
             {
                 for (int parentIndex = 0; parentIndex < noParents; parentIndex++)
                 {
-                    if (!ObjectId.TryParseAsciiHexReadOnlySpan(array.Slice(offset, ObjectId.Sha1CharCount), out ObjectId parentId))
+                    if (!ObjectId.TryParse(array.Slice(offset, ObjectId.Sha1CharCount), out ObjectId parentId))
                     {
                         ParseAssert($"Log parse error, parent {parentIndex} for {objectId}");
                         revision = default;

--- a/Plugins/GitUIPluginInterfaces/ObjectId.cs
+++ b/Plugins/GitUIPluginInterfaces/ObjectId.cs
@@ -153,6 +153,8 @@ namespace GitUIPluginInterfaces
         /// <param name="array">The char span to parse.</param>
         /// <param name="objectId">The parsed <see cref="ObjectId"/>.</param>
         /// <returns><c>true</c> if parsing succeeded, otherwise <c>false</c>.</returns>
+        [MustUseReturnValue]
+        [SuppressMessage("Style", "IDE0057:Use range operator", Justification = "Performance")]
         public static bool TryParse(in ReadOnlySpan<char> array, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
         {
             if (array.Length != Sha1CharCount)
@@ -161,7 +163,7 @@ namespace GitUIPluginInterfaces
                 return false;
             }
 
-            if (!uint.TryParse(array[..8], NumberStyles.AllowHexSpecifier, provider: null, out uint i1)
+            if (!uint.TryParse(array.Slice(0, 8), NumberStyles.AllowHexSpecifier, provider: null, out uint i1)
                 || !uint.TryParse(array.Slice(8, 8), NumberStyles.AllowHexSpecifier, provider: null, out uint i2)
                 || !uint.TryParse(array.Slice(16, 8), NumberStyles.AllowHexSpecifier, provider: null, out uint i3)
                 || !uint.TryParse(array.Slice(24, 8), NumberStyles.AllowHexSpecifier, provider: null, out uint i4)
@@ -187,6 +189,7 @@ namespace GitUIPluginInterfaces
         /// <param name="objectId">The parsed <see cref="ObjectId"/>.</param>
         /// <returns><c>true</c> if parsing succeeded, otherwise <c>false</c>.</returns>
         [MustUseReturnValue]
+        [SuppressMessage("Style", "IDE0057:Use range operator", Justification = "Performance")]
         public static bool TryParse(in ReadOnlySpan<byte> array, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
         {
             if (array.Length != Sha1CharCount)
@@ -195,7 +198,7 @@ namespace GitUIPluginInterfaces
                 return false;
             }
 
-            if (!Utf8Parser.TryParse(array[..8], out uint i1, out int _, standardFormat: 'X')
+            if (!Utf8Parser.TryParse(array.Slice(0, 8), out uint i1, out int _, standardFormat: 'X')
                 || !Utf8Parser.TryParse(array.Slice(8, 8), out uint i2, out int _, standardFormat: 'X')
                 || !Utf8Parser.TryParse(array.Slice(16, 8), out uint i3, out int _, standardFormat: 'X')
                 || !Utf8Parser.TryParse(array.Slice(24, 8), out uint i4, out int _, standardFormat: 'X')

--- a/Plugins/GitUIPluginInterfaces/ObjectId.cs
+++ b/Plugins/GitUIPluginInterfaces/ObjectId.cs
@@ -1,5 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
+﻿using System.Buffers.Text;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 
@@ -14,7 +15,7 @@ namespace GitUIPluginInterfaces
     /// </remarks>
     public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
     {
-        private static readonly ThreadLocal<byte[]> _buffer = new(() => new byte[Sha1ByteCount], trackAllValues: false);
+        private static readonly ThreadLocal<byte[]> _buffer = new(() => new byte[_sha1ByteCount], trackAllValues: false);
         private static readonly Random _random = new();
 
         /// <summary>
@@ -48,10 +49,53 @@ namespace GitUIPluginInterfaces
 
         public bool IsArtificial => this == WorkTreeId || this == IndexId || this == CombinedDiffId;
 
-        private const int Sha1ByteCount = 20;
+        private const int _sha1ByteCount = 20;
         public const int Sha1CharCount = 40;
 
         #region Parsing
+
+        /// <summary>
+        /// Parses an <see cref="ObjectId"/> from <paramref name="s"/>.
+        /// </summary>
+        /// <remarks>
+        /// For parsing to succeed, <paramref name="s"/> must be a valid 40-character SHA-1 string.
+        /// Any extra characters at the end will cause parsing to fail.
+        /// </remarks>
+        /// <param name="s">The string to try parsing from.</param>
+        /// <returns>The parsed <see cref="ObjectId"/>.</returns>
+        /// <exception cref="FormatException"><paramref name="s"/> did not contain a valid 40-character SHA-1 hash, or <paramref name="s"/> is <see langword="null"/>.</exception>
+        [MustUseReturnValue]
+        public static ObjectId Parse(string s)
+        {
+            if (s?.Length is not Sha1CharCount || !TryParse(s.AsSpan(), out ObjectId id))
+            {
+                throw new FormatException($"Unable to parse object ID \"{s}\".");
+            }
+
+            return id;
+        }
+
+        /// <summary>
+        /// Parses an <see cref="ObjectId"/> from a regex <see cref="Capture"/> that was produced by matching against <paramref name="s"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>This method avoids the temporary string created by calling <see cref="Capture.Value"/>.</para>
+        /// <para>For parsing to succeed, <paramref name="s"/> must be a valid 40-character SHA-1 string.</para>
+        /// </remarks>
+        /// <param name="s">The string that the regex <see cref="Capture"/> was produced from.</param>
+        /// <param name="capture">The regex capture/group that describes the location of the SHA-1 hash within <paramref name="s"/>.</param>
+        /// <returns>The parsed <see cref="ObjectId"/>.</returns>
+        /// <exception cref="FormatException"><paramref name="s"/> did not contain a valid 40-character SHA-1 hash.</exception>
+        [MustUseReturnValue]
+        public static ObjectId Parse(string s, Capture capture)
+        {
+            if (s is null || capture?.Length is not Sha1CharCount || !TryParse(s.AsSpan(capture.Index, capture.Length), out ObjectId id))
+            {
+                throw new FormatException($"Unable to parse object ID \"{s}\".");
+            }
+
+            return id;
+        }
 
         /// <summary>
         /// Attempts to parse an <see cref="ObjectId"/> from <paramref name="s"/>.
@@ -66,13 +110,13 @@ namespace GitUIPluginInterfaces
         /// <returns><c>true</c> if parsing was successful, otherwise <c>false</c>.</returns>
         public static bool TryParse(string? s, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
         {
-            if (s?.Length is not Sha1CharCount)
+            if (s is null)
             {
                 objectId = default;
                 return false;
             }
 
-            return TryParse(s, 0, out objectId);
+            return TryParse(s.AsSpan(), out objectId);
         }
 
         /// <summary>
@@ -95,201 +139,21 @@ namespace GitUIPluginInterfaces
                 return false;
             }
 
-            var success = true;
-
-            var i1 = HexToUInt32(offset);
-            var i2 = HexToUInt32(offset + 8);
-            var i3 = HexToUInt32(offset + 16);
-            var i4 = HexToUInt32(offset + 24);
-            var i5 = HexToUInt32(offset + 32);
-
-            if (success)
-            {
-                objectId = new ObjectId(i1, i2, i3, i4, i5);
-                return true;
-            }
-
-            objectId = default;
-            return false;
-
-            uint HexToUInt32(int j)
-            {
-                return (uint)(HexCharToInt(s[j]) << 28 |
-                              HexCharToInt(s[j + 1]) << 24 |
-                              HexCharToInt(s[j + 2]) << 20 |
-                              HexCharToInt(s[j + 3]) << 16 |
-                              HexCharToInt(s[j + 4]) << 12 |
-                              HexCharToInt(s[j + 5]) << 8 |
-                              HexCharToInt(s[j + 6]) << 4 |
-                              HexCharToInt(s[j + 7]));
-            }
-
-            int HexCharToInt(char c)
-            {
-                if (c is >= '0' and <= '9')
-                {
-                    return c - 48;
-                }
-
-                if (c is >= 'a' and <= 'f')
-                {
-                    return c - 87;
-                }
-
-                success = false;
-                return -1;
-            }
+            return TryParse(s.AsSpan(offset, Sha1CharCount), out objectId);
         }
 
         /// <summary>
-        /// Parses an <see cref="ObjectId"/> from <paramref name="s"/>.
+        /// Parses an <see cref="ObjectId"/> from a span of chars <paramref name="array"/>.
         /// </summary>
         /// <remarks>
-        /// For parsing to succeed, <paramref name="s"/> must be a valid 40-character SHA-1 string.
-        /// Any extra characters at the end will cause parsing to fail, unlike for
-        /// overload <see cref="Parse(string,int)"/>.
+        /// <para>This method reads human-readable chars.
+        /// Several git commands emit them in this form.</para>
+        /// <para>For parsing to succeed, <paramref name="array"/> must contain 40 chars.</para>
         /// </remarks>
-        /// <param name="s">The string to try parsing from.</param>
-        /// <returns>The parsed <see cref="ObjectId"/>.</returns>
-        /// <exception cref="FormatException"><paramref name="s"/> did not contain a valid 40-character SHA-1 hash, or <paramref name="s"/> is <see langword="null"/>.</exception>
-        [MustUseReturnValue]
-        public static ObjectId Parse(string s)
-        {
-            if (s?.Length is not Sha1CharCount || !TryParse(s, 0, out var id))
-            {
-                throw new FormatException($"Unable to parse object ID \"{s}\".");
-            }
-
-            return id;
-        }
-
-        /// <summary>
-        /// Parses an <see cref="ObjectId"/> from <paramref name="s"/>.
-        /// </summary>
-        /// <remarks>
-        /// For parsing to succeed, <paramref name="s"/> must contain a valid 40-character SHA-1 starting at <paramref name="offset"/>.
-        /// Any extra characters before or after this substring will be ignored, unlike for
-        /// overload <see cref="Parse(string)"/>.
-        /// </remarks>
-        /// <param name="s">The string to try parsing from.</param>
-        /// <param name="offset">The position within <paramref name="s"/> to start parsing from.</param>
-        /// <returns>The parsed <see cref="ObjectId"/>.</returns>
-        /// <exception cref="FormatException"><paramref name="s"/> did not contain a valid 40-character SHA-1 hash, or <paramref name="s"/> is <see langword="null"/>.</exception>
-        [MustUseReturnValue]
-        public static ObjectId Parse(string s, int offset)
-        {
-            if (!TryParse(s, offset, out var id))
-            {
-                throw new FormatException($"Unable to parse object ID \"{s}\" at offset {offset}.");
-            }
-
-            return id;
-        }
-
-        /// <summary>
-        /// Parses an <see cref="ObjectId"/> from <paramref name="stream"/>.
-        /// </summary>
-        /// <remarks>
-        /// For parsing to succeed, it must be possible to read 20 bytes from <paramref name="stream"/>.
-        /// </remarks>
-        /// <param name="stream">The stream to read bytes from.</param>
-        /// <returns>The parsed <see cref="ObjectId"/>.</returns>
-        /// <exception cref="IOException">General error reading from <paramref name="stream"/>.</exception>
-        /// <exception cref="EndOfStreamException"><paramref name="stream"/> ended before 20 bytes could be read.</exception>
-        [MustUseReturnValue]
-        public static ObjectId Parse(Stream stream)
-        {
-            var buffer = _buffer.Value;
-
-            stream.ReadBytes(buffer, offset: 0, count: Sha1ByteCount);
-
-            return Parse(buffer, index: 0);
-        }
-
-        /// <summary>
-        /// Parses an <see cref="ObjectId"/> from <paramref name="bytes"/> at the given <paramref name="index"/>.
-        /// </summary>
-        /// <remarks>
-        /// For parsing to succeed, there must be 20 bytes in <paramref name="bytes"/> starting at <paramref name="index"/>.
-        /// </remarks>
-        /// <param name="bytes">The byte array to parse from.</param>
-        /// <param name="index">The index within <paramref name="bytes"/> to commence parsing from.</param>
-        /// <returns>The parsed <see cref="ObjectId"/>.</returns>
-        [MustUseReturnValue]
-        public static ObjectId Parse(byte[] bytes, int index)
-        {
-            return new ObjectId(Read(), Read(), Read(), Read(), Read());
-
-            uint Read() => (uint)((bytes[index++] << 24) |
-                                  (bytes[index++] << 16) |
-                                  (bytes[index++] << 8) |
-                                   bytes[index++]);
-        }
-
-        /// <summary>
-        /// Parses an <see cref="ObjectId"/> from ASCII <paramref name="bytes"/> at the given <paramref name="index"/>.
-        /// </summary>
-        /// <remarks>
-        /// <para>Unlike <see cref="Parse(byte[],int)"/> which reads raw bytes, this method reads human-readable
-        /// ASCII-encoded bytes, which are more verbose. Several git commands emit them in this form.</para>
-        /// <para>For parsing to succeed, there must be 40 bytes in <paramref name="bytes"/> starting at <paramref name="index"/>.</para>
-        /// </remarks>
-        /// <param name="bytes">The byte array to parse from.</param>
-        /// <param name="index">The index within <paramref name="bytes"/> to commence parsing from.</param>
+        /// <param name="array">The char span to parse.</param>
         /// <param name="objectId">The parsed <see cref="ObjectId"/>.</param>
         /// <returns><c>true</c> if parsing succeeded, otherwise <c>false</c>.</returns>
-        [MustUseReturnValue]
-        public static bool TryParseAsciiHexBytes(byte[] bytes, int index, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
-        {
-            if (index < 0 || index > bytes.Length - Sha1CharCount)
-            {
-                objectId = default;
-                return false;
-            }
-
-            return TryParseAsciiHexBytes(
-                new ArraySegment<byte>(bytes, index, Sha1CharCount),
-                out objectId);
-        }
-
-        [MustUseReturnValue]
-        public static bool TryParseAsciiHexBytes(ArraySegment<byte> bytes, int index, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
-        {
-            // TODO get rid of this overload? slice the array segment instead
-
-            if (bytes.Array is null)
-            {
-                objectId = default;
-                return false;
-            }
-
-            if (index < 0 || bytes.Offset + index + Sha1CharCount > bytes.Array.Length)
-            {
-                objectId = default;
-                return false;
-            }
-
-            return TryParseAsciiHexBytes(
-                new ArraySegment<byte>(bytes.Array, bytes.Offset + index, Sha1CharCount),
-                out objectId);
-        }
-
-        /// <summary>
-        /// Parses an <see cref="ObjectId"/> from a segment of <paramref name="bytes"/> containing ASCII characters.
-        /// </summary>
-        /// <remarks>
-        /// <para>Unlike <see cref="Parse(byte[],int)"/> which reads raw bytes, this method reads human-readable
-        /// ASCII-encoded bytes, which are more verbose. Several git commands emit them in this form.</para>
-        /// <para>For parsing to succeed, <paramref name="bytes"/> must contain 40 bytes.</para>
-        /// </remarks>
-        /// <param name="bytes">The byte array to parse from.</param>
-        /// <param name="objectId">The parsed <see cref="ObjectId"/>.</param>
-        /// <returns><c>true</c> if parsing succeeded, otherwise <c>false</c>.</returns>
-        [MustUseReturnValue]
-        public static bool TryParseAsciiHexBytes(ArraySegment<byte> bytes, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
-            => TryParseAsciiHexReadOnlySpan(bytes.AsSpan(), out objectId);
-
-        public static bool TryParseAsciiHexReadOnlySpan(in ReadOnlySpan<byte> array, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
+        public static bool TryParse(in ReadOnlySpan<char> array, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
         {
             if (array.Length != Sha1CharCount)
             {
@@ -297,73 +161,52 @@ namespace GitUIPluginInterfaces
                 return false;
             }
 
-            var success = true;
-
-            var i1 = HexAsciiBytesToUInt32(in array, 0);
-            var i2 = HexAsciiBytesToUInt32(in array, 8);
-            var i3 = HexAsciiBytesToUInt32(in array, 16);
-            var i4 = HexAsciiBytesToUInt32(in array, 24);
-            var i5 = HexAsciiBytesToUInt32(in array, 32);
-
-            if (success)
+            if (!uint.TryParse(array[..8], NumberStyles.AllowHexSpecifier, provider: null, out uint i1)
+                || !uint.TryParse(array.Slice(8, 8), NumberStyles.AllowHexSpecifier, provider: null, out uint i2)
+                || !uint.TryParse(array.Slice(16, 8), NumberStyles.AllowHexSpecifier, provider: null, out uint i3)
+                || !uint.TryParse(array.Slice(24, 8), NumberStyles.AllowHexSpecifier, provider: null, out uint i4)
+                || !uint.TryParse(array.Slice(32, 8), NumberStyles.AllowHexSpecifier, provider: null, out uint i5))
             {
-                objectId = new ObjectId(i1, i2, i3, i4, i5);
-                return true;
+                objectId = default;
+                return false;
             }
 
-            objectId = default;
-            return false;
-
-            uint HexAsciiBytesToUInt32(in ReadOnlySpan<byte> array, int j)
-            {
-                return (uint)(HexAsciiByteToInt(array[j]) << 28 |
-                              HexAsciiByteToInt(array[j + 1]) << 24 |
-                              HexAsciiByteToInt(array[j + 2]) << 20 |
-                              HexAsciiByteToInt(array[j + 3]) << 16 |
-                              HexAsciiByteToInt(array[j + 4]) << 12 |
-                              HexAsciiByteToInt(array[j + 5]) << 8 |
-                              HexAsciiByteToInt(array[j + 6]) << 4 |
-                              HexAsciiByteToInt(array[j + 7]));
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            int HexAsciiByteToInt(byte b)
-            {
-                if (b is >= (byte)'0' and <= (byte)'9')
-                {
-                    return b - 48;
-                }
-
-                if (b is >= (byte)'a' and <= (byte)'f')
-                {
-                    return b - 87;
-                }
-
-                success = false;
-                return -1;
-            }
+            objectId = new ObjectId(i1, i2, i3, i4, i5);
+            return true;
         }
 
         /// <summary>
-        /// Parses an <see cref="ObjectId"/> from a regex <see cref="Capture"/> that was produced by matching against <paramref name="s"/>.
+        /// Parses an <see cref="ObjectId"/> from a span of bytes <paramref name="array"/> containing ASCII characters.
         /// </summary>
         /// <remarks>
-        /// <para>This method avoids the temporary string created by calling <see cref="Capture.Value"/>.</para>
-        /// <para>For parsing to succeed, <paramref name="s"/> must be a valid 40-character SHA-1 string.</para>
+        /// <para>This method reads human-readable ASCII-encoded bytes (more verbose than raw values).
+        /// Several git commands emit them in this form.</para>
+        /// <para>For parsing to succeed, <paramref name="array"/> must contain 40 bytes.</para>
         /// </remarks>
-        /// <param name="s">The string that the regex <see cref="Capture"/> was produced from.</param>
-        /// <param name="capture">The regex capture/group that describes the location of the SHA-1 hash within <paramref name="s"/>.</param>
-        /// <returns>The parsed <see cref="ObjectId"/>.</returns>
-        /// <exception cref="FormatException"><paramref name="s"/> did not contain a valid 40-character SHA-1 hash.</exception>
+        /// <param name="array">The byte span to parse.</param>
+        /// <param name="objectId">The parsed <see cref="ObjectId"/>.</param>
+        /// <returns><c>true</c> if parsing succeeded, otherwise <c>false</c>.</returns>
         [MustUseReturnValue]
-        public static ObjectId Parse(string s, Capture capture)
+        public static bool TryParse(in ReadOnlySpan<byte> array, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
         {
-            if (s is null || capture?.Length is not Sha1CharCount || !TryParse(s, capture.Index, out var id))
+            if (array.Length != Sha1CharCount)
             {
-                throw new FormatException($"Unable to parse object ID \"{s}\".");
+                objectId = default;
+                return false;
             }
 
-            return id;
+            if (!Utf8Parser.TryParse(array[..8], out uint i1, out int _, standardFormat: 'X')
+                || !Utf8Parser.TryParse(array.Slice(8, 8), out uint i2, out int _, standardFormat: 'X')
+                || !Utf8Parser.TryParse(array.Slice(16, 8), out uint i3, out int _, standardFormat: 'X')
+                || !Utf8Parser.TryParse(array.Slice(24, 8), out uint i4, out int _, standardFormat: 'X')
+                || !Utf8Parser.TryParse(array.Slice(32, 8), out uint i5, out int _, standardFormat: 'X'))
+            {
+                objectId = default;
+                return false;
+            }
+
+            objectId = new ObjectId(i1, i2, i3, i4, i5);
+            return true;
         }
 
         #endregion
@@ -388,9 +231,9 @@ namespace GitUIPluginInterfaces
         {
             // ReSharper disable once LoopCanBeConvertedToQuery
             // ReSharper disable once ForCanBeConvertedToForeach
-            for (var i = 0; i < s.Length; i++)
+            for (int i = 0; i < s.Length; i++)
             {
-                var c = s[i];
+                char c = s[i];
                 if (!char.IsDigit(c) && (c < 'a' || c > 'f'))
                 {
                     return false;
@@ -419,7 +262,7 @@ namespace GitUIPluginInterfaces
 
         public int CompareTo(ObjectId other)
         {
-            var result = 0;
+            int result = 0;
 
             _ = Compare(_i1, other._i1) ||
                 Compare(_i2, other._i2) ||
@@ -431,7 +274,7 @@ namespace GitUIPluginInterfaces
 
             bool Compare(uint i, uint j)
             {
-                var c = i.CompareTo(j);
+                int c = i.CompareTo(j);
 
                 if (c != 0)
                 {
@@ -472,7 +315,7 @@ namespace GitUIPluginInterfaces
             }
 
             char* buffer = stackalloc char[Sha1CharCount];
-            var p = buffer;
+            char* p = buffer;
 
             Write(_i1);
             Write(_i2);
@@ -524,7 +367,7 @@ namespace GitUIPluginInterfaces
                 return false;
             }
 
-            var i = 0;
+            int i = 0;
 
             return
                 TestInt(_i1) &&
@@ -547,7 +390,7 @@ namespace GitUIPluginInterfaces
 
                 bool TestDigit(uint j)
                 {
-                    var c = j < 10 ? (char)('0' + j) : (char)(j + 0x57);
+                    char c = j < 10 ? (char)('0' + j) : (char)(j + 0x57);
                     return other[i++] == c;
                 }
             }
@@ -563,23 +406,5 @@ namespace GitUIPluginInterfaces
         public static bool operator !=(ObjectId? left, ObjectId? right) => !Equals(left, right);
 
         #endregion
-    }
-
-    internal static class StreamExtensions
-    {
-        public static void ReadBytes(this Stream stream, byte[] buffer, int offset, int count)
-        {
-            while (offset != count)
-            {
-                var read = stream.Read(buffer, offset, count - offset);
-
-                if (read == 0)
-                {
-                    throw new EndOfStreamException();
-                }
-
-                offset += read;
-            }
-        }
     }
 }

--- a/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
@@ -94,7 +94,7 @@ namespace GitCommandsTests.Git
         {
             Assert.AreEqual(
                 sha1.Substring(offset, 40),
-                ObjectId.Parse(sha1, offset).ToString());
+                ObjectId.Parse(sha1.Substring(offset, 40)).ToString());
         }
 
         [Test]
@@ -238,14 +238,11 @@ namespace GitCommandsTests.Git
         [TestCase(HexAscii, 2, "0102030405060708090a0b0c0d0e0f1011121314")]
         [TestCase(HexAscii, 3, "102030405060708090a0b0c0d0e0f10111213141")]
         [TestCase(HexAscii, 26, "0d0e0f101112131415161718191a1b1c1d1e1f20")]
-        [TestCase(HexAscii, 27, null)]
-        [TestCase(HexAscii, -1, null)]
-        [TestCase(NonHexAscii, 0, null)]
-        public void TryParseAsciiHexBytes_works_as_expected(string source, int offset, [CanBeNull] string expected)
+        public void TryParse_works_as_expected(string source, int offset, [CanBeNull] string expected)
         {
-            var sourceBytes = Encoding.ASCII.GetBytes(source);
+            byte[] sourceBytes = Encoding.ASCII.GetBytes(source);
 
-            Assert.AreEqual(expected is not null, ObjectId.TryParseAsciiHexBytes(sourceBytes, offset, out var id));
+            Assert.AreEqual(expected is not null, ObjectId.TryParse(sourceBytes.AsSpan(offset, 40), out ObjectId id));
 
             if (expected is not null)
             {
@@ -253,24 +250,28 @@ namespace GitCommandsTests.Git
             }
         }
 
-        [Test]
-        public void TryParseAsciiHexBytes_returns_false_when_array_null()
+        [TestCase(NonHexAscii, 0, null)]
+        public void TryParse_bytes_throws_with_illegal_input(string source, int offset, [CanBeNull] string expected)
         {
-            Assert.False(ObjectId.TryParseAsciiHexBytes(default, out ObjectId objectId));
+            byte[] sourceBytes = Encoding.ASCII.GetBytes(source);
+            Assert.AreEqual(expected is not null, ObjectId.TryParse(sourceBytes.AsSpan(offset, 40), out ObjectId id));
+        }
+
+        [Test]
+        public void TryParse_returns_false_when_array_null()
+        {
+            Assert.False(ObjectId.TryParse(default, out ObjectId objectId));
             Assert.Null(objectId);
-            Assert.False(ObjectId.TryParseAsciiHexBytes(default(ArraySegment<byte>), 0, out objectId));
+            Assert.False(ObjectId.TryParse(default(Span<byte>), out objectId));
             Assert.Null(objectId);
         }
 
         [Test]
-        public void TryParseAsciiHexBytes_returns_false_when_bounds_check_fails()
+        public void TryParse_returns_false_when_bounds_check_fails()
         {
-            var bytes = new byte[ObjectId.Sha1CharCount];
-            ArraySegment<byte> segment = new(bytes);
+            byte[] bytes = new byte[ObjectId.Sha1CharCount];
 
-            Assert.False(ObjectId.TryParseAsciiHexBytes(segment, -1, out ObjectId objectId));
-            Assert.Null(objectId);
-            Assert.False(ObjectId.TryParseAsciiHexBytes(segment, 1, out objectId));
+            Assert.False(ObjectId.TryParse(bytes.AsSpan(1), out ObjectId objectId));
             Assert.Null(objectId);
         }
 

--- a/UnitTests/GitCommands.Tests/GitRevisionInfoProviderTests.cs
+++ b/UnitTests/GitCommands.Tests/GitRevisionInfoProviderTests.cs
@@ -32,9 +32,7 @@ namespace GitCommandsTests
             var item = Substitute.For<IGitItem>();
 
             // ObjectId checks input, use Try to get an illegal value
-            ObjectId objectId;
-            var sourceBytes = Encoding.ASCII.GetBytes("");
-            ObjectId.TryParseAsciiHexBytes(sourceBytes, 0, out objectId);
+            ObjectId.TryParse("", out ObjectId objectId);
             item.ObjectId.Returns(objectId);
 
             ((Action)(() => _provider.LoadChildren(item))).Should().Throw<ArgumentException>();


### PR DESCRIPTION
## Proposed changes

Use optimized Utf8Parser(Span<>) methods to parse Git commit hashes.

Remove unused methods.

Benchmark for `TryParse(in ReadOnlySpan<byte> array)` that run in average 3.1 times for each commit (for linux repo).
To parse 100000 commits (default in GE) was before 290 ms, now it is 110 ms
The total load time therefore reduced with 550 ms. For GE this is about 160 ms.

There is a similar performance improvement for other methods but they are not performance critical.

I may add that reducing checks and additional method calls is critical in these scenarios.
Using a loop instead of five separate calls with fixed parameters was 160 ms.
Using multiple wrapper calls instead of calling the Span methods directly could add similar delay.

As the grid is displayed before all data is parsed, the visible difference is smaller.

## Test methodology <!-- How did you ensure quality? -->

Tests are updated
Note that some test cases were removed when unused methods were removed.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
