### PR TITLE
Remove RevisionGraphRevision._parents

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/BranchFinder.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/BranchFinder.cs
@@ -55,7 +55,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         {
             Validates.NotNull(node.GitRevision);
 
-            bool isTheFirstBranch = parent is null || node.Parents.IsEmpty || node.Parents.Last() == parent; // note: Parents are stored in reverse order
+            bool isTheFirstBranch = parent is null || node.Parents.FirstOrDefault() == parent;
             string? mergedInto;
             string? mergedWith;
             (mergedInto, mergedWith) = ParseMergeMessage(node.GitRevision.Subject, appendPullRequest: isTheFirstBranch);

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -687,30 +687,32 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             /// <returns><see langword="true"/> if scores for the revisions are validated; otherwise <see langword="false"/>.</returns>
             public bool ValidateTopoOrder()
             {
-                int i = 0;
+                int nodeIndex = -1;
                 foreach (RevisionGraphRevision node in _revisionGraph._revisionByObjectId.Values)
                 {
-                    for (int j = 0; j < node.Parents.Count(); j++)
+                    ++nodeIndex;
+
+                    int parentIndex = -1;
+                    foreach (RevisionGraphRevision parent in node.Parents)
                     {
-                        RevisionGraphRevision parent = node.Parents.ElementAt(j);
+                        ++parentIndex;
                         if (parent.Score <= node.Score)
                         {
-                            Console.WriteLine($"Node {i}:{node.Score} parent {j}:{parent.Score} has a lower score");
+                            Trace.WriteLine($"Node {nodeIndex}:{node.Score} parent {parentIndex}:{parent.Score} has a lower score");
                             return false;
                         }
                     }
 
-                    for (int j = 0; j < node.Children.Count(); j++)
+                    int childIndex = -1;
+                    foreach (RevisionGraphRevision child in node.Children)
                     {
-                        RevisionGraphRevision child = node.Children.ElementAt(j);
+                        ++childIndex;
                         if (node.Score <= child.Score)
                         {
-                            Console.WriteLine($"Node {i}:{node.Score} child {j}:{child.Score} has a higher score");
+                            Trace.WriteLine($"Node {nodeIndex}:{node.Score} child {childIndex}:{child.Score} has a higher score");
                             return false;
                         }
                     }
-
-                    i++;
                 }
 
                 return true;


### PR DESCRIPTION
## Proposed changes

Remove redundant field `RevisionGraphRevision._parents`, use `_startSegments` instead.
The affected property `Parents` is only used for getting tooltip information and for tests.

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).