### PR TITLE
Implement RevisionGraphRow.FirstParentOrSelf without LaneSharing

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRevision.cs
@@ -10,7 +10,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
     //     |
     //     *  <- parent revision
     [DebuggerDisplay("{Objectid}")]
-    public class RevisionGraphRevision
+    public sealed class RevisionGraphRevision
     {
         private ImmutableStack<RevisionGraphRevision> _parents = ImmutableStack<RevisionGraphRevision>.Empty;
         private ImmutableStack<RevisionGraphRevision> _children = ImmutableStack<RevisionGraphRevision>.Empty;
@@ -138,11 +138,13 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             }
 
             ImmutableInterlocked.Push(ref _parents, parent);
+
+            bool isFirstChildOfParent = parent.Children.IsEmpty;
             parent.AddChild(this);
 
             maxScore = parent.EnsureScoreIsAbove(Score + 1);
 
-            _startSegments.Enqueue(new RevisionGraphSegment(parent, this));
+            _startSegments.Enqueue(new RevisionGraphSegment(parent, this, isFirstChildOfParent));
         }
 
         private void AddChild(RevisionGraphRevision child)

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -1,6 +1,5 @@
 ﻿// Hotfix of #11292 for release 4.2: Due to heavy performance issues with the Linux repo, do not determine the kind of LaneSharing of secondary segments.
 // This deactivates #10915 which avoided the multiple drawing of shared graph segments.
-// This reactivates a minor hyperactivity of line-straightening over commits (#11059).
 #define ALL_PRIMARY_LANES
 
 using Microsoft;
@@ -24,7 +23,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
     // The segments can be returned in the order how it is stored.
     // Segments are not the same as lanes.A crossing segment is a lane, but multiple segments can connect to the revision.
     // Therefore, a single lane can have multiple segments.
-    public class RevisionGraphRow : IRevisionGraphRow
+    public sealed class RevisionGraphRow : IRevisionGraphRow
     {
         private static readonly Lane _noLane = new(Index: -1, LaneSharing.ExclusiveOrPrimary);
 
@@ -297,13 +296,12 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         /// </returns>
         public RevisionGraphSegment FirstParentOrSelf(RevisionGraphSegment segment)
         {
-            if (segment.Parent != Revision
-                || GetLaneForSegment(segment).Sharing != LaneSharing.ExclusiveOrPrimary)
+            if (segment.Parent == Revision && segment.IsFirstChildOfParent)
             {
-                return segment;
+                return Segments.FirstOrDefault(s => s.Child == Revision, defaultValue: segment);
             }
 
-            return Segments.FirstOrDefault(s => s.Child == Revision, defaultValue: segment);
+            return segment;
         }
     }
 }

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
@@ -18,13 +18,16 @@ namespace GitUI.UserControls.RevisionGrid.Graph
     //     | /
     //     *    <- Parent
     [DebuggerDisplay("Child: {Child} - Parent: {Parent}")]
-    public class RevisionGraphSegment
+    public sealed class RevisionGraphSegment
     {
-        public RevisionGraphSegment(RevisionGraphRevision parent, RevisionGraphRevision child)
+        public RevisionGraphSegment(RevisionGraphRevision parent, RevisionGraphRevision child, bool isFirstChildOfParent)
         {
             Parent = parent;
             Child = child;
+            IsFirstChildOfParent = isFirstChildOfParent;
         }
+
+        public bool IsFirstChildOfParent { get; }
 
         public LaneInfo? LaneInfo { get; set; }
 

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneNodeLocatorTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneNodeLocatorTests.cs
@@ -40,7 +40,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
             }
             else
             {
-                segments.Add(new RevisionGraphSegment(node, null));
+                segments.Add(new RevisionGraphSegment(parent: node, child: null, isFirstChildOfParent: false));
             }
 
             _revisionGraphRowProvider.GetSegmentsForRow(row).Returns(x => revisionGraphRow);
@@ -127,8 +127,8 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
             const int lane = 3;
             RevisionGraphRevision parentNode = new(GitUIPluginInterfaces.ObjectId.WorkTreeId, 0);
             RevisionGraphRevision childNode = new(GitUIPluginInterfaces.ObjectId.WorkTreeId, 0);
-            RevisionGraphSegment segment = new(parentNode, childNode);
-            var laneNode = SetupLaneRow(row, lane, laneCount: lane + 1, firstSegment: segment);
+            RevisionGraphSegment segment = new(parentNode, childNode, isFirstChildOfParent: true);
+            RevisionGraphRevision laneNode = SetupLaneRow(row, lane, laneCount: lane + 1, firstSegment: segment);
 
 #if !DEBUG
             // innermost "return" in RELEASE build

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphRowTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphRowTests.cs
@@ -7,9 +7,9 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
     [TestFixture]
     public class RevisionGraphRowTests
     {
-        private RevisionGraphSegment _segment = new(parent: new(ObjectId.IndexId, guessScore: 0), child: new(ObjectId.WorkTreeId, guessScore: 0));
-        private RevisionGraphSegment _segment1 = new(parent: new(ObjectId.Random(), guessScore: 0), child: new(ObjectId.Random(), guessScore: 0));
-        private RevisionGraphSegment _segment2 = new(parent: new(ObjectId.Random(), guessScore: 0), child: new(ObjectId.Random(), guessScore: 0));
+        private RevisionGraphSegment _segment = new(parent: new(ObjectId.IndexId, guessScore: 0), child: new(ObjectId.WorkTreeId, guessScore: 0), isFirstChildOfParent: true);
+        private RevisionGraphSegment _segment1 = new(parent: new(ObjectId.Random(), guessScore: 0), child: new(ObjectId.Random(), guessScore: 0), isFirstChildOfParent: true);
+        private RevisionGraphSegment _segment2 = new(parent: new(ObjectId.Random(), guessScore: 0), child: new(ObjectId.Random(), guessScore: 0), isFirstChildOfParent: true);
 
         [Test]
         public void MoveLanesRight_should_do_nothing_if_empty([Values(-1, 0, 1)] int fromLane)


### PR DESCRIPTION
Follow-up to #11294
Reduces unnecessary gaps in the graph but does not completely restore the initial behavior from #11059 before #11294

## Proposed changes

Implement `RevisionGraphRow.FirstParentOrSelf()` without `LaneSharing`
by adding `RevisionGraphSegment.IsFirstChildOfParent`

This is incomplete because the graph lanes can be sorted differently than the children, i.e. the graph does not always reflect the topology: the merge destination branch may not be the left one.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before (#11294) | After: same as initial (#11059)

![image](https://github.com/gitextensions/gitextensions/assets/36601201/1920ee4e-d022-4a6f-b340-0198d16eff86)   ![image](https://github.com/gitextensions/gitextensions/assets/36601201/79fb3417-c76d-4375-b155-ccaf828a70c4)

### But Initial (#11059) | After: same as Before (#11294)

![image](https://github.com/gitextensions/gitextensions/assets/36601201/003d5963-f827-4bd0-a5ca-30be576b01b4)   ![image](https://github.com/gitextensions/gitextensions/assets/36601201/a631ce0b-8f72-47b7-8545-045e885a4601)

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).