### PR TITLE
Checkout: fix git error when branch name is ambiguous

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -821,7 +821,8 @@ namespace GitCommands
             {
                 parent,
                 $"^{child}",
-                "--count"
+                "--count",
+                "--"
             };
             ExecutionResult result = _gitExecutable.Execute(args, cache: cache ? GitCommandCache : null, throwOnErrorExit: throwOnErrorExit);
             string output = result.StandardOutput;

--- a/IntegrationTests/UI.IntegrationTests/GitCommands/GitModuleTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/GitCommands/GitModuleTests.cs
@@ -22,6 +22,28 @@ namespace GitCommandsTests
         }
 
         [Test]
+        public void GetCommitCount_Should_manage_ambiguous_argument()
+        {
+            const string ambiguousName = "script";
+            CommitData initialCommit = CreateCommitWithAmbiguousFolder("commit1");
+            CreateCommitWithAmbiguousFolder("commit2");
+            CommitData tipOfMainBranchCommit = CreateCommitWithAmbiguousFolder("commit3");
+
+            // Create a branch with same name than a folder inside repo
+            _refRepo.CreateBranch(ambiguousName, tipOfMainBranchCommit.Hash);
+
+            int? exitCode = _gitModule.GetCommitCount(initialCommit.Hash, ambiguousName);
+
+            exitCode.Should().Be(0);
+
+            CommitData CreateCommitWithAmbiguousFolder(string commitMessage)
+            {
+                string hash = _refRepo.CreateCommitRelative(ambiguousName, "main_file.txt", commitMessage, commitMessage);
+                return new CommitData(hash, commitMessage, $"{hash} {commitMessage}", ObjectId.Parse(hash));
+            }
+        }
+
+        [Test]
         public void RebasePatchesBuiltAccordingToGitRebaseFiles_EnsureRebaseFileFormatWithGit()
         {
             string content = "line1" + Environment.NewLine;


### PR DESCRIPTION
When trying to checkout a branch **with the same name than an existing folder** like 'scripts" in GitExtensions repository, git fails when running command line: git rev-list afe67a23d35300169ba539bb220be43e788dbfb0 ^scripts --count

 with error:
   fatal: ambiguous argument 'scripts': both revision and filename
   Use '--' to separate paths from revisions, like this:
   'git <command> [<revision>...] -- [<file>...]'

Fix: replace by command line:line
git rev-list afe67a23d35300169ba539bb220be43e788dbfb0 ^scripts --count --

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/bfc21afa-0440-4d61-aa61-0da5d5f2a9d0)

### After

No error

## Test methodology <!-- How did you ensure quality? -->

- Manual (and command line)

## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 33.33.33
- Build d1d0db08325987de1e2dc10a170a10e96f65292e (Dirty)
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.21
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.21 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.10 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
