### PR TITLE
FormPush: Allow push from other tabs even if no branch is selected in 1st tab

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -283,7 +283,7 @@ namespace GitUI.CommandsDialogs
                 return false;
             }
 
-            if (_NO_TRANSLATE_Branch.Text != AllRefs
+            if (TabControlTagBranch.SelectedTab == BranchTab && _NO_TRANSLATE_Branch.Text != AllRefs
                 && (string.IsNullOrWhiteSpace(_NO_TRANSLATE_Branch.Text)
                     || _NO_TRANSLATE_Branch.Text == DetachedHeadParser.DetachedBranch
                     || string.IsNullOrWhiteSpace(RemoteBranch.Text)


### PR DESCRIPTION
Check if a branch is selected only if the 1st tab is the selected one
and so allowing to push tags (from 2nd tab) or multiple branch (3rd tab) even if no branch is selected in 1st tab.

It's more likely to happen if you are in a submodule that has no branch checked out but you want to push something...

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 8f017f6b0bc303f5fdb54aa5e61da791a8248da3
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.21
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.21 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.10 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
