### PR TITLE
Fix commit graph crash when commit message started with a new line

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -459,7 +459,7 @@ namespace GitCommands
             if (keepBody && revision.HasMultiLineMessage)
             {
                 // Handle '\v' (Shift-Enter) as '\n' for users that by habit avoid Enter to 'send'
-                int currentOffset = lengthSubject - 1;
+                int currentOffset = lengthSubject;
                 int verticalFeedIndex;
                 while ((verticalFeedIndex = decoded.Slice(currentOffset).IndexOf('\v')) >= 0)
                 {

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=subject_starts_with_newline.verified.json
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=subject_starts_with_newline.verified.json
@@ -1,0 +1,27 @@
+﻿{
+  "ObjectId": {
+    "IsArtificial": false
+  },
+  "Guid": "8452225978d76fc1a95b2fdc4a5b6dca16658ad6",
+  "TreeGuid": {
+    "IsArtificial": false
+  },
+  "Author": "IEVin",
+  "AuthorEmail": "i.e.vin@ya.ru",
+  "AuthorUnixTime": 1698711360,
+  "AuthorDate": "DateTimeOffset_1",
+  "Committer": "IEVin",
+  "CommitterEmail": "i.e.vin@ya.ru",
+  "CommitUnixTime": 1698711360,
+  "CommitDate": "DateTimeOffset_1",
+  "BuildStatus": null,
+  "Subject": "",
+  "Body": "\ncommit message subject starts with a newline symbol",
+  "HasMultiLineMessage": true,
+  "HasNotes": false,
+  "IsArtificial": false,
+  "IsStash": false,
+  "ReflogSelector": null,
+  "HasParent": false,
+  "FirstParentId": null
+}

--- a/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
+++ b/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
@@ -63,6 +63,7 @@ namespace GitCommandsTests
         [TestCase("reflogselector_empty", true, true)]
         [TestCase("notes_data", true, false, true, true)]
         [TestCase("notes_empty", true, false, true, true)]
+        [TestCase("subject_starts_with_newline", true)]
         public async Task TryParseRevision_test(string testName, bool expectedReturn, bool hasReflogSelector = false, bool hasEmptyReflogSelector = true, bool hasNotes = false)
         {
             string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData/RevisionReader", testName + ".bin");

--- a/UnitTests/GitCommands.Tests/TestData/RevisionReader/subject_starts_with_newline.bin
+++ b/UnitTests/GitCommands.Tests/TestData/RevisionReader/subject_starts_with_newline.bin
@@ -1,0 +1,9 @@
+8452225978d76fc1a95b2fdc4a5b6dca16658ad64b825dc642cb6eb9a060e54bf8d69288fbee4904
+1698711360
+1698711360
+IEVin
+i.e.vin@ya.ru
+IEVin
+i.e.vin@ya.ru
+
+commit message subject starts with a newline symbol


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11299 [NBug] Specified argument was out of the range of valid values

## Proposed changes

- Fix exception in commit graph

## Test methodology <!-- How did you ensure quality? -->

- Open a a problematic repository in GE before and after that fix


## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.41.0.windows.1
- Windows 11 (22H2)

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
