### PR TITLE
Do not launch debugger on Debug.Fail in test run

### DIFF
--- a/GitExtUtils/DebugHelpers.cs
+++ b/GitExtUtils/DebugHelpers.cs
@@ -21,7 +21,7 @@ public static class DebugHelpers
     [DoesNotReturn]
     public static void Fail(string message)
     {
-        if (Debugger.IsAttached)
+        if (Debugger.IsAttached || IsTestRunning)
         {
             Debug.Fail(message);
         }
@@ -35,4 +35,7 @@ public static class DebugHelpers
             }
         }
     }
+
+    private static bool IsTestRunning
+        => Application.ExecutablePath.EndsWith("testhost.exe");
 }


### PR DESCRIPTION
Follow-up to #11270

## Proposed changes

`DebugHelper`: Just call `Debug.Fail()` when running tests - instead of `Debugger.Launch()`.
The test runner catches debug assertions.

## Test methodology <!-- How did you ensure quality? -->

- run tests for debug build

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).