### PR TITLE
Improve performance of AppSettings of type ISetting<T>

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -449,12 +449,12 @@ namespace GitCommands
             set => SetBool("showresetallchanges", value);
         }
 
-        public static ISetting<bool> ShowConEmuTab => Setting.Create(DetailedSettingsPath, nameof(ShowConEmuTab), true);
-        public static ISetting<string> ConEmuStyle => Setting.Create(DetailedSettingsPath, nameof(ConEmuStyle), "<Solarized Light>");
-        public static ISetting<string> ConEmuTerminal => Setting.Create(DetailedSettingsPath, nameof(ConEmuTerminal), "bash");
-        public static ISetting<bool> UseBrowseForFileHistory => Setting.Create(DetailedSettingsPath, nameof(UseBrowseForFileHistory), true);
-        public static ISetting<bool> UseDiffViewerForBlame => Setting.Create(DetailedSettingsPath, nameof(UseDiffViewerForBlame), false);
-        public static ISetting<bool> ShowGpgInformation => Setting.Create(DetailedSettingsPath, nameof(ShowGpgInformation), true);
+        public static ISetting<bool> ShowConEmuTab { get; } = Setting.Create(DetailedSettingsPath, nameof(ShowConEmuTab), true);
+        public static ISetting<string> ConEmuStyle { get; } = Setting.Create(DetailedSettingsPath, nameof(ConEmuStyle), "<Solarized Light>");
+        public static ISetting<string> ConEmuTerminal { get; } = Setting.Create(DetailedSettingsPath, nameof(ConEmuTerminal), "bash");
+        public static ISetting<bool> UseBrowseForFileHistory { get; } = Setting.Create(DetailedSettingsPath, nameof(UseBrowseForFileHistory), true);
+        public static ISetting<bool> UseDiffViewerForBlame { get; } = Setting.Create(DetailedSettingsPath, nameof(UseDiffViewerForBlame), false);
+        public static ISetting<bool> ShowGpgInformation { get; } = Setting.Create(DetailedSettingsPath, nameof(ShowGpgInformation), true);
 
         public static CommitInfoPosition CommitInfoPosition
         {
@@ -1004,7 +1004,7 @@ namespace GitCommands
             set => SetBool("DontConfirmCommitIfNoBranch", value);
         }
 
-        public static readonly ISetting<bool> ConfirmBranchCheckout = Setting.Create(ConfirmationsSettingsPath, nameof(ConfirmBranchCheckout), false);
+        public static ISetting<bool> ConfirmBranchCheckout { get; } = Setting.Create(ConfirmationsSettingsPath, nameof(ConfirmBranchCheckout), false);
 
         public static bool? AutoPopStashAfterPull
         {

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -175,6 +175,8 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.ShowConEmuTab)], true, false, true);
                 yield return (properties[nameof(AppSettings.ConEmuStyle)], "<Solarized Light>", true, true);
                 yield return (properties[nameof(AppSettings.ConEmuTerminal)], "bash", true, true);
+                yield return (properties[nameof(AppSettings.UseBrowseForFileHistory)], true, false, true);
+                yield return (properties[nameof(AppSettings.UseDiffViewerForBlame)], false, false, true);
                 yield return (properties[nameof(AppSettings.ShowGpgInformation)], true, false, true);
 
                 yield return (properties[nameof(AppSettings.ShowSplitViewLayout)], true, false, false);
@@ -229,6 +231,7 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.AlwaysShowAdvOpt)], false, false, false);
                 yield return (properties[nameof(AppSettings.DontConfirmAmend)], false, false, false);
                 yield return (properties[nameof(AppSettings.DontConfirmCommitIfNoBranch)], false, false, false);
+                yield return (properties[nameof(AppSettings.ConfirmBranchCheckout)], false, false, false);
                 yield return (properties[nameof(AppSettings.AutoPopStashAfterPull)], null, true, false);
                 yield return (properties[nameof(AppSettings.AutoPopStashAfterCheckoutBranch)], null, true, false);
                 yield return (properties[nameof(AppSettings.AutoPullOnPushRejectedAction)], null, true, false);


### PR DESCRIPTION
## Proposed changes

- Call the factory method `ISetting<T>.Create<T>()` only once, i.e. not every setting access
- Turn `AppSettings.ConfirmBranchCheckout` into a get-only property in order to be compatible with `AppSettingsTests`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing + added testcases

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).