### PR TITLE
Remove GitUICommands functions wrapping BrowseRepo

### DIFF
--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1898,21 +1898,6 @@ namespace GitUI
             InvokeEvent(owner, PostRegisterPlugin);
         }
 
-        public void BrowseGoToRef(string refName, bool showNoRevisionMsg, bool toggleSelection = false)
-        {
-            BrowseRepo?.GoToRef(refName, showNoRevisionMsg, toggleSelection);
-        }
-
-        public void BrowseSetWorkingDir(string path, ObjectId? selectedId = null, ObjectId? firstId = null)
-        {
-            BrowseRepo?.SetWorkingDir(path, selectedId, firstId);
-        }
-
-        public IReadOnlyList<GitRevision>? GetSelectedRevisions()
-        {
-            return BrowseRepo?.GetSelectedRevisions();
-        }
-
         public IGitRemoteCommand CreateRemoteCommand()
         {
             return new GitRemoteCommand(this);

--- a/GitUI/LeftPanel/BaseBranchLeafNode.cs
+++ b/GitUI/LeftPanel/BaseBranchLeafNode.cs
@@ -74,7 +74,7 @@ namespace GitUI.LeftPanel
                 string branch = RelatedBranch is null || !Control.ModifierKeys.HasFlag(Keys.Alt)
                     ? FullPath
                     : RelatedBranch;
-                UICommands.BrowseGoToRef(branch, showNoRevisionMsg: true, toggleSelection: Control.ModifierKeys.HasFlag(Keys.Control));
+                UICommands.BrowseRepo?.GoToRef(branch, showNoRevisionMsg: true, toggleSelection: Control.ModifierKeys.HasFlag(Keys.Control));
                 TreeViewNode.TreeView?.Focus();
             });
         }

--- a/GitUI/LeftPanel/BaseRevisionNode.cs
+++ b/GitUI/LeftPanel/BaseRevisionNode.cs
@@ -108,7 +108,7 @@ namespace GitUI.LeftPanel
 
             TreeViewNode.TreeView?.BeginInvoke(() =>
             {
-                UICommands.BrowseGoToRef(ObjectId.ToString(), showNoRevisionMsg: true, toggleSelection: Control.ModifierKeys.HasFlag(Keys.Control));
+                UICommands.BrowseRepo?.GoToRef(ObjectId.ToString(), showNoRevisionMsg: true, toggleSelection: Control.ModifierKeys.HasFlag(Keys.Control));
                 TreeViewNode.TreeView?.Focus();
             });
         }

--- a/GitUI/LeftPanel/SubmoduleNode.cs
+++ b/GitUI/LeftPanel/SubmoduleNode.cs
@@ -63,11 +63,11 @@ namespace GitUI.LeftPanel
 
             if (Info.Detailed?.RawStatus is not null)
             {
-                UICommands.BrowseSetWorkingDir(Info.Path, ObjectId.WorkTreeId, Info.Detailed.RawStatus.OldCommit);
+                UICommands.BrowseRepo?.SetWorkingDir(Info.Path, ObjectId.WorkTreeId, Info.Detailed.RawStatus.OldCommit);
                 return;
             }
 
-            UICommands.BrowseSetWorkingDir(Info.Path);
+            UICommands.BrowseRepo?.SetWorkingDir(Info.Path);
         }
 
         public void LaunchGitExtensions()
@@ -83,7 +83,7 @@ namespace GitUI.LeftPanel
             if (IsCurrent)
             {
                 // Get the current (most likely) selections from the grid
-                IReadOnlyList<GitRevision>? revs = UICommands.GetSelectedRevisions() ?? new List<GitRevision>();
+                IReadOnlyList<GitRevision> revs = UICommands.BrowseRepo?.GetSelectedRevisions() ?? Array.Empty<GitRevision>();
                 selected = revs.Count > 0 ? revs[0].ObjectId : null;
                 first = revs.Count > 1 ? revs[^1].ObjectId : null;
             }


### PR DESCRIPTION
## Proposed changes

Replace `GitUICommands.Browse*` wrapper functions with direct calls `GitUICommands.BrowseRepo?.*` in order to
- reduce the size of `IGitUICommands`
- emphasize the optionality of those functions

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).