### PR TITLE
RevisionGraph: improve internal structures

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/ColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/ColumnProvider.cs
@@ -27,10 +27,6 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         {
         }
 
-        public virtual void LoadingCompleted()
-        {
-        }
-
         /// <summary>Renders the content of a cell in this column.</summary>
         public abstract void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style);
 

--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -197,11 +197,6 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             _graphCache.Reset();
         }
 
-        public override void LoadingCompleted()
-        {
-            _revisionGraph.LoadingCompleted();
-        }
-
         public override void Refresh(int rowHeight, in VisibleRowRange range)
         {
             // Hide graph column when there it is disabled

--- a/GitUI/UserControls/RevisionGrid/Graph/LaneInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneInfo.cs
@@ -2,22 +2,25 @@
 {
     public class LaneInfo
     {
-        public LaneInfo(RevisionGraphSegment startSegment, LaneInfo? derivedFrom)
+        public LaneInfo(RevisionGraphSegment startSegment)
         {
-            StartRevision = derivedFrom is null ? startSegment.Child : startSegment.Parent;
+            StartRevision = startSegment.Child;
 
+            int colorSeed = StartRevision.Objectid.GetHashCode() ^ startSegment.Parent.Objectid.GetHashCode();
+            Color = RevisionGraphLaneColor.GetColorForLane(colorSeed);
+        }
+
+        public LaneInfo(RevisionGraphSegment startSegment, LaneInfo derivedFrom)
+        {
+            StartRevision = startSegment.Parent;
             int colorSeed = StartRevision.Objectid.GetHashCode();
-            if (derivedFrom is null)
-            {
-                colorSeed ^= startSegment.Parent.Objectid.GetHashCode();
-            }
 
             do
             {
                 Color = RevisionGraphLaneColor.GetColorForLane(colorSeed);
                 ++colorSeed;
             }
-            while (Color == derivedFrom?.Color);
+            while (Color == derivedFrom.Color);
         }
 
         public int Color { get; private set; }

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -627,6 +627,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 {
                     // Reset flags to ensure the cache isn't marked dirty before we even got to rebuilding it.
                     _orderedNodesCacheInvalid = false;
+                    _orderedNodesCache = ImmutableArray<RevisionGraphRevision>.Empty;
 
                     _orderedNodesCache = _revisionByObjectId.Values.OrderBy(n => n.Score).ToImmutableArray();
 

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
@@ -383,7 +383,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
             // merge
             // |    \
             // inner real
-            int maxScore = _mergeCommitNode.GetTestAccessor().AddParent(_innerCommitNode);
+            _mergeCommitNode.GetTestAccessor().AddParent(_innerCommitNode);
             _mergeCommitNode.GetTestAccessor().AddParent(_realCommitNode);
             _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));
 
@@ -408,7 +408,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
             // |   /
             // real
             _artificialCommitNode.GetTestAccessor().AddParent(_undetectedMergeCommitNode);
-            int maxScore = _undetectedMergeCommitNode.GetTestAccessor().AddParent(_realCommitNode);
+            _undetectedMergeCommitNode.GetTestAccessor().AddParent(_realCommitNode);
             _undetectedMergeCommitNode.GetTestAccessor().AddParent(_innerCommitNode);
             _innerCommitNode.GetTestAccessor().AddParent(_realCommitNode);
             _laneNodeLocator.FindPrevNode(Arg.Any<int>(), Arg.Any<int>()).Returns(x => (_realCommitNode, isAtNode: false));


### PR DESCRIPTION
## Proposed changes

General changes to improve cpu execution and to
limit allocations. Some changes are very minor like
using for instead of foreach, other changes the data structures.

Separate storage of nodes that has no GitRevision.
This allows to remove a separate node storage and
to simplify the code.

Use ImmutableArray instead of array and list for the ordered caches
to improve allocations.

Force update data grid when revision graph nodes have been modified

The order of nodes in the revision graph may change if the commits are
listed out of order or if artificial commits are inserted.
The revision graph was (normally) invalidated but the data grid was only
refreshed if scrolling.

Use separate counter for revisions to limit
the lock time for _revisionByObjectId.Count

Rename variables and add comments

Remove unused IsRevisionRelative().

--

This is partly a test of how you can use CoPilot to optimize code.
It is maybe 1/5 times you get something that works and 1/10 that something works.
Quite often CoPilot insists on something that is not an improvement.
But that is not so bad, there are improvements in the end. 

This code is running when revisions are loaded, so performance is important.
Also minor changes could make a difference.

I will add some comments about decisions in an own review of the code.

Tests mostly on Linux repo, limiting loading to 100K commits.

This reduces the time RevisionDataGridView.Add() runs from about 1000-1400 ms to 400-600ms.
However, the normal load time (as reported by RevisionReader) is mostly unchanged at 3000 - 3400 ms, so it seem like git-log delivers commits slower than they are handled here. 
The total time for git-log to write to a file is about 1900 ms so there is something more to it, maybe something with reading the stream (there are changes in .NET7 I will try later).
So there may be a potential for some minor improvements later.
The decreased allocation seem to give more consistent running times (less gc).

The incorrect insertion of artificial commits (that #11266 made more visible) is fixed at least.
I still get some visual issues when scrolling a lot, but better than before.
Similar with no grid when rebasing, I have not seen that lately.
More changes may be needed lock-cache-refresh handling, this is a step forward.
## Test methodology <!-- How did you ensure quality? -->

There are tests for graph loading.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
