### PR TITLE
Scripts: add new option {cHead}

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2990,7 +2990,7 @@ namespace GitCommands
         }
 
         /// <summary>Dirty but fast. This sometimes fails.</summary>
-        public static string GetSelectedBranchFast(string? repositoryPath, bool setDefaultIfEmpty = true)
+        public static string GetSelectedBranchFast(string? repositoryPath, bool emptyIfDetached = false)
         {
             if (string.IsNullOrEmpty(repositoryPath))
             {
@@ -3021,7 +3021,7 @@ namespace GitCommands
 
             if (!headFileContents.StartsWith("ref: "))
             {
-                return setDefaultIfEmpty ? DetachedHeadParser.DetachedBranch : string.Empty;
+                return emptyIfDetached ? string.Empty : DetachedHeadParser.DetachedBranch;
             }
 
             const string prefix = "ref: refs/heads/";
@@ -3034,14 +3034,9 @@ namespace GitCommands
             return headFileContents[prefix.Length..].TrimEnd();
         }
 
-        /// <summary>
-        /// Gets the current branch.
-        /// </summary>
-        /// <param name="setDefaultIfEmpty">Return "(no branch)" if detached.</param>
-        /// <returns>Current branch name.</returns>
-        public string GetSelectedBranch(bool setDefaultIfEmpty)
+        public string GetSelectedBranch(bool emptyIfDetached = false)
         {
-            string head = GetSelectedBranchFast(WorkingDir, setDefaultIfEmpty);
+            string head = GetSelectedBranchFast(WorkingDir, emptyIfDetached);
 
             if (!string.IsNullOrEmpty(head))
             {
@@ -3057,12 +3052,7 @@ namespace GitCommands
 
             return result.ExitedSuccessfully
                 ? result.StandardOutput
-                : setDefaultIfEmpty ? DetachedHeadParser.DetachedBranch : string.Empty;
-        }
-
-        public string GetSelectedBranch()
-        {
-            return GetSelectedBranch(true);
+                : emptyIfDetached ? string.Empty : DetachedHeadParser.DetachedBranch;
         }
 
         public bool IsDetachedHead()

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -17,20 +17,20 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private readonly TranslationString _scriptSettingsPageHelpDisplayContent = new(@"Use {option} for normal replacement.
 Use {{option}} for quoted replacement.
 
-User Input:
+User inputs:
 {UserInput}
 {UserFiles}
 
-Working Dir:
+Working directory:
 {WorkingDir}
 
 Repository:
 {RepoName}
 
-Selected Commits:
+Selected commits:
 {sHashes}
 
-Selected Branch:
+Selected revision:
 {sTag}
 {sBranch}
 {sLocalBranch}
@@ -47,7 +47,8 @@ Selected Branch:
 {sAuthorDate}
 {sCommitDate}
 
-Current Branch:
+Currently checked out revision:
+{HEAD}   (checked out branch name or checked out commit hash)
 {cTag}
 {cBranch}
 {cLocalBranch}

--- a/GitUI/Script/ScriptOptionsParser.cs
+++ b/GitUI/Script/ScriptOptionsParser.cs
@@ -13,6 +13,8 @@ namespace GitUI.Script
         /// </summary>
         private const string currentMessage = "cMessage";
 
+        private const string head = "HEAD";
+
         /// <summary>
         /// Gets the list of available script options.
         /// </summary>
@@ -34,6 +36,7 @@ namespace GitUI.Script
             "sCommitter",
             "sAuthorDate",
             "sCommitDate",
+            head,
             "cTag",
             "cBranch",
             "cLocalBranch",
@@ -113,7 +116,7 @@ namespace GitUI.Script
                     continue;
                 }
 
-                if (currentRevision is null && option.StartsWith("c"))
+                if (currentRevision is null && (option.StartsWith("c") || option == head))
                 {
                     currentRevision = GetCurrentRevision(uiCommands.GitModule, currentTags, currentLocalBranches, currentRemoteBranches, currentBranches,
                         loadBody: Contains(arguments, currentMessage));
@@ -368,6 +371,15 @@ namespace GitUI.Script
 
                 case "cTag":
                     newString = SelectOneRef(currentTags);
+                    break;
+
+                case head:
+                    newString = uiCommands.GitModule.GetSelectedBranch(emptyIfDetached: true);
+                    if (string.IsNullOrEmpty(newString))
+                    {
+                        newString = currentRevision.Guid;
+                    }
+
                     break;
 
                 case "cBranch":

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9573,20 +9573,20 @@ See the changes in the commit form.</source>
         <source>Use {option} for normal replacement.
 Use {{option}} for quoted replacement.
 
-User Input:
+User inputs:
 {UserInput}
 {UserFiles}
 
-Working Dir:
+Working directory:
 {WorkingDir}
 
 Repository:
 {RepoName}
 
-Selected Commits:
+Selected commits:
 {sHashes}
 
-Selected Branch:
+Selected revision:
 {sTag}
 {sBranch}
 {sLocalBranch}
@@ -9603,7 +9603,8 @@ Selected Branch:
 {sAuthorDate}
 {sCommitDate}
 
-Current Branch:
+Currently checked out revision:
+{HEAD}   (checked out branch name or checked out commit hash)
 {cTag}
 {cBranch}
 {cLocalBranch}

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -881,7 +881,7 @@ namespace GitUI
 
             // Reset the "cache" for current branch
             CurrentBranch = new(() => Module.IsValidGitWorkingDir()
-                      ? Module.GetSelectedBranch(setDefaultIfEmpty: false)
+                      ? Module.GetSelectedBranch(emptyIfDetached: true)
                       : "");
 
             // Revision info is read in three parallel steps:

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -128,8 +128,14 @@ namespace GitUIPluginInterfaces
         string GetEffectiveSetting(string setting);
         string GetEffectiveGitSetting(string setting, bool cache = true);
 
-        /// <summary>Gets the current branch; or "(no branch)" if HEAD is detached.</summary>
-        string GetSelectedBranch();
+        /// <summary>
+        /// Gets the name of the currently checked out branch.
+        /// </summary>
+        /// <param name="emptyIfDetached">Defines the value returned if HEAD is detached. <see langword="true"/> to return <see cref="string.Empty"/>; <see langword="false"/> to return "(no branch)".</param>
+        /// <returns>
+        /// The name of the branch (for example: "main"); the value requested by <paramref name="emptyIfDetached"/>, if HEAD is detached.
+        /// </returns>
+        string GetSelectedBranch(bool emptyIfDetached = false);
 
         /// <summary>true if ".git" directory does NOT exist.</summary>
         bool IsBareRepository();

--- a/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
+++ b/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
@@ -355,6 +355,40 @@ namespace GitUITests.Script
         }
 
         [Test]
+        public void ParseScriptArguments_resolve_HEAD_with_checkedout_branch_name()
+        {
+            string option = "HEAD";
+            string branchName = "this_is_my_branch_name";
+            _module.GetSelectedBranch(emptyIfDetached: true).Returns(branchName);
+
+            string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
+                arguments: "{" + option + "}", option,
+                owner: null, scriptHostControl: null, uiCommands: _commands, allSelectedRevisions: null, selectedTags: null,
+                selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
+                currentTags: null,
+                currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
+
+            result.Should().Be(branchName);
+        }
+
+        [Test]
+        public void ParseScriptArguments_resolve_HEAD_with_detached_head_hash()
+        {
+            string option = "HEAD";
+            string detachedHeadHash = "d54e5cf78a403d5ace3299549be0f6cabee50a63";
+            _module.GetSelectedBranch(emptyIfDetached: true).Returns(string.Empty);
+
+            string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
+                arguments: "{" + option + "}", option,
+                owner: null, scriptHostControl: null, uiCommands: _commands, allSelectedRevisions: null, selectedTags: null,
+                selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
+                currentTags: null, currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null,
+                currentRevision: new GitRevision(ObjectId.Parse(detachedHeadHash)), currentRemote: null);
+
+            result.Should().Be(detachedHeadHash);
+        }
+
+        [Test]
         public void ParseScriptArguments_resolve_QuotedWithBackslashAtEnd()
         {
             _module.WorkingDir.Returns("C:\\test path with whitespaces\\");


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes [this comment](https://github.com/gitextensions/gitextensions/issues/1826#issuecomment-1759308175)

## Proposed changes

- introduce a new option `{HEAD}` that contains the name of the currently checkout branch (and as a consequence avoid user branch selector when using {cLocalBranch}) or the hash of the commit if in detached head
- update the help text so that the user understand that the options are acting on a revision and so has a little more clue that {cLocalBranch} will not return the current checkout branch but let the user select a branch among all defined on the revision. Same for tags, remote, branch...

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/fd449827-9bd9-4d6d-826c-26b61cfcf54d)

### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/cafd75fb-db84-4495-bc7e-8ce92d91294e)

## Test methodology <!-- How did you ensure quality? -->

- Unit tests
- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build af8e9e153708dc4f087d65f1c5726ae4a4a6cd5f (Dirty)
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.21
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.21 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.10 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
