### PR TITLE
Remove ObjectId.Equals(string)

### DIFF
--- a/GitCommands/Git/GitDescribeProvider.cs
+++ b/GitCommands/Git/GitDescribeProvider.cs
@@ -39,7 +39,7 @@ namespace GitCommands.Git
             }
 
             string commitHash = description[(commitHashPos + 2)..];
-            if (commitHash.Length == 0 || !revision.Equals(commitHash))
+            if (commitHash.Length == 0 || revision.ToString() != commitHash)
             {
                 return (description, string.Empty);
             }

--- a/Plugins/GitUIPluginInterfaces/ObjectId.cs
+++ b/Plugins/GitUIPluginInterfaces/ObjectId.cs
@@ -356,49 +356,6 @@ namespace GitUIPluginInterfaces
                    _i5 == other._i5;
         }
 
-        /// <summary>
-        /// Gets whether <paramref name="other"/> is equivalent to this <see cref="ObjectId"/>.
-        /// </summary>
-        /// <remarks>
-        /// <para>This method does not allocate.</para>
-        /// <para><paramref name="other"/> must be lower case and not have any surrounding white space.</para>
-        /// </remarks>
-        public bool Equals(string? other)
-        {
-            if (other?.Length is not Sha1CharCount)
-            {
-                return false;
-            }
-
-            int i = 0;
-
-            return
-                TestInt(_i1) &&
-                TestInt(_i2) &&
-                TestInt(_i3) &&
-                TestInt(_i4) &&
-                TestInt(_i5);
-
-            bool TestInt(uint k)
-            {
-                return
-                    TestDigit(k >> 28) &&
-                    TestDigit((k >> 24) & 0xF) &&
-                    TestDigit((k >> 20) & 0xF) &&
-                    TestDigit((k >> 16) & 0xF) &&
-                    TestDigit((k >> 12) & 0xF) &&
-                    TestDigit((k >> 8) & 0xF) &&
-                    TestDigit((k >> 4) & 0xF) &&
-                    TestDigit(k & 0xF);
-
-                bool TestDigit(uint j)
-                {
-                    char c = j < 10 ? (char)('0' + j) : (char)(j + 0x57);
-                    return other[i++] == c;
-                }
-            }
-        }
-
         /// <inheritdoc />
         public override bool Equals(object? obj) => obj is ObjectId id && Equals(id);
 

--- a/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
@@ -291,19 +291,13 @@ namespace GitCommandsTests.Git
         }
 
         [Test]
-        public void Equals_with_string()
+        public void Equals_with_random()
         {
             for (var i = 0; i < 100; i++)
             {
                 var objectId = ObjectId.Random();
-                Assert.True(objectId.Equals(objectId.ToString()));
+                Assert.True(objectId.Equals(objectId));
             }
-
-            Assert.False(ObjectId.Random().Equals((string)null));
-            Assert.False(ObjectId.Random().Equals(""));
-            Assert.False(ObjectId.Random().Equals("gibberish"));
-            Assert.False(ObjectId.Parse("0123456789012345678901234567890123456789").Equals(" 0123456789012345678901234567890123456789 "));
-            Assert.False(ObjectId.Parse("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").Equals("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
         }
 
         [Test]

--- a/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
@@ -291,16 +291,6 @@ namespace GitCommandsTests.Git
         }
 
         [Test]
-        public void Equals_with_random()
-        {
-            for (var i = 0; i < 100; i++)
-            {
-                var objectId = ObjectId.Random();
-                Assert.True(objectId.Equals(objectId));
-            }
-        }
-
-        [Test]
         public void Equals_using_operator()
         {
             string objectIdString = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";


### PR DESCRIPTION
## Proposed changes

only one usage

This is adding some additional code when data structures are changed in a separate PR.
This can be optimized, but I do not feel it is worth it.
Only used in an async call to get CommitInfo where several Git commands are called.
This will cause one string allocation too.

![image](https://github.com/gitextensions/gitextensions/assets/6248932/605ccfba-b1e9-4a62-8ad8-def1ea60168e)

Related to #11223 as this PR removes some additional changes there.

## Screenshots <!-- Remove this section if PR does not change UI -->

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
