### PR TITLE
Use static Regex in a few more situations

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -850,16 +850,8 @@ namespace GitUI
 
         public int SetSelectionFilter(string selectionFilter)
         {
-            Regex regex = RegexForSelecting(selectionFilter);
-            SelectItems(item => regex.IsMatch(item.Name));
+            SelectItems(item => string.IsNullOrEmpty(selectionFilter) || Regex.IsMatch(item.Name, selectionFilter, RegexOptions.IgnoreCase));
             return FileStatusListView.SelectedIndices.Count;
-
-            Regex RegexForSelecting(string value)
-            {
-                return string.IsNullOrEmpty(value)
-                    ? new Regex("^$", RegexOptions.Compiled)
-                    : new Regex(value, RegexOptions.Compiled | RegexOptions.IgnoreCase);
-            }
         }
 
         public void StoreNextIndexToSelect()
@@ -1900,7 +1892,7 @@ namespace GitUI
 
             try
             {
-                _filter = new Regex(value, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                _filter = new Regex(value, RegexOptions.IgnoreCase);
                 FilterComboBox.BackColor = _activeInputColor;
             }
             catch

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/ApiClient.cs
@@ -81,8 +81,7 @@ namespace AzureDevOpsIntegration
 
             buildDefinitions = await HttpGetAsync<ListWrapper<BuildDefinition>>(BuildDefinitionsUrl);
 
-            Regex tfsBuildDefinitionNameFilter = new(buildDefinitionNameFilter, RegexOptions.Compiled);
-            return GetBuildDefinitionsIds(buildDefinitions.Value.Where(b => tfsBuildDefinitionNameFilter.IsMatch(b.Name)));
+            return GetBuildDefinitionsIds(buildDefinitions.Value.Where(b => Regex.IsMatch(b.Name, buildDefinitionNameFilter)));
         }
 
         private static string? GetBuildDefinitionsIds(IEnumerable<BuildDefinition>? buildDefinitions)

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -111,17 +111,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
 
         private IEnumerable<string> GetObsoleteBranchNames(RefreshContext context, string curBranch)
         {
-            RegexOptions options;
-            if (context.RegexIgnoreCase)
-            {
-                options = RegexOptions.Compiled | RegexOptions.IgnoreCase;
-            }
-            else
-            {
-                options = RegexOptions.Compiled;
-            }
-
-            Regex regex = string.IsNullOrEmpty(context.RegexFilter) ? null : new Regex(context.RegexFilter, options);
+            RegexOptions options = context.RegexIgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
             bool regexMustMatch = !context.RegexDoesNotMatch;
 
             GitArgumentBuilder args = new("branch")
@@ -142,7 +132,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
             return _commandOutputParser.GetBranchNames(result.StandardOutput)
                                         .Where(branchName => branchName != curBranch && branchName != context.ReferenceBranch)
                                         .Where(branchName => (!context.IncludeRemotes || branchName.StartsWith(context.RemoteRepositoryName + "/"))
-                                                            && (regex is null || regex.IsMatch(branchName) == regexMustMatch));
+                                                            && (string.IsNullOrEmpty(context.RegexFilter) || Regex.IsMatch(branchName, context.RegexFilter, options) == regexMustMatch));
         }
 
         private void Delete_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Proposed changes

Skip Compiled regex for a few non static regex

That are not expected to be executing extremely often, why interpreted regex is expected to be faster.

--

A refresh of regex usage according to https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-regex
- 
- 
- 

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->

## Test methodology <!-- How did you ensure quality? -->

- 
- 
- 

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
