### PR TITLE
Move IScriptHostControl functions to IBrowseRepo

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -228,7 +228,7 @@ namespace GitUI.CommandsDialogs
 
         private UpdateTargets _selectedRevisionUpdatedTargets = UpdateTargets.None;
 
-        public override RevisionGridControl RevisionGridControl { get => RevisionGrid; }
+        public RevisionGridControl RevisionGridControl => RevisionGrid;
 
         /// <summary>
         /// Open Browse - main GUI including dashboard.

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -676,18 +676,10 @@ namespace GitUI.CommandsDialogs
 
         #region IBrowseRepo
 
-        public void GoToRef(string refName, bool showNoRevisionMsg, bool toggleSelection = false)
-        {
-            using (WaitCursorScope.Enter())
-            {
-                RevisionGrid.GoToRef(refName, showNoRevisionMsg, toggleSelection);
-            }
-        }
-
-        public IReadOnlyList<GitRevision> GetSelectedRevisions()
-        {
-            return RevisionGrid.GetSelectedRevisions();
-        }
+        public GitRevision? GetLatestSelectedRevision() => RevisionGrid.LatestSelectedRevision;
+        public IReadOnlyList<GitRevision> GetSelectedRevisions() => RevisionGrid.GetSelectedRevisions();
+        public Point GetQuickItemSelectorLocation() => RevisionGrid.GetQuickItemSelectorLocation();
+        public void GoToRef(string refName, bool showNoRevisionMsg, bool toggleSelection = false) => RevisionGrid.GoToRef(refName, showNoRevisionMsg, toggleSelection);
 
         #endregion
 
@@ -1013,7 +1005,7 @@ namespace GitUI.CommandsDialogs
                         DisplayStyle = ToolStripItemDisplayStyle.ImageAndText
                     };
 
-                    button.Click += (s, e) => ScriptsRunner.RunScript(script.HotkeyCommandIdentifier, this, RevisionGrid);
+                    button.Click += (s, e) => ScriptsRunner.RunScript(script.HotkeyCommandIdentifier, this, scriptHostControl: null);
 
                     // add to toolstrip
                     ToolStripScripts.Items.Add(button);

--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -132,14 +132,8 @@ namespace GitUI
 
             bool ExecuteScriptCommand()
             {
-                RevisionGridControl revisionGridControl = this as RevisionGridControl;
-                if (revisionGridControl is null)
-                {
-                    revisionGridControl = (FindForm() as GitModuleForm)?.RevisionGridControl;
-                }
-
                 IScriptsRunner scriptsRunner = UICommands.GetRequiredService<IScriptsRunner>();
-                return scriptsRunner.RunScript(command, FindForm() as GitModuleForm, revisionGridControl);
+                return scriptsRunner.RunScript(command, FindForm() as GitModuleForm, this as IScriptHostControl);
             }
         }
 

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -105,7 +105,7 @@ namespace GitUI
 
         protected override bool ExecuteCommand(int command)
         {
-            return ScriptsRunner.RunScript(command, this, RevisionGridControl)
+            return ScriptsRunner.RunScript(command, this)
                 || base.ExecuteCommand(command);
         }
 

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -25,8 +25,6 @@ namespace GitUI
         /// </summary>
         internal static bool IsUnitTestActive { get; set; }
 
-        public virtual RevisionGridControl? RevisionGridControl { get; }
-
         public IHotkeySettingsLoader HotkeySettingsReader
         {
             get => _hotkeySettingsLoader ?? throw new InvalidOperationException($"{GetType().FullName} was constructed incorrectly.");

--- a/GitUI/ScriptsEngine/IScriptHostControl.cs
+++ b/GitUI/ScriptsEngine/IScriptHostControl.cs
@@ -1,11 +1,5 @@
-﻿using GitUIPluginInterfaces;
+﻿namespace GitUI.ScriptsEngine;
 
-namespace GitUI.ScriptsEngine
+public interface IScriptHostControl
 {
-    public interface IScriptHostControl
-    {
-        GitRevision? GetLatestSelectedRevision();
-        IReadOnlyList<GitRevision> GetSelectedRevisions();
-        Point GetQuickItemSelectorLocation();
-    }
 }

--- a/GitUI/ScriptsEngine/IScriptsRunner.cs
+++ b/GitUI/ScriptsEngine/IScriptsRunner.cs
@@ -8,7 +8,7 @@ namespace GitUI.ScriptsEngine
         bool RunEventScripts<THostForm>(ScriptEvent scriptEvent, THostForm form)
             where THostForm : IGitModuleForm, IWin32Window;
 
-        bool RunScript<THostForm>(int scriptId, THostForm form, RevisionGridControl? revisionGrid = null)
+        bool RunScript<THostForm>(int scriptId, THostForm form, IScriptHostControl? scriptHostControl = null)
             where THostForm : IGitModuleForm, IWin32Window;
     }
 }

--- a/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
+++ b/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
@@ -16,12 +16,12 @@ namespace GitUI.ScriptsEngine
             private const string PluginPrefix = "plugin:";
             private const string NavigateToPrefix = "navigateTo:";
 
-            public static bool RunScript<THostForm>(ScriptInfo script, THostForm form, RevisionGridControl? revisionGrid)
+            public static bool RunScript<THostForm>(ScriptInfo script, THostForm form, IScriptHostControl? scriptHostControl = null)
                 where THostForm : IGitModuleForm, IWin32Window
             {
                 try
                 {
-                    return RunScriptInternal(script, form, form.UICommands, revisionGrid);
+                    return RunScriptInternal(script, form, form.UICommands, scriptHostControl);
                 }
                 catch (ExternalOperationException ex) when (ex is not UserExternalOperationException)
                 {
@@ -29,7 +29,7 @@ namespace GitUI.ScriptsEngine
                 }
             }
 
-            private static bool RunScriptInternal(ScriptInfo script, IWin32Window owner, IGitUICommands uiCommands, RevisionGridControl? revisionGrid)
+            private static bool RunScriptInternal(ScriptInfo script, IWin32Window owner, IGitUICommands uiCommands, IScriptHostControl? scriptHostControl)
             {
                 if (string.IsNullOrEmpty(script.Command))
                 {
@@ -37,7 +37,7 @@ namespace GitUI.ScriptsEngine
                 }
 
                 string? arguments = script.Arguments;
-                if (!string.IsNullOrEmpty(arguments) && revisionGrid is null)
+                if (!string.IsNullOrEmpty(arguments) && uiCommands.BrowseRepo is null)
                 {
                     string? optionDependingOnSelectedRevision
                         = ScriptOptionsParser.Options.FirstOrDefault(option => ScriptOptionsParser.DependsOnSelectedRevision(option)
@@ -57,7 +57,7 @@ namespace GitUI.ScriptsEngine
                 }
 
                 string? originalCommand = script.Command;
-                (string? argument, bool abort) = ScriptOptionsParser.Parse(script.Arguments, uiCommands, owner, revisionGrid);
+                (string? argument, bool abort) = ScriptOptionsParser.Parse(script.Arguments, uiCommands, owner, scriptHostControl);
                 if (abort)
                 {
                     throw new UserExternalOperationException($"{TranslatedStrings.ScriptText}: '{script.Name}'{Environment.NewLine}{TranslatedStrings.ScriptErrorOptionWithoutRevisionText}",
@@ -102,7 +102,7 @@ namespace GitUI.ScriptsEngine
 
                 if (command.StartsWith(NavigateToPrefix))
                 {
-                    if (revisionGrid is null)
+                    if (uiCommands.BrowseRepo is null)
                     {
                         return false;
                     }
@@ -115,7 +115,7 @@ namespace GitUI.ScriptsEngine
 
                         if (revisionRef is not null)
                         {
-                            revisionGrid.GoToRef(revisionRef, true);
+                            uiCommands.BrowseRepo.GoToRef(revisionRef, true);
                         }
                     }
 

--- a/GitUI/ScriptsEngine/ScriptsManager.cs
+++ b/GitUI/ScriptsEngine/ScriptsManager.cs
@@ -57,7 +57,7 @@ namespace GitUI.ScriptsEngine
         {
             foreach (ScriptInfo script in GetScripts().Where(scriptInfo => scriptInfo.Enabled && scriptInfo.OnEvent == scriptEvent))
             {
-                bool executed = ScriptRunner.RunScript(script, form, revisionGrid: null);
+                bool executed = ScriptRunner.RunScript(script, form);
                 if (!executed)
                 {
                     return false;
@@ -67,7 +67,7 @@ namespace GitUI.ScriptsEngine
             return true;
         }
 
-        public bool RunScript<THostForm>(int scriptId, THostForm form, RevisionGridControl? revisionGrid = null)
+        public bool RunScript<THostForm>(int scriptId, THostForm form, IScriptHostControl? scriptHostControl = null)
             where THostForm : IGitModuleForm, IWin32Window
         {
             ScriptInfo? scriptInfo = GetScript(scriptId);
@@ -77,7 +77,7 @@ namespace GitUI.ScriptsEngine
                     new ExternalOperationException(workingDirectory: form.UICommands.GitModule.WorkingDir));
             }
 
-            return ScriptRunner.RunScript(scriptInfo, form, revisionGrid);
+            return ScriptRunner.RunScript(scriptInfo, form, scriptHostControl);
         }
 
         public string? SerializeIntoXml()

--- a/GitUI/UserControls/InteractiveGitActionControl.cs
+++ b/GitUI/UserControls/InteractiveGitActionControl.cs
@@ -239,12 +239,12 @@ namespace GitUI.UserControls
             switch (_action)
             {
                 case GitAction.Bisect:
-                    if (Form is not FormBrowse || Form.RevisionGridControl is null)
+                    if (Form is not FormBrowse formBrowse)
                     {
                         return;
                     }
 
-                    using (FormBisect frm = new(Form.RevisionGridControl))
+                    using (FormBisect frm = new(formBrowse.RevisionGridControl))
                     {
                         frm.ShowDialog(this);
                     }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -52,7 +52,7 @@ namespace GitUI
     }
 
     [DefaultEvent("DoubleClick")]
-    public sealed partial class RevisionGridControl : GitModuleControl, IScriptHostControl, ICheckRefs, IRunScript, IRevisionGridFilter, IRevisionGridInfo, IRevisionGridUpdate
+    public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, IRunScript, IRevisionGridFilter, IRevisionGridInfo, IRevisionGridUpdate
     {
         public event EventHandler<DoubleClickRevisionEventArgs>? DoubleClickRevision;
         public event EventHandler<FilterChangedEventArgs>? FilterChanged;
@@ -3090,19 +3090,6 @@ namespace GitUI
 
         #endregion
 
-        #region IScriptHostControl
-
-        GitRevision? IScriptHostControl.GetLatestSelectedRevision()
-            => LatestSelectedRevision;
-
-        IReadOnlyList<GitRevision> IScriptHostControl.GetSelectedRevisions()
-            => GetSelectedRevisions();
-
-        Point IScriptHostControl.GetQuickItemSelectorLocation()
-            => GetQuickItemSelectorLocation();
-
-        #endregion
-
         #region IRevisionGridInfo
 
         IReadOnlyList<GitRevision> IRevisionGridInfo.GetSelectedRevisions()
@@ -3120,7 +3107,7 @@ namespace GitUI
         void IRunScript.Execute(int scriptId)
         {
             IScriptsRunner scriptsRunner = UICommands.GetRequiredService<IScriptsRunner>();
-            scriptsRunner.RunScript(scriptId, FindForm() as GitModuleForm, this);
+            scriptsRunner.RunScript(scriptId, FindForm() as GitModuleForm);
         }
 
         internal TestAccessor GetTestAccessor()

--- a/Plugins/GitUIPluginInterfaces/IBrowseRepo.cs
+++ b/Plugins/GitUIPluginInterfaces/IBrowseRepo.cs
@@ -1,9 +1,10 @@
-﻿namespace GitUIPluginInterfaces
+﻿namespace GitUIPluginInterfaces;
+
+public interface IBrowseRepo
 {
-    public interface IBrowseRepo
-    {
-        void GoToRef(string refName, bool showNoRevisionMsg, bool toggleSelection = false);
-        void SetWorkingDir(string? path, ObjectId? selectedId = null, ObjectId? firstId = null);
-        IReadOnlyList<GitRevision> GetSelectedRevisions();
-    }
+    GitRevision? GetLatestSelectedRevision();
+    IReadOnlyList<GitRevision> GetSelectedRevisions();
+    Point GetQuickItemSelectorLocation();
+    void GoToRef(string refName, bool showNoRevisionMsg, bool toggleSelection = false);
+    void SetWorkingDir(string? path, ObjectId? selectedId = null, ObjectId? firstId = null);
 }

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -12,7 +12,7 @@ namespace GitUIPluginInterfaces
         event EventHandler<GitUIEventArgs> PostRegisterPlugin;
         event EventHandler<GitUIEventArgs> PreCommit;
 
-        public IBrowseRepo? BrowseRepo { get; set; }
+        IBrowseRepo? BrowseRepo { get; set; }
 
         IGitModule GitModule { get; }
 

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -12,14 +12,16 @@ namespace GitUIPluginInterfaces
         event EventHandler<GitUIEventArgs> PostRegisterPlugin;
         event EventHandler<GitUIEventArgs> PreCommit;
 
-        IGitModule GitModule { get; }
+        public IBrowseRepo? BrowseRepo { get; set; }
 
-        IGitRemoteCommand CreateRemoteCommand();
+        IGitModule GitModule { get; }
 
         /// <summary>
         /// RepoChangedNotifier.Notify() should be called after each action that changes repo state
         /// </summary>
         ILockableNotifier RepoChangedNotifier { get; }
+
+        IGitRemoteCommand CreateRemoteCommand();
 
         bool StartCommandLineProcessDialog(IWin32Window? owner, string? command, ArgumentString arguments);
         bool StartCommandLineProcessDialog(IWin32Window? owner, IGitCommand command);

--- a/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
+++ b/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
@@ -181,11 +181,13 @@ namespace GitUITests.Script
                 Subject = Subject,
                 Body = $"{Subject}\n\nline3"
             };
-            _scriptHostControl.GetLatestSelectedRevision().Returns(x => revision);
+            IBrowseRepo browseRepo = Substitute.For<IBrowseRepo>();
+            browseRepo.GetLatestSelectedRevision().Returns(x => revision);
+            _commands.BrowseRepo.Returns(browseRepo);
 
             string expectedMessage = $"{Subject}\\n\\nline3";
 
-            (string? arguments, bool abort) result = ScriptOptionsParser.Parse("echo {{sSubject}} {{sMessage}}", _commands, owner: null, _scriptHostControl);
+            (string? arguments, bool abort) result = ScriptOptionsParser.Parse("echo {{sSubject}} {{sMessage}}", _commands, owner: null, scriptHostControl: null);
 
             result.arguments.Should().Be($"echo \"{revision.Subject}\" \"{expectedMessage}\"");
             result.abort.Should().Be(false);
@@ -339,8 +341,6 @@ namespace GitUITests.Script
 
             ServiceContainer serviceContainer = new();
             serviceContainer.AddService(repositoryDescriptionProvider);
-
-            _scriptHostControl = Substitute.For<IScriptHostControl>();
 
             _commands = new GitUICommands(serviceContainer, new GitModule(""));
 


### PR DESCRIPTION
Fixes first part of https://github.com/gitextensions/gitextensions/pull/11321#discussion_r1380833106

## Proposed changes

- Move all current `IScriptHostControl` functions to `IBrowseRepo` because
  - RevisionGridControl access is provided via `IGitUICommands.BrowseRepo`
  - RevisionGridControl access is needed in addition to other script hosts in the future
    That's why keep the empty `IScriptHostControl`.
- Provide `IWin32Window owner` to `FormQuickItemSelector.ShowDialog`
- Remove obsolete property `virtual RevisionGridControl? GitModuleForm.RevisionGridControl`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- adapt existing tests
- reactivate ignored test

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).