### PR TITLE
SetDocumentationBaseUrl using ProductVersion

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -133,7 +133,7 @@ namespace GitCommands
             const string defaultDevelopmentVersion = "33.33";
             if (!string.IsNullOrWhiteSpace(version) && !version.StartsWith(defaultDevelopmentVersion))
             {
-                // We expect version to be something starting with "X.Y"
+                // We expect version to be something starting with "X.Y" (ignore patch versions)
                 Match match = Regex.Match(version, @"^(\d+)\.(\d+)");
                 if (match.Success)
                 {

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -122,7 +122,7 @@ namespace GitCommands
             get => _documentationBaseUrl ?? throw new InvalidOperationException($"Call {nameof(SetDocumentationBaseUrl)} first to set the documentation base URL.");
         }
 
-        internal static void SetDocumentationBaseUrl(string currentGitBranch)
+        internal static void SetDocumentationBaseUrl(string version)
         {
             if (_documentationBaseUrl is not null)
             {
@@ -130,14 +130,14 @@ namespace GitCommands
             }
 
             string? docVersion = "en/main/";
-
-            if (!string.IsNullOrWhiteSpace(currentGitBranch))
+            const string defaultDevelopmentVersion = "33.33";
+            if (!string.IsNullOrWhiteSpace(version) && !version.StartsWith(defaultDevelopmentVersion))
             {
-                // We expect current branch to be something line "release/X.Y"
-                Match match = Regex.Match(currentGitBranch, "release/\\d*\\.\\d*");
+                // We expect version to be something starting with "X.Y"
+                Match match = Regex.Match(version, @"^(\d+)\.(\d+)");
                 if (match.Success)
                 {
-                    docVersion = $"en/{currentGitBranch.Replace("/", "-")}/";
+                    docVersion = $"en/release-{match.Groups[1]}.{match.Groups[2]}/";
                 }
             }
 

--- a/GitExtensions/Program.cs
+++ b/GitExtensions/Program.cs
@@ -61,7 +61,7 @@ namespace GitExtensions
             // There's no perf hit calling Initialise() multiple times.
             UserEnvironmentInformation.Initialise(ThisAssembly.Git.Sha, ThisAssembly.Git.IsDirty);
 
-            AppSettings.SetDocumentationBaseUrl(ThisAssembly.Git.Branch);
+            AppSettings.SetDocumentationBaseUrl(AppSettings.ProductVersion);
 
             ThemeModule.Load();
 #if SUPPORT_THEME_HOOKS

--- a/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
@@ -51,7 +51,7 @@ namespace GitUITests.GitUICommandsTests
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            AppSettings.SetDocumentationBaseUrl("master");
+            AppSettings.SetDocumentationBaseUrl("33.33.33");
         }
 
         [OneTimeTearDown]

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -16,21 +16,24 @@ namespace GitCommandsTests.Settings
         [TestCase(null, "https://git-extensions-documentation.readthedocs.org/en/main/")]
         [TestCase("", "https://git-extensions-documentation.readthedocs.org/en/main/")]
         [TestCase("\t", "https://git-extensions-documentation.readthedocs.org/en/main/")]
-        [TestCase("master", "https://git-extensions-documentation.readthedocs.org/en/main/")]
-        [TestCase("feature/test/mystuff", "https://git-extensions-documentation.readthedocs.org/en/main/")]
-        [TestCase("releases", "https://git-extensions-documentation.readthedocs.org/en/main/")]
-        [TestCase("releases/4.5", "https://git-extensions-documentation.readthedocs.org/en/main/")]
-        [TestCase("release", "https://git-extensions-documentation.readthedocs.org/en/main/")]
-        [TestCase("release/a", "https://git-extensions-documentation.readthedocs.org/en/main/")]
-        [TestCase("release/5", "https://git-extensions-documentation.readthedocs.org/en/main/")]
-        [TestCase("release/a4.5", "https://git-extensions-documentation.readthedocs.org/en/main/")]
-        [TestCase("release/4.5", "https://git-extensions-documentation.readthedocs.org/en/release-4.5/")]
-        [TestCase("release/40.501", "https://git-extensions-documentation.readthedocs.org/en/release-40.501/")]
-        public void SetDocumentationBaseUrl_should_currectly_append_verison(string currentGitBranch, string expected)
+        [TestCase("33.33", "https://git-extensions-documentation.readthedocs.org/en/main/")]
+        [TestCase("33.33.33", "https://git-extensions-documentation.readthedocs.org/en/main/")]
+        [TestCase("33.33.33.33", "https://git-extensions-documentation.readthedocs.org/en/main/")]
+        [TestCase("a", "https://git-extensions-documentation.readthedocs.org/en/main/")]
+        [TestCase("5", "https://git-extensions-documentation.readthedocs.org/en/main/")]
+        [TestCase("v4.5", "https://git-extensions-documentation.readthedocs.org/en/main/")]
+        [TestCase("4.5", "https://git-extensions-documentation.readthedocs.org/en/release-4.5/")]
+        [TestCase("4.5.", "https://git-extensions-documentation.readthedocs.org/en/release-4.5/")]
+        [TestCase("4.5.0", "https://git-extensions-documentation.readthedocs.org/en/release-4.5/")]
+        [TestCase("4.5.2", "https://git-extensions-documentation.readthedocs.org/en/release-4.5/")]
+        [TestCase("4.5.2.1", "https://git-extensions-documentation.readthedocs.org/en/release-4.5/")]
+        [TestCase("4.5.2x", "https://git-extensions-documentation.readthedocs.org/en/release-4.5/")]
+        [TestCase("40.501.123", "https://git-extensions-documentation.readthedocs.org/en/release-40.501/")]
+        public void SetDocumentationBaseUrl_should_currectly_append_version(string version, string expected)
         {
             AppSettings.GetTestAccessor().ResetDocumentationBaseUrl();
 
-            AppSettings.SetDocumentationBaseUrl(currentGitBranch);
+            AppSettings.SetDocumentationBaseUrl(version);
             AppSettings.DocumentationBaseUrl.Should().Be(expected);
         }
 

--- a/UnitTests/GitUI.Tests/UserManual/StandardHtmlUserManualFixture.cs
+++ b/UnitTests/GitUI.Tests/UserManual/StandardHtmlUserManualFixture.cs
@@ -13,7 +13,7 @@ namespace GitUITests.UserManual
         public void GetUrl(string subFolder, string anchor, string expected)
         {
             AppSettings.GetTestAccessor().ResetDocumentationBaseUrl();
-            AppSettings.SetDocumentationBaseUrl("master");
+            AppSettings.SetDocumentationBaseUrl("33.33.33");
 
             StandardHtmlUserManual sut = new(subFolder, anchor);
 


### PR DESCRIPTION
Fixes #11338
Supersedes #11339

## Proposed changes

- Pass `AppSettings.ProductVersion` to `AppSettings.SetDocumentationBaseUrl` 

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- adapted tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).