### PR TITLE
Follow file names in merge commits and all refs

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -224,9 +224,9 @@ namespace GitUI.CommandsDialogs
                 return null;
             }
 
-            ObjectId objectId = rev.IsArtificial ? RevisionGrid.CurrentCheckout : rev.ObjectId;
+            ObjectId? objectId = rev.IsArtificial ? RevisionGrid.CurrentCheckout : rev.ObjectId;
 
-            return RevisionGrid.FilePathByObjectId.TryGetValue(objectId, out string? path) ? path : null;
+            return RevisionGrid.GetRevisionFileName(FileName, objectId);
         }
 
         private void FileChangesSelectionChanged(object sender, EventArgs e)

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -696,6 +696,10 @@ namespace GitUI.CommandsDialogs
             }
 
             public RevisionGridControl RevisionGrid => _form.RevisionGrid;
+
+            public Editor.FileViewer FileViewer => _form.View;
+
+            public void SelectViewTab() => _form.tabControl1.SelectedTab = _form.ViewTab;
         }
     }
 }

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RevisionFileNameTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RevisionFileNameTests.cs
@@ -1,0 +1,67 @@
+﻿using System.ComponentModel.Design;
+using CommonTestUtils;
+using GitCommands;
+using GitUI;
+using GitUIPluginInterfaces;
+using NSubstitute;
+
+namespace GitUITests.UserControls.RevisionGrid;
+
+[TestFixture]
+[Apartment(ApartmentState.STA)]
+public class RevisionFileNameTests
+{
+    private RevisionGridControl _revisionGridControl;
+    private MockExecutable _executable;
+    private IGitCommandRunner _commandRunner;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _revisionGridControl = new RevisionGridControl();
+        _executable = new MockExecutable();
+        _commandRunner = new GitCommandRunner(_executable, () => GitModule.SystemEncoding);
+
+        ServiceContainer serviceContainer = new();
+        serviceContainer.AddService(Substitute.For<GitUI.Hotkey.IHotkeySettingsManager>());
+        serviceContainer.AddService(Substitute.For<ResourceManager.IHotkeySettingsLoader>());
+
+        IGitModule gitModule = Substitute.For<IGitModule>();
+        gitModule.GitExecutable.Returns(_ => _executable);
+        gitModule.GitCommandRunner.Returns(_ => _commandRunner);
+
+        GitUICommands uiCommands = new(serviceContainer, gitModule);
+
+        IGitUICommandsSource uiCommandsSource = Substitute.For<IGitUICommandsSource>();
+        uiCommandsSource.UICommands.Returns(_ => uiCommands);
+
+        _revisionGridControl.UICommandsSource = uiCommandsSource;
+        _revisionGridControl.FilePathByObjectId = new();
+    }
+
+    [TestCase("17b2a8777e43dff588284c9661206c97ccb6cf8e", "a.txt")]
+    [TestCase("83ec7c0a516f00b67aa9915d8e673a26510c2eed", "b.txt")]
+    public void GetRevisionFileName_should_query_git_and_return_file_name(string objectId, string expectedFileName)
+    {
+        const string path = "a.txt";
+        string actualFileName;
+        string line = $"-c log.showSignature=false log --format=\"????%H\" --name-only --follow --diff-merges=separate  --find-renames --find-copies {objectId} --max-count=1 -- a.txt";
+
+        bool originalFollowRenamesInFileHistoryExactOnly = AppSettings.FollowRenamesInFileHistoryExactOnly;
+        AppSettings.FollowRenamesInFileHistoryExactOnly = false;
+
+        try
+        {
+            using (_executable.StageOutput(line, $"????{objectId}\n{expectedFileName}"))
+            {
+                actualFileName = _revisionGridControl.GetRevisionFileName(path, ObjectId.Parse(objectId));
+            }
+        }
+        finally
+        {
+            AppSettings.FollowRenamesInFileHistoryExactOnly = originalFollowRenamesInFileHistoryExactOnly;
+        }
+
+        Assert.AreEqual(expectedFileName, actualFileName);
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10970.

## Proposed changes

- Added `-m` and `--all` options to `git log` operation in the `BuildPathFilter` method in order to get the file name for all displayed commits in the File History dialog

## Test methodology <!-- How did you ensure quality? -->

- Manual (tested the FH dialog in various repositories - the Diff and View tabs show correct content in all commits)

## Test environment(s) <!-- Remove any that don't apply -->

- GIT  2.42.0.windows.2
- Windows 10

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
