### PR TITLE
Trigger RepoChangedNotifier after script / plugin

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -786,8 +786,7 @@ namespace GitUI.CommandsDialogs
                     {
                         if (plugin.Execute(new GitUIEventArgs(this, UICommands)))
                         {
-                            _gitStatusMonitor.InvalidateGitWorkingDirectoryStatus();
-                            RefreshRevisions();
+                            UICommands.RepoChangedNotifier.Notify();
                         }
                     };
 
@@ -1014,13 +1013,7 @@ namespace GitUI.CommandsDialogs
                         DisplayStyle = ToolStripItemDisplayStyle.ImageAndText
                     };
 
-                    button.Click += delegate
-                    {
-                        if (ScriptsRunner.RunScript(script.HotkeyCommandIdentifier, this, RevisionGrid).NeedsGridRefresh)
-                        {
-                            RefreshRevisions();
-                        }
-                    };
+                    button.Click += (s, e) => ScriptsRunner.RunScript(script.HotkeyCommandIdentifier, this, RevisionGrid);
 
                     // add to toolstrip
                     ToolStripScripts.Items.Add(button);

--- a/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
+++ b/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
@@ -87,7 +87,13 @@ namespace GitUI.ScriptsEngine
                             if (string.Equals(plugin.Name, command, StringComparison.CurrentCultureIgnoreCase))
                             {
                                 GitUIEventArgs eventArgs = new(owner, uiCommands);
-                                return new CommandStatus(executed: true, needsGridRefresh: plugin.Execute(eventArgs));
+                                if (plugin.Execute(eventArgs))
+                                {
+                                    uiCommands.RepoChangedNotifier.Notify();
+                                    return new CommandStatus(executed: true, needsGridRefresh: true);
+                                }
+
+                                return new CommandStatus(executed: true, needsGridRefresh: false);
                             }
                         }
                     }
@@ -124,6 +130,8 @@ namespace GitUI.ScriptsEngine
                     {
                         return false;
                     }
+
+                    uiCommands.RepoChangedNotifier.Notify();
                 }
                 else
                 {

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -3082,16 +3082,7 @@ namespace GitUI
                 case Command.CompareSelectedCommits: compareSelectedCommitsMenuItem_Click(this, EventArgs.Empty); break;
                 case Command.DeleteRef: DeleteRef(); break;
                 case Command.RenameRef: RenameRef(); break;
-                default:
-                    {
-                        CommandStatus result = base.ExecuteCommand(cmd);
-                        if (result.NeedsGridRefresh)
-                        {
-                            PerformRefreshRevisions();
-                        }
-
-                        return result;
-                    }
+                default: return base.ExecuteCommand(cmd);
             }
 
             return true;
@@ -3129,10 +3120,7 @@ namespace GitUI
         void IRunScript.Execute(int scriptId)
         {
             IScriptsRunner scriptsRunner = UICommands.GetRequiredService<IScriptsRunner>();
-            if (scriptsRunner.RunScript(scriptId, FindForm() as GitModuleForm, this).NeedsGridRefresh)
-            {
-                PerformRefreshRevisions();
-            }
+            scriptsRunner.RunScript(scriptId, FindForm() as GitModuleForm, this);
         }
 
         internal TestAccessor GetTestAccessor()


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/pull/11273#discussion_r1361134225
Replaces the undesired #11278

## Proposed changes

Trigger the `IGitUICommands.RepoChangedNotifier` after the execution of scripts and plugins
instead of manually performing updates on `CommandStatus.NeedsGridRefresh`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
