### PR TITLE
Source generate the boilerplate

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -1,7 +1,9 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
+#if NET6_0_OR_GREATER
 [assembly: System.Runtime.Versioning.SupportedOSPlatform("windows7.0")]
+#endif
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information

--- a/GitExtensions.Analyzers.CSharp/Generators/FormDefaultConstructorGenerator.cs
+++ b/GitExtensions.Analyzers.CSharp/Generators/FormDefaultConstructorGenerator.cs
@@ -1,0 +1,162 @@
+﻿using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace System.Windows.Forms.Generators;
+
+[Generator(LanguageNames.CSharp)]
+internal class FormDefaultConstructorGenerator : IIncrementalGenerator
+{
+    private static void Execute(SourceProductionContext context, Compilation compilation, ImmutableArray<string?> candidateTypes)
+    {
+        if (candidateTypes.IsEmpty)
+        {
+            return;
+        }
+
+        foreach (string? candidateType in candidateTypes)
+        {
+            if (string.IsNullOrEmpty(candidateType))
+            {
+                continue;
+            }
+
+            Debug.WriteLine($"candidateType: {candidateType}");
+
+            bool generateDefaultCtor = true;
+            bool containsInitializeComponent = false;
+            string? @namespace = null;
+            string typeName = candidateType!;
+
+            if (compilation.GetSymbolsWithName(candidateType!, SymbolFilter.Type).FirstOrDefault() is INamedTypeSymbol typeSymbol)
+            {
+                Debug.WriteLine($"symbol: {candidateType}");
+
+                if (typeSymbol.InstanceConstructors.Length > 0)
+                {
+                    foreach (IMethodSymbol ctor in typeSymbol.InstanceConstructors)
+                    {
+                        if (ctor.Parameters.Length == 0)
+                        {
+                            generateDefaultCtor = false;
+                            break;
+                        }
+                    }
+
+                    if (generateDefaultCtor)
+                    {
+                        generateDefaultCtor = InheritsFrom(typeSymbol);
+
+                        if (generateDefaultCtor)
+                        {
+                            @namespace = typeSymbol.ContainingNamespace.ToString();
+                            containsInitializeComponent = typeSymbol.MemberNames.Contains("InitializeComponent");
+
+                            if (typeSymbol.IsGenericType)
+                            {
+                                typeName = $"{candidateType}<{string.Join(", ", typeSymbol.TypeArguments)}>";
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (generateDefaultCtor)
+            {
+                string ctorBody = containsInitializeComponent ? "InitializeComponent();" : "";
+                Debug.WriteLine($"Generating .ctor for {candidateType}");
+                string? code = $@"
+namespace {@namespace}
+{{
+    partial class {typeName}
+    {{
+#pragma warning disable CS0618 // Type or member is obsolete
+        [System.Obsolete(""For VS designer and translation test only. Do not remove."")]
+        public {candidateType}()
+        {{
+            {ctorBody}
+        }}
+#pragma warning restore CS0618 // Type or member is obsolete
+    }}
+}}
+";
+                if (code is not null)
+                {
+                    context.AddSource($"{candidateType}_ctor.g.cs", code);
+                }
+            }
+        }
+
+        static bool InheritsFrom(INamedTypeSymbol symbol)
+        {
+            while (true)
+            {
+                if (symbol.ToString() == "System.Windows.Forms.Form")
+                {
+                    return true;
+                }
+
+                if (symbol.ToString() == "System.Windows.Forms.UserControl")
+                {
+                    return true;
+                }
+
+                if (symbol.BaseType is not null)
+                {
+                    symbol = symbol.BaseType;
+                    continue;
+                }
+
+                break;
+            }
+
+            return false;
+        }
+    }
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        IncrementalValuesProvider<string?> syntaxProvider = context.SyntaxProvider.CreateSyntaxProvider(
+            predicate: static (syntaxNode, _) => IsSupportedSyntaxNode(syntaxNode),
+            transform: static (generatorSyntaxContext, _) => GetTypeName(generatorSyntaxContext.Node));
+
+        IncrementalValueProvider<(Compilation, ImmutableArray<string?>)> compilationAndTypes
+            = context.CompilationProvider.Combine(syntaxProvider.Collect());
+
+        context.RegisterSourceOutput(
+            compilationAndTypes,
+            (context, source) => Execute(context, source.Item1, source.Item2));
+    }
+
+    private static string? GetTypeName(SyntaxNode node)
+    {
+        string? typeName = null;
+
+        if (node is ClassDeclarationSyntax classSyntax)
+        {
+            typeName = classSyntax.Identifier.ToString();
+        }
+
+        Debug.WriteLine($"typeName: {typeName}");
+        return typeName;
+    }
+
+    public static bool IsSupportedSyntaxNode(SyntaxNode syntaxNode)
+    {
+#pragma warning disable SA1513 // Closing brace should be followed by blank line
+        if (syntaxNode is ClassDeclarationSyntax
+            {
+                BaseList: BaseListSyntax
+                {
+                    Types.Count: > 0
+                }
+            })
+        {
+            return true;
+        }
+#pragma warning restore SA1513 // Closing brace should be followed by blank line
+
+        return false;
+    }
+}

--- a/GitExtensions.Analyzers.CSharp/GitExtensions.Analyzers.CSharp.csproj
+++ b/GitExtensions.Analyzers.CSharp/GitExtensions.Analyzers.CSharp.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>GitExtensions.Analyzers</RootNamespace>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>Preview</LangVersion>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);RS2007</NoWarn>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsRoslynComponent>true</IsRoslynComponent>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+  </ItemGroup>
+
+</Project>

--- a/GitExtensions.Analyzers.CSharp/Properties/launchSettings.json
+++ b/GitExtensions.Analyzers.CSharp/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "GitExtensions.Analyzers.CSharp": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "..\\GitUI\\GitUI.csproj"
+    }
+  }
+}

--- a/GitExtensions.sln
+++ b/GitExtensions.sln
@@ -212,7 +212,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BugReporter.IntegrationTest
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitExtensions.Plugins.GitlabIntegration", "Plugins\BuildServerIntegration\GitlabIntegration\GitExtensions.Plugins.GitlabIntegration.csproj", "{B12E0ABB-4E0D-47B4-BFF2-30EEDA4E279B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitlabIntegration.Tests", "UnitTests\Plugins\BuildServerIntegration\GitlabIntegration.Tests\GitlabIntegration.Tests.csproj", "{12A695E2-0AF3-43A1-B09B-CFA433AAC01C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitlabIntegration.Tests", "UnitTests\Plugins\BuildServerIntegration\GitlabIntegration.Tests\GitlabIntegration.Tests.csproj", "{12A695E2-0AF3-43A1-B09B-CFA433AAC01C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "analyzers", "analyzers", "{AA402478-7729-4C65-8A99-D07CFB118C0B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitExtensions.Analyzers.CSharp", "GitExtensions.Analyzers.CSharp\GitExtensions.Analyzers.CSharp.csproj", "{4CC94A8B-133E-4316-913C-05126D88D646}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -402,6 +406,10 @@ Global
 		{12A695E2-0AF3-43A1-B09B-CFA433AAC01C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{12A695E2-0AF3-43A1-B09B-CFA433AAC01C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{12A695E2-0AF3-43A1-B09B-CFA433AAC01C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4CC94A8B-133E-4316-913C-05126D88D646}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CC94A8B-133E-4316-913C-05126D88D646}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CC94A8B-133E-4316-913C-05126D88D646}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4CC94A8B-133E-4316-913C-05126D88D646}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -464,6 +472,7 @@ Global
 		{7695AF7E-99B3-4B3A-8588-AC9ABD378293} = {958D7C09-1FA5-4438-A6A0-B3E8BD96E291}
 		{B12E0ABB-4E0D-47B4-BFF2-30EEDA4E279B} = {F1B97F5D-CA42-4280-94A1-CE412BEA20DF}
 		{12A695E2-0AF3-43A1-B09B-CFA433AAC01C} = {BC90FFE0-7770-4979-884E-9F9F294C58C0}
+		{4CC94A8B-133E-4316-913C-05126D88D646} = {AA402478-7729-4C65-8A99-D07CFB118C0B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {ECECB7EA-BCCF-44AD-B63E-C2FA45589FB0}

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
@@ -15,14 +15,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private readonly IRevisionGridInfo _revisionGridInfo;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormBisect()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormBisect(RevisionGridControl revisionGrid)
             : base(revisionGrid.UICommands)
         {

--- a/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormGoToCommit.cs
@@ -17,12 +17,6 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         private readonly AsyncLoader _tagsLoader = new();
         private readonly AsyncLoader _branchesLoader = new();
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormGoToCommit()
-        {
-            InitializeComponent();
-        }
-
         public FormGoToCommit(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormAddFiles.cs
+++ b/GitUI/CommandsDialogs/FormAddFiles.cs
@@ -4,12 +4,6 @@ namespace GitUI.CommandsDialogs
 {
     public sealed partial class FormAddFiles : GitModuleForm
     {
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormAddFiles()
-        {
-            InitializeComponent();
-        }
-
         public FormAddFiles(GitUICommands commands, string? addFile = null)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -15,14 +15,6 @@ namespace GitUI.CommandsDialogs
         private readonly IFullPathResolver _fullPathResolver;
         private readonly bool _localExclude;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormAddToGitIgnore()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormAddToGitIgnore(GitUICommands commands, bool localExclude, params string[] filePatterns)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -45,12 +45,6 @@ namespace GitUI.CommandsDialogs
 
         private static readonly List<PatchFile> Skipped = new();
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormApplyPatch()
-        {
-            InitializeComponent();
-        }
-
         public FormApplyPatch(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormArchive.cs
+++ b/GitUI/CommandsDialogs/FormArchive.cs
@@ -82,12 +82,6 @@ namespace GitUI.CommandsDialogs
             Tar
         }
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormArchive()
-        {
-            InitializeComponent();
-        }
-
         public FormArchive(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormBlame.cs
+++ b/GitUI/CommandsDialogs/FormBlame.cs
@@ -6,14 +6,6 @@ namespace GitUI.CommandsDialogs
     {
         public string FileName { get; }
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormBlame()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         private FormBlame(GitUICommands commands)
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -231,15 +231,6 @@ namespace GitUI.CommandsDialogs
 
         public override RevisionGridControl RevisionGridControl { get => RevisionGrid; }
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormBrowse()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-            InitializeComplete();
-        }
-
         /// <summary>
         /// Open Browse - main GUI including dashboard.
         /// </summary>

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -44,14 +44,6 @@ namespace GitUI.CommandsDialogs
         private IReadOnlyList<IGitRef>? _localBranches;
         private IReadOnlyList<IGitRef>? _remoteBranches;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormCheckoutBranch()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormCheckoutBranch(GitUICommands commands, string branch, bool remote, IReadOnlyList<ObjectId>? containRevisions = null)
             : base(commands, true)
         {

--- a/GitUI/CommandsDialogs/FormCheckoutRevision.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutRevision.cs
@@ -12,12 +12,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _noRevisionSelectedMsgBox = new("Select 1 revision to checkout.");
         private readonly TranslationString _noRevisionSelectedMsgBoxCaption = new("Checkout");
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormCheckoutRevision()
-        {
-            InitializeComponent();
-        }
-
         public FormCheckoutRevision(GitUICommands commands)
             : base(commands, enablePositionRestore: false)
         {

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -18,12 +18,6 @@ namespace GitUI.CommandsDialogs
 
         public GitRevision? Revision { get; set; }
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormCherryPick()
-        {
-            InitializeComponent();
-        }
-
         public FormCherryPick(GitUICommands commands, GitRevision? revision)
             : base(commands, enablePositionRestore: false)
         {

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -13,12 +13,6 @@ namespace GitUI.CommandsDialogs
             new("Are you sure you want to cleanup the repository?");
         private readonly TranslationString _reallyCleanupQuestionCaption = new("Cleanup");
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormCleanupRepository()
-        {
-            InitializeComponent();
-        }
-
         public FormCleanupRepository(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -29,14 +29,6 @@ namespace GitUI.CommandsDialogs
         private readonly IReadOnlyList<string> _defaultBranchItems;
         private string? _puttySshKey;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormClone()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormClone(GitUICommands commands, string? url, bool openedFromProtocolHandler, EventHandler<GitModuleEventArgs>? gitModuleChanged)
             : base(commands, enablePositionRestore: false)
         {

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -206,14 +206,6 @@ namespace GitUI.CommandsDialogs
         /// The Amend checkbox is disabled after soft reset.
         private bool PushForced => (Amend.Checked || !Amend.Enabled) && AppSettings.CommitAndPushForcedWhenAmend;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormCommit()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormCommit(GitUICommands commands, CommitKind commitKind = CommitKind.Normal, GitRevision? editedCommit = null, string? commitMessage = null)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormCompareToBranch.cs
+++ b/GitUI/CommandsDialogs/FormCompareToBranch.cs
@@ -4,12 +4,6 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormCompareToBranch : GitModuleForm
     {
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormCompareToBranch()
-        {
-            InitializeComponent();
-        }
-
         public FormCompareToBranch(GitUICommands commands, ObjectId? selectedCommit)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -20,12 +20,6 @@ namespace GitUI.CommandsDialogs
         public bool UserAbleToChangeRevision { get; set; } = true;
         public bool CouldBeOrphan { get; set; } = true;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormCreateBranch()
-        {
-            InitializeComponent();
-        }
-
         public FormCreateBranch(GitUICommands commands, ObjectId? objectId, string? newBranchNamePrefix = null)
             : base(commands, enablePositionRestore: false)
         {

--- a/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -21,14 +21,6 @@ namespace GitUI.CommandsDialogs
         private readonly IGitTagController _gitTagController;
         private string _currentRemote = "";
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormCreateTag()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormCreateTag(GitUICommands commands, ObjectId? objectId)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -19,14 +19,6 @@ namespace GitUI.CommandsDialogs
         private string? _currentBranch;
         private HashSet<string>? _mergedBranches;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormDeleteBranch()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormDeleteBranch(GitUICommands commands, IEnumerable<string> defaultBranches)
             : base(commands, enablePositionRestore: false)
         {

--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.cs
@@ -19,14 +19,6 @@ namespace GitUI.CommandsDialogs
         private readonly TaskManager _taskManager = ThreadHelper.CreateTaskManager();
         private HashSet<string> _mergedBranches;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormDeleteRemoteBranch()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormDeleteRemoteBranch(GitUICommands commands, string defaultRemoteBranch)
             : base(commands, enablePositionRestore: false)
         {

--- a/GitUI/CommandsDialogs/FormDeleteTag.cs
+++ b/GitUI/CommandsDialogs/FormDeleteTag.cs
@@ -8,12 +8,6 @@ namespace GitUI.CommandsDialogs
 {
     public partial class FormDeleteTag : GitModuleForm
     {
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormDeleteTag()
-        {
-            InitializeComponent();
-        }
-
         public FormDeleteTag(GitUICommands commands, string? tag)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormDiff.cs
+++ b/GitUI/CommandsDialogs/FormDiff.cs
@@ -33,14 +33,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _btnSwapTooltip = new("Swap BASE and Compare commits");
         private readonly TranslationString _ckCompareToMergeBase = new("Compare to merge &base");
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormDiff()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormDiff(
             GitUICommands commands,
             ObjectId firstId,

--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -16,12 +16,6 @@ namespace GitUI.CommandsDialogs
 
         private bool _hasChanges;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormEditor()
-        {
-            InitializeComponent();
-        }
-
         public FormEditor(GitUICommands commands, string? fileName, bool showWarning, bool readOnly = false, int? lineNumber = null)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -29,14 +29,6 @@ namespace GitUI.CommandsDialogs
 
         private string FileName { get; set; }
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormFileHistory()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         /// <summary>
         /// Open FileHistory form.
         /// </summary>

--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -34,12 +34,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _failCreatePatch =
             new("Unable to create patch file(s)");
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormFormatPatch()
-        {
-            InitializeComponent();
-        }
-
         public FormFormatPatch(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormGitAttributes.cs
+++ b/GitUI/CommandsDialogs/FormGitAttributes.cs
@@ -24,14 +24,6 @@ namespace GitUI.CommandsDialogs
         public string GitAttributesFile = string.Empty;
         private readonly IFullPathResolver _fullPathResolver;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormGitAttributes()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormGitAttributes(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -59,14 +59,6 @@ namespace GitUI.CommandsDialogs
 
         private readonly IGitIgnoreDialogModel _dialogModel;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormGitIgnore()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormGitIgnore(GitUICommands commands, bool localExclude)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormLog.cs
+++ b/GitUI/CommandsDialogs/FormLog.cs
@@ -4,12 +4,6 @@
     {
         private readonly CancellationTokenSequence _viewChangesSequence = new();
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormLog()
-        {
-            InitializeComponent();
-        }
-
         public FormLog(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormMailMap.cs
+++ b/GitUI/CommandsDialogs/FormMailMap.cs
@@ -24,14 +24,6 @@ namespace GitUI.CommandsDialogs
         public string MailMapFile = string.Empty;
         private readonly IFullPathResolver _fullPathResolver;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormMailMap()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormMailMap(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -17,14 +17,6 @@ namespace GitUI.CommandsDialogs
         private readonly string? _defaultBranch;
         private ICommitMessageManager _commitMessageManager;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormMergeBranch()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         /// <summary>Initializes <see cref="FormMergeBranch"/>.</summary>
         /// <param name="defaultBranch">Branch to merge into the current branch.</param>
         public FormMergeBranch(GitUICommands commands, string? defaultBranch)

--- a/GitUI/CommandsDialogs/FormMergeSubmodule.cs
+++ b/GitUI/CommandsDialogs/FormMergeSubmodule.cs
@@ -13,14 +13,6 @@ namespace GitUI.CommandsDialogs
 
         private readonly string _filename;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormMergeSubmodule()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormMergeSubmodule(GitUICommands commands, string filename)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -125,14 +125,6 @@ namespace GitUI.CommandsDialogs
 
         public bool ErrorOccurred { get; private set; }
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormPull()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormPull(GitUICommands commands, string? defaultRemoteBranch, string? defaultRemote, AppSettings.PullAction pullAction)
             : base(commands, enablePositionRestore: false)
         {

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -88,14 +88,6 @@ namespace GitUI.CommandsDialogs
 
         #endregion
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormPush()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormPush(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -52,12 +52,6 @@ namespace GitUI.CommandsDialogs
         private readonly string? _defaultToBranch;
         private readonly bool _startRebaseImmediately;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormRebase()
-        {
-            InitializeComponent();
-        }
-
         public FormRebase(GitUICommands commands, string? defaultBranch)
             : base(commands, enablePositionRestore: false)
         {

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -32,12 +32,6 @@ namespace GitUI.CommandsDialogs
         private bool _isDirtyDir;
         private int _lastHitRowIndex;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormReflog()
-        {
-            InitializeComponent();
-        }
-
         public FormReflog(GitUICommands uiCommands)
             : base(uiCommands)
         {

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -94,14 +94,6 @@ Inactive remote is completely invisible to git.");
             new("An inactive remote named \"{0}\" already exists.");
         #endregion
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormRemotes()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormRemotes(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormRenameBranch.cs
+++ b/GitUI/CommandsDialogs/FormRenameBranch.cs
@@ -12,14 +12,6 @@ namespace GitUI.CommandsDialogs
         private readonly GitBranchNameOptions _gitBranchNameOptions = new(AppSettings.AutoNormaliseSymbol);
         private readonly string _oldName;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormRenameBranch()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormRenameBranch(GitUICommands commands, string defaultBranch)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -120,14 +120,6 @@ namespace GitUI.CommandsDialogs
         private int _conflictItemsCount;
         private readonly CancellationTokenSequence _customDiffToolsSequence = new();
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormResolveConflicts()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormResolveConflicts(GitUICommands commands, bool offerCommit = true)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormRevertCommit.cs
+++ b/GitUI/CommandsDialogs/FormRevertCommit.cs
@@ -14,14 +14,6 @@ namespace GitUI.CommandsDialogs
 
         private bool _isMerge;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormRevertCommit()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormRevertCommit(GitUICommands commands, GitRevision revision)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -26,14 +26,6 @@ namespace GitUI.CommandsDialogs
         private SettingsPageReference? _initialPage;
         private bool _saved = false;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormSettings()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormSettings(GitUICommands commands, SettingsPageReference? initialPage = null)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
@@ -6,14 +6,9 @@ using ResourceManager;
 
 namespace GitUI.CommandsDialogs
 {
-    public sealed class FormSparseWorkingCopy : GitModuleForm
+    public sealed partial class FormSparseWorkingCopy : GitModuleForm
     {
         private IDisposable? _disposable1;
-
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormSparseWorkingCopy()
-        {
-        }
 
         public FormSparseWorkingCopy(GitUICommands commands)
             : base(commands)

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -20,13 +20,6 @@ namespace GitUI.CommandsDialogs
         public bool ManageStashes { get; set; }
         private GitStash? _currentWorkingDirStashItem;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormStash()
-        {
-            InitializeComponent();
-            CompleteTheInitialization();
-        }
-
         public FormStash(GitUICommands commands, string? initialStash = null)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormSubmodules.cs
+++ b/GitUI/CommandsDialogs/FormSubmodules.cs
@@ -20,12 +20,6 @@ namespace GitUI.CommandsDialogs
         private readonly BindingList<IGitSubmoduleInfo?> _modules = new();
         private GitSubmoduleInfo? _oldSubmoduleInfo;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormSubmodules()
-        {
-            InitializeComponent();
-        }
-
         public FormSubmodules(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -37,14 +37,6 @@ namespace GitUI.CommandsDialogs
             { "using", "recovery.cs" },
         };
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormVerify()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormVerify(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -21,12 +21,6 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _patchFileFilterString = new("Patch file (*.Patch)");
         private readonly TranslationString _patchFileFilterTitle = new("Select patch file");
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormViewPatch()
-        {
-            InitializeComponent();
-        }
-
         public FormViewPatch(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -26,14 +26,6 @@ namespace GitUI.CommandsDialogs.RepoHosting
         private readonly AsyncLoader _remoteLoader = new();
         private bool _ignoreFirstRemoteLoading = true;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private CreatePullRequestForm()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public CreatePullRequestForm(GitUICommands commands, IRepositoryHostPlugin repoHost, string? chooseRemote, string? chooseBranch)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -33,14 +33,6 @@ namespace GitUI.CommandsDialogs.RepoHosting
         private IReadOnlyList<IPullRequestInformation>? _pullRequestsInfo;
         private readonly AsyncLoader _loader = new();
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private ViewPullRequestsForm()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public ViewPullRequestsForm(GitUICommands commands, IRepositoryHostPlugin gitHoster)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/SettingsDialog/ConfigFileSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/ConfigFileSettingsPage.cs
@@ -4,7 +4,7 @@ using Microsoft;
 
 namespace GitUI.CommandsDialogs.SettingsDialog
 {
-    public class ConfigFileSettingsPage : SettingsPageWithHeader, ILocalSettingsPage
+    public partial class ConfigFileSettingsPage : SettingsPageWithHeader, ILocalSettingsPage
     {
         protected ConfigFileSettingsSet ConfigFileSettingsSet => CommonLogic.ConfigFileSettingsSet;
         protected ConfigFileSettings? CurrentSettings { get; private set; }

--- a/GitUI/CommandsDialogs/SettingsDialog/DistributedSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/DistributedSettingsPage.cs
@@ -4,7 +4,7 @@ using Microsoft;
 
 namespace GitUI.CommandsDialogs.SettingsDialog
 {
-    public class DistributedSettingsPage : SettingsPageWithHeader, IDistributedSettingsPage
+    public partial class DistributedSettingsPage : SettingsPageWithHeader, IDistributedSettingsPage
     {
         protected DistributedSettingsSet DistributedSettingsSet => CommonLogic.DistributedSettingsSet;
         protected DistributedSettings? CurrentSettings { get; private set; }

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsPageWithHeader.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsPageWithHeader.cs
@@ -3,7 +3,7 @@ using GitUIPluginInterfaces;
 
 namespace GitUI.CommandsDialogs.SettingsDialog
 {
-    public class SettingsPageWithHeader : SettingsPageBase, IGlobalSettingsPage
+    public partial class SettingsPageWithHeader : SettingsPageBase, IGlobalSettingsPage
     {
         private SettingsPageHeader? _header;
 

--- a/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
+++ b/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
@@ -14,12 +14,6 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
         private readonly TranslationString _remoteAndLocalPathRequired
             = new("A remote path and local path are required");
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormAddSubmodule()
-        {
-            InitializeComponent();
-        }
-
         public FormAddSubmodule(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -16,12 +16,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         public IReadOnlyList<IGitRef>? ExistingBranches { get; set; }
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormCreateWorktree()
-        {
-            InitializeComponent();
-        }
-
         public FormCreateWorktree(GitUICommands commands, string? path)
             : base(commands)
         {

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -18,12 +18,6 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         public bool ShouldRefreshRevisionGrid { get; private set; }
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormManageWorktree()
-        {
-            InitializeComponent();
-        }
-
         public FormManageWorktree(GitUICommands commands)
             : base(commands, enablePositionRestore: false)
         {

--- a/GitUI/GitExtensionsDialog.cs
+++ b/GitUI/GitExtensionsDialog.cs
@@ -12,14 +12,6 @@ namespace GitUI
     {
         private static readonly Pen FooterDividerPen = new(KnownColor.ControlLight.MakeBackgroundDarkerBy(0.04));
 
-        /// <summary>Creates a new <see cref="GitExtensionsForm"/> without position restore.</summary>
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        protected GitExtensionsDialog()
-            : base()
-        {
-            InitializeComponent();
-        }
-
         /// <summary>Creates a new <see cref="GitExtensionsForm"/> indicating position restore.</summary>
         /// <param name="enablePositionRestore">Indicates whether the <see cref="Form"/>'s position
         /// will be restored upon being re-opened.</param>

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -1,10 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- To be removed when NRT annotations are complete -->
     <Nullable>annotations</Nullable>
+
+    <!--
+    For debug purposes uncomment these lines:
+    
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>
+    -->
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,6 +39,10 @@
     <ProjectReference Include="..\Externals\NetSpell.SpellChecker\SpellChecker.csproj" />
     <ProjectReference Include="..\ResourceManager\ResourceManager.csproj" />
     <ProjectReference Include="..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\GitExtensions.Analyzers.CSharp\GitExtensions.Analyzers.CSharp.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer"  />
   </ItemGroup>
 
   <ItemGroup>

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -5,12 +5,6 @@ namespace GitUI.HelperDialogs
 {
     public partial class FormChooseCommit : GitModuleForm
     {
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormChooseCommit()
-        {
-            InitializeComponent();
-        }
-
         private FormChooseCommit(GitUICommands commands)
             : base(commands)
         {

--- a/GitUI/HelperDialogs/FormCommitDiff.cs
+++ b/GitUI/HelperDialogs/FormCommitDiff.cs
@@ -4,12 +4,6 @@ namespace GitUI.HelperDialogs
 {
     public sealed partial class FormCommitDiff : GitModuleForm
     {
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormCommitDiff()
-        {
-            InitializeComponent();
-        }
-
         public FormCommitDiff(GitUICommands commands, ObjectId? objectId)
             : base(commands)
         {

--- a/GitUI/HelperDialogs/FormEdit.cs
+++ b/GitUI/HelperDialogs/FormEdit.cs
@@ -2,12 +2,6 @@
 {
     public partial class FormEdit : GitModuleForm
     {
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private FormEdit()
-        {
-            InitializeComponent();
-        }
-
         public FormEdit(GitUICommands commands, string text)
             : base(commands)
         {

--- a/GitUI/HelperDialogs/FormProcess.cs
+++ b/GitUI/HelperDialogs/FormProcess.cs
@@ -10,7 +10,7 @@ namespace GitUI.HelperDialogs
     /// <returns>if handled.</returns>
     public delegate bool HandleOnExit(ref bool isError, FormProcess form);
 
-    public class FormProcess : FormStatus
+    public partial class FormProcess : FormStatus
     {
         public string Remote { get; set; }
         public string ProcessString { get; }
@@ -19,14 +19,6 @@ namespace GitUI.HelperDialogs
         public readonly string WorkingDirectory;
         public HandleOnExit? HandleOnExitCallback { get; set; }
         public readonly Dictionary<string, string> ProcessEnvVariables = new();
-
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private protected FormProcess()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-            : base()
-        {
-        }
 
         private FormProcess(GitUICommands? commands, ConsoleOutputControl? outputControl, ArgumentString arguments, string workingDirectory, string? input, bool useDialogSettings, string? process)
             : base(commands, outputControl, useDialogSettings)

--- a/GitUI/HelperDialogs/FormRemoteProcess.cs
+++ b/GitUI/HelperDialogs/FormRemoteProcess.cs
@@ -28,15 +28,6 @@ Do you want to register the host's fingerprint and restart the process?");
         private bool _restart;
         private string _urlTryingToConnect = string.Empty;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormRemoteProcess()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-            : base()
-        {
-            InitializeComponent();
-        }
-
         public FormRemoteProcess(GitUICommands commands, ArgumentString arguments)
             : base(commands, arguments, commands.Module.WorkingDir, input: null, useDialogSettings: true)
         {

--- a/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -16,14 +16,6 @@ namespace GitUI.HelperDialogs
         public static FormResetAnotherBranch Create(GitUICommands commands, GitRevision revision)
             => new(commands, revision ?? throw new NotSupportedException(TranslatedStrings.NoRevision));
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormResetAnotherBranch()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         private FormResetAnotherBranch(GitUICommands commands, GitRevision revision)
             : base(commands)
         {

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -24,14 +24,6 @@ namespace GitUI.HelperDialogs
         public static FormResetCurrentBranch Create(GitUICommands commands, GitRevision revision, ResetType resetType = ResetType.Soft)
             => new(commands, revision ?? throw new NotSupportedException(TranslatedStrings.NoRevision), resetType);
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormResetCurrentBranch()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         private FormResetCurrentBranch(GitUICommands commands, GitRevision revision, ResetType resetType)
             : base(commands)
         {

--- a/GitUI/HelperDialogs/FormStatus.cs
+++ b/GitUI/HelperDialogs/FormStatus.cs
@@ -13,12 +13,6 @@ namespace GitUI.HelperDialogs
         private protected Action<FormStatus>? ProcessCallback;
         private protected Action<FormStatus>? AbortCallback;
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-        private protected FormStatus()
-            : this(commands: null, consoleOutput: null, useDialogSettings: true)
-        {
-        }
-
         public FormStatus(GitUICommands? commands, ConsoleOutputControl? consoleOutput, bool useDialogSettings)
             : base(commands, enablePositionRestore: true)
         {

--- a/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
+++ b/GitUI/UserControls/RevisionGrid/FormRevisionFilter.cs
@@ -17,14 +17,6 @@ namespace GitUI.UserControls.RevisionGrid
         private readonly TranslationString _pathFilter = new("&Path filter");
         private readonly TranslationString _branches = new("&Branches");
 
-        [Obsolete("For VS designer and translation test only. Do not remove.")]
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        private FormRevisionFilter()
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        {
-            InitializeComponent();
-        }
-
         public FormRevisionFilter(GitUICommands commands, FilterInfo filterInfo)
             : base(commands, enablePositionRestore: false)
         {

--- a/Packages.props
+++ b/Packages.props
@@ -31,6 +31,10 @@
     <PackageReference Update="System.Reactive.Interfaces" Version="5.0.0" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" /> <!-- Required by GitExtensions.Plugins.AutoCompileSubmodules -->
 
+    <!-- Analyzers -->
+    <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0-beta1.23364.2" PrivateAssets="all" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
+
     <!-- Setup infra -->
     <PackageReference Update="NETStandard.Library" Version="2.0.0" />
     <PackageReference Update="vswhere" Version="2.8.4" />


### PR DESCRIPTION
Windows Forms designer requires a default constructor to be able to open a form on the design surface.

This, however, does not work in situations where some parameters must be set in the constructor (e.g., dependency injection).

Previously, we would create a default constructor specifically for the Windows Forms designer integration. However, this implies a lot of unnecessary overhead.

Emit the default constructors for the designer integration with source generators.

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
