### PR TITLE
Reset selection when opening a repo without a checkout

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -567,6 +567,8 @@ namespace GitUI.UserControls.RevisionGrid
         /// </summary>
         private IList<int> CalculateGraphIndices()
         {
+            // This will assert if switching from one repo with no checkout but with a revision selected
+            // to a repo also without a checkout. This is handled below.
             DebugHelpers.Assert(_loadedToBeSelectedRevisionsCount == ToBeSelectedObjectIds.Count,
                 $"{nameof(CalculateGraphIndices)}() was called before all expected revisions were loaded.");
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -974,9 +974,16 @@ namespace GitUI
                     // If the current checkout (HEAD) is changed, don't get the currently selected rows,
                     // select the new current checkout instead.
                     CurrentCheckout = currentCheckout.Value;
-                    if (CurrentCheckout != previousCheckout && CurrentCheckout is not null)
+                    if (CurrentCheckout != previousCheckout)
                     {
-                        currentlySelectedObjectIds = new List<ObjectId> { CurrentCheckout };
+                        if (CurrentCheckout is null)
+                        {
+                            currentlySelectedObjectIds = null;
+                        }
+                        else
+                        {
+                            currentlySelectedObjectIds = new List<ObjectId> { CurrentCheckout };
+                        }
                     }
 
                     // Exclude the 'stash' ref, it is specially handled when stashes are shown


### PR DESCRIPTION
## Proposed changes

When refreshing a repo, an attempt is done to preserve the selection.
This detection is done by resetting the selection if the checkedout commit changes, selecting HEAD if there is one, otherwise none.
The 'unselect' was only done if the new repo had a checkedout. So no checkedout tried to select a commit that no longer exists (unless it was an artificial commit).
There was an assert especially when opening an empty repo.

Some comments:
* The assert could be replaced with a Trace printout, the situation is handled
* Selection could be kept if there is at least one artificial.
* If no selection, artificial could be selected if shown.
* As commented in the code:
```
            // This will assert if switching from one repo with no checkout but with a revision selected
            // to a repo also without a checkout. This is handled below.
```

## Test methodology <!-- How did you ensure quality? -->

Manual
I do not think a test is beneficial here.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
