### PR TITLE
Prepare FileViewer for git-grep

### DIFF
--- a/GitUI/Editor/Diff/CombinedDiffHighlightService.cs
+++ b/GitUI/Editor/Diff/CombinedDiffHighlightService.cs
@@ -6,6 +6,9 @@ namespace GitUI.Editor.Diff
 {
     public class CombinedDiffHighlightService : DiffHighlightService
     {
+        private static readonly string[] _diffFullPrefixes = { "  ", "++", "+ ", " +", "--", "- ", " -" };
+        private static readonly string[] _diffSearchPrefixes = { "+", "-", " +", " -" };
+
         public static new CombinedDiffHighlightService Instance { get; } = new();
 
         protected CombinedDiffHighlightService()
@@ -15,6 +18,16 @@ namespace GitUI.Editor.Diff
         protected override int GetDiffContentOffset()
         {
             return 2;
+        }
+
+        public override string[] GetFullDiffPrefixes()
+        {
+            return _diffFullPrefixes;
+        }
+
+        public override bool IsSearchMatch(string line)
+        {
+            return line.StartsWithAny(_diffSearchPrefixes);
         }
 
         protected override int TryHighlightAddedAndDeletedLines(IDocument document, int line, LineSegment lineSegment)

--- a/GitUI/Editor/Diff/ITextHighlightService.cs
+++ b/GitUI/Editor/Diff/ITextHighlightService.cs
@@ -1,0 +1,15 @@
+﻿using ICSharpCode.TextEditor.Document;
+using JetBrains.Annotations;
+
+namespace GitUI.Editor.Diff
+{
+    public interface ITextHighlightService
+    {
+        /// <summary>
+        /// Add text highlighting to the document.
+        /// This is primarily used to highlight changed files for diffs
+        /// </summary>
+        /// <param name="document">The document to highlight.</param>
+        void AddTextHighlighting([NotNull] IDocument document);
+    }
+}

--- a/GitUI/Editor/Diff/RangeDiffHighlightService.cs
+++ b/GitUI/Editor/Diff/RangeDiffHighlightService.cs
@@ -6,6 +6,9 @@ namespace GitUI.Editor.Diff
 {
     public class RangeDiffHighlightService : DiffHighlightService
     {
+        private static readonly string[] _diffFullPrefixes = { "      ", "    ++", "    + ", "     +", "    --", "    - ", "     -", "    +-", "    -+", "    " };
+        private static readonly string[] _diffSearchPrefixes = { "    " };
+
         public static new RangeDiffHighlightService Instance { get; } = new();
 
         protected RangeDiffHighlightService()
@@ -18,7 +21,18 @@ namespace GitUI.Editor.Diff
             return 6;
         }
 
-        public override void AddPatchHighlighting(IDocument document)
+        public override string[] GetFullDiffPrefixes()
+        {
+            return _diffFullPrefixes;
+        }
+
+        // For range-diff, this is a negative check, search is for headers
+        public override bool IsSearchMatch(string line)
+        {
+            return !line.StartsWithAny(_diffSearchPrefixes);
+        }
+
+        public override void AddTextHighlighting(IDocument document)
         {
             bool forceAbort = false;
 

--- a/GitUI/Editor/Diff/TextHighlightService.cs
+++ b/GitUI/Editor/Diff/TextHighlightService.cs
@@ -1,0 +1,22 @@
+﻿using GitExtUtils.GitUI.Theming;
+using GitUI.Theming;
+using ICSharpCode.TextEditor.Document;
+
+namespace GitUI.Editor.Diff
+{
+    public class TextHighlightService : ITextHighlightService
+    {
+        /// <summary>
+        /// Base class for highlighting, not adding any highlighting.
+        /// </summary>
+        public static TextHighlightService Instance { get; } = new();
+
+        protected TextHighlightService()
+        {
+        }
+
+        public virtual void AddTextHighlighting(IDocument document)
+        {
+        }
+    }
+}

--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -408,7 +408,6 @@ namespace GitUI.Editor
             // internalFileViewerControl
             // 
             internalFileViewer.Dock = DockStyle.Fill;
-            internalFileViewer.FirstVisibleLine = 0;
             internalFileViewer.IsReadOnly = false;
             internalFileViewer.Location = new Point(0, 40);
             internalFileViewer.Margin = new Padding(0);

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -33,13 +33,12 @@ namespace GitUI.Editor
         void SetText(string text, Action? openWithDifftool, bool isDiff = false);
         void SetHighlighting(string syntax);
         void SetHighlightingForFile(string filename);
-        void HighlightLine(int line, Color color);
         void HighlightLines(int startLine, int endLine, Color color);
         void ClearHighlighting();
         string GetSelectedText();
         int GetSelectionPosition();
         int GetSelectionLength();
-        void AddPatchHighlighting();
+        void AddTextHighlighting();
         Action? OpenWithDifftool { get; }
         int VScrollPosition { get; set; }
 

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -30,7 +30,7 @@ namespace GitUI.Editor
         Task FindNextAsync(bool searchForwardOrOpenWithDifftool);
 
         string GetText();
-        void SetText(string text, Action? openWithDifftool, bool isDiff = false);
+        void SetText(string text, Action? openWithDifftool);
         void SetHighlighting(string syntax);
         void SetHighlightingForFile(string filename);
         void HighlightLines(int startLine, int endLine, Color color);
@@ -38,7 +38,6 @@ namespace GitUI.Editor
         string GetSelectedText();
         int GetSelectionPosition();
         int GetSelectionLength();
-        void AddTextHighlighting();
         Action? OpenWithDifftool { get; }
         int VScrollPosition { get; set; }
 
@@ -48,12 +47,8 @@ namespace GitUI.Editor
         bool ShowTabs { get; set; }
         int VRulerPosition { get; set; }
         bool IsReadOnly { get; set; }
-        bool Visible { get; set; }
 
-        int FirstVisibleLine { get; set; }
         int GetLineFromVisualPosY(int visualPosY);
-        int LineAtCaret { get; set; }
-        string GetLineText(int line);
         int TotalNumberOfLines { get; }
 
         /// <summary>

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormEditorTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormEditorTests.cs
@@ -48,7 +48,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                         Assert.False(form.GetTestAccessor().HasChanges);
 
                         FileViewerInternal fileViewerInternal = form.GetTestAccessor().FileViewer.GetTestAccessor().FileViewerInternal;
-                        fileViewerInternal.SetText(fileViewerInternal.GetText() + "!", openWithDifftool: null, isDiff: false);
+                        fileViewerInternal.SetText(fileViewerInternal.GetText() + "!", openWithDifftool: null);
 
                         Assert.True(form.GetTestAccessor().HasChanges);
 
@@ -86,7 +86,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                         Assert.False(form.GetTestAccessor().HasChanges);
 
                         FileViewerInternal fileViewerInternal = form.GetTestAccessor().FileViewer.GetTestAccessor().FileViewerInternal;
-                        fileViewerInternal.SetText(fileViewerInternal.GetText() + "!", openWithDifftool: null, isDiff: false);
+                        fileViewerInternal.SetText(fileViewerInternal.GetText() + "!", openWithDifftool: null);
 
                         Assert.True(form.GetTestAccessor().HasChanges);
 
@@ -94,7 +94,7 @@ namespace GitExtensions.UITests.CommandsDialogs
 
                         Assert.False(form.GetTestAccessor().HasChanges);
 
-                        Assert.AreEqual(lineNumerDefault, fileViewerInternal.CurrentFileLine(false));
+                        Assert.AreEqual(lineNumerDefault, fileViewerInternal.CurrentFileLine());
 
                         return Task.CompletedTask;
                     });
@@ -138,7 +138,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                     form =>
                     {
                         FileViewerInternal fileViewerInternal = form.GetTestAccessor().FileViewer.GetTestAccessor().FileViewerInternal;
-                        fileViewerInternal.SetText(fileViewerInternal.GetText() + "!", openWithDifftool: null, isDiff: false);
+                        fileViewerInternal.SetText(fileViewerInternal.GetText() + "!", openWithDifftool: null);
                         form.GetTestAccessor().SaveChanges();
                         return Task.CompletedTask;
                     });


### PR DESCRIPTION
## Proposed changes

The primary intention with this PR is to prepare FileViewer for git-grep in #4912 
A separate PR will be opened for the actual changes, the UI is to be discussed.
However, these changes improves the structure regardless and is opened separatetly.

### Refactor highlighting

Add a base class for the highlight service primarily used for diff highlighting.
Rename AddPatchHighlighting() to AddTextHighlighting() as the method
also have other uses.

The DiffHighlightService also handles the format for patching etc,
used when copying patches and navigating next/previous.

Separate the unrelated HighlightLines() currently only used by Blame to
mark all kind of lines.

Remove unused HighlightLine()

### Separate internals to FileViewerInternal

Limit exposure of internal structure by moving some text handling
to FileViewerInternal.
Remove the unused functions from IFileViewer.

Refactor goto next/previous change, separate range-diff.
Do not got the empty last line for range-diff.
Include the 'context header' when presenting the diff.

## Screenshots <!-- Remove this section if PR does not change UI -->

No real  changes, some improvements to the behavior.

When increasing the context size.
(header with function name is shown for the default context size 3)
If there is no diff divider, just another line is shown.

Before
![image](https://github.com/gitextensions/gitextensions/assets/6248932/787ca9bb-d40e-4710-9f3a-e357fda74317)

After
![image](https://github.com/gitextensions/gitextensions/assets/6248932/19ca9027-67b6-45b6-8828-bfb9a4222987)

If advancing range-diff at last occurrence, the diff stay on the last match.

Before
![image](https://github.com/gitextensions/gitextensions/assets/6248932/2abab3e4-0a0b-4d6b-acd2-e99a5ba23902)

After
![image](https://github.com/gitextensions/gitextensions/assets/6248932/5568619f-ed94-44e2-bca4-a9e372ec3319)

## Test methodology <!-- How did you ensure quality? -->

Manual, some tests exists

## Merge strategy

- Rebase merge (PR submitter must change the commit message for the last commit).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
