### PR TITLE
GitLab exception with concurrent access

### DIFF
--- a/Plugins/BuildServerIntegration/GitlabIntegration/GitlabAdapter.cs
+++ b/Plugins/BuildServerIntegration/GitlabIntegration/GitlabAdapter.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.Composition;
+﻿using System.Collections.Concurrent;
+using System.ComponentModel.Composition;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using GitExtensions.Plugins.GitlabIntegration.ApiClient;
@@ -15,7 +16,7 @@ namespace GitExtensions.Plugins.GitlabIntegration
     public class GitlabAdapter : IBuildServerAdapter
     {
         public const string PluginName = "Gitlab";
-        private readonly Dictionary<string, DateTime> _loadedItems = new();
+        private readonly ConcurrentDictionary<string, DateTime> _loadedItems = new();
 
         private readonly IGitlabApiClientFactory _apiClientFactory;
         private IGitlabApiClient? _apiClient;
@@ -129,7 +130,7 @@ namespace GitExtensions.Plugins.GitlabIntegration
         {
             foreach (var item in items)
             {
-                if (_loadedItems.ContainsKey(item.Sha) == false || _loadedItems[item.Sha] < item.UpdatedAt)
+                if (!_loadedItems.TryGetValue(item.Sha, out DateTime dateTime) || dateTime < item.UpdatedAt)
                 {
                     _loadedItems[item.Sha] = item.UpdatedAt;
                     observer.OnNext(item.ToBuildInfo());


### PR DESCRIPTION
## Proposed changes

GitLab occasionally raises exceptions when reloading bigger repos (like Linux).
The "pipeline loader" starts tasks that also access this specific Dictionary.

```
System.InvalidOperationException
  HResult=0x80131509
  Message=Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
  Source=System.Private.CoreLib
  StackTrace:
   at System.ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported()
   at System.Collections.Generic.Dictionary`2.FindValue(TKey key)
   at System.Collections.Generic.Dictionary`2.ContainsKey(TKey key)
   at GitExtensions.Plugins.GitlabIntegration.GitlabAdapter.ProcessLoadedBuilds(IEnumerable`1 items, IObserver`1 observer) in C:\dev\gc\gitextensions_4\Plugins\BuildServerIntegration\GitlabIntegration\GitlabAdapter.cs:line 132
   at GitExtensions.Plugins.GitlabIntegration.GitlabAdapter.<>c__DisplayClass13_0.<ObserveBuildsAsync>b__1(Task`1 x) in C:\dev\gc\gitextensions_4\Plugins\BuildServerIntegration\GitlabIntegration\GitlabAdapter.cs:line 95
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
```

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
