### PR TITLE
RevisionGridControl: Hide tooltip on Escape

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -228,7 +228,6 @@ namespace GitUI
             _gridView.CellMouseDown += OnGridViewCellMouseDown;
             _gridView.MouseDoubleClick += OnGridViewDoubleClick;
             _gridView.MouseClick += OnGridViewMouseClick;
-            _gridView.MouseEnter += (_, e) => _toolTipProvider.OnCellMouseEnter();
             _gridView.CellMouseMove += (_, e) => _toolTipProvider.OnCellMouseMove(e);
 
             // Allow to drop patch file on revision grid

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -811,12 +811,15 @@ namespace GitUI
                     return true; // never select all revisions
 
                 case Keys.Escape:
-                    _toolTipProvider.Hide();
-                    return true;
+                    if (_toolTipProvider.Hide())
+                    {
+                        return true;
+                    }
 
-                default:
-                    return base.ProcessHotkey(keyData);
+                    break;
             }
+
+            return base.ProcessHotkey(keyData);
         }
 
         public void ReloadHotkeys()

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -801,17 +801,23 @@ namespace GitUI
 
         public override bool ProcessHotkey(Keys keyData)
         {
-            if (keyData == (Keys.Control | Keys.A))
+            switch (keyData)
             {
-                if (FindForm() is GitExtensionsFormBase form)
-                {
-                    form.ProcessHotkey(keyData);
-                }
+                case Keys.Control | Keys.A:
+                    if (FindForm() is GitExtensionsFormBase form)
+                    {
+                        form.ProcessHotkey(keyData);
+                    }
 
-                return true; // never select all revisions
+                    return true; // never select all revisions
+
+                case Keys.Escape:
+                    _toolTipProvider.Hide();
+                    return true;
+
+                default:
+                    return base.ProcessHotkey(keyData);
             }
-
-            return base.ProcessHotkey(keyData);
         }
 
         public void ReloadHotkeys()

--- a/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
@@ -17,10 +17,16 @@ namespace GitUI
             _gridView = gridView;
         }
 
-        public void Hide()
+        /// <summary>
+        /// Hides the tooltip.
+        /// </summary>
+        /// <returns>Returns <cref>true</cref> if the tooltip was active.</returns>
+        public bool Hide()
         {
+            bool wasActive = _toolTip.Active;
             _toolTip.Active = false;
             _toolTip.AutoPopDelay = 32767;
+            return wasActive;
         }
 
         public void OnCellMouseMove(DataGridViewCellMouseEventArgs e)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
@@ -1,4 +1,5 @@
-﻿using GitUI.UserControls.RevisionGrid;
+﻿using System.Diagnostics;
+using GitUI.UserControls.RevisionGrid;
 using GitUI.UserControls.RevisionGrid.Columns;
 
 namespace GitUI
@@ -19,11 +20,6 @@ namespace GitUI
         public void Hide()
         {
             _toolTip.Active = false;
-        }
-
-        public void OnCellMouseEnter()
-        {
-            _toolTip.Active = false;
             _toolTip.AutoPopDelay = 32767;
         }
 
@@ -36,8 +32,6 @@ namespace GitUI
                 return;
             }
 
-            var oldText = _toolTip.GetToolTip(_gridView);
-
             // Always generated tooltip text of first column (graph) because it **really** depends of the pixel hovered
             if (e.ColumnIndex != 0 && _previousRowIndex == e.RowIndex && _previousColumnIndex == e.ColumnIndex)
             {
@@ -47,9 +41,8 @@ namespace GitUI
             _previousRowIndex = e.RowIndex;
             _previousColumnIndex = e.ColumnIndex;
 
-            var newText = GetToolTipText();
-
-            if (newText != oldText)
+            string newText = GetToolTipText();
+            if (_toolTip.GetToolTip(_gridView) != newText)
             {
                 _toolTip.SetToolTip(_gridView, newText);
             }
@@ -78,9 +71,10 @@ namespace GitUI
                         return _gridView.Rows[e.RowIndex].Cells[e.ColumnIndex].FormattedValue?.ToString() ?? "";
                     }
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
                     // Ignore exception when fetching tooltip. It's not worth crashing for.
+                    Trace.WriteLine(ex);
                 }
 
                 // no tooltip unless always active or truncated

--- a/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
@@ -16,6 +16,11 @@ namespace GitUI
             _gridView = gridView;
         }
 
+        public void Hide()
+        {
+            _toolTip.Active = false;
+        }
+
         public void OnCellMouseEnter()
         {
             _toolTip.Active = false;


### PR DESCRIPTION
## Proposed changes

- Hide RevisionGrid tooltip on `Escape` keypress

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).