### PR TITLE
editor: Add feature to move line up/down with ALT + UP/DOWN

### DIFF
--- a/GitExtensions/Properties/launchSettings.json
+++ b/GitExtensions/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "GitExtensions": {
       "commandName": "Project",
-      "commandLineArgs": "browse \"$(MSBuildThisFileDirectory)..\""
+      "commandLineArgs": "browse ."
     },
     "Dashboard": {
       "commandName": "Project"
@@ -18,6 +18,10 @@
     "Editor": {
       "commandName": "Project",
       "commandLineArgs": "fileeditor GitExtensions.settings"
+    },
+    "pull": {
+      "commandName": "Project",
+      "commandLineArgs": "pull"
     }
   }
 }

--- a/GitExtensions/Properties/launchSettings.json
+++ b/GitExtensions/Properties/launchSettings.json
@@ -14,6 +14,10 @@
     "FileHistory": {
       "commandName": "Project",
       "commandLineArgs": "filehistory GitExtensions.settings"
+    },
+    "Editor": {
+      "commandName": "Project",
+      "commandLineArgs": "fileeditor GitExtensions.settings"
     }
   }
 }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1959,23 +1959,35 @@ namespace GitUI.Editor
                 case Command.Find: internalFileViewer.Find(); break;
                 case Command.FindNextOrOpenWithDifftool: internalFileViewer.InvokeAndForget(() => internalFileViewer.FindNextAsync(searchForwardOrOpenWithDifftool: true)); break;
                 case Command.FindPrevious: internalFileViewer.InvokeAndForget(() => internalFileViewer.FindNextAsync(searchForwardOrOpenWithDifftool: false)); break;
-                case Command.GoToLine: goToLineToolStripMenuItem.PerformClick(); break;
-                case Command.IncreaseNumberOfVisibleLines: increaseNumberOfLinesToolStripMenuItem.PerformClick(); break;
-                case Command.DecreaseNumberOfVisibleLines: decreaseNumberOfLinesToolStripMenuItem.PerformClick(); break;
-                case Command.ShowEntireFile: showEntireFileToolStripMenuItem.PerformClick(); break;
-                case Command.TreatFileAsText: treatAllFilesAsTextToolStripMenuItem.PerformClick(); break;
-                case Command.NextChange: nextChangeButton.PerformClick(); break;
-                case Command.PreviousChange: previousChangeButton.PerformClick(); break;
+                case Command.GoToLine: return PerformClickIfAvailable(goToLineToolStripMenuItem);
+                case Command.IncreaseNumberOfVisibleLines: return PerformClickIfAvailable(increaseNumberOfLinesToolStripMenuItem);
+                case Command.DecreaseNumberOfVisibleLines: return PerformClickIfAvailable(decreaseNumberOfLinesToolStripMenuItem);
+                case Command.ShowEntireFile: return PerformClickIfAvailable(showEntireFileToolStripMenuItem);
+                case Command.TreatFileAsText: return PerformClickIfAvailable(treatAllFilesAsTextToolStripMenuItem);
+                case Command.NextChange: return PerformClickIfAvailable(nextChangeButton);
+                case Command.PreviousChange: return PerformClickIfAvailable(previousChangeButton);
                 case Command.NextOccurrence: internalFileViewer.GoToNextOccurrence(); break;
                 case Command.PreviousOccurrence: internalFileViewer.GoToPreviousOccurrence(); break;
                 case Command.StageLines: return StageSelectedLines();
                 case Command.UnstageLines: return UnstageSelectedLines();
                 case Command.ResetLines: return ResetSelectedLines();
-                case Command.IgnoreAllWhitespace: ignoreAllWhitespaceChangesToolStripMenuItem.PerformClick(); break;
+                case Command.IgnoreAllWhitespace: return PerformClickIfAvailable(ignoreAllWhitespaceChangesToolStripMenuItem);
                 default: return base.ExecuteCommand(cmd);
             }
 
             return true;
+
+            bool PerformClickIfAvailable(ToolStripItem item)
+            {
+                if (item.Enabled && item.Available)
+                {
+                    item.PerformClick();
+                    return true;
+                }
+
+                // Don't handle the hotkey to let the control handle it if an action is bound to it
+                return false;
+            }
         }
 
         private string GetShortcutKeyDisplayString(Command cmd)


### PR DESCRIPTION
by better handling of hotkeys in FileViewer
i.e. let a chance to the editor control to handle it if the feature with the associated hotkey is not available/enabled

+ add a Debug Launch profile to be able to test it

Integration of https://github.com/gitextensions/ICSharpCode.TextEditor/pull/33 in GitExtensions

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

None.

### After

![move_lines](https://github.com/gitextensions/ICSharpCode.TextEditor/assets/460196/74948f29-84ef-4119-a46a-05fef6b79813)


## Test methodology <!-- How did you ensure quality? -->

- Manual ( With the added Debug Launch profile)

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
