### PR TITLE
RevisionReader: No reflog for notes

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -381,7 +381,8 @@ namespace GitCommands
                     return false;
                 }
 
-                revision.ReflogSelector = decoded.Slice(0, lineLength).ToString();
+                // No reflogselector for notes and such
+                revision.ReflogSelector = lineLength > 0 ? decoded.Slice(0, lineLength).ToString() : null;
                 decoded = decoded.Slice(lineLength + 1);
             }
 

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=reflogselector_empty.verified.json
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=reflogselector_empty.verified.json
@@ -1,0 +1,40 @@
+﻿{
+  "ObjectId": {
+    "IsArtificial": false
+  },
+  "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
+  "ParentIds": [
+    {
+      "IsArtificial": false
+    },
+    {
+      "IsArtificial": false
+    },
+    {
+      "IsArtificial": false
+    }
+  ],
+  "TreeGuid": {
+    "IsArtificial": false
+  },
+  "Author": "Gerhard Olsson",
+  "AuthorEmail": "gerhardol@users.noreply.github.com",
+  "AuthorUnixTime": 1624479586,
+  "AuthorDate": "DateTimeOffset_1",
+  "Committer": "Gerhard Olsson",
+  "CommitterEmail": "gerhardol@users.noreply.github.com",
+  "CommitUnixTime": 1624479586,
+  "CommitDate": "DateTimeOffset_1",
+  "BuildStatus": null,
+  "Subject": "wip tests",
+  "Body": "wip tests\n\nsecond line\nthird line before multiple whitespace",
+  "HasMultiLineMessage": true,
+  "HasNotes": false,
+  "IsArtificial": false,
+  "IsStash": false,
+  "ReflogSelector": null,
+  "HasParent": true,
+  "FirstParentId": {
+    "IsArtificial": false
+  }
+}

--- a/UnitTests/GitCommands.Tests/TestData/RevisionReader/reflogselector_empty.bin
+++ b/UnitTests/GitCommands.Tests/TestData/RevisionReader/reflogselector_empty.bin
@@ -1,0 +1,15 @@
+0c350e248500e4e893e6d17dcc61591cc1cd64e71bcb98ebe109b0a9a569b6c827d55f97730cdb247b89abaf240ec4e057a2304659cbde7b1e7bb68e 7b89abaf240ec4e057a2304659cbde7b1e7bb68e 7b89abaf240ec4e057a2304659cbde7b1e7bb68e
+1624479586
+1624479586
+Gerhard Olsson
+gerhardol@users.noreply.github.com
+Gerhard Olsson
+gerhardol@users.noreply.github.com
+
+wip tests
+
+second line
+third line before multiple whitespace
+		
+
+


### PR DESCRIPTION
## Proposed changes

Regression in #11225

Reflog selector identifies stashes and only listed with git-stash-list. However, the reflogselector can still be empty occasionally also in this situation for instance when Git Notes are displayed. These empty reflog selectors should not be presented as stashes.
For efficiency reasons the test is only for null values, i.e. empty reflog selectors must be presented as null. (In addition, a string should not be allocated even if string interning should eliminate the allocation need, there is still overhead).
https://github.com/gitextensions/gitextensions/blob/master/Plugins/GitUIPluginInterfaces/GitRevision.cs#L111

## Test methodology <!-- How did you ensure quality? -->

Test adjusted

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
