### PR TITLE
Bypass hotkeys processing when inside SearchControl

### DIFF
--- a/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -565,6 +565,16 @@ namespace GitUI.LeftPanel
             e.Handled = true;
         }
 
+        public override bool ProcessHotkey(Keys keyData)
+        {
+            if (_txtBranchCriterion.ContainsFocus && IsTextEditKey(keyData))
+            {
+                return false;
+            }
+
+            return base.ProcessHotkey(keyData);
+        }
+
         protected override CommandStatus ExecuteCommand(int cmd)
         {
             switch ((Command)cmd)


### PR DESCRIPTION
Fixes #11122 

## Proposed changes
Bypass hotkeys processing when the user is in branch search control. This should eliminate the possibility of unexpected behavior while editing. 

## Test methodology <!-- How did you ensure quality? -->

Manual

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.41.0
- Microsoft Windows NT 10.0.22621.0

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
