### PR TITLE
Remove IRunScript & IScriptHostControl and prepare IScriptOptionsProvider

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -315,7 +315,7 @@ namespace GitUI.CommandsDialogs
 
             _aheadBehindDataProvider = new AheadBehindDataProvider(() => Module.GitExecutable);
             toolStripButtonPush.Initialize(_aheadBehindDataProvider);
-            repoObjectsTree.Initialize(_aheadBehindDataProvider, filterRevisionGridBySpaceSeparatedRefs: ToolStripFilters.SetBranchFilter, refsSource: RevisionGrid, revisionGridInfo: RevisionGrid, scriptRunner: RevisionGrid);
+            repoObjectsTree.Initialize(_aheadBehindDataProvider, filterRevisionGridBySpaceSeparatedRefs: ToolStripFilters.SetBranchFilter, refsSource: RevisionGrid, revisionGridInfo: RevisionGrid);
             revisionDiff.Bind(revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, revisionFileTree: fileTree, () => RevisionGrid.CurrentFilter.PathFilter, RefreshGitStatusMonitor);
 
             // Show blame by default if not started from command line
@@ -1005,7 +1005,7 @@ namespace GitUI.CommandsDialogs
                         DisplayStyle = ToolStripItemDisplayStyle.ImageAndText
                     };
 
-                    button.Click += (s, e) => ScriptsRunner.RunScript(script.HotkeyCommandIdentifier, this, scriptHostControl: null);
+                    button.Click += (s, e) => ExecuteCommand(script.HotkeyCommandIdentifier);
 
                     // add to toolstrip
                     ToolStripScripts.Items.Add(button);

--- a/GitUI/CommandsDialogs/UserScriptContextMenuExtensions.cs
+++ b/GitUI/CommandsDialogs/UserScriptContextMenuExtensions.cs
@@ -16,11 +16,13 @@ namespace GitUI.CommandsDialogs
         /// <param name="contextMenu">The context menu to add user scripts to.</param>
         /// <param name="hostMenuItem">The menu item user scripts not marked as <see cref="ScriptInfo.AddToRevisionGridContextMenu"/> are added to.</param>
         /// <param name="scriptInvoker">The handler that handles user script invocation.</param>
-        public static void AddUserScripts(this ContextMenuStrip contextMenu, ToolStripMenuItem hostMenuItem, Action<int> scriptInvoker, IServiceProvider serviceProvider)
+        /// <param name="serviceProvider">The DI service provider.</param>
+        public static void AddUserScripts(this ContextMenuStrip contextMenu, ToolStripMenuItem hostMenuItem, Func<int, bool> scriptInvoker, IServiceProvider serviceProvider)
         {
             ArgumentNullException.ThrowIfNull(contextMenu);
             ArgumentNullException.ThrowIfNull(hostMenuItem);
             ArgumentNullException.ThrowIfNull(scriptInvoker);
+            ArgumentNullException.ThrowIfNull(serviceProvider);
 
             RemoveOwnScripts(contextMenu, hostMenuItem);
             int hostItemIndex = contextMenu.Items.IndexOf(hostMenuItem);

--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -133,7 +133,7 @@ namespace GitUI
             bool ExecuteScriptCommand()
             {
                 IScriptsRunner scriptsRunner = UICommands.GetRequiredService<IScriptsRunner>();
-                return scriptsRunner.RunScript(command, owner: this, UICommands, this as IScriptHostControl);
+                return scriptsRunner.RunScript(command, owner: this, UICommands, this as IScriptOptionsProvider);
             }
         }
 

--- a/GitUI/GitModuleControl.cs
+++ b/GitUI/GitModuleControl.cs
@@ -133,7 +133,7 @@ namespace GitUI
             bool ExecuteScriptCommand()
             {
                 IScriptsRunner scriptsRunner = UICommands.GetRequiredService<IScriptsRunner>();
-                return scriptsRunner.RunScript(command, FindForm() as GitModuleForm, this as IScriptHostControl);
+                return scriptsRunner.RunScript(command, owner: this, UICommands, this as IScriptHostControl);
             }
         }
 

--- a/GitUI/GitModuleForm.cs
+++ b/GitUI/GitModuleForm.cs
@@ -103,7 +103,7 @@ namespace GitUI
 
         protected override bool ExecuteCommand(int command)
         {
-            return ScriptsRunner.RunScript(command, this)
+            return ScriptsRunner.RunScript(command, owner: this, UICommands)
                 || base.ExecuteCommand(command);
         }
 

--- a/GitUI/LeftPanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.ContextActions.cs
@@ -245,7 +245,7 @@ namespace GitUI.LeftPanel
 
             if (hasSingleSelection && selectedLocalBranch?.Visible == true)
             {
-                contextMenu.AddUserScripts(runScriptToolStripMenuItem, _scriptRunner.Execute, UICommands);
+                contextMenu.AddUserScripts(runScriptToolStripMenuItem, ExecuteCommand, UICommands);
             }
             else
             {

--- a/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -8,7 +8,6 @@ using GitExtUtils.GitUI.Theming;
 using GitUI.CommandDialogs;
 using GitUI.CommandsDialogs;
 using GitUI.Properties;
-using GitUI.ScriptsEngine;
 using GitUI.UserControls;
 using GitUI.UserControls.RevisionGrid;
 using GitUIPluginInterfaces;
@@ -38,7 +37,6 @@ namespace GitUI.LeftPanel
         private bool _searchCriteriaChanged;
         private ICheckRefs _refsSource;
         private IRevisionGridInfo _revisionGridInfo;
-        private IRunScript _scriptRunner;
 
         public RepoObjectsTree()
         {
@@ -221,13 +219,12 @@ namespace GitUI.LeftPanel
         }
 
         public void Initialize(IAheadBehindDataProvider? aheadBehindDataProvider, Action<string?> filterRevisionGridBySpaceSeparatedRefs,
-            ICheckRefs refsSource, IRevisionGridInfo revisionGridInfo, IRunScript scriptRunner)
+            ICheckRefs refsSource, IRevisionGridInfo revisionGridInfo)
         {
             _aheadBehindDataProvider = aheadBehindDataProvider;
             _filterRevisionGridBySpaceSeparatedRefs = filterRevisionGridBySpaceSeparatedRefs;
             _refsSource = refsSource;
             _revisionGridInfo = revisionGridInfo;
-            _scriptRunner = scriptRunner;
 
             // This lazily sets the command source, invoking OnUICommandsSourceSet, which is required for setting up
             // notifications for each Tree.

--- a/GitUI/ScriptsEngine/IRunScript.cs
+++ b/GitUI/ScriptsEngine/IRunScript.cs
@@ -1,8 +1,0 @@
-﻿namespace GitUI.ScriptsEngine
-{
-    // TODO: deprecate
-    public interface IRunScript
-    {
-        void Execute(int scriptId);
-    }
-}

--- a/GitUI/ScriptsEngine/IScriptHostControl.cs
+++ b/GitUI/ScriptsEngine/IScriptHostControl.cs
@@ -1,5 +1,0 @@
-﻿namespace GitUI.ScriptsEngine;
-
-public interface IScriptHostControl
-{
-}

--- a/GitUI/ScriptsEngine/IScriptOptionsProvider.cs
+++ b/GitUI/ScriptsEngine/IScriptOptionsProvider.cs
@@ -1,0 +1,16 @@
+﻿namespace GitUI.ScriptsEngine;
+
+public interface IScriptOptionsProvider
+{
+    /// <summary>
+    ///  The list of script argument options which are supported by this provider.
+    /// </summary>
+    IReadOnlyList<string> Options { get; }
+
+    /// <summary>
+    ///  Retrieves the information for placeholders in script arguments.
+    /// </summary>
+    /// <param name="option">The option identifier which is to be replaced.</param>
+    /// <returns>The value to be used for the script argument.</returns>
+    string GetValue(string option);
+}

--- a/GitUI/ScriptsEngine/IScriptsRunner.cs
+++ b/GitUI/ScriptsEngine/IScriptsRunner.cs
@@ -8,6 +8,6 @@ namespace GitUI.ScriptsEngine
         bool RunEventScripts<THostForm>(ScriptEvent scriptEvent, THostForm form)
             where THostForm : IGitModuleForm, IWin32Window;
 
-        bool RunScript(int scriptId, IWin32Window owner, IGitUICommands commands, IScriptHostControl? scriptHostControl = null);
+        bool RunScript(int scriptId, IWin32Window owner, IGitUICommands commands, IScriptOptionsProvider? scriptOptionsProvider = null);
     }
 }

--- a/GitUI/ScriptsEngine/IScriptsRunner.cs
+++ b/GitUI/ScriptsEngine/IScriptsRunner.cs
@@ -1,4 +1,4 @@
-﻿using GitCommands;
+﻿using GitUIPluginInterfaces;
 using ResourceManager;
 
 namespace GitUI.ScriptsEngine
@@ -8,7 +8,6 @@ namespace GitUI.ScriptsEngine
         bool RunEventScripts<THostForm>(ScriptEvent scriptEvent, THostForm form)
             where THostForm : IGitModuleForm, IWin32Window;
 
-        bool RunScript<THostForm>(int scriptId, THostForm form, IScriptHostControl? scriptHostControl = null)
-            where THostForm : IGitModuleForm, IWin32Window;
+        bool RunScript(int scriptId, IWin32Window owner, IGitUICommands commands, IScriptHostControl? scriptHostControl = null);
     }
 }

--- a/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
+++ b/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
@@ -15,11 +15,11 @@ namespace GitUI.ScriptsEngine
             private const string PluginPrefix = "plugin:";
             private const string NavigateToPrefix = "navigateTo:";
 
-            public static bool RunScript(ScriptInfo script, IWin32Window owner, IGitUICommands commands, IScriptHostControl? scriptHostControl = null)
+            public static bool RunScript(ScriptInfo script, IWin32Window owner, IGitUICommands commands, IScriptOptionsProvider? scriptOptionsProvider = null)
             {
                 try
                 {
-                    return RunScriptInternal(script, owner, commands, scriptHostControl);
+                    return RunScriptInternal(script, owner, commands, scriptOptionsProvider);
                 }
                 catch (ExternalOperationException ex) when (ex is not UserExternalOperationException)
                 {
@@ -27,7 +27,7 @@ namespace GitUI.ScriptsEngine
                 }
             }
 
-            private static bool RunScriptInternal(ScriptInfo script, IWin32Window owner, IGitUICommands uiCommands, IScriptHostControl? scriptHostControl)
+            private static bool RunScriptInternal(ScriptInfo script, IWin32Window owner, IGitUICommands uiCommands, IScriptOptionsProvider? scriptOptionsProvider)
             {
                 if (string.IsNullOrEmpty(script.Command))
                 {
@@ -55,7 +55,7 @@ namespace GitUI.ScriptsEngine
                 }
 
                 string? originalCommand = script.Command;
-                (string? argument, bool abort) = ScriptOptionsParser.Parse(script.Arguments, uiCommands, owner, scriptHostControl);
+                (string? argument, bool abort) = ScriptOptionsParser.Parse(script.Arguments, uiCommands, owner, scriptOptionsProvider);
                 if (abort)
                 {
                     throw new UserExternalOperationException($"{TranslatedStrings.ScriptText}: '{script.Name}'{Environment.NewLine}{TranslatedStrings.ScriptErrorOptionWithoutRevisionText}",

--- a/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
+++ b/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
@@ -4,7 +4,6 @@ using GitExtUtils;
 using GitUI.HelperDialogs;
 using GitUI.NBugReports;
 using GitUIPluginInterfaces;
-using ResourceManager;
 
 namespace GitUI.ScriptsEngine
 {
@@ -16,12 +15,11 @@ namespace GitUI.ScriptsEngine
             private const string PluginPrefix = "plugin:";
             private const string NavigateToPrefix = "navigateTo:";
 
-            public static bool RunScript<THostForm>(ScriptInfo script, THostForm form, IScriptHostControl? scriptHostControl = null)
-                where THostForm : IGitModuleForm, IWin32Window
+            public static bool RunScript(ScriptInfo script, IWin32Window owner, IGitUICommands commands, IScriptHostControl? scriptHostControl = null)
             {
                 try
                 {
-                    return RunScriptInternal(script, form, form.UICommands, scriptHostControl);
+                    return RunScriptInternal(script, owner, commands, scriptHostControl);
                 }
                 catch (ExternalOperationException ex) when (ex is not UserExternalOperationException)
                 {

--- a/GitUI/ScriptsEngine/ScriptsManager.cs
+++ b/GitUI/ScriptsEngine/ScriptsManager.cs
@@ -5,6 +5,7 @@ using System.Xml.Serialization;
 using GitCommands;
 using GitExtUtils;
 using GitUI.NBugReports;
+using GitUIPluginInterfaces;
 using ResourceManager;
 
 namespace GitUI.ScriptsEngine
@@ -57,7 +58,7 @@ namespace GitUI.ScriptsEngine
         {
             foreach (ScriptInfo script in GetScripts().Where(scriptInfo => scriptInfo.Enabled && scriptInfo.OnEvent == scriptEvent))
             {
-                bool executed = ScriptRunner.RunScript(script, form);
+                bool executed = ScriptRunner.RunScript(script, owner: form, form.UICommands);
                 if (!executed)
                 {
                     return false;
@@ -67,17 +68,16 @@ namespace GitUI.ScriptsEngine
             return true;
         }
 
-        public bool RunScript<THostForm>(int scriptId, THostForm form, IScriptHostControl? scriptHostControl = null)
-            where THostForm : IGitModuleForm, IWin32Window
+        public bool RunScript(int scriptId, IWin32Window owner, IGitUICommands commands, IScriptHostControl? scriptHostControl = null)
         {
             ScriptInfo? scriptInfo = GetScript(scriptId);
             if (scriptInfo is null)
             {
                 throw new UserExternalOperationException($"{TranslatedStrings.ScriptErrorCantFind}: '{scriptId}'",
-                    new ExternalOperationException(workingDirectory: form.UICommands.GitModule.WorkingDir));
+                    new ExternalOperationException(workingDirectory: commands.GitModule.WorkingDir));
             }
 
-            return ScriptRunner.RunScript(scriptInfo, form, scriptHostControl);
+            return ScriptRunner.RunScript(scriptInfo, owner, commands, scriptHostControl);
         }
 
         public string? SerializeIntoXml()

--- a/GitUI/ScriptsEngine/ScriptsManager.cs
+++ b/GitUI/ScriptsEngine/ScriptsManager.cs
@@ -68,7 +68,7 @@ namespace GitUI.ScriptsEngine
             return true;
         }
 
-        public bool RunScript(int scriptId, IWin32Window owner, IGitUICommands commands, IScriptHostControl? scriptHostControl = null)
+        public bool RunScript(int scriptId, IWin32Window owner, IGitUICommands commands, IScriptOptionsProvider? scriptOptionsProvider = null)
         {
             ScriptInfo? scriptInfo = GetScript(scriptId);
             if (scriptInfo is null)
@@ -77,7 +77,7 @@ namespace GitUI.ScriptsEngine
                     new ExternalOperationException(workingDirectory: commands.GitModule.WorkingDir));
             }
 
-            return ScriptRunner.RunScript(scriptInfo, owner, commands, scriptHostControl);
+            return ScriptRunner.RunScript(scriptInfo, owner, commands, scriptOptionsProvider);
         }
 
         public string? SerializeIntoXml()

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -18,7 +18,6 @@ using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.HelperDialogs;
 using GitUI.Hotkey;
 using GitUI.Properties;
-using GitUI.ScriptsEngine;
 using GitUI.UserControls;
 using GitUI.UserControls.RevisionGrid;
 using GitUI.UserControls.RevisionGrid.Columns;
@@ -52,7 +51,7 @@ namespace GitUI
     }
 
     [DefaultEvent("DoubleClick")]
-    public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, IRunScript, IRevisionGridFilter, IRevisionGridInfo, IRevisionGridUpdate
+    public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, IRevisionGridFilter, IRevisionGridInfo, IRevisionGridUpdate
     {
         public event EventHandler<DoubleClickRevisionEventArgs>? DoubleClickRevision;
         public event EventHandler<FilterChangedEventArgs>? FilterChanged;
@@ -2027,7 +2026,7 @@ namespace GitUI
 
             SetEnabled(openPullRequestPageStripMenuItem, !string.IsNullOrWhiteSpace(revision.BuildStatus?.PullRequestUrl));
 
-            mainContextMenu.AddUserScripts(runScriptToolStripMenuItem, ((IRunScript)this).Execute, UICommands);
+            mainContextMenu.AddUserScripts(runScriptToolStripMenuItem, ExecuteCommand, UICommands);
 
             UpdateSeparators();
 
@@ -3102,13 +3101,6 @@ namespace GitUI
         #endregion
 
         bool ICheckRefs.Contains(ObjectId objectId) => _gridView.Contains(objectId);
-
-        // TODO: refactor out
-        void IRunScript.Execute(int scriptId)
-        {
-            IScriptsRunner scriptsRunner = UICommands.GetRequiredService<IScriptsRunner>();
-            scriptsRunner.RunScript(scriptId, FindForm() as GitModuleForm);
-        }
 
         internal TestAccessor GetTestAccessor()
             => new(this);

--- a/IntegrationTests/UI.IntegrationTests/ScriptEngine/ScriptRunnerTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/ScriptEngine/ScriptRunnerTests.cs
@@ -3,7 +3,6 @@ using System.Reflection;
 using CommonTestUtils;
 using FluentAssertions;
 using FluentAssertions.Specialized;
-using GitCommands;
 using GitUI;
 using GitUI.CommandsDialogs;
 using GitUI.NBugReports;
@@ -83,7 +82,7 @@ namespace GitExtensions.UITests.ScriptEngine
         {
             _exampleScript.Command = command;
 
-            bool result = ScriptsManager.ScriptRunner.RunScript(_exampleScript, _mockForm);
+            bool result = ScriptsManager.ScriptRunner.RunScript(_exampleScript, _mockForm, _mockForm.UICommands);
 
             result.Should().BeFalse();
         }
@@ -94,7 +93,7 @@ namespace GitExtensions.UITests.ScriptEngine
             _exampleScript.Command = "{git}";
             _exampleScript.Arguments = "";
 
-            bool result = ScriptsManager.ScriptRunner.RunScript(_exampleScript, _mockForm);
+            bool result = ScriptsManager.ScriptRunner.RunScript(_exampleScript, _mockForm, _mockForm.UICommands);
 
             result.Should().BeTrue();
         }
@@ -105,7 +104,7 @@ namespace GitExtensions.UITests.ScriptEngine
             _exampleScript.Command = "{git}";
             _exampleScript.Arguments = "--version";
 
-            bool result = ScriptsManager.ScriptRunner.RunScript(_exampleScript, _mockForm);
+            bool result = ScriptsManager.ScriptRunner.RunScript(_exampleScript, _mockForm, _mockForm.UICommands);
 
             result.Should().BeTrue();
         }
@@ -119,7 +118,7 @@ namespace GitExtensions.UITests.ScriptEngine
             GitRevision revision = new(ObjectId.IndexId);
             _module.GetRevision(shortFormat: true, loadRefs: true).Returns(x => revision);
 
-            bool result = ScriptsManager.ScriptRunner.RunScript(_exampleScript, _mockForm);
+            bool result = ScriptsManager.ScriptRunner.RunScript(_exampleScript, _mockForm, _mockForm.UICommands);
 
             result.Should().BeTrue();
         }

--- a/IntegrationTests/UI.IntegrationTests/ScriptEngine/ScriptRunnerTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/ScriptEngine/ScriptRunnerTests.cs
@@ -202,7 +202,7 @@ namespace GitExtensions.UITests.ScriptEngine
             });
         }
 
-        private static bool ExecuteRunScript(ScriptInfo script, IWin32Window owner, IGitUICommands uiCommands, IScriptHostControl? scriptHostControl = null)
+        private static bool ExecuteRunScript(ScriptInfo script, IWin32Window owner, IGitUICommands uiCommands, IScriptOptionsProvider? scriptOptionsProvider = null)
         {
             try
             {
@@ -212,7 +212,7 @@ namespace GitExtensions.UITests.ScriptEngine
                         script,
                         owner,
                         uiCommands,
-                        scriptHostControl
+                        scriptOptionsProvider
                     });
                 return result;
             }

--- a/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
+++ b/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
@@ -17,13 +17,13 @@ namespace GitUITests.Script
     {
         private IGitUICommands _commands;
         private IGitModule _module;
-        private IScriptHostControl _scriptHostControl;
+        private IScriptOptionsProvider _scriptOptionsProvider;
 
         [SetUp]
         public void Setup()
         {
             _module = Substitute.For<IGitModule>();
-            _scriptHostControl = Substitute.For<IScriptHostControl>();
+            _scriptOptionsProvider = Substitute.For<IScriptOptionsProvider>();
 
             _commands = Substitute.For<IGitUICommands>();
             _commands.GitModule.Returns(_module);
@@ -125,7 +125,7 @@ namespace GitUITests.Script
         [Test]
         public void Parse_should_throw_if_module_null()
         {
-            ((Action)(() => ScriptOptionsParser.Parse(arguments: "bla", uiCommands: null, owner: null, scriptHostControl: null))).Should()
+            ((Action)(() => ScriptOptionsParser.Parse(arguments: "bla", uiCommands: null, owner: null, scriptOptionsProvider: null))).Should()
                 .Throw<ArgumentNullException>()
                 .WithMessage("Value cannot be null. (Parameter 'uiCommands')");
         }
@@ -136,7 +136,7 @@ namespace GitUITests.Script
         [TestCase("\t")]
         public void Parse_should_return_without_process_if_arguments_unset(string arguments)
         {
-            (string? arguments, bool abort) result = ScriptOptionsParser.Parse(arguments, uiCommands: null, owner: null, scriptHostControl: null);
+            (string? arguments, bool abort) result = ScriptOptionsParser.Parse(arguments, uiCommands: null, owner: null, scriptOptionsProvider: null);
 
             result.arguments.Should().Be(arguments);
             result.abort.Should().Be(false);
@@ -147,7 +147,7 @@ namespace GitUITests.Script
         {
             const string arguments = "{openUrl} https://gitlab.com{zeDefaultRemotePathFromUrl}/tree/{zeBranch}";
 
-            (string? arguments, bool abort) result = ScriptOptionsParser.Parse(arguments: arguments, _commands, owner: null, scriptHostControl: null);
+            (string? arguments, bool abort) result = ScriptOptionsParser.Parse(arguments: arguments, _commands, owner: null, scriptOptionsProvider: null);
 
             result.arguments.Should().Be(arguments);
             result.abort.Should().Be(false);
@@ -166,7 +166,7 @@ namespace GitUITests.Script
 
             string expectedMessage = $"{Subject}\\n\\nline3";
 
-            (string? arguments, bool abort) result = ScriptOptionsParser.Parse("echo {{cSubject}} {{cMessage}}", _commands, owner: null, scriptHostControl: null);
+            (string? arguments, bool abort) result = ScriptOptionsParser.Parse("echo {{cSubject}} {{cMessage}}", _commands, owner: null, scriptOptionsProvider: null);
 
             result.arguments.Should().Be($"echo \"{revision.Subject}\" \"{expectedMessage}\"");
             result.abort.Should().Be(false);
@@ -187,7 +187,7 @@ namespace GitUITests.Script
 
             string expectedMessage = $"{Subject}\\n\\nline3";
 
-            (string? arguments, bool abort) result = ScriptOptionsParser.Parse("echo {{sSubject}} {{sMessage}}", _commands, owner: null, scriptHostControl: null);
+            (string? arguments, bool abort) result = ScriptOptionsParser.Parse("echo {{sSubject}} {{sMessage}}", _commands, owner: null, scriptOptionsProvider: null);
 
             result.arguments.Should().Be($"echo \"{revision.Subject}\" \"{expectedMessage}\"");
             result.abort.Should().Be(false);
@@ -198,7 +198,7 @@ namespace GitUITests.Script
         {
             string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{openUrl} https://gitlab.com{cDefaultRemotePathFromUrl}/tree/{sBranch}", option: "cDefaultRemotePathFromUrl",
-                owner: null, scriptHostControl: null, uiCommands: null, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptOptionsProvider: null, uiCommands: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
@@ -214,7 +214,7 @@ namespace GitUITests.Script
 
             string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{openUrl} https://gitlab.com{cDefaultRemotePathFromUrl}/tree/{sBranch}", option: "cDefaultRemotePathFromUrl",
-                owner: null, scriptHostControl: null, _commands, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptOptionsProvider: null, _commands, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote);
@@ -229,7 +229,7 @@ namespace GitUITests.Script
 
             string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{openUrl} https://gitlab.com{sRemotePathFromUrl}/tree/{sBranch}", option: "sRemotePathFromUrl",
-                owner: null, scriptHostControl: null, uiCommands: null, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptOptionsProvider: null, uiCommands: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, noSelectedRemotes, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
@@ -246,7 +246,7 @@ namespace GitUITests.Script
 
             string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{openUrl} https://gitlab.com{sRemotePathFromUrl}/tree/{sBranch}", option: "sRemotePathFromUrl",
-                owner: null, scriptHostControl: null, _commands, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptOptionsProvider: null, _commands, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
@@ -265,7 +265,7 @@ namespace GitUITests.Script
 
             string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
-                owner: null, scriptHostControl: null, uiCommands: null, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptOptionsProvider: null, uiCommands: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: remoteBranches, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
@@ -284,7 +284,7 @@ namespace GitUITests.Script
 
             string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
-                owner: null, scriptHostControl: null, uiCommands: null, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptOptionsProvider: null, uiCommands: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: remoteBranches, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
@@ -303,7 +303,7 @@ namespace GitUITests.Script
 
             string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
-                owner: null, scriptHostControl: null, uiCommands: null, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptOptionsProvider: null, uiCommands: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: remoteBranches, currentRevision: null, currentRemote: null);
@@ -322,7 +322,7 @@ namespace GitUITests.Script
 
             string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
-                owner: null, scriptHostControl: null, uiCommands: null, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptOptionsProvider: null, uiCommands: null, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: remoteBranches, currentRevision: null, currentRemote: null);
@@ -346,7 +346,7 @@ namespace GitUITests.Script
 
             string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
-                owner: null, scriptHostControl: null, _commands, allSelectedRevisions: null, selectedTags: null,
+                owner: null, scriptOptionsProvider: null, _commands, allSelectedRevisions: null, selectedTags: null,
                 selectedBranches: null, selectedLocalBranches: null, selectedRemoteBranches: null, selectedRemotes: null, selectedRevision: null,
                 currentTags: null,
                 currentBranches: null, currentLocalBranches: null, currentRemoteBranches: null, currentRevision: null, currentRemote: null);
@@ -375,6 +375,23 @@ namespace GitUITests.Script
 
             result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments("{sMessage}", "sMessage", null, null, null, null, null, null, null, null, null, gitRevision, null, null, null, null, null, null);
             result.Should().Be("test string with \"double qoutes\" and escaped \\\"double qoutes\\\"");
+        }
+
+        [Test]
+        public void Parse_should_resolve_IScriptOptionsProvider_options()
+        {
+            const string option1 = nameof(option1);
+            const string option2 = nameof(option2);
+            const string value1 = nameof(value1);
+            const string value2 = nameof(value2);
+            _scriptOptionsProvider.Options.Returns(new string[] { option1, option2 });
+            _scriptOptionsProvider.GetValue(option1).Returns(value1);
+            _scriptOptionsProvider.GetValue(option2).Returns(value2);
+
+            (string? arguments, bool abort) = ScriptOptionsParser.Parse("foo {{" + option1 + "}} bar {" + option2 + "}", Substitute.For<IGitUICommands>(), owner: null, _scriptOptionsProvider);
+
+            arguments.Should().Be($"foo \"{value1}\" bar {value2}");
+            abort.Should().BeFalse();
         }
     }
 }


### PR DESCRIPTION
Supersedes #11321

## Proposed changes

- Remove IRunScript
- Turn empty `IScriptHostControl` into `IScriptOptionsProvider` with `string GetValue(string option)`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).