### PR TITLE
Plumb service provider to settings pages

### DIFF
--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -170,7 +170,7 @@ namespace GitExtensions
                     {
                         CheckSettingsLogic checkSettingsLogic = new(commonLogic);
                         SettingsPageHostMock fakePageHost = new(checkSettingsLogic);
-                        using var checklistSettingsPage = SettingsPageBase.Create<ChecklistSettingsPage>(fakePageHost);
+                        using var checklistSettingsPage = SettingsPageBase.Create<ChecklistSettingsPage>(fakePageHost, _serviceContainer);
                         if (!checklistSettingsPage.CheckSettings())
                         {
                             if (!checkSettingsLogic.AutoSolveAllSettings() || !checklistSettingsPage.CheckSettings())

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -104,47 +104,49 @@ namespace GitUI.CommandsDialogs
 
             settingsTreeView.SuspendLayout();
 
-            ChecklistSettingsPage checklistSettingsPage = SettingsPageBase.Create<ChecklistSettingsPage>(this);
+            IServiceProvider serviceProvider = UICommands;
+
+            ChecklistSettingsPage checklistSettingsPage = SettingsPageBase.Create<ChecklistSettingsPage>(this, serviceProvider);
 
             // Git Extensions settings
             settingsTreeView.AddSettingsPage(new GitExtensionsSettingsGroup(), null, Images.GitExtensionsLogo16);
             var gitExtPageRef = GitExtensionsSettingsGroup.GetPageReference();
             settingsTreeView.AddSettingsPage(checklistSettingsPage, gitExtPageRef, icon: null, asRoot: true);
 
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<GeneralSettingsPage>(this), gitExtPageRef, Images.GeneralSettings);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<GeneralSettingsPage>(this, serviceProvider), gitExtPageRef, Images.GeneralSettings);
 
             // >> Appearance
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<AppearanceSettingsPage>(this), gitExtPageRef, Images.Appearance);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<AppearanceSettingsPage>(this, serviceProvider), gitExtPageRef, Images.Appearance);
             var appearanceSettingsPage = AppearanceSettingsPage.GetPageReference();
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<SortingSettingsPage>(this), appearanceSettingsPage, Images.SortBy);
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ColorsSettingsPage>(this), appearanceSettingsPage, Images.Colors);
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<AppearanceFontsSettingsPage>(this), appearanceSettingsPage, Images.Font.AdaptLightness());
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ConsoleStyleSettingsPage>(this), appearanceSettingsPage, Images.Console);
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<RevisionLinksSettingsPage>(this), gitExtPageRef, Images.Link.AdaptLightness());
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<SortingSettingsPage>(this, serviceProvider), appearanceSettingsPage, Images.SortBy);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ColorsSettingsPage>(this, serviceProvider), appearanceSettingsPage, Images.Colors);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<AppearanceFontsSettingsPage>(this, serviceProvider), appearanceSettingsPage, Images.Font.AdaptLightness());
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ConsoleStyleSettingsPage>(this, serviceProvider), appearanceSettingsPage, Images.Console);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<RevisionLinksSettingsPage>(this, serviceProvider), gitExtPageRef, Images.Link.AdaptLightness());
 
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<BuildServerIntegrationSettingsPage>(this), gitExtPageRef, Images.Integration);
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ScriptsSettingsPage>(this), gitExtPageRef, Images.Console);
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<HotkeysSettingsPage>(this), gitExtPageRef, Images.Hotkey);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<BuildServerIntegrationSettingsPage>(this, serviceProvider), gitExtPageRef, Images.Integration);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ScriptsSettingsPage>(this, serviceProvider), gitExtPageRef, Images.Console);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<HotkeysSettingsPage>(this, serviceProvider), gitExtPageRef, Images.Hotkey);
 
             if (EnvUtils.RunningOnWindows())
             {
-                settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ShellExtensionSettingsPage>(this), gitExtPageRef, Images.ShellExtensions);
+                settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ShellExtensionSettingsPage>(this, serviceProvider), gitExtPageRef, Images.ShellExtensions);
             }
 
             // >> Advanced
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<AdvancedSettingsPage>(this), gitExtPageRef, Images.AdvancedSettings);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<AdvancedSettingsPage>(this, serviceProvider), gitExtPageRef, Images.AdvancedSettings);
             SettingsPageReference advancedPageRef = AdvancedSettingsPage.GetPageReference();
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ConfirmationsSettingsPage>(this), advancedPageRef, Images.BisectGood);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ConfirmationsSettingsPage>(this, serviceProvider), advancedPageRef, Images.BisectGood);
 
             // >> Detailed
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<DetailedSettingsPage>(this), gitExtPageRef, Images.Settings);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<DetailedSettingsPage>(this, serviceProvider), gitExtPageRef, Images.Settings);
             var detailedSettingsPage = DetailedSettingsPage.GetPageReference();
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<FormBrowseRepoSettingsPage>(this), detailedSettingsPage, Images.BranchFolder);
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<CommitDialogSettingsPage>(this), detailedSettingsPage, Images.CommitSummary);
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<DiffViewerSettingsPage>(this), detailedSettingsPage, Images.Diff);
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<BlameViewerSettingsPage>(this), detailedSettingsPage, Images.Blame);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<FormBrowseRepoSettingsPage>(this, serviceProvider), detailedSettingsPage, Images.BranchFolder);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<CommitDialogSettingsPage>(this, serviceProvider), detailedSettingsPage, Images.CommitSummary);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<DiffViewerSettingsPage>(this, serviceProvider), detailedSettingsPage, Images.Diff);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<BlameViewerSettingsPage>(this, serviceProvider), detailedSettingsPage, Images.Blame);
 
-            var sshSettingsPage = SettingsPageBase.Create<SshSettingsPage>(this);
+            var sshSettingsPage = SettingsPageBase.Create<SshSettingsPage>(this, serviceProvider);
             settingsTreeView.AddSettingsPage(sshSettingsPage, gitExtPageRef, Images.Key);
             checklistSettingsPage.SshSettingsPage = sshSettingsPage;
 
@@ -152,21 +154,21 @@ namespace GitUI.CommandsDialogs
             settingsTreeView.AddSettingsPage(new GitSettingsGroup(), null, Images.GitLogo16);
             var gitPageRef = GitSettingsGroup.GetPageReference();
 
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<GitSettingsPage>(this), gitPageRef, Images.FolderOpen);
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<GitConfigSettingsPage>(this), gitPageRef, Images.GeneralSettings);
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<GitConfigAdvancedSettingsPage>(this), gitPageRef, Images.AdvancedSettings);
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<GitRootIntroductionPage>(this), gitPageRef, icon: null, asRoot: true);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<GitSettingsPage>(this, serviceProvider), gitPageRef, Images.FolderOpen);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<GitConfigSettingsPage>(this, serviceProvider), gitPageRef, Images.GeneralSettings);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<GitConfigAdvancedSettingsPage>(this, serviceProvider), gitPageRef, Images.AdvancedSettings);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<GitRootIntroductionPage>(this, serviceProvider), gitPageRef, icon: null, asRoot: true);
 
             // Plugins settings
             settingsTreeView.AddSettingsPage(new PluginsSettingsGroup(), null, Images.Plugin);
             SettingsPageReference pluginsPageRef = PluginsSettingsGroup.GetPageReference();
-            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<PluginRootIntroductionPage>(this), pluginsPageRef, icon: null, asRoot: true);
+            settingsTreeView.AddSettingsPage(SettingsPageBase.Create<PluginRootIntroductionPage>(this, serviceProvider), pluginsPageRef, icon: null, asRoot: true);
 
             lock (PluginRegistry.Plugins)
             {
                 var pluginEntries = PluginRegistry.Plugins
                     .Where(p => p.HasSettings)
-                    .Select(plugin => (Plugin: plugin, Page: PluginSettingsPage.CreateSettingsPageFromPlugin(this, plugin)))
+                    .Select(plugin => (Plugin: plugin, Page: PluginSettingsPage.CreateSettingsPageFromPlugin(this, plugin, UICommands)))
                     .OrderBy(entry => entry.Page.GetTitle(), StringComparer.CurrentCultureIgnoreCase);
 
                 foreach (var entry in pluginEntries)

--- a/GitUI/CommandsDialogs/SettingsDialog/AutoLayoutSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/AutoLayoutSettingsPage.cs
@@ -7,6 +7,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog
     {
         private ISettingsLayout? _settingsLayout;
 
+        public AutoLayoutSettingsPage(IServiceProvider serviceProvider)
+           : base(serviceProvider)
+        {
+        }
+
         protected virtual ISettingsLayout GetSettingsLayout()
         {
             if (_settingsLayout is null)

--- a/GitUI/CommandsDialogs/SettingsDialog/ConfigFileSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/ConfigFileSettingsPage.cs
@@ -6,6 +6,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 {
     public partial class ConfigFileSettingsPage : SettingsPageWithHeader, ILocalSettingsPage
     {
+        public ConfigFileSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
+        {
+        }
+
         protected ConfigFileSettingsSet ConfigFileSettingsSet => CommonLogic.ConfigFileSettingsSet;
         protected ConfigFileSettings? CurrentSettings { get; private set; }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/DistributedSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/DistributedSettingsPage.cs
@@ -6,6 +6,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 {
     public partial class DistributedSettingsPage : SettingsPageWithHeader, IDistributedSettingsPage
     {
+        public DistributedSettingsPage(IServiceProvider serviceProvider)
+           : base(serviceProvider)
+        {
+        }
+
         protected DistributedSettingsSet DistributedSettingsSet => CommonLogic.DistributedSettingsSet;
         protected DistributedSettings? CurrentSettings { get; private set; }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.Designer.cs
@@ -375,6 +375,7 @@
             this.Name = "AdvancedSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Size = new System.Drawing.Size(1616, 769);
+            this.Text = "Advanced";
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
             this.grpUpdates.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AdvancedSettingsPage.cs
@@ -4,10 +4,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class AdvancedSettingsPage : SettingsPageWithHeader
     {
-        public AdvancedSettingsPage()
+        public AdvancedSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Advanced";
             InitializeComplete();
 
             var autoNormaliseSymbols = new[]

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.Designer.cs
@@ -226,6 +226,7 @@
             this.Name = "AppearanceFontsSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Size = new System.Drawing.Size(2148, 1371);
+            this.Text = "Fonts";
             this.gbFonts.ResumeLayout(false);
             this.gbFonts.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
@@ -236,6 +237,7 @@
         }
 
         #endregion
+
         private System.Windows.Forms.GroupBox gbFonts;
         private System.Windows.Forms.Button diffFontChangeButton;
         private System.Windows.Forms.Button applicationFontChangeButton;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceFontsSettingsPage.cs
@@ -10,10 +10,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private Font? _commitFont;
         private Font? _monospaceFont;
 
-        public AppearanceFontsSettingsPage()
+        public AppearanceFontsSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Fonts";
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.Designer.cs
@@ -530,6 +530,7 @@
             Name = "AppearanceSettingsPage";
             Padding = new Padding(8);
             Size = new Size(1502, 599);
+            Text = "Appearance";
             tlpnlMain.ResumeLayout(false);
             tlpnlMain.PerformLayout();
             gbGeneral.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -18,10 +18,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private readonly TranslationString _noImageServiceTooltip = new($"A default image, if the provider has no image for the email address.\r\n\r\nClick this info icon for more details.");
         private readonly TranslationString _avatarProviderTooltip = new($"The avatar provider defines the source for user-defined avatar images.\r\nThe \"Default\" provider uses GitHub and Gravatar,\r\nthe \"Custom\" provider allows you to set custom provider URLs and\r\n\"None\" disables user-defined avatars.\r\n\r\nClick this info icon for more details.");
 
-        public AppearanceSettingsPage()
+        public AppearanceSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Appearance";
             InitializeComplete();
 
             FillComboBoxWithEnumValues<AvatarProvider>(AvatarProvider);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.Designer.cs
@@ -225,6 +225,7 @@
             this.Controls.Add(this.groupBoxBlameSettings);
             this.Name = "BlameViewerSettingsPage";
             this.Size = new System.Drawing.Size(341, 272);
+            this.Text = "Blame viewer";
             this.groupBoxBlameSettings.ResumeLayout(false);
             this.groupBoxBlameSettings.PerformLayout();
             this.tableLayoutPanelBlameSettings.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.cs
@@ -4,10 +4,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class BlameViewerSettingsPage : SettingsPageWithHeader
     {
-        public BlameViewerSettingsPage()
+        public BlameViewerSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Blame viewer";
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.Designer.cs
@@ -137,6 +137,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.MinimumSize = new System.Drawing.Size(454, 286);
             this.Name = "BuildServerIntegrationSettingsPage";
             this.Size = new System.Drawing.Size(1552, 894);
+            this.Text = "Build server integration";
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
@@ -15,10 +15,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private IConfigFileRemoteSettingsManager? _remotesManager;
         private JoinableTask<object>? _populateBuildServerTypeTask;
 
-        public BuildServerIntegrationSettingsPage()
+        public BuildServerIntegrationSettingsPage(IServiceProvider serviceProvider)
+           : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Build server integration";
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.Designer.cs
@@ -509,6 +509,7 @@
             this.MinimumSize = new System.Drawing.Size(680, 460);
             this.Name = "ChecklistSettingsPage";
             this.Size = new System.Drawing.Size(1015, 608);
+            this.Text = "Checklist";
             groupBox1.ResumeLayout(false);
             groupBox1.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -133,10 +133,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         /// </summary>
         public SshSettingsPage? SshSettingsPage { get; set; }
 
-        public ChecklistSettingsPage()
+        public ChecklistSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Checklist";
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.Designer.cs
@@ -313,6 +313,7 @@
             this.Name = "ColorsSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Size = new System.Drawing.Size(1527, 599);
+            this.Text = "Colors";
             tlpnlMain.ResumeLayout(false);
             tlpnlMain.PerformLayout();
             this.gbRevisionGraph.ResumeLayout(false);
@@ -330,6 +331,7 @@
         }
 
         #endregion
+    
         private System.Windows.Forms.GroupBox gbRevisionGraph;
         private System.Windows.Forms.CheckBox DrawNonRelativesTextGray;
         private System.Windows.Forms.CheckBox DrawNonRelativesGray;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.cs
@@ -18,10 +18,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private static readonly TranslationString DefaultThemeName =
             new("default");
 
-        public ColorsSettingsPage()
+        public ColorsSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Colors";
             sbOpenThemeFolder.AutoSize = false;
 
             _NO_TRANSLATE_cbSelectTheme.SelectedIndexChanged += ComboBoxTheme_SelectedIndexChanged;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.Designer.cs
@@ -45,7 +45,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.chkEnsureCommitMessageSecondLineEmpty = new System.Windows.Forms.CheckBox();
             this.groupBoxBehaviour.SuspendLayout();
             this.tableLayoutPanelBehaviour.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize) (this
+            ((System.ComponentModel.ISupportInitialize)(this
                 ._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages)).BeginInit();
             this.grpAdditionalButtons.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
@@ -122,16 +122,16 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Location =
                 new System.Drawing.Point(360, 118);
             this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Maximum =
-                new decimal(new int[] {999, 0, 0, 0});
+                new decimal(new int[] { 999, 0, 0, 0 });
             this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Minimum =
-                new decimal(new int[] {1, 0, 0, 0});
+                new decimal(new int[] { 1, 0, 0, 0 });
             this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Name =
                 "_NO_TRANSLATE_CommitDialogNumberOfPreviousMessages";
             this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Size =
                 new System.Drawing.Size(123, 23);
             this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.TabIndex = 4;
             this._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages.Value =
-                new decimal(new int[] {1, 0, 0, 0});
+                new decimal(new int[] { 1, 0, 0, 0 });
             // 
             // lblCommitDialogNumberOfPreviousMessages
             // 
@@ -248,11 +248,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.Controls.Add(this.groupBoxBehaviour);
             this.Name = "CommitDialogSettingsPage";
             this.Size = new System.Drawing.Size(1014, 950);
+            this.Text = "Commit dialog";
             this.groupBoxBehaviour.ResumeLayout(false);
             this.groupBoxBehaviour.PerformLayout();
             this.tableLayoutPanelBehaviour.ResumeLayout(false);
             this.tableLayoutPanelBehaviour.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize) (this
+            ((System.ComponentModel.ISupportInitialize)(this
                 ._NO_TRANSLATE_CommitDialogNumberOfPreviousMessages)).EndInit();
             this.grpAdditionalButtons.ResumeLayout(false);
             this.grpAdditionalButtons.PerformLayout();

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/CommitDialogSettingsPage.cs
@@ -4,10 +4,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class CommitDialogSettingsPage : SettingsPageWithHeader
     {
-        public CommitDialogSettingsPage()
+        public CommitDialogSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Commit dialog";
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.Designer.cs
@@ -398,6 +398,7 @@
             Name = "ConfirmationsSettingsPage";
             Padding = new Padding(8);
             Size = new Size(1429, 758);
+            Text = "Confirmations";
             tlpnlMain.ResumeLayout(false);
             tlpnlMain.PerformLayout();
             gbConfirmations.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConfirmationsSettingsPage.cs
@@ -4,10 +4,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class ConfirmationsSettingsPage : SettingsPageWithHeader
     {
-        public ConfirmationsSettingsPage()
+        public ConfirmationsSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Confirmations";
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.Designer.cs
@@ -136,6 +136,7 @@
             this.Controls.Add(this.groupBoxConsoleSettings);
             this.Name = "ConsoleStyleSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
+            this.Text = "Console style";
             this.groupBoxConsoleSettings.ResumeLayout(false);
             this.groupBoxConsoleSettings.PerformLayout();
             this.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ConsoleStyleSettingsPage.cs
@@ -7,10 +7,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
     {
         private Font? _consoleFont;
 
-        public ConsoleStyleSettingsPage()
+        public ConsoleStyleSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Console style";
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DetailedSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DetailedSettingsPage.Designer.cs
@@ -272,6 +272,7 @@
             this.Name = "DetailedSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Size = new System.Drawing.Size(1340, 889);
+            this.Text = "Detailed";
             this.PushWindowGB.ResumeLayout(false);
             this.PushWindowGB.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DetailedSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DetailedSettingsPage.cs
@@ -5,10 +5,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class DetailedSettingsPage : DistributedSettingsPage
     {
-        public DetailedSettingsPage()
+        public DetailedSettingsPage(IServiceProvider serviceProvider)
+           : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Detailed";
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
@@ -93,7 +93,8 @@
             this.chkRememberIgnoreWhiteSpacePreference.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkRememberIgnoreWhiteSpacePreference.Location = new System.Drawing.Point(3, 3);
             this.chkRememberIgnoreWhiteSpacePreference.Name = "chkRememberIgnoreWhiteSpacePreference";
-            this.chkRememberIgnoreWhiteSpacePreference.Size = new System.Drawing.Size(325, 19);            this.chkRememberIgnoreWhiteSpacePreference.Text = "Remember the \'Ignore whitespaces\' preference";
+            this.chkRememberIgnoreWhiteSpacePreference.Size = new System.Drawing.Size(325, 19);
+            this.chkRememberIgnoreWhiteSpacePreference.Text = "Remember the \'Ignore whitespaces\' preference";
             this.chkRememberIgnoreWhiteSpacePreference.UseVisualStyleBackColor = true;
             // 
             // chkRememberShowNonPrintingCharsPreference
@@ -251,6 +252,7 @@
             this.Name = "DiffViewerSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Size = new System.Drawing.Size(1763, 1325);
+            this.Text = "Diff viewer";
             this.tlpnlGeneral.ResumeLayout(false);
             this.tlpnlGeneral.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.VerticalRulerPosition)).EndInit();

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
@@ -4,10 +4,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class DiffViewerSettingsPage : SettingsPageWithHeader
     {
-        public DiffViewerSettingsPage()
+        public DiffViewerSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Diff viewer";
             InitializeComplete();
 
             chkShowDiffForAllParents.Text = TranslatedStrings.ShowDiffForAllParentsText;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.Designer.cs
@@ -136,6 +136,7 @@
             this.Name = "FormBrowseRepoSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Size = new System.Drawing.Size(457, 215);
+            this.Text = "Browse repository window";
             this.gbGeneral.ResumeLayout(false);
             this.gbGeneral.PerformLayout();
             this.gbTabs.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormBrowseRepoSettingsPage.cs
@@ -8,10 +8,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private readonly ShellProvider _shellProvider = new();
         private int _cboTerminalPreviousIndex = -1;
 
-        public FormBrowseRepoSettingsPage()
+        public FormBrowseRepoSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Browse repository window";
             cboTerminal.DisplayMember = "Name";
             InitializeComplete();
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.Designer.cs
@@ -537,6 +537,7 @@
             this.Name = "GeneralSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Size = new System.Drawing.Size(1279, 523);
+            this.Text = "General";
             tlpnlMain.ResumeLayout(false);
             tlpnlMain.PerformLayout();
             this.groupBoxTelemetry.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
@@ -14,12 +14,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private readonly TranslationString _fetchAll = new("Fetch all");
         private readonly TranslationString _fetchAndPruneAll = new("Fetch and prune all");
 
-        public GeneralSettingsPage()
+        public GeneralSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
             InitializeComponent();
-            Text = "General";
             InitializeComplete();
 
             if (LicenseManager.UsageMode == LicenseUsageMode.Designtime || GitModuleForm.IsUnitTestActive)

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.Designer.cs
@@ -96,6 +96,7 @@
             this.Controls.Add(this.checkBoxRebaseAutosquash);
             this.Name = "GitConfigAdvancedSettingsPage";
             this.Size = new System.Drawing.Size(1439, 516);
+            this.Text = "Advanced";
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
@@ -8,10 +8,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private record GitSettingUiMapping(string GitSettingKey, CheckBox MappedCheckbox);
         private readonly List<GitSettingUiMapping> _gitSettings;
 
-        public GitConfigAdvancedSettingsPage()
+        public GitConfigAdvancedSettingsPage(IServiceProvider serviceProvider)
+           : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Advanced";
             InitializeComplete();
 
             _gitSettings = new List<GitSettingUiMapping>

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.Designer.cs
@@ -492,6 +492,7 @@
             this.Controls.Add(this.tableLayoutPanelGitConfig);
             this.Name = "GitConfigSettingsPage";
             this.Size = new System.Drawing.Size(1277, 715);
+            this.Text = "Config";
             this.InvalidGitPathGlobal.ResumeLayout(false);
             this.InvalidGitPathGlobal.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -15,10 +15,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private readonly GitConfigSettingsPageController _controller;
         private DiffMergeToolConfigurationManager? _diffMergeToolConfigurationManager;
 
-        public GitConfigSettingsPage()
+        public GitConfigSettingsPage(IServiceProvider serviceProvider)
+           : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Config";
 
             txtDiffToolPath.Enabled =
                 btnDiffToolBrowse.Enabled =

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitRootIntroductionPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitRootIntroductionPage.Designer.cs
@@ -47,6 +47,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.Controls.Add(this.label1);
             this.Name = "GitRootIntroductionPage";
             this.Size = new System.Drawing.Size(473, 229);
+            this.Text = "Git Settings";
             this.ResumeLayout(false);
 
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitRootIntroductionPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitRootIntroductionPage.cs
@@ -5,10 +5,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class GitRootIntroductionPage : SettingsPageBase
     {
-        public GitRootIntroductionPage()
+        public GitRootIntroductionPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Git Settings";
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.Designer.cs
@@ -278,6 +278,7 @@
             this.Name = "GitSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Size = new System.Drawing.Size(647, 614);
+            this.Text = "Paths";
             tlpnlEnvironment.ResumeLayout(false);
             tlpnlEnvironment.PerformLayout();
             tlpnlGitPaths.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitSettingsPage.cs
@@ -7,10 +7,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
     {
         private readonly TranslationString _homeIsSetToString = new("HOME is set to:");
 
-        public GitSettingsPage()
+        public GitSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Paths";
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/HotkeysSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/HotkeysSettingsPage.Designer.cs
@@ -48,6 +48,7 @@
             this.MinimumSize = new System.Drawing.Size(670, 330);
             this.Name = "HotkeysSettingsPage";
             this.Size = new System.Drawing.Size(670, 330);
+            this.Text = "Hotkeys";
             this.ResumeLayout(false);
 
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/HotkeysSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/HotkeysSettingsPage.cs
@@ -2,10 +2,10 @@
 {
     public partial class HotkeysSettingsPage : SettingsPageWithHeader
     {
-        public HotkeysSettingsPage()
+        public HotkeysSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Hotkeys";
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.Designer.cs
@@ -643,6 +643,7 @@
             this.Controls.Add(this.splitContainer1);
             this.Name = "RevisionLinksSettingsPage";
             this.Size = new System.Drawing.Size(1174, 549);
+            this.Text = "Revision links";
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel1.PerformLayout();
             this.splitContainer1.Panel2.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/RevisionLinksSettingsPage.cs
@@ -12,12 +12,12 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private readonly TranslationString _addTemplate = new("Add {0} templates");
         private ExternalLinksManager? _externalLinksManager;
 
-        public RevisionLinksSettingsPage()
+        public RevisionLinksSettingsPage(IServiceProvider serviceProvider)
+           : base(serviceProvider)
         {
             InitializeComponent();
             CaptionCol.Width = DpiUtil.Scale(150);
             splitContainer1.Panel1MinSize = toolStripManageCategories.Width;
-            Text = "Revision links";
             InitializeComplete();
             LinksGrid.AutoGenerateColumns = false;
             CaptionCol.DataPropertyName = nameof(ExternalLinkFormat.Caption);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.Designer.cs
@@ -200,6 +200,7 @@
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "ScriptsSettingsPage";
             this.Size = new System.Drawing.Size(1335, 885);
+            this.Text = "Scripts";
             this.panel2.ResumeLayout(false);
             this.panel2.PerformLayout();
             this.panelButtons.ResumeLayout(false);
@@ -210,6 +211,7 @@
         }
 
         #endregion
+    
         private System.Windows.Forms.Button btnMoveUp;
         private System.Windows.Forms.Button btnMoveDown;
         private System.Windows.Forms.Button btnArgumentsHelp;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -85,10 +85,10 @@ Current Branch:
         // we need to track that so we load images before we bind the list
         private bool _imagsLoaded;
 
-        public ScriptsSettingsPage()
+        public ScriptsSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Scripts";
 
             // stop the localisation of the propertygrid
             propertyGrid1.Text = string.Empty;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.Designer.cs
@@ -267,6 +267,7 @@
             this.Name = "ShellExtensionSettingsPage";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Size = new System.Drawing.Size(1502, 331);
+            this.Text = "Shell extension";
             panel1.ResumeLayout(false);
             this.tlpnlMain.ResumeLayout(false);
             this.tlpnlMain.PerformLayout();

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ShellExtensionSettingsPage.cs
@@ -16,10 +16,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 * Unchecked: not added to the menu");
 
         private bool _isLoading = false;
-        public ShellExtensionSettingsPage()
+        public ShellExtensionSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Shell extension";
             UpdateRegistrationStatus();
             InitializeComplete();
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/SortingSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/SortingSettingsPage.Designer.cs
@@ -252,6 +252,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Name = "SortingSettingsPage";
             Padding = new Padding(8);
             Size = new Size(1527, 685);
+            Text = "Sorting";
             tlpnlMain.ResumeLayout(false);
             tlpnlMain.PerformLayout();
             gbGeneral.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/SortingSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/SortingSettingsPage.cs
@@ -16,10 +16,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             "The remotes matching the pattern will be shown before the others.\n" +
             "Separate the priorities with ';'.");
 
-        public SortingSettingsPage()
+        public SortingSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Sorting";
             InitializeComplete();
 
             FillComboBoxWithEnumValues<RevisionSortOrder>(_NO_TRANSLATE_cmbRevisionsSortBy);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.Designer.cs
@@ -333,6 +333,7 @@
             this.Controls.Add(this.groupBox1);
             this.Name = "SshSettingsPage";
             this.Size = new System.Drawing.Size(899, 633);
+            this.Text = "SSH";
             tableLayoutPanel2.ResumeLayout(false);
             tableLayoutPanel2.PerformLayout();
             tableLayoutPanel3.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
@@ -7,10 +7,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class SshSettingsPage : SettingsPageWithHeader
     {
-        public SshSettingsPage()
+        public SshSettingsPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "SSH";
             InitializeComplete();
 
             label18.SetForeColorForBackColor();

--- a/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginRootIntroductionPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginRootIntroductionPage.Designer.cs
@@ -48,6 +48,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             this.Controls.Add(this.label1);
             this.Name = "PluginRootIntroductionPage";
             this.Size = new System.Drawing.Size(473, 229);
+            this.Text = "Plugins Settings";
             this.ResumeLayout(false);
 
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginRootIntroductionPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginRootIntroductionPage.cs
@@ -5,10 +5,10 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class PluginRootIntroductionPage : SettingsPageBase
     {
-        public PluginRootIntroductionPage()
+        public PluginRootIntroductionPage(IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             InitializeComponent();
-            Text = "Plugins Settings";
             InitializeComplete();
         }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
@@ -8,7 +8,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Plugins
         private IGitPlugin? _gitPlugin;
         private GitPluginSettingsContainer? _settingsContainer;
 
-        public PluginSettingsPage()
+        public PluginSettingsPage(IServiceProvider serviceProvider)
+           : base(serviceProvider)
         {
             InitializeComponent();
         }
@@ -35,9 +36,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Plugins
             InitializeComplete();
         }
 
-        public static PluginSettingsPage CreateSettingsPageFromPlugin(ISettingsPageHost pageHost, IGitPlugin gitPlugin)
+        public static PluginSettingsPage CreateSettingsPageFromPlugin(ISettingsPageHost pageHost, IGitPlugin gitPlugin, IServiceProvider serviceProvider)
         {
-            var result = Create<PluginSettingsPage>(pageHost);
+            var result = Create<PluginSettingsPage>(pageHost, serviceProvider);
             result.Init(gitPlugin);
             return result;
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsPageWithHeader.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsPageWithHeader.cs
@@ -7,6 +7,11 @@ namespace GitUI.CommandsDialogs.SettingsDialog
     {
         private SettingsPageHeader? _header;
 
+        public SettingsPageWithHeader(IServiceProvider serviceProvider)
+            : base(serviceProvider)
+        {
+        }
+
         public override Control GuiControl => _header ??= new SettingsPageHeader(this);
 
         public virtual void SetGlobalSettings()

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -133,10 +133,6 @@ This action will be performed without warning while checking out branch.</source
         <source>Appearance</source>
         <target />
       </trans-unit>
-      <trans-unit id="AvatarProvider.Text">
-        <source>Default</source>
-        <target />
-      </trans-unit>
       <trans-unit id="ClearImageCache.Text">
         <source>Clear image cache</source>
         <target />
@@ -1376,20 +1372,6 @@ The primary difftool can still be selected by clicking the main menu entry.</sou
       </trans-unit>
       <trans-unit id="chkShowDiffForAllParents.Text">
         <source>Show file differences for all parents in browse dialog</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="chkShowDiffForAllParents.ToolTipText">
-        <source>Show all differences between the selected commits, not limiting to only one difference.
-
-- For a single selected commit, show the difference with its parent commit.
-- For a single selected merge commit, show the difference with all parents.
-- For two selected commits with a common ancestor (BASE), show the difference
-between the commits as well as the difference from BASE to the selected commits.
-See documentation for more details about icons and range diffs.
-- For multiple selected commits (up to four), show the difference for
-all the first selected with the last selected commit.
-- For more than four selected commits, show the difference from the first to
-the last selected commit.</source>
         <target />
       </trans-unit>
       <trans-unit id="gbGeneral.Text">
@@ -9701,12 +9683,6 @@ Current Branch:
       </trans-unit>
       <trans-unit id="lblMenuEntries.Text">
         <source>Configuration of items in the context menu</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="menuHelp.toolTip1">
-        <source>* Checked: at top level for direct access
-* Intermediate: in a cascaded context menu
-* Unchecked: not added to the menu</source>
         <target />
       </trans-unit>
     </body>

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPageTests.NoPlugins.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPageTests.NoPlugins.cs
@@ -2,6 +2,7 @@
 using CommonTestUtils.MEF;
 using GitCommands;
 using GitExtensions.UITests;
+using GitUI;
 using GitUI.CommandsDialogs.SettingsDialog;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;
 using GitUIPluginInterfaces;
@@ -61,7 +62,7 @@ namespace UITests.CommandsDialogs.SettingsDialog.Pages
                         Size = new(800, 400)
                     };
 
-                    _settingsPage = SettingsPageBase.Create<BuildServerIntegrationSettingsPage>(_form);
+                    _settingsPage = SettingsPageBase.Create<BuildServerIntegrationSettingsPage>(_form, GitUICommands.EmptyServiceProvider);
                     _settingsPage.Dock = DockStyle.Fill;
 
                     _form.Controls.Add(_settingsPage);

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPageTests.WithPlugins.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPageTests.WithPlugins.cs
@@ -2,6 +2,7 @@
 using CommonTestUtils.MEF;
 using GitCommands;
 using GitExtensions.UITests;
+using GitUI;
 using GitUI.CommandsDialogs.SettingsDialog;
 using GitUI.CommandsDialogs.SettingsDialog.Pages;
 using GitUIPluginInterfaces;
@@ -83,7 +84,7 @@ namespace UITests.CommandsDialogs.SettingsDialog.Pages
                         Size = new(800, 400)
                     };
 
-                    _settingsPage = SettingsPageBase.Create<BuildServerIntegrationSettingsPage>(_form);
+                    _settingsPage = SettingsPageBase.Create<BuildServerIntegrationSettingsPage>(_form, GitUICommands.EmptyServiceProvider);
                     _settingsPage.Dock = DockStyle.Fill;
 
                     _form.Controls.Add(_settingsPage);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

An addendum to #11142. This allows reusing registered instances in the Settings dialog pages.

❗ This change on its own breaks the Windows Forms designer integration for the affected components. The designer integration is fixe by #11249.