### PR TITLE
Build arm64 in CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,9 +70,14 @@ build_script:
     # build VC++
     dotnet build .\scripts\native.proj -c Release --verbosity q --nologo /bl:.\artifacts\log\native.binlog
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+    dotnet build .\scripts\native.proj -c Release --verbosity q --nologo /p:Arm64Build=true /bl:.\artifacts\log\native.binlog
+    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 - ps: |
     # build .NET
     $cmd = "dotnet build -c Release --verbosity q --nologo /bl:.\artifacts\log\build.binlog $buildArgs"
+    Invoke-Expression $cmd
+    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+    $cmd += " /p:Arm64Build=true"
     Invoke-Expression $cmd
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,7 +70,7 @@ build_script:
     # build VC++
     dotnet build .\scripts\native.proj -c Release --verbosity q --nologo /bl:.\artifacts\log\native.binlog
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
-    dotnet build .\scripts\native.proj -c Release --verbosity q --nologo /p:Arm64Build=true /bl:.\artifacts\log\native.binlog
+    dotnet build .\scripts\native.proj -c Release --verbosity q --nologo /p:Arm64Build=true /bl:.\artifacts\log\native.arm64.binlog
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 - ps: |
     # build .NET


### PR DESCRIPTION
Per discussion in #10649, the work to build for arm64 has been done, but not the work to include that in official builds.

This PR adds the arm64 build to CI so that it can ship with each release.