### PR TITLE
Symbolic links to .git in WSL

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -108,7 +108,20 @@ namespace GitCommands
                 string gitDir = Path.Combine(WorkingDir, ".git");
                 if (superprojectPath is null && File.Exists(gitDir))
                 {
-                    foreach (string line in File.ReadLines(gitDir))
+                    IEnumerable<string> lines;
+                    try
+                    {
+                        lines = File.ReadLines(gitDir);
+                    }
+                    catch (IOException)
+                    {
+                        // If we cannot read the .git file, assume it's not a submodule
+                        // See also special handling of WSL .git symbolic links in PathUtil.IsWslLink()
+                        // Symbolic links to submodule .git is not expected and not supported.
+                        return (null, null, null);
+                    }
+
+                    foreach (string line in lines)
                     {
                         const string gitdir = "gitdir:";
 

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -164,6 +164,25 @@ namespace GitCommands
             return path.Replace(WslLocalhostPrefix, WslPrefix, StringComparison.OrdinalIgnoreCase);
         }
 
+        /// <summary>
+        /// WSL links are not fully supported by the Windows or .NET
+        /// This is a workaround to handle symbolic links to .git directories in WSL,
+        /// other use cases are not considered.
+        /// Note especially that this method is not checking if the link points to a file or directory.
+        /// </summary>
+        /// <param name="path">The path to check.</param>
+        /// <returns><see langword="true"/> if the path seem to be a link; otherwise, <see langword="false"/>.</returns>
+        public static bool IsWslLink(string path)
+        {
+            // FileAttributes.ReparsePoint is a 'reasonable' indicator for a WSL link.
+            // File.Exists() (without trailing separator) is true but
+            // Directory.Exists() is false for links to both files and directories.
+            // To access these paths, native WSL utilities are required.
+            return IsWslPrefixPath(path)
+                 && File.Exists(RemoveTrailingPathSeparator(path))
+                 && File.GetAttributes(path).HasFlag(FileAttributes.ReparsePoint);
+        }
+
         public static string Resolve(string path, string relativePath = "")
         {
             if (string.IsNullOrWhiteSpace(path))

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -201,7 +201,11 @@ namespace GitCommands.Submodules
             bool isCurrentTopProject)
         {
             string path = topProject.WorkingDir;
-            string name = Directory.Exists(path) ? Path.GetFileName(Path.GetDirectoryName(path)) : path;
+
+            // Workaround for links to .git directories on WSL, assume links are to .git directories
+            string name = (Directory.Exists(path) || File.Exists(PathUtil.RemoveTrailingPathSeparator(path)) || PathUtil.IsWslLink(path))
+                    ? Path.GetFileName(Path.GetDirectoryName(path))
+                    : path;
             name += GetBranchNameSuffix(path, noBranchText);
             result.TopProject = new SubmoduleInfo(text: name, path, bold: isCurrentTopProject);
         }
@@ -270,6 +274,7 @@ namespace GitCommands.Submodules
 
         private static string GetModuleBranch(string path, string noBranchText)
         {
+            // Note: This will fail for WSL symbolic links to .git directories
             string branch = GitModule.GetSelectedBranchFast(path);
             string text = DetachedHeadParser.IsDetachedHead(branch) ? noBranchText : branch;
             return $"({text})";

--- a/GitUI/CommandsDialogs/FormCleanupRepository.cs
+++ b/GitUI/CommandsDialogs/FormCleanupRepository.cs
@@ -176,7 +176,7 @@ namespace GitUI.CommandsDialogs
             if (result != DialogResult.OK
                 || !(subFoldersToClean = dialog.SelectedPath).StartsWith(Module.WorkingDir)
                 || !Directory.Exists(subFoldersToClean)
-                || subFoldersToClean.Equals(Module.WorkingDirGitDir.TrimEnd(Path.DirectorySeparatorChar)))
+                || subFoldersToClean.Equals(PathUtil.RemoveTrailingPathSeparator(Module.WorkingDirGitDir)))
             {
                 return null;
             }

--- a/UnitTests/GitCommands.Tests/Git/GitDirectoryResolverTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/GitDirectoryResolverTests.cs
@@ -62,7 +62,7 @@ namespace GitCommandsTests.Git
         public void Resolve_should_return_path_to_git_folder_if_present()
         {
             _directory.Exists(_gitWorkingDir).Returns(true);
-            _file.Exists(Arg.Any<string>()).Returns(false);
+            _file.Exists(Arg.Any<string>()).Returns(true);
 
             _resolver.Resolve(_workingDir).Should().Be(_gitWorkingDir);
         }


### PR DESCRIPTION
Fixes #11303

## Proposed changes

Symbolic links in WSL cannot be accessed from Windows.
This adds some workarounds that makes it possible to open such repos,
that has been created for instance with Google's repo tool.

All access from Windows will fail, only access by WSL native like "wsl git" works.
At least the following do not work:
* Display of branch names for (mostly using .git/HEAD to get the name). wsl git can be used here.
* Git commands using Windows Git (like difftool from submenu with all tools) will fail. (Even listing of tools fail, for instance when closing settings).
* GE Settings cannot be read/write to local repo
* Commands using the local .git config will not work. This includes Commit, rebase etc

You can still view information and compare branches though
All issues will likely not be resolved, unless the filesystem in WSL is updated

I doubt linked git repos will be a common use for GE, so there should not be too many complaints.
WSL support in general is a hack.

## Test methodology <!-- How did you ensure quality? -->

Manual - basically impossible to test the actual problem

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
