### PR TITLE
Convert GitCommandHelpers.CheckoutCmd() -> GitCheckoutRevisionCmd

### DIFF
--- a/GitCommands/Git/Commands/GitCheckoutBranchCmd.cs
+++ b/GitCommands/Git/Commands/GitCheckoutBranchCmd.cs
@@ -11,12 +11,6 @@ namespace GitCommands.Git.Commands
 
     public sealed class GitCheckoutBranchCmd : GitCommand
     {
-        public string BranchName { get; }
-        public bool Remote { get; }
-        public LocalChangesAction LocalChanges { get; }
-        public string? NewBranchName { get; }
-        public CheckoutNewBranchMode NewBranchMode { get; }
-
         public GitCheckoutBranchCmd(
             string branchName,
             bool remote,
@@ -32,7 +26,12 @@ namespace GitCommands.Git.Commands
         }
 
         public override bool AccessesRemote => false;
+        public string BranchName { get; }
         public override bool ChangesRepoState => true;
+        public LocalChangesAction LocalChanges { get; }
+        public CheckoutNewBranchMode NewBranchMode { get; }
+        public string? NewBranchName { get; }
+        public bool Remote { get; }
 
         protected override ArgumentString BuildArguments()
         {

--- a/GitCommands/Git/Commands/GitCheckoutRevisionCmd.cs
+++ b/GitCommands/Git/Commands/GitCheckoutRevisionCmd.cs
@@ -1,0 +1,31 @@
+﻿using GitExtUtils;
+using GitUIPluginInterfaces;
+
+namespace GitCommands.Git.Commands
+{
+    public sealed class GitCheckoutRevisionCmd : GitCommand
+    {
+        public GitCheckoutRevisionCmd(
+            ObjectId revision,
+            LocalChangesAction localChanges = LocalChangesAction.DontChange)
+        {
+            Revision = revision;
+            LocalChanges = localChanges == LocalChangesAction.Stash ? LocalChangesAction.DontChange : localChanges;
+        }
+
+        public override bool AccessesRemote => false;
+        public override bool ChangesRepoState => true;
+        public LocalChangesAction LocalChanges { get; }
+        public ObjectId Revision { get; }
+
+        protected override ArgumentString BuildArguments()
+        {
+            return new GitArgumentBuilder("checkout")
+            {
+                { LocalChanges == LocalChangesAction.Merge, "--merge" },
+                { LocalChanges == LocalChangesAction.Reset, "--force" },
+                Revision.ToString().QuoteNE()
+            };
+        }
+    }
+}

--- a/GitCommands/Git/Commands/GitCommandHelpers.cs
+++ b/GitCommands/Git/Commands/GitCommandHelpers.cs
@@ -285,16 +285,6 @@ namespace GitCommands.Git.Commands
             };
         }
 
-        public static ArgumentString CheckoutCmd(string branchOrRevisionName, LocalChangesAction changesAction)
-        {
-            return new GitArgumentBuilder("checkout")
-            {
-                { changesAction == LocalChangesAction.Merge, "--merge" },
-                { changesAction == LocalChangesAction.Reset, "--force" },
-                branchOrRevisionName.Quote()
-            };
-        }
-
         /// <summary>Create a new orphan branch from <paramref name="startPoint"/> and switch to it.</summary>
         public static ArgumentString CreateOrphanCmd(string newBranchName, ObjectId? startPoint = null)
         {

--- a/GitUI/CommandsDialogs/FormCheckoutRevision.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutRevision.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using GitCommands;
 using GitCommands.Git.Commands;
 using GitUI.HelperDialogs;
@@ -52,7 +52,7 @@ namespace GitUI.CommandsDialogs
                     return;
                 }
 
-                string command = GitCommandHelpers.CheckoutCmd(selectedObjectId.ToString(), Force.Checked ? LocalChangesAction.Reset : 0);
+                string command = new GitCheckoutRevisionCmd(selectedObjectId, Force.Checked ? LocalChangesAction.Reset : 0).Arguments;
                 success = FormProcess.ShowDialog(this, UICommands, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
                 if (success)
                 {

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCheckoutRevisionCmdTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCheckoutRevisionCmdTest.cs
@@ -1,0 +1,30 @@
+﻿using GitCommands;
+using GitCommands.Git.Commands;
+using GitUIPluginInterfaces;
+
+namespace GitCommandsTests.Git.Commands
+{
+    [TestFixture]
+    public sealed class GitCheckoutRevisionCmdTest
+    {
+        [Test]
+        public void TestConstructor()
+        {
+            GitCheckoutRevisionCmd cmd = new(ObjectId.IndexId);
+
+            Assert.IsNotNull(cmd);
+            Assert.AreEqual(LocalChangesAction.DontChange, cmd.LocalChanges);
+            Assert.IsFalse(cmd.AccessesRemote);
+            Assert.IsTrue(cmd.ChangesRepoState);
+        }
+
+        [TestCase(LocalChangesAction.DontChange, "checkout \"2222222222222222222222222222222222222222\"")]
+        [TestCase(LocalChangesAction.Merge, "checkout --merge \"2222222222222222222222222222222222222222\"")]
+        [TestCase(LocalChangesAction.Reset, "checkout --force \"2222222222222222222222222222222222222222\"")]
+        [TestCase(LocalChangesAction.Stash, "checkout \"2222222222222222222222222222222222222222\"")]
+        public void Assert_arguments(LocalChangesAction action, string expected)
+        {
+            Assert.AreEqual(expected, new GitCheckoutRevisionCmd(ObjectId.IndexId, action).Arguments);
+        }
+    }
+}

--- a/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Commands/GitCommandHelpersTest.cs
@@ -253,23 +253,6 @@ namespace GitCommandsTests.Git.Commands
         }
 
         [Test]
-        public void CheckoutCmd()
-        {
-            Assert.AreEqual(
-                "checkout \"branch\"",
-                GitCommandHelpers.CheckoutCmd("branch", LocalChangesAction.DontChange).Arguments);
-            Assert.AreEqual(
-                "checkout --merge \"branch\"",
-                GitCommandHelpers.CheckoutCmd("branch", LocalChangesAction.Merge).Arguments);
-            Assert.AreEqual(
-                "checkout --force \"branch\"",
-                GitCommandHelpers.CheckoutCmd("branch", LocalChangesAction.Reset).Arguments);
-            Assert.AreEqual(
-                "checkout \"branch\"",
-                GitCommandHelpers.CheckoutCmd("branch", LocalChangesAction.Stash).Arguments);
-        }
-
-        [Test]
         public void RemoveCmd()
         {
             // TODO file names should be quoted


### PR DESCRIPTION
This change is necessary for the upcoming work that generalises and unifies branch/revision checkout functionality and UI dialogs.