### PR TITLE
Let git deny the commit if committer is not specified

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2702,15 +2702,17 @@ namespace GitUI.CommandsDialogs
         {
             ThreadHelper.FileAndForget(async () =>
                 {
-                    // Do not cache results in order to update the info on FormActivate
-                    string userName = Module.GetEffectiveGitSetting(SettingKeyString.UserName, cache: false) ?? "USER NOT CONFIGURED";
-                    string userEmail = Module.GetEffectiveGitSetting(SettingKeyString.UserEmail, cache: false) ?? "E-MAIL NOT CONFIGURED";
-                    string committer = $"{_commitCommitterInfo.Text} {userName} <{userEmail}>";
+                    string committer = $"{_commitCommitterInfo.Text} {GetSetting(SettingKeyString.UserName)} <{GetSetting(SettingKeyString.UserEmail)}>";
 
                     await this.SwitchToMainThreadAsync();
                     commitAuthorStatus.Text = string.IsNullOrWhiteSpace(toolAuthor.Text)
                         ? committer
                         : $"{committer} {_commitAuthorInfo.Text} {toolAuthor.Text}";
+
+                    return;
+
+                    // Do not cache results in order to update the info on FormActivate
+                    string GetSetting(string key) => Module.GetEffectiveGitSetting(key, cache: false) ?? $"/{string.Format(TranslatedStrings.NotConfigured, key)}/";
                 });
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -451,16 +451,6 @@ namespace GitUI.CommandsDialogs
             base.OnApplicationActivated();
         }
 
-        protected override void OnActivated(EventArgs e)
-        {
-            if (!_bypassActivatedEventHandler)
-            {
-                UpdateAuthorInfo();
-            }
-
-            base.OnActivated(e);
-        }
-
         protected override void OnFormClosed(FormClosedEventArgs e)
         {
             // Do not attempt to store again if the form has already been closed. Unfortunately, OnFormClosed is always called by Close.
@@ -2713,29 +2703,14 @@ namespace GitUI.CommandsDialogs
             ThreadHelper.FileAndForget(async () =>
                 {
                     // Do not cache results in order to update the info on FormActivate
-                    string userName = GetSetting(SettingKeyString.UserName);
-                    string userEmail = GetSetting(SettingKeyString.UserEmail);
+                    string userName = Module.GetEffectiveGitSetting(SettingKeyString.UserName, cache: false) ?? "USER NOT CONFIGURED";
+                    string userEmail = Module.GetEffectiveGitSetting(SettingKeyString.UserEmail, cache: false) ?? "E-MAIL NOT CONFIGURED";
                     string committer = $"{_commitCommitterInfo.Text} {userName} <{userEmail}>";
 
                     await this.SwitchToMainThreadAsync();
                     commitAuthorStatus.Text = string.IsNullOrWhiteSpace(toolAuthor.Text)
                         ? committer
                         : $"{committer} {_commitAuthorInfo.Text} {toolAuthor.Text}";
-
-                    return;
-
-                    string GetSetting(string key)
-                    {
-                        try
-                        {
-                            return Module.GetEffectiveGitSetting(key, cache: false);
-                        }
-                        catch (ExternalOperationException ex)
-                        {
-                            Trace.WriteLine(ex);
-                            return "INVALID";
-                        }
-                    }
                 });
         }
 

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2713,14 +2713,29 @@ namespace GitUI.CommandsDialogs
             ThreadHelper.FileAndForget(async () =>
                 {
                     // Do not cache results in order to update the info on FormActivate
-                    string userName = Module.GetEffectiveGitSetting(SettingKeyString.UserName, cache: false);
-                    string userEmail = Module.GetEffectiveGitSetting(SettingKeyString.UserEmail, cache: false);
+                    string userName = GetSetting(SettingKeyString.UserName);
+                    string userEmail = GetSetting(SettingKeyString.UserEmail);
                     string committer = $"{_commitCommitterInfo.Text} {userName} <{userEmail}>";
 
                     await this.SwitchToMainThreadAsync();
                     commitAuthorStatus.Text = string.IsNullOrWhiteSpace(toolAuthor.Text)
                         ? committer
                         : $"{committer} {_commitAuthorInfo.Text} {toolAuthor.Text}";
+
+                    return;
+
+                    string GetSetting(string key)
+                    {
+                        try
+                        {
+                            return Module.GetEffectiveGitSetting(key, cache: false);
+                        }
+                        catch (ExternalOperationException ex)
+                        {
+                            Trace.WriteLine(ex);
+                            return "INVALID";
+                        }
+                    }
                 });
         }
 

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -176,6 +176,7 @@ following command.
         private readonly TranslationString _failedToLoadAnAssembly = new("Failed to load an assembly");
         private readonly TranslationString _failedToLoadFileOrAssemblyFormat = new("Could not load file or assembly '{0}'.");
         private readonly TranslationString _failedToLoadFileOrAssemblyText = new("Most of the times the error is temporary, likely caused by Windows Update.");
+        private readonly TranslationString _notConfigured = new("{0} not configured");
 
         // public only because of FormTranslate
         public TranslatedStrings()
@@ -360,5 +361,6 @@ following command.
         public static string FailedToLoadAnAssembly => _instance.Value._failedToLoadAnAssembly.Text;
         public static string FailedToLoadFileOrAssemblyFormat => _instance.Value._failedToLoadFileOrAssemblyFormat.Text;
         public static string FailedToLoadFileOrAssemblyText => _instance.Value._failedToLoadFileOrAssemblyText.Text;
+        public static string NotConfigured => _instance.Value._notConfigured.Text;
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -10269,6 +10269,10 @@ following command.
         <source>Git revision does not exist</source>
         <target />
       </trans-unit>
+      <trans-unit id="_notConfigured.Text">
+        <source>{0} not configured</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_okText.Text">
         <source>OK</source>
         <target />

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -78,7 +78,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         }
 
         [Test]
-        public void Should_update_committer_info_on_form_activated()
+        public void Should_not_update_committer_info_on_form_activated()
         {
             RunFormTest(async form =>
             {
@@ -103,7 +103,7 @@ namespace GitExtensions.UITests.CommandsDialogs
 
                 await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
 
-                Assert.AreEqual("Committer new author <new_author@mail.com>", commitAuthorStatus.Text);
+                Assert.AreEqual("Committer author <author@mail.com>", commitAuthorStatus.Text);
             });
         }
 

--- a/Plugins/GitUIPluginInterfaces/ExecutionResult.cs
+++ b/Plugins/GitUIPluginInterfaces/ExecutionResult.cs
@@ -2,6 +2,8 @@
 {
     public readonly struct ExecutionResult
     {
+        public const int Success = 0;
+
         public string StandardOutput { get; }
         public string StandardError { get; }
         public int? ExitCode { get; }
@@ -13,7 +15,7 @@
             ExitCode = exitCode;
         }
 
-        public bool ExitedSuccessfully => ExitCode == 0;
+        public bool ExitedSuccessfully => ExitCode == Success;
 
         public string AllOutput => string.Concat(StandardOutput, Environment.NewLine, StandardError);
     }

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -126,7 +126,14 @@ namespace GitUIPluginInterfaces
 
         string GetSetting(string setting);
         string GetEffectiveSetting(string setting);
-        string GetEffectiveGitSetting(string setting, bool cache = true);
+
+        /// <summary>
+        /// Get the effective config setting from git.
+        /// </summary>
+        /// <param name="setting">The setting key.</param>
+        /// <param name="cache"><see langword="true"/> if the result shall be cached.</param>
+        /// <returns>The value of the setting or <see langword="null"/> if the value is not set.</returns>
+        string? GetEffectiveGitSetting(string setting, bool cache = true);
 
         /// <summary>
         /// Gets the name of the currently checked out branch.


### PR DESCRIPTION
Fixes #11366
Fixes #11368

## Proposed changes

- Let git deny the commit if committer is not specified
  - Let `GetEffectiveGitSetting` return ``null` if the setting is not set
  - Remove `FormCommit.OnActivated` in order to avoid repeated exception popups from the only called function `UpdateAuthorInfo`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Exception (repeated exceptions unless repeating `Esc`)

### After

![image](https://github.com/gitextensions/gitextensions/assets/36601201/a947b1c4-0085-48cc-b8f1-f609899a82f6)

## Test methodology <!-- How did you ensure quality? -->

- manual
- adapt affected testcase

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).