### PR TITLE
BugReportForm: Remove badly used `DpiUtil.Scale()`

### DIFF
--- a/BugReporter/BugReportForm.cs
+++ b/BugReporter/BugReportForm.cs
@@ -55,9 +55,7 @@ Send report?");
             // Scaling
             exceptionTypeLabel.Image = DpiUtil.Scale(exceptionTypeLabel.Image);
             exceptionDetails.PropertyColumnWidth = DpiUtil.Scale(101);
-            exceptionDetails.PropertyColumnWidth = DpiUtil.Scale(101);
-            DpiUtil.Scale(sendAndQuitButton.MinimumSize);
-            DpiUtil.Scale(btnCopy.MinimumSize);
+            exceptionDetails.InformationColumnWidth = DpiUtil.Scale(350);
 
             warningLabel.MaximumSize = new Size(warningLabel.Width, 0);
             warningLabel.AutoSize = true;


### PR DESCRIPTION
Theses usages have no effect as the value should be re-affected.

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 286b49ba21e909d81c8399ffb3ad2745a611c22f
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.21
- DPI 96dpi (no scaling)
- Portable: False


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
