### PR TITLE
Load hotkeys consistently

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1404,6 +1404,7 @@ namespace GitUI.CommandsDialogs
             LoadHotkeys(HotkeySettingsName);
             RevisionGrid.ReloadHotkeys();
             RevisionGrid.ReloadTranslation();
+            RevisionInfo.ReloadHotkeys();
             fileTree.ReloadHotkeys();
             revisionDiff.ReloadHotkeys();
             repoObjectsTree.ReloadHotkeys();

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -326,11 +326,6 @@ namespace GitUI.CommandsDialogs
 
             DiffText.SetFileLoader(GetNextPatchFile);
             DiffText.Font = AppSettings.FixedWidthFont;
-        }
-
-        protected override void OnUICommandsSourceSet(IGitUICommandsSource source)
-        {
-            base.OnUICommandsSourceSet(source);
 
             ReloadHotkeys();
             LoadCustomDifftools();

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -351,11 +351,6 @@ See the changes in the commit form.");
                     Images.FolderSubmodule // Submodule
                 }
             };
-        }
-
-        protected override void OnUICommandsSourceSet(IGitUICommandsSource source)
-        {
-            base.OnUICommandsSourceSet(source);
 
             ReloadHotkeys();
         }

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -145,6 +145,12 @@ namespace GitUI.CommitInfo
             base.Dispose(disposing);
         }
 
+        protected override void OnRuntimeLoad()
+        {
+            base.OnRuntimeLoad();
+            ReloadHotkeys();
+        }
+
         protected override void OnUICommandsSourceSet(IGitUICommandsSource source)
         {
             base.OnUICommandsSourceSet(source);
@@ -161,13 +167,16 @@ namespace GitUI.CommitInfo
                 _commitDataBodyRenderer = new CommitDataBodyRenderer(() => Module, _linkFactory);
                 _refsFormatter = new RefsFormatter(_linkFactory);
 
-                LoadHotkeys(FormBrowse.HotkeySettingsName);
-
                 source.UICommandsChanged += delegate { RefreshSortedTags(); };
 
                 // call this event handler also now (necessary for "Contained in branches/tags")
                 RefreshSortedTags();
             }
+        }
+
+        internal void ReloadHotkeys()
+        {
+            LoadHotkeys(FormBrowse.HotkeySettingsName);
         }
 
         private void RefreshSortedTags()

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -748,18 +748,13 @@ namespace GitUI.Editor
         {
             base.OnRuntimeLoad();
 
+            ReloadHotkeys();
+
             Font = AppSettings.FixedWidthFont;
 
             string[] encodings = AppSettings.AvailableEncodings.Values.Select(e => e.EncodingName).ToArray();
             encodingToolStripComboBox.Items.AddRange(encodings);
             encodingToolStripComboBox.ResizeDropDownWidth(50, 250);
-        }
-
-        protected override void OnUICommandsSourceSet(IGitUICommandsSource source)
-        {
-            base.OnUICommandsSourceSet(source);
-
-            ReloadHotkeys();
         }
 
         // Private methods

--- a/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -337,13 +337,17 @@ namespace GitUI.LeftPanel
             }
         }
 
+        protected override void OnRuntimeLoad()
+        {
+            base.OnRuntimeLoad();
+            ReloadHotkeys();
+        }
+
         protected override void OnUICommandsSourceSet(IGitUICommandsSource source)
         {
             _selectionCancellationTokenSequence.CancelCurrent();
 
             base.OnUICommandsSourceSet(source);
-
-            ReloadHotkeys();
 
             CreateBranches();
             CreateRemotes();

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -540,9 +540,9 @@ namespace GitUI
             ShowLoading();
         }
 
-        protected override void OnUICommandsSourceSet(IGitUICommandsSource source)
+        protected override void OnRuntimeLoad()
         {
-            base.OnUICommandsSourceSet(source);
+            base.OnRuntimeLoad();
 
             ReloadHotkeys();
             LoadCustomDifftools();


### PR DESCRIPTION
Fixes #11329

## Proposed changes

- Always call `ReloadHotkeys` from `OnRuntimeLoad`
  There is no need to call it from `OnUICommandsSourceSet` because the ServiceProvider shall not be exchanged during runtime.
  In addition, `OnUICommandsSourceSet` is not always triggered as necessary.
- Call all `ReloadHotkeys` from `FormBrowse.HandleSettingsChanged`
- Call `LoadCustomDifftools` only once from `OnRuntimeLoad`, too

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).