### PR TITLE
FormCommit always has a _currentFilesList

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -168,7 +168,7 @@ namespace GitUI.CommandsDialogs
         private readonly List<string> _formattedLines = new();
 
         private CommitKind _commitKind;
-        private FileStatusList? _currentFilesList;
+        private FileStatusList _currentFilesList;
         private bool _skipUpdate;
         private FileStatusItem? _currentItem;
         private bool _currentItemStaged;
@@ -213,6 +213,8 @@ namespace GitUI.CommandsDialogs
             _editedCommit = editedCommit;
 
             InitializeComponent();
+
+            _currentFilesList = Unstaged;
 
             CommitAndPush.Text = _commitAndPush.Text;
 
@@ -652,18 +654,15 @@ namespace GitUI.CommandsDialogs
 
         private void MoveSelection(int direction)
         {
-            FileStatusList list = Message.Focused ? Staged : _currentFilesList;
-            if (list is null)
+            if (Message.Focused)
             {
-                // If a user is keyboard-happy, we may receive KeyUp event before we have selected a file list control.
-                return;
+                _currentFilesList = Staged;
             }
 
-            _currentFilesList = list;
-            int itemsCount = list.AllItemsCount;
+            int itemsCount = _currentFilesList.AllItemsCount;
             if (itemsCount != 0)
             {
-                list.SelectedIndex = (list.SelectedIndex + direction + itemsCount) % itemsCount;
+                _currentFilesList.SelectedIndex = (_currentFilesList.SelectedIndex + direction + itemsCount) % itemsCount;
             }
         }
 
@@ -828,8 +827,6 @@ namespace GitUI.CommandsDialogs
             {
                 return false;
             }
-
-            Validates.NotNull(_currentFilesList);
 
             if (_currentFilesList.SelectedItem?.Item is not null)
             {
@@ -1131,7 +1128,7 @@ namespace GitUI.CommandsDialogs
 
         private void RestoreSelectedFiles(IReadOnlyList<GitItemStatus> unstagedFiles, IReadOnlyList<GitItemStatus> stagedFiles, IReadOnlyList<GitItemStatus>? lastSelection)
         {
-            if (_currentFilesList?.IsEmpty is not false)
+            if (!_currentFilesList.IsEmpty)
             {
                 SelectStoredNextIndex();
                 return;
@@ -2085,7 +2082,7 @@ namespace GitUI.CommandsDialogs
             _shouldRescanChanges = false;
             try
             {
-                if (_currentFilesList is null || !_currentFilesList.SelectedItems.Any())
+                if (!_currentFilesList.SelectedItems.Any())
                 {
                     return;
                 }


### PR DESCRIPTION
Addresses https://github.com/gitextensions/gitextensions/pull/11239#discussion_r1391544925

## Proposed changes

- FormCommit always has a `_currentFilesList`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).