### PR TITLE
CommitMessageManager: Fixup ThrowIfNull

### DIFF
--- a/GitCommands/CommitMessageManager.cs
+++ b/GitCommands/CommitMessageManager.cs
@@ -90,7 +90,7 @@ namespace GitCommands
 
         internal CommitMessageManager(Control owner, string workingDirGitDir, Encoding commitEncoding, IFileSystem fileSystem, string? overriddenCommitMessage = null)
         {
-            ArgumentNullException.ThrowIfNull(nameof(owner));
+            ArgumentNullException.ThrowIfNull(owner);
 
             _owner = owner;
             _fileSystem = fileSystem;

--- a/UnitTests/CommonTestUtils/ReferenceRepository.cs
+++ b/UnitTests/CommonTestUtils/ReferenceRepository.cs
@@ -13,6 +13,9 @@ namespace CommonTestUtils
         public const string AuthorFullIdentity = $"{AuthorName} <{AuthorEmail}>";
         private readonly GitModuleTestHelper _moduleTestHelper = new();
 
+        // We don't expect any failures so that we won't be switching to the main thread or showing messages
+        public static Control DummyOwner { get; } = new();
+
         public ReferenceRepository()
         {
             CreateCommit("A commit message", "A");
@@ -177,8 +180,7 @@ namespace CommonTestUtils
                 repository.Config.Set(SettingKeyString.UserEmail, "author@mail.com");
             }
 
-            // We don't expect any failures so that we won't be switching to the main thread or showing messages
-            CommitMessageManager commitMessageManager = new(owner: null!, Module.WorkingDirGitDir, Module.CommitEncoding);
+            CommitMessageManager commitMessageManager = new(DummyOwner, Module.WorkingDirGitDir, Module.CommitEncoding);
 #pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             commitMessageManager.ResetCommitMessageAsync().GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002 // Avoid problematic synchronous waits

--- a/UnitTests/GitCommands.Tests/CommitMessageManagerTests.cs
+++ b/UnitTests/GitCommands.Tests/CommitMessageManagerTests.cs
@@ -33,7 +33,7 @@ namespace GitCommandsTests
         private CommitMessageManager _manager;
 
         // We don't expect any failures so that we won't be switching to the main thread or showing messages
-        private readonly Control? _owner = null!;
+        private readonly Control _owner = ReferenceRepository.DummyOwner;
 
         public CommitMessageManagerTests()
         {


### PR DESCRIPTION
Fixes self-delusion

## Proposed changes

Actually check the CommitMessageManager ctor argument `owner` for `null`, not its name

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- adapted existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).