### PR TITLE
Add conditionals to script parameters

### DIFF
--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -26,6 +26,10 @@ User inputs:
 {UserInput:a popup label=a default value using {sLocalBranch}}
 {UserFiles}
 
+Conditional:
+{if:option}{/if}
+{ifnot:option}{/ifnot}
+
 Working directory:
 {WorkingDir}
 

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -9798,6 +9798,10 @@ User inputs:
 {UserInput:a popup label=a default value using {sLocalBranch}}
 {UserFiles}
 
+Conditional:
+{if:option}{/if}
+{ifnot:option}{/ifnot}
+
 Working directory:
 {WorkingDir}
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Add conditional parameters, e.g. `{if:SelectedFiles} --files {SelectedFiles}{/if}`. The condition is based on whether the parameter is available, e.g. the script was executed from the diff view and any files are selected. Otherwise, the text in between is discarded. Also added `{ifnot:option}` for the opposite condition/fallback.

### Before

No way to condition parameters based on presence or absence.

### After

Can use `{if:parameterName}` to determine of an option is present.

## Test methodology <!-- How did you ensure quality? -->

TBD

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 43e20df903d2826bb4f41e890830fac9f39c2537
- Git 2.42.0.windows.1
- Microsoft Windows NT 10.0.19045.0
- .NET 6.0.24
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.21 [D:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.24 [D:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```


<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
