### PR TITLE
Remove use of `var` to follow project code style

### DIFF
--- a/GitExtUtils/LazyStringSplit.cs
+++ b/GitExtUtils/LazyStringSplit.cs
@@ -133,13 +133,13 @@ namespace GitExtUtils
 
         public static string? FirstOrDefault(this LazyStringSplit split)
         {
-            using var enumerator = split.GetEnumerator();
+            using LazyStringSplit.Enumerator enumerator = split.GetEnumerator();
             return enumerator.MoveNext() ? enumerator.Current : null;
         }
 
         public static string? LastOrDefault(this LazyStringSplit split)
         {
-            using var enumerator = split.GetEnumerator();
+            using LazyStringSplit.Enumerator enumerator = split.GetEnumerator();
 
             if (!enumerator.MoveNext())
             {

--- a/GitUI/Avatars/AvatarDownloader.cs
+++ b/GitUI/Avatars/AvatarDownloader.cs
@@ -30,11 +30,11 @@ namespace GitUI.Avatars
 
             ClearOldCacheEntries();
 
-            var errorCount = 0;
+            int errorCount = 0;
 
             while (true)
             {
-                var (_, task) = _downloads.GetOrAdd(imageUrl, _ => (DateTime.UtcNow, DownloadAsync(imageUrl)));
+                (DateTime _, Task<Image?> task) = _downloads.GetOrAdd(imageUrl, _ => (DateTime.UtcNow, DownloadAsync(imageUrl)));
 
                 // If we discover a faulted task, remove it and try again
                 if (task.IsFaulted || task.IsCanceled)
@@ -82,9 +82,9 @@ namespace GitUI.Avatars
 
         private void ClearOldCacheEntries()
         {
-            var now = DateTime.UtcNow;
+            DateTime now = DateTime.UtcNow;
 
-            foreach ((var key, (DateTime time, Task<Image?> _)) in _downloads)
+            foreach ((Uri key, (DateTime time, Task<Image?> _)) in _downloads)
             {
                 if (now - time > TimeSpan.FromSeconds(30))
                 {

--- a/GitUI/Avatars/AvatarMemoryCache.cs
+++ b/GitUI/Avatars/AvatarMemoryCache.cs
@@ -30,7 +30,7 @@ namespace GitUI.Avatars
             (string email, int imageSize) key = (email, imageSize);
             lock (_cache)
             {
-                if (_cache.TryGetValue(key, out var cachedImage))
+                if (_cache.TryGetValue(key, out Image? cachedImage))
                 {
                     return cachedImage;
                 }
@@ -44,7 +44,7 @@ namespace GitUI.Avatars
                 {
                     lock (_cache)
                     {
-                        if (_cache.TryGetValue(key, out var cachedImage))
+                        if (_cache.TryGetValue(key, out Image? cachedImage))
                         {
                             return cachedImage;
                         }

--- a/GitUI/Avatars/CustomAvatarProvider.UriTemplateData.cs
+++ b/GitUI/Avatars/CustomAvatarProvider.UriTemplateData.cs
@@ -37,8 +37,8 @@ namespace GitUI.Avatars
             {
                 using (hashAlgorithm)
                 {
-                    var inputBytes = Encoding.UTF8.GetBytes(input);
-                    var hashBytes = hashAlgorithm.ComputeHash(inputBytes);
+                    byte[] inputBytes = Encoding.UTF8.GetBytes(input);
+                    byte[] hashBytes = hashAlgorithm.ComputeHash(inputBytes);
                     return HexString.FromByteArray(hashBytes);
                 }
             }

--- a/GitUI/Avatars/CustomAvatarProvider.cs
+++ b/GitUI/Avatars/CustomAvatarProvider.cs
@@ -26,9 +26,9 @@ namespace GitUI.Avatars
         {
             UriTemplateData templateData = new(email, name, imageSize);
 
-            foreach (var provider in _subProvider)
+            foreach (IAvatarProvider provider in _subProvider)
             {
-                var avatar = provider switch
+                Image avatar = provider switch
                 {
                     UriTemplateResolver r => await _downloader.DownloadImageAsync(r.ResolveTemplate(templateData)),
                     _ => await provider.GetAvatarAsync(email, name, imageSize),
@@ -56,7 +56,7 @@ namespace GitUI.Avatars
                 throw new ArgumentNullException(nameof(downloader));
             }
 
-            var providerParts = customProviderTemplates
+            IAvatarProvider[] providerParts = customProviderTemplates
                 .LazySplit(';')
                 .Select(p => p.Trim())
                 .Select(p => FromTemplateSegment(downloader, p))
@@ -79,9 +79,9 @@ namespace GitUI.Avatars
             // and try to parse it as an AvatarProvider enum.
             if (providerTemplate.StartsWith("<") && providerTemplate.EndsWith(">"))
             {
-                var providerName = providerTemplate[1..^1];
+                string providerName = providerTemplate[1..^1];
 
-                if (Enum.TryParse<AvatarProvider>(providerName, true, out var provider)
+                if (Enum.TryParse<AvatarProvider>(providerName, true, out AvatarProvider provider)
                     && provider != AvatarProvider.Custom)
                 {
                     return AvatarService.CreateAvatarProvider(provider, null, downloader);

--- a/GitUI/Avatars/GravatarProvider.cs
+++ b/GitUI/Avatars/GravatarProvider.cs
@@ -47,7 +47,7 @@ namespace GitUI.Avatars
         /// <inheritdoc/>
         public Task<Image?> GetAvatarAsync(string email, string? name, int imageSize)
         {
-            var hash = ComputeHash(email);
+            string hash = ComputeHash(email);
 
             UriBuilder uri = new("https", "www.gravatar.com")
             {
@@ -55,7 +55,7 @@ namespace GitUI.Avatars
                 Query = _queryString + imageSize
             };
 
-            var avatarUri = uri.Uri;
+            Uri avatarUri = uri.Uri;
 
             // TODO NULLABLE UriBuilder.Uri doesn't appear to be nullable
             if (avatarUri is null)
@@ -69,8 +69,8 @@ namespace GitUI.Avatars
         private string ComputeHash(string email)
         {
             // Gravatar doesn't specify an encoding
-            var emailBytes = Encoding.UTF8.GetBytes(email.Trim().ToLowerInvariant());
-            var hashBytes = _md5.ComputeHash(emailBytes);
+            byte[] emailBytes = Encoding.UTF8.GetBytes(email.Trim().ToLowerInvariant());
+            byte[] hashBytes = _md5.ComputeHash(emailBytes);
 
             return HexString.FromByteArray(hashBytes);
         }

--- a/GitUI/Avatars/InitialsAvatarProvider.cs
+++ b/GitUI/Avatars/InitialsAvatarProvider.cs
@@ -153,25 +153,25 @@ namespace GitUI.Avatars
         {
             lock (_avatarColors)
             {
-                var fontSizeEstimation = size / 4.0f;
+                float fontSizeEstimation = size / 4.0f;
                 Font font = new(AppSettings.CommitFont.FontFamily, fontSizeEstimation);
 
                 SizeF textSize = _graphics.MeasureString(text, font);
 
                 // Adjust font size with the measure
-                var sizeSquare = Math.Max((int)textSize.Width, (int)textSize.Height);
+                int sizeSquare = Math.Max((int)textSize.Width, (int)textSize.Height);
                 font = new Font(AppSettings.CommitFont.FontFamily, fontSizeEstimation * size / sizeSquare);
                 textSize = _graphics.MeasureString(text, font);
 
                 Bitmap img = new(size, size);
 
-                using var drawing = Graphics.FromImage(img);
+                using Graphics drawing = Graphics.FromImage(img);
                 drawing.Clear(backColor);
                 drawing.SmoothingMode = SmoothingMode.AntiAlias;
                 drawing.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
 
-                var x = textSize.Width >= textSize.Height ? 0 : (textSize.Height - textSize.Width) / 2;
-                var y = textSize.Width >= textSize.Height ? (textSize.Width - textSize.Height) / 2 : 0;
+                float x = textSize.Width >= textSize.Height ? 0 : (textSize.Height - textSize.Width) / 2;
+                float y = textSize.Width >= textSize.Height ? (textSize.Width - textSize.Height) / 2 : 0;
                 drawing.DrawString(text, font, foreColor, x, y);
                 drawing.Save();
 

--- a/GitUI/Avatars/MultiCacheCleaner.cs
+++ b/GitUI/Avatars/MultiCacheCleaner.cs
@@ -23,7 +23,7 @@
         /// <inheritdoc/>
         public async Task ClearCacheAsync()
         {
-            foreach (var cacheCleaner in _inner)
+            foreach (IAvatarCacheCleaner cacheCleaner in _inner)
             {
                 await cacheCleaner.ClearCacheAsync();
             }

--- a/GitUI/Avatars/SafetynetAvatarProvider.cs
+++ b/GitUI/Avatars/SafetynetAvatarProvider.cs
@@ -38,7 +38,7 @@ namespace GitUI.Avatars
 
             try
             {
-                var image = await _avatarProvider.GetAvatarAsync(email, name, imageSize);
+                Image image = await _avatarProvider.GetAvatarAsync(email, name, imageSize);
 
                 if (image is not null)
                 {

--- a/GitUI/Avatars/StaticImageAvatarProvider.cs
+++ b/GitUI/Avatars/StaticImageAvatarProvider.cs
@@ -21,7 +21,7 @@
         {
             lock (_sizeCache)
             {
-                if (_sizeCache.TryGetValue(imageSize, out var image))
+                if (_sizeCache.TryGetValue(imageSize, out Image image))
                 {
                     return image;
                 }

--- a/GitUI/Avatars/TemplateFormatter.cs
+++ b/GitUI/Avatars/TemplateFormatter.cs
@@ -19,14 +19,14 @@ namespace GitUI.Avatars
         public static Func<TInput, string> Create<TInput>(string template, Func<string, Func<TInput, string?>> valueMapperProvider)
         {
             List<Action<StringBuilder, TInput>> formatParts = new();
-            var position = 0;
+            int position = 0;
 
             while (true)
             {
-                var variableStartIndex = template.IndexOf('{', position);
-                var fixIndex = variableStartIndex < 0 ? template.Length : variableStartIndex;
+                int variableStartIndex = template.IndexOf('{', position);
+                int fixIndex = variableStartIndex < 0 ? template.Length : variableStartIndex;
 
-                var fixValue = template[position..fixIndex];
+                string fixValue = template[position..fixIndex];
                 formatParts.Add((sb, _) => sb.Append(fixValue));
 
                 if (variableStartIndex < 0)
@@ -36,7 +36,7 @@ namespace GitUI.Avatars
 
                 position = variableStartIndex + 1;
 
-                var variableEndIndex = template.IndexOf('}', position);
+                int variableEndIndex = template.IndexOf('}', position);
 
                 if (variableEndIndex < 0)
                 {
@@ -45,8 +45,8 @@ namespace GitUI.Avatars
 
                 position = variableEndIndex + 1;
 
-                var variableName = template.Substring(variableStartIndex + 1, variableEndIndex - variableStartIndex - 1);
-                var inputParser = valueMapperProvider(variableName);
+                string variableName = template.Substring(variableStartIndex + 1, variableEndIndex - variableStartIndex - 1);
+                Func<TInput, string?> inputParser = valueMapperProvider(variableName);
                 formatParts.Add((sb, i) => sb.Append(inputParser(i)));
             }
 
@@ -60,7 +60,7 @@ namespace GitUI.Avatars
         {
             StringBuilder sb = new();
 
-            foreach (var formatter in formatParts)
+            foreach (Action<StringBuilder, TInput> formatter in formatParts)
             {
                 formatter(sb, input);
             }

--- a/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
+++ b/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
@@ -23,12 +23,12 @@ namespace GitUI.CommandsDialogs.AboutBoxDialog
                 SuspendLayout();
                 Controls.Clear();
 
-                var tabControl = GetNewTabControl();
+                TabControl tabControl = GetNewTabControl();
 
-                var tabCaptions = new[] { _developers.Text, _translators.Text, _designers.Text };
-                var textBoxes = new TextBox[tabCaptions.Length];
-                var tabPages = new TabPage[tabCaptions.Length];
-                for (var i = 0; i < tabCaptions.Length; i++)
+                string[] tabCaptions = new[] { _developers.Text, _translators.Text, _designers.Text };
+                TextBox[] textBoxes = new TextBox[tabCaptions.Length];
+                TabPage[] tabPages = new TabPage[tabCaptions.Length];
+                for (int i = 0; i < tabCaptions.Length; i++)
                 {
                     textBoxes[i] = GetNewTextBox();
                     tabPages[i] = GetNewTabPage(textBoxes[i], tabCaptions[i]);

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/Dashboard.cs
@@ -77,7 +77,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 userRepositoriesList.HoverColor = selectedTheme.PrimaryLight;
                 userRepositoriesList.MainBackColor = selectedTheme.Primary;
 
-                foreach (var item in flpnlContribute.Controls.OfType<LinkLabel>().Union(flpnlStart.Controls.OfType<LinkLabel>()))
+                foreach (LinkLabel item in flpnlContribute.Controls.OfType<LinkLabel>().Union(flpnlStart.Controls.OfType<LinkLabel>()))
                 {
                     item.LinkColor = selectedTheme.PrimaryText;
                 }
@@ -100,12 +100,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                             CreateLink(panel, _develop.Text, Images.Develop.AdaptLightness(), GitHubItem_Click);
                             CreateLink(panel, _donate.Text, Images.DollarSign, DonateItem_Click);
                             CreateLink(panel, _translate.Text, Images.Translate.AdaptLightness(), TranslateItem_Click);
-                            var lastControl = CreateLink(panel, _issues.Text, Images.Bug, IssuesItem_Click);
+                            Control lastControl = CreateLink(panel, _issues.Text, Images.Bug, IssuesItem_Click);
                             return lastControl;
                         },
                         (panel, lastControl) =>
                         {
-                            var height = lastControl.Location.Y + lastControl.Size.Height + panel.Padding.Bottom;
+                            int height = lastControl.Location.Y + lastControl.Size.Height + panel.Padding.Bottom;
                             panel.Height = height;
                             panel.MinimumSize = new Size(0, height);
                         });
@@ -115,9 +115,9 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                         {
                             CreateLink(panel, _createRepository.Text, Images.RepoCreate, createItem_Click);
                             CreateLink(panel, _openRepository.Text, Images.RepoOpen, openItem_Click);
-                            var lastControl = CreateLink(panel, _cloneRepository.Text, Images.CloneRepoGit, cloneItem_Click);
+                            Control lastControl = CreateLink(panel, _cloneRepository.Text, Images.CloneRepoGit, cloneItem_Click);
 
-                            foreach (var gitHoster in PluginRegistry.GitHosters)
+                            foreach (GitUIPluginInterfaces.RepositoryHosts.IRepositoryHostPlugin gitHoster in PluginRegistry.GitHosters)
                             {
                                 lastControl = CreateLink(panel, string.Format(_cloneFork.Text, gitHoster.Name), Images.CloneRepoGitHub,
                                     (repoSender, eventArgs) => UICommands.StartCloneForkFromHoster(this, gitHoster, GitModuleChanged));
@@ -127,7 +127,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                         },
                         (panel, lastControl) =>
                         {
-                            var height = lastControl.Location.Y + lastControl.Size.Height + panel.Padding.Bottom;
+                            int height = lastControl.Location.Y + lastControl.Size.Height + panel.Padding.Bottom;
                             panel.MinimumSize = new Size(0, height);
                         });
                 }
@@ -143,7 +143,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                     panel.SuspendLayout();
                     panel.Controls.Clear();
 
-                    var lastControl = addLinks(panel);
+                    Control lastControl = addLinks(panel);
 
                     panel.ResumeLayout(false);
                     panel.PerformLayout();
@@ -153,8 +153,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
                 Control CreateLink(Control container, string text, Image icon, EventHandler handler)
                 {
-                    var padding24 = DpiUtil.Scale(24);
-                    var padding3 = DpiUtil.Scale(3);
+                    int padding24 = DpiUtil.Scale(24);
+                    int padding3 = DpiUtil.Scale(3);
                     LinkLabel linkLabel = new()
                     {
                         AutoSize = true,
@@ -182,7 +182,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         protected virtual void OnModuleChanged(object sender, GitModuleEventArgs e)
         {
-            var handler = GitModuleChanged;
+            EventHandler<GitModuleEventArgs> handler = GitModuleChanged;
             handler?.Invoke(this, e);
         }
 

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesList.cs
@@ -274,7 +274,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
             IReadOnlyList<RecentRepoInfo> recentRepositories;
             IReadOnlyList<RecentRepoInfo> favouriteRepositories;
-            using (var graphics = CreateGraphics())
+            using (Graphics graphics = CreateGraphics())
             {
                 (recentRepositories, favouriteRepositories) = _controller.PreRenderRepositories(graphics, textBoxSearch.Text);
             }
@@ -291,7 +291,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
                 _hasInvalidRepos = false;
 
-                var groups = new[] { _lvgRecentRepositories }
+                ListViewGroup[] groups = new[] { _lvgRecentRepositories }
                     .Concat(recentRepositories.Concat(favouriteRepositories)
                         .Select(repo => repo.Repo.Category)
                         .Where(c => !string.IsNullOrWhiteSpace(c))
@@ -315,7 +315,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
             void BindRepositories(IReadOnlyList<RecentRepoInfo> repos, bool isFavourite)
             {
-                for (var index = 0; index < repos.Count; index++)
+                for (int index = 0; index < repos.Count; index++)
                 {
                     RecentRepoInfo recent = repos[index];
                     ListViewItem item = new(recent.Caption)
@@ -360,7 +360,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         protected virtual void OnModuleChanged(GitModuleEventArgs args)
         {
-            var handler = GitModuleChanged;
+            EventHandler<GitModuleEventArgs> handler = GitModuleChanged;
             handler?.Invoke(this, args);
         }
 
@@ -398,10 +398,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         private static SelectedRepositoryItem? GetSelectedRepositoryItem(ToolStripItem? menuItem)
         {
             // Retrieve the ContextMenuStrip that owns this ToolStripItem
-            var contextMenu = menuItem?.Owner as ContextMenuStrip;
+            ContextMenuStrip contextMenu = menuItem?.Owner as ContextMenuStrip;
 
             // Get the control that is displaying this context menu
-            var selected = contextMenu?.Tag as SelectedRepositoryItem;
+            SelectedRepositoryItem selected = contextMenu?.Tag as SelectedRepositoryItem;
             if (string.IsNullOrWhiteSpace(selected?.Repository?.Path))
             {
                 return null;
@@ -417,7 +417,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 return null;
             }
 
-            var selected = listView1.SelectedItems[0].Tag as Repository;
+            Repository selected = listView1.SelectedItems[0].Tag as Repository;
             if (string.IsNullOrWhiteSpace(selected?.Path))
             {
                 return null;
@@ -434,13 +434,13 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private Size GetTileSize(IEnumerable<RecentRepoInfo> recentRepositories, IEnumerable<RecentRepoInfo> favouriteRepositories)
         {
-            var spacing1 = DpiUtil.Scale(1f);
-            var spacing2 = DpiUtil.Scale(2f);
+            float spacing1 = DpiUtil.Scale(1f);
+            float spacing2 = DpiUtil.Scale(2f);
 
             var longestPath = recentRepositories.Union(favouriteRepositories)
                                                 .Select(r =>
                                                 {
-                                                    var size = TextRenderer.MeasureText(r.Caption, AppSettings.Font);
+                                                    Size size = TextRenderer.MeasureText(r.Caption, AppSettings.Font);
                                                     return new
                                                     {
                                                         r.Caption,
@@ -450,15 +450,15 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                                                 })
                                                .OrderByDescending(r => r.Width)
                                                .First();
-            var branchTextSize = TextRenderer.MeasureText("A", _secondaryFont);
+            Size branchTextSize = TextRenderer.MeasureText("A", _secondaryFont);
 
-            var width = AppSettings.RecentReposComboMinWidth;
+            int width = AppSettings.RecentReposComboMinWidth;
             if (width < 1)
             {
                 width = longestPath.Width + imageList1.ImageSize.Width;
             }
 
-            var height = longestPath.Height + (2 * branchTextSize.Height) +
+            float height = longestPath.Height + (2 * branchTextSize.Height) +
                 /* offset from top and bottom */(2 * spacing2) +
                 /* twice space between text */(2 * spacing1);
 
@@ -467,7 +467,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private static void RepositoryContextAction(ToolStripItem? menuItem, Action<SelectedRepositoryItem> action)
         {
-            var selected = GetSelectedRepositoryItem(menuItem);
+            SelectedRepositoryItem selected = GetSelectedRepositoryItem(menuItem);
             if (selected is not null)
             {
                 action(selected);
@@ -476,8 +476,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private static string ShortenText(string text, Font font, float maxWidth)
         {
-            var ellipsis = '…';
-            var width = TextRenderer.MeasureText(text, font).Width;
+            char ellipsis = '…';
+            int width = TextRenderer.MeasureText(text, font).Width;
             if (width < maxWidth)
             {
                 return text;
@@ -512,7 +512,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private bool PromptUserConfirm(string question, string caption)
         {
-            var dialogResult = MessageBox.Show(this,
+            DialogResult dialogResult = MessageBox.Show(this,
                 question,
                 caption,
                 MessageBoxButtons.YesNo,
@@ -524,7 +524,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private void UpdateCategoryName(string originalName, string? newName)
         {
-            foreach (var repository in GetRepositories().Where(r => r.Category == originalName))
+            foreach (Repository repository in GetRepositories().Where(r => r.Category == originalName))
             {
                 ThreadHelper.JoinableTaskFactory.Run(() => _controller.AssignCategoryAsync(repository, newName));
             }
@@ -540,7 +540,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private void contextMenuStrip_Opening(object sender, CancelEventArgs e)
         {
-            var selected = GetSelectedRepository();
+            Repository selected = GetSelectedRepository();
 
             tsmiRemoveFromList.Visible =
                 toolStripMenuItem1.Visible =
@@ -564,12 +564,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private void listView1_DrawItem(object sender, DrawListViewItemEventArgs e)
         {
-            var spacing1 = DpiUtil.Scale(1f);
-            var spacing2 = DpiUtil.Scale(2f);
-            var spacing4 = DpiUtil.Scale(4f);
-            var spacing6 = DpiUtil.Scale(6f);
+            float spacing1 = DpiUtil.Scale(1f);
+            float spacing2 = DpiUtil.Scale(2f);
+            float spacing4 = DpiUtil.Scale(4f);
+            float spacing6 = DpiUtil.Scale(6f);
 
-            var textOffset = spacing2 + imageList1.ImageSize.Width + spacing2;
+            float textOffset = spacing2 + imageList1.ImageSize.Width + spacing2;
             int textWidth = e.Bounds.Width - (int)textOffset;
 
             if (e.Item == HoveredItem || e.Item.Selected)
@@ -596,7 +596,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             // render path
             PointF textPadding = new(e.Bounds.Left + spacing4, e.Bounds.Top + spacing6);
             PointF pointPath = new(textPadding.X + textOffset, textPadding.Y);
-            var pathBounds = DrawText(e.Graphics, e.Item.Text, AppSettings.Font, _foreColorBrush, textWidth, pointPath, spacing4 * 2);
+            RectangleF pathBounds = DrawText(e.Graphics, e.Item.Text, AppSettings.Font, _foreColorBrush, textWidth, pointPath, spacing4 * 2);
 
             if (e.Item.SubItems.Count > 1)
             {
@@ -616,10 +616,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
             RectangleF DrawText(Graphics g, string text, Font font, Brush brush, int maxTextWidth, PointF location, float spacing)
             {
-                var textBounds = TextRenderer.MeasureText(text, font);
-                var minWidth = Math.Min(textBounds.Width + spacing, maxTextWidth);
+                Size textBounds = TextRenderer.MeasureText(text, font);
+                float minWidth = Math.Min(textBounds.Width + spacing, maxTextWidth);
                 RectangleF bounds = new(location, new SizeF(minWidth, textBounds.Height));
-                var text1 = Math.Abs(maxTextWidth - minWidth) < float.Epsilon ? ShortenText(text, font, minWidth) : text;
+                string text1 = Math.Abs(maxTextWidth - minWidth) < float.Epsilon ? ShortenText(text, font, minWidth) : text;
                 g.DrawString(text1, font, brush, bounds, StringFormat.GenericTypographic);
 
                 return bounds;
@@ -664,7 +664,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             if (e.KeyCode == Keys.Enter)
             {
                 // Open the first repo in the list
-                var items = listView1.Items;
+                ListView.ListViewItemCollection items = listView1.Items;
                 if (items.Count == 0)
                 {
                     return;
@@ -714,7 +714,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         private void mnuConfigure_Click(object sender, EventArgs e)
         {
             using FormRecentReposSettings frm = new();
-            var result = frm.ShowDialog(this);
+            DialogResult result = frm.ShowDialog(this);
             if (result == DialogResult.OK)
             {
                 ShowRecentRepositories();
@@ -728,10 +728,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
                 return;
             }
 
-            var menus = new ToolStripItem[] { mnuConfigure };
-            var menuStrip = form.FindDescendantOfType<MenuStrip>(p => p.Name == "mainMenuStrip");
+            ToolStripItem[] menus = new ToolStripItem[] { mnuConfigure };
+            MenuStrip menuStrip = form.FindDescendantOfType<MenuStrip>(p => p.Name == "mainMenuStrip");
             Validates.NotNull(menuStrip);
-            var dashboardMenu = (ToolStripMenuItem)menuStrip.Items.Cast<ToolStripItem>().SingleOrDefault(p => p.Name == "dashboardToolStripMenuItem");
+            ToolStripMenuItem dashboardMenu = (ToolStripMenuItem)menuStrip.Items.Cast<ToolStripItem>().SingleOrDefault(p => p.Name == "dashboardToolStripMenuItem");
             dashboardMenu?.DropDownItems.AddRange(menus);
         }
 
@@ -745,7 +745,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             tsmiCategories.DropDown.SuspendLayout();
             tsmiCategories.DropDownItems.Clear();
 
-            var categories = GetCategories();
+            List<string> categories = GetCategories();
             if (categories.Count > 0)
             {
                 tsmiCategories.DropDownItems.Add(tsmiCategoryNone);
@@ -779,13 +779,13 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private void tsmiCategory_Click(object sender, EventArgs e)
         {
-            var selectedRepositoryItem = GetSelectedRepositoryItem((sender as ToolStripMenuItem)?.OwnerItem);
+            SelectedRepositoryItem selectedRepositoryItem = GetSelectedRepositoryItem((sender as ToolStripMenuItem)?.OwnerItem);
             if (selectedRepositoryItem is null)
             {
                 return;
             }
 
-            var category = (sender as ToolStripMenuItem)?.Tag as string;
+            string category = (sender as ToolStripMenuItem)?.Tag as string;
             ThreadHelper.JoinableTaskFactory.Run(() => _controller.AssignCategoryAsync(selectedRepositoryItem.Repository, category));
             ShowRecentRepositories();
         }
@@ -828,10 +828,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private void tsmiCategoryRename_Click(object sender, EventArgs e)
         {
-            var categoryGroup = (ListViewGroup)contextMenuStripCategory.Tag;
+            ListViewGroup categoryGroup = (ListViewGroup)contextMenuStripCategory.Tag;
             string originalName = categoryGroup.Name;
 
-            var categories = GetCategories();
+            List<string> categories = GetCategories();
             categories.Remove(originalName);
 
             if (PromptCategoryName(categories, originalName, out string? newName))
@@ -842,7 +842,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private void tsmiCategoryDelete_Click(object sender, EventArgs e)
         {
-            var categoryGroup = (ListViewGroup)contextMenuStripCategory.Tag;
+            ListViewGroup categoryGroup = (ListViewGroup)contextMenuStripCategory.Tag;
             string name = categoryGroup.Name;
             string question = string.Format(_deleteCategoryQuestion.Text, name, categoryGroup.Items.Count);
 
@@ -856,14 +856,14 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         private void tsmiCategoryClear_Click(object sender, EventArgs e)
         {
-            var repositories = GetRepositories().ToList();
+            List<Repository> repositories = GetRepositories().ToList();
             string question = string.Format(_clearRecentCategoryQuestion.Text, repositories.Count);
             if (!PromptUserConfirm(question, _clearRecentCategoryCaption.Text))
             {
                 return;
             }
 
-            foreach (var repository in repositories)
+            foreach (Repository repository in repositories)
             {
                 ThreadHelper.JoinableTaskFactory.Run(
                     () => RepositoryHistoryManager.Locals.RemoveRecentAsync(repository.Path));

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
@@ -81,16 +81,16 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
             };
 
             _allRecentRepositories ??= ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync);
-            var repositories = Filter(_allRecentRepositories, pattern);
+            IList<Repository> repositories = Filter(_allRecentRepositories, pattern);
             splitter.SplitRecentRepos(repositories, pinnedRepos, allRecentRepos);
-            var recentRepositories = pinnedRepos.Union(allRecentRepos).ToList();
+            List<RecentRepoInfo> recentRepositories = pinnedRepos.Union(allRecentRepos).ToList();
 
             _allFavoriteRepositories ??= ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadFavouriteHistoryAsync);
             repositories = Filter(_allFavoriteRepositories, pattern);
             pinnedRepos.Clear();
             allRecentRepos.Clear();
             splitter.SplitRecentRepos(repositories, pinnedRepos, allRecentRepos);
-            var favouriteRepositories = pinnedRepos.Union(allRecentRepos).ToList();
+            List<RecentRepoInfo> favouriteRepositories = pinnedRepos.Union(allRecentRepos).ToList();
 
             return (recentRepositories, favouriteRepositories);
         }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBisect.cs
@@ -39,7 +39,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             UpdateButtonsState();
 
-            var revisions = _revisionGridInfo.GetSelectedRevisions();
+            IReadOnlyList<GitRevision> revisions = _revisionGridInfo.GetSelectedRevisions();
             if (revisions.Count > 1)
             {
                 if (MessageBox.Show(this, _bisectStart.Text, Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
@@ -53,7 +53,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             void BisectRange(ObjectId startRevision, ObjectId endRevision)
             {
-                var command = Commands.ContinueBisect(GitBisectOption.Good, startRevision);
+                GitExtUtils.ArgumentString command = Commands.ContinueBisect(GitBisectOption.Good, startRevision);
                 bool success = FormProcess.ShowDialog(this, UICommands, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
                 if (!success)
                 {

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
@@ -169,7 +169,7 @@ namespace GitUI.CommandsDialogs
                 {
                     toolbarItem.Visible = !toolbarItem.Visible;
 
-                    if (!BelongToAGroup(toolbarItem, out var group))
+                    if (!BelongToAGroup(toolbarItem, out string group))
                     {
                         SaveVisibilitySetting(toolbarItem.Name, toolbarItem.Visible, IsVisibleByDefault(toolbarItem.Name));
                     }
@@ -229,7 +229,7 @@ namespace GitUI.CommandsDialogs
             shouldHideNextSeparator = true;
             for (int i = senderToolStrip.Items.Count - 1; i >= 0; i--)
             {
-                var item = senderToolStrip.Items[i];
+                ToolStripItem item = senderToolStrip.Items[i];
 
                 if (item is ToolStripSeparator { Visible: false })
                 {
@@ -386,9 +386,9 @@ namespace GitUI.CommandsDialogs
             toolStripMenuItemTarget.DropDownItems.Clear();
 
             List<ToolStripItem> toolStripItems = new();
-            foreach (var menuCommand in menuCommands)
+            foreach (MenuCommand menuCommand in menuCommands)
             {
-                var toolStripItem = MenuCommand.CreateToolStripItem(menuCommand);
+                ToolStripItem toolStripItem = MenuCommand.CreateToolStripItem(menuCommand);
                 toolStripItems.Add(toolStripItem);
 
                 if (toolStripItem is ToolStripMenuItem toolStripMenuItem)
@@ -423,9 +423,9 @@ namespace GitUI.CommandsDialogs
 
         public void OnMenuCommandsPropertyChanged()
         {
-            var menuCommands = GetNavigateAndViewMenuCommands();
+            IEnumerable<MenuCommand> menuCommands = GetNavigateAndViewMenuCommands();
 
-            foreach (var menuCommand in menuCommands)
+            foreach (MenuCommand menuCommand in menuCommands)
             {
                 menuCommand.SetCheckForRegisteredMenuItems();
                 menuCommand.UpdateMenuItemsShortcutKeyDisplayString();

--- a/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
@@ -131,12 +131,12 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                     splitter.Graphics.Dispose();
                 }
 
-                foreach (var repo in pinnedRepos)
+                foreach (RecentRepoInfo repo in pinnedRepos)
                 {
                     PinnedLB.Items.Add(GetRepositoryListViewItem(repo, repo.Repo.Anchor == Repository.RepositoryAnchor.Pinned));
                 }
 
-                foreach (var repo in allRecentRepos)
+                foreach (RecentRepoInfo repo in allRecentRepos)
                 {
                     AllRecentLB.Items.Add(GetRepositoryListViewItem(repo, repo.Repo.Anchor == Repository.RepositoryAnchor.AllRecent));
                 }
@@ -359,9 +359,9 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void listView_DrawItem(object sender, DrawListViewItemEventArgs e)
         {
-            var listView = (ListView)sender;
+            ListView listView = (ListView)sender;
 
-            var rowBounds = e.Bounds;
+            Rectangle rowBounds = e.Bounds;
             int leftMargin = e.Item.GetBounds(ItemBoundsPortion.Label).Left;
             Rectangle bounds = new(leftMargin, rowBounds.Top, rowBounds.Width - leftMargin, rowBounds.Height);
 

--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -68,15 +68,15 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 Client github = new();
                 Repository gitExtRepo = github.getRepository("gitextensions", "gitextensions");
 
-                var configData = gitExtRepo?.GetRef("heads/configdata");
+                GitHubReference configData = gitExtRepo?.GetRef("heads/configdata");
 
-                var tree = configData?.GetTree();
+                GitHubTree tree = configData?.GetTree();
                 if (tree is null)
                 {
                     return;
                 }
 
-                var releases = tree.Tree.FirstOrDefault(entry => "GitExtensions.releases".Equals(entry.Path, StringComparison.InvariantCultureIgnoreCase));
+                GitHubTreeEntry releases = tree.Tree.FirstOrDefault(entry => "GitExtensions.releases".Equals(entry.Path, StringComparison.InvariantCultureIgnoreCase));
 
                 if (releases?.Blob.Value is not null)
                 {
@@ -111,10 +111,10 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
         private void CheckForNewerVersion(string releases)
         {
-            var versions = ReleaseVersion.Parse(releases);
-            var updates = ReleaseVersion.GetNewerVersions(CurrentVersion, AppSettings.CheckForReleaseCandidates, versions);
+            IEnumerable<ReleaseVersion> versions = ReleaseVersion.Parse(releases);
+            IEnumerable<ReleaseVersion> updates = ReleaseVersion.GetNewerVersions(CurrentVersion, AppSettings.CheckForReleaseCandidates, versions);
 
-            var update = updates.OrderBy(version => version.Version).LastOrDefault();
+            ReleaseVersion update = updates.OrderBy(version => version.Version).LastOrDefault();
             if (update is not null)
             {
                 UpdateFound = true;
@@ -270,7 +270,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         {
             ConfigFile cfg = new(fileName: "");
             cfg.LoadFromString(versionsStr);
-            var sections = cfg.GetConfigSections("Version");
+            IEnumerable<IConfigSection> sections = cfg.GetConfigSections("Version");
             sections = sections.Concat(cfg.GetConfigSections("RCVersion"));
 
             return sections.Select(FromSection).WhereNotNull();
@@ -281,7 +281,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
             bool checkForReleaseCandidates,
             IEnumerable<ReleaseVersion> availableVersions)
         {
-            var versions = availableVersions.Where(version =>
+            IEnumerable<ReleaseVersion> versions = availableVersions.Where(version =>
                     version.ReleaseType == ReleaseType.Major ||
                     version.ReleaseType == ReleaseType.HotFix ||
                     (checkForReleaseCandidates && version.ReleaseType == ReleaseType.ReleaseCandidate));

--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -326,7 +326,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             void commandsSource_GitUICommandsChanged(object sender, GitUICommandsChangedEventArgs e)
             {
-                var oldCommands = e.OldCommands;
+                GitUICommands oldCommands = e.OldCommands;
                 if (oldCommands is not null)
                 {
                     oldCommands.PreCheckoutBranch -= GitUICommands_PreCheckout;
@@ -341,14 +341,14 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             void commandsSource_activate(IGitUICommandsSource sender)
             {
-                var newCommands = sender.UICommands;
+                GitUICommands newCommands = sender.UICommands;
                 newCommands.PreCheckoutBranch += GitUICommands_PreCheckout;
                 newCommands.PreCheckoutRevision += GitUICommands_PreCheckout;
                 newCommands.PostCheckoutBranch += GitUICommands_PostCheckout;
                 newCommands.PostCheckoutRevision += GitUICommands_PostCheckout;
                 newCommands.PostRepositoryChanged += GitUICommands_PostRepositoryChanged;
 
-                var module = newCommands.Module;
+                GitModule module = newCommands.Module;
                 StartWatchingChanges(module.WorkingDir, module.WorkingDirGitDir);
             }
 

--- a/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
@@ -135,7 +135,7 @@
 
         public void UnregisterMenuItems(IEnumerable<ToolStripMenuItem> items)
         {
-            foreach (var item in items)
+            foreach (ToolStripMenuItem item in items)
             {
                 _registeredMenuItems.Remove(item);
             }
@@ -147,7 +147,7 @@
             {
                 bool isChecked = IsCheckedFunc();
 
-                foreach (var item in _registeredMenuItems)
+                foreach (ToolStripMenuItem item in _registeredMenuItems)
                 {
                     item.Checked = isChecked;
                 }
@@ -157,7 +157,7 @@
             {
                 bool isEnabled = IsEnabledFunc();
 
-                foreach (var item in _registeredMenuItems)
+                foreach (ToolStripMenuItem item in _registeredMenuItems)
                 {
                     item.Enabled = isEnabled;
                 }
@@ -166,7 +166,7 @@
 
         public void UpdateMenuItemsShortcutKeyDisplayString()
         {
-            foreach (var item in _registeredMenuItems)
+            foreach (ToolStripMenuItem item in _registeredMenuItems)
             {
                 item.ShortcutKeyDisplayString = ShortcutKeyDisplayString;
             }

--- a/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
+++ b/GitUI/CommandsDialogs/BuildReportTabPageExtension.cs
@@ -47,8 +47,8 @@ namespace GitUI.CommandsDialogs
 
             try
             {
-                var buildResultPageEnabled = revision is not null && IsBuildResultPageEnabled();
-                var buildInfoIsAvailable = !string.IsNullOrEmpty(revision?.BuildStatus?.Url);
+                bool buildResultPageEnabled = revision is not null && IsBuildResultPageEnabled();
+                bool buildInfoIsAvailable = !string.IsNullOrEmpty(revision?.BuildStatus?.Url);
 
                 if (buildResultPageEnabled && buildInfoIsAvailable)
                 {
@@ -64,7 +64,7 @@ namespace GitUI.CommandsDialogs
 
                     SetTabPageContent(revision);
 
-                    var isFavIconMissing = _buildReportTabPage.ImageIndex < 0;
+                    bool isFavIconMissing = _buildReportTabPage.ImageIndex < 0;
 
                     if (isFavIconMissing || _tabControl.SelectedTab == _buildReportTabPage)
                     {
@@ -181,21 +181,21 @@ namespace GitUI.CommandsDialogs
 
             _buildReportWebBrowser.Navigated -= BuildReportWebBrowserOnNavigated;
 
-            var favIconUrl = DetermineFavIconUrl(_buildReportWebBrowser.Document);
+            string favIconUrl = DetermineFavIconUrl(_buildReportWebBrowser.Document);
 
             if (favIconUrl is not null)
             {
                 ThreadHelper.FileAndForget(async () =>
                     {
-                        using var imageStream = await DownloadRemoteImageFileAsync(favIconUrl);
+                        using Stream imageStream = await DownloadRemoteImageFileAsync(favIconUrl);
                         if (imageStream is not null)
                         {
                             await _tabControl.SwitchToMainThreadAsync();
 
-                            var favIconImage = Image.FromStream(imageStream)
+                            Image favIconImage = Image.FromStream(imageStream)
                                                     .GetThumbnailImage(16, 16, null, IntPtr.Zero);
-                            var imageCollection = _tabControl.ImageList.Images;
-                            var imageIndex = _buildReportTabPage.ImageIndex;
+                            ImageList.ImageCollection imageCollection = _tabControl.ImageList.Images;
+                            int imageIndex = _buildReportTabPage.ImageIndex;
 
                             if (imageIndex < 0)
                             {
@@ -221,7 +221,7 @@ namespace GitUI.CommandsDialogs
 
         private IGitModule GetModule()
         {
-            var module = _getModule();
+            IGitModule module = _getModule();
 
             if (module is null)
             {
@@ -233,8 +233,8 @@ namespace GitUI.CommandsDialogs
 
         private static string? DetermineFavIconUrl(HtmlDocument htmlDocument)
         {
-            var links = htmlDocument.GetElementsByTagName("link");
-            var favIconLink =
+            HtmlElementCollection links = htmlDocument.GetElementsByTagName("link");
+            HtmlElement favIconLink =
                 links.Cast<HtmlElement>()
                      .SingleOrDefault(x => x.GetAttribute("rel").ToLowerInvariant() == "shortcut icon");
 
@@ -243,7 +243,7 @@ namespace GitUI.CommandsDialogs
                 return null;
             }
 
-            var href = favIconLink.GetAttribute("href");
+            string href = favIconLink.GetAttribute("href");
 
             if (htmlDocument.Url.PathAndQuery == "/")
             {
@@ -260,10 +260,10 @@ namespace GitUI.CommandsDialogs
         private static async Task<Stream?> DownloadRemoteImageFileAsync(string uri)
         {
 #pragma warning disable SYSLIB0014 // 'WebRequest.Create(string)' is obsolete
-            var request = (HttpWebRequest)WebRequest.Create(uri);
+            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(uri);
 #pragma warning restore SYSLIB0014 // 'WebRequest.Create(string)' is obsolete
 
-            var response = await GetWebResponseAsync(request).ConfigureAwait(false);
+            HttpWebResponse response = await GetWebResponseAsync(request).ConfigureAwait(false);
 
             // Check that the remote file was found. The ContentType
             // check is performed since a request for a non-existent

--- a/GitUI/CommandsDialogs/CommitDialog/FormCommitTemplateSettings.cs
+++ b/GitUI/CommandsDialogs/CommitDialog/FormCommitTemplateSettings.cs
@@ -46,7 +46,7 @@ namespace GitUI.CommandsDialogs.CommitDialog
             else if (_commitTemplates.Length < _maxCommitTemplates)
             {
                 // Migration: keep the one configured and complete with empty ones
-                var previousCommitTemplates = _commitTemplates;
+                CommitTemplateItem[] previousCommitTemplates = _commitTemplates;
                 _commitTemplates = new CommitTemplateItem[_maxCommitTemplates];
                 for (int i = 0; i < _commitTemplates.Length; i++)
                 {

--- a/GitUI/CommandsDialogs/CommitDialog/WordWrapper.cs
+++ b/GitUI/CommandsDialogs/CommitDialog/WordWrapper.cs
@@ -5,7 +5,7 @@ namespace GitUI.CommandsDialogs.CommitDialog
         private static IEnumerable<string> InternalWrapSingleLine(string line, int lineLimit)
         {
             WrapperState wrapper = new(lineLimit);
-            foreach (var word in line.Split())
+            foreach (string word in line.Split())
             {
                 if (!wrapper.CanAddWord(word))
                 {
@@ -23,7 +23,7 @@ namespace GitUI.CommandsDialogs.CommitDialog
 
         public static string WrapSingleLine(string text, int lineLimit)
         {
-            var lines = InternalWrapSingleLine(text, lineLimit);
+            IEnumerable<string> lines = InternalWrapSingleLine(text, lineLimit);
             return string.Join(Environment.NewLine, lines);
         }
 
@@ -50,13 +50,13 @@ namespace GitUI.CommandsDialogs.CommitDialog
 
             public bool CanAddWord(string word)
             {
-                var newLength = _wordsLength + _wordList.Count + word.Length;
+                int newLength = _wordsLength + _wordList.Count + word.Length;
                 return (newLength < _lineLimit) || _wordList.Any() == false;
             }
 
             public string GetLineAndReset()
             {
-                var line = string.Join(" ", _wordList);
+                string line = string.Join(" ", _wordList);
                 Reset();
                 return line;
             }

--- a/GitUI/CommandsDialogs/FormAbout.cs
+++ b/GitUI/CommandsDialogs/FormAbout.cs
@@ -31,8 +31,8 @@ namespace GitUI.CommandsDialogs
             pictureDonate.Click += delegate { OsShellUtil.OpenUrlInDefaultBrowser(FormDonate.DonationUrl); };
             linkLabelIcons.LinkClicked += delegate { OsShellUtil.OpenUrlInDefaultBrowser(@"http://p.yusukekamiyamane.com/"); };
 
-            var contributorsList = GetContributorList();
-            var thanksToContributorsText = string.Format(_thanksToContributors.Text, contributorsList.Count);
+            IReadOnlyList<string> contributorsList = GetContributorList();
+            string thanksToContributorsText = string.Format(_thanksToContributors.Text, contributorsList.Count);
 
             Random random = new();
 
@@ -54,7 +54,7 @@ namespace GitUI.CommandsDialogs
             void ThankNextContributor()
             {
                 // Select a contributor at random
-                var contributorName = contributorsList[random.Next(contributorsList.Count)].Trim();
+                string contributorName = contributorsList[random.Next(contributorsList.Count)].Trim();
 
                 _NO_TRANSLATE_ThanksTo.Text = thanksToContributorsText + contributorName;
             }

--- a/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -53,7 +53,7 @@ namespace GitUI.CommandsDialogs
 
         private void AddToIgnoreClick(object sender, EventArgs e)
         {
-            var patterns = GetCurrentPatterns().ToArray();
+            string[] patterns = GetCurrentPatterns().ToArray();
             if (patterns.Length == 0)
             {
                 Close();
@@ -62,7 +62,7 @@ namespace GitUI.CommandsDialogs
 
             try
             {
-                var fileName = ExcludeFile;
+                string fileName = ExcludeFile;
                 Validates.NotNull(fileName);
                 FileInfoExtensions.MakeFileTemporaryWritable(fileName, x =>
                 {
@@ -73,7 +73,7 @@ namespace GitUI.CommandsDialogs
                         gitIgnoreFileAddition.Append(Environment.NewLine);
                     }
 
-                    foreach (var pattern in patterns)
+                    foreach (string pattern in patterns)
                     {
                         gitIgnoreFileAddition.Append(pattern);
                         gitIgnoreFileAddition.Append(Environment.NewLine);

--- a/GitUI/CommandsDialogs/FormArchive.cs
+++ b/GitUI/CommandsDialogs/FormArchive.cs
@@ -130,7 +130,7 @@ namespace GitUI.CommandsDialogs
             {
                 string format = GetSelectedOutputFormat() == OutputFormat.Zip ? "zip" : "tar";
 
-                var arguments = string.Format(@"archive --format=""{0}"" {1} --output ""{2}"" {3}", format, revision, saveFileDialog.FileName, GetPathArgumentFromGui());
+                string arguments = string.Format(@"archive --format=""{0}"" {1} --output ""{2}"" {3}", format, revision, saveFileDialog.FileName, GetPathArgumentFromGui());
                 FormProcess.ShowDialog(this, UICommands, arguments, Module.WorkingDir, input: null, useDialogSettings: true);
                 Close();
             }
@@ -148,7 +148,7 @@ namespace GitUI.CommandsDialogs
             else if (checkboxRevisionFilter.Checked)
             {
                 // 1. get all changed (and not deleted files) from selected to current revision
-                var files = UICommands.Module.GetDiffFilesWithUntracked(DiffSelectedRevision?.Guid, SelectedRevision?.Guid, StagedStatus.None).Where(f => !f.IsDeleted);
+                IEnumerable<GitItemStatus> files = UICommands.Module.GetDiffFilesWithUntracked(DiffSelectedRevision?.Guid, SelectedRevision?.Guid, StagedStatus.None).Where(f => !f.IsDeleted);
 
                 // 2. wrap file names with ""
                 // 3. join together with space as separator

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -156,7 +156,7 @@ namespace GitUI.CommandsDialogs
 
         private void ApplyLayout()
         {
-            var controls1 = new Control[]
+            Control[] controls1 = new Control[]
             {
                 tlpnlBranches,
                 horLine,
@@ -170,9 +170,9 @@ namespace GitUI.CommandsDialogs
             Width = tlpnlMain.PreferredSize.Width + 50;
 
             int height;
-            for (var i = 0; i < controls1.Length; i++)
+            for (int i = 0; i < controls1.Length; i++)
             {
-                var margin = controls1[i].Margin;
+                Padding margin = controls1[i].Margin;
                 height = controls1[i].Height + margin.Top + margin.Bottom;
                 _controls.Add(controls1[i], height);
 
@@ -195,7 +195,7 @@ namespace GitUI.CommandsDialogs
 
             if (_containRevisions is null)
             {
-                var branches = LocalBranch.Checked ? GetLocalBranches() : GetRemoteBranches();
+                IEnumerable<IGitRef> branches = LocalBranch.Checked ? GetLocalBranches() : GetRemoteBranches();
 
                 branchNames = branches.Select(b => b.Name);
             }
@@ -220,7 +220,7 @@ namespace GitUI.CommandsDialogs
                 HashSet<string> result = new();
                 if (_containRevisions.Count > 0)
                 {
-                    var branches = Module.GetAllBranchesWhichContainGivenCommit(_containRevisions[0], LocalBranch.Checked,
+                    IEnumerable<string> branches = Module.GetAllBranchesWhichContainGivenCommit(_containRevisions[0], LocalBranch.Checked,
                             !LocalBranch.Checked)
                         .Where(a => !DetachedHeadParser.IsDetachedHead(a) &&
                                     !a.EndsWith("/HEAD"));
@@ -229,8 +229,8 @@ namespace GitUI.CommandsDialogs
 
                 for (int index = 1; index < _containRevisions.Count; index++)
                 {
-                    var containRevision = _containRevisions[index];
-                    var branches =
+                    ObjectId containRevision = _containRevisions[index];
+                    IEnumerable<string> branches =
                         Module.GetAllBranchesWhichContainGivenCommit(containRevision, LocalBranch.Checked,
                                 !LocalBranch.Checked)
                             .Where(a => !DetachedHeadParser.IsDetachedHead(a) &&
@@ -257,10 +257,10 @@ namespace GitUI.CommandsDialogs
             // if the user hits [Enter] at any point, we need to trigger txtCustomBranchName Leave event
             Ok.Focus();
 
-            var branchName = Branches.Text.Trim();
-            var isRemote = Remotebranch.Checked;
-            var newBranchName = (string?)null;
-            var newBranchMode = CheckoutNewBranchMode.DontCreate;
+            string branchName = Branches.Text.Trim();
+            bool isRemote = Remotebranch.Checked;
+            string newBranchName = (string?)null;
+            CheckoutNewBranchMode newBranchMode = CheckoutNewBranchMode.DontCreate;
 
             if (isRemote)
             {
@@ -288,8 +288,8 @@ namespace GitUI.CommandsDialogs
                     IGitRef remoteBranchRef = GetRemoteBranchRef(branchName);
                     if (localBranchRef is not null && remoteBranchRef is not null && localBranchRef.ObjectId is not null && remoteBranchRef.ObjectId is not null)
                     {
-                        var mergeBaseGuid = Module.GetMergeBase(localBranchRef.ObjectId, remoteBranchRef.ObjectId);
-                        var isResetFastForward = localBranchRef.ObjectId == mergeBaseGuid;
+                        ObjectId mergeBaseGuid = Module.GetMergeBase(localBranchRef.ObjectId, remoteBranchRef.ObjectId);
+                        bool isResetFastForward = localBranchRef.ObjectId == mergeBaseGuid;
 
                         if (!isResetFastForward)
                         {
@@ -316,7 +316,7 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            var localChanges = ChangesMode;
+            LocalChangesAction localChanges = ChangesMode;
             if (localChanges != LocalChangesAction.Reset && chkSetLocalChangesActionAsDefault.Checked)
             {
                 AppSettings.CheckoutBranchAction = localChanges;
@@ -342,7 +342,7 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            var originalId = Module.GetCurrentCheckout();
+            ObjectId originalId = Module.GetCurrentCheckout();
 
             bool success = ScriptsRunner.RunEventScripts(ScriptEvent.BeforeCheckout, this);
             if (!success)
@@ -384,7 +384,7 @@ namespace GitUI.CommandsDialogs
                     }
                 }
 
-                var currentId = Module.GetCurrentCheckout();
+                ObjectId currentId = Module.GetCurrentCheckout();
 
                 if (originalId != currentId)
                 {
@@ -440,7 +440,7 @@ namespace GitUI.CommandsDialogs
         {
             lbChanges.Text = "";
 
-            var branch = Branches.Text;
+            string branch = Branches.Text;
             if (string.IsNullOrWhiteSpace(branch) || !Remotebranch.Checked)
             {
                 _remoteName = string.Empty;
@@ -451,7 +451,7 @@ namespace GitUI.CommandsDialogs
             {
                 _remoteName = GitRefName.GetRemoteName(branch, Module.GetRemoteNames());
                 _localBranchName = Module.GetLocalTrackingBranchName(_remoteName, branch) ?? "";
-                var remoteBranchName = _remoteName.Length > 0 ? branch[(_remoteName.Length + 1)..] : branch;
+                string remoteBranchName = _remoteName.Length > 0 ? branch[(_remoteName.Length + 1)..] : branch;
                 _newLocalBranchName = string.Concat(_remoteName, "_", remoteBranchName);
                 int i = 2;
                 while (LocalBranchExists(_newLocalBranchName))
@@ -475,11 +475,11 @@ namespace GitUI.CommandsDialogs
             {
                 ThreadHelper.FileAndForget(async () =>
                     {
-                        var currentCheckout = Module.GetCurrentCheckout();
+                        ObjectId currentCheckout = Module.GetCurrentCheckout();
 
                         Validates.NotNull(currentCheckout);
 
-                        var text = Module.GetCommitCountString(currentCheckout.ToString(), branch);
+                        string text = Module.GetCommitCountString(currentCheckout.ToString(), branch);
 
                         await this.SwitchToMainThreadAsync();
 
@@ -543,8 +543,8 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var caretPosition = txtCustomBranchName.SelectionStart;
-            var normalisedBranchName = _branchNameNormaliser.Normalise(txtCustomBranchName.Text, _gitBranchNameOptions);
+            int caretPosition = txtCustomBranchName.SelectionStart;
+            string normalisedBranchName = _branchNameNormaliser.Normalise(txtCustomBranchName.Text, _gitBranchNameOptions);
             txtCustomBranchName.Text = normalisedBranchName;
             txtCustomBranchName.SelectionStart = caretPosition;
         }

--- a/GitUI/CommandsDialogs/FormCheckoutRevision.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutRevision.cs
@@ -28,7 +28,7 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                var selectedObjectId = commitPickerSmallControl1.SelectedObjectId;
+                GitUIPluginInterfaces.ObjectId selectedObjectId = commitPickerSmallControl1.SelectedObjectId;
 
                 if (selectedObjectId is null)
                 {
@@ -36,7 +36,7 @@ namespace GitUI.CommandsDialogs
                     return;
                 }
 
-                var checkedOutObjectId = Module.GetCurrentCheckout();
+                GitUIPluginInterfaces.ObjectId checkedOutObjectId = Module.GetCurrentCheckout();
 
                 Debug.Assert(checkedOutObjectId is not null, "checkedOutObjectId is not null");
 

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -75,7 +75,7 @@ namespace GitUI.CommandsDialogs
                         string text = Clipboard.GetText(TextDataFormat.Text) ?? string.Empty;
 
                         // See if it's a valid URL.
-                        if (TryExtractUrl(text, out var possibleURL))
+                        if (TryExtractUrl(text, out string possibleURL))
                         {
                             _NO_TRANSLATE_From.Text = possibleURL;
                         }
@@ -90,10 +90,10 @@ namespace GitUI.CommandsDialogs
                 // that the cloned repository is hosted on the same server
                 if (string.IsNullOrWhiteSpace(_NO_TRANSLATE_From.Text) && Module.IsValidGitWorkingDir())
                 {
-                    var currentBranchRemote = Module.GetSetting(string.Format(SettingKeyString.BranchRemote, Module.GetSelectedBranch()));
+                    string currentBranchRemote = Module.GetSetting(string.Format(SettingKeyString.BranchRemote, Module.GetSelectedBranch()));
                     if (string.IsNullOrEmpty(currentBranchRemote))
                     {
-                        var remotes = Module.GetRemoteNames();
+                        IReadOnlyList<string> remotes = Module.GetRemoteNames();
 
                         if (remotes.Any(s => s.Equals("origin", StringComparison.InvariantCultureIgnoreCase)))
                         {
@@ -156,7 +156,7 @@ namespace GitUI.CommandsDialogs
                 _branchListLoader.Cancel();
 
                 // validate if destination path is supplied
-                var destination = _NO_TRANSLATE_To.Text;
+                string destination = _NO_TRANSLATE_To.Text;
                 if (string.IsNullOrWhiteSpace(destination))
                 {
                     MessageBox.Show(this, _errorDestinationNotSupplied.Text, _errorCloneFailed.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -171,7 +171,7 @@ namespace GitUI.CommandsDialogs
                     return;
                 }
 
-                var dirTo = Path.Combine(destination, _NO_TRANSLATE_NewDirectory.Text);
+                string dirTo = Path.Combine(destination, _NO_TRANSLATE_NewDirectory.Text);
 
                 // this will fail if the path is anyhow invalid
                 dirTo = PathUtil.Resolve(dirTo);
@@ -210,7 +210,7 @@ namespace GitUI.CommandsDialogs
                 string sourceRepo = PathUtil.IsLocalFile(_NO_TRANSLATE_From.Text)
                     ? UICommands.Module.GetGitExecPath(_NO_TRANSLATE_From.Text)
                     : _NO_TRANSLATE_From.Text;
-                var cloneCmd = Commands.Clone(sourceRepo,
+                GitExtUtils.ArgumentString cloneCmd = Commands.Clone(sourceRepo,
                     UICommands.Module.GetGitExecPath(dirTo),
                     CentralRepository.Checked,
                     cbIntializeAllSubmodules.Checked,
@@ -267,7 +267,7 @@ namespace GitUI.CommandsDialogs
 
         private void FromBrowseClick(object sender, EventArgs e)
         {
-            var userSelectedPath = OsShellUtil.PickFolder(this, _NO_TRANSLATE_From.Text);
+            string userSelectedPath = OsShellUtil.PickFolder(this, _NO_TRANSLATE_From.Text);
 
             if (userSelectedPath is not null)
             {
@@ -279,7 +279,7 @@ namespace GitUI.CommandsDialogs
 
         private void ToBrowseClick(object sender, EventArgs e)
         {
-            var userSelectedPath = OsShellUtil.PickFolder(this, _NO_TRANSLATE_To.Text);
+            string userSelectedPath = OsShellUtil.PickFolder(this, _NO_TRANSLATE_To.Text);
 
             if (userSelectedPath is not null)
             {
@@ -446,7 +446,7 @@ namespace GitUI.CommandsDialogs
                 return false;
             }
 
-            var parts = contents.Split(' ');
+            string[] parts = contents.Split(' ');
             foreach (string s in parts)
             {
                 if (PathUtil.CanBeGitURL(s))

--- a/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -65,8 +65,8 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var caretPosition = BranchNameTextBox.SelectionStart;
-            var branchName = _branchNameNormaliser.Normalise(BranchNameTextBox.Text, _gitBranchNameOptions);
+            int caretPosition = BranchNameTextBox.SelectionStart;
+            string branchName = _branchNameNormaliser.Normalise(BranchNameTextBox.Text, _gitBranchNameOptions);
             BranchNameTextBox.Text = branchName;
             BranchNameTextBox.SelectionStart = caretPosition;
         }
@@ -77,7 +77,7 @@ namespace GitUI.CommandsDialogs
 
             // ensure all labels are wrapped if required
             // this must happen only after the label texts have been set
-            foreach (var label in this.FindDescendantsOfType<Label>())
+            foreach (Label label in this.FindDescendantsOfType<Label>())
             {
                 label.AutoSize = true;
             }
@@ -95,7 +95,7 @@ namespace GitUI.CommandsDialogs
             // if the user hits [Enter] at any point, we need to trigger BranchNameTextBox Leave event
             Ok.Focus();
 
-            var objectId = commitPickerSmallControl1.SelectedObjectId;
+            ObjectId objectId = commitPickerSmallControl1.SelectedObjectId;
             if (objectId is null)
             {
                 MessageBox.Show(this, _noRevisionSelected.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -103,7 +103,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var branchName = BranchNameTextBox.Text.Trim();
+            string branchName = BranchNameTextBox.Text.Trim();
             if (string.IsNullOrWhiteSpace(branchName))
             {
                 MessageBox.Show(_branchNameIsEmpty.Text, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -120,9 +120,9 @@ namespace GitUI.CommandsDialogs
 
             try
             {
-                var originalHash = Module.GetCurrentCheckout();
+                ObjectId originalHash = Module.GetCurrentCheckout();
 
-                var command = Orphan.Checked
+                GitExtUtils.ArgumentString command = Orphan.Checked
                     ? Commands.CreateOrphan(branchName, objectId)
                     : Commands.Branch(branchName, objectId.ToString(), chkbxCheckoutAfterCreate.Checked);
 

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -66,7 +66,7 @@ namespace GitUI.CommandsDialogs
 
         private void Delete_Click(object sender, EventArgs e)
         {
-            var selectedBranches = Branches.GetSelectedBranches().ToArray();
+            IGitRef[] selectedBranches = Branches.GetSelectedBranches().ToArray();
             if (!selectedBranches.Any())
             {
                 return;

--- a/GitUI/CommandsDialogs/FormDeleteTag.cs
+++ b/GitUI/CommandsDialogs/FormDeleteTag.cs
@@ -52,7 +52,7 @@ namespace GitUI.CommandsDialogs
 
         private void RemoveRemoteTag(string tagName)
         {
-            var pushCmd = string.Format("push \"{0}\" :refs/tags/{1}", remotesComboboxControl1.SelectedRemote, tagName);
+            string pushCmd = string.Format("push \"{0}\" :refs/tags/{1}", remotesComboboxControl1.SelectedRemote, tagName);
 
             bool success = ScriptsRunner.RunEventScripts(ScriptEvent.BeforePush, this);
             if (!success)

--- a/GitUI/CommandsDialogs/FormEditor.cs
+++ b/GitUI/CommandsDialogs/FormEditor.cs
@@ -71,7 +71,7 @@ namespace GitUI.CommandsDialogs
             // only offer to save if there's something to save.
             if (HasChanges)
             {
-                var saveChangesAnswer = MessageBox.Show(this, _saveChanges.Text, _saveChangesCaption.Text,
+                DialogResult saveChangesAnswer = MessageBox.Show(this, _saveChanges.Text, _saveChangesCaption.Text,
                                          MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
                 switch (saveChangesAnswer)
                 {

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -82,7 +82,7 @@ namespace GitUI.CommandsDialogs
 
             Diff.ExtraDiffArgumentsChanged += (sender, e) => UpdateSelectedFileViewers();
 
-            var isSubmodule = GitModule.IsValidGitWorkingDir(_fullPathResolver.Resolve(FileName));
+            bool isSubmodule = GitModule.IsValidGitWorkingDir(_fullPathResolver.Resolve(FileName));
 
             if (isSubmodule)
             {
@@ -236,7 +236,7 @@ namespace GitUI.CommandsDialogs
 
         private void SetTitle(string? alternativeFileName = null)
         {
-            var str = new StringBuilder()
+            StringBuilder str = new StringBuilder()
                 .Append("File History - ")
                 .Append(FileName);
 
@@ -252,7 +252,7 @@ namespace GitUI.CommandsDialogs
 
         private void UpdateSelectedFileViewers(bool force = false)
         {
-            var selectedRevisions = RevisionGrid.GetSelectedRevisions();
+            IReadOnlyList<GitRevision> selectedRevisions = RevisionGrid.GetSelectedRevisions();
 
             if (selectedRevisions.Count == 0)
             {
@@ -260,7 +260,7 @@ namespace GitUI.CommandsDialogs
             }
 
             GitRevision revision = selectedRevisions[0];
-            var children = RevisionGrid.GetRevisionChildren(revision.ObjectId);
+            IReadOnlyList<ObjectId> children = RevisionGrid.GetRevisionChildren(revision.ObjectId);
             string fileName = GetFileNameForRevision(revision) ?? FileName;
 
             SetTitle(fileName);
@@ -379,7 +379,7 @@ namespace GitUI.CommandsDialogs
 
         private void OpenFilesWithDiffTool(RevisionDiffKind diffKind, object sender)
         {
-            var item = sender as ToolStripMenuItem;
+            ToolStripMenuItem item = sender as ToolStripMenuItem;
             if (item?.DropDownItems != null)
             {
                 // "main menu" clicked, cancel dropdown manually, invoke default mergetool
@@ -387,9 +387,9 @@ namespace GitUI.CommandsDialogs
                 item.Owner.Hide();
             }
 
-            var toolName = item?.Tag as string;
-            var selectedRevisions = RevisionGrid.GetSelectedRevisions();
-            var orgFileName = selectedRevisions.Count != 0
+            string toolName = item?.Tag as string;
+            IReadOnlyList<GitRevision> selectedRevisions = RevisionGrid.GetSelectedRevisions();
+            string orgFileName = selectedRevisions.Count != 0
                 ? GetFileNameForRevision(selectedRevisions[0])
                 : null;
 
@@ -479,7 +479,7 @@ namespace GitUI.CommandsDialogs
 
         private void cherryPickThisCommitToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var selectedRevisions = RevisionGrid.GetSelectedRevisions();
+            IReadOnlyList<GitRevision> selectedRevisions = RevisionGrid.GetSelectedRevisions();
             if (selectedRevisions.Count == 1)
             {
                 UICommands.StartCherryPickDialog(this, selectedRevisions[0]);
@@ -488,7 +488,7 @@ namespace GitUI.CommandsDialogs
 
         private void revertCommitToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var selectedRevisions = RevisionGrid.GetSelectedRevisions();
+            IReadOnlyList<GitRevision> selectedRevisions = RevisionGrid.GetSelectedRevisions();
             if (selectedRevisions.Count == 1)
             {
                 UICommands.StartRevertCommitDialog(this, selectedRevisions[0]);
@@ -497,7 +497,7 @@ namespace GitUI.CommandsDialogs
 
         private void FileHistoryContextMenuOpening(object sender, CancelEventArgs e)
         {
-            var selectedRevisions = RevisionGrid.GetSelectedRevisions();
+            IReadOnlyList<GitRevision> selectedRevisions = RevisionGrid.GetSelectedRevisions();
 
             diffToolRemoteLocalStripMenuItem.Enabled =
                 selectedRevisions.Count == 1 && selectedRevisions[0].ObjectId != ObjectId.WorkTreeId &&
@@ -538,7 +538,7 @@ namespace GitUI.CommandsDialogs
             if (e.Command == "gotocommit")
             {
                 Validates.NotNull(e.Data);
-                if (Module.TryResolvePartialCommitId(e.Data, out var objectId))
+                if (Module.TryResolvePartialCommitId(e.Data, out ObjectId? objectId))
                 {
                     if (!RevisionGrid.SetSelectedRevision(objectId))
                     {

--- a/GitUI/CommandsDialogs/FormFormatPatch.cs
+++ b/GitUI/CommandsDialogs/FormFormatPatch.cs
@@ -46,7 +46,7 @@ namespace GitUI.CommandsDialogs
 
         private void Browse_Click(object sender, EventArgs e)
         {
-            var userSelectedPath = OsShellUtil.PickFolder(this);
+            string userSelectedPath = OsShellUtil.PickFolder(this);
 
             if (userSelectedPath is not null)
             {
@@ -120,19 +120,19 @@ namespace GitUI.CommandsDialogs
             string rev2 = "";
             string result = "";
 
-            var revisions = RevisionGrid.GetSelectedRevisions(SortDirection.Descending);
+            IReadOnlyList<GitRevision> revisions = RevisionGrid.GetSelectedRevisions(SortDirection.Descending);
             if (revisions.Count > 0)
             {
                 if (revisions.Count == 1)
                 {
-                    var parents = revisions[0].ParentIds;
+                    IReadOnlyList<ObjectId> parents = revisions[0].ParentIds;
                     rev1 = parents?.Count > 0 ? parents[0].ToString() : "";
                     rev2 = revisions[0].Guid;
                     result = Module.FormatPatch(rev1, rev2, savePatchesToDir);
                 }
                 else if (revisions.Count == 2)
                 {
-                    var parents = revisions[0].ParentIds;
+                    IReadOnlyList<ObjectId> parents = revisions[0].ParentIds;
                     rev1 = parents?.Count > 0 ? parents[0].ToString() : "";
                     rev2 = revisions[1].Guid;
                     result = Module.FormatPatch(rev1, rev2, savePatchesToDir);
@@ -143,7 +143,7 @@ namespace GitUI.CommandsDialogs
                     foreach (GitRevision revision in revisions)
                     {
                         n++;
-                        var parents = revision.ParentIds;
+                        IReadOnlyList<ObjectId> parents = revision.ParentIds;
                         rev1 = parents?.Count > 0 ? parents[0].ToString() : "";
                         rev2 = revision.Guid;
                         result += Module.FormatPatch(rev1, rev2, savePatchesToDir, n);

--- a/GitUI/CommandsDialogs/FormGitAttributes.cs
+++ b/GitUI/CommandsDialogs/FormGitAttributes.cs
@@ -43,7 +43,7 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                var path = _fullPathResolver.Resolve(".gitattributes");
+                string path = _fullPathResolver.Resolve(".gitattributes");
                 if (File.Exists(path))
                 {
                     _NO_TRANSLATE_GitAttributesText.ViewFileAsync(path!);
@@ -91,7 +91,7 @@ namespace GitUI.CommandsDialogs
 
         private void FormGitAttributesClosing(object sender, FormClosingEventArgs e)
         {
-            var needToClose = false;
+            bool needToClose = false;
 
             if (!IsFileUpToDate())
             {

--- a/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -137,7 +137,7 @@ namespace GitUI.CommandsDialogs
                         ExcludeFile,
                         x =>
                         {
-                            var fileContent = _NO_TRANSLATE_GitIgnoreEdit.GetText();
+                            string fileContent = _NO_TRANSLATE_GitIgnoreEdit.GetText();
                             if (!fileContent.EndsWith(Environment.NewLine))
                             {
                                 fileContent += Environment.NewLine;
@@ -190,10 +190,10 @@ namespace GitUI.CommandsDialogs
 
         private void AddDefaultClick(object sender, EventArgs e)
         {
-            var defaultIgnorePatterns = File.Exists(DefaultIgnorePatternsFile) ? File.ReadAllLines(DefaultIgnorePatternsFile) : DefaultIgnorePatterns;
+            string[] defaultIgnorePatterns = File.Exists(DefaultIgnorePatternsFile) ? File.ReadAllLines(DefaultIgnorePatternsFile) : DefaultIgnorePatterns;
 
-            var currentFileContent = _NO_TRANSLATE_GitIgnoreEdit.GetText();
-            var patternsToAdd = defaultIgnorePatterns
+            string currentFileContent = _NO_TRANSLATE_GitIgnoreEdit.GetText();
+            string[] patternsToAdd = defaultIgnorePatterns
                 .Except(currentFileContent.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries))
                 .ToArray();
             if (patternsToAdd.Length == 0)

--- a/GitUI/CommandsDialogs/FormInit.cs
+++ b/GitUI/CommandsDialogs/FormInit.cs
@@ -40,7 +40,7 @@ namespace GitUI.CommandsDialogs
 
         private void InitClick(object sender, EventArgs e)
         {
-            var directoryPath = _NO_TRANSLATE_Directory.Text;
+            string directoryPath = _NO_TRANSLATE_Directory.Text;
 
             if (!IsRootedDirectoryPath(directoryPath))
             {
@@ -95,7 +95,7 @@ namespace GitUI.CommandsDialogs
 
         private void BrowseClick(object sender, EventArgs e)
         {
-            var userSelectedPath = OsShellUtil.PickFolder(this);
+            string userSelectedPath = OsShellUtil.PickFolder(this);
 
             if (userSelectedPath is not null)
             {

--- a/GitUI/CommandsDialogs/FormRevertCommit.cs
+++ b/GitUI/CommandsDialogs/FormRevertCommit.cs
@@ -35,7 +35,7 @@ namespace GitUI.CommandsDialogs
             parentListPanel.Visible = _isMerge;
             if (_isMerge)
             {
-                var parents = Module.GetParentRevisions(Revision.ObjectId);
+                IReadOnlyList<GitRevision> parents = Module.GetParentRevisions(Revision.ObjectId);
 
                 for (int i = 0; i < parents.Count; i++)
                 {

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -63,7 +63,7 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                foreach (var settingsPage in SettingsPages)
+                foreach (ISettingsPage settingsPage in SettingsPages)
                 {
                     settingsPage.LoadSettings();
                 }
@@ -110,14 +110,14 @@ namespace GitUI.CommandsDialogs
 
             // Git Extensions settings
             settingsTreeView.AddSettingsPage(new GitExtensionsSettingsGroup(), null, Images.GitExtensionsLogo16);
-            var gitExtPageRef = GitExtensionsSettingsGroup.GetPageReference();
+            SettingsPageReference gitExtPageRef = GitExtensionsSettingsGroup.GetPageReference();
             settingsTreeView.AddSettingsPage(checklistSettingsPage, gitExtPageRef, icon: null, asRoot: true);
 
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<GeneralSettingsPage>(this, serviceProvider), gitExtPageRef, Images.GeneralSettings);
 
             // >> Appearance
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<AppearanceSettingsPage>(this, serviceProvider), gitExtPageRef, Images.Appearance);
-            var appearanceSettingsPage = AppearanceSettingsPage.GetPageReference();
+            SettingsPageReference appearanceSettingsPage = AppearanceSettingsPage.GetPageReference();
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<SortingSettingsPage>(this, serviceProvider), appearanceSettingsPage, Images.SortBy);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<ColorsSettingsPage>(this, serviceProvider), appearanceSettingsPage, Images.Colors);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<AppearanceFontsSettingsPage>(this, serviceProvider), appearanceSettingsPage, Images.Font.AdaptLightness());
@@ -140,19 +140,19 @@ namespace GitUI.CommandsDialogs
 
             // >> Detailed
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<DetailedSettingsPage>(this, serviceProvider), gitExtPageRef, Images.Settings);
-            var detailedSettingsPage = DetailedSettingsPage.GetPageReference();
+            SettingsPageReference detailedSettingsPage = DetailedSettingsPage.GetPageReference();
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<FormBrowseRepoSettingsPage>(this, serviceProvider), detailedSettingsPage, Images.BranchFolder);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<CommitDialogSettingsPage>(this, serviceProvider), detailedSettingsPage, Images.CommitSummary);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<DiffViewerSettingsPage>(this, serviceProvider), detailedSettingsPage, Images.Diff);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<BlameViewerSettingsPage>(this, serviceProvider), detailedSettingsPage, Images.Blame);
 
-            var sshSettingsPage = SettingsPageBase.Create<SshSettingsPage>(this, serviceProvider);
+            SshSettingsPage sshSettingsPage = SettingsPageBase.Create<SshSettingsPage>(this, serviceProvider);
             settingsTreeView.AddSettingsPage(sshSettingsPage, gitExtPageRef, Images.Key);
             checklistSettingsPage.SshSettingsPage = sshSettingsPage;
 
             // Git settings
             settingsTreeView.AddSettingsPage(new GitSettingsGroup(), null, Images.GitLogo16);
-            var gitPageRef = GitSettingsGroup.GetPageReference();
+            SettingsPageReference gitPageRef = GitSettingsGroup.GetPageReference();
 
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<GitSettingsPage>(this, serviceProvider), gitPageRef, Images.FolderOpen);
             settingsTreeView.AddSettingsPage(SettingsPageBase.Create<GitConfigSettingsPage>(this, serviceProvider), gitPageRef, Images.GeneralSettings);
@@ -166,14 +166,14 @@ namespace GitUI.CommandsDialogs
 
             lock (PluginRegistry.Plugins)
             {
-                var pluginEntries = PluginRegistry.Plugins
+                IOrderedEnumerable<(GitUIPluginInterfaces.IGitPlugin plugin, PluginSettingsPage page)> pluginEntries = PluginRegistry.Plugins
                     .Where(p => p.HasSettings)
                     .Select(plugin => (Plugin: plugin, Page: PluginSettingsPage.CreateSettingsPageFromPlugin(this, plugin, UICommands)))
                     .OrderBy(entry => entry.Page.GetTitle(), StringComparer.CurrentCultureIgnoreCase);
 
-                foreach (var entry in pluginEntries)
+                foreach ((GitUIPluginInterfaces.IGitPlugin plugin, PluginSettingsPage page) entry in pluginEntries)
                 {
-                    settingsTreeView.AddSettingsPage(entry.Page, pluginsPageRef, entry.Plugin.Icon as Bitmap);
+                    settingsTreeView.AddSettingsPage(entry.page, pluginsPageRef, entry.plugin.Icon as Bitmap);
                 }
             }
 
@@ -184,7 +184,7 @@ namespace GitUI.CommandsDialogs
         {
             panelCurrentSettingsPage.Controls.Clear();
 
-            var settingsPage = e.SettingsPage;
+            ISettingsPage settingsPage = e.SettingsPage;
 
             _lastSelectedSettingsPageType = settingsPage.GetType();
 
@@ -227,7 +227,7 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                foreach (var settingsPage in SettingsPages)
+                foreach (ISettingsPage settingsPage in SettingsPages)
                 {
                     settingsPage.SaveSettings();
                 }

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopy.cs
@@ -92,7 +92,7 @@ namespace GitUI.CommandsDialogs
 
             Panel panelHeader = CreateViewHeader();
 
-            Panel panelFooter = CreateViewFooter(sparse, tooltip, out var btnSave, out var btnCancel);
+            Panel panelFooter = CreateViewFooter(sparse, tooltip, out Button btnSave, out Button btnCancel);
 
             Control panelOnOff = CreateViewOnOff(sparse, tooltip);
 

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -50,7 +50,7 @@ namespace GitUI.CommandsDialogs
         {
             if (e.KeyCode == Keys.Escape && e.Modifiers == Keys.None)
             {
-                var focusedControl = this.FindFocusedControl();
+                Control focusedControl = this.FindFocusedControl();
 
                 switch (focusedControl)
                 {
@@ -117,7 +117,7 @@ namespace GitUI.CommandsDialogs
 
         private void Initialize()
         {
-            var stashedItems = Module.GetStashes().ToList();
+            List<GitStash> stashedItems = Module.GetStashes().ToList();
 
             _currentWorkingDirStashItem = new GitStash(-1, _currentWorkingDirChanges.Text);
 
@@ -263,17 +263,17 @@ namespace GitUI.CommandsDialogs
                     {
                         ParentIds = new[] { headId }
                     };
-                    var indexItems = gitItemStatuses.Where(item => item.Staged == StagedStatus.Index).ToList();
-                    var workTreeItems = gitItemStatuses.Where(item => item.Staged != StagedStatus.Index).ToList();
+                    List<GitItemStatus> indexItems = gitItemStatuses.Where(item => item.Staged == StagedStatus.Index).ToList();
+                    List<GitItemStatus> workTreeItems = gitItemStatuses.Where(item => item.Staged != StagedStatus.Index).ToList();
                     Stashed.SetStashDiffs(headRev, indexRev, ResourceManager.TranslatedStrings.Index, indexItems, workTreeRev, ResourceManager.TranslatedStrings.Workspace, workTreeItems);
                 }
             }
             else
             {
-                var firstId = Module.RevParse(gitStash.Name + "^");
-                var firstRev = firstId is null ? null : new GitRevision(firstId);
+                ObjectId firstId = Module.RevParse(gitStash.Name + "^");
+                GitRevision firstRev = firstId is null ? null : new GitRevision(firstId);
 
-                var selectedId = Module.RevParse(gitStash.Name);
+                ObjectId selectedId = Module.RevParse(gitStash.Name);
                 Validates.NotNull(selectedId);
                 GitRevision secondRev = new(selectedId);
                 if (firstId is not null)
@@ -306,7 +306,7 @@ namespace GitUI.CommandsDialogs
         {
             using (WaitCursorScope.Enter())
             {
-                var msg = !string.IsNullOrWhiteSpace(StashMessage.Text) ? " " + StashMessage.Text.Trim() : string.Empty;
+                string msg = !string.IsNullOrWhiteSpace(StashMessage.Text) ? " " + StashMessage.Text.Trim() : string.Empty;
                 UICommands.StashSave(this, chkIncludeUntrackedFiles.Checked, StashKeepIndex.Checked, msg);
                 Initialize();
             }
@@ -316,7 +316,7 @@ namespace GitUI.CommandsDialogs
         {
             using (WaitCursorScope.Enter())
             {
-                var msg = !string.IsNullOrWhiteSpace(StashMessage.Text) ? " " + StashMessage.Text.Trim() : string.Empty;
+                string msg = !string.IsNullOrWhiteSpace(StashMessage.Text) ? " " + StashMessage.Text.Trim() : string.Empty;
                 UICommands.StashSave(this, chkIncludeUntrackedFiles.Checked, StashKeepIndex.Checked, msg, Stashed.SelectedItems.Select(i => i.Item.Name).ToList());
                 Initialize();
             }
@@ -326,7 +326,7 @@ namespace GitUI.CommandsDialogs
         {
             using (new WaitCursorScope())
             {
-                var stashName = GetStashName();
+                string stashName = GetStashName();
                 if (!AppSettings.DontConfirmStashDrop)
                 {
                     TaskDialogPage page = new()

--- a/GitUI/CommandsDialogs/FormSubmodules.cs
+++ b/GitUI/CommandsDialogs/FormSubmodules.cs
@@ -66,7 +66,7 @@ namespace GitUI.CommandsDialogs
         private void Initialize()
         {
             _bw?.CancelAsync();
-            var waitScope = WaitCursorScope.Enter();
+            WaitCursorScope waitScope = WaitCursorScope.Enter();
             _oldSubmoduleInfo = null;
             if (Submodules.SelectedRows.Count == 1)
             {
@@ -85,7 +85,7 @@ namespace GitUI.CommandsDialogs
             };
             _bw.DoWork += (sender, e) =>
             {
-                foreach (var oldSubmodule in Module.GetSubmodulesInfo().Where(submodule => submodule is not null))
+                foreach (IGitSubmoduleInfo oldSubmodule in Module.GetSubmodulesInfo().Where(submodule => submodule is not null))
                 {
                     if (_bw.CancellationPending)
                     {
@@ -176,7 +176,7 @@ namespace GitUI.CommandsDialogs
                     Module.UnstageFile(".gitmodules");
                 }
 
-                var configFile = Module.LocalConfigFile;
+                GitCommands.Settings.ConfigFileSettings configFile = Module.LocalConfigFile;
                 configFile.RemoveConfigSection("submodule \"" + SubModuleName.Text + "\"");
                 configFile.Save();
 
@@ -186,7 +186,7 @@ namespace GitUI.CommandsDialogs
 
         private void Pull_Click(object sender, EventArgs e)
         {
-            var submodule = Module.GetSubmodule(SubModuleLocalPath.Text);
+            GitModule submodule = Module.GetSubmodule(SubModuleLocalPath.Text);
 
             UICommands.WithGitModule(submodule).StartPullDialog(this);
 

--- a/GitUI/CommandsDialogs/FormVerify.LostObject.cs
+++ b/GitUI/CommandsDialogs/FormVerify.LostObject.cs
@@ -82,7 +82,7 @@ namespace GitUI.CommandsDialogs
                     throw new ArgumentException("Raw source must be non-empty string", raw);
                 }
 
-                var patternMatch = RawDataRegex.Match(raw);
+                Match patternMatch = RawDataRegex.Match(raw);
 
                 // show failed assertion for unsupported cases (for developers)
                 // if you get this message,
@@ -96,22 +96,22 @@ namespace GitUI.CommandsDialogs
                     return null;
                 }
 
-                var matchedGroups = patternMatch.Groups;
-                var rawType = matchedGroups[1].Value;
-                var objectType = GetObjectType(matchedGroups[3]);
-                var objectId = ObjectId.Parse(raw, matchedGroups[4]);
+                GroupCollection matchedGroups = patternMatch.Groups;
+                string rawType = matchedGroups[1].Value;
+                LostObjectType objectType = GetObjectType(matchedGroups[3]);
+                ObjectId objectId = ObjectId.Parse(raw, matchedGroups[4]);
                 LostObject result = new(objectType, rawType, objectId);
 
                 if (objectType == LostObjectType.Commit)
                 {
-                    var commitLog = GetLostCommitLog();
-                    var logPatternMatch = LogRegex.Match(commitLog);
+                    string commitLog = GetLostCommitLog();
+                    Match logPatternMatch = LogRegex.Match(commitLog);
                     if (logPatternMatch.Success)
                     {
                         result.Author = module.ReEncodeStringFromLossless(logPatternMatch.Groups["author"].Value);
                         result.Subject = module.ReEncodeCommitMessage(logPatternMatch.Groups["subject"].Value) ?? "";
                         result.Date = DateTimeUtils.ParseUnixTime(logPatternMatch.Groups["date"].Value);
-                        var firstParent = logPatternMatch.Groups["first_parent"].Value;
+                        string firstParent = logPatternMatch.Groups["first_parent"].Value;
                         if (!string.IsNullOrEmpty(firstParent))
                         {
                             result.Parent = ObjectId.Parse(firstParent);
@@ -120,8 +120,8 @@ namespace GitUI.CommandsDialogs
                 }
                 else if (objectType == LostObjectType.Tag)
                 {
-                    var tagData = GetLostTagData();
-                    var tagPatternMatch = TagRegex.Match(tagData);
+                    string tagData = GetLostTagData();
+                    Match tagPatternMatch = TagRegex.Match(tagData);
                     if (tagPatternMatch.Success)
                     {
                         result.Parent = ObjectId.Parse(tagData, tagPatternMatch.Groups[1]);
@@ -133,8 +133,8 @@ namespace GitUI.CommandsDialogs
                 }
                 else if (objectType == LostObjectType.Blob)
                 {
-                    var hash = objectId.ToString();
-                    var blobPath = Path.Combine(module.WorkingDirGitDir, "objects", hash[..2], hash[2..ObjectId.Sha1CharCount]);
+                    string hash = objectId.ToString();
+                    string blobPath = Path.Combine(module.WorkingDirGitDir, "objects", hash[..2], hash[2..ObjectId.Sha1CharCount]);
                     result.Date = new FileInfo(blobPath).CreationTime;
                 }
 

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -80,7 +80,7 @@ namespace GitUI.CommandsDialogs
 
         private void SaveObjectsClick(object sender, EventArgs e)
         {
-            var options = GetOptions();
+            string options = GetOptions();
             FormProcess.ShowDialog(this, UICommands, arguments: $"fsck-objects --lost-found{options}", Module.WorkingDir, input: null, useDialogSettings: true);
             UpdateLostObjects();
         }
@@ -108,7 +108,7 @@ namespace GitUI.CommandsDialogs
         private void mnuLostObjectsCreateTag_Click(object sender, EventArgs e)
         {
             using FormCreateTag frm = new(UICommands, GetCurrentGitRevision());
-            var dialogResult = frm.ShowDialog(this);
+            DialogResult dialogResult = frm.ShowDialog(this);
             if (dialogResult == DialogResult.OK)
             {
                 UpdateLostObjects();
@@ -118,7 +118,7 @@ namespace GitUI.CommandsDialogs
         private void mnuLostObjectsCreateBranch_Click(object sender, EventArgs e)
         {
             using FormCreateBranch frm = new(UICommands, GetCurrentGitRevision());
-            var dialogResult = frm.ShowDialog(this);
+            DialogResult dialogResult = frm.ShowDialog(this);
             if (dialogResult == DialogResult.OK)
             {
                 UpdateLostObjects();
@@ -134,7 +134,7 @@ namespace GitUI.CommandsDialogs
         private void btnRestoreSelectedObjects_Click(object sender, EventArgs e)
         {
             DeleteLostFoundTags();
-            var restoredObjectsCount = CreateLostFoundTags();
+            int restoredObjectsCount = CreateLostFoundTags();
 
             if (restoredObjectsCount == 0)
             {
@@ -243,7 +243,7 @@ namespace GitUI.CommandsDialogs
                 return content.Contains("<html", StringComparison.InvariantCultureIgnoreCase) ? "recovery.html" : "recovery.xml";
             }
 
-            foreach (var pair in LanguagesStartOfFile)
+            foreach (KeyValuePair<string, string> pair in LanguagesStartOfFile)
             {
                 if (content.StartsWith(pair.Key))
                 {
@@ -307,7 +307,7 @@ namespace GitUI.CommandsDialogs
 
         private string GetOptions()
         {
-            var options = string.Empty;
+            string options = string.Empty;
 
             if (Unreachable.Checked)
             {
@@ -329,7 +329,7 @@ namespace GitUI.CommandsDialogs
 
         private void ViewCurrentItem()
         {
-            var currentItem = CurrentItem;
+            LostObject currentItem = CurrentItem;
             if (currentItem is null)
             {
                 return;
@@ -347,7 +347,7 @@ namespace GitUI.CommandsDialogs
 
         private int CreateLostFoundTags()
         {
-            var selectedLostObjects = Warnings.Rows
+            List<LostObject> selectedLostObjects = Warnings.Rows
                 .Cast<DataGridViewRow>()
                 .Select(row => row.Cells[columnIsLostObjectSelected.Index])
                 .Where(cell => (bool?)cell.Value == true)
@@ -360,11 +360,11 @@ namespace GitUI.CommandsDialogs
                 return 0;
             }
 
-            var currentTag = 0;
-            foreach (var lostObject in selectedLostObjects)
+            int currentTag = 0;
+            foreach (LostObject lostObject in selectedLostObjects)
             {
                 currentTag++;
-                var tagName = lostObject.ObjectType == LostObjectType.Tag ? lostObject.TagName : currentTag.ToString();
+                string tagName = lostObject.ObjectType == LostObjectType.Tag ? lostObject.TagName : currentTag.ToString();
                 GitCreateTagArgs createTagArgs = new($"{RestoredObjectsTagPrefix}{tagName}", lostObject.ObjectId);
                 _gitTagController.CreateTag(createTagArgs, this);
             }
@@ -374,7 +374,7 @@ namespace GitUI.CommandsDialogs
 
         private void DeleteLostFoundTags()
         {
-            foreach (var head in Module.GetRefs(RefsFilter.Tags))
+            foreach (IGitRef head in Module.GetRefs(RefsFilter.Tags))
             {
                 if (head.Name.StartsWith(RestoredObjectsTagPrefix))
                 {
@@ -409,10 +409,10 @@ namespace GitUI.CommandsDialogs
         {
             if (Warnings?.SelectedRows.Count is > 0 && Warnings.SelectedRows[0].DataBoundItem is not null)
             {
-                var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
-                var isCommit = lostObject.ObjectType == LostObjectType.Commit;
-                var isBlob = lostObject.ObjectType == LostObjectType.Blob;
-                var contextMenu = Warnings.SelectedRows[0].ContextMenuStrip;
+                LostObject lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
+                bool isCommit = lostObject.ObjectType == LostObjectType.Commit;
+                bool isBlob = lostObject.ObjectType == LostObjectType.Blob;
+                ContextMenuStrip contextMenu = Warnings.SelectedRows[0].ContextMenuStrip;
                 contextMenu.Items[1].Enabled = isCommit;
                 contextMenu.Items[2].Enabled = isCommit;
                 contextMenu.Items[4].Enabled = isCommit;
@@ -434,7 +434,7 @@ namespace GitUI.CommandsDialogs
         {
             if (Warnings?.SelectedRows.Count is > 0 && Warnings.SelectedRows[0].DataBoundItem is not null)
             {
-                var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
+                LostObject lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
                 ClipboardUtil.TrySetText(lostObject.ObjectId.ToString());
             }
         }
@@ -443,7 +443,7 @@ namespace GitUI.CommandsDialogs
         {
             if (Warnings?.SelectedRows.Count is > 0 && Warnings.SelectedRows[0].DataBoundItem is not null)
             {
-                var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
+                LostObject lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
                 ObjectId? parent = lostObject.Parent;
 
                 if (parent is not null)
@@ -460,7 +460,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
+            LostObject lostObject = (LostObject)Warnings.SelectedRows[0].DataBoundItem;
 
             if (lostObject.ObjectType == LostObjectType.Blob)
             {

--- a/GitUI/CommandsDialogs/FormViewPatch.cs
+++ b/GitUI/CommandsDialogs/FormViewPatch.cs
@@ -50,7 +50,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var patch = (Patch)GridChangedFiles.SelectedRows[0].DataBoundItem;
+            Patch patch = (Patch)GridChangedFiles.SelectedRows[0].DataBoundItem;
 
             if (patch is null)
             {
@@ -84,9 +84,9 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                var text = System.IO.File.ReadAllText(PatchFileNameEdit.Text, GitModule.LosslessEncoding);
-                var patches = PatchProcessor.CreatePatchesFromString(text, new Lazy<Encoding>(() => Module.FilesEncoding)).ToList();
-                var patchesList = new SortablePatchesList();
+                string text = System.IO.File.ReadAllText(PatchFileNameEdit.Text, GitModule.LosslessEncoding);
+                List<Patch> patches = PatchProcessor.CreatePatchesFromString(text, new Lazy<Encoding>(() => Module.FilesEncoding)).ToList();
+                SortablePatchesList patchesList = new SortablePatchesList();
                 patchesList.AddRange(patches);
                 GridChangedFiles.DataSource = patchesList;
             }

--- a/GitUI/CommandsDialogs/RememberFileContextMenuController.cs
+++ b/GitUI/CommandsDialogs/RememberFileContextMenuController.cs
@@ -89,11 +89,11 @@ namespace GitUI.CommandsDialogs
                 return null;
             }
 
-            var name = (!isSecondRevision && !string.IsNullOrWhiteSpace(item.Item.OldName)
+            string name = (!isSecondRevision && !string.IsNullOrWhiteSpace(item.Item.OldName)
                     ? item.Item.OldName
                     : item.Item.Name)
                 ?.ToPosixPath();
-            var id = (isSecondRevision ? item.SecondRevision : item.FirstRevision)?.ObjectId;
+            ObjectId id = (isSecondRevision ? item.SecondRevision : item.FirstRevision)?.ObjectId;
             if (string.IsNullOrWhiteSpace(name) || id is null)
             {
                 return null;

--- a/GitUI/CommandsDialogs/RepoHosting/DiscussionHtmlCreator.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/DiscussionHtmlCreator.cs
@@ -15,9 +15,9 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
             if (entries is not null)
             {
-                foreach (var entry in entries)
+                foreach (IDiscussionEntry entry in entries)
                 {
-                    var cde = entry as ICommitDiscussionEntry;
+                    ICommitDiscussionEntry cde = entry as ICommitDiscussionEntry;
 
                     AddLine(html, "<div class='entry {0}'>", cde is null ? "commentEntry" : " commitEntry");
 
@@ -53,7 +53,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                 if (_cssData is null)
                 {
                     _cssData = _cssDataRaw;
-                    foreach (var elem in SystemInfoReplacement)
+                    foreach (KeyValuePair<string, string> elem in SystemInfoReplacement)
                     {
                         _cssData = _cssData.Replace(elem.Key, elem.Value);
                     }
@@ -71,9 +71,9 @@ namespace GitUI.CommandsDialogs.RepoHosting
             {
                 if (_systemInfoReplacement is null)
                 {
-                    var props = typeof(SystemColors).GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.GetProperty).ToList();
+                    List<PropertyInfo> props = typeof(SystemColors).GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.GetProperty).ToList();
 
-                    var kvps = from prop in props
+                    IEnumerable<KeyValuePair<string, string>> kvps = from prop in props
                                where prop.PropertyType == typeof(Color)
                                let c = (Color)prop.GetValue(null, null)
                                select new KeyValuePair<string, string>("SC." + prop.Name, string.Format("#{0:X2}{1:X2}{2:X2}", c.R, c.G, c.B));

--- a/GitUI/CommandsDialogs/RevisionGpgInfoControl.cs
+++ b/GitUI/CommandsDialogs/RevisionGpgInfoControl.cs
@@ -34,7 +34,7 @@ namespace GitUI.CommandsDialogs
             else
             {
                 DisplayCommitSignatureStatus(info.CommitStatus);
-                var message = EnvUtils.ReplaceLinuxNewLinesDependingOnPlatform(info.CommitVerificationMessage);
+                string message = EnvUtils.ReplaceLinuxNewLinesDependingOnPlatform(info.CommitVerificationMessage);
                 txtCommitGpgInfo.Text = info.CommitStatus != CommitStatus.NoSignature ? message : _commitNotSigned.Text;
 
                 DisplayTagSignatureStatus(info.TagStatus);

--- a/GitUI/CommandsDialogs/SearchControl.cs
+++ b/GitUI/CommandsDialogs/SearchControl.cs
@@ -70,12 +70,12 @@ namespace GitUI.CommandsDialogs
 
         private void SearchForCandidates(IEnumerable<T> candidates)
         {
-            var selectionStart = txtSearchBox.SelectionStart;
-            var selectionLength = txtSearchBox.SelectionLength;
+            int selectionStart = txtSearchBox.SelectionStart;
+            int selectionLength = txtSearchBox.SelectionLength;
             listBoxSearchResult.BeginUpdate();
             listBoxSearchResult.Items.Clear();
 
-            foreach (var candidate in candidates.Take(20))
+            foreach (T candidate in candidates.Take(20))
             {
                 listBoxSearchResult.Items.Add(candidate);
             }
@@ -101,11 +101,11 @@ namespace GitUI.CommandsDialogs
 
             listBoxSearchResult.Visible = true;
 
-            var txtBoxOnScreen = PointToScreen(txtSearchBox.Location + new Size(0, txtSearchBox.Height));
+            Point txtBoxOnScreen = PointToScreen(txtSearchBox.Location + new Size(0, txtSearchBox.Height));
             if (ParentForm is not null && !ParentForm.Controls.Contains(listBoxSearchResult))
             {
                 ParentForm.Controls.Add(listBoxSearchResult);
-                var listBoxLocationOnScreen = txtBoxOnScreen;
+                Point listBoxLocationOnScreen = txtBoxOnScreen;
                 listBoxSearchResult.Location = ParentForm.PointToClient(listBoxLocationOnScreen);
             }
 
@@ -194,7 +194,7 @@ namespace GitUI.CommandsDialogs
             {
                 if (listBoxSearchResult.Items.Count > 1)
                 {
-                    var newSelectedIndex = listBoxSearchResult.SelectedIndex - 1;
+                    int newSelectedIndex = listBoxSearchResult.SelectedIndex - 1;
                     if (newSelectedIndex < 0)
                     {
                         newSelectedIndex = listBoxSearchResult.Items.Count - 1;

--- a/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -154,7 +154,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         {
             if (EnvUtils.RunningOnWindows())
             {
-                foreach (var command in GetWindowsCommandLocations())
+                foreach (string command in GetWindowsCommandLocations())
                 {
                     if (TestGitCommand(command))
                     {
@@ -208,7 +208,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     yield return AppSettings.GitCommandValue;
                 }
 
-                foreach (var path in GetGitLocations())
+                foreach (string path in GetGitLocations())
                 {
                     if (Directory.Exists(path + @"bin\"))
                     {
@@ -216,7 +216,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
                     }
                 }
 
-                foreach (var path in GetGitLocations())
+                foreach (string path in GetGitLocations())
                 {
                     if (Directory.Exists(path + @"cmd\"))
                     {

--- a/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/FormAvailableEncodings.cs
@@ -14,7 +14,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
 
         private void LoadEncoding()
         {
-            var includedEncoding = AppSettings.AvailableEncodings;
+            Dictionary<string, Encoding> includedEncoding = AppSettings.AvailableEncodings;
             ListIncludedEncodings.BeginUpdate();
             try
             {
@@ -78,7 +78,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         {
             if (ListIncludedEncodings.SelectedItem is not null)
             {
-                var index = ListIncludedEncodings.SelectedIndex;
+                int index = ListIncludedEncodings.SelectedIndex;
                 ListAvailableEncodings.Items.Add(ListIncludedEncodings.SelectedItem);
                 ListIncludedEncodings.Items.RemoveAt(index);
             }
@@ -87,7 +87,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         private void ListIncludedEncodings_SelectedValueChanged(object sender, EventArgs e)
         {
             // Get selected encoding
-            var encoding = ListIncludedEncodings.SelectedItem as Encoding;
+            Encoding encoding = ListIncludedEncodings.SelectedItem as Encoding;
             Type? encodingType = null;
 
             // Get type if exists

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -129,7 +129,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.EnableAutoScale = chkEnableAutoScale.Checked;
             AppSettings.TruncatePathMethod = GetTruncatePathMethodString(truncatePathMethod.SelectedIndex);
 
-            var shouldClearCache =
+            bool shouldClearCache =
                 AppSettings.AvatarProvider != (AvatarProvider)AvatarProvider.SelectedValue
                 || AppSettings.AvatarFallbackType != (AvatarFallbackType)_NO_TRANSLATE_NoImageService.SelectedValue
                 || AppSettings.CustomAvatarTemplate != txtCustomAvatarTemplate.Text;
@@ -225,7 +225,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void ManageAvatarOptionsDisplay()
         {
-            var showCustomTemplate = (AvatarProvider)AvatarProvider.SelectedValue == GitCommands.AvatarProvider.Custom;
+            bool showCustomTemplate = (AvatarProvider)AvatarProvider.SelectedValue == GitCommands.AvatarProvider.Custom;
 
             lblCustomAvatarTemplate.Visible = showCustomTemplate;
             txtCustomAvatarTemplate.Visible = showCustomTemplate;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ChecklistSettingsPage.cs
@@ -215,7 +215,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private void DiffToolFix_Click(object sender, EventArgs e)
         {
             Validates.NotNull(_diffMergeToolConfigurationManager);
-            var diffTool = _diffMergeToolConfigurationManager.ConfiguredDiffTool;
+            string diffTool = _diffMergeToolConfigurationManager.ConfiguredDiffTool;
             if (string.IsNullOrEmpty(diffTool))
             {
                 GotoPageGlobalSettings();
@@ -228,7 +228,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private void MergeToolFix_Click(object sender, EventArgs e)
         {
             Validates.NotNull(_diffMergeToolConfigurationManager);
-            var mergeTool = _diffMergeToolConfigurationManager.ConfiguredMergeTool;
+            string mergeTool = _diffMergeToolConfigurationManager.ConfiguredMergeTool;
             if (string.IsNullOrEmpty(mergeTool))
             {
                 GotoPageGlobalSettings();
@@ -285,14 +285,14 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         {
             _diffMergeToolConfigurationManager = new DiffMergeToolConfigurationManager(() => CheckSettingsLogic.CommonLogic.ConfigFileSettingsSet.EffectiveSettings);
 
-            var isValid = PerformChecks();
+            bool isValid = PerformChecks();
             CheckAtStartup.Checked = IsCheckAtStartupChecked(isValid);
             return isValid;
 
             bool PerformChecks()
             {
                 bool result = true;
-                foreach (var func in CheckFuncs())
+                foreach (Func<bool> func in CheckFuncs())
                 {
                     try
                     {
@@ -329,7 +329,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private static bool IsCheckAtStartupChecked(bool isValid)
         {
-            var retValue = AppSettings.CheckSettings;
+            bool retValue = AppSettings.CheckSettings;
 
             if (isValid && retValue)
             {
@@ -349,7 +349,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         /// <seealso href="https://github.com/gitextensions/gitextensions/issues/3511#issuecomment-313633897"/>
         private bool CheckGitCredentialWinStore()
         {
-            var setting = GetGlobalSetting(SettingKeyString.CredentialHelper) ?? string.Empty;
+            string setting = GetGlobalSetting(SettingKeyString.CredentialHelper) ?? string.Empty;
             if (setting.IndexOf("git-credential-winstore.exe", StringComparison.OrdinalIgnoreCase) < 0)
             {
                 GcmDetected.Visible = false;
@@ -431,7 +431,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Validates.NotNull(_diffMergeToolConfigurationManager);
 
             DiffTool.Visible = true;
-            var diffTool = _diffMergeToolConfigurationManager.ConfiguredDiffTool;
+            string diffTool = _diffMergeToolConfigurationManager.ConfiguredDiffTool;
             if (string.IsNullOrEmpty(diffTool))
             {
                 RenderSettingUnset(DiffTool, DiffTool_Fix, _adviceDiffToolConfiguration.Text);
@@ -454,7 +454,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             Validates.NotNull(_diffMergeToolConfigurationManager);
 
             MergeTool.Visible = true;
-            var mergeTool = _diffMergeToolConfigurationManager.ConfiguredMergeTool;
+            string mergeTool = _diffMergeToolConfigurationManager.ConfiguredMergeTool;
             if (string.IsNullOrEmpty(mergeTool))
             {
                 RenderSettingUnset(MergeTool, MergeTool_Fix, _configureMergeTool.Text);
@@ -521,7 +521,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             GitExtensionsInstall.Visible = true;
 
-            var installDir = AppSettings.GetInstallDir();
+            string installDir = AppSettings.GetInstallDir();
 
             if (string.IsNullOrEmpty(installDir))
             {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DetailedSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DetailedSettingsPage.cs
@@ -48,7 +48,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             detailedSettings.SmtpServer = SmtpServer.Text;
 
-            if (int.TryParse(SmtpServerPort.Text, out var port))
+            if (int.TryParse(SmtpServerPort.Text, out int port))
             {
                 detailedSettings.SmtpPort = port;
             }
@@ -58,7 +58,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             detailedSettings.GetRemoteBranchesDirectlyFromRemote = chkRemotesFromServer.Checked;
             detailedSettings.AddMergeLogMessages = addLogMessages.Checked;
 
-            if (int.TryParse(nbMessages.Text, out var messagesCount))
+            if (int.TryParse(nbMessages.Text, out int messagesCount))
             {
                 detailedSettings.MergeLogMessagesCount = messagesCount;
             }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -155,7 +155,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             try
             {
-                var path = Environment.GetEnvironmentVariable("HOMEDRIVE") +
+                string path = Environment.GetEnvironmentVariable("HOMEDRIVE") +
                            Environment.GetEnvironmentVariable("HOMEPATH");
                 if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
                 {
@@ -173,7 +173,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             try
             {
-                var path = Environment.GetEnvironmentVariable("USERPROFILE");
+                string path = Environment.GetEnvironmentVariable("USERPROFILE");
                 if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
                 {
                     MessageBox.Show(this, string.Format(_gitconfigFoundUserprofile.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
@@ -190,7 +190,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             try
             {
-                var path = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+                string path = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
                 if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
                 {
                     MessageBox.Show(this, string.Format(_gitconfigFoundPersonalFolder.Text, Environment.GetFolderPath(Environment.SpecialFolder.Personal)),
@@ -240,7 +240,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void otherHomeBrowse_Click(object sender, EventArgs e)
         {
-            var userSelectedPath = OsShellUtil.PickFolder(this, Environment.GetEnvironmentVariable("USERPROFILE"));
+            string userSelectedPath = OsShellUtil.PickFolder(this, Environment.GetEnvironmentVariable("USERPROFILE"));
 
             if (userSelectedPath is not null)
             {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GeneralSettingsPage.cs
@@ -168,7 +168,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void DefaultCloneDestinationBrowseClick(object sender, EventArgs e)
         {
-            var userSelectedPath = OsShellUtil.PickFolder(this, cbDefaultCloneDestination.Text);
+            string userSelectedPath = OsShellUtil.PickFolder(this, cbDefaultCloneDestination.Text);
 
             if (userSelectedPath is not null)
             {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/SshSettingsPage.cs
@@ -28,7 +28,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             PageantPath.Text = AppSettings.Pageant;
             AutostartPageant.Checked = AppSettings.AutoStartPageant;
 
-            var sshPath = AppSettings.SshPath;
+            string sshPath = AppSettings.SshPath;
             if (string.IsNullOrEmpty(sshPath))
             {
                 OpenSSH.Checked = true;

--- a/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Plugins/PluginSettingsPage.cs
@@ -16,9 +16,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Plugins
 
         private void CreateSettingsControls()
         {
-            var settings = GetSettings();
+            IEnumerable<ISetting> settings = GetSettings();
 
-            foreach (var setting in settings)
+            foreach (ISetting setting in settings)
             {
                 AddSettingControl(setting.CreateControlBinding());
             }
@@ -38,7 +38,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Plugins
 
         public static PluginSettingsPage CreateSettingsPageFromPlugin(ISettingsPageHost pageHost, IGitPlugin gitPlugin, IServiceProvider serviceProvider)
         {
-            var result = Create<PluginSettingsPage>(pageHost, serviceProvider);
+            PluginSettingsPage result = Create<PluginSettingsPage>(pageHost, serviceProvider);
             result.Init(gitPlugin);
             return result;
         }
@@ -82,7 +82,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Plugins
 
             labelNoSettings.Visible = !_gitPlugin.HasSettings;
 
-            var layout = base.CreateSettingsLayout();
+            ISettingsLayout layout = base.CreateSettingsLayout();
 
             tableLayoutPanel1.Controls.Add(layout.GetControl(), 0, 1);
 

--- a/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/AzureDevopsExternalLinkDefinitionExtractor.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/AzureDevopsExternalLinkDefinitionExtractor.cs
@@ -29,7 +29,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
             accountName ??= "ACCOUNT_NAME";
             repoName ??= "REPO_NAME";
 
-            var azureDevopsUrl = $"https://dev.azure.com/{accountName}";
+            string azureDevopsUrl = $"https://dev.azure.com/{accountName}";
             ExternalLinkDefinition definition = new()
             {
                 Name = string.Format(CodeLink.Text, ServiceName),

--- a/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/GitHubExternalLinkDefinitionExtractor.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/GitHubExternalLinkDefinitionExtractor.cs
@@ -29,7 +29,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
             organizationName ??= "ORGANIZATION_NAME";
             repoName ??= "REPO_NAME";
 
-            var gitHubUrl = $"https://github.com/{organizationName}/{repoName}";
+            string gitHubUrl = $"https://github.com/{organizationName}/{repoName}";
             ExternalLinkDefinition definition = new()
             {
                 Name = string.Format(CodeLink.Text, ServiceName),

--- a/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
+++ b/GitUI/CommandsDialogs/SubmodulesDialog/FormAddSubmodule.cs
@@ -31,7 +31,7 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
 
         private void BrowseClick(object sender, EventArgs e)
         {
-            var userSelectedPath = OsShellUtil.PickFolder(this, Directory.Text);
+            string userSelectedPath = OsShellUtil.PickFolder(this, Directory.Text);
 
             if (userSelectedPath is not null)
             {
@@ -49,7 +49,7 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
 
             using (WaitCursorScope.Enter())
             {
-                var command = Commands.AddSubmodule(Directory.Text, LocalPath.Text, Branch.Text, chkForce.Checked);
+                ArgumentString command = Commands.AddSubmodule(Directory.Text, LocalPath.Text, Branch.Text, chkForce.Checked);
                 FormProcess.ShowDialog(this, UICommands, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
                 Close();
             }
@@ -90,7 +90,7 @@ namespace GitUI.CommandsDialogs.SubmodulesDialog
             }
 
             GitArgumentBuilder gitArguments = new("ls-remote") { "--heads", url.ToPosixPath().Quote() };
-            var heads = gitExecutable.GetOutput(gitArguments);
+            string heads = gitExecutable.GetOutput(gitArguments);
             return heads.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries)
                         .Select(head =>
                         {

--- a/GitUI/CommandsDialogs/ToolStripPushButton.cs
+++ b/GitUI/CommandsDialogs/ToolStripPushButton.cs
@@ -38,7 +38,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            var data = aheadBehindData[branchName];
+            AheadBehindData data = aheadBehindData[branchName];
             Text = data.ToDisplay();
             DisplayStyle = ToolStripItemDisplayStyle.ImageAndText;
             ToolTipText = GetToolTipText(data);

--- a/GitUI/CommandsDialogs/UserScriptContextMenuExtensions.cs
+++ b/GitUI/CommandsDialogs/UserScriptContextMenuExtensions.cs
@@ -26,10 +26,10 @@ namespace GitUI.CommandsDialogs
             int hostItemIndex = contextMenu.Items.IndexOf(hostMenuItem);
             int lastScriptItemIndex = hostItemIndex;
 
-            var scriptsManager = serviceProvider.GetRequiredService<IScriptsManager>();
+            IScriptsManager scriptsManager = serviceProvider.GetRequiredService<IScriptsManager>();
             IEnumerable<ScriptInfo> scripts = scriptsManager.GetScripts().Where(x => x.Enabled);
 
-            var hotkeySettingsLoader = serviceProvider.GetRequiredService<IHotkeySettingsLoader>();
+            IHotkeySettingsLoader hotkeySettingsLoader = serviceProvider.GetRequiredService<IHotkeySettingsLoader>();
             IReadOnlyList<HotkeyCommand> hotkeys = hotkeySettingsLoader.LoadHotkeys(FormSettings.HotkeySettingsName);
 
             foreach (ScriptInfo script in scripts)

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -32,7 +32,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
             void LoadBranchesAsync()
             {
-                var selectedBranch = UICommands.GitModule.GetSelectedBranch();
+                string selectedBranch = UICommands.GitModule.GetSelectedBranch();
                 ExistingBranches = Module.GetRefs(RefsFilter.Heads);
                 comboBoxBranches.Text = TranslatedStrings.LoadingData;
                 ThreadHelper.FileAndForget(async () =>
@@ -163,7 +163,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
             void UpdateWorktreePath()
             {
-                var branchNameNormalized = NormalizeBranchName(radioButtonCheckoutExistingBranch.Checked
+                string branchNameNormalized = NormalizeBranchName(radioButtonCheckoutExistingBranch.Checked
                     ? ((IGitRef)comboBoxBranches.SelectedItem)?.Name ?? string.Empty
                     : textBoxNewBranchName.Text);
                 newWorktreeDirectory.Text = $"{_initialDirectoryPath}_{branchNameNormalized}";

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -61,14 +61,14 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
             _worktrees = new List<WorkTree>();
             WorkTree? currentWorktree = null;
-            foreach (var line in lines.LazySplit('\n'))
+            foreach (string line in lines.LazySplit('\n'))
             {
                 if (string.IsNullOrWhiteSpace(line))
                 {
                     continue;
                 }
 
-                var strings = line.Split(' ');
+                string[] strings = line.Split(' ');
                 if (strings[0] == "worktree")
                 {
                     currentWorktree = new WorkTree { Path = Module.GetWindowsPath(line[9..]) };
@@ -108,7 +108,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             Font font = Worktrees.DefaultCellStyle.Font;
             Font deletedFont = new(font.FontFamily, font.Size, font.Style | FontStyle.Strikeout);
 
-            for (var i = 0; i < Worktrees.Rows.Count; i++)
+            for (int i = 0; i < Worktrees.Rows.Count; i++)
             {
                 if (_worktrees[i].IsDeleted)
                 {
@@ -162,7 +162,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         private void buttonDeleteSelectedWorktree_Click(object sender, EventArgs e)
         {
-            if (!CanActOnSelectedWorkspace(out var workTree))
+            if (!CanActOnSelectedWorkspace(out WorkTree workTree))
             {
                 return;
             }
@@ -186,7 +186,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
         private void buttonOpenSelectedWorktree_Click(object sender, EventArgs e)
         {
-            if (!CanActOnSelectedWorkspace(out var workTree))
+            if (!CanActOnSelectedWorkspace(out WorkTree workTree))
             {
                 return;
             }

--- a/GitUI/CommitInfo/CommitInfoHeader.cs
+++ b/GitUI/CommitInfo/CommitInfoHeader.cs
@@ -30,7 +30,7 @@ namespace GitUI.CommitInfo
             _commitDataManager = new CommitDataManager(() => Module);
             _commitDataHeaderRenderer = new CommitDataHeaderRenderer(labelFormatter, _dateFormatter, headerRenderer, _linkFactory);
 
-            using (var g = CreateGraphics())
+            using (Graphics g = CreateGraphics())
             {
                 rtbRevisionHeader.Font = _commitDataHeaderRenderer.GetFont(g);
             }
@@ -55,8 +55,8 @@ namespace GitUI.CommitInfo
         {
             this.InvokeAndForget(() =>
             {
-                var data = _commitDataManager.CreateFromRevision(revision, children);
-                var header = _commitDataHeaderRenderer.Render(data, showRevisionsAsLinks: CommandClicked is not null);
+                CommitData data = _commitDataManager.CreateFromRevision(revision, children);
+                string header = _commitDataHeaderRenderer.Render(data, showRevisionsAsLinks: CommandClicked is not null);
 
                 rtbRevisionHeader.SuspendLayout();
 
@@ -79,7 +79,7 @@ namespace GitUI.CommitInfo
 
         private void LoadAuthorImage(GitRevision? revision)
         {
-            var showAvatar = AppSettings.ShowAuthorAvatarInCommitInfo;
+            bool showAvatar = AppSettings.ShowAuthorAvatarInCommitInfo;
             avatarControl.Visible = showAvatar;
 
             if (!showAvatar)

--- a/GitUI/CommitInfo/RefsFormatter.cs
+++ b/GitUI/CommitInfo/RefsFormatter.cs
@@ -34,7 +34,7 @@ namespace GitUI.CommitInfo
                 return string.Empty;
             }
 
-            var (formattedBranches, truncated) = FilterAndFormatBranches(branches, showAsLinks, limit);
+            (IEnumerable<string> formattedBranches, bool truncated) = FilterAndFormatBranches(branches, showAsLinks, limit);
             return ToString(formattedBranches, TranslatedStrings.ContainedInBranches, TranslatedStrings.ContainedInNoBranch, "branches", truncated);
         }
 
@@ -46,7 +46,7 @@ namespace GitUI.CommitInfo
             }
 
             bool truncate = limit && tags.Count > MaximumDisplayedLinesIfLimited;
-            var formattedTags = FormatTags(truncate ? tags.Take(MaximumDisplayedRefsIfLimited) : tags);
+            IEnumerable<string> formattedTags = FormatTags(truncate ? tags.Take(MaximumDisplayedRefsIfLimited) : tags);
             return ToString(formattedTags, TranslatedStrings.ContainedInTags, TranslatedStrings.ContainedInNoTag, "tags", truncate);
 
             IEnumerable<string> FormatTags(IEnumerable<string> selectedTags)
@@ -72,7 +72,7 @@ namespace GitUI.CommitInfo
             bool allowLocal = AppSettings.CommitInfoShowContainedInBranchesLocal;
             bool allowRemote = getRemote;
 
-            foreach (var branch in branches)
+            foreach (string branch in branches)
             {
                 string noPrefixBranch = branch ?? string.Empty;
                 bool branchIsLocal;
@@ -96,7 +96,7 @@ namespace GitUI.CommitInfo
 
                 if ((branchIsLocal && allowLocal) || (!branchIsLocal && allowRemote))
                 {
-                    var branchText = showAsLinks
+                    string branchText = showAsLinks
                         ? _linkFactory.CreateBranchLink(noPrefixBranch)
                         : WebUtility.HtmlEncode(noPrefixBranch);
 
@@ -127,7 +127,7 @@ namespace GitUI.CommitInfo
                 return WebUtility.HtmlEncode(textIfEmpty);
             }
 
-            var sb = new StringBuilder()
+            StringBuilder sb = new StringBuilder()
                 .AppendLine(WebUtility.HtmlEncode(prefix))
                 .Append(linksJoined);
             if (truncated)

--- a/GitUI/CustomDiffMergeToolProvider.cs
+++ b/GitUI/CustomDiffMergeToolProvider.cs
@@ -60,10 +60,10 @@ namespace GitUI
 
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
-                foreach (var menu in menus)
+                foreach (CustomDiffMergeTool menu in menus)
                 {
                     menu.MenuItem.DropDown = new ContextMenuStrip(components);
-                    foreach (var tool in tools)
+                    foreach (string tool in tools)
                     {
                         ToolStripMenuItem item = new(tool) { Tag = tool };
 
@@ -108,7 +108,7 @@ namespace GitUI
 
             static void InitMenus(IList<CustomDiffMergeTool> menus)
             {
-                foreach (var menu in menus)
+                foreach (CustomDiffMergeTool menu in menus)
                 {
                     menu.MenuItem.DropDown = null;
                 }

--- a/GitUI/Editor/CommitMessageHighlightingStrategy.cs
+++ b/GitUI/Editor/CommitMessageHighlightingStrategy.cs
@@ -22,11 +22,11 @@ namespace GitUI.Editor
 
         protected override void MarkTokens(IDocument document, IList<LineSegment> lines)
         {
-            var summaryLineNumber = -1;
-            var seenDividingSpace = false;
-            var descriptionStartLineNumber = -1;
+            int summaryLineNumber = -1;
+            bool seenDividingSpace = false;
+            int descriptionStartLineNumber = -1;
 
-            foreach (var line in document.LineSegmentCollection)
+            foreach (LineSegment line in document.LineSegmentCollection)
             {
                 if (summaryLineNumber == -1)
                 {
@@ -62,16 +62,16 @@ namespace GitUI.Editor
 
             // NOTE the pattern of removing then adding markers might look suboptimal, but tracking their presence isn't reliable as they can be removed without warning
 
-            foreach (var line in lines)
+            foreach (LineSegment line in lines)
             {
-                var lineNumber = line.LineNumber;
+                int lineNumber = line.LineNumber;
 
                 if (TryHighlightComment(document, line))
                 {
                 }
                 else
                 {
-                    var color = lineNumber == summaryLineNumber ? ColorSummary : ColorNormal;
+                    HighlightColor color = lineNumber == summaryLineNumber ? ColorSummary : ColorNormal;
 
                     line.Words = new List<TextWord>(capacity: 1)
                         { new TextWord(document, line, 0, line.Length, color, hasDefaultColor: false) };
@@ -108,7 +108,7 @@ namespace GitUI.Editor
             {
                 if (_overlengthDescriptionMarkers.Count != 0)
                 {
-                    foreach (var marker in _overlengthDescriptionMarkers)
+                    foreach (TextMarker marker in _overlengthDescriptionMarkers)
                     {
                         document.MarkerStrategy.RemoveMarker(marker);
                     }
@@ -119,9 +119,9 @@ namespace GitUI.Editor
                 return;
             }
 
-            var markerIndex = 0;
+            int markerIndex = 0;
 
-            foreach (var line in document.LineSegmentCollection)
+            foreach (LineSegment line in document.LineSegmentCollection)
             {
                 if (line.LineNumber < descriptionStartLineNumber)
                 {
@@ -130,8 +130,8 @@ namespace GitUI.Editor
 
                 if (line.Length > maxDescriptionLength)
                 {
-                    var markerOffset = line.Offset + maxDescriptionLength;
-                    var markerLength = line.Length - maxDescriptionLength;
+                    int markerOffset = line.Offset + maxDescriptionLength;
+                    int markerLength = line.Length - maxDescriptionLength;
 
                     TextMarker overlengthMarker;
                     if (markerIndex < _overlengthDescriptionMarkers.Count)
@@ -152,13 +152,13 @@ namespace GitUI.Editor
                 }
             }
 
-            var toRemove = _overlengthDescriptionMarkers.Count - markerIndex;
+            int toRemove = _overlengthDescriptionMarkers.Count - markerIndex;
 
             if (toRemove > 0)
             {
-                for (var i = 0; i < toRemove; i++)
+                for (int i = 0; i < toRemove; i++)
                 {
-                    var marker = _overlengthDescriptionMarkers[markerIndex + i];
+                    TextMarker marker = _overlengthDescriptionMarkers[markerIndex + i];
                     document.MarkerStrategy.RemoveMarker(marker);
                 }
 

--- a/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
+++ b/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
@@ -13,11 +13,11 @@ namespace GitUI.Editor.Diff
         public DiffLinesInfo Analyze(string diffContent)
         {
             DiffLinesInfo ret = new();
-            var isCombinedDiff = PatchProcessor.IsCombinedDiff(diffContent);
-            var lineNumInDiff = 0;
-            var leftLineNum = DiffLineInfo.NotApplicableLineNum;
-            var rightLineNum = DiffLineInfo.NotApplicableLineNum;
-            var isHeaderLineLocated = false;
+            bool isCombinedDiff = PatchProcessor.IsCombinedDiff(diffContent);
+            int lineNumInDiff = 0;
+            int leftLineNum = DiffLineInfo.NotApplicableLineNum;
+            int rightLineNum = DiffLineInfo.NotApplicableLineNum;
+            bool isHeaderLineLocated = false;
             string[] lines = diffContent.Split(Delimiters.LineFeed);
             for (int i = 0; i < lines.Length; i++)
             {
@@ -38,7 +38,7 @@ namespace GitUI.Editor.Diff
                         LineType = DiffLineType.Header
                     };
 
-                    var lineNumbers = regex.Match(line);
+                    Match lineNumbers = regex.Match(line);
                     leftLineNum = int.Parse(lineNumbers.Groups["leftStart"].Value);
                     rightLineNum = int.Parse(lineNumbers.Groups["rightStart"].Value);
 

--- a/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
+++ b/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
@@ -49,18 +49,18 @@ namespace GitUI.Editor.Diff
 
         public override void Paint(Graphics g, Rectangle rect)
         {
-            var numbersWidth = Width - TextHorizontalMargin;
-            var leftWidth = TextHorizontalMargin + (numbersWidth / 2);
-            var rightWidth = rect.Width - leftWidth;
+            int numbersWidth = Width - TextHorizontalMargin;
+            int leftWidth = TextHorizontalMargin + (numbersWidth / 2);
+            int rightWidth = rect.Width - leftWidth;
 
-            var fontHeight = textArea.TextView.FontHeight;
-            var lineNumberPainterColor = textArea.Document.HighlightingStrategy.GetColorFor("LineNumbers");
-            var fillBrush = textArea.Enabled ? BrushRegistry.GetBrush(lineNumberPainterColor.BackgroundColor) : SystemBrushes.InactiveBorder;
-            var drawBrush = BrushRegistry.GetBrush(lineNumberPainterColor.Color);
+            int fontHeight = textArea.TextView.FontHeight;
+            ICSharpCode.TextEditor.Document.HighlightColor lineNumberPainterColor = textArea.Document.HighlightingStrategy.GetColorFor("LineNumbers");
+            Brush fillBrush = textArea.Enabled ? BrushRegistry.GetBrush(lineNumberPainterColor.BackgroundColor) : SystemBrushes.InactiveBorder;
+            Brush drawBrush = BrushRegistry.GetBrush(lineNumberPainterColor.Color);
 
-            for (var y = 0; y < ((DrawingPosition.Height + textArea.TextView.VisibleLineDrawingRemainder) / fontHeight) + 1; ++y)
+            for (int y = 0; y < ((DrawingPosition.Height + textArea.TextView.VisibleLineDrawingRemainder) / fontHeight) + 1; ++y)
             {
-                var ypos = drawingPosition.Y + (fontHeight * y) - textArea.TextView.VisibleLineDrawingRemainder;
+                int ypos = drawingPosition.Y + (fontHeight * y) - textArea.TextView.VisibleLineDrawingRemainder;
                 Rectangle backgroundRectangle = new(drawingPosition.X, ypos, drawingPosition.Width, fontHeight);
                 if (!rect.IntersectsWith(backgroundRectangle))
                 {
@@ -68,7 +68,7 @@ namespace GitUI.Editor.Diff
                 }
 
                 g.FillRectangle(fillBrush, backgroundRectangle);
-                var curLine = textArea.Document.GetFirstLogicalLine(textArea.Document.GetVisibleLine(textArea.TextView.FirstVisibleLine) + y);
+                int curLine = textArea.Document.GetFirstLogicalLine(textArea.Document.GetVisibleLine(textArea.TextView.FirstVisibleLine) + y);
 
                 if (curLine >= textArea.Document.TotalNumberOfLines)
                 {
@@ -80,7 +80,7 @@ namespace GitUI.Editor.Diff
                     continue;
                 }
 
-                var diffLine = _diffLines[curLine + 1];
+                DiffLineInfo diffLine = _diffLines[curLine + 1];
                 if (diffLine.LineType != DiffLineType.Context)
                 {
                     using Brush brush = diffLine.LineType switch

--- a/GitUI/Editor/Diff/LinePrefixHelper.cs
+++ b/GitUI/Editor/Diff/LinePrefixHelper.cs
@@ -22,7 +22,7 @@ namespace GitUI.Editor.Diff
 
             while (beginIndex < document.TotalNumberOfLines)
             {
-                var lineSegment = _segmentGetter.GetSegment(document, beginIndex);
+                ISegment lineSegment = _segmentGetter.GetSegment(document, beginIndex);
 
                 if (lineSegment.Length > 0
                     && DoesLineStartWith(document, lineSegment.Offset, prefixStrs))

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -95,7 +95,7 @@ namespace GitUI.Editor
 
             IList<TextMarker> selectionMarkers = GetTextMarkersMatchingWord(text);
 
-            foreach (var selectionMarker in selectionMarkers)
+            foreach (TextMarker selectionMarker in selectionMarkers)
             {
                 TextEditor.Document.MarkerStrategy.AddMarker(selectionMarker);
             }
@@ -241,7 +241,7 @@ namespace GitUI.Editor
 
             if (isDiff)
             {
-                var index = TextEditor.ActiveTextAreaControl.TextArea.LeftMargins.IndexOf(_lineNumbersControl);
+                int index = TextEditor.ActiveTextAreaControl.TextArea.LeftMargins.IndexOf(_lineNumbersControl);
                 if (index == -1)
                 {
                     TextEditor.ActiveTextAreaControl.TextArea.InsertLeftMargin(0, _lineNumbersControl);
@@ -275,7 +275,7 @@ namespace GitUI.Editor
 
             if (_shouldScrollToBottom || _shouldScrollToTop)
             {
-                var scrollBar = TextEditor.ActiveTextAreaControl.VScrollBar;
+                VScrollBar scrollBar = TextEditor.ActiveTextAreaControl.VScrollBar;
                 if (scrollBar.Visible)
                 {
                     scrollBar.Value = _shouldScrollToTop ? 0 : Math.Max(0, scrollBar.Maximum - scrollBar.Height - _bottomBlankHeight);
@@ -372,7 +372,7 @@ namespace GitUI.Editor
             get { return TextEditor.ActiveTextAreaControl.HScrollBar?.Value ?? 0; }
             set
             {
-                var scrollBar = TextEditor.ActiveTextAreaControl.HScrollBar;
+                HScrollBar scrollBar = TextEditor.ActiveTextAreaControl.HScrollBar;
                 if (scrollBar is null)
                 {
                     return;
@@ -389,7 +389,7 @@ namespace GitUI.Editor
             get { return TextEditor.ActiveTextAreaControl.VScrollBar?.Value ?? 0; }
             set
             {
-                var scrollBar = TextEditor.ActiveTextAreaControl.VScrollBar;
+                VScrollBar scrollBar = TextEditor.ActiveTextAreaControl.VScrollBar;
                 if (scrollBar is null)
                 {
                     return;
@@ -510,7 +510,7 @@ namespace GitUI.Editor
 
         public void ClearHighlighting()
         {
-            var document = TextEditor.Document;
+            IDocument document = TextEditor.Document;
             document.MarkerStrategy.RemoveAll(t => true);
         }
 
@@ -529,9 +529,9 @@ namespace GitUI.Editor
 
         private void TextArea_MouseWheel(object sender, MouseEventArgs e)
         {
-            var isScrollingTowardTop = e.Delta > 0;
-            var isScrollingTowardBottom = e.Delta < 0;
-            var scrollBar = TextEditor.ActiveTextAreaControl.VScrollBar;
+            bool isScrollingTowardTop = e.Delta > 0;
+            bool isScrollingTowardBottom = e.Delta < 0;
+            VScrollBar scrollBar = TextEditor.ActiveTextAreaControl.VScrollBar;
 
             if (isScrollingTowardTop && (scrollBar.Value == 0))
             {
@@ -672,7 +672,7 @@ namespace GitUI.Editor
                     return;
                 }
 
-                var viewPosition = _currentViewPosition;
+                ViewPosition viewPosition = _currentViewPosition;
                 if (_viewer.TotalNumberOfLines == viewPosition.TotalNumberOfLines)
                 {
                     _viewer.FirstVisibleLine = viewPosition.FirstVisibleLine;
@@ -707,7 +707,7 @@ namespace GitUI.Editor
             /// <returns>The current line number at the caret offset</returns>
             public int CurrentFileLine(bool isDiff)
             {
-                var viewPosition = _currentViewPosition;
+                ViewPosition viewPosition = _currentViewPosition;
                 if (isDiff && _viewer.GetLineText(0) == viewPosition.FirstLine && viewPosition.ActiveLineNum is not null)
                 {
                     // prefer the RightLineNum that is for the current revision

--- a/GitUI/Editor/GitHighlightingStrategyBase.cs
+++ b/GitUI/Editor/GitHighlightingStrategyBase.cs
@@ -80,9 +80,9 @@ namespace GitUI.Editor
 
         protected bool IsComment(IDocument document, LineSegment line)
         {
-            for (var i = 0; i < line.Length; i++)
+            for (int i = 0; i < line.Length; i++)
             {
-                var c = document.GetCharAt(line.Offset + i);
+                char c = document.GetCharAt(line.Offset + i);
 
                 if (char.IsWhiteSpace(c))
                 {
@@ -97,9 +97,9 @@ namespace GitUI.Editor
 
         protected static bool IsEmptyOrWhiteSpace(IDocument document, LineSegment line)
         {
-            for (var i = 0; i < line.Length; i++)
+            for (int i = 0; i < line.Length; i++)
             {
-                var c = document.GetCharAt(line.Offset + i);
+                char c = document.GetCharAt(line.Offset + i);
 
                 if (!char.IsWhiteSpace(c))
                 {

--- a/GitUI/Editor/RebaseTodoHighlightingStrategy.cs
+++ b/GitUI/Editor/RebaseTodoHighlightingStrategy.cs
@@ -35,7 +35,7 @@ namespace GitUI.Editor
 
         protected override void MarkTokens(IDocument document, IList<LineSegment> lines)
         {
-            foreach (var line in lines)
+            foreach (LineSegment line in lines)
             {
                 if (!TryHighlightComment(document, line) &&
                     !TryHighlightInteractiveRebaseCommand(document, line))
@@ -63,16 +63,16 @@ namespace GitUI.Editor
                 return false;
             }
 
-            var c = document.GetCharAt(line.Offset);
+            char c = document.GetCharAt(line.Offset);
 
-            if (!_commandByFirstChar.TryGetValue(c, out var cmd))
+            if (!_commandByFirstChar.TryGetValue(c, out (string longForm, HighlightColor color, string[] options) cmd))
             {
                 return false;
             }
 
-            var state = State.Command;
-            var index = 1;
-            var idStartIndex = -1;
+            State state = State.Command;
+            int index = 1;
+            int idStartIndex = -1;
 
             while (index < line.Length)
             {
@@ -133,7 +133,7 @@ namespace GitUI.Editor
                     {
                         if (char.IsWhiteSpace(c))
                         {
-                            var idLength = index - idStartIndex;
+                            int idLength = index - idStartIndex;
 
                             if (idLength < 4)
                             {

--- a/GitUI/FontUtil.cs
+++ b/GitUI/FontUtil.cs
@@ -8,10 +8,10 @@
 #pragma warning disable SA1305 // Field names should not use Hungarian notation
         static FontUtil()
         {
-            var hTheme = NativeMethods.OpenThemeData(IntPtr.Zero, "TEXTSTYLE");
+            IntPtr hTheme = NativeMethods.OpenThemeData(IntPtr.Zero, "TEXTSTYLE");
             if (hTheme != IntPtr.Zero)
             {
-                NativeMethods.GetThemeFont(hTheme, IntPtr.Zero, NativeMethods.TEXT_MAININSTRUCTION, 0, NativeMethods.TMT_FONT, out var pFont);
+                NativeMethods.GetThemeFont(hTheme, IntPtr.Zero, NativeMethods.TEXT_MAININSTRUCTION, 0, NativeMethods.TMT_FONT, out NativeMethods.LOGFONT pFont);
 
                 MainInstructionFont = Font.FromLogFont(pFont);
 

--- a/GitUI/FormPuttyError.cs
+++ b/GitUI/FormPuttyError.cs
@@ -11,7 +11,7 @@ namespace GitUI
         public static bool AskForKey(IWin32Window parent, [NotNullWhen(returnValue: true)] out string? keyPath)
         {
             using FormPuttyError form = new();
-            var result = form.ShowDialog(parent);
+            DialogResult result = form.ShowDialog(parent);
             keyPath = form.KeyPath;
             return result == DialogResult.Retry;
         }
@@ -26,7 +26,7 @@ namespace GitUI
 
         private void LoadSSHKey_Click(object sender, EventArgs e)
         {
-            var pathLoaded = BrowseForPrivateKey.BrowseAndLoad(this);
+            string pathLoaded = BrowseForPrivateKey.BrowseAndLoad(this);
             if (!string.IsNullOrEmpty(pathLoaded))
             {
                 KeyPath = pathLoaded;

--- a/GitUI/GitExtensionsForm.cs
+++ b/GitUI/GitExtensionsForm.cs
@@ -26,7 +26,7 @@ namespace GitUI
         /// will be restored upon being re-opened.</param>
         protected GitExtensionsForm(bool enablePositionRestore)
         {
-            var needsPositionSave = enablePositionRestore;
+            bool needsPositionSave = enablePositionRestore;
             _needsPositionRestore = enablePositionRestore;
 
             FormClosing += GitExtensionsForm_FormClosing;
@@ -96,7 +96,7 @@ namespace GitUI
                 return;
             }
 
-            var position = _windowPositionManager.LoadPosition(this);
+            WindowPosition position = _windowPositionManager.LoadPosition(this);
             if (position is null)
             {
                 return;
@@ -117,7 +117,7 @@ namespace GitUI
 
             SuspendLayout();
 
-            var windowCentred = StartPosition == FormStartPosition.CenterParent;
+            bool windowCentred = StartPosition == FormStartPosition.CenterParent;
             StartPosition = FormStartPosition.Manual;
 
             if (FormBorderStyle == FormBorderStyle.Sizable ||

--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -127,7 +127,7 @@ namespace GitUI
 
         protected override CommandStatus ExecuteCommand(int command)
         {
-            var result = ExecuteScriptCommand();
+            CommandStatus result = ExecuteScriptCommand();
             if (!result.Executed)
             {
                 result = base.ExecuteCommand(command);
@@ -137,13 +137,13 @@ namespace GitUI
 
             CommandStatus ExecuteScriptCommand()
             {
-                var revisionGridControl = this as RevisionGridControl;
+                RevisionGridControl revisionGridControl = this as RevisionGridControl;
                 if (revisionGridControl is null)
                 {
                     revisionGridControl = (FindForm() as GitModuleForm)?.RevisionGridControl;
                 }
 
-                var scriptsRunner = UICommands.GetRequiredService<IScriptsRunner>();
+                IScriptsRunner scriptsRunner = UICommands.GetRequiredService<IScriptsRunner>();
                 return scriptsRunner.RunScript(command, FindForm() as GitModuleForm, revisionGridControl);
             }
         }

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <ProjectReference Include="..\GitExtensions.Analyzers.CSharp\GitExtensions.Analyzers.CSharp.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer"  />
+    <ProjectReference Include="..\GitExtensions.Analyzers.CSharp\GitExtensions.Analyzers.CSharp.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 
   <ItemGroup>
@@ -67,7 +67,9 @@
 
     <!-- Settings -->
     <None Update="Properties\Settings.settings" Generator="SettingsSingleFileGenerator" LastGenOutput="Settings.Designer.cs" />
-    <Compile Update="Properties\Settings.Designer.cs" AutoGen="True" DependentUpon="Settings.settings" />
+    <Compile Update="Properties\Settings.Designer.cs" AutoGen="True" DependentUpon="Settings.settings">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+    </Compile>
 
     <None Include="Properties\DataSources\*.datasource" />
   </ItemGroup>

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -49,7 +49,7 @@ namespace GitUI
                 return;
             }
 
-            var firstId = item.FirstRevision?.ObjectId ?? item.SecondRevision.FirstParentId;
+            ObjectId firstId = item.FirstRevision?.ObjectId ?? item.SecondRevision.FirstParentId;
 
             openWithDiffTool ??= OpenWithDiffTool;
 
@@ -123,7 +123,7 @@ namespace GitUI
             {
                 if (firstId == ObjectId.CombinedDiffId)
                 {
-                    var diffOfConflict = fileViewer.Module.GetCombinedDiffContent(selectedId, file.Name,
+                    string diffOfConflict = fileViewer.Module.GetCombinedDiffContent(selectedId, file.Name,
                         fileViewer.GetExtraDiffArguments(), fileViewer.Encoding);
 
                     cancellationToken.ThrowIfCancellationRequested();
@@ -132,12 +132,12 @@ namespace GitUI
                         : diffOfConflict;
                 }
 
-                var task = file.GetSubmoduleStatusAsync();
+                Task<GitSubmoduleStatus?> task = file.GetSubmoduleStatusAsync();
 
                 if (file.IsSubmodule && task is not null)
                 {
                     // Patch already evaluated
-                    var status = await task;
+                    GitSubmoduleStatus status = await task;
 
                     cancellationToken.ThrowIfCancellationRequested();
                     return status is not null
@@ -202,7 +202,7 @@ namespace GitUI
 
         public static void UnMask(this Control control)
         {
-            var panel = FindMaskPanel(control);
+            LoadingControl panel = FindMaskPanel(control);
             if (panel is not null)
             {
                 control.Controls.Remove(panel);

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -24,7 +24,7 @@ namespace GitUI.HelperDialogs
 
             if (!string.IsNullOrEmpty(preselectCommit))
             {
-                var objectId = Module.RevParse(preselectCommit);
+                ObjectId objectId = Module.RevParse(preselectCommit);
                 if (objectId is not null)
                 {
                     revisionGrid.SelectedId = objectId;
@@ -42,7 +42,7 @@ namespace GitUI.HelperDialogs
 
         private void btnOK_Click(object sender, EventArgs e)
         {
-            var revisions = revisionGrid.GetSelectedRevisions();
+            IReadOnlyList<GitRevision> revisions = revisionGrid.GetSelectedRevisions();
 
             if (revisions.Count == 1)
             {
@@ -70,7 +70,7 @@ namespace GitUI.HelperDialogs
 
         private void linkLabelParent_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            var linkLabel = (LinkLabel)sender;
+            LinkLabel linkLabel = (LinkLabel)sender;
             ObjectId parentId = (ObjectId)linkLabel.Tag;
 
             if (!revisionGrid.SetSelectedRevision(parentId))
@@ -81,7 +81,7 @@ namespace GitUI.HelperDialogs
 
         private void revisionGrid_SelectionChanged(object sender, EventArgs e)
         {
-            var revisions = revisionGrid.GetSelectedRevisions();
+            IReadOnlyList<GitRevision> revisions = revisionGrid.GetSelectedRevisions();
 
             if (revisions.Count != 1)
             {
@@ -97,7 +97,7 @@ namespace GitUI.HelperDialogs
                 return;
             }
 
-            var parents = SelectedRevision.ParentIds;
+            IReadOnlyList<ObjectId> parents = SelectedRevision.ParentIds;
 
             if (parents?.Count is not > 0)
             {

--- a/GitUI/HelperDialogs/FormProcess.cs
+++ b/GitUI/HelperDialogs/FormProcess.cs
@@ -42,7 +42,7 @@ namespace GitUI.HelperDialogs
             ProcessString = process ?? AppSettings.GitCommand;
             ProcessArguments = arguments;
 
-            var displayPath = PathUtil.GetDisplayPath(WorkingDirectory);
+            string displayPath = PathUtil.GetDisplayPath(WorkingDirectory);
             if (!string.IsNullOrWhiteSpace(displayPath))
             {
                 Text += $" ({displayPath})";

--- a/GitUI/HelperDialogs/FormRemoteProcess.cs
+++ b/GitUI/HelperDialogs/FormRemoteProcess.cs
@@ -73,7 +73,7 @@ Do you want to register the host's fingerprint and restart the process?");
             // An error occurred!
             if (isError && Plink)
             {
-                var output = GetOutputString();
+                string output = GetOutputString();
 
                 // there might be another error, this condition is too weak
                 /*
@@ -87,7 +87,7 @@ Do you want to register the host's fingerprint and restart the process?");
                 // If the authentication failed because of a missing key, ask the user to supply one.
                 if (output.Contains("FATAL ERROR") && output.Contains("authentication"))
                 {
-                    if (FormPuttyError.AskForKey(this, out var loadedKey))
+                    if (FormPuttyError.AskForKey(this, out string? loadedKey))
                     {
                         // To prevent future authentication errors, save this key for this remote.
                         if (!string.IsNullOrEmpty(loadedKey) && !string.IsNullOrEmpty(Remote) &&

--- a/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -48,10 +48,10 @@ namespace GitUI.HelperDialogs
 
         private IGitRef[] GetLocalBranchesWithoutCurrent()
         {
-            var currentBranch = Module.GetSelectedBranch();
-            var isDetachedHead = currentBranch == DetachedHeadParser.DetachedBranch;
+            string currentBranch = Module.GetSelectedBranch();
+            bool isDetachedHead = currentBranch == DetachedHeadParser.DetachedBranch;
 
-            var selectedRevisionRemotes = _revision.Refs.Where(r => r.IsRemote).ToList();
+            List<IGitRef> selectedRevisionRemotes = _revision.Refs.Where(r => r.IsRemote).ToList();
 
             return Module.GetRefs(RefsFilter.Heads)
                 .Where(r => r.IsHead)
@@ -74,14 +74,14 @@ namespace GitUI.HelperDialogs
 
         private void Ok_Click(object sender, EventArgs e)
         {
-            var gitRefToReset = _localGitRefs.FirstOrDefault(b => b.Name == Branches.Text);
+            IGitRef gitRefToReset = _localGitRefs.FirstOrDefault(b => b.Name == Branches.Text);
             if (gitRefToReset is null)
             {
                 MessageBox.Show(string.Format(_localRefInvalid.Text, Branches.Text), TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            var command = Commands.PushLocal(gitRefToReset.CompleteName, _revision.ObjectId, Module.GetGitExecPath(Module.WorkingDir), ForceReset.Checked);
+            GitExtUtils.ArgumentString command = Commands.PushLocal(gitRefToReset.CompleteName, _revision.ObjectId, Module.GetGitExecPath(Module.WorkingDir), ForceReset.Checked);
             bool success = FormProcess.ShowDialog(this, UICommands, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
             if (success)
             {

--- a/GitUI/HelperDialogs/FormResetCurrentBranch.cs
+++ b/GitUI/HelperDialogs/FormResetCurrentBranch.cs
@@ -79,7 +79,7 @@ namespace GitUI.HelperDialogs
             {
                 if (MessageBox.Show(this, _resetHardWarning.Text, _resetCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation) == DialogResult.Yes)
                 {
-                    var currentCheckout = Module.GetCurrentCheckout();
+                    ObjectId currentCheckout = Module.GetCurrentCheckout();
                     bool success = FormProcess.ShowDialog(this, UICommands, arguments: Commands.Reset(ResetMode.Hard, Revision.Guid), Module.WorkingDir, input: null, useDialogSettings: true);
                     if (success)
                     {

--- a/GitUI/Infrastructure/Plink.cs
+++ b/GitUI/Infrastructure/Plink.cs
@@ -75,9 +75,9 @@ namespace GitUI.Infrastructure
         {
             host = GetPlinkCompatibleUrl(host);
 
-            var args = $"/k \"\"{AppSettings.Plink}\" -T {host}\"";
+            string args = $"/k \"\"{AppSettings.Plink}\" -T {host}\"";
 
-            using var process = _executable.Start(args, createWindow: true, redirectInput: false, redirectOutput: false, outputEncoding: null);
+            using GitUIPluginInterfaces.IProcess process = _executable.Start(args, createWindow: true, redirectInput: false, redirectOutput: false, outputEncoding: null);
             return await process.WaitForExitAsync() == 0;
         }
 

--- a/GitUI/Infrastructure/PuttyHelpers.cs
+++ b/GitUI/Infrastructure/PuttyHelpers.cs
@@ -90,7 +90,7 @@ namespace GitUI.Infrastructure
 
             static bool IsPageantRunning()
             {
-                var pageantProcName = Path.GetFileNameWithoutExtension(AppSettings.Pageant);
+                string pageantProcName = Path.GetFileNameWithoutExtension(AppSettings.Pageant);
                 return Process.GetProcessesByName(pageantProcName).Length != 0;
             }
         }

--- a/GitUI/Infrastructure/Telemetry/AppEnvironmentTelemetryInitializer.cs
+++ b/GitUI/Infrastructure/Telemetry/AppEnvironmentTelemetryInitializer.cs
@@ -9,7 +9,7 @@ namespace GitUI.Infrastructure.Telemetry
         public void Initialize(ITelemetry telemetry)
         {
             string sshClient;
-            var sshPath = AppSettings.SshPath;
+            string sshPath = AppSettings.SshPath;
             if (string.IsNullOrEmpty(sshPath))
             {
                 sshClient = "OpenSSH";

--- a/GitUI/Infrastructure/Telemetry/MonitorsTelemetryInitializer.cs
+++ b/GitUI/Infrastructure/Telemetry/MonitorsTelemetryInitializer.cs
@@ -8,15 +8,15 @@ namespace GitUI.Infrastructure.Telemetry
     {
         public void Initialize(ITelemetry telemetry)
         {
-            var properties = telemetry.Context.GlobalProperties;
+            IDictionary<string, string> properties = telemetry.Context.GlobalProperties;
             properties["Monitor count"] = Screen.AllScreens.Length.ToString();
             properties["Monitor primary DPI"] = DpiUtil.DpiX.ToString();
 
             for (int i = 0; i < Screen.AllScreens.Length; i++)
             {
-                var key = Screen.AllScreens[i].Primary ? "primary" : $"secondary{i}";
+                string key = Screen.AllScreens[i].Primary ? "primary" : $"secondary{i}";
 
-                var bounds = Screen.AllScreens[i].Bounds;
+                Rectangle bounds = Screen.AllScreens[i].Bounds;
                 properties[$"Monitor {key} resolution"] = $"{bounds.Width}x{bounds.Height}";
             }
         }

--- a/GitUI/Infrastructure/Telemetry/ThemingTelemetryInitializer.cs
+++ b/GitUI/Infrastructure/Telemetry/ThemingTelemetryInitializer.cs
@@ -7,8 +7,8 @@ namespace GitUI.Infrastructure.Telemetry
     {
         public void Initialize(ITelemetry telemetry)
         {
-            var properties = telemetry.Context.GlobalProperties;
-            var themeSettings = Theming.ThemeModule.Settings;
+            IDictionary<string, string> properties = telemetry.Context.GlobalProperties;
+            GitExtUtils.GitUI.Theming.ThemeSettings themeSettings = Theming.ThemeModule.Settings;
             properties["Theme dark"] = FlagString(themeSettings.Theme.Id.Name == "dark");
             properties["Theme builtin"] = FlagString(themeSettings.Theme.Id.IsBuiltin);
             properties["Theme systemstyles"] = FlagString(themeSettings.UseSystemVisualStyle);

--- a/GitUI/LeftPanel/BranchPathNode.cs
+++ b/GitUI/LeftPanel/BranchPathNode.cs
@@ -17,13 +17,13 @@ namespace GitUI.LeftPanel
 
         public void DeleteAll()
         {
-            var branches = Nodes.DepthEnumerator<LocalBranchNode>().Select(branch => branch.FullPath);
+            IEnumerable<string> branches = Nodes.DepthEnumerator<LocalBranchNode>().Select(branch => branch.FullPath);
             UICommands.StartDeleteBranchDialog(ParentWindow(), branches);
         }
 
         public void CreateBranch()
         {
-            var newBranchNamePrefix = FullPath + PathSeparator;
+            string newBranchNamePrefix = FullPath + PathSeparator;
             UICommands.StartCreateBranchDialog(ParentWindow(), objectId: null, newBranchNamePrefix);
         }
     }

--- a/GitUI/LeftPanel/ContextMenu/GitRefsSortByContextMenuItem.cs
+++ b/GitUI/LeftPanel/ContextMenu/GitRefsSortByContextMenuItem.cs
@@ -16,13 +16,13 @@ namespace GitUI.LeftPanel.ContextMenu
             Image = Images.SortBy;
             Text = TranslatedStrings.SortBy;
 
-            foreach (var option in EnumHelper.GetValues<GitRefsSortBy>().Select(e => (Text: e.GetDescription(), Value: e)))
+            foreach ((string text, GitRefsSortBy value) option in EnumHelper.GetValues<GitRefsSortBy>().Select(e => (Text: e.GetDescription(), Value: e)))
             {
                 ToolStripMenuItem item = new()
                 {
-                    Text = option.Text,
+                    Text = option.text,
                     Image = null,
-                    Tag = option.Value
+                    Tag = option.value
                 };
 
                 item.Click += Item_Click;
@@ -35,7 +35,7 @@ namespace GitUI.LeftPanel.ContextMenu
 
         private void RequerySortingMethod()
         {
-            var currentSort = AppSettings.RefsSortBy;
+            GitRefsSortBy currentSort = AppSettings.RefsSortBy;
             foreach (ToolStripMenuItem item in DropDownItems)
             {
                 item.Checked = currentSort.Equals(item.Tag);
@@ -46,7 +46,7 @@ namespace GitUI.LeftPanel.ContextMenu
         {
             if (sender is ToolStripMenuItem item)
             {
-                var sortingType = (GitRefsSortBy)item.Tag;
+                GitRefsSortBy sortingType = (GitRefsSortBy)item.Tag;
                 AppSettings.RefsSortBy = sortingType;
 
                 _onSortByChanged?.Invoke();

--- a/GitUI/LeftPanel/ContextMenu/GitRefsSortOrderContextMenuItem.cs
+++ b/GitUI/LeftPanel/ContextMenu/GitRefsSortOrderContextMenuItem.cs
@@ -18,13 +18,13 @@ namespace GitUI.LeftPanel.ContextMenu
             Text = TranslatedStrings.SortOrder;
             Name = MenuItemName;
 
-            foreach (var option in EnumHelper.GetValues<GitRefsSortOrder>().Select(e => (Text: e.GetDescription(), Value: e)))
+            foreach ((string text, GitRefsSortOrder value) option in EnumHelper.GetValues<GitRefsSortOrder>().Select(e => (Text: e.GetDescription(), Value: e)))
             {
                 ToolStripMenuItem item = new()
                 {
-                    Text = option.Text,
+                    Text = option.text,
                     Image = null,
-                    Tag = option.Value
+                    Tag = option.value
                 };
 
                 item.Click += Item_Click;
@@ -37,7 +37,7 @@ namespace GitUI.LeftPanel.ContextMenu
 
         private void RequerySortingMethod()
         {
-            var currentSort = AppSettings.RefsSortOrder;
+            GitRefsSortOrder currentSort = AppSettings.RefsSortOrder;
             foreach (ToolStripMenuItem item in DropDownItems)
             {
                 item.Checked = currentSort.Equals(item.Tag);
@@ -48,7 +48,7 @@ namespace GitUI.LeftPanel.ContextMenu
         {
             if (sender is ToolStripMenuItem item)
             {
-                var sortingType = (GitRefsSortOrder)item.Tag;
+                GitRefsSortOrder sortingType = (GitRefsSortOrder)item.Tag;
                 AppSettings.RefsSortOrder = sortingType;
 
                 _onSortOrderChanged?.Invoke();

--- a/GitUI/LeftPanel/LocalBranchTree.cs
+++ b/GitUI/LeftPanel/LocalBranchTree.cs
@@ -51,7 +51,7 @@ namespace GitUI.LeftPanel
             #endregion
 
             Nodes nodes = new(this);
-            var aheadBehindData = _aheadBehindDataProvider?.GetData();
+            IDictionary<string, AheadBehindData> aheadBehindData = _aheadBehindDataProvider?.GetData();
             string currentBranch = _revisionGridInfo.GetCurrentBranch();
             Dictionary<string, BaseRevisionNode> pathToNode = new();
             foreach (IGitRef branch in PrioritizedBranches(branches))
@@ -67,7 +67,7 @@ namespace GitUI.LeftPanel
                     localBranchNode.UpdateAheadBehind(aheadBehind.ToDisplay(), aheadBehind.RemoteRef);
                 }
 
-                var parent = localBranchNode.CreateRootNode(pathToNode, (tree, parentPath) => new BranchPathNode(tree, parentPath));
+                BaseRevisionNode parent = localBranchNode.CreateRootNode(pathToNode, (tree, parentPath) => new BranchPathNode(tree, parentPath));
                 if (parent is not null)
                 {
                     nodes.AddNode(parent);
@@ -96,7 +96,7 @@ namespace GitUI.LeftPanel
                 return;
             }
 
-            var currentBranch = Nodes.DepthEnumerator<LocalBranchNode>().FirstOrDefault(b => b.IsCurrent);
+            LocalBranchNode currentBranch = Nodes.DepthEnumerator<LocalBranchNode>().FirstOrDefault(b => b.IsCurrent);
             TreeViewNode.TreeView.SelectedNode = currentBranch?.TreeViewNode;
         }
     }

--- a/GitUI/LeftPanel/Node.cs
+++ b/GitUI/LeftPanel/Node.cs
@@ -100,7 +100,7 @@ namespace GitUI.LeftPanel
 
         public static void OnNode<T>(TreeNode treeNode, Action<T> action) where T : class, INode
         {
-            var node = GetNodeSafe<T>(treeNode);
+            T node = GetNodeSafe<T>(treeNode);
 
             if (node is not null)
             {

--- a/GitUI/LeftPanel/Nodes.cs
+++ b/GitUI/LeftPanel/Nodes.cs
@@ -44,14 +44,14 @@
         /// </summary>
         public IEnumerable<TNode> DepthEnumerator<TNode>() where TNode : NodeBase
         {
-            foreach (var node in this)
+            foreach (Node node in this)
             {
                 if (node is TNode node1)
                 {
                     yield return node1;
                 }
 
-                foreach (var subNode in node.Nodes.DepthEnumerator<TNode>())
+                foreach (TNode subNode in node.Nodes.DepthEnumerator<TNode>())
                 {
                     yield return subNode;
                 }
@@ -67,21 +67,21 @@
         {
             HashSet<Node> prevNodes = new();
 
-            for (var i = 0; i < treeViewNode.Nodes.Count; i++)
+            for (int i = 0; i < treeViewNode.Nodes.Count; i++)
             {
                 prevNodes.Add(Node.GetNode(treeViewNode.Nodes[i]));
             }
 
-            var oldNodeIdx = 0;
+            int oldNodeIdx = 0;
 
-            foreach (var node in this)
+            foreach (Node node in this)
             {
                 TreeNode treeNode;
 
                 if (oldNodeIdx < treeViewNode.Nodes.Count)
                 {
                     treeNode = treeViewNode.Nodes[oldNodeIdx];
-                    var oldNode = Node.GetNode(treeNode);
+                    Node oldNode = Node.GetNode(treeNode);
 
                     if (!oldNode.Equals(node) && !prevNodes.Contains(node))
                     {

--- a/GitUI/LeftPanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.ContextActions.cs
@@ -131,7 +131,7 @@ namespace GitUI.LeftPanel
 
             RegisterClick(filterForSelectedRefsMenuItem, () =>
             {
-                var refPaths = GetSelectedNodes().OfType<IGitRefActions>().Select(b => b.FullPath);
+                IEnumerable<string> refPaths = GetSelectedNodes().OfType<IGitRefActions>().Select(b => b.FullPath);
                 _filterRevisionGridBySpaceSeparatedRefs(refPaths.Join(" "));
             });
 
@@ -215,7 +215,7 @@ namespace GitUI.LeftPanel
             copyContextMenuItem.Enable(hasSingleSelection && (selectedNode is BaseBranchLeafNode or StashNode) && selectedNode.Visible);
             filterForSelectedRefsMenuItem.Enable(selectedNodes.OfType<IGitRefActions>().Any()); // enable if selection contains refs
 
-            var selectedLocalBranch = selectedNode as LocalBranchNode;
+            LocalBranchNode selectedLocalBranch = selectedNode as LocalBranchNode;
 
             foreach (ToolStripItemWithKey item in _localBranchMenuItems)
             {

--- a/GitUI/LeftPanel/RepoObjectsTree.SettingsContextMenu.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.SettingsContextMenu.cs
@@ -12,10 +12,10 @@ namespace GitUI.LeftPanel
         private void FixInvalidTreeToPositionIndices()
         {
             // Sort by index, then force assign 0-based sequential indices
-            var treeToIndex = GetTreeToPositionIndex();
+            Dictionary<Tree, int> treeToIndex = GetTreeToPositionIndex();
 
             int i = 0;
-            foreach (var kvp in treeToIndex.OrderBy(kvp => kvp.Value))
+            foreach (KeyValuePair<Tree, int> kvp in treeToIndex.OrderBy(kvp => kvp.Value))
             {
                 treeToIndex[kvp.Key] = i;
                 ++i;
@@ -47,9 +47,9 @@ namespace GitUI.LeftPanel
 
         private void ReorderTreeNode(TreeNode node, bool up)
         {
-            var tree = (Tree)node.Tag;
-            var treeToIndex = GetTreeToPositionIndex();
-            var indexToTree = treeToIndex.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
+            Tree tree = (Tree)node.Tag;
+            Dictionary<Tree, int> treeToIndex = GetTreeToPositionIndex();
+            Dictionary<int, Tree> indexToTree = treeToIndex.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
 
             int currIndex = treeToIndex[tree];
 
@@ -67,7 +67,7 @@ namespace GitUI.LeftPanel
             }
             while (!indexToTree[swapIndex].TreeViewNode.IsVisible);
 
-            var swapWithTree = indexToTree[swapIndex];
+            Tree swapWithTree = indexToTree[swapIndex];
 
             // Swap indices
             treeToIndex[tree] = treeToIndex[swapWithTree];

--- a/GitUI/LeftPanel/SubmoduleNode.cs
+++ b/GitUI/LeftPanel/SubmoduleNode.cs
@@ -32,7 +32,7 @@ namespace GitUI.LeftPanel
             // Extract submodule name and branch
             // e.g. Info.Text = "Externals/conemu-inside [no branch]"
             // Note that the branch portion won't be there if the user hasn't yet init'd + updated the submodule.
-            var pathAndBranch = Info.Text.Split(Delimiters.Space, 2);
+            string[] pathAndBranch = Info.Text.Split(Delimiters.Space, 2);
             Trace.Assert(pathAndBranch.Length >= 1);
             SubmoduleName = pathAndBranch[0].SubstringAfterLast('/'); // Remove path
             BranchText = pathAndBranch.Length == 2 ? " " + pathAndBranch[1] : "";

--- a/GitUI/LeftPanel/TagTree.cs
+++ b/GitUI/LeftPanel/TagTree.cs
@@ -20,7 +20,7 @@ namespace GitUI.LeftPanel
                 token.ThrowIfCancellationRequested();
 
                 TagNode tagNode = new(this, tag.ObjectId, tag.Name, visible: true);
-                var parent = tagNode.CreateRootNode(pathToNodes, (tree, parentPath) => new BasePathNode(tree, parentPath));
+                BaseRevisionNode parent = tagNode.CreateRootNode(pathToNodes, (tree, parentPath) => new BasePathNode(tree, parentPath));
 
                 if (parent is not null)
                 {

--- a/GitUI/LeftPanel/Tree.cs
+++ b/GitUI/LeftPanel/Tree.cs
@@ -144,14 +144,14 @@ namespace GitUI.LeftPanel
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            var expandedNodesState = firstTime ? new HashSet<string>() : TreeViewNode.GetExpandedNodesState();
+            HashSet<string> expandedNodesState = firstTime ? new HashSet<string>() : TreeViewNode.GetExpandedNodesState();
             Nodes.FillTreeViewNode(TreeViewNode);
 
-            var selectedNode = TreeViewNode.TreeView.SelectedNode;
+            TreeNode selectedNode = TreeViewNode.TreeView.SelectedNode;
 
             if (originalSelectedNodeFullNamePath != selectedNode?.GetFullNamePath())
             {
-                var node = TreeViewNode.GetNodeFromPath(originalSelectedNodeFullNamePath);
+                TreeNode node = TreeViewNode.GetNodeFromPath(originalSelectedNodeFullNamePath);
 
                 if (node is not null)
                 {

--- a/GitUI/Plugin/GitPluginSettingsContainer.cs
+++ b/GitUI/Plugin/GitPluginSettingsContainer.cs
@@ -41,7 +41,7 @@ namespace GitUI
                 return ExternalSettings.GetValue($"{_pluginName}{name}");
             }
 
-            var value = ExternalSettings.GetValue($"{_pluginId}.{name}");
+            string value = ExternalSettings.GetValue($"{_pluginId}.{name}");
 
             // for old plugin setting processing
             if (value is null)

--- a/GitUI/Plugin/PluginRegistry.cs
+++ b/GitUI/Plugin/PluginRegistry.cs
@@ -27,7 +27,7 @@ namespace GitUI
 
                 try
                 {
-                    foreach (var plugin in ManagedExtensibility.GetExports<IGitPlugin>().Select(lazy => lazy.Value))
+                    foreach (IGitPlugin plugin in ManagedExtensibility.GetExports<IGitPlugin>().Select(lazy => lazy.Value))
                     {
                         Validates.NotNull(plugin.Description);
 

--- a/GitUI/RepositoryHistoryUIService.cs
+++ b/GitUI/RepositoryHistoryUIService.cs
@@ -93,7 +93,7 @@ namespace GitUI
             List<RecentRepoInfo> pinnedRepos = new();
             List<RecentRepoInfo> allRecentRepos = new();
 
-            using (var graphics = OwnerForm.CreateGraphics())
+            using (Graphics graphics = OwnerForm.CreateGraphics())
             {
                 RecentRepoSplitter splitter = new()
                 {
@@ -104,7 +104,7 @@ namespace GitUI
                 splitter.SplitRecentRepos(repositoryHistory, pinnedRepos, allRecentRepos);
             }
 
-            foreach (var repo in pinnedRepos.Union(allRecentRepos).GroupBy(k => k.Repo.Category).OrderBy(k => k.Key))
+            foreach (IGrouping<string, RecentRepoInfo> repo in pinnedRepos.Union(allRecentRepos).GroupBy(k => k.Repo.Category).OrderBy(k => k.Key))
             {
                 AddFavouriteRepositories(repo.Key, repo.ToList());
             }
@@ -123,7 +123,7 @@ namespace GitUI
                 }
 
                 menuItemCategory.DropDown.SuspendLayout();
-                foreach (var r in repos)
+                foreach (RecentRepoInfo r in repos)
                 {
                     AddRecentRepositories(menuItemCategory, r.Repo, r.Caption);
                 }
@@ -143,7 +143,7 @@ namespace GitUI
                 return;
             }
 
-            using (var graphics = OwnerForm.CreateGraphics())
+            using (Graphics graphics = OwnerForm.CreateGraphics())
             {
                 RecentRepoSplitter splitter = new()
                 {
@@ -154,7 +154,7 @@ namespace GitUI
                 splitter.SplitRecentRepos(repositoryHistory, pinnedRepos, allRecentRepos);
             }
 
-            foreach (var repo in pinnedRepos)
+            foreach (RecentRepoInfo repo in pinnedRepos)
             {
                 AddRecentRepositories(container, repo.Repo, repo.Caption);
             }
@@ -166,7 +166,7 @@ namespace GitUI
                     container.DropDownItems.Add(new ToolStripSeparator());
                 }
 
-                foreach (var repo in allRecentRepos)
+                foreach (RecentRepoInfo repo in allRecentRepos)
                 {
                     AddRecentRepositories(container, repo.Repo, repo.Caption);
                 }

--- a/GitUI/ScriptsEngine/SplitButton.cs
+++ b/GitUI/ScriptsEngine/SplitButton.cs
@@ -359,7 +359,7 @@ namespace GitUI.ScriptsEngine
         {
             // Figure out where our text and image should go
 
-            CalculateButtonTextAndImageLayout(ref bounds, out var text_rectangle, out var image_rectangle);
+            CalculateButtonTextAndImageLayout(ref bounds, out Rectangle text_rectangle, out Rectangle image_rectangle);
 
             // draw the image
             if (Image is not null)
@@ -407,7 +407,7 @@ namespace GitUI.ScriptsEngine
 
             Point[] arrow = { new Point(middle.X - 2, middle.Y - 1), new Point(middle.X + 3, middle.Y - 1), new Point(middle.X, middle.Y + 2) };
 
-            var brush = Enabled
+            Brush brush = Enabled
                 ? SystemBrushes.ControlText
                 : SystemBrushes.ButtonShadow;
 

--- a/GitUI/Shells/BashShell.cs
+++ b/GitUI/Shells/BashShell.cs
@@ -15,7 +15,7 @@ namespace GitUI.Shells
             Name = ShellName;
             Icon = Images.GitForWindows;
 
-            if (PathUtil.TryFindShellPath(GitBashExe, out var exePath))
+            if (PathUtil.TryFindShellPath(GitBashExe, out string? exePath))
             {
                 ExecutableName = GitBashExe;
                 ExecutablePath = exePath;

--- a/GitUI/Shells/CmdShell.cs
+++ b/GitUI/Shells/CmdShell.cs
@@ -11,7 +11,7 @@ namespace GitUI.Shells
             Icon = Images.cmd;
 
             ExecutableName = "cmd.exe";
-            if (PathUtil.TryFindShellPath(ExecutableName, out var exePath))
+            if (PathUtil.TryFindShellPath(ExecutableName, out string? exePath))
             {
                 ExecutablePath = exePath;
                 ExecutableCommandLine = exePath.Quote();

--- a/GitUI/Shells/PowerShellShell.cs
+++ b/GitUI/Shells/PowerShellShell.cs
@@ -11,7 +11,7 @@ namespace GitUI.Shells
             Icon = Images.powershell;
 
             ExecutableName = "powershell.exe";
-            if (PathUtil.TryFindShellPath(ExecutableName, out var exePath))
+            if (PathUtil.TryFindShellPath(ExecutableName, out string? exePath))
             {
                 ExecutablePath = exePath;
                 ExecutableCommandLine = exePath.Quote();

--- a/GitUI/Shells/PwshShell.cs
+++ b/GitUI/Shells/PwshShell.cs
@@ -11,7 +11,7 @@ namespace GitUI.Shells
             Icon = Images.pwsh;
 
             ExecutableName = "pwsh.exe";
-            if (PathUtil.TryFindShellPath(ExecutableName, out var exePath))
+            if (PathUtil.TryFindShellPath(ExecutableName, out string? exePath))
             {
                 ExecutablePath = exePath;
                 ExecutableCommandLine = exePath.Quote();

--- a/GitUI/Shells/ShellProvider.cs
+++ b/GitUI/Shells/ShellProvider.cs
@@ -13,7 +13,7 @@ namespace GitUI.Shells
 
         public string GetShellCommandLine(string? shellType)
         {
-            var shell = GetShell(shellType);
+            IShellDescriptor shell = GetShell(shellType);
 
             if (!shell.HasExecutable || shell.ExecutableCommandLine is null)
             {

--- a/GitUI/SpellChecker/SpellCheckEditControl.cs
+++ b/GitUI/SpellChecker/SpellCheckEditControl.cs
@@ -81,8 +81,8 @@ namespace GitUI.SpellChecker
             DrawLines(IllFormedLines, DrawType.Mark);
 
             // Mark first line if it is blank
-            var lh = LineHeight();
-            var ypos = _richTextBox.GetPositionFromCharIndex(0).Y;
+            int lh = LineHeight();
+            int ypos = _richTextBox.GetPositionFromCharIndex(0).Y;
             if (_richTextBox.Text.Length > 1 &&
 
                 // check for textBox.Text.Length>1 instead of textBox.Text.Length!=0 because there might be only a \n
@@ -102,10 +102,10 @@ namespace GitUI.SpellChecker
 
         private void DrawLines(IEnumerable<TextPos> list, DrawType type)
         {
-            foreach (var textPos in list)
+            foreach (TextPos textPos in list)
             {
-                var start = _richTextBox.GetPositionFromCharIndex(textPos.Start);
-                var end = _richTextBox.GetPositionFromCharIndex(textPos.End);
+                Point start = _richTextBox.GetPositionFromCharIndex(textPos.Start);
+                Point end = _richTextBox.GetPositionFromCharIndex(textPos.End);
 
                 // The position above now points to the top left corner of the character.
                 // We need to account for the character height so the underlines go
@@ -152,18 +152,18 @@ namespace GitUI.SpellChecker
         private void DrawWave(Point start, Point end)
         {
             using Pen pen = new(Color.Red, DpiUtil.ScaleX);
-            var waveWidth = DpiUtil.Scale(4);
-            var waveHalfWidth = waveWidth >> 1;
+            int waveWidth = DpiUtil.Scale(4);
+            int waveHalfWidth = waveWidth >> 1;
             if ((end.X - start.X) > waveWidth)
             {
                 List<Point> pl = new();
-                for (var i = start.X; i <= (end.X - waveHalfWidth); i += waveWidth)
+                for (int i = start.X; i <= (end.X - waveHalfWidth); i += waveWidth)
                 {
                     pl.Add(new Point(i, start.Y));
                     pl.Add(new Point(i + waveHalfWidth, start.Y + waveHalfWidth));
                 }
 
-                var p = pl.ToArray();
+                Point[] p = pl.ToArray();
                 _bufferGraphics!.DrawLines(pen, p);
             }
             else
@@ -174,8 +174,8 @@ namespace GitUI.SpellChecker
 
         private void DrawMark(Point start, Point end)
         {
-            var col = Color.FromArgb(120, 255, 255, 0);
-            var lineHeight = LineHeight();
+            Color col = Color.FromArgb(120, 255, 255, 0);
+            int lineHeight = LineHeight();
             using Pen pen = new(col, lineHeight);
             start.Offset(0, -lineHeight / 2);
             end.Offset(0, -lineHeight / 2);

--- a/GitUI/SpellChecker/TextBoxHelper.cs
+++ b/GitUI/SpellChecker/TextBoxHelper.cs
@@ -18,9 +18,9 @@ namespace GitUI.SpellChecker
                 return tb.Font.Height;
             }
 
-            var lineNumber = rtb.GetLineFromCharIndex(index);
-            var lineIndex = NativeMethods.SendMessageW(rtb.Handle, NativeMethods.EM_LINEINDEX, (IntPtr)lineNumber, IntPtr.Zero).ToInt32();
-            var lineLength = NativeMethods.SendMessageW(rtb.Handle, NativeMethods.EM_LINELENGTH, (IntPtr)index, IntPtr.Zero).ToInt32();
+            int lineNumber = rtb.GetLineFromCharIndex(index);
+            int lineIndex = NativeMethods.SendMessageW(rtb.Handle, NativeMethods.EM_LINEINDEX, (IntPtr)lineNumber, IntPtr.Zero).ToInt32();
+            int lineLength = NativeMethods.SendMessageW(rtb.Handle, NativeMethods.EM_LINELENGTH, (IntPtr)index, IntPtr.Zero).ToInt32();
 
             NativeMethods.CHARRANGE charRange = new()
             {
@@ -44,8 +44,8 @@ namespace GitUI.SpellChecker
                 right = 10000000 ////(int)(rtb.Width * anInch + 20);
             };
 
-            var canvas = Graphics.FromHwnd(rtb.Handle);
-            var canvasHdc = canvas.GetHdc();
+            Graphics canvas = Graphics.FromHwnd(rtb.Handle);
+            IntPtr canvasHdc = canvas.GetHdc();
 
             NativeMethods.FORMATRANGE formatRange = new()
             {

--- a/GitUI/SplitterManager.cs
+++ b/GitUI/SplitterManager.cs
@@ -24,7 +24,7 @@ namespace GitUI
 
         public void RestoreSplitters()
         {
-            foreach (var splitter in _splitters)
+            foreach (SplitterData splitter in _splitters)
             {
                 splitter.RestoreFromSettings(_settings);
             }
@@ -32,7 +32,7 @@ namespace GitUI
 
         public void SaveSplitters()
         {
-            foreach (var splitter in _splitters)
+            foreach (SplitterData splitter in _splitters)
             {
                 splitter.SaveToSettings(_settings);
             }
@@ -72,8 +72,8 @@ namespace GitUI
 
                 if (prevSize > 0 && prevDistance > 0)
                 {
-                    var fixedPanel = _splitter.FixedPanel;
-                    var splitterWidth = _splitter.SplitterWidth;
+                    FixedPanel fixedPanel = _splitter.FixedPanel;
+                    int splitterWidth = _splitter.SplitterWidth;
                     if (SplitterSize == prevSize && _dpi == prevDpi)
                     {
                         SetSplitterDistance(fixedPanel == FixedPanel.Panel2 ? prevDistance + splitterWidth : prevDistance);

--- a/GitUI/Theming/Renderers/ButtonRenderer.cs
+++ b/GitUI/Theming/Renderers/ButtonRenderer.cs
@@ -9,7 +9,7 @@ namespace GitUI.Theming
         public override int RenderBackground(IntPtr hdc, int partid, int stateid, Rectangle prect,
             NativeMethods.RECTCLS pcliprect)
         {
-            using var ctx = CreateRenderContext(hdc, pcliprect);
+            using Context ctx = CreateRenderContext(hdc, pcliprect);
             switch ((Parts)partid)
             {
                 case Parts.BP_GROUPBOX:
@@ -41,7 +41,7 @@ namespace GitUI.Theming
 
         private static void RenderPushButton(Context ctx, State.Push stateid, Rectangle prect)
         {
-            var border = prect.Inclusive();
+            Rectangle border = prect.Inclusive();
             switch (stateid)
             {
                 case State.Push.PBS_DISABLED:
@@ -129,7 +129,7 @@ namespace GitUI.Theming
             }
 
             ctx.Graphics.FillRectangle(backBrush, prect);
-            var border = prect.Inclusive();
+            Rectangle border = prect.Inclusive();
             ctx.Graphics.DrawRectangle(borderPen, border);
 
             switch (stateid)
@@ -153,7 +153,7 @@ namespace GitUI.Theming
                     int y1 = border.Top + (border.Height / 4);
                     int y2 = border.Top + (border.Height / 2);
                     int y3 = border.Bottom - (border.Height / 4);
-                    var points = new[]
+                    Point[] points = new[]
                     {
                         new Point(x1, y2),
                         new Point(x2, y3),
@@ -205,10 +205,10 @@ namespace GitUI.Theming
 
             using (ctx.HighQuality())
             {
-                var rect = prect.Inclusive();
+                Rectangle rect = prect.Inclusive();
                 ctx.Graphics.FillEllipse(backBrush, rect);
                 ctx.Graphics.DrawEllipse(SystemPens.FromSystemColor(foreColor), rect);
-                var padding = DpiUtil.Scale(new Size(-3, -3));
+                Size padding = DpiUtil.Scale(new Size(-3, -3));
                 switch (stateid)
                 {
                     case State.Radio.RBS_CHECKEDNORMAL:

--- a/GitUI/Theming/Renderers/ComboBoxRenderer.cs
+++ b/GitUI/Theming/Renderers/ComboBoxRenderer.cs
@@ -9,7 +9,7 @@ namespace GitUI.Theming
         public override int RenderBackground(IntPtr hdc, int partid, int stateid, Rectangle prect,
             NativeMethods.RECTCLS pcliprect)
         {
-            using var ctx = CreateRenderContext(hdc, pcliprect);
+            using Context ctx = CreateRenderContext(hdc, pcliprect);
             switch ((Parts)partid)
             {
                 case Parts.CP_BACKGROUND:
@@ -113,7 +113,7 @@ namespace GitUI.Theming
 
         private static int RenderDropDownButton(Context ctx, State.DropDown stateid, Rectangle prect)
         {
-            var border = prect.Inclusive();
+            Rectangle border = prect.Inclusive();
             switch (stateid)
             {
                 case State.DropDown.CBXS_HOT:
@@ -186,7 +186,7 @@ namespace GitUI.Theming
             int y1 = prect.Top + ((prect.Height - h) / 2);
             int y2 = y1 + h;
 
-            var arrowPoints = new[]
+            Point[] arrowPoints = new[]
             {
                 new Point(x1, y1),
                 new Point(x2, y2),

--- a/GitUI/Theming/Renderers/EditRenderer.cs
+++ b/GitUI/Theming/Renderers/EditRenderer.cs
@@ -7,7 +7,7 @@ namespace GitUI.Theming
         public override int RenderBackground(IntPtr hdc, int partid, int stateid, Rectangle prect,
             NativeMethods.RECTCLS pcliprect)
         {
-            using var ctx = CreateRenderContext(hdc, pcliprect);
+            using Context ctx = CreateRenderContext(hdc, pcliprect);
             return (Parts)partid switch
             {
                 Parts.EP_EDITTEXT => RenderEditText(ctx, stateid, prect),

--- a/GitUI/Theming/Renderers/HeaderRenderer.cs
+++ b/GitUI/Theming/Renderers/HeaderRenderer.cs
@@ -9,7 +9,7 @@ namespace GitUI.Theming
         public override int RenderBackground(IntPtr hdc, int partId, int stateId, Rectangle prect,
             NativeMethods.RECTCLS pcliprect)
         {
-            using var ctx = CreateRenderContext(hdc, pcliprect);
+            using Context ctx = CreateRenderContext(hdc, pcliprect);
             switch ((Parts)partId)
             {
                 case Parts.None:
@@ -20,7 +20,7 @@ namespace GitUI.Theming
 
                 case Parts.HP_HEADERITEM:
                 {
-                    var backBrush = GetBackBrush((State.Item)stateId);
+                    Brush backBrush = GetBackBrush((State.Item)stateId);
                     ctx.Graphics.FillRectangle(backBrush, prect);
                     ctx.Graphics.DrawLine(SystemPens.ControlDark,
                         new Point(prect.Right - 1, prect.Top),
@@ -30,7 +30,7 @@ namespace GitUI.Theming
 
                 case Parts.HP_HEADERSORTARROW:
                 {
-                    var arrowPoints = GetArrowPolygon((State.SortArrow)stateId, prect);
+                    Point[] arrowPoints = GetArrowPolygon((State.SortArrow)stateId, prect);
                     ctx.Graphics.FillRectangle(SystemBrushes.Control, prect);
                     using (ctx.HighQuality())
                     {

--- a/GitUI/Theming/Renderers/ThemeRenderer.cs
+++ b/GitUI/Theming/Renderers/ThemeRenderer.cs
@@ -64,7 +64,7 @@ namespace GitUI.Theming
         /// <param name="hwnd">win32 window handle.</param>
         public void AddThemeData(IntPtr hwnd)
         {
-            var htheme = NativeMethods.OpenThemeData(hwnd, Clsid);
+            IntPtr htheme = NativeMethods.OpenThemeData(hwnd, Clsid);
             _themeDataHandles.Add(htheme);
         }
 
@@ -73,7 +73,7 @@ namespace GitUI.Theming
 
         public void Dispose()
         {
-            foreach (var htheme in _themeDataHandles)
+            foreach (IntPtr htheme in _themeDataHandles)
             {
                 NativeMethods.CloseThemeData(htheme);
             }
@@ -102,7 +102,7 @@ namespace GitUI.Theming
 
             private Graphics CreateGraphics()
             {
-                var graphics = Graphics.FromHdcInternal(_hdc);
+                Graphics graphics = Graphics.FromHdcInternal(_hdc);
                 _originalClip = graphics.Clip;
                 if (_clip is not null)
                 {

--- a/GitUI/Theming/Renderers/TreeViewRenderer.cs
+++ b/GitUI/Theming/Renderers/TreeViewRenderer.cs
@@ -10,7 +10,7 @@ namespace GitUI.Theming
         public override int RenderBackground(IntPtr hdc, int partid, int stateid, Rectangle prect,
             NativeMethods.RECTCLS pcliprect)
         {
-            using var ctx = CreateRenderContext(hdc, pcliprect);
+            using Context ctx = CreateRenderContext(hdc, pcliprect);
             return (Parts)partid switch
             {
                 Parts.TVP_GLYPH => RenderGlyph(ctx, (State.Glyph)stateid, prect),
@@ -164,7 +164,7 @@ namespace GitUI.Theming
             int x1 = prect.Left + ((prect.Width - w) / 2);
             int x2 = x1 + w;
 
-            var arrowPoints = new[]
+            Point[] arrowPoints = new[]
             {
                 new Point(x1, y1),
                 new Point(x2, y2),
@@ -190,7 +190,7 @@ namespace GitUI.Theming
             int y1 = prect.Top + ((prect.Height - h) / 2);
             int y2 = y1 + h;
 
-            var arrowPoints = new[]
+            Point[] arrowPoints = new[]
             {
                 new Point(x1, y1),
                 new Point(x2, y2),

--- a/GitUI/Theming/SystemBrushesCache.cs
+++ b/GitUI/Theming/SystemBrushesCache.cs
@@ -20,7 +20,7 @@ namespace GitUI.Theming
 
         public IntPtr GetBrush(int colorref)
         {
-            if (!_cache.TryGetValue(colorref, out var handle))
+            if (!_cache.TryGetValue(colorref, out HandleRef handle))
             {
                 IntPtr hbrush = CreateSolidBrush(colorref);
                 handle = new HandleRef(this, hbrush);

--- a/GitUI/Theming/ThemeBasedHighlighting.cs
+++ b/GitUI/Theming/ThemeBasedHighlighting.cs
@@ -21,9 +21,9 @@ namespace GitUI.Theming
         public void MarkTokens(IDocument document)
         {
             _original.MarkTokens(document);
-            foreach (var line in document.LineSegmentCollection)
+            foreach (LineSegment line in document.LineSegmentCollection)
             {
-                foreach (var word in line.Words)
+                foreach (TextWord word in line.Words)
                 {
                     if (word.SyntaxColor is not null)
                     {
@@ -38,7 +38,7 @@ namespace GitUI.Theming
             _original.MarkTokens(document, lines);
             foreach (LineSegment line in lines)
             {
-                foreach (var word in line.Words)
+                foreach (TextWord word in line.Words)
                 {
                     if (word.SyntaxColor is not null)
                     {

--- a/GitUI/Theming/ThemeLoader.cs
+++ b/GitUI/Theming/ThemeLoader.cs
@@ -40,7 +40,7 @@ namespace GitUI.Theming
             string content = _themeFileReader.ReadThemeFile(themeFileName);
             Stylesheet stylesheet = _parser.Parse(content);
 
-            foreach (var importDirective in stylesheet.ImportRules)
+            foreach (IImportRule importDirective in stylesheet.ImportRules)
             {
                 ImportTheme(themeFileName, importDirective, allowedClasses, cssImportChain, themeColors);
             }
@@ -78,8 +78,8 @@ namespace GitUI.Theming
 
         private static void ParseRule(string themeFileName, StyleRule rule, in IReadOnlyList<string> allowedClasses, ThemeColors themeColors)
         {
-            var color = GetColor(themeFileName, rule);
-            var classNames = GetClassNames(themeFileName, rule);
+            Color color = GetColor(themeFileName, rule);
+            string[] classNames = GetClassNames(themeFileName, rule);
 
             string colorName = classNames[0];
             if (!classNames.Skip(1).All(allowedClasses.Contains))
@@ -112,7 +112,7 @@ namespace GitUI.Theming
 
         private static string[] GetClassNames(string themeFileName, StyleRule rule)
         {
-            var selectorText = rule.Selector.Text;
+            string selectorText = rule.Selector.Text;
             if (!selectorText.StartsWith(ClassSelector))
             {
                 throw StyleRuleThemeException(rule, themeFileName);

--- a/GitUI/Theming/ThemeRepository.cs
+++ b/GitUI/Theming/ThemeRepository.cs
@@ -57,7 +57,7 @@ namespace GitUI.Theming
                 throw new InvalidOperationException("Only user-defined theme can be deleted");
             }
 
-            var themePath = _themePathProvider.GetThemePath(themeId);
+            string themePath = _themePathProvider.GetThemePath(themeId);
             File.Delete(themePath);
         }
 

--- a/GitUI/Theming/Win32ColorTranslator.cs
+++ b/GitUI/Theming/Win32ColorTranslator.cs
@@ -15,8 +15,8 @@
 
         public static int GetSystemColorIndex(KnownColor name)
         {
-            var ole = ColorTranslator.ToOle(Color.FromKnownColor(name));
-            var result = ole & 0xffffff;
+            int ole = ColorTranslator.ToOle(Color.FromKnownColor(name));
+            int result = ole & 0xffffff;
             return result;
         }
     }

--- a/GitUI/UserControls/AvatarControl.cs
+++ b/GitUI/UserControls/AvatarControl.cs
@@ -21,7 +21,7 @@ namespace GitUI
 
             clearImagecacheToolStripMenuItem.Click += delegate { ClearCache(); };
 
-            foreach (var avatarProvider in EnumHelper.GetValues<AvatarProvider>())
+            foreach (AvatarProvider avatarProvider in EnumHelper.GetValues<AvatarProvider>())
             {
                 ToolStripMenuItem item = new()
                 {
@@ -40,7 +40,7 @@ namespace GitUI
                 avatarProviderToolStripMenuItem.DropDownItems.Add(item);
             }
 
-            foreach (var defaultImageType in EnumHelper.GetValues<AvatarFallbackType>())
+            foreach (AvatarFallbackType defaultImageType in EnumHelper.GetValues<AvatarFallbackType>())
             {
                 ToolStripMenuItem item = new()
                 {
@@ -120,7 +120,7 @@ namespace GitUI
 
             Size = _avatarImage.Size = size;
 
-            var email = Email;
+            string email = Email;
 
             if (!AppSettings.ShowAuthorAvatarInCommitInfo || string.IsNullOrWhiteSpace(email))
             {
@@ -128,8 +128,8 @@ namespace GitUI
                 return;
             }
 
-            var token = _cancellationTokenSequence.Next();
-            var image = await _avatarProvider.GetAvatarAsync(email, AuthorName, Math.Max(size.Width, size.Height));
+            CancellationToken token = _cancellationTokenSequence.Next();
+            Image image = await _avatarProvider.GetAvatarAsync(email, AuthorName, Math.Max(size.Width, size.Height));
 
             if (!token.IsCancellationRequested)
             {
@@ -141,7 +141,7 @@ namespace GitUI
 
         private void OnClearCacheClick(object sender, EventArgs e)
         {
-            var email = Email;
+            string email = Email;
 
             if (string.IsNullOrWhiteSpace(email))
             {

--- a/GitUI/UserControls/CommitDiff.cs
+++ b/GitUI/UserControls/CommitDiff.cs
@@ -52,7 +52,7 @@ namespace GitUI.UserControls
                 DiffFiles.SetDiffs(new[] { revision });
                 if (fileToSelect is not null)
                 {
-                    var itemToSelect = DiffFiles.AllItems.FirstOrDefault(i => i.Item.Name == fileToSelect);
+                    FileStatusItem itemToSelect = DiffFiles.AllItems.FirstOrDefault(i => i.Item.Name == fileToSelect);
                     if (itemToSelect is not null)
                     {
                         DiffFiles.SelectedGitItem = itemToSelect.Item;

--- a/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
+++ b/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
@@ -90,7 +90,7 @@ namespace GitUI.UserControls
 
             try
             {
-                var commandLine = new ArgumentBuilder { command.Quote(), arguments }.ToString();
+                string commandLine = new ArgumentBuilder { command.Quote(), arguments }.ToString();
                 ConsoleCommandLineOutputProcessor outputProcessor = new(commandLine.Length, FireDataReceived);
 
                 ConEmuStartInfo startInfo = new()
@@ -102,7 +102,7 @@ namespace GitUI.UserControls
                     StartupDirectory = workDir
                 };
 
-                foreach (var (name, value) in envVariables)
+                foreach ((string name, string value) in envVariables)
                 {
                     startInfo.SetEnv(name, value);
                 }
@@ -168,7 +168,7 @@ namespace GitUI.UserControls
 
         public void AnsiStreamChunkReceived(object sender, AnsiStreamChunkEventArgs args)
         {
-            var text = args.GetText(GitModule.SystemEncoding);
+            string text = args.GetText(GitModule.SystemEncoding);
             string? filtered = FilterOutConsoleCommandLine(text);
             if (filtered is not null)
             {

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -197,7 +197,7 @@ namespace GitUI.UserControls
             tsddbtnRevisionFilter.BackColor = toolBackColor;
             tsddbtnRevisionFilter.ForeColor = toolForeColor;
 
-            var toolTextBoxBackColor = SystemColors.Window;
+            Color toolTextBoxBackColor = SystemColors.Window;
             tscboBranchFilter.BackColor = toolTextBoxBackColor;
             tscboBranchFilter.ForeColor = toolForeColor;
             tstxtRevisionFilter.BackColor = toolTextBoxBackColor;
@@ -211,7 +211,7 @@ namespace GitUI.UserControls
                 selectedIndex = 0;
             }
 
-            var selectedMenuItem = tssbtnShowBranches.DropDownItems[selectedIndex];
+            ToolStripItem selectedMenuItem = tssbtnShowBranches.DropDownItems[selectedIndex];
             tssbtnShowBranches.Image = selectedMenuItem.Image;
             tssbtnShowBranches.Text = selectedMenuItem.Text;
             tssbtnShowBranches.ToolTipText = selectedMenuItem.ToolTipText;
@@ -311,7 +311,7 @@ namespace GitUI.UserControls
 
             void BindBranches(string[] branches)
             {
-                var autoCompleteList = tscboBranchFilter.AutoCompleteCustomSource.Cast<string>();
+                IEnumerable<string> autoCompleteList = tscboBranchFilter.AutoCompleteCustomSource.Cast<string>();
                 if (!autoCompleteList.SequenceEqual(branches))
                 {
                     tscboBranchFilter.AutoCompleteCustomSource.Clear();

--- a/GitUI/UserControls/FolderBrowserButton.cs
+++ b/GitUI/UserControls/FolderBrowserButton.cs
@@ -38,7 +38,7 @@ namespace GitUI.UserControls
             directoryInfoPath ??= getter();
 
             // TODO: do we need ParentForm or is "this" ok?
-            var userSelectedPath = OsShellUtil.PickFolder(ParentForm, directoryInfoPath);
+            string userSelectedPath = OsShellUtil.PickFolder(ParentForm, directoryInfoPath);
 
             if (userSelectedPath is not null)
             {

--- a/GitUI/UserControls/HelpImageDisplayUserControl.cs
+++ b/GitUI/UserControls/HelpImageDisplayUserControl.cs
@@ -194,7 +194,7 @@ namespace GitUI.Help
             }
 
             // apply size to control
-            var form = TopLevelControl as Form;
+            Form form = TopLevelControl as Form;
             Size s = new();
             Size ms = new();
             if (form is not null)

--- a/GitUI/UserControls/MainThreadScheduler.cs
+++ b/GitUI/UserControls/MainThreadScheduler.cs
@@ -12,8 +12,8 @@ namespace GitUI.UserControls
         {
             CancellationDisposable cancellationDisposable = new();
             SingleAssignmentDisposable disposable = new();
-            var normalizedTime = Scheduler.Normalize(dueTime);
-            var token = cancellationDisposable.Token;
+            TimeSpan normalizedTime = Scheduler.Normalize(dueTime);
+            CancellationToken token = cancellationDisposable.Token;
             ThreadHelper.JoinableTaskFactory.RunAsync(
                 async () =>
                 {

--- a/GitUI/UserControls/NativeListView.cs
+++ b/GitUI/UserControls/NativeListView.cs
@@ -23,7 +23,7 @@ namespace GitUI.UserControls
 
         protected override void WndProc(ref Message m)
         {
-            var message = m;
+            Message message = m;
             switch (m.Msg)
             {
                 default:

--- a/GitUI/UserControls/NativeTreeViewDoubleClickDecorator.cs
+++ b/GitUI/UserControls/NativeTreeViewDoubleClickDecorator.cs
@@ -49,7 +49,7 @@ namespace GitUI.UserControls
         private void OnMouseDown(object sender, MouseEventArgs e)
         {
             // We only care about double-clicks on the node itself, not the plus/minus part
-            var hitTest = _treeView.HitTest(e.Location);
+            TreeViewHitTestInfo hitTest = _treeView.HitTest(e.Location);
             if (hitTest.Location == TreeViewHitTestLocations.PlusMinus)
             {
                 return;

--- a/GitUI/UserControls/PathFormatter.cs
+++ b/GitUI/UserControls/PathFormatter.cs
@@ -51,7 +51,7 @@ namespace GitUI
 
                     BinarySearch.Find(min: 0, count: maxStep + 1, step =>
                     {
-                        var (tmpPrefix, tmpText, tmpSuffix) = FormatString(name, oldName, step, isNameTruncated: step % 2 == 0);
+                        (string tmpPrefix, string tmpText, string tmpSuffix) = FormatString(name, oldName, step, isNameTruncated: step % 2 == 0);
                         int measuredWidth = MeasureString(tmpPrefix, tmpText, tmpSuffix).Width;
                         bool isShortEnough = measuredWidth <= maxWidth;
 
@@ -73,8 +73,8 @@ namespace GitUI
         public static (string text, string? suffix) FormatTextForFileNameOnly(string name, string? oldName)
         {
             name = name.TrimEnd(PathUtil.PosixDirectorySeparatorChar);
-            var fileName = Path.GetFileName(name);
-            var oldFileName = Path.GetFileName(oldName);
+            string fileName = Path.GetFileName(name);
+            string oldFileName = Path.GetFileName(oldName);
             string? suffix = fileName == oldFileName ? null : FormatOldName(oldFileName);
             return (fileName, suffix);
         }
@@ -87,7 +87,7 @@ namespace GitUI
 
         public Size MeasureString(string? str, bool withPadding = false)
         {
-            var formatFlags = FilePathStringFormat;
+            TextFormatFlags formatFlags = FilePathStringFormat;
             if (!withPadding)
             {
                 formatFlags |= TextFormatFlags.NoPadding;
@@ -112,12 +112,12 @@ namespace GitUI
                 int nameTruncatedChars = isNameTruncated ? step - numberOfTruncatedChars : numberOfTruncatedChars;
                 int oldNameTruncatedChars = step - nameTruncatedChars;
 
-                var (path, filename) = SplitPathName(TruncatePath(name, name.Length - oldNameTruncatedChars));
+                (string path, string filename) = SplitPathName(TruncatePath(name, name.Length - oldNameTruncatedChars));
                 string? suffix = FormatOldName(TruncatePath(oldName, oldName.Length - oldNameTruncatedChars));
                 return (path, filename, suffix);
             }
 
-            var (prefix, text) = SplitPathName(TruncatePath(name, name.Length - step));
+            (string prefix, string text) = SplitPathName(TruncatePath(name, name.Length - step));
             return (prefix, text, null);
 
             static string TruncatePath(string path, int length)
@@ -133,7 +133,7 @@ namespace GitUI
                 }
 
                 // The win32 method PathCompactPathEx is only supported on Windows
-                var truncatePathMethod = AppSettings.TruncatePathMethod;
+                TruncatePathMethod truncatePathMethod = AppSettings.TruncatePathMethod;
 
                 if (truncatePathMethod == TruncatePathMethod.Compact && EnvUtils.RunningOnWindows())
                 {

--- a/GitUI/UserControls/RevisionGrid/AuthorRevisionHighlighting.cs
+++ b/GitUI/UserControls/RevisionGrid/AuthorRevisionHighlighting.cs
@@ -17,9 +17,9 @@ namespace GitUI.UserControls
                 return false;
             }
 
-            var revision = selectedRevisions.FirstOrDefault();
+            GitRevision revision = selectedRevisions.FirstOrDefault();
 
-            var changed = !string.Equals(revision?.AuthorEmail, AuthorEmailToHighlight, StringComparison.OrdinalIgnoreCase);
+            bool changed = !string.Equals(revision?.AuthorEmail, AuthorEmailToHighlight, StringComparison.OrdinalIgnoreCase);
             if (changed)
             {
                 AuthorEmailToHighlight = revision is not null

--- a/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
@@ -32,8 +32,8 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
         public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {
-            var monospaceFont = style.MonospaceFont;
-            if (!_widthByLengthByFont.TryGetValue(monospaceFont, out var widthByLength))
+            Font monospaceFont = style.MonospaceFont;
+            if (!_widthByLengthByFont.TryGetValue(monospaceFont, out int[] widthByLength))
             {
                 widthByLength = Enumerable.Range(0, ObjectId.Sha1CharCount + 1).Select(c => TextRenderer.MeasureText(new string('8', c), monospaceFont).Width).ToArray();
 
@@ -42,7 +42,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
             if (!revision.IsArtificial)
             {
-                var i = Array.FindIndex(widthByLength, w => w > Column.Width);
+                int i = Array.FindIndex(widthByLength, w => w > Column.Width);
 
                 if (i == -1 && Column.Width > widthByLength[^1])
                 {

--- a/GitUI/UserControls/RevisionGrid/Columns/MultilineIndicator.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MultilineIndicator.cs
@@ -65,10 +65,10 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
             _e.Graphics.FillRectangle(_indicatorBackBrush, indicatorRect);
 
-            var x = indicatorRect.X + paddingX;
-            var y = indicatorRect.Y + paddingTop;
+            int x = indicatorRect.X + paddingX;
+            int y = indicatorRect.Y + paddingTop;
 
-            for (var i = 0; i < DotCount; i++)
+            for (int i = 0; i < DotCount; i++)
             {
                 _e.Graphics.FillRectangle(_indicatorForeBrush, x, y, dotSize, dotSize);
                 x += dotSize + dotSpacing;

--- a/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
@@ -30,7 +30,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         private void AddItem(string displayText, Func<GitRevision, string> extractRevisionText, Image image, char? hotkey)
         {
-            var textToCopy = ExtractRevisionTexts(extractRevisionText);
+            string[] textToCopy = ExtractRevisionTexts(extractRevisionText);
             if (textToCopy is null)
             {
                 return;
@@ -77,7 +77,7 @@ namespace GitUI.UserControls.RevisionGrid
                 return null;
             }
 
-            var gitRevisions = _revisionFunc?.Invoke();
+            IReadOnlyList<GitRevision> gitRevisions = _revisionFunc?.Invoke();
             if (gitRevisions?.Count is not > 0)
             {
                 return null;
@@ -88,7 +88,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         private void OnDropDownOpening(object sender, EventArgs e)
         {
-            var revisions = _revisionFunc?.Invoke();
+            IReadOnlyList<GitRevision> revisions = _revisionFunc?.Invoke();
             if (revisions?.Count is not > 0)
             {
                 HideDropDown();
@@ -100,7 +100,7 @@ namespace GitUI.UserControls.RevisionGrid
 
             List<string> branchNames = new();
             List<string> tagNames = new();
-            foreach (var revision in revisions)
+            foreach (GitRevision revision in revisions)
             {
                 GitRefListsForRevision refLists = new(revision);
                 branchNames.AddRange(refLists.GetAllBranchNames());
@@ -116,7 +116,7 @@ namespace GitUI.UserControls.RevisionGrid
                 MenuUtil.SetAsCaptionMenuItem(caption, Owner);
                 DropDownItems.Add(caption);
 
-                foreach (var name in branchNames)
+                foreach (string name in branchNames)
                 {
                     AddItem(name, textToCopy: name, Images.Branch.AdaptLightness(), hotkey: null);
                 }
@@ -131,7 +131,7 @@ namespace GitUI.UserControls.RevisionGrid
                 MenuUtil.SetAsCaptionMenuItem(caption, Owner);
                 DropDownItems.Add(caption);
 
-                foreach (var name in tagNames)
+                foreach (string name in tagNames)
                 {
                     AddItem(name, textToCopy: name, Images.Tag, hotkey: null);
                 }

--- a/GitUI/UserControls/RevisionGrid/FormQuickGitRefSelector.cs
+++ b/GitUI/UserControls/RevisionGrid/FormQuickGitRefSelector.cs
@@ -17,11 +17,11 @@ namespace GitUI.UserControls.RevisionGrid
 
         public void Init(Action action, IReadOnlyList<IGitRef> refs)
         {
-            var items = refs.OrderBy(r => r.IsTag).ThenBy(r => r.Name).Select(GetItemData).ToList();
+            List<ItemData> items = refs.OrderBy(r => r.IsTag).ThenBy(r => r.Name).Select(GetItemData).ToList();
 
             ItemData GetItemData(IGitRef gitRef)
             {
-                var suffix = gitRef.IsTag ? $" ({_tag.Text})" : string.Empty;
+                string suffix = gitRef.IsTag ? $" ({_tag.Text})" : string.Empty;
                 return new ItemData($"{gitRef.Name}{suffix}", gitRef);
             }
 

--- a/GitUI/UserControls/RevisionGrid/FormQuickItemSelector.cs
+++ b/GitUI/UserControls/RevisionGrid/FormQuickItemSelector.cs
@@ -31,19 +31,19 @@
             }
 
             // constrain the listbox min width, otherwise the button may not have enough space
-            var longestItemWidth = 150f;
+            float longestItemWidth = 150f;
             try
             {
                 lbxRefs.BeginUpdate();
 
                 using Graphics graphics = lbxRefs.CreateGraphics();
-                foreach (var item in items)
+                foreach (ItemData item in items)
                 {
                     lbxRefs.Items.Add(item);
 
                     // assume that the branch names or tags are never longer than MaxRefLength symbols long
                     // if they are (sanity!) - don't resize past beyond certain limit
-                    var label = item.Label.Length > MaxRefLength ? item.Label[..MaxRefLength] : item.Label;
+                    string label = item.Label.Length > MaxRefLength ? item.Label[..MaxRefLength] : item.Label;
                     longestItemWidth = Math.Max(longestItemWidth, graphics.MeasureString(label, lbxRefs.Font).Width);
                 }
             }

--- a/GitUI/UserControls/RevisionGrid/FormQuickStringSelector.cs
+++ b/GitUI/UserControls/RevisionGrid/FormQuickStringSelector.cs
@@ -13,7 +13,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         public void Init(IReadOnlyList<string> strings)
         {
-            var items = strings.OrderBy(s => s).Select(s => new ItemData(s, s)).ToList();
+            List<ItemData> items = strings.OrderBy(s => s).Select(s => new ItemData(s, s)).ToList();
 
             Init(items, _actionSelect.Text);
         }

--- a/GitUI/UserControls/RevisionGrid/Graph/BranchFinder.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/BranchFinder.cs
@@ -26,7 +26,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         {
             Validates.NotNull(node.GitRevision);
 
-            foreach (var gitReference in node.GitRevision.Refs)
+            foreach (GitUIPluginInterfaces.IGitRef gitReference in node.GitRevision.Refs)
             {
                 if (gitReference.IsHead || gitReference.IsRemote || gitReference.IsStash)
                 {
@@ -74,12 +74,12 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         {
             string? into = null;
             string? with = null;
-            var match = MergeRegex.Match(commitSubject);
+            Match match = MergeRegex.Match(commitSubject);
             if (match.Success)
             {
-                var matchPullRequest = match.Groups[2];
-                var matchWith = match.Groups[4];
-                var matchInto = match.Groups[7];
+                Group matchPullRequest = match.Groups[2];
+                Group matchWith = match.Groups[4];
+                Group matchInto = match.Groups[7];
                 into = matchInto.Success ? matchInto.Value : "master";
                 with = matchWith.Success ? matchWith.Value : "?";
                 if (appendPullRequest && matchPullRequest.Success)

--- a/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/LaneInfoProvider.cs
@@ -20,7 +20,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
         public string GetLaneInfo(int rowIndex, int lane)
         {
-            (var node, bool isAtNode) = _nodeLocator.FindPrevNode(rowIndex, lane);
+            (RevisionGraphRevision node, bool isAtNode) = _nodeLocator.FindPrevNode(rowIndex, lane);
             if (node is null)
             {
                 return string.Empty;

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -158,7 +158,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         public RevisionGraphRevision? GetNodeForRow(int row)
         {
             // Use a local variable, because the cached list can be reset
-            var localOrderedNodesCache = BuildOrderedNodesCache(row);
+            RevisionGraphRevision[] localOrderedNodesCache = BuildOrderedNodesCache(row);
             if (row >= localOrderedNodesCache.Length)
             {
                 return null;
@@ -170,7 +170,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         public IRevisionGraphRow? GetSegmentsForRow(int row)
         {
             // Use a local variable, because the cached list can be reset
-            var localOrderedRowCache = _orderedRowCache;
+            IList<RevisionGraphRow> localOrderedRowCache = _orderedRowCache;
             if (localOrderedRowCache is null || row < 0 || row >= localOrderedRowCache.Count)
             {
                 return null;
@@ -182,7 +182,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         public void HighlightBranch(ObjectId id)
         {
             // Clear current highlighting
-            foreach (var revision in _nodes)
+            foreach (RevisionGraphRevision revision in _nodes)
             {
                 revision.IsRelative = false;
             }
@@ -216,7 +216,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 if (insertScore is not null && _nodeByObjectId is not null)
                 {
                     // This revision is to be inserted before a certain node
-                    foreach (var (_, graphRevision) in _nodeByObjectId)
+                    foreach ((ObjectId _, RevisionGraphRevision graphRevision) in _nodeByObjectId)
                     {
                         if (graphRevision.Score < insertScore)
                         {
@@ -362,7 +362,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                     // This is the first row. Start with only the startsegments of this row
                     segments = new List<RevisionGraphSegment>(revisionStartSegments);
 
-                    foreach (var startSegment in revisionStartSegments)
+                    foreach (RevisionGraphSegment startSegment in revisionStartSegments)
                     {
                         startSegment.LaneInfo = new LaneInfo(startSegment, derivedFrom: null);
                     }
@@ -376,7 +376,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                     segments = new List<RevisionGraphSegment>(previousRevisionGraphRow.Segments.Count + revisionStartSegments.Length);
 
                     // Loop through all segments that do not end in the previous row
-                    foreach (var segment in previousRevisionGraphRow.Segments.Where(s => s.Parent != previousRevisionGraphRow.Revision))
+                    foreach (RevisionGraphSegment segment in previousRevisionGraphRow.Segments.Where(s => s.Parent != previousRevisionGraphRow.Revision))
                     {
                         segments.Add(segment);
 
@@ -390,7 +390,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                                 segments.AddRange(revisionStartSegments);
                             }
 
-                            foreach (var startSegment in revisionStartSegments)
+                            foreach (RevisionGraphSegment startSegment in revisionStartSegments)
                             {
                                 if (startSegment == revisionStartSegments[0])
                                 {
@@ -416,7 +416,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                         // Add new segments started by this revision to the end
                         segments.AddRange(revisionStartSegments);
 
-                        foreach (var startSegment in revisionStartSegments)
+                        foreach (RevisionGraphSegment startSegment in revisionStartSegments)
                         {
                             startSegment.LaneInfo = new LaneInfo(startSegment, derivedFrom: null);
                         }
@@ -579,9 +579,9 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             // Only used for unit testing.
             public bool ValidateTopoOrder()
             {
-                foreach (var node in _revisionGraph._nodes)
+                foreach (RevisionGraphRevision node in _revisionGraph._nodes)
                 {
-                    foreach (var parent in node.Parents)
+                    foreach (RevisionGraphRevision parent in node.Parents)
                     {
                         if (parent.Score <= node.Score)
                         {
@@ -589,7 +589,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                         }
                     }
 
-                    foreach (var child in node.Children)
+                    foreach (RevisionGraphRevision child in node.Children)
                     {
                         if (node.Score <= child.Score)
                         {

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -65,9 +65,9 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             stack.Push(this);
             while (stack.Count > 0)
             {
-                var revision = stack.Pop();
+                RevisionGraphRevision revision = stack.Pop();
 
-                foreach (var parent in revision.Parents)
+                foreach (RevisionGraphRevision parent in revision.Parents)
                 {
                     if (parent.Score > revision.Score)
                     {
@@ -114,11 +114,11 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
             while (stack.Count > 0)
             {
-                var revision = stack.Pop();
+                RevisionGraphRevision revision = stack.Pop();
 
                 revision.IsRelative = true;
 
-                foreach (var parent in revision.Parents)
+                foreach (RevisionGraphRevision parent in revision.Parents)
                 {
                     if (parent.IsRelative)
                     {

--- a/GitUI/UserControls/RevisionGrid/NavigationHistory.cs
+++ b/GitUI/UserControls/RevisionGrid/NavigationHistory.cs
@@ -40,8 +40,8 @@ namespace GitUI.UserControls.RevisionGrid
                 throw new InvalidOperationException();
             }
 
-            var curr = _prevItems.Pop();
-            var prev = _prevItems.Peek();
+            ObjectId curr = _prevItems.Pop();
+            ObjectId prev = _prevItems.Peek();
             _nextItems.Push(curr);
             return prev;
         }
@@ -62,7 +62,7 @@ namespace GitUI.UserControls.RevisionGrid
                 throw new InvalidOperationException();
             }
 
-            var next = _nextItems.Pop();
+            ObjectId next = _nextItems.Pop();
             _prevItems.Push(next);
             return next;
         }

--- a/GitUI/UserControls/RevisionGrid/ParentChildNavigationHistory.cs
+++ b/GitUI/UserControls/RevisionGrid/ParentChildNavigationHistory.cs
@@ -25,13 +25,13 @@ namespace GitUI.UserControls.RevisionGrid
 
         public void NavigateToPreviousParent(ObjectId current)
         {
-            var parent = _parentHistory.Pop();
+            ObjectId parent = _parentHistory.Pop();
             Navigate(current, parent, NavigationDirection.Parent);
         }
 
         public void NavigateToPreviousChild(ObjectId current)
         {
-            var child = _childHistory.Pop();
+            ObjectId child = _childHistory.Pop();
             Navigate(current, child, NavigationDirection.Child);
         }
 

--- a/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/QuickSearchProvider.cs
@@ -50,7 +50,7 @@ namespace GitUI
 
         public void OnKeyPress(KeyPressEventArgs e)
         {
-            var curIndex = _gridView.SelectedRows.Count > 0
+            int curIndex = _gridView.SelectedRows.Count > 0
                 ? _gridView.SelectedRows[0].Index
                 : -1;
 
@@ -92,7 +92,7 @@ namespace GitUI
 
         public void NextResult(bool down)
         {
-            var curIndex = -1;
+            int curIndex = -1;
             if (_gridView.SelectedRows.Count > 0)
             {
                 curIndex = _gridView.SelectedRows[0].Index;
@@ -101,7 +101,7 @@ namespace GitUI
             RestartQuickSearchTimer();
 
             bool reverse = !down;
-            var nextIndex = 0;
+            int nextIndex = 0;
             if (curIndex >= 0)
             {
                 nextIndex = reverse ? curIndex - 1 : curIndex + 1;
@@ -139,7 +139,7 @@ namespace GitUI
                 return;
             }
 
-            var matchIndex = reverse
+            int? matchIndex = reverse
                 ? SearchBackwards()
                 : SearchForward();
 

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -106,7 +106,7 @@ namespace GitUI.UserControls.RevisionGrid
             {
                 if (Columns[e.ColumnIndex].Tag is ColumnProvider provider)
                 {
-                    var revision = GetRevision(e.RowIndex);
+                    GitRevision? revision = GetRevision(e.RowIndex);
                     if (revision is not null)
                     {
                         provider.OnCellFormatting(e, revision);
@@ -123,7 +123,7 @@ namespace GitUI.UserControls.RevisionGrid
                         Debug.Assert(_rowHeight != 0, "_rowHeight != 0");
 
                         // Refresh column providers
-                        foreach (var columnProvider in _columnProviders)
+                        foreach (ColumnProvider columnProvider in _columnProviders)
                         {
                             columnProvider.Refresh(_rowHeight, _visibleRowRange);
                         }
@@ -195,11 +195,11 @@ namespace GitUI.UserControls.RevisionGrid
                     return null;
                 }
 
-                var data = new ObjectId[SelectedRows.Count];
+                ObjectId[] data = new ObjectId[SelectedRows.Count];
 
-                for (var i = 0; i < SelectedRows.Count; i++)
+                for (int i = 0; i < SelectedRows.Count; i++)
                 {
-                    var row = _revisionGraph.GetNodeForRow(SelectedRows[i].Index);
+                    RevisionGraphRevision? row = _revisionGraph.GetNodeForRow(SelectedRows[i].Index);
 
                     if (row?.GitRevision is not null)
                     {
@@ -279,7 +279,7 @@ namespace GitUI.UserControls.RevisionGrid
 
             Debug.Assert(_rowHeight != 0, "_rowHeight != 0");
 
-            var revision = GetRevision(e.RowIndex);
+            GitRevision? revision = GetRevision(e.RowIndex);
 
             if (e.RowIndex < 0 ||
                 e.RowIndex >= RowCount ||
@@ -334,7 +334,7 @@ namespace GitUI.UserControls.RevisionGrid
                 insertScore = -1;
                 if (insertRange > 0 && parents is not null)
                 {
-                    foreach (var parentId in parents)
+                    foreach (ObjectId parentId in parents)
                     {
                         if (_revisionGraph.TryGetNode(parentId, out RevisionGraphRevision? parentRev))
                         {
@@ -364,7 +364,7 @@ namespace GitUI.UserControls.RevisionGrid
             ClearToBeSelected();
 
             // The graphdata is stored in one of the columnproviders, clear this last
-            foreach (var columnProvider in _columnProviders)
+            foreach (ColumnProvider columnProvider in _columnProviders)
             {
                 columnProvider.Clear();
             }
@@ -723,7 +723,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         private void NotifyProvidersVisibleRowRangeChanged()
         {
-            foreach (var provider in _columnProviders)
+            foreach (ColumnProvider provider in _columnProviders)
             {
                 provider.OnVisibleRowsChanged(_visibleRowRange);
             }
@@ -737,7 +737,7 @@ namespace GitUI.UserControls.RevisionGrid
             UpdateVisibleRowRange();
 
             // Refresh column providers
-            foreach (var columnProvider in _columnProviders)
+            foreach (ColumnProvider columnProvider in _columnProviders)
             {
                 columnProvider.Refresh(_rowHeight, _visibleRowRange);
             }
@@ -748,7 +748,7 @@ namespace GitUI.UserControls.RevisionGrid
         private void UpdateRowHeight()
         {
             // TODO allow custom grid row spacing
-            using var g = Graphics.FromHwnd(Handle);
+            using Graphics g = Graphics.FromHwnd(Handle);
             _rowHeight = (int)g.MeasureString("By", _normalFont).Height + DpiUtil.Scale(9);
             //// + AppSettings.GridRowSpacing
             RowTemplate.Height = _rowHeight;
@@ -761,12 +761,12 @@ namespace GitUI.UserControls.RevisionGrid
 
         public GitRevision? GetRevision(ObjectId objectId)
         {
-            return _revisionGraph.TryGetNode(objectId, out var node) ? node.GitRevision : null;
+            return _revisionGraph.TryGetNode(objectId, out RevisionGraphRevision? node) ? node.GitRevision : null;
         }
 
         public int? TryGetRevisionIndex(ObjectId? objectId)
         {
-            return objectId is not null && _revisionGraph.TryGetRowIndex(objectId, out var index) ? index : null;
+            return objectId is not null && _revisionGraph.TryGetRowIndex(objectId, out int index) ? index : null;
         }
 
         public IReadOnlyList<ObjectId> GetRevisionChildren(ObjectId objectId)
@@ -774,9 +774,9 @@ namespace GitUI.UserControls.RevisionGrid
             // We do not need a lock here since we load the data from the first commit and walk through all
             // parents. Children are always loaded, since we start at the newest commit.
             // With lock, loading the commit info slows down terribly.
-            if (_revisionGraph.TryGetNode(objectId, out var node))
+            if (_revisionGraph.TryGetNode(objectId, out RevisionGraphRevision? node))
             {
-                var children = node.Children.Select(d => d.GitRevision!.ObjectId).ToList();
+                List<ObjectId> children = node.Children.Select(d => d.GitRevision!.ObjectId).ToList();
                 children.Reverse();
                 return children;
             }
@@ -807,7 +807,7 @@ namespace GitUI.UserControls.RevisionGrid
 
                     break;
                 case Keys.Control | Keys.C:
-                    var selectedRevisions = SelectedObjectIds;
+                    IReadOnlyList<ObjectId>? selectedRevisions = SelectedObjectIds;
                     if (selectedRevisions?.Count is > 0)
                     {
                         ClipboardUtil.TrySetText(string.Join(Environment.NewLine, selectedRevisions));
@@ -822,7 +822,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         protected override void OnMouseDown(MouseEventArgs e)
         {
-            var hit = HitTest(e.X, e.Y);
+            HitTestInfo hit = HitTest(e.X, e.Y);
 
             if (hit.Type == DataGridViewHitTestType.None)
             {

--- a/GitUI/UserControls/RevisionGrid/RevisionGridRefRenderer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridRefRenderer.cs
@@ -15,20 +15,20 @@ namespace GitUI
 
         public static void DrawRef(bool isRowSelected, Font font, ref int offset, string name, Color headColor, RefArrowType arrowType, in Rectangle bounds, Graphics graphics, bool dashedLine = false, bool fill = false)
         {
-            var paddingLeftRight = !string.IsNullOrEmpty(name) ? DpiUtil.Scale(4) : DpiUtil.Scale(1);
-            var paddingTopBottom = DpiUtil.Scale(2);
-            var marginRight = DpiUtil.Scale(7);
+            int paddingLeftRight = !string.IsNullOrEmpty(name) ? DpiUtil.Scale(4) : DpiUtil.Scale(1);
+            int paddingTopBottom = DpiUtil.Scale(2);
+            int marginRight = DpiUtil.Scale(7);
 
-            var textColor = fill ? headColor : ColorHelper.Lerp(headColor, Color.Black, 0.25F);
+            Color textColor = fill ? headColor : ColorHelper.Lerp(headColor, Color.Black, 0.25F);
 
             Size textSize = !string.IsNullOrEmpty(name)
                 ? TextRenderer.MeasureText(graphics, name, font, Size.Empty, TextFormatFlags.NoPadding)
                 : new(0, TextRenderer.MeasureText(graphics, " ", font, Size.Empty, TextFormatFlags.NoPadding).Height);
 
-            var arrowWidth = arrowType == RefArrowType.None ? 0 : bounds.Height / 2;
+            int arrowWidth = arrowType == RefArrowType.None ? 0 : bounds.Height / 2;
 
-            var backgroundHeight = textSize.Height + paddingTopBottom + paddingTopBottom - 1;
-            var outerMarginTopBottom = (bounds.Height - backgroundHeight) / 2;
+            int backgroundHeight = textSize.Height + paddingTopBottom + paddingTopBottom - 1;
+            int outerMarginTopBottom = (bounds.Height - backgroundHeight) / 2;
 
             Rectangle rect = new(
                 bounds.X + offset,
@@ -61,17 +61,17 @@ namespace GitUI
 
         private static void DrawRefBackground(bool isRowSelected, Graphics graphics, Color color, Rectangle bounds, int radius, RefArrowType arrowType, bool dashedLine, bool fill)
         {
-            var oldMode = graphics.SmoothingMode;
+            SmoothingMode oldMode = graphics.SmoothingMode;
             graphics.SmoothingMode = SmoothingMode.AntiAlias;
 
             try
             {
-                using var path = CreateRoundRectPath(bounds, radius);
+                using GraphicsPath path = CreateRoundRectPath(bounds, radius);
                 if (fill)
                 {
-                    var color1 = ColorHelper.Lerp(color, SystemColors.Window, 0.92F);
-                    var color2 = ColorHelper.Lerp(color1, SystemColors.Window, 0.9f);
-                    using var brush = new LinearGradientBrush(bounds, color1, color2, angle: 90);
+                    Color color1 = ColorHelper.Lerp(color, SystemColors.Window, 0.92F);
+                    Color color2 = ColorHelper.Lerp(color1, SystemColors.Window, 0.9f);
+                    using LinearGradientBrush brush = new LinearGradientBrush(bounds, color1, color2, angle: 90);
                     graphics.FillPath(brush, path);
                 }
                 else if (isRowSelected)
@@ -172,10 +172,10 @@ namespace GitUI
 
         internal static GraphicsPath CreateRoundRectPath(Rectangle rect, int radius)
         {
-            var left = rect.X;
-            var top = rect.Y;
-            var right = left + rect.Width;
-            var bottom = top + rect.Height;
+            int left = rect.X;
+            int top = rect.Y;
+            int right = left + rect.Width;
+            int bottom = top + rect.Height;
 
             GraphicsPath path = new();
             path.AddArc(left, top, radius, radius, startAngle: 180, sweepAngle: 90);

--- a/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
@@ -31,7 +31,7 @@ namespace GitUI
 
         public void OnCellMouseMove(DataGridViewCellMouseEventArgs e)
         {
-            var revision = _gridView.GetRevision(e.RowIndex);
+            GitUIPluginInterfaces.GitRevision revision = _gridView.GetRevision(e.RowIndex);
 
             if (revision is null)
             {
@@ -65,13 +65,13 @@ namespace GitUI
                 try
                 {
                     if (_gridView.Columns[e.ColumnIndex].Tag is ColumnProvider provider &&
-                        provider.TryGetToolTip(e, revision, out var toolTip) &&
+                        provider.TryGetToolTip(e, revision, out string? toolTip) &&
                         !string.IsNullOrWhiteSpace(toolTip))
                     {
                         return toolTip;
                     }
 
-                    if (_isTruncatedByCellPos.TryGetValue(new Point(e.ColumnIndex, e.RowIndex), out var showToolTip)
+                    if (_isTruncatedByCellPos.TryGetValue(new Point(e.ColumnIndex, e.RowIndex), out bool showToolTip)
                         && showToolTip)
                     {
                         return _gridView.Rows[e.RowIndex].Cells[e.ColumnIndex].FormattedValue?.ToString() ?? "";

--- a/GitUI/UserControls/SortDiffListContextMenuItem.cs
+++ b/GitUI/UserControls/SortDiffListContextMenuItem.cs
@@ -47,7 +47,7 @@ namespace GitUI.UserControls
 
             _allItems = new[] { _filePathSortItem, _fileExtensionSortItem, _fileStatusSortItem, };
 
-            foreach (var item in AllItems())
+            foreach (ToolStripMenuItem item in AllItems())
             {
                 item.Click += Item_Click;
                 DropDownItems.Add(item);
@@ -64,8 +64,8 @@ namespace GitUI.UserControls
 
         private void RequerySortingMethod()
         {
-            var currentSort = _sortService.DiffListSorting;
-            foreach (var item in AllItems())
+            DiffListSortType currentSort = _sortService.DiffListSorting;
+            foreach (ToolStripMenuItem item in AllItems())
             {
                 item.Checked = currentSort.Equals(item.Tag);
             }
@@ -73,8 +73,8 @@ namespace GitUI.UserControls
 
         private void Item_Click(object sender, EventArgs e)
         {
-            var item = (ToolStripMenuItem)sender;
-            var sortingType = (DiffListSortType)item.Tag;
+            ToolStripMenuItem item = (ToolStripMenuItem)sender;
+            DiffListSortType sortingType = (DiffListSortType)item.Tag;
             _sortService.DiffListSorting = sortingType;
         }
 

--- a/GitUI/UserControls/TreeViewExtensions.cs
+++ b/GitUI/UserControls/TreeViewExtensions.cs
@@ -10,10 +10,10 @@
         /// </summary>
         public static string GetFullNamePath(this TreeNode node)
         {
-            var sep = node.TreeView is not null ? node.TreeView.PathSeparator : "\\";
+            string sep = node.TreeView is not null ? node.TreeView.PathSeparator : "\\";
 
             string result = GetNameOrText(node);
-            var currNode = node;
+            TreeNode currNode = node;
             while (currNode.Parent is not null)
             {
                 currNode = currNode.Parent;
@@ -45,9 +45,9 @@
         /// </summary>
         public static void RestoreExpandedNodesState(this TreeNode node, HashSet<string> expandedNodes)
         {
-            foreach (var path in expandedNodes)
+            foreach (string path in expandedNodes)
             {
-                var foundNode = GetNodeFromPath(node, path);
+                TreeNode foundNode = GetNodeFromPath(node, path);
                 foundNode?.Expand();
             }
         }
@@ -74,7 +74,7 @@
 
             foreach (TreeNode childNode in node.Nodes)
             {
-                var foundNode = GetNodeFromPath(childNode, path);
+                TreeNode foundNode = GetNodeFromPath(childNode, path);
                 if (foundNode is not null)
                 {
                     return foundNode;

--- a/GitUI/UserEnvironmentInformation.cs
+++ b/GitUI/UserEnvironmentInformation.cs
@@ -33,7 +33,7 @@ namespace GitUI
                 gitVer = null;
             }
 
-            var gitVersionInfo = GetGitVersionInfo(gitVer, GitVersion.LastSupportedVersion, GitVersion.LastRecommendedVersion);
+            string gitVersionInfo = GetGitVersionInfo(gitVer, GitVersion.LastSupportedVersion, GitVersion.LastRecommendedVersion);
 
             // Build and open FormAbout design to make sure info still looks good if you change this code.
             StringBuilder sb = new();
@@ -85,8 +85,8 @@ namespace GitUI
             try
             {
                 string output = dotnet.GetOutput(args);
-                var desktopAppMatches = Regex.Matches(output, @"^(?=.*\bMicrosoft\.WindowsDesktop\.App\b)[^\n\r]*", RegexOptions.Multiline).Cast<Match>();
-                var desktopAppLines = string.Join(Environment.NewLine, desktopAppMatches);
+                IEnumerable<Match> desktopAppMatches = Regex.Matches(output, @"^(?=.*\bMicrosoft\.WindowsDesktop\.App\b)[^\n\r]*", RegexOptions.Multiline).Cast<Match>();
+                string desktopAppLines = string.Join(Environment.NewLine, desktopAppMatches);
 
                 desktopAppLines = Regex.Replace(desktopAppLines, "^", "    ", RegexOptions.Multiline);
                 sb.AppendLine($"{desktopAppLines}");

--- a/GitUI/UserManual/StandardHtmlUserManual.cs
+++ b/GitUI/UserManual/StandardHtmlUserManual.cs
@@ -15,7 +15,7 @@ namespace GitUI.UserManual
 
         public string GetUrl()
         {
-            var subFolder = string.IsNullOrEmpty(_subFolder) ? string.Empty : _subFolder + ".html";
+            string subFolder = string.IsNullOrEmpty(_subFolder) ? string.Empty : _subFolder + ".html";
 
             return (AppSettings.DocumentationBaseUrl + subFolder).Combine("#", _anchorName)!;
         }

--- a/GitUI/WaitCursorScope.cs
+++ b/GitUI/WaitCursorScope.cs
@@ -25,7 +25,7 @@
         /// </summary>
         public static WaitCursorScope Enter(Cursor? cursor = null)
         {
-            var cursorAtStartOfScope = Cursor.Current;
+            Cursor cursorAtStartOfScope = Cursor.Current;
 
             Cursor.Current = cursor ?? Cursors.WaitCursor;
 

--- a/GitUI/WebBrowserEmulationMode.cs
+++ b/GitUI/WebBrowserEmulationMode.cs
@@ -19,11 +19,11 @@ namespace GitUI
             }
 
             // FeatureControl settings are per-process
-            var appName = System.IO.Path.GetFileName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName);
+            string appName = System.IO.Path.GetFileName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName);
 
             const string featureControlRegKey = @"HKEY_CURRENT_USER\Software\Microsoft\Internet Explorer\Main\FeatureControl\";
 
-            if (TryGetBrowserEmulationMode(out var emulationMode))
+            if (TryGetBrowserEmulationMode(out uint emulationMode))
             {
                 try
                 {
@@ -45,11 +45,11 @@ namespace GitUI
             try
             {
                 int browserVersion;
-                using (var ieKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Internet Explorer",
+                using (RegistryKey ieKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Internet Explorer",
                     RegistryKeyPermissionCheck.ReadSubTree,
                     System.Security.AccessControl.RegistryRights.QueryValues))
                 {
-                    var version = ieKey.GetValue("svcVersion");
+                    object version = ieKey.GetValue("svcVersion");
                     if (version is null)
                     {
                         version = ieKey.GetValue("Version");

--- a/GitUI/WindowsJumpListManager.cs
+++ b/GitUI/WindowsJumpListManager.cs
@@ -167,7 +167,7 @@ namespace GitUI
             SafeInvoke(() =>
             {
                 // One ApplicationId, so all windows must share the same jumplist
-                var jumpList = JumpList.CreateJumpList();
+                JumpList jumpList = JumpList.CreateJumpList();
                 jumpList.ClearAllUserTasks();
                 jumpList.KnownCategoryToDisplay = JumpListKnownCategoryType.Recent;
                 jumpList.Refresh();
@@ -177,7 +177,7 @@ namespace GitUI
 
             if (ToolbarButtonsCreated && _deferredAddToRecent is not null)
             {
-                var recentRepoAddToRecent = _deferredAddToRecent;
+                string recentRepoAddToRecent = _deferredAddToRecent;
                 _deferredAddToRecent = null;
                 AddToRecent(recentRepoAddToRecent);
             }

--- a/Plugins/GitUIPluginInterfaces/BuildServerIntegration/BuildDurationFormatter.cs
+++ b/Plugins/GitUIPluginInterfaces/BuildServerIntegration/BuildDurationFormatter.cs
@@ -11,7 +11,7 @@
         {
             if (durationMilliseconds.HasValue)
             {
-                var timeText = TimeSpan.FromMilliseconds(durationMilliseconds.Value).ToString(@"mm\:ss");
+                string timeText = TimeSpan.FromMilliseconds(durationMilliseconds.Value).ToString(@"mm\:ss");
                 return $"({timeText})";
             }
 

--- a/Plugins/GitUIPluginInterfaces/CredentialsManager.cs
+++ b/Plugins/GitUIPluginInterfaces/CredentialsManager.cs
@@ -27,7 +27,7 @@ namespace GitUIPluginInterfaces
 
         public void Save()
         {
-            var credentials = Credentials.ToList();
+            List<KeyValuePair<string, NetworkCredential>> credentials = Credentials.ToList();
             if (credentials.Count < 1)
             {
                 return;
@@ -35,7 +35,7 @@ namespace GitUIPluginInterfaces
 
             Credentials.Clear();
 
-            foreach (var networkCredentials in credentials)
+            foreach (KeyValuePair<string, NetworkCredential> networkCredentials in credentials)
             {
                 if (networkCredentials.Value is null)
                 {
@@ -50,13 +50,13 @@ namespace GitUIPluginInterfaces
 
         protected NetworkCredential GetCredentialOrDefault(SettingLevel settingLevel, string name, NetworkCredential defaultValue)
         {
-            var targetName = GetWindowsCredentialsTarget(name, settingLevel);
+            string targetName = GetWindowsCredentialsTarget(name, settingLevel);
             if (string.IsNullOrWhiteSpace(targetName))
             {
                 return defaultValue;
             }
 
-            if (Credentials.TryGetValue(targetName, out var result) || AdysTechCredentialManagerWrapper.TryGetCredentials(targetName, out result))
+            if (Credentials.TryGetValue(targetName, out NetworkCredential? result) || AdysTechCredentialManagerWrapper.TryGetCredentials(targetName, out result))
             {
                 return result ?? defaultValue;
             }
@@ -66,7 +66,7 @@ namespace GitUIPluginInterfaces
 
         protected void SetCredentials(SettingLevel settingLevel, string name, NetworkCredential? value)
         {
-            var targetName = GetWindowsCredentialsTarget(name, settingLevel);
+            string targetName = GetWindowsCredentialsTarget(name, settingLevel);
             Validates.NotNull(targetName);
             Credentials.AddOrUpdate(targetName, value, (s, credential) => value);
         }
@@ -79,7 +79,7 @@ namespace GitUIPluginInterfaces
             }
 
             Validates.NotNull(_getWorkingDir);
-            var suffix = _getWorkingDir();
+            string suffix = _getWorkingDir();
             return string.IsNullOrWhiteSpace(suffix) ? null : $"{name}_{suffix}";
         }
 

--- a/Plugins/GitUIPluginInterfaces/FontParser.cs
+++ b/Plugins/GitUIPluginInterfaces/FontParser.cs
@@ -38,7 +38,7 @@ namespace GitUIPluginInterfaces
                     fontSize = fontSize.Replace(".", CultureInfo.InvariantCulture.NumberFormat.NumberDecimalSeparator);
                 }
 
-                var fontStyle = parts.Length > 3 && parts[3] == "1" ? FontStyle.Bold : FontStyle.Regular;
+                FontStyle fontStyle = parts.Length > 3 && parts[3] == "1" ? FontStyle.Bold : FontStyle.Regular;
                 fontStyle |= parts.Length > 4 && parts[4] == "1" ? FontStyle.Italic : FontStyle.Regular;
 
                 return new Font(parts[0], float.Parse(fontSize, CultureInfo.InvariantCulture), fontStyle);

--- a/Plugins/GitUIPluginInterfaces/ISettingsSource.cs
+++ b/Plugins/GitUIPluginInterfaces/ISettingsSource.cs
@@ -46,7 +46,7 @@ namespace GitUIPluginInterfaces
         {
             string? stringValue = GetValue(name);
 
-            if (int.TryParse(stringValue, out var result))
+            if (int.TryParse(stringValue, out int result))
             {
                 return result;
             }
@@ -67,7 +67,7 @@ namespace GitUIPluginInterfaces
         {
             string? stringValue = GetValue(name);
 
-            if (float.TryParse(stringValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var result))
+            if (float.TryParse(stringValue, NumberStyles.Float, CultureInfo.InvariantCulture, out float result))
             {
                 return result;
             }
@@ -93,7 +93,7 @@ namespace GitUIPluginInterfaces
         {
             string? stringValue = GetValue(name);
 
-            if (DateTime.TryParseExact(stringValue, "yyyy/M/dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var result))
+            if (DateTime.TryParseExact(stringValue, "yyyy/M/dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime result))
             {
                 return result;
             }

--- a/Plugins/GitUIPluginInterfaces/PluginsPathScanner.cs
+++ b/Plugins/GitUIPluginInterfaces/PluginsPathScanner.cs
@@ -27,7 +27,7 @@
         /// <returns>An enumeration of found dll files.</returns>
         public static IEnumerable<FileInfo> GetFiles(params string?[] pluginsPaths)
         {
-            var result = Enumerable.Empty<FileInfo>();
+            IEnumerable<FileInfo> result = Enumerable.Empty<FileInfo>();
 
             foreach (string? pluginsPath in pluginsPaths)
             {
@@ -37,7 +37,7 @@
 
                     result = Enumerable.Concat(result, directory.GetFiles("*.dll"));
 
-                    foreach (var childDirectory in directory.GetDirectories())
+                    foreach (DirectoryInfo childDirectory in directory.GetDirectories())
                     {
                         result = Enumerable.Concat(result, childDirectory.GetFiles("*.dll"));
                     }

--- a/Plugins/GitUIPluginInterfaces/Settings/BoolSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/BoolSetting.cs
@@ -62,7 +62,7 @@ namespace GitUIPluginInterfaces
 
             public override void SaveSetting(ISettingsSource settings, CheckBox control)
             {
-                var controlValue = control.GetNullableChecked();
+                bool? controlValue = control.GetNullableChecked();
                 if (settings.SettingLevel == SettingLevel.Effective)
                 {
                     if (Setting.ValueOrDefault(settings) == controlValue)

--- a/Plugins/GitUIPluginInterfaces/Settings/ChoiceSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/ChoiceSetting.cs
@@ -60,7 +60,7 @@
 
             public override void SaveSetting(ISettingsSource settings, ComboBox control)
             {
-                var controlValue = control.SelectedItem?.ToString();
+                string controlValue = control.SelectedItem?.ToString();
                 if (settings.SettingLevel == SettingLevel.Effective)
                 {
                     if (Setting.ValueOrDefault(settings) == controlValue)

--- a/Plugins/GitUIPluginInterfaces/Settings/CredentialsSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/CredentialsSetting.cs
@@ -26,14 +26,14 @@ namespace GitUIPluginInterfaces
         {
             if (settings.SettingLevel == SettingLevel.Effective)
             {
-                var currentCredentials = GetValueOrDefault(settings);
+                NetworkCredential currentCredentials = GetValueOrDefault(settings);
                 if (currentCredentials.UserName == userName && currentCredentials.Password == password)
                 {
                     return;
                 }
             }
 
-            var newCredentials = string.IsNullOrWhiteSpace(userName)
+            NetworkCredential newCredentials = string.IsNullOrWhiteSpace(userName)
                 ? null
                 : new NetworkCredential(userName, password);
             SetCredentials(settings.SettingLevel, Name, newCredentials);
@@ -61,7 +61,7 @@ namespace GitUIPluginInterfaces
             {
                 if (SettingLevelSupported(settings.SettingLevel))
                 {
-                    var credentials = Setting.GetValueOrDefault(settings);
+                    NetworkCredential credentials = Setting.GetValueOrDefault(settings);
                     control.UserName = credentials.UserName;
                     control.Password = credentials.Password;
                     control.Enabled = true;

--- a/Plugins/GitUIPluginInterfaces/Settings/NumberSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/NumberSetting.cs
@@ -95,7 +95,7 @@
 
             public override void SaveSetting(ISettingsSource settings, TextBox control)
             {
-                var controlValue = control.Text;
+                string controlValue = control.Text;
 
                 if (settings.SettingLevel == SettingLevel.Effective)
                 {
@@ -126,7 +126,7 @@
                 return null;
             }
 
-            var type = typeof(T);
+            Type type = typeof(T);
             if (type == typeof(int))
             {
                 return int.Parse(value);

--- a/Plugins/GitUIPluginInterfaces/Settings/PasswordSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/PasswordSetting.cs
@@ -48,7 +48,7 @@
 
             public override void SaveSetting(ISettingsSource settings, TextBox control)
             {
-                var controlValue = control.Text;
+                string controlValue = control.Text;
                 if (settings.SettingLevel == SettingLevel.Effective)
                 {
                     if (Setting.ValueOrDefault(settings) == controlValue)

--- a/Plugins/GitUIPluginInterfaces/Settings/StringSetting.cs
+++ b/Plugins/GitUIPluginInterfaces/Settings/StringSetting.cs
@@ -67,7 +67,7 @@
 
             public override void SaveSetting(ISettingsSource settings, TextBox control)
             {
-                var controlValue = control.Text;
+                string controlValue = control.Text;
                 if (settings.SettingLevel == SettingLevel.Effective)
                 {
                     if (Setting.ValueOrDefault(settings) == controlValue)


### PR DESCRIPTION

Note: done automatically by VS (with 2 or 3 small adaptations -- code indentation and tuples not 100% well handled--)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 03e983f6479d7fafa2ea21a13281c1d6270b6794
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.21
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.21 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.10 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
