### PR TITLE
Provide IServiceProvider to FormStatus

### DIFF
--- a/GitUI/HelperDialogs/FormProcess.cs
+++ b/GitUI/HelperDialogs/FormProcess.cs
@@ -19,7 +19,7 @@ namespace GitUI.HelperDialogs
         public HandleOnExit? HandleOnExitCallback { get; set; }
         public readonly Dictionary<string, string> ProcessEnvVariables = new();
 
-        private FormProcess(GitUICommands? commands, ConsoleOutputControl? outputControl, ArgumentString arguments, string workingDirectory, string? input, bool useDialogSettings, string? process)
+        private FormProcess(GitUICommands commands, ConsoleOutputControl? outputControl, ArgumentString arguments, string workingDirectory, string? input, bool useDialogSettings, string? process)
             : base(commands, outputControl, useDialogSettings)
         {
             ProcessCallback = ProcessStart;
@@ -51,7 +51,7 @@ namespace GitUI.HelperDialogs
             ConsoleOutput.DataReceived += DataReceivedCore;
         }
 
-        public FormProcess(GitUICommands? commands, ArgumentString arguments, string workingDirectory, string? input, bool useDialogSettings, string? process = null)
+        public FormProcess(GitUICommands commands, ArgumentString arguments, string workingDirectory, string? input, bool useDialogSettings, string? process = null)
             : this(commands, outputControl: null, arguments, workingDirectory, input, useDialogSettings, process)
         {
         }
@@ -59,7 +59,7 @@ namespace GitUI.HelperDialogs
         // Note that "DialogResult FormProcess.ShowDialog(owner)" may exit when the process (command) finishes,
         // so that result is other than OK or Cancel.
 
-        public static bool ShowDialog(IWin32Window? owner, GitUICommands? commands, ArgumentString arguments, string workingDirectory, string? input, bool useDialogSettings, string? process = null)
+        public static bool ShowDialog(IWin32Window? owner, GitUICommands commands, ArgumentString arguments, string workingDirectory, string? input, bool useDialogSettings, string? process = null)
         {
             DebugHelpers.Assert(owner is not null, "Progress window must be owned by another window! This is a bug, please correct and send a pull request with a fix.");
 
@@ -68,7 +68,7 @@ namespace GitUI.HelperDialogs
             return !formProcess.ErrorOccurred();
         }
 
-        public static string ReadDialog(IWin32Window? owner, GitUICommands? commands, ArgumentString arguments, string workingDirectory, string? input, bool useDialogSettings)
+        public static string ReadDialog(IWin32Window? owner, GitUICommands commands, ArgumentString arguments, string workingDirectory, string? input, bool useDialogSettings)
         {
             DebugHelpers.Assert(owner is not null, "Progress window must be owned by another window! This is a bug, please correct and send a pull request with a fix.");
 

--- a/GitUI/HelperDialogs/FormStatus.cs
+++ b/GitUI/HelperDialogs/FormStatus.cs
@@ -13,9 +13,11 @@ namespace GitUI.HelperDialogs
         private protected Action<FormStatus>? ProcessCallback;
         private protected Action<FormStatus>? AbortCallback;
 
-        public FormStatus(GitUICommands? commands, ConsoleOutputControl? consoleOutput, bool useDialogSettings)
+        public FormStatus(GitUICommands commands, ConsoleOutputControl? consoleOutput, bool useDialogSettings)
             : base(commands, enablePositionRestore: true)
         {
+            ArgumentNullException.ThrowIfNull(commands);
+
             _useDialogSettings = useDialogSettings;
 
             ConsoleOutput = consoleOutput ?? ConsoleOutputControl.CreateInstance();

--- a/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
+++ b/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
@@ -124,6 +124,7 @@ namespace GitUI.ScriptsEngine
 
                 if (!script.RunInBackground)
                 {
+                    // TODO: Remove downcast from IGitUICommands to GitUICommands after https://github.com/gitextensions/gitextensions/pull/11269
                     bool success = FormProcess.ShowDialog(owner, uiCommands as GitUICommands, argument, uiCommands.GitModule.WorkingDir, null, true, process: command);
                     if (!success)
                     {

--- a/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
+++ b/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
@@ -124,7 +124,7 @@ namespace GitUI.ScriptsEngine
 
                 if (!script.RunInBackground)
                 {
-                    bool success = FormProcess.ShowDialog(owner, commands: null, argument, uiCommands.GitModule.WorkingDir, null, true, process: command);
+                    bool success = FormProcess.ShowDialog(owner, uiCommands as GitUICommands, argument, uiCommands.GitModule.WorkingDir, null, true, process: command);
                     if (!success)
                     {
                         return false;


### PR DESCRIPTION
Fixes: preparation for git output / history control

## Proposed changes

- Ensure that `FormStatus` has a `GitUICommands` instance.
- Pass GitUICommands instance to FormStatus when running scripts by downcasting from IGitUICommands to GitUICommands
- Make GitUICommands instance mandatory for FormStatus & FormProcess

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).