### PR TITLE
Fixup regression in Commands.Arguments.Commit

### DIFF
--- a/GitCommands/Git/Commands.cs
+++ b/GitCommands/Git/Commands.cs
@@ -25,7 +25,7 @@ public static partial class Commands
             });
     }
 
-    public static IGitCommand CreateTag(GitCreateTagArgs gitCreateTagArgs, string? tagMessageFileName)
+    public static IGitCommand CreateTag(GitCreateTagArgs gitCreateTagArgs, string? tagMessageFileName, Func<string, string?> getPathForGitExecution)
     {
         Validate(gitCreateTagArgs, tagMessageFileName);
 
@@ -34,7 +34,7 @@ public static partial class Commands
             {
                     { gitCreateTagArgs.Force, "-f" },
                     GetArgumentForOperation(gitCreateTagArgs),
-                    { gitCreateTagArgs.Operation.CanProvideMessage(), $"-F {tagMessageFileName.Quote()}" },
+                    { gitCreateTagArgs.Operation.CanProvideMessage(), $"-F {getPathForGitExecution(tagMessageFileName).Quote()}" },
                     gitCreateTagArgs.TagName.Trim().Quote(),
                     "--",
                     gitCreateTagArgs.ObjectId

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -188,7 +188,7 @@ namespace GitCommands
         public string WorkingDirGitDir { get; private set; }
 
         /// <inherit/>
-        public string GetGitExecPath(string? path) => PathUtil.GetGitExecPath(path, _wslDistro);
+        public string GetPathForGitExecution(string? path) => PathUtil.GetPathForGitExecution(path, _wslDistro);
 
         /// <inherit/>
         public string GetWindowsPath(string path) => PathUtil.GetWindowsPath(path, _wslDistro);
@@ -1461,7 +1461,7 @@ namespace GitCommands
                     "--break-rewrites",
                     { start is not null, $"--start-number {start}" },
                     { !string.IsNullOrEmpty(from), $"{from.Quote()}..{to.Quote()}", $"--root {to.Quote()}" },
-                    $"-o {GetGitExecPath(output).Quote()}"
+                    $"-o {GetPathForGitExecution(output).Quote()}"
                 });
         }
 
@@ -2029,7 +2029,7 @@ namespace GitCommands
                 {
                     "add",
                     name.Quote(),
-                    GetGitExecPath(path).QuoteNE()
+                    GetPathForGitExecution(path).QuoteNE()
                 });
         }
 

--- a/GitCommands/Git/Tag/GitTagController.cs
+++ b/GitCommands/Git/Tag/GitTagController.cs
@@ -53,7 +53,7 @@ namespace GitCommands.Git.Tag
 
             try
             {
-                return _uiCommands.StartCommandLineProcessDialog(parentWindow, Commands.CreateTag(args, _uiCommands.GitModule.GetGitExecPath(tagMessageFileName)));
+                return _uiCommands.StartCommandLineProcessDialog(parentWindow, Commands.CreateTag(args, _uiCommands.GitModule.GetPathForGitExecution(tagMessageFileName)));
             }
             finally
             {

--- a/GitCommands/Git/Tag/GitTagController.cs
+++ b/GitCommands/Git/Tag/GitTagController.cs
@@ -53,7 +53,7 @@ namespace GitCommands.Git.Tag
 
             try
             {
-                return _uiCommands.StartCommandLineProcessDialog(parentWindow, Commands.CreateTag(args, _uiCommands.GitModule.GetPathForGitExecution(tagMessageFileName)));
+                return _uiCommands.StartCommandLineProcessDialog(parentWindow, Commands.CreateTag(args, tagMessageFileName, _uiCommands.GitModule.GetPathForGitExecution));
             }
             finally
             {

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -284,7 +284,7 @@ namespace GitCommands
         /// <param name="path">The path as seen by the Git Extensions Windows (native) application.</param>
         /// <param name="wslDistro">The name of the distro or empty for non WSL paths.</param>
         /// <returns>The Posix path if Windows Git (not a WSL distro), WSL path for WSL Git.</returns>
-        public static string GetGitExecPath(string? path, string? wslDistro)
+        public static string GetPathForGitExecution(string? path, string? wslDistro)
         {
             if (string.IsNullOrEmpty(path))
             {

--- a/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
+++ b/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
@@ -329,13 +329,13 @@ namespace GitCommands.Remotes
             // If URL is in a Windows path, it may need to be converted to WSL Git path
             if (remoteUrl is not null && !Uri.IsWellFormedUriString(remoteUrl, UriKind.RelativeOrAbsolute))
             {
-                remoteUrl = module.GetGitExecPath(remoteUrl);
+                remoteUrl = module.GetPathForGitExecution(remoteUrl);
             }
 
             UpdateSettings(module, remoteName, remoteDisabled, SettingKeyString.RemoteUrl, remoteUrl);
             if (remotePushUrl is not null && !Uri.IsWellFormedUriString(remotePushUrl, UriKind.RelativeOrAbsolute))
             {
-                remotePushUrl = module.GetGitExecPath(remotePushUrl);
+                remotePushUrl = module.GetPathForGitExecution(remotePushUrl);
             }
 
             UpdateSettings(module, remoteName, remoteDisabled, SettingKeyString.RemotePushUrl, remotePushUrl);

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -184,7 +184,7 @@ namespace GitUI.CommandsDialogs
 
                 if (PatchFileMode.Checked)
                 {
-                    string gitPatch = Module.GetGitExecPath(patchFile);
+                    string gitPatch = Module.GetPathForGitExecution(patchFile);
                     ArgumentString arguments = IsDiffFile(patchFile)
                         ? Commands.ApplyDiffPatch(ignoreWhiteSpace, gitPatch)
                         : Commands.ApplyMailboxPatch(signOff, ignoreWhiteSpace, gitPatch);

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -184,10 +184,9 @@ namespace GitUI.CommandsDialogs
 
                 if (PatchFileMode.Checked)
                 {
-                    string gitPatch = Module.GetPathForGitExecution(patchFile);
                     ArgumentString arguments = IsDiffFile(patchFile)
-                        ? Commands.ApplyDiffPatch(ignoreWhiteSpace, gitPatch)
-                        : Commands.ApplyMailboxPatch(signOff, ignoreWhiteSpace, gitPatch);
+                        ? Commands.ApplyDiffPatch(ignoreWhiteSpace, patchFile, Module.GetPathForGitExecution)
+                        : Commands.ApplyMailboxPatch(signOff, ignoreWhiteSpace, patchFile, Module.GetPathForGitExecution);
 
                     FormProcess.ShowDialog(this, UICommands, arguments, Module.WorkingDir, input: null, useDialogSettings: true);
                 }

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -207,16 +207,17 @@ namespace GitUI.CommandsDialogs
                     branch = null;
                 }
 
-                string sourceRepo = PathUtil.IsLocalFile(_NO_TRANSLATE_From.Text)
-                    ? UICommands.Module.GetPathForGitExecution(_NO_TRANSLATE_From.Text)
-                    : _NO_TRANSLATE_From.Text;
-                GitExtUtils.ArgumentString cloneCmd = Commands.Clone(sourceRepo,
-                    UICommands.Module.GetPathForGitExecution(dirTo),
+                GitExtUtils.ArgumentString cloneCmd = Commands.Clone(_NO_TRANSLATE_From.Text,
+                    dirTo,
+                    UICommands.Module.GetPathForGitExecution,
                     CentralRepository.Checked,
                     cbIntializeAllSubmodules.Checked,
                     branch, depth, isSingleBranch);
                 using (FormRemoteProcess fromProcess = new(UICommands, cloneCmd))
                 {
+                    string sourceRepo = PathUtil.IsLocalFile(_NO_TRANSLATE_From.Text)
+                        ? UICommands.Module.GetPathForGitExecution(_NO_TRANSLATE_From.Text)
+                        : _NO_TRANSLATE_From.Text;
                     fromProcess.SetUrlTryingToConnect(sourceRepo);
                     fromProcess.ShowDialog(this);
 
@@ -228,7 +229,7 @@ namespace GitUI.CommandsDialogs
 
                 ThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
-                    await RepositoryHistoryManager.Remotes.AddAsMostRecentAsync(sourceRepo);
+                    await RepositoryHistoryManager.Remotes.AddAsMostRecentAsync(_NO_TRANSLATE_From.Text);
                     await RepositoryHistoryManager.Locals.AddAsMostRecentAsync(dirTo);
                 });
 

--- a/GitUI/CommandsDialogs/FormClone.cs
+++ b/GitUI/CommandsDialogs/FormClone.cs
@@ -208,10 +208,10 @@ namespace GitUI.CommandsDialogs
                 }
 
                 string sourceRepo = PathUtil.IsLocalFile(_NO_TRANSLATE_From.Text)
-                    ? UICommands.Module.GetGitExecPath(_NO_TRANSLATE_From.Text)
+                    ? UICommands.Module.GetPathForGitExecution(_NO_TRANSLATE_From.Text)
                     : _NO_TRANSLATE_From.Text;
                 GitExtUtils.ArgumentString cloneCmd = Commands.Clone(sourceRepo,
-                    UICommands.Module.GetGitExecPath(dirTo),
+                    UICommands.Module.GetPathForGitExecution(dirTo),
                     CentralRepository.Checked,
                     cbIntializeAllSubmodules.Checked,
                     branch, depth, isSingleBranch);

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1381,6 +1381,7 @@ namespace GitUI.CommandsDialogs
                         toolAuthor.Text,
                         _useFormCommitMessage,
                         _commitMessageManager.CommitMessagePath,
+                        Module.GetPathForGitExecution,
                         noVerifyToolStripMenuItem.Checked,
                         gpgSignCommitToolStripComboBox.SelectedIndex > 0,
                         toolStripGpgKeyTextBox.Text,

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -109,7 +109,7 @@ namespace GitUI.CommandsDialogs
                                                             noCommit.Checked,
                                                             _NO_TRANSLATE_mergeStrategy.Text,
                                                             allowUnrelatedHistories.Checked,
-                                                            Module.GetGitExecPath(mergeMessagePath),
+                                                            Module.GetPathForGitExecution(mergeMessagePath),
                                                             addLogMessages.Checked ? (int)nbMessages.Value : (int?)null);
             success = FormProcess.ShowDialog(this, UICommands, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
 

--- a/GitUI/CommandsDialogs/FormMergeBranch.cs
+++ b/GitUI/CommandsDialogs/FormMergeBranch.cs
@@ -109,7 +109,8 @@ namespace GitUI.CommandsDialogs
                                                             noCommit.Checked,
                                                             _NO_TRANSLATE_mergeStrategy.Text,
                                                             allowUnrelatedHistories.Checked,
-                                                            Module.GetPathForGitExecution(mergeMessagePath),
+                                                            mergeMessagePath,
+                                                            Module.GetPathForGitExecution,
                                                             addLogMessages.Checked ? (int)nbMessages.Value : (int?)null);
             success = FormProcess.ShowDialog(this, UICommands, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
 

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -371,10 +371,10 @@ namespace GitUI.CommandsDialogs.RepoHosting
             GitUICommands uiCommands = new(GitUICommands.EmptyServiceProvider, new GitModule(null));
 
             string repoSrc = PathUtil.IsLocalFile(repo.CloneUrl)
-                ? uiCommands.Module.GetGitExecPath(repo.CloneUrl)
+                ? uiCommands.Module.GetPathForGitExecution(repo.CloneUrl)
                 : repo.CloneUrl;
 
-            GitExtUtils.ArgumentString cmd = Commands.Clone(repoSrc, uiCommands.Module.GetGitExecPath(targetDir), depth: GetDepth());
+            GitExtUtils.ArgumentString cmd = Commands.Clone(repoSrc, uiCommands.Module.GetPathForGitExecution(targetDir), depth: GetDepth());
 
             FormRemoteProcess formRemoteProcess = new(uiCommands, cmd)
             {

--- a/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ForkAndCloneForm.cs
@@ -370,15 +370,11 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
             GitUICommands uiCommands = new(GitUICommands.EmptyServiceProvider, new GitModule(null));
 
-            string repoSrc = PathUtil.IsLocalFile(repo.CloneUrl)
-                ? uiCommands.Module.GetPathForGitExecution(repo.CloneUrl)
-                : repo.CloneUrl;
-
-            GitExtUtils.ArgumentString cmd = Commands.Clone(repoSrc, uiCommands.Module.GetPathForGitExecution(targetDir), depth: GetDepth());
+            GitExtUtils.ArgumentString cmd = Commands.Clone(repo.CloneUrl, targetDir, uiCommands.Module.GetPathForGitExecution, depth: GetDepth());
 
             FormRemoteProcess formRemoteProcess = new(uiCommands, cmd)
             {
-                Remote = repoSrc
+                Remote = repo.CloneUrl
             };
 
             formRemoteProcess.ShowDialog();

--- a/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -81,7 +81,7 @@ namespace GitUI.HelperDialogs
                 return;
             }
 
-            GitExtUtils.ArgumentString command = Commands.PushLocal(gitRefToReset.CompleteName, _revision.ObjectId, Module.GetGitExecPath(Module.WorkingDir), ForceReset.Checked);
+            GitExtUtils.ArgumentString command = Commands.PushLocal(gitRefToReset.CompleteName, _revision.ObjectId, Module.GetPathForGitExecution(Module.WorkingDir), ForceReset.Checked);
             bool success = FormProcess.ShowDialog(this, UICommands, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
             if (success)
             {

--- a/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -81,7 +81,7 @@ namespace GitUI.HelperDialogs
                 return;
             }
 
-            GitExtUtils.ArgumentString command = Commands.PushLocal(gitRefToReset.CompleteName, _revision.ObjectId, Module.GetPathForGitExecution(Module.WorkingDir), ForceReset.Checked);
+            GitExtUtils.ArgumentString command = Commands.PushLocal(gitRefToReset.CompleteName, _revision.ObjectId, Module.WorkingDir, Module.GetPathForGitExecution, ForceReset.Checked);
             bool success = FormProcess.ShowDialog(this, UICommands, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
             if (success)
             {

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -77,7 +77,7 @@ namespace GitUIPluginInterfaces
         /// </summary>
         /// <param name="path">The Windows (native) path as seen by the application.</param>
         /// <returns>The Posix path if Windows Git, WSL path for WSL Git.</returns>
-        public string GetGitExecPath(string? path);
+        public string GetPathForGitExecution(string? path);
 
         /// <summary>
         /// Convert a path to Windows application (native) format.

--- a/UnitTests/GitCommands.Tests/Git/CommandsTests.CreateTag.cs
+++ b/UnitTests/GitCommands.Tests/Git/CommandsTests.CreateTag.cs
@@ -1,3 +1,4 @@
+using GitCommands;
 using GitCommands.Git;
 using GitCommands.Git.Tag;
 using GitUIPluginInterfaces;
@@ -18,14 +19,14 @@ namespace GitCommandsTests_Git
         public void Validate_should_throw_if_tag_name_invalid(string tagName)
         {
             GitCreateTagArgs args = new(tagName, Revision);
-            Assert.Throws<ArgumentException>(() => Commands.CreateTag(args, TagMessageFile));
+            Assert.Throws<ArgumentException>(() => Commands.CreateTag(args, TagMessageFile, PathUtil.ToPosixPath));
         }
 
         [Test]
         public void Validate_should_throw_if_tag_revision_invalid()
         {
             GitCreateTagArgs args = new(TagName, null);
-            Assert.Throws<ArgumentException>(() => Commands.CreateTag(args, TagMessageFile));
+            Assert.Throws<ArgumentException>(() => Commands.CreateTag(args, TagMessageFile, PathUtil.ToPosixPath));
         }
 
         [TestCase(null)]
@@ -34,14 +35,14 @@ namespace GitCommandsTests_Git
         public void Validate_should_throw_for_SignWithSpecificKey_if_tag_keyId_invalid(string signKeyId)
         {
             GitCreateTagArgs args = new(TagName, Revision, TagOperation.SignWithSpecificKey, signKeyId: signKeyId);
-            Assert.Throws<ArgumentException>(() => Commands.CreateTag(args, TagMessageFile));
+            Assert.Throws<ArgumentException>(() => Commands.CreateTag(args, TagMessageFile, PathUtil.ToPosixPath));
         }
 
         [Test]
         public void ToLine_should_throw_if_operation_not_supported()
         {
             GitCreateTagArgs args = new(TagName, Revision, (TagOperation)10);
-            Assert.Throws<NotSupportedException>(() => Commands.CreateTag(args, TagMessageFile));
+            Assert.Throws<NotSupportedException>(() => Commands.CreateTag(args, TagMessageFile, PathUtil.ToPosixPath));
         }
 
         [TestCase(true, "tag -f -s -F \"c:/.git/TAGMESSAGE\" \"bla\" -- 0123456789012345678901234567890123456789")]
@@ -49,7 +50,7 @@ namespace GitCommandsTests_Git
         public void ToLine_should_render_force_flag(bool force, string expected)
         {
             GitCreateTagArgs args = new(TagName, Revision, TagOperation.SignWithDefaultKey, TagMessage, KeyId, force);
-            IGitCommand cmd = Commands.CreateTag(args, TagMessageFile);
+            IGitCommand cmd = Commands.CreateTag(args, TagMessageFile, PathUtil.ToPosixPath);
 
             string cmdLine = cmd.Arguments;
 
@@ -63,7 +64,7 @@ namespace GitCommandsTests_Git
         public void ToLine_should_render_different_operations(TagOperation operation, string expected)
         {
             GitCreateTagArgs args = new(TagName, Revision, operation, signKeyId: KeyId, force: true);
-            IGitCommand cmd = Commands.CreateTag(args, TagMessageFile);
+            IGitCommand cmd = Commands.CreateTag(args, TagMessageFile, PathUtil.ToPosixPath);
 
             string actualCmdLine = cmd.Arguments;
 

--- a/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
@@ -46,10 +46,10 @@ namespace GitCommandsTests_Git
         {
             Assert.AreEqual(
                 "apply \"hello/world.patch\"",
-                Commands.ApplyDiffPatch(false, "hello\\world.patch").Arguments);
+                Commands.ApplyDiffPatch(false, "hello\\world.patch", PathUtil.ToPosixPath).Arguments);
             Assert.AreEqual(
                 "apply --ignore-whitespace \"hello/world.patch\"",
-                Commands.ApplyDiffPatch(true, "hello\\world.patch").Arguments);
+                Commands.ApplyDiffPatch(true, "hello\\world.patch", PathUtil.ToPosixPath).Arguments);
         }
 
         [TestCase(false, false, "hello\\world.patch", "am --3way \"hello/world.patch\"")]
@@ -61,7 +61,7 @@ namespace GitCommandsTests_Git
         {
             Assert.AreEqual(
                 expected,
-                Commands.ApplyMailboxPatch(signOff, ignoreWhitespace, patchFile).Arguments);
+                Commands.ApplyMailboxPatch(signOff, ignoreWhitespace, patchFile, PathUtil.ToPosixPath).Arguments);
         }
 
         [Test]
@@ -136,34 +136,34 @@ namespace GitCommandsTests_Git
         {
             Assert.AreEqual(
                 "clone -v --progress \"from\" \"to\"",
-                Commands.Clone("from", "to").Arguments);
+                Commands.Clone("from", "to", PathUtil.ToPosixPath).Arguments);
             Assert.AreEqual(
                 "clone -v --progress \"from/path\" \"to/path\"",
-                Commands.Clone("from/path", "to/path").Arguments);
+                Commands.Clone("from/path", "to/path", PathUtil.ToPosixPath).Arguments);
             Assert.AreEqual(
                 "clone -v --bare --progress \"from\" \"to\"",
-                Commands.Clone("from", "to", central: true).Arguments);
+                Commands.Clone("from", "to", PathUtil.ToPosixPath, central: true).Arguments);
             Assert.AreEqual(
                 "clone -v --recurse-submodules --progress \"from\" \"to\"",
-                Commands.Clone("from", "to", initSubmodules: true).Arguments);
+                Commands.Clone("from", "to", PathUtil.ToPosixPath, initSubmodules: true).Arguments);
             Assert.AreEqual(
                 "clone -v --recurse-submodules --progress \"from\" \"to\"",
-                Commands.Clone("from", "to", initSubmodules: true).Arguments);
+                Commands.Clone("from", "to", PathUtil.ToPosixPath, initSubmodules: true).Arguments);
             Assert.AreEqual(
                 "clone -v --depth 2 --progress \"from\" \"to\"",
-                Commands.Clone("from", "to", depth: 2).Arguments);
+                Commands.Clone("from", "to", PathUtil.ToPosixPath, depth: 2).Arguments);
             Assert.AreEqual(
                 "clone -v --single-branch --progress \"from\" \"to\"",
-                Commands.Clone("from", "to", isSingleBranch: true).Arguments);
+                Commands.Clone("from", "to", PathUtil.ToPosixPath, isSingleBranch: true).Arguments);
             Assert.AreEqual(
                 "clone -v --no-single-branch --progress \"from\" \"to\"",
-                Commands.Clone("from", "to", isSingleBranch: false).Arguments);
+                Commands.Clone("from", "to", PathUtil.ToPosixPath, isSingleBranch: false).Arguments);
             Assert.AreEqual(
                 "clone -v --progress --branch branch \"from\" \"to\"",
-                Commands.Clone("from", "to", branch: "branch").Arguments);
+                Commands.Clone("from", "to", PathUtil.ToPosixPath, branch: "branch").Arguments);
             Assert.AreEqual(
                 "clone -v --progress --no-checkout \"from\" \"to\"",
-                Commands.Clone("from", "to", branch: null).Arguments);
+                Commands.Clone("from", "to", PathUtil.ToPosixPath, branch: null).Arguments);
         }
 
         [Test]
@@ -171,28 +171,31 @@ namespace GitCommandsTests_Git
         {
             Assert.AreEqual(
                 "commit -F \"COMMITMESSAGE\"",
-                Commands.Commit(amend: false, useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE").Arguments);
+                Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath).Arguments);
+            Assert.AreEqual(
+                "commit -F \"adapted_commit_message_path\"",
+                Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", path => "adapted_commit_message_path").Arguments);
             Assert.AreEqual(
                 "commit --amend -F \"COMMITMESSAGE\"",
-                Commands.Commit(amend: true, useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE").Arguments);
+                Commands.Commit(amend: true, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath).Arguments);
             Assert.AreEqual(
                 "commit --signoff -F \"COMMITMESSAGE\"",
-                Commands.Commit(amend: false, signOff: true, useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE").Arguments);
+                Commands.Commit(amend: false, signOff: true, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath).Arguments);
             Assert.AreEqual(
                 "commit --author=\"foo\" -F \"COMMITMESSAGE\"",
-                Commands.Commit(amend: false, author: "foo", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE").Arguments);
+                Commands.Commit(amend: false, signOff: false, author: "foo", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath).Arguments);
             Assert.AreEqual(
                 "commit",
-                Commands.Commit(amend: false, useExplicitCommitMessage: false).Arguments);
+                Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: false, commitMessageFile: null, PathUtil.ToPosixPath).Arguments);
             Assert.AreEqual(
                 "commit --no-verify -F \"COMMITMESSAGE\"",
-                Commands.Commit(amend: false, noVerify: true, useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE").Arguments);
+                Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath, noVerify: true).Arguments);
             Assert.AreEqual(
                 "commit -S -F \"COMMITMESSAGE\"",
-                Commands.Commit(amend: false, gpgSign: true, useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE").Arguments);
+                Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath, gpgSign: true).Arguments);
             Assert.AreEqual(
                 "commit -Skey -F \"COMMITMESSAGE\"",
-                Commands.Commit(amend: false, gpgSign: true, gpgKeyId: "key", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE").Arguments);
+                Commands.Commit(amend: false, signOff: false, author: "", useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath, gpgSign: true, gpgKeyId: "key").Arguments);
         }
 
         [TestCase(@"  ""author <author@mail.com>""  ", @"commit --author=""author <author@mail.com>"" -F ""COMMITMESSAGE""")]
@@ -200,7 +203,7 @@ namespace GitCommandsTests_Git
         [TestCase(@"author <author@mail.com>", @"commit --author=""author <author@mail.com>"" -F ""COMMITMESSAGE""")]
         public void CommitCmdShouldTrimAuthor(string input, string expected)
         {
-            ArgumentString actual = Commands.Commit(false, author: input, useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE");
+            ArgumentString actual = Commands.Commit(amend: false, signOff: false, author: input, useExplicitCommitMessage: true, commitMessageFile: "COMMITMESSAGE", PathUtil.ToPosixPath);
             StringAssert.AreEqualIgnoringCase(expected, actual);
         }
 
@@ -217,7 +220,7 @@ namespace GitCommandsTests_Git
         [TestCase(true, true, @"", true, true, true, @"12345678", @"commit --amend --no-verify --signoff -S12345678 -F ""COMMITMESSAGE""")]
         public void CommitCmdTests(bool amend, bool signOff, string author, bool useExplicitCommitMessage, bool noVerify, bool gpgSign, string gpgKeyId, string expected)
         {
-            ArgumentString actual = Commands.Commit(amend, signOff, author, useExplicitCommitMessage, "COMMITMESSAGE", noVerify, gpgSign, gpgKeyId);
+            ArgumentString actual = Commands.Commit(amend, signOff, author, useExplicitCommitMessage, "COMMITMESSAGE", PathUtil.ToPosixPath, noVerify, gpgSign, gpgKeyId);
             StringAssert.AreEqualIgnoringCase(expected, actual);
         }
 
@@ -359,7 +362,7 @@ namespace GitCommandsTests_Git
         [TestCase(false, true, false, null, false, "\t", null, "merge --no-ff --squash branch")]
         [TestCase(false, true, false, null, false, "\n", null, "merge --no-ff --squash branch")]
         [TestCase(false, true, false, null, false, "foo", null, "merge --no-ff --squash -F \"foo\" branch")]
-        [TestCase(false, true, false, null, false, "D:\\myrepo\\.git\\file", null, "merge --no-ff --squash -F \"D:\\myrepo\\.git\\file\" branch")]
+        [TestCase(false, true, false, null, false, "D:\\myrepo\\.git\\file", null, "merge --no-ff --squash -F \"D:/myrepo/.git/file\" branch")]
 
         // log parameter
         [TestCase(true, true, false, null, false, null, -1, "merge --squash branch")]
@@ -367,7 +370,7 @@ namespace GitCommandsTests_Git
         [TestCase(true, true, false, null, false, null, 5, "merge --squash --log=5 branch")]
         public void MergeBranchCmd(bool allowFastForward, bool squash, bool noCommit, string strategy, bool allowUnrelatedHistories, string mergeCommitFilePath, int? log, string expected)
         {
-            Assert.AreEqual(expected, Commands.MergeBranch("branch", allowFastForward, squash, noCommit, strategy, allowUnrelatedHistories, mergeCommitFilePath, log).Arguments);
+            Assert.AreEqual(expected, Commands.MergeBranch("branch", allowFastForward, squash, noCommit, strategy, allowUnrelatedHistories, mergeCommitFilePath, PathUtil.ToPosixPath, log).Arguments);
         }
 
         [Test]
@@ -442,7 +445,7 @@ namespace GitCommandsTests_Git
         [TestCase("branchx", @"c:/my/path", true, ExpectedResult = @"push ""file://c:/my/path"" ""1111111111111111111111111111111111111111:branchx"" --force")]
         public string PushLocalCmd(string gitRef, string repoDir, bool force)
         {
-            return Commands.PushLocal(gitRef, ObjectId.WorkTreeId, repoDir, force).Arguments;
+            return Commands.PushLocal(gitRef, ObjectId.WorkTreeId, repoDir, PathUtil.ToPosixPath, force).Arguments;
         }
 
         [Test]

--- a/UnitTests/GitCommands.Tests/Git/Tag/GitTagControllerTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Tag/GitTagControllerTest.cs
@@ -25,7 +25,7 @@ namespace GitCommandsTests.Git.Tag
 
             _uiCommands = Substitute.For<IGitUICommands>();
             _uiCommands.GitModule.WorkingDir.Returns(_workingDir);
-            _uiCommands.GitModule.GetGitExecPath(_tagMessageFile).Returns(_tagMessageFile);
+            _uiCommands.GitModule.GetPathForGitExecution(_tagMessageFile).Returns(_tagMessageFile);
 
             _controller = new GitTagController(_uiCommands, _fileSystem);
         }

--- a/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
+++ b/UnitTests/GitCommands.Tests/Helpers/PathUtilTest.cs
@@ -305,9 +305,9 @@ namespace GitCommandsTests.Helpers
         [TestCase(@"\\wsl$\Ubuntu\work\..\GitExtensions\", "", @"//wsl$/Ubuntu/work/../GitExtensions/")]
         [TestCase(@"C:\work\..\GitExtensions\", "", @"C:/work/../GitExtensions/")]
         [TestCase(@"work\..\GitExtensions\", "", @"work/../GitExtensions/")]
-        public void GetGitExecPath_GetWindowsPath_default(string path, string wslDistro, string expected)
+        public void GetPathForGitExecution_GetWindowsPath_default(string path, string wslDistro, string expected)
         {
-            PathUtil.GetGitExecPath(path, wslDistro).Should().Be(expected);
+            PathUtil.GetPathForGitExecution(path, wslDistro).Should().Be(expected);
             PathUtil.GetWindowsPath(expected, wslDistro).Should().Be(path);
         }
 
@@ -316,16 +316,16 @@ namespace GitCommandsTests.Helpers
         [TestCase(@"\\wsl$\Ubuntu-20.04\work\..\GitExtensions\", "Ubuntu-20.04", @"/work/../GitExtensions/")]
         [TestCase(@"C:\work\..\GitExtensions\", "Ubuntu", @"/mnt/c/work/../GitExtensions/")]
         [TestCase(@"work\..\GitExtensions\", "Ubuntu", @"work/../GitExtensions/")]
-        public void GetGitExecPath_wsl(string path, string wslDistro, string expected)
+        public void GetPathForGitExecution_wsl(string path, string wslDistro, string expected)
         {
-            PathUtil.GetGitExecPath(path, wslDistro).Should().Be(expected);
+            PathUtil.GetPathForGitExecution(path, wslDistro).Should().Be(expected);
         }
 
         [TestCase(@"\\wsl$/Ubuntu/work/../GitExtensions", "Ubuntu", @"//wsl$/Ubuntu/work/../GitExtensions")]
         [TestCase(@"\\wsl$\Ubuntu-20.04\work\..\GitExtensions\", "Ubuntu", @"//wsl$/Ubuntu-20.04/work/../GitExtensions/")]
-        public void GetGitExecPath_unexpected_usage(string path, string wslDistro, string expected)
+        public void GetPathForGitExecution_unexpected_usage(string path, string wslDistro, string expected)
         {
-            PathUtil.GetGitExecPath(path, wslDistro).Should().Be(expected);
+            PathUtil.GetPathForGitExecution(path, wslDistro).Should().Be(expected);
         }
 
         // Mostly opposite to GetRepoPath_wsl


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/pull/11308/files#r1394980653

## Proposed changes

- Restore adapted path for `commit` command
- Rename `GetGitExecPath` to `GetPathForGitExecution` in order to avoid misleading abbreviation
- Force all callers to pass `GitModule.GetPathForGitExecution`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- adapted existing tests
- add testcase for the regression

## Please do not squash merge!

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).