### PR TITLE
Limit HEAD parents when inserting artificial in grid

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -312,7 +312,7 @@ namespace GitUI.UserControls.RevisionGrid
         /// <param name="insertWithMatch">Insert the (artificial) revision with the first match in headParents or first if no match found (or headParents is null).</param>
         /// <param name="insertRange">Number of scores "reserved" in the list when inserting.</param>
         /// <param name="parents">Parent ids for the revision to find (and insert before).</param>
-        public void Add(GitRevision revision, bool insertWithMatch = false, int insertRange = 0, IEnumerable<ObjectId>? parents = null)
+        public void Add(GitRevision revision, bool insertWithMatch = false, int insertRange = 0, IReadOnlyList<ObjectId>? parents = null)
         {
             // Where to insert the revision, null is last
             int? insertScore = null;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1382,7 +1382,7 @@ namespace GitUI
                         // (can occur when filtering or limiting number of loaded commits)
                         // Try to find the revision where to attach the artificial, first is not found
                         // null means that no matching should be done (just add), so use an empty list if no parents were found
-                        refresh = AddArtificialRevisions(headParents ?? new List<ObjectId>());
+                        refresh = AddArtificialRevisions(headParents ?? Array.Empty<ObjectId>());
                     }
 
                     // All revisions are loaded (but maybe not yet the grid)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1274,7 +1274,8 @@ namespace GitUI
                     && !Module.IsBareRepository();
             }
 
-            bool AddArtificialRevisions(IEnumerable<ObjectId> headParents = null)
+            // Add artificial revisions to the graph.
+            bool AddArtificialRevisions(IReadOnlyList<ObjectId>? headParents = null)
             {
                 if (!ShowArtificialRevisions())
                 {
@@ -1367,19 +1368,19 @@ namespace GitUI
                         await semaphoreUpdateGrid.WaitAsync(cancellationToken);
                     }
 
-                    IEnumerable<ObjectId> headParents = null;
+                    IReadOnlyList<ObjectId>? headParents = null;
                     bool refresh = false;
                     if (!headIsHandled && ShowArtificialRevisions())
                     {
                         if (CurrentCheckout is not null)
                         {
                             // Not found, so search for its parents
-                            headParents = TryGetParents(Module, _filterInfo, CurrentCheckout);
+                            headParents = TryGetParents(Module, _filterInfo, CurrentCheckout).ToList();
                         }
 
                         // If parents are rewritten HEAD may not be included
                         // Insert the artificial commits where relevant if possible, otherwise first
-                        refresh = AddArtificialRevisions(headParents);
+                        refresh = AddArtificialRevisions(headParents ?? Enumerable.Empty<ObjectId>().ToList());
                     }
 
                     // All revisions are loaded (but maybe not yet the grid)
@@ -1389,7 +1390,7 @@ namespace GitUI
                         _gridView.ToBeSelectedObjectIds.Count > 0)
                     {
                         ObjectId notSelectedId = _gridView.ToBeSelectedObjectIds[0];
-                        IEnumerable<ObjectId> parents = null;
+                        IReadOnlyList<ObjectId> parents = null;
 
                         // Try to reuse headParents for parents to the commit to be selected
                         if (headParents is not null && notSelectedId == CurrentCheckout)
@@ -1403,7 +1404,7 @@ namespace GitUI
                         else if (!notSelectedId.IsArtificial)
                         {
                             // Ignore if the not selected is artificial, it is likely that the settings was changed
-                            parents = TryGetParents(Module, _filterInfo, notSelectedId);
+                            parents = TryGetParents(Module, _filterInfo, notSelectedId).ToList();
                         }
 
                         // Try to select the first of the parents
@@ -1504,14 +1505,16 @@ namespace GitUI
 
             static IEnumerable<ObjectId> TryGetParents(GitModule module, FilterInfo filterInfo, ObjectId objectId)
             {
+                // Limit the search to decrease command time (this may add seconds in big repos)
+                // It is only the first that are considered interesting to select.
                 GitArgumentBuilder args = new("rev-list")
                 {
-                    { filterInfo.HasCommitsLimit, $"--max-count={filterInfo.CommitsLimit}" },
+                    $"--max-count=50",
                     objectId
                 };
 
                 ExecutionResult result = module.GitExecutable.Execute(args, throwOnErrorExit: false);
-                foreach (var line in result.StandardOutput.LazySplit('\n'))
+                foreach (string line in result.StandardOutput.LazySplit('\n'))
                 {
                     if (ObjectId.TryParse(line, out var parentId))
                     {

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1378,8 +1378,10 @@ namespace GitUI
                             headParents = TryGetParents(Module, _filterInfo, CurrentCheckout).ToList();
                         }
 
-                        // If parents are rewritten HEAD may not be included
-                        // Insert the artificial commits where relevant if possible, otherwise first
+                        // HEAD where to insert the artificial was not found
+                        // (can occur when filtering or limiting number of loaded commits)
+                        // Try to find the revision where to attach the artificial, first is not found
+                        // null means that no matching should be done (just add), so use an empty list if no parents were found
                         refresh = AddArtificialRevisions(headParents ?? new List<ObjectId>());
                     }
 
@@ -1390,7 +1392,7 @@ namespace GitUI
                         _gridView.ToBeSelectedObjectIds.Count > 0)
                     {
                         ObjectId notSelectedId = _gridView.ToBeSelectedObjectIds[0];
-                        IReadOnlyList<ObjectId> parents = null;
+                        IReadOnlyList<ObjectId>? parents = null;
 
                         // Try to reuse headParents for parents to the commit to be selected
                         if (headParents is not null && notSelectedId == CurrentCheckout)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1380,7 +1380,7 @@ namespace GitUI
 
                         // If parents are rewritten HEAD may not be included
                         // Insert the artificial commits where relevant if possible, otherwise first
-                        refresh = AddArtificialRevisions(headParents ?? Enumerable.Empty<ObjectId>().ToList());
+                        refresh = AddArtificialRevisions(headParents ?? new List<ObjectId>());
                     }
 
                     // All revisions are loaded (but maybe not yet the grid)


### PR DESCRIPTION
## Proposed changes

HEAD may not be included in git-log in some scenarios. One example is an old checkout in the Linux repo where 100K commits is about a year. Another is when filtering.

In this scenario there is no HEAD the artificial commits cannot be inserted while loading.
The HEAD parents are then listed to find the first descendant in the grid, or first in the grid if no head parent is found.

Similar scenario for the revision to be reselected. When switching repo the HEAD is always selected.

Previously, a match was tried in all HEAD parents. This command requires 1.5 s in the linux repo,
delaying the the time until the spinner is dismissed. The number of parents to try is limited to around 50 ms instead.

In addition, the command ran a second time as the
result was not enumerated when trying to find the revision to select.

--

This is not a normal user problem, this is a "cloning Linux a year ago and not checking out new branches" problem.
Still annoying when investigating other improvements.

Note that Artificial are not inserted correctly after this, likely due to a timing problem.
Fixed in later PR.

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
