### PR TITLE
Add hotkey to ToolStripButton Default Pull/Fetch

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using GitCommands;
 using GitExtUtils.GitUI.Theming;
+using GitUI.Hotkey;
 using GitUI.Properties;
 using GitUI.Shells;
 using GitUI.UserControls;
@@ -304,6 +305,8 @@ namespace GitUI.CommandsDialogs
                     toolStripButtonPull.ToolTipText = _pullOpenDialog.Text;
                     break;
             }
+
+            toolStripButtonPull.ToolTipText += GetShortcutKeys(Command.QuickPullOrFetch).ToShortcutKeyToolTipString();
         }
 
         private Brush UpdateCommitButtonAndGetBrush(IReadOnlyList<GitItemStatus>? status, bool showCount)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1910,6 +1910,7 @@ namespace GitUI.CommandsDialogs
             // Toolbar
             AddNotes = 8,
             FindFileInSelectedCommit = 9,
+            QuickPullOrFetch = 48,
             QuickFetch = 11,
             QuickPull = 12,
             QuickPush = 13,
@@ -2041,6 +2042,7 @@ namespace GitUI.CommandsDialogs
                 case Command.CheckoutBranch: UICommands.StartCheckoutBranch(this); break;
                 case Command.QuickFetch: QuickFetch(); break;
                 case Command.QuickPull: DoPull(pullAction: AppSettings.PullAction.Merge, isSilent: true); break;
+                case Command.QuickPullOrFetch: toolStripButtonPull.PerformButtonClick(); break;
                 case Command.QuickPush: UICommands.StartPushDialog(this, true); break;
                 case Command.CloseRepository: SetWorkingDir(""); break;
                 case Command.Stash: UICommands.StashSave(this, AppSettings.IncludeUntrackedFilesInManualStash); break;

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -293,6 +293,7 @@ namespace GitUI.Hotkey
                     Hk(FormBrowse.Command.Push, Keys.Control | Keys.Up),
                     Hk(FormBrowse.Command.QuickFetch, Keys.Control | Keys.Shift | Keys.Down),
                     Hk(FormBrowse.Command.QuickPull, Keys.Control | Keys.Shift | Keys.P),
+                    Hk(FormBrowse.Command.QuickPullOrFetch, Keys.F8),
                     Hk(FormBrowse.Command.QuickPush, Keys.Control | Keys.Shift | Keys.Up),
                     Hk(FormBrowse.Command.Rebase, Keys.Control | Keys.Shift | Keys.E),
                     Hk(FormBrowse.Command.Stash, Keys.Control | Keys.Alt | Keys.Up),

--- a/GitUI/Hotkey/KeysExtensions.cs
+++ b/GitUI/Hotkey/KeysExtensions.cs
@@ -80,6 +80,11 @@ namespace GitUI.Hotkey
             return key.ToText();
         }
 
+        public static string ToShortcutKeyToolTipString(this Keys key)
+        {
+            return key == Keys.None ? "" : $" ({key.ToShortcutKeyDisplayString()})";
+        }
+
         private static string? ToCultureSpecificString(this Keys key)
         {
             if (key == Keys.None)


### PR DESCRIPTION
## Proposed changes

- Add hotkey `F8` (default) to ToolStripButton `Default Pull/Fetch`

## Screenshots <!-- Remove this section if PR does not change UI -->

### After

![image](https://github.com/gitextensions/gitextensions/assets/36601201/1e71974a-24d9-4f34-a811-a514f1d84d56)

![image](https://github.com/gitextensions/gitextensions/assets/36601201/e08682c5-e6f4-450e-8cdc-dc41b42d5388)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).