### PR TITLE
Deactivate very slow handling of lane sharing

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -1,4 +1,9 @@
-﻿using Microsoft;
+﻿// Hotfix of #11292 for release 4.2: Due to heavy performance issues with the Linux repo, do not determine the kind of LaneSharing of secondary segments.
+// This deactivates #10915 which avoided the multiple drawing of shared graph segments.
+// This reactivates a minor hyperactivity of line-straightening over commits (#11059).
+#define ALL_PRIMARY_LANES
+
+using Microsoft;
 
 namespace GitUI.UserControls.RevisionGrid.Graph
 {
@@ -122,7 +127,11 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                         }
                         else
                         {
+#if ALL_PRIMARY_LANES
+                            laneSharing = LaneSharing.ExclusiveOrPrimary;
+#else
                             laneSharing = LaneSharing.DifferentEnd;
+#endif
                         }
 
                         return new Lane(_revisionLane, laneSharing);
@@ -188,12 +197,16 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
                     LaneSharing GetSecondarySharingOfContinuedSegment()
                     {
+#if ALL_PRIMARY_LANES
+                        return LaneSharing.ExclusiveOrPrimary;
+#else
                         return _previousRow.GetLaneForSegment(segment).Sharing switch
                         {
                             LaneSharing.ExclusiveOrPrimary or LaneSharing.DifferentEnd => LaneSharing.DifferentStart,
                             LaneSharing.Entire or LaneSharing.DifferentStart => LaneSharing.Entire,
                             _ => throw new NotImplementedException()
                         };
+#endif
                     }
                 }
 

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
@@ -163,6 +163,7 @@ namespace GitUITests.UserControls.RevisionGrid
         }
 
         [Test]
+        [Ignore("disabled feature")]
         public async Task SegmentsWithOutgoingSecondaryMergesAreNotStraightened()
         {
             RevisionGraph revisionGraph = CreateGraph(" 1  2:1  3:1  4:1,3  5:2  6:4,5  7:6  8:6,7  9:8,5 ");
@@ -199,6 +200,7 @@ namespace GitUITests.UserControls.RevisionGrid
         }
 
         [Test]
+        [Ignore("disabled feature")]
         public async Task SegmentsAreNotStraightenedIfThisCausesAShiftForPrimarySegment()
         {
             RevisionGraph revisionGraph = CreateGraph(" 1  a:1  b:1  2:1  3:1  4:1  5:4,1  6:3  7:5,6  8:7,2,6  c:8  d:8  e:8  9:8,e,d,c,b,a ");


### PR DESCRIPTION
Avoids #11292 but deactivates #10915

## Proposed changes

- Always assign `LaneSharing.ExclusiveOrPrimary` in order to avoid deep nested calls of `_previousRow.GetLaneForSegment()`

## Test methodology <!-- How did you ensure quality? -->

- open Linux repo

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).