### PR TITLE
IDE000028 Collection expressions

### DIFF
--- a/BugReporter/ExceptionDetails.cs
+++ b/BugReporter/ExceptionDetails.cs
@@ -10,7 +10,7 @@ namespace BugReporter
 {
     internal partial class ExceptionDetails : UserControl
     {
-        private readonly Dictionary<TreeNode, SerializableException> _exceptionDetailsList = new();
+        private readonly Dictionary<TreeNode, SerializableException> _exceptionDetailsList = [];
 
         public ExceptionDetails()
         {

--- a/BugReporter/Serialization/SerializableException.cs
+++ b/BugReporter/Serialization/SerializableException.cs
@@ -46,7 +46,7 @@ namespace BugReporter.Serialization
                         if (entry.Value is not null)
                         {
                             // Assign 'Data' property only if there is at least one entry with non-null value
-                            Data ??= new SerializableDictionary<object, object>();
+                            Data ??= [];
 
                             Data.Add(entry.Key, entry.Value);
                         }
@@ -65,7 +65,7 @@ namespace BugReporter.Serialization
 
                 if (exception is AggregateException)
                 {
-                    InnerExceptions = new List<SerializableException>();
+                    InnerExceptions = [];
 
                     foreach (Exception innerException in ((AggregateException)exception).InnerExceptions)
                     {
@@ -195,7 +195,7 @@ namespace BugReporter.Serialization
 
             if (extendedProperties.Any())
             {
-                SerializableDictionary<string, object> extendedInformation = new();
+                SerializableDictionary<string, object> extendedInformation = [];
 
                 foreach (PropertyInfo property in extendedProperties.Where(property => property.GetValue(exception, null) is not null))
                 {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="scripts\Tests.props" />
 
   <PropertyGroup>
-    <LangVersion>10</LangVersion>
+    <LangVersion>12</LangVersion>
     <NoWarn>$(NoWarn);1573;1591;1712</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>

--- a/Externals/NetSpell.SpellChecker/Dictionary/Affix/AffixRule.cs
+++ b/Externals/NetSpell.SpellChecker/Dictionary/Affix/AffixRule.cs
@@ -17,7 +17,7 @@ namespace NetSpell.SpellChecker.Dictionary.Affix
         /// <summary>
         ///     Collection of text entries that make up this rule
         /// </summary>
-        public AffixEntryCollection AffixEntries { get; set; } = new();
+        public AffixEntryCollection AffixEntries { get; set; } = [];
 
         /// <summary>
         ///     Name of the Affix rule

--- a/Externals/NetSpell.SpellChecker/Dictionary/WordDictionary.cs
+++ b/Externals/NetSpell.SpellChecker/Dictionary/WordDictionary.cs
@@ -224,10 +224,11 @@ namespace NetSpell.SpellChecker.Dictionary
             // Step 3 Remove suffix, Search BaseWords
 
             // save suffixed words for use when removing prefix
-            List<string> suffixWords = new();
-
-            // Add word to suffix word list
-            suffixWords.Add(word);
+            List<string> suffixWords =
+            [
+                // Add word to suffix word list
+                word,
+            ];
 
             foreach (AffixRule rule in SuffixRules.Values)
             {
@@ -306,8 +307,8 @@ namespace NetSpell.SpellChecker.Dictionary
         /// </returns>
         public List<string> ExpandWord(Word word)
         {
-            List<string> suffixWords = new();
-            List<string> words = new();
+            List<string> suffixWords = [];
+            List<string> words = [];
 
             suffixWords.Add(word.Text);
             string prefixKeys = "";
@@ -644,7 +645,7 @@ namespace NetSpell.SpellChecker.Dictionary
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public Dictionary<string, Word> BaseWords { get; } = new Dictionary<string, Word>();
+        public Dictionary<string, Word> BaseWords { get; } = [];
 
         /// <summary>
         ///     Copyright text for the dictionary
@@ -710,28 +711,28 @@ namespace NetSpell.SpellChecker.Dictionary
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public PhoneticRuleCollection PhoneticRules { get; } = new();
+        public PhoneticRuleCollection PhoneticRules { get; } = [];
 
         /// <summary>
         ///     Collection of affix prefixes for the base words in this dictionary
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public AffixRuleCollection PrefixRules { get; } = new();
+        public AffixRuleCollection PrefixRules { get; } = [];
 
         /// <summary>
         ///     List of characters to use when generating suggestions using the near miss strategy
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public List<string> ReplaceCharacters { get; } = new List<string>();
+        public List<string> ReplaceCharacters { get; } = [];
 
         /// <summary>
         ///     Collection of affix suffixes for the base words in this dictionary
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public AffixRuleCollection SuffixRules { get; } = new();
+        public AffixRuleCollection SuffixRules { get; } = [];
 
         /// <summary>
         ///     List of characters to try when generating suggestions using the near miss strategy
@@ -754,7 +755,7 @@ namespace NetSpell.SpellChecker.Dictionary
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public Dictionary<string, string> UserWords { get; } = new Dictionary<string, string>();
+        public Dictionary<string, string> UserWords { get; } = [];
 
         /// <summary>
         ///     List of text saved from when 'Contains' is called.
@@ -764,7 +765,7 @@ namespace NetSpell.SpellChecker.Dictionary
         /// <remarks>
         ///     These are not actual words.
         /// </remarks>
-        internal List<string> PossibleBaseWords { get; } = new List<string>();
+        internal List<string> PossibleBaseWords { get; } = [];
 
         #region Component Designer generated code
 

--- a/Externals/NetSpell.SpellChecker/Spelling.cs
+++ b/Externals/NetSpell.SpellChecker/Spelling.cs
@@ -980,14 +980,14 @@ namespace NetSpell.SpellChecker
 
             Initialize();
 
-            List<Word> tempSuggestion = new();
+            List<Word> tempSuggestion = [];
 
             if ((SuggestionMode == SuggestionEnum.PhoneticNearMiss
                 || SuggestionMode == SuggestionEnum.Phonetic)
                 && _dictionary.PhoneticRules.Count > 0)
             {
                 // generate phonetic code for possible root word
-                Dictionary<string, string> codes = new();
+                Dictionary<string, string> codes = [];
                 foreach (string tempWord in _dictionary.PossibleBaseWords)
                 {
                     string tempCode = _dictionary.PhoneticCode(tempWord);
@@ -1145,7 +1145,7 @@ namespace NetSpell.SpellChecker
         #region public properties
 
         private WordDictionary _dictionary;
-        private readonly HashSet<string> _autoCompleteWords = new();
+        private readonly HashSet<string> _autoCompleteWords = [];
         private string _replacementWord = "";
         private StringBuilder _text = new();
         private int _wordIndex;
@@ -1244,7 +1244,7 @@ namespace NetSpell.SpellChecker
         /// </remarks>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public List<string> IgnoreList { get; } = new List<string>();
+        public List<string> IgnoreList { get; } = [];
 
         /// <summary>
         ///     Ignore words with digits when spell checking
@@ -1270,7 +1270,7 @@ namespace NetSpell.SpellChecker
         /// </remarks>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public Dictionary<string, string> ReplaceList { get; } = new Dictionary<string, string>();
+        public Dictionary<string, string> ReplaceList { get; } = [];
 
         /// <summary>
         ///     The word to used when replacing the misspelled word
@@ -1310,7 +1310,7 @@ namespace NetSpell.SpellChecker
         /// <seealso cref="MaxSuggestions"/>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public List<string> Suggestions { get; } = new List<string>();
+        public List<string> Suggestions { get; } = [];
 
         /// <summary>
         ///     The text to spell check

--- a/GitCommands/ArgumentBuilderExtensions.cs
+++ b/GitCommands/ArgumentBuilderExtensions.cs
@@ -298,7 +298,7 @@ namespace GitCommands
             }
 
             // Clone command as argument builder
-            List<BatchArgumentItem> batches = new();
+            List<BatchArgumentItem> batches = [];
             int currentBatchItemCount = 0;
             int currentArgumentLength = baseArgument.Length;
             ArgumentBuilder lastBatchBuilder = arguments.Aggregate(builder, (currentBatchBuilder, argument) =>
@@ -319,7 +319,7 @@ namespace GitCommands
                     // Return new argument builder
                     currentBatchItemCount = 1;
                     currentArgumentLength = baseArgument.Length + 1 + argument.Length;
-                    return new ArgumentBuilder() { baseArgument, argument };
+                    return [baseArgument, argument];
                 }
 
                 currentBatchBuilder.Add(argument);

--- a/GitCommands/CommitTemplateManager.cs
+++ b/GitCommands/CommitTemplateManager.cs
@@ -53,7 +53,7 @@ namespace GitCommands
             }
         }
 
-        private static readonly List<RegisteredCommitTemplateItem> RegisteredTemplatesStorage = new();
+        private static readonly List<RegisteredCommitTemplateItem> RegisteredTemplatesStorage = [];
         private readonly IFileSystem _fileSystem;
         private readonly Func<IGitModule> _getModule;
         private readonly IFullPathResolver _fullPathResolver;

--- a/GitCommands/Config/ConfigFile.cs
+++ b/GitCommands/Config/ConfigFile.cs
@@ -9,7 +9,7 @@ namespace GitCommands.Config
         private static Encoding GetEncoding() => GitModule.SystemEncoding;
         public static readonly char[] CommentChars = { ';', '#' };
 
-        private readonly List<IConfigSection> _configSections = new();
+        private readonly List<IConfigSection> _configSections = [];
 
         public string FileName { get; }
 

--- a/GitCommands/Config/ConfigSection.cs
+++ b/GitCommands/Config/ConfigSection.cs
@@ -79,7 +79,7 @@ namespace GitCommands.Config
             }
             else
             {
-                _configKeys[key] = new List<string> { value };
+                _configKeys[key] = [value];
             }
         }
 
@@ -87,7 +87,7 @@ namespace GitCommands.Config
         {
             if (!_configKeys.ContainsKey(key))
             {
-                _configKeys[key] = new List<string>();
+                _configKeys[key] = [];
             }
 
             _configKeys[key].Add(value);

--- a/GitCommands/CustomDiffMergeToolCache.cs
+++ b/GitCommands/CustomDiffMergeToolCache.cs
@@ -92,7 +92,7 @@ namespace GitCommands
         /// <returns>list with tool names.</returns>
         private static IEnumerable<string> ParseCustomDiffMergeTool(string output, string defaultTool)
         {
-            List<string> tools = new();
+            List<string> tools = [];
 
             // Simple parsing of the textual output opposite to porcelain format
             // https://github.com/git/git/blob/main/git-mergetool--lib.sh#L298

--- a/GitCommands/ExternalLinks/ExternalLinkDefinition.cs
+++ b/GitCommands/ExternalLinks/ExternalLinkDefinition.cs
@@ -34,7 +34,7 @@ namespace GitCommands.ExternalLinks
         /// <summary>
         /// List of formats to be applied for each revision part matched by SearchPattern
         /// </summary>
-        public BindingList<ExternalLinkFormat> LinkFormats { get; } = new BindingList<ExternalLinkFormat>();
+        public BindingList<ExternalLinkFormat> LinkFormats { get; } = [];
 
         /// <summary>Short name for this link def</summary>
         public string? Name { get; set; }
@@ -64,7 +64,7 @@ namespace GitCommands.ExternalLinks
             }
         }
 
-        public HashSet<RemotePart> RemoteSearchInParts { get; } = new HashSet<RemotePart>();
+        public HashSet<RemotePart> RemoteSearchInParts { get; } = [];
 
         /// <summary>
         /// RegEx for remote parts that have to be transformed into links
@@ -91,7 +91,7 @@ namespace GitCommands.ExternalLinks
             }
         }
 
-        public HashSet<RevisionPart> SearchInParts { get; } = new HashSet<RevisionPart>();
+        public HashSet<RevisionPart> SearchInParts { get; } = [];
 
         /// <summary>
         /// RegEx for revision parts that have to be transformed into links

--- a/GitCommands/ExternalLinks/ExternalLinkFormat.cs
+++ b/GitCommands/ExternalLinks/ExternalLinkFormat.cs
@@ -15,7 +15,7 @@ namespace GitCommands.ExternalLinks
 
         public ExternalLink Apply(Match? remoteMatch, Match? revisionMatch, GitRevision revision)
         {
-            List<string> groups = new();
+            List<string> groups = [];
             AddGroupsFromMatches(remoteMatch);
             AddGroupsFromMatches(revisionMatch);
             object[] groupsArray = groups.ToArray<object>();

--- a/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
+++ b/GitCommands/ExternalLinks/ExternalLinkRevisionParser.cs
@@ -43,7 +43,7 @@ namespace GitCommands.ExternalLinks
 
         private IEnumerable<Match?> ParseRemotes(ExternalLinkDefinition definition)
         {
-            List<Match?> allMatches = new();
+            List<Match?> allMatches = [];
 
             if (string.IsNullOrWhiteSpace(definition.RemoteSearchPattern) || definition.RemoteSearchPatternRegex?.Value is null)
             {
@@ -51,7 +51,7 @@ namespace GitCommands.ExternalLinks
                 return allMatches;
             }
 
-            List<string> remoteUrls = new();
+            List<string> remoteUrls = [];
 
             IEnumerable<ConfigFileRemote> remotes = _remotesManager.LoadRemotes(false);
             IEnumerable<ConfigFileRemote> matchingRemotes = GetMatchingRemotes(definition, remotes);
@@ -93,7 +93,7 @@ namespace GitCommands.ExternalLinks
 
         private static IEnumerable<ExternalLink> ParseRevision(GitRevision revision, ExternalLinkDefinition definition, Match? remoteMatch)
         {
-            List<IEnumerable<ExternalLink>> links = new();
+            List<IEnumerable<ExternalLink>> links = [];
 
             if (definition.SearchInParts.Contains(ExternalLinkDefinition.RevisionPart.LocalBranches))
             {
@@ -126,7 +126,7 @@ namespace GitCommands.ExternalLinks
                 yield break;
             }
 
-            List<Match> allMatches = new();
+            List<Match> allMatches = [];
 
             MatchCollection matches = definition.SearchPatternRegex.Value.Matches(part);
             for (int i = 0; i < matches.Count; i++)

--- a/GitCommands/FileHelper.cs
+++ b/GitCommands/FileHelper.cs
@@ -79,7 +79,7 @@ namespace GitCommands
             }
 
             string[] lines = result.StandardOutput.Split(Delimiters.NullAndLineFeed);
-            Dictionary<string, string> attributes = new();
+            Dictionary<string, string> attributes = [];
             for (int i = 0; i < lines.Length - 2; i += 3)
             {
                 attributes[lines[i + 1].Trim()] = lines[i + 2].Trim();

--- a/GitCommands/Git/AheadBehindDataProvider.cs
+++ b/GitCommands/Git/AheadBehindDataProvider.cs
@@ -84,7 +84,7 @@ namespace GitCommands.Git
             }
 
             MatchCollection matches = _aheadBehindRegEx.Matches(result.StandardOutput);
-            Dictionary<string, AheadBehindData> aheadBehindForBranchesData = new();
+            Dictionary<string, AheadBehindData> aheadBehindForBranchesData = [];
             foreach (Match match in matches)
             {
                 string branch = match.Groups["branch"].Value;

--- a/GitCommands/Git/Commands.Arguments.cs
+++ b/GitCommands/Git/Commands.Arguments.cs
@@ -362,10 +362,12 @@ namespace GitCommands.Git
                     return string.Empty;
                 }
 
-                ArgumentBuilder builder = new();
-                builder.Add((option & RefsFilter.Heads) != 0, "refs/heads/");
-                builder.Add((option & RefsFilter.Remotes) != 0, "refs/remotes/");
-                builder.Add((option & RefsFilter.Tags) != 0, "refs/tags/");
+                ArgumentBuilder builder = new()
+                {
+                    { (option & RefsFilter.Heads) != 0, "refs/heads/" },
+                    { (option & RefsFilter.Remotes) != 0, "refs/remotes/" },
+                    { (option & RefsFilter.Tags) != 0, "refs/tags/" }
+                };
 
                 return builder;
             }

--- a/GitCommands/Git/GetAllChangedFilesOutputParser.cs
+++ b/GitCommands/Git/GetAllChangedFilesOutputParser.cs
@@ -38,7 +38,7 @@ namespace GitCommands.Git
         /// <returns>list with the git items.</returns>
         internal List<GitItemStatus> GetAllChangedFilesFromString_v1(string getAllChangedFilesCommandOutput, bool fromDiff, StagedStatus staged)
         {
-            List<GitItemStatus> diffFiles = new();
+            List<GitItemStatus> diffFiles = [];
 
             if (string.IsNullOrEmpty(getAllChangedFilesCommandOutput))
             {
@@ -164,7 +164,7 @@ namespace GitCommands.Git
         /// <returns>list with the parsed GitItemStatus.</returns>
         private static IReadOnlyList<GitItemStatus> GetAllChangedFilesFromString_v2(string getAllChangedFilesCommandOutput)
         {
-            List<GitItemStatus> diffFiles = new();
+            List<GitItemStatus> diffFiles = [];
 
             if (string.IsNullOrEmpty(getAllChangedFilesCommandOutput))
             {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -454,7 +454,7 @@ namespace GitCommands
         /// <inheritdoc />
         public IReadOnlyList<string> GetSubmodulesLocalPaths(bool recursive = true)
         {
-            List<string> localPaths = new();
+            List<string> localPaths = [];
             try
             {
                 DoGetSubmodulesLocalPaths(this, "", localPaths, recursive);
@@ -740,7 +740,7 @@ namespace GitCommands
         {
             filename = filename.ToPosixPath();
 
-            List<ConflictData> list = new();
+            List<ConflictData> list = [];
             GitArgumentBuilder args = new("ls-files")
             {
                 "-z",
@@ -797,7 +797,7 @@ namespace GitCommands
                 | (AppSettings.ShowSuperprojectTags ? RefsFilter.Tags : RefsFilter.NoFilter);
             if (refsFilter == RefsFilter.NoFilter)
             {
-                return new Dictionary<IGitRef, IGitItem?>();
+                return [];
             }
 
             string? command = Commands.GetRefs(refsFilter, noLocks: noLocks, GitRefsSortBy.committerdate, GitRefsSortOrder.Descending, maxSuperRefCount);
@@ -918,12 +918,12 @@ namespace GitCommands
             }
             else
             {
-                args = new ArgumentBuilder()
-                {
+                args =
+                [
                     "/c",
                     $"\"{AppSettings.GitCommand.QuoteNE()}",
                     "gui\""
-                };
+                ];
                 new Executable("cmd.exe", WorkingDir).Start(args);
             }
         }
@@ -1336,7 +1336,7 @@ namespace GitCommands
             if (resetId != ObjectId.IndexId)
             {
                 Lazy<List<GitItemStatus>> initialStatus = new(() => GetAllChangedFilesWithSubmodulesStatus().ToList());
-                List<GitItemStatus> filesToUnstage = new();
+                List<GitItemStatus> filesToUnstage = [];
                 foreach (GitItemStatus item in selectedItems)
                 {
                     if (item.Staged == StagedStatus.Index)
@@ -1352,10 +1352,10 @@ namespace GitCommands
                 BatchUnstageFiles(filesToUnstage, progressAction);
             }
 
-            List<string> filesInUse = new();
-            List<string> filesToCheckout = new();
-            List<string> filesToReset = new();
-            List<string> filesCannotCheckout = new();
+            List<string> filesInUse = [];
+            List<string> filesToCheckout = [];
+            List<string> filesToReset = [];
+            List<string> filesCannotCheckout = [];
             output = new();
             Lazy<List<GitItemStatus>> postUnstageStatus = new(() => GetAllChangedFilesWithSubmodulesStatus().ToList());
 
@@ -1853,8 +1853,8 @@ namespace GitCommands
         /// <returns><see langword="true" /> if changes should be rescanned; otherwise <see langword="false" />.</returns>.
         public bool BatchUnstageFiles(IEnumerable<GitItemStatus> selectedItems, Action<BatchProgressEventArgs>? action = null)
         {
-            List<GitItemStatus> files = new();
-            List<string> filesToRemove = new();
+            List<GitItemStatus> files = [];
+            List<string> filesToRemove = [];
             bool shouldRescanChanges = false;
             foreach (GitItemStatus item in selectedItems)
             {
@@ -2055,7 +2055,7 @@ namespace GitCommands
             IReadOnlyList<Remote> ParseRemotes(ExecutionResult result)
             {
                 IEnumerable<string> lines = result.StandardOutput.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries);
-                List<Remote> remotes = new();
+                List<Remote> remotes = [];
 
                 // See tests for explanation of the format
 
@@ -2489,7 +2489,7 @@ namespace GitCommands
 
             static IReadOnlyList<GitItemStatus> GetAssumeUnchangedFilesFromString(string lsString)
             {
-                List<GitItemStatus> result = new();
+                List<GitItemStatus> result = [];
 
                 foreach (string line in lsString.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries))
                 {
@@ -2512,7 +2512,7 @@ namespace GitCommands
 
             static IReadOnlyList<GitItemStatus> GetSkipWorktreeFilesFromString(string lsString, bool excludeAssumeUnchangedFiles)
             {
-                List<GitItemStatus> result = new();
+                List<GitItemStatus> result = [];
 
                 foreach (string line in lsString.LazySplit('\n', StringSplitOptions.RemoveEmptyEntries))
                 {
@@ -2912,8 +2912,8 @@ namespace GitCommands
         {
             MatchCollection matches = _refRegex.Matches(refList);
 
-            List<IGitRef> gitRefs = new();
-            Dictionary<string, GitRef> headByRemote = new();
+            List<IGitRef> gitRefs = [];
+            Dictionary<string, GitRef> headByRemote = [];
 
             foreach (Match match in matches)
             {
@@ -3212,7 +3212,7 @@ namespace GitCommands
             // We see the content of the chunks, where the first is a markdown header, the second
             // is a blank line, and third is an introductory paragraph about the project.
 
-            Dictionary<ObjectId, GitBlameCommit> commitByObjectId = new();
+            Dictionary<ObjectId, GitBlameCommit> commitByObjectId = [];
 
             // Pre-allocate the list with a capacity estimated from the approximate git blame length to describe a file line
             const int GitBlameLengthPerLineHeuristicValue = 120;
@@ -3999,7 +3999,7 @@ namespace GitCommands
 
         public (int totalCount, Dictionary<string, int> countByName) GetCommitsByContributor(DateTime? since = null, DateTime? until = null)
         {
-            Dictionary<string, int> countByName = new();
+            Dictionary<string, int> countByName = [];
             int totalCommits = 0;
 
             Regex regex = new(@"^\s*(?<count>\d+)\s+(?<name>.*)$");

--- a/GitCommands/Git/GitVersion.cs
+++ b/GitCommands/Git/GitVersion.cs
@@ -28,7 +28,7 @@ namespace GitCommands
         /// </summary>
         public static readonly GitVersion LastVersionWithoutKnownLimitations = new("2.15.2");
 
-        private static readonly Dictionary<string, GitVersion> _current = new();
+        private static readonly Dictionary<string, GitVersion> _current = [];
 
         /// <summary>
         /// GitVersion for the native ("Windows") Git

--- a/GitCommands/Git/RevisionDiffProvider.cs
+++ b/GitCommands/Git/RevisionDiffProvider.cs
@@ -66,7 +66,7 @@ namespace GitCommands.Git
                     firstRevision + ", " + secondRevision);
             }
 
-            ArgumentBuilder extra = new();
+            ArgumentBuilder extra = [];
             firstRevision = ArtificialToDiffOptions(firstRevision);
             secondRevision = ArtificialToDiffOptions(secondRevision);
 

--- a/GitCommands/Patches/PatchManager.cs
+++ b/GitCommands/Patches/PatchManager.cs
@@ -223,7 +223,7 @@ namespace GitCommands.Patches
             string diff = text[(patchPos - 1)..];
 
             string[] chunks = diff.Split(new[] { "\n@@" }, StringSplitOptions.RemoveEmptyEntries);
-            List<Chunk> selectedChunks = new();
+            List<Chunk> selectedChunks = [];
             int i = 0;
             int currentPos = patchPos - 1;
 
@@ -324,10 +324,10 @@ namespace GitCommands.Patches
 
     internal sealed class SubChunk
     {
-        public List<PatchLine> PreContext { get; } = new List<PatchLine>();
-        public List<PatchLine> RemovedLines { get; } = new List<PatchLine>();
-        public List<PatchLine> AddedLines { get; } = new List<PatchLine>();
-        public List<PatchLine> PostContext { get; } = new List<PatchLine>();
+        public List<PatchLine> PreContext { get; } = [];
+        public List<PatchLine> RemovedLines { get; } = [];
+        public List<PatchLine> AddedLines { get; } = [];
+        public List<PatchLine> PostContext { get; } = [];
         public string? WasNoNewLineAtTheEnd { get; set; }
         public string? IsNoNewLineAtTheEnd { get; set; }
 
@@ -511,7 +511,7 @@ namespace GitCommands.Patches
     internal sealed class Chunk
     {
         private int _startLine;
-        private readonly List<SubChunk> _subChunks = new();
+        private readonly List<SubChunk> _subChunks = [];
         private SubChunk? _currentSubChunk;
 
         private SubChunk CurrentSubChunk

--- a/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
+++ b/GitCommands/Remotes/ConfigFileRemoteSettingsManager.cs
@@ -196,7 +196,7 @@ namespace GitCommands.Remotes
         // TODO: candidate for Async implementations
         public IEnumerable<ConfigFileRemote> LoadRemotes(bool loadDisabled)
         {
-            List<ConfigFileRemote> remotes = new();
+            List<ConfigFileRemote> remotes = [];
             IGitModule module = _getModule();
             if (module is null)
             {

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -198,7 +198,7 @@ namespace GitCommands
         /// <returns>List with GitRevisions.</returns>
         private IReadOnlyCollection<GitRevision> GetRevisionsFromArguments(GitArgumentBuilder arguments, CancellationToken cancellationToken)
         {
-            List<GitRevision> revisions = new();
+            List<GitRevision> revisions = [];
 
             using IProcess process = _module.GitCommandRunner.RunDetached(cancellationToken, arguments, redirectOutput: true, outputEncoding: GitModule.LosslessEncoding);
             foreach (ReadOnlyMemory<byte> chunk in process.StandardOutput.BaseStream.SplitLogOutput())

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -900,7 +900,7 @@ namespace GitCommands
             set => SetBool("revisiongraphdrawnonrelativestextgray", value);
         }
 
-        public static readonly Dictionary<string, Encoding> AvailableEncodings = new();
+        public static readonly Dictionary<string, Encoding> AvailableEncodings = [];
 
         public enum PullAction
         {

--- a/GitCommands/Settings/GitExtSettingsCache.cs
+++ b/GitCommands/Settings/GitExtSettingsCache.cs
@@ -7,7 +7,7 @@ namespace GitCommands.Settings
     [DebuggerDisplay("{_byNameMap.Count} cached {" + nameof(SettingsFilePath) + ",nq}")]
     public class GitExtSettingsCache : FileSettingsCache
     {
-        private readonly XmlSerializableDictionary<string, string> _encodedNameMap = new();
+        private readonly XmlSerializableDictionary<string, string> _encodedNameMap = [];
 
         public GitExtSettingsCache(string settingsFilePath, bool autoSave = true)
             : base(settingsFilePath, autoSave)

--- a/GitCommands/Submodules/SubmoduleStatusProvider.cs
+++ b/GitCommands/Submodules/SubmoduleStatusProvider.cs
@@ -39,7 +39,7 @@ namespace GitCommands.Submodules
 
         private readonly CancellationTokenSequence _submodulesStructureSequence = new();
         private readonly CancellationTokenSequence _submodulesStatusSequence = new();
-        private readonly Dictionary<string, SubmoduleInfo> _submoduleInfos = new();
+        private readonly Dictionary<string, SubmoduleInfo> _submoduleInfos = [];
         private DateTime _previousSubmoduleUpdateTime;
         private SubmoduleInfoResult? _submoduleInfoResult;
 

--- a/GitCommands/UserRepositoryHistory/Legacy/RepositoryHistorySurrogate.cs
+++ b/GitCommands/UserRepositoryHistory/Legacy/RepositoryHistorySurrogate.cs
@@ -18,6 +18,6 @@ namespace GitCommands.UserRepositoryHistory.Legacy
         {
         }
 
-        public List<UserRepositoryHistory.Repository> Repositories { get; } = new List<UserRepositoryHistory.Repository>();
+        public List<UserRepositoryHistory.Repository> Repositories { get; } = [];
     }
 }

--- a/GitCommands/UserRepositoryHistory/RecentRepoInfo.cs
+++ b/GitCommands/UserRepositoryHistory/RecentRepoInfo.cs
@@ -60,9 +60,9 @@
 
         public void SplitRecentRepos(IList<Repository> recentRepositories, List<RecentRepoInfo> pinnedRepoList, List<RecentRepoInfo> allRecentRepoList)
         {
-            SortedList<string, List<RecentRepoInfo>> orderedRepos = new();
-            List<RecentRepoInfo> pinnedRepos = new();
-            List<RecentRepoInfo> allRecentRepos = new();
+            SortedList<string, List<RecentRepoInfo>> orderedRepos = [];
+            List<RecentRepoInfo> pinnedRepos = [];
+            List<RecentRepoInfo> allRecentRepos = [];
 
             bool middleDot = ShorteningStrategy == ShorteningRecentRepoPathStrategy.MiddleDots;
             bool signDir = ShorteningStrategy == ShorteningRecentRepoPathStrategy.MostSignDir;
@@ -176,11 +176,11 @@
             bool existsShortName = orderedRepos.TryGetValue(repoInfo.Caption!, out List<RecentRepoInfo> list);
             if (!existsShortName)
             {
-                list = new List<RecentRepoInfo>();
+                list = [];
                 orderedRepos.Add(repoInfo.Caption!, list);
             }
 
-            List<RecentRepoInfo> tmpList = new();
+            List<RecentRepoInfo> tmpList = [];
             if (existsShortName)
             {
                 for (int i = list.Count - 1; i >= 0; i--)
@@ -351,7 +351,7 @@
 
             if (!orderedRepos.TryGetValue(repoInfo.Caption!, out List<RecentRepoInfo> list))
             {
-                list = new List<RecentRepoInfo>();
+                list = [];
                 orderedRepos.Add(repoInfo.Caption!, list);
             }
 

--- a/GitCommands/Utils/WeakRefCache.cs
+++ b/GitCommands/Utils/WeakRefCache.cs
@@ -7,7 +7,7 @@ namespace GitCommands.Utils
 {
     public class WeakRefCache : IDisposable
     {
-        private readonly Dictionary<string, WeakReference> _weakMap = new();
+        private readonly Dictionary<string, WeakReference> _weakMap = [];
         private readonly Timer _clearTimer = new(60 * 1000);
 
         public static readonly WeakRefCache Default = new();

--- a/GitExtUtils/GitUI/ControlThreadingExtensions.cs
+++ b/GitExtUtils/GitUI/ControlThreadingExtensions.cs
@@ -15,7 +15,7 @@ namespace GitUI
             cts.Cancel();
             _preCancelledToken = cts.Token;
 
-            _controlDisposed = new ConditionalWeakTable<IComponent, StrongBox<CancellationToken>>();
+            _controlDisposed = [];
         }
 
 #pragma warning disable VSTHRD004 // Await SwitchToMainThreadAsync

--- a/GitExtUtils/GitUI/Theming/ThemeFix.cs
+++ b/GitExtUtils/GitUI/Theming/ThemeFix.cs
@@ -7,10 +7,10 @@ namespace GitExtUtils.GitUI.Theming
     public static class ThemeFix
     {
         private static readonly ConditionalWeakTable<IWin32Window, IWin32Window> AlreadyFixedControls =
-            new();
+            [];
 
         private static readonly ConditionalWeakTable<IWin32Window, IWin32Window> AlreadyFixedContextMenuOwners =
-            new();
+            [];
 
         public static ThemeSettings ThemeSettings { private get; set; } = ThemeSettings.Default;
 

--- a/GitExtUtils/GitUI/ToolStripExThemeAwareRenderer.cs
+++ b/GitExtUtils/GitUI/ToolStripExThemeAwareRenderer.cs
@@ -5,7 +5,7 @@ namespace GitUI
 {
     internal sealed class ToolStripExThemeAwareRenderer : ToolStripExProfessionalRenderer
     {
-        private static readonly ConditionalWeakTable<Bitmap, Bitmap> AdaptedImagesCache = new();
+        private static readonly ConditionalWeakTable<Bitmap, Bitmap> AdaptedImagesCache = [];
 
         public ToolStripExThemeAwareRenderer()
         {

--- a/GitExtUtils/GitUI/ToolStripExtensions.cs
+++ b/GitExtUtils/GitUI/ToolStripExtensions.cs
@@ -5,10 +5,10 @@ namespace GitUI
 {
     public static class ToolStripExtensions
     {
-        private static readonly ConditionalWeakTable<ToolStrip, IMenuItemBackgroundFilter> MenuItemBackgroundFilters = new();
-        private static readonly ConditionalWeakTable<ToolStrip, ToolStripExSystemRenderer> ExtendedSystemRenderers = new();
-        private static readonly ConditionalWeakTable<ToolStrip, ToolStripExProfessionalRenderer> ExtendedProfessionalRenderers = new();
-        private static readonly ConditionalWeakTable<ToolStrip, ToolStripExThemeAwareRenderer> ExtendedThemeAwareRenderers = new();
+        private static readonly ConditionalWeakTable<ToolStrip, IMenuItemBackgroundFilter> MenuItemBackgroundFilters = [];
+        private static readonly ConditionalWeakTable<ToolStrip, ToolStripExSystemRenderer> ExtendedSystemRenderers = [];
+        private static readonly ConditionalWeakTable<ToolStrip, ToolStripExProfessionalRenderer> ExtendedProfessionalRenderers = [];
+        private static readonly ConditionalWeakTable<ToolStrip, ToolStripExThemeAwareRenderer> ExtendedThemeAwareRenderers = [];
 
         public static void AttachMenuItemBackgroundFilter(this ToolStrip toolStrip, IMenuItemBackgroundFilter? value)
         {

--- a/GitExtUtils/Linq/LinqExtensions.cs
+++ b/GitExtUtils/Linq/LinqExtensions.cs
@@ -125,7 +125,7 @@ namespace System.Linq
                 return Array.Empty<T>();
             }
 
-            List<T> list = new();
+            List<T> list = [];
 
             do
             {

--- a/GitExtensions.ruleset
+++ b/GitExtensions.ruleset
@@ -10,6 +10,7 @@
     <Rule Id="VSTHRD110" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1010" Action="None" />
     <Rule Id="SA1101" Action="None" />
     <Rule Id="SA1116" Action="None" />
     <Rule Id="SA1117" Action="None" />

--- a/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -25,7 +25,7 @@ namespace GitUI.AutoCompletion
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            HashSet<string> autoCompleteWords = new();
+            HashSet<string> autoCompleteWords = [];
 
             IGitModule module = GetModule();
             ArgumentString cmd = Commands.GetAllChangedFiles(true, UntrackedFilesMode.Default, noLocks: true);
@@ -133,7 +133,7 @@ namespace GitUI.AutoCompletion
         {
             IEnumerable<string> autoCompleteRegexes = ReadOrInitializeAutoCompleteRegexes();
 
-            Dictionary<string, Regex> regexes = new();
+            Dictionary<string, Regex> regexes = [];
 
             foreach (string line in autoCompleteRegexes)
             {

--- a/GitUI/Avatars/StaticImageAvatarProvider.cs
+++ b/GitUI/Avatars/StaticImageAvatarProvider.cs
@@ -3,7 +3,7 @@
     public sealed class StaticImageAvatarProvider : IAvatarProvider
     {
         private readonly Image _image;
-        private readonly Dictionary<int, Image> _sizeCache = new();
+        private readonly Dictionary<int, Image> _sizeCache = [];
 
         public StaticImageAvatarProvider(Image image)
         {

--- a/GitUI/Avatars/TemplateFormatter.cs
+++ b/GitUI/Avatars/TemplateFormatter.cs
@@ -18,7 +18,7 @@ namespace GitUI.Avatars
         /// </remarks>
         public static Func<TInput, string> Create<TInput>(string template, Func<string, Func<TInput, string?>> valueMapperProvider)
         {
-            List<Action<StringBuilder, TInput>> formatParts = new();
+            List<Action<StringBuilder, TInput>> formatParts = [];
             int position = 0;
 
             while (true)

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/FormDashboardCategoryTitle.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/FormDashboardCategoryTitle.cs
@@ -7,7 +7,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
         private readonly TranslationString _categoryNameRequiredText = new("Category name is required");
         private readonly TranslationString _categoryNameExistsText = new("Category name already exists");
         private readonly TranslationString _renameCategoryText = new("Rename category");
-        private readonly List<string> _existingCategories = new();
+        private readonly List<string> _existingCategories = [];
 
         public FormDashboardCategoryTitle()
         {

--- a/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/DashboardControl/UserRepositoriesListController.cs
@@ -65,8 +65,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog.DashboardControl
 
         public (IReadOnlyList<RecentRepoInfo> recentRepositories, IReadOnlyList<RecentRepoInfo> favouriteRepositories) PreRenderRepositories(Graphics g, string pattern)
         {
-            List<RecentRepoInfo> pinnedRepos = new();
-            List<RecentRepoInfo> allRecentRepos = new();
+            List<RecentRepoInfo> pinnedRepos = [];
+            List<RecentRepoInfo> allRecentRepos = [];
 
             RecentRepoSplitter splitter = new()
             {

--- a/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormBrowseMenus.cs
@@ -32,7 +32,7 @@ namespace GitUI.CommandsDialogs
 
         // we have to remember which items we registered with the menucommands because other
         // location (RevisionGrid) can register items too!
-        private readonly List<ToolStripMenuItem> _itemsRegisteredWithMenuCommand = new();
+        private readonly List<ToolStripMenuItem> _itemsRegisteredWithMenuCommand = [];
 
         public FormBrowseMenus(ToolStrip menuStrip)
         {
@@ -279,7 +279,7 @@ namespace GitUI.CommandsDialogs
                 case MainMenuItem.NavigateMenu:
                     if (_navigateMenuCommands is null)
                     {
-                        _navigateMenuCommands = new List<MenuCommand>();
+                        _navigateMenuCommands = [];
                     }
                     else
                     {
@@ -292,7 +292,7 @@ namespace GitUI.CommandsDialogs
                 case MainMenuItem.ViewMenu:
                     if (_viewMenuCommands is null)
                     {
-                        _viewMenuCommands = new List<MenuCommand>();
+                        _viewMenuCommands = [];
                     }
                     else
                     {
@@ -385,7 +385,7 @@ namespace GitUI.CommandsDialogs
         {
             toolStripMenuItemTarget.DropDownItems.Clear();
 
-            List<ToolStripItem> toolStripItems = new();
+            List<ToolStripItem> toolStripItems = [];
             foreach (MenuCommand menuCommand in menuCommands)
             {
                 ToolStripItem toolStripItem = MenuCommand.CreateToolStripItem(menuCommand);

--- a/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormRecentReposSettings.cs
@@ -108,8 +108,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 PinnedLB.Items.Clear();
                 AllRecentLB.Items.Clear();
 
-                List<RecentRepoInfo> pinnedRepos = new();
-                List<RecentRepoInfo> allRecentRepos = new();
+                List<RecentRepoInfo> pinnedRepos = [];
+                List<RecentRepoInfo> allRecentRepos = [];
 
                 RecentRepoSplitter splitter = new()
                 {
@@ -267,7 +267,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
                 lb = null;
             }
 
-            repos = new List<RecentRepoInfo>();
+            repos = [];
             if (lb?.SelectedItems.Count > 0)
             {
                 foreach (ListViewItem item in lb.SelectedItems)

--- a/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/MenuCommand.cs
@@ -71,7 +71,7 @@
             return toolStripMenuItem;
         }
 
-        private readonly List<ToolStripMenuItem> _registeredMenuItems = new();
+        private readonly List<ToolStripMenuItem> _registeredMenuItems = [];
 
         /// <summary>
         /// if true all other properties have no meaning.

--- a/GitUI/CommandsDialogs/CommitDialog/WordWrapper.cs
+++ b/GitUI/CommandsDialogs/CommitDialog/WordWrapper.cs
@@ -29,7 +29,7 @@ namespace GitUI.CommandsDialogs.CommitDialog
 
         private class WrapperState
         {
-            private readonly List<string> _wordList = new();
+            private readonly List<string> _wordList = [];
             private int _wordsLength;
             private readonly int _lineLimit;
 

--- a/GitUI/CommandsDialogs/FormApplyPatch.cs
+++ b/GitUI/CommandsDialogs/FormApplyPatch.cs
@@ -43,7 +43,7 @@ namespace GitUI.CommandsDialogs
 
         #endregion
 
-        private static readonly List<PatchFile> Skipped = new();
+        private static readonly List<PatchFile> Skipped = [];
 
         public FormApplyPatch(GitUICommands commands)
             : base(commands)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -224,7 +224,7 @@ namespace GitUI.CommandsDialogs
 
         private TabPage? _consoleTabPage;
 
-        private readonly Dictionary<Brush, Icon> _overlayIconByBrush = new();
+        private readonly Dictionary<Brush, Icon> _overlayIconByBrush = [];
 
         private UpdateTargets _selectedRevisionUpdatedTargets = UpdateTargets.None;
 

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -37,7 +37,7 @@ namespace GitUI.CommandsDialogs
         private string _localBranchName = "";
         private readonly IGitBranchNameNormaliser _branchNameNormaliser;
         private readonly GitBranchNameOptions _gitBranchNameOptions = new(AppSettings.AutoNormaliseSymbol);
-        private readonly Dictionary<Control, int> _controls = new();
+        private readonly Dictionary<Control, int> _controls = [];
 
         private IReadOnlyList<IGitRef>? _localBranches;
         private IReadOnlyList<IGitRef>? _remoteBranches;
@@ -216,7 +216,7 @@ namespace GitUI.CommandsDialogs
 
             IReadOnlyList<string> GetContainsRevisionBranches()
             {
-                HashSet<string> result = new();
+                HashSet<string> result = [];
                 if (_containRevisions.Count > 0)
                 {
                     IEnumerable<string> branches = Module.GetAllBranchesWhichContainGivenCommit(_containRevisions[0], LocalBranch.Checked,

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -107,7 +107,7 @@ namespace GitUI.CommandsDialogs
 
         private void btnPick_Click(object sender, EventArgs e)
         {
-            ArgumentBuilder args = new();
+            ArgumentBuilder args = [];
             bool canExecute = true;
 
             if (_isMerge)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -165,7 +165,7 @@ namespace GitUI.CommandsDialogs
         private readonly SplitterManager _splitterManager = new(new AppSettingsPath("CommitDialog"));
         private readonly Subject<string> _selectionFilterSubject = new();
         private readonly IFullPathResolver _fullPathResolver;
-        private readonly List<string> _formattedLines = new();
+        private readonly List<string> _formattedLines = [];
 
         private CommitKind _commitKind;
         private FileStatusList _currentFilesList;
@@ -619,11 +619,11 @@ namespace GitUI.CommandsDialogs
 
         public void LoadCustomDifftools()
         {
-            List<CustomDiffMergeTool> menus = new()
-            {
+            List<CustomDiffMergeTool> menus =
+            [
                 new(openWithDifftoolToolStripMenuItem, openWithDifftoolToolStripMenuItem_Click),
                 new(stagedOpenDifftoolToolStripMenuItem9, stagedOpenDifftoolToolStripMenuItem9_Click),
-            };
+            ];
 
             new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true, cancellationToken: _customDiffToolsSequence.Next());
         }
@@ -1038,8 +1038,8 @@ namespace GitUI.CommandsDialogs
         {
             IReadOnlyList<GitItemStatus> lastSelection = _currentSelection ?? Array.Empty<GitItemStatus>();
 
-            List<GitItemStatus> unstagedFiles = new();
-            List<GitItemStatus> stagedFiles = new();
+            List<GitItemStatus> unstagedFiles = [];
+            List<GitItemStatus> stagedFiles = [];
 
             foreach (GitItemStatus fileStatus in allChangedFiles)
             {
@@ -1959,7 +1959,7 @@ namespace GitUI.CommandsDialogs
                     toolStripProgressBar1.Maximum = items.Count * 2;
                     toolStripProgressBar1.Value = 0;
 
-                    List<GitItemStatus> files = new();
+                    List<GitItemStatus> files = [];
 
                     foreach (GitItemStatus item in items)
                     {
@@ -1983,14 +1983,14 @@ namespace GitUI.CommandsDialogs
                         InitializedStaged();
                         List<GitItemStatus> unstagedFiles = Unstaged.GitItemStatuses.ToList();
                         _skipUpdate = true;
-                        HashSet<string?> names = new();
+                        HashSet<string?> names = [];
                         foreach (GitItemStatus item in files)
                         {
                             names.Add(item.Name);
                             names.Add(item.OldName);
                         }
 
-                        HashSet<GitItemStatus> unstagedItems = new();
+                        HashSet<GitItemStatus> unstagedItems = [];
 
                         foreach (GitItemStatus item in unstagedFiles)
                         {

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -42,7 +42,7 @@ namespace GitUI.CommandsDialogs
             }
             else
             {
-                _mergedBranches = new();
+                _mergedBranches = [];
                 foreach (string branch in Module.GetMergedBranches())
                 {
                     if (branch.StartsWith("* "))

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -75,7 +75,7 @@ namespace GitUI.CommandsDialogs
 
             RevisionGrid.SelectedId = revision?.ObjectId;
             RevisionGrid.ShowBuildServerInfo = true;
-            RevisionGrid.FilePathByObjectId = new();
+            RevisionGrid.FilePathByObjectId = [];
 
             FileName = fileName;
             SetTitle();
@@ -190,11 +190,11 @@ namespace GitUI.CommandsDialogs
 
         public void LoadCustomDifftools()
         {
-            List<CustomDiffMergeTool> menus = new()
-            {
+            List<CustomDiffMergeTool> menus =
+            [
                 new(openWithDifftoolToolStripMenuItem, OpenWithDifftoolToolStripMenuItem_Click),
                 new(diffToolRemoteLocalStripMenuItem, diffToolRemoteLocalStripMenuItem_Click),
-            };
+            ];
 
             new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true, cancellationToken: _customDiffToolsSequence.Next());
         }

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -325,7 +325,7 @@ namespace GitUI.CommandsDialogs
                         // It only returns the heads that are already known to the repository. This
                         // doesn't return heads that are new on the server. This can be updated using
                         // update branch info in the manage remotes dialog.
-                        _heads = new List<IGitRef>();
+                        _heads = [];
                         foreach (IGitRef head in Module.GetRefs(RefsFilter.Remotes))
                         {
                             if (!head.Name.StartsWith(_NO_TRANSLATE_Remotes.Text, StringComparison.CurrentCultureIgnoreCase))

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -410,7 +410,7 @@ namespace GitUI.CommandsDialogs
             else
             {
                 // Push Multiple Branches Tab selected
-                List<GitPushAction> pushActions = new();
+                List<GitPushAction> pushActions = [];
                 Validates.NotNull(_branchTable);
                 foreach (DataRow row in _branchTable.Rows)
                 {

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -46,7 +46,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _hoverShowImageLabelText = new("Hover to see scenario when fast forward is possible.");
         #endregion
 
-        private static readonly List<PatchFile> Skipped = new();
+        private static readonly List<PatchFile> Skipped = [];
 
         private readonly string? _defaultBranch;
         private readonly string? _defaultToBranch;
@@ -101,7 +101,7 @@ namespace GitUI.CommandsDialogs
 
             // Offer rebase on refs also for tags (but not stash, notes etc)
             List<GitRef> refs = _startRebaseImmediately
-                ? new()
+                ? []
                 : Module.GetRefs(RefsFilter.Heads | RefsFilter.Remotes | RefsFilter.Tags).OfType<GitRef>().ToList();
             cboBranches.DataSource = refs;
             cboBranches.DisplayMember = nameof(GitRef.Name);

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -57,9 +57,12 @@ namespace GitUI.CommandsDialogs
             lblDirtyWorkingDirectory.Visible = _isDirtyDir;
             resetCurrentBranchOnThisCommitToolStripMenuItem.Enabled = _isBranchCheckedOut;
 
-            List<string> branches = new() { "HEAD" };
-            branches.AddRange(UICommands.Module.GetRefs(RefsFilter.Heads).Select(r => r.Name).OrderBy(n => n));
-            branches.AddRange(UICommands.Module.GetRemoteBranches().Select(r => r.Name).OrderBy(n => n));
+            List<string> branches =
+            [
+                "HEAD",
+                .. UICommands.Module.GetRefs(RefsFilter.Heads).Select(r => r.Name).OrderBy(n => n),
+                .. UICommands.Module.GetRemoteBranches().Select(r => r.Name).OrderBy(n => n),
+            ];
             Branches.DataSource = branches;
         }
 

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -301,10 +301,10 @@ namespace GitUI.CommandsDialogs
 
         private void LoadCustomMergetools()
         {
-            List<CustomDiffMergeTool> menus = new()
-            {
+            List<CustomDiffMergeTool> menus =
+            [
                 new(customMergetool, customMergetool_Click),
-            };
+            ];
 
             const int ToolDelay = 500;
             new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: false, ToolDelay, cancellationToken: _customDiffToolsSequence.Next());
@@ -366,14 +366,14 @@ namespace GitUI.CommandsDialogs
             string filePath = _fullPathResolver.Resolve(fileName);
             DateTime lastWriteTimeBeforeMerge = File.Exists(filePath) ? File.GetLastWriteTime(filePath) : DateTime.Now;
 
-            ArgumentBuilder args = new()
-            {
+            ArgumentBuilder args =
+            [
                 mergeScript.Quote(),
                 FixPath(filePath).Quote(),
                 FixPath(remoteFileName).Quote(),
                 FixPath(localFileName).Quote(),
                 FixPath(baseFileName).Quote()
-            };
+            ];
 
             new Executable("wscript", Module.WorkingDir).Start(args);
 
@@ -1189,9 +1189,9 @@ namespace GitUI.CommandsDialogs
                     IReadOnlyList<ConflictData> items = GetConflicts();
                     _conflictItemsCount = items.Count;
 
-                    List<ConflictData> filesDeletedLocallyAndModifiedRemotely = new();
-                    List<ConflictData> filesModifiedLocallyAndDeletedRemotely = new();
-                    List<ConflictData> filesRemaining = new();
+                    List<ConflictData> filesDeletedLocallyAndModifiedRemotely = [];
+                    List<ConflictData> filesModifiedLocallyAndDeletedRemotely = [];
+                    List<ConflictData> filesRemaining = [];
 
                     // Insert(0, conflictData) is needed the task dialog shows the same order of files as selected in the grid
                     foreach (ConflictData conflictData in items)

--- a/GitUI/CommandsDialogs/FormSubmodules.cs
+++ b/GitUI/CommandsDialogs/FormSubmodules.cs
@@ -17,7 +17,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _removeSelectedSubmodule = new("Are you sure you want remove the selected submodule?");
         private readonly TranslationString _removeSelectedSubmoduleCaption = new("Remove");
 
-        private readonly BindingList<IGitSubmoduleInfo?> _modules = new();
+        private readonly BindingList<IGitSubmoduleInfo?> _modules = [];
         private GitSubmoduleInfo? _oldSubmoduleInfo;
 
         public FormSubmodules(GitUICommands commands)

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -18,7 +18,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _selectLostObjectsToRestoreMessage = new("Select objects to restore.");
         private readonly TranslationString _selectLostObjectsToRestoreCaption = new("Restore lost objects");
 
-        private readonly List<LostObject> _lostObjects = new();
+        private readonly List<LostObject> _lostObjects = [];
         private readonly SortableLostObjectsList _filteredLostObjects = new();
         private readonly DataGridViewCheckBoxHeaderCell _selectedItemsHeader = new();
         private readonly IGitTagController _gitTagController;

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -371,10 +371,10 @@ namespace GitUI.CommandsDialogs.RepoHosting
 
         private void SplitAndLoadDiff(string diffData, string baseSha, string secondSha)
         {
-            _diffCache = new Dictionary<string, string>();
+            _diffCache = [];
 
             List<string> fileParts = Regex.Split(diffData, @"(?:\n|^)diff --git ").Where(el => el?.Trim().Length is > 10).ToList();
-            List<GitItemStatus> giss = new();
+            List<GitItemStatus> giss = [];
 
             // baseSha is the sha of the merge to ("master") sha, the commit to be firstId
             GitRevision? firstRev = ObjectId.TryParse(baseSha, out ObjectId? firstId) ? new GitRevision(firstId) : null;

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -212,14 +212,14 @@ namespace GitUI.CommandsDialogs
 
         public void LoadCustomDifftools()
         {
-            List<CustomDiffMergeTool> menus = new()
-            {
+            List<CustomDiffMergeTool> menus =
+            [
                 new(firstToSelectedToolStripMenuItem, firstToSelectedToolStripMenuItem_Click),
                 new(selectedToLocalToolStripMenuItem, selectedToLocalToolStripMenuItem_Click),
                 new(firstToLocalToolStripMenuItem, firstToLocalToolStripMenuItem_Click),
                 new(diffWithRememberedDifftoolToolStripMenuItem, diffWithRememberedDiffToolToolStripMenuItem_Click),
                 new(diffTwoSelectedDifftoolToolStripMenuItem, diffTwoSelectedDiffToolToolStripMenuItem_Click)
-            };
+            ];
 
             new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true, cancellationToken: _customDiffToolsSequence.Next());
         }

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -188,7 +188,7 @@ See the changes in the commit form.");
                 tvGitTree.BeginUpdate();
 
                 // Save state only when there is selected node
-                List<string> tryNodes = new();
+                List<string> tryNodes = [];
 
                 // When blame control is visible, taking the filename from the revision selected to blame
                 // because the file could have been renamed in between
@@ -502,7 +502,7 @@ See the changes in the commit form.");
         {
             if (e.Item is TreeNode { Tag: GitItem gitItem })
             {
-                StringCollection fileList = new();
+                StringCollection fileList = [];
                 string fileName = _fullPathResolver.Resolve(gitItem.FileName);
 
                 fileList.Add(fileName.ToNativePath());

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigAdvancedSettingsPage.cs
@@ -14,14 +14,14 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             InitializeComponent();
             InitializeComplete();
 
-            _gitSettings = new List<GitSettingUiMapping>
-            {
+            _gitSettings =
+            [
                 new("pull.rebase", checkBoxPullRebase),
                 new("fetch.prune", checkBoxFetchPrune),
                 new("rebase.autoStash", checkBoxRebaseAutostash),
                 new("rebase.autosquash", checkBoxRebaseAutosquash),
                 new("rebase.updateRefs", checkBoxUpdateRefs)
-            };
+            ];
 
             checkBoxUpdateRefs.Visible = GitVersion.Current.SupportUpdateRefs;
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -82,7 +82,7 @@ Currently checked out revision:
             ColorDepth = ColorDepth.Depth32Bit
         };
 
-        private readonly BindingList<ScriptInfoProxy> _scripts = new();
+        private readonly BindingList<ScriptInfoProxy> _scripts = [];
         private readonly IScriptsManager _scriptsManager;
         private SimpleHelpDisplayDialog? _argumentsCheatSheet;
         private bool _handlingCheck;

--- a/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/AzureDevopsExternalLinkDefinitionExtractor.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/AzureDevopsExternalLinkDefinitionExtractor.cs
@@ -17,7 +17,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
 
         public override IList<ExternalLinkDefinition> GetDefinitions(string remoteUrl)
         {
-            List<ExternalLinkDefinition> externalLinkDefinitions = new();
+            List<ExternalLinkDefinition> externalLinkDefinitions = [];
             string? accountName = null;
             string? repoName = null;
 

--- a/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/GitHubExternalLinkDefinitionExtractor.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/RevisionLinks/GitHubExternalLinkDefinitionExtractor.cs
@@ -17,7 +17,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.RevisionLinks
 
         public override IList<ExternalLinkDefinition> GetDefinitions(string remoteUrl)
         {
-            List<ExternalLinkDefinition> externalLinkDefinitions = new();
+            List<ExternalLinkDefinition> externalLinkDefinitions = [];
             string? organizationName = null;
             string? repoName = null;
 

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsPageBase.cs
@@ -12,7 +12,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
     /// </summary>
     public abstract partial class SettingsPageBase : GitExtensionsControl, ISettingsPage
     {
-        private readonly List<ISettingControlBinding> _controlBindings = new();
+        private readonly List<ISettingControlBinding> _controlBindings = [];
         private IReadOnlyList<string>? _childrenText;
         private ISettingsPageHost? _pageHost;
 
@@ -174,7 +174,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog
         /// </summary>
         private static IReadOnlyList<string> GetChildrenText(Control control)
         {
-            List<string> texts = new();
+            List<string> texts = [];
 
             Queue<Control> queue = new();
             queue.Enqueue(control);

--- a/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/SettingsTreeViewUserControl.cs
@@ -8,9 +8,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog
     public sealed partial class SettingsTreeViewUserControl : UserControl
     {
         private bool _isSelectionChangeTriggeredByGoto;
-        private List<TreeNode> _nodesFoundByTextBox = new();
-        private readonly Dictionary<SettingsPageReference, TreeNode> _pages2NodeMap = new();
-        private readonly List<ISettingsPage> _settingsPages = new();
+        private List<TreeNode> _nodesFoundByTextBox = [];
+        private readonly Dictionary<SettingsPageReference, TreeNode> _pages2NodeMap = [];
+        private readonly List<ISettingsPage> _settingsPages = [];
 
         public event EventHandler<SettingsPageSelectedEventArgs>? SettingsPageSelected;
         public IEnumerable<ISettingsPage> SettingsPages => _settingsPages;

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -59,7 +59,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
             };
             string lines = Module.GitExecutable.GetOutput(args);
 
-            _worktrees = new List<WorkTree>();
+            _worktrees = [];
             WorkTree? currentWorktree = null;
             foreach (string line in lines.LazySplit('\n'))
             {

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -264,7 +264,7 @@ namespace GitUI.CommitInfo
             }
 
             int i = 0;
-            Dictionary<string, int> dict = new();
+            Dictionary<string, int> dict = [];
             foreach (string entry in tree.LazySplit('\n'))
             {
                 if (dict.ContainsKey(entry))
@@ -371,11 +371,10 @@ namespace GitUI.CommitInfo
 
                 ThreadHelper.FileAndForget(async () =>
                 {
-                    List<Task> tasks = new()
-                    {
+                    List<Task> tasks = [
                         UpdateCommitMessageAsync().WithCancellation(cancellationToken),
                         LoadLinksForRevisionAsync(initialRevision, settings).WithCancellation(cancellationToken)
-                    };
+                    ];
 
                     // No branch/tag data for artificial commands
                     if (AppSettings.CommitInfoShowContainedInBranches)
@@ -466,7 +465,7 @@ namespace GitUI.CommitInfo
                             return null;
                         }
 
-                        Dictionary<string, string> result = new();
+                        Dictionary<string, string> result = [];
 
                         foreach (IGitRef gitRef in refs)
                         {
@@ -833,7 +832,7 @@ namespace GitUI.CommitInfo
             private const string _remoteBranchPrefix = "remotes/";
             private readonly string _currentBranch;
             private readonly bool _isDetachedHead;
-            private readonly Dictionary<string, int> _orderByBranch = new();
+            private readonly Dictionary<string, int> _orderByBranch = [];
 
             public BranchComparer(List<string> branches, string currentBranch)
             {

--- a/GitUI/CommitInfo/RefsFormatter.cs
+++ b/GitUI/CommitInfo/RefsFormatter.cs
@@ -57,7 +57,7 @@ namespace GitUI.CommitInfo
 
         private (IEnumerable<string> formattedBranches, bool truncated) FilterAndFormatBranches(IEnumerable<string> branches, bool showAsLinks, bool limit)
         {
-            List<string> formattedBranches = new();
+            List<string> formattedBranches = [];
             bool truncated = false;
 
             const string remotesPrefix = "remotes/";

--- a/GitUI/Design/PropertySorter.cs
+++ b/GitUI/Design/PropertySorter.cs
@@ -12,7 +12,7 @@ namespace GitUI.Design
         public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
         {
             PropertyDescriptorCollection pdc = TypeDescriptor.GetProperties(value, attributes);
-            List<(string, int)> orderedProperties = new();
+            List<(string, int)> orderedProperties = [];
             foreach (PropertyDescriptor pd in pdc)
             {
                 Attribute attribute = pd.Attributes[typeof(PropertyOrderAttribute)];

--- a/GitUI/Editor/BlameAuthorMargin.cs
+++ b/GitUI/Editor/BlameAuthorMargin.cs
@@ -12,7 +12,7 @@ namespace GitUI.Editor
         private List<Image?>? _avatars;
         private readonly Color _backgroundColor;
         private List<GitBlameEntry>? _blameLines;
-        private readonly Dictionary<int, SolidBrush> _brushs = new();
+        private readonly Dictionary<int, SolidBrush> _brushs = [];
         private bool _isVisible = true;
 
         public BlameAuthorMargin(TextArea textArea) : base(textArea)

--- a/GitUI/Editor/CommitMessageHighlightingStrategy.cs
+++ b/GitUI/Editor/CommitMessageHighlightingStrategy.cs
@@ -8,7 +8,7 @@ namespace GitUI.Editor
     {
         private static HighlightColor ColorSummary { get; } = new(SystemColors.WindowText, bold: true, italic: false);
 
-        private readonly List<TextMarker> _overlengthDescriptionMarkers = new();
+        private readonly List<TextMarker> _overlengthDescriptionMarkers = [];
 
         private readonly TextMarker _markerSummaryTooLong = new(0, 0, TextMarkerType.WaveLine, Color.Red) { ToolTip = "Summary line is too long." };
         private readonly TextMarker _markerSpacerNeeded = new(0, 0, TextMarkerType.WaveLine, Color.Red) { ToolTip = "There must be a blank line after the summary." };

--- a/GitUI/Editor/Diff/DiffLinesInfo.cs
+++ b/GitUI/Editor/Diff/DiffLinesInfo.cs
@@ -2,7 +2,7 @@
 {
     public sealed class DiffLinesInfo
     {
-        private readonly Dictionary<int, DiffLineInfo> _diffLines = new();
+        private readonly Dictionary<int, DiffLineInfo> _diffLines = [];
 
         public IReadOnlyDictionary<int, DiffLineInfo> DiffLines => _diffLines;
 

--- a/GitUI/Editor/Diff/LinePrefixHelper.cs
+++ b/GitUI/Editor/Diff/LinePrefixHelper.cs
@@ -18,7 +18,7 @@ namespace GitUI.Editor.Diff
 
         public List<ISegment> GetLinesStartingWith(IDocument document, ref int beginIndex, string[] prefixStrs, ref bool found)
         {
-            List<ISegment> result = new();
+            List<ISegment> result = [];
 
             while (beginIndex < document.TotalNumberOfLines)
             {

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -115,7 +115,7 @@ namespace GitUI.Editor
                 return Array.Empty<TextMarker>();
             }
 
-            List<TextMarker> selectionMarkers = new();
+            List<TextMarker> selectionMarkers = [];
 
             string textContent = TextEditor.Document.TextContent;
             int indexMatch = -1;

--- a/GitUI/Editor/FindAndReplaceForm.cs
+++ b/GitUI/Editor/FindAndReplaceForm.cs
@@ -30,7 +30,7 @@ namespace GitUI
             new("Replaced {0} occurrences.");
 
         private readonly Dictionary<TextEditorControl, HighlightGroup> _highlightGroups =
-            new();
+            [];
 
         private readonly TextEditorSearcher _search;
         private TextEditorControl? _editor;
@@ -700,7 +700,7 @@ namespace GitUI
     {
         private readonly IDocument _document;
         private readonly TextEditorControl _editor;
-        private readonly List<TextMarker> _markers = new();
+        private readonly List<TextMarker> _markers = [];
 
         public HighlightGroup(TextEditorControl editor)
         {

--- a/GitUI/Editor/GitHighlightingStrategyBase.cs
+++ b/GitUI/Editor/GitHighlightingStrategyBase.cs
@@ -57,7 +57,7 @@ namespace GitUI.Editor
 
         public string[] Extensions => Array.Empty<string>();
 
-        public Dictionary<string, string> Properties { get; } = new Dictionary<string, string>();
+        public Dictionary<string, string> Properties { get; } = [];
 
         public HighlightColor GetColorFor(string name)
         {

--- a/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -682,7 +682,7 @@ namespace GitUI.Editor.RichTextBoxExtension
             try
             {
                 // to store formatting
-                List<KeyValuePair<int, string>> colFormat = new();
+                List<KeyValuePair<int, string>> colFormat = [];
                 string strT = ProcessTags(rtb, colFormat, bParaFormat);
 
                 // apply format by replacing and inserting HTML tags
@@ -1226,7 +1226,7 @@ namespace GitUI.Editor.RichTextBoxExtension
             {
                 scf = new Stack<CHARFORMAT>();
                 spf = new Stack<PARAFORMAT>();
-                links = new List<KeyValuePair<int, int>>();
+                links = [];
                 hyperlink = null;
                 hyperlinkStart = -1;
                 charFormatChanged = false;

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1816,7 +1816,7 @@ namespace GitUI
 
         private static IReadOnlyDictionary<string, string?> InitializeArguments(IReadOnlyList<string> args)
         {
-            Dictionary<string, string?> arguments = new();
+            Dictionary<string, string?> arguments = [];
 
             for (int i = 2; i < args.Count; i++)
             {

--- a/GitUI/HelperDialogs/FormProcess.cs
+++ b/GitUI/HelperDialogs/FormProcess.cs
@@ -17,7 +17,7 @@ namespace GitUI.HelperDialogs
         public string? ProcessInput { get; }
         public readonly string WorkingDirectory;
         public HandleOnExit? HandleOnExitCallback { get; set; }
-        public readonly Dictionary<string, string> ProcessEnvVariables = new();
+        public readonly Dictionary<string, string> ProcessEnvVariables = [];
 
         private FormProcess(GitUICommands commands, ConsoleOutputControl? outputControl, ArgumentString arguments, string workingDirectory, string? input, bool useDialogSettings, string? process)
             : base(commands, outputControl, useDialogSettings)

--- a/GitUI/HelperDialogs/FormSelectMultipleBranches.cs
+++ b/GitUI/HelperDialogs/FormSelectMultipleBranches.cs
@@ -43,7 +43,7 @@ namespace GitUI.HelperDialogs
 
         public IReadOnlyList<IGitRef> GetSelectedBranches()
         {
-            List<IGitRef> branches = new();
+            List<IGitRef> branches = [];
 
             foreach (IGitRef head in Branches.CheckedItems)
             {

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -43,7 +43,7 @@ namespace GitUI.Hotkey
     internal class HotkeySettingsManager : IHotkeySettingsManager
     {
         private static readonly XmlSerializer? _serializer = new(typeof(HotkeySettings[]), new[] { typeof(HotkeyCommand) });
-        private readonly HashSet<Keys> _usedKeys = new();
+        private readonly HashSet<Keys> _usedKeys = [];
         private readonly IScriptsManager _scriptsManager;
 
         public HotkeySettingsManager(IScriptsManager scriptsManager)
@@ -110,7 +110,7 @@ namespace GitUI.Hotkey
                 return;
             }
 
-            Dictionary<string, HotkeyCommand> defaultCommands = new();
+            Dictionary<string, HotkeyCommand> defaultCommands = [];
 
             FillDictionaryWithCommands();
             AssignHotkeysFromLoaded();

--- a/GitUI/Hotkey/KeysExtensions.cs
+++ b/GitUI/Hotkey/KeysExtensions.cs
@@ -24,7 +24,7 @@ namespace GitUI.Hotkey
             // Retrieve the modifiers, mask away the rest
             Keys modifier = key & Keys.Modifiers;
 
-            List<Keys> modifierList = new();
+            List<Keys> modifierList = [];
 
             void AddIfContains(Keys m)
             {

--- a/GitUI/LeftPanel/BaseRefTree.cs
+++ b/GitUI/LeftPanel/BaseRefTree.cs
@@ -124,7 +124,7 @@ namespace GitUI.LeftPanel
                 Regex.CacheSize = (regexes.Length * 2) + additionalRegexCacheEntries;
             }
 
-            Dictionary<string, int> orderByNodeKey = new();
+            Dictionary<string, int> orderByNodeKey = [];
             foreach (T node in references)
             {
                 int currentOrder = 0;

--- a/GitUI/LeftPanel/ContextMenu/MenuItemsGenerator.cs
+++ b/GitUI/LeftPanel/ContextMenu/MenuItemsGenerator.cs
@@ -22,14 +22,14 @@ namespace GitUI.LeftPanel.ContextMenu
 
         private Dictionary<MenuItemKey, ToolStripItem> CreateItemsIndex()
         {
-            Dictionary<MenuItemKey, ToolStripItem> itemsIndex = new();
+            Dictionary<MenuItemKey, ToolStripItem> itemsIndex = [];
             _items.Value.ForEach(r => itemsIndex.Add(r.Key, r.Item));
             return itemsIndex;
         }
 
         private List<ToolStripItemWithKey> CreateItems()
         {
-            List<ToolStripItemWithKey> items = new();
+            List<ToolStripItemWithKey> items = [];
             Generate(items);
             return items;
         }

--- a/GitUI/LeftPanel/ContextMenu/MenuItemsStrings.cs
+++ b/GitUI/LeftPanel/ContextMenu/MenuItemsStrings.cs
@@ -21,7 +21,7 @@ namespace GitUI.LeftPanel.ContextMenu
         /// <see cref="ICanDelete"/>
         internal TranslationString Delete;
 
-        internal Dictionary<MenuItemKey, TranslationString> Tooltips { get; } = new Dictionary<MenuItemKey, TranslationString>();
+        internal Dictionary<MenuItemKey, TranslationString> Tooltips { get; } = [];
 
         public MenuItemsStrings()
         {

--- a/GitUI/LeftPanel/LocalBranchTree.cs
+++ b/GitUI/LeftPanel/LocalBranchTree.cs
@@ -53,7 +53,7 @@ namespace GitUI.LeftPanel
             Nodes nodes = new(this);
             IDictionary<string, AheadBehindData> aheadBehindData = _aheadBehindDataProvider?.GetData();
             string currentBranch = _revisionGridInfo.GetCurrentBranch();
-            Dictionary<string, BaseRevisionNode> pathToNode = new();
+            Dictionary<string, BaseRevisionNode> pathToNode = [];
             foreach (IGitRef branch in PrioritizedBranches(branches))
             {
                 token.ThrowIfCancellationRequested();

--- a/GitUI/LeftPanel/Nodes.cs
+++ b/GitUI/LeftPanel/Nodes.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class Nodes : IEnumerable<Node>
     {
-        private readonly List<Node> _nodesList = new();
+        private readonly List<Node> _nodesList = [];
 
         public Tree? Tree { get; }
 
@@ -65,7 +65,7 @@
         /// </summary>
         internal void FillTreeViewNode(TreeNode treeViewNode)
         {
-            HashSet<Node> prevNodes = new();
+            HashSet<Node> prevNodes = [];
 
             for (int i = 0; i < treeViewNode.Nodes.Count; i++)
             {

--- a/GitUI/LeftPanel/RemoteBranchTree.cs
+++ b/GitUI/LeftPanel/RemoteBranchTree.cs
@@ -21,10 +21,10 @@ namespace GitUI.LeftPanel
         {
             // More than one local can point to a single remote branch, pick one of them.
             Nodes nodes = new(this);
-            Dictionary<string, BaseRevisionNode> pathToNodes = new();
+            Dictionary<string, BaseRevisionNode> pathToNodes = [];
             IDictionary<string, AheadBehindData>? aheadBehindData = _aheadBehindDataProvider?.GetData()?.DistinctBy(r => r.Value.RemoteRef).ToDictionary(r => r.Value.RemoteRef, r => r.Value);
 
-            List<RemoteRepoNode> enabledRemoteRepoNodes = new();
+            List<RemoteRepoNode> enabledRemoteRepoNodes = [];
             Dictionary<string, Remote> remoteByName = ThreadHelper.JoinableTaskFactory.Run(Module.GetRemotesAsync).ToDictionary(r => r.Name);
 
             ConfigFileRemoteSettingsManager remotesManager = new(() => Module);
@@ -77,7 +77,7 @@ namespace GitUI.LeftPanel
             IReadOnlyList<Remote> disabledRemotes = remotesManager.GetDisabledRemotes();
             if (disabledRemotes.Count > 0)
             {
-                List<RemoteRepoNode> disabledRemoteRepoNodes = new();
+                List<RemoteRepoNode> disabledRemoteRepoNodes = [];
                 foreach (Remote remote in disabledRemotes)
                 {
                     RemoteRepoNode node = new(this, remote.Name, remotesManager, remote, false);

--- a/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -24,7 +24,7 @@ namespace GitUI.LeftPanel
 
         private NativeTreeViewDoubleClickDecorator _doubleClickDecorator;
         private NativeTreeViewExplorerNavigationDecorator _explorerNavigationDecorator;
-        private readonly List<Tree> _rootNodes = new();
+        private readonly List<Tree> _rootNodes = [];
         private readonly SearchControl<string> _txtBranchCriterion;
         private LocalBranchTree _branchesTree;
         private RemoteBranchTree _remotesTree;
@@ -169,7 +169,7 @@ namespace GitUI.LeftPanel
 
                 IEnumerable<string> CollectFilterCandidates()
                 {
-                    List<string> list = new();
+                    List<string> list = [];
 
                     foreach (TreeNode rootNode in treeMain.Nodes)
                     {
@@ -308,7 +308,7 @@ namespace GitUI.LeftPanel
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 HashSet<string> mergedBranches = selectedGuid is null
-                    ? new HashSet<string>()
+                    ? []
                     : (await Module.GetMergedBranchesAsync(includeRemote: true, fullRefname: true, commit: selectedGuid)).ToHashSet();
 
                 selectedRevision?.Refs.ForEach(gitRef => mergedBranches.Remove(gitRef.CompleteName));
@@ -509,7 +509,7 @@ namespace GitUI.LeftPanel
             List<TreeNode> SearchTree(string text, IEnumerable<TreeNode> nodes)
             {
                 Queue<TreeNode> queue = new(nodes);
-                List<TreeNode> ret = new();
+                List<TreeNode> ret = [];
 
                 while (queue.Count != 0)
                 {

--- a/GitUI/LeftPanel/StashTree.cs
+++ b/GitUI/LeftPanel/StashTree.cs
@@ -33,7 +33,7 @@ namespace GitUI.LeftPanel
         private Nodes FillStashTree(IReadOnlyCollection<GitRevision> stashes, CancellationToken token)
         {
             Nodes nodes = new(this);
-            Dictionary<string, BaseRevisionNode> pathToNodes = new();
+            Dictionary<string, BaseRevisionNode> pathToNodes = [];
 
             foreach (GitRevision stash in stashes)
             {

--- a/GitUI/LeftPanel/SubmoduleTree.cs
+++ b/GitUI/LeftPanel/SubmoduleTree.cs
@@ -194,7 +194,7 @@ namespace GitUI.LeftPanel
 
             Validates.NotNull(threadModule);
 
-            List<SubmoduleNode> submoduleNodes = new();
+            List<SubmoduleNode> submoduleNodes = [];
 
             // We always want to display submodules rooted from the top project.
             CreateSubmoduleNodes(result, threadModule, ref submoduleNodes);
@@ -291,7 +291,7 @@ namespace GitUI.LeftPanel
             GitModule topModule = threadModule.GetTopModule();
 
             // Build a mapping of top-module-relative path to node
-            Dictionary<string, Node> pathToNodes = new();
+            Dictionary<string, Node> pathToNodes = [];
 
             // Add existing SubmoduleNodes
             foreach (SubmoduleNode node in submoduleNodes)
@@ -317,7 +317,7 @@ namespace GitUI.LeftPanel
 
             // Now build the tree
             DummyNode rootNode = new();
-            HashSet<Node> nodesInTree = new();
+            HashSet<Node> nodesInTree = [];
             foreach (SubmoduleNode node in submoduleNodes)
             {
                 Node parentNode = rootNode;

--- a/GitUI/LeftPanel/TagTree.cs
+++ b/GitUI/LeftPanel/TagTree.cs
@@ -13,7 +13,7 @@ namespace GitUI.LeftPanel
         protected override Nodes FillTree(IReadOnlyList<IGitRef> tags, CancellationToken token)
         {
             Nodes nodes = new(this);
-            Dictionary<string, BaseRevisionNode> pathToNodes = new();
+            Dictionary<string, BaseRevisionNode> pathToNodes = [];
 
             foreach (IGitRef tag in tags)
             {

--- a/GitUI/LeftPanel/Tree.cs
+++ b/GitUI/LeftPanel/Tree.cs
@@ -144,7 +144,7 @@ namespace GitUI.LeftPanel
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            HashSet<string> expandedNodesState = firstTime ? new HashSet<string>() : TreeViewNode.GetExpandedNodesState();
+            HashSet<string> expandedNodesState = firstTime ? [] : TreeViewNode.GetExpandedNodesState();
             Nodes.FillTreeViewNode(TreeViewNode);
 
             TreeNode selectedNode = TreeViewNode.TreeView.SelectedNode;

--- a/GitUI/Plugin/PluginRegistry.cs
+++ b/GitUI/Plugin/PluginRegistry.cs
@@ -9,7 +9,7 @@ namespace GitUI
     {
         public static IList<IGitPlugin> Plugins { get; } = new List<IGitPlugin>();
 
-        public static List<IRepositoryHostPlugin> GitHosters { get; } = new List<IRepositoryHostPlugin>();
+        public static List<IRepositoryHostPlugin> GitHosters { get; } = [];
 
         public static bool PluginsRegistered { get; private set; }
 

--- a/GitUI/RepositoryHistoryUIService.cs
+++ b/GitUI/RepositoryHistoryUIService.cs
@@ -89,8 +89,8 @@ namespace GitUI
 
         private void PopulateFavouriteRepositoriesMenu(ToolStripDropDownItem container, in IList<Repository> repositoryHistory)
         {
-            List<RecentRepoInfo> pinnedRepos = new();
-            List<RecentRepoInfo> allRecentRepos = new();
+            List<RecentRepoInfo> pinnedRepos = [];
+            List<RecentRepoInfo> allRecentRepos = [];
 
             using (Graphics graphics = OwnerForm.CreateGraphics())
             {
@@ -133,8 +133,8 @@ namespace GitUI
 
         public void PopulateRecentRepositoriesMenu(ToolStripDropDownItem container)
         {
-            List<RecentRepoInfo> pinnedRepos = new();
-            List<RecentRepoInfo> allRecentRepos = new();
+            List<RecentRepoInfo> pinnedRepos = [];
+            List<RecentRepoInfo> allRecentRepos = [];
 
             IList<Repository> repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync);
             if (repositoryHistory.Count < 1)

--- a/GitUI/ScriptsEngine/ScriptOptionsParser.cs
+++ b/GitUI/ScriptsEngine/ScriptOptionsParser.cs
@@ -96,16 +96,16 @@ namespace GitUI.ScriptsEngine
             GitRevision? currentRevision = null;
 
             IReadOnlyList<GitRevision> allSelectedRevisions = Array.Empty<GitRevision>();
-            List<IGitRef> selectedLocalBranches = new();
-            List<IGitRef> selectedRemoteBranches = new();
-            List<string> selectedRemotes = new();
-            List<IGitRef> selectedBranches = new();
-            List<IGitRef> selectedTags = new();
-            List<IGitRef> currentLocalBranches = new();
-            List<IGitRef> currentRemoteBranches = new();
+            List<IGitRef> selectedLocalBranches = [];
+            List<IGitRef> selectedRemoteBranches = [];
+            List<string> selectedRemotes = [];
+            List<IGitRef> selectedBranches = [];
+            List<IGitRef> selectedTags = [];
+            List<IGitRef> currentLocalBranches = [];
+            List<IGitRef> currentRemoteBranches = [];
             string currentRemote = "";
-            List<IGitRef> currentBranches = new();
-            List<IGitRef> currentTags = new();
+            List<IGitRef> currentBranches = [];
+            List<IGitRef> currentTags = [];
 
             foreach (string option in GetOptions(Options, scriptOptionsProvider))
             {

--- a/GitUI/ScriptsEngine/ScriptsManager.cs
+++ b/GitUI/ScriptsEngine/ScriptsManager.cs
@@ -28,7 +28,7 @@ namespace GitUI.ScriptsEngine
 
             static void FixAmbiguousHotkeyCommandIdentifiers(BindingList<ScriptInfo> loadedScripts)
             {
-                HashSet<int> ids = new();
+                HashSet<int> ids = [];
 
                 foreach (ScriptInfo script in loadedScripts)
                 {
@@ -189,7 +189,7 @@ namespace GitUI.ScriptsEngine
                 const string paramSeparator = "<_PARAM_SEPARATOR_>";
                 const string scriptSeparator = "<_SCRIPT_SEPARATOR_>";
 
-                BindingList<ScriptInfo> scripts = new();
+                BindingList<ScriptInfo> scripts = [];
 
                 if (inputString.Contains(paramSeparator) || inputString.Contains(scriptSeparator))
                 {

--- a/GitUI/SortableBindingList.cs
+++ b/GitUI/SortableBindingList.cs
@@ -9,7 +9,7 @@ namespace GitUI
     /// <remarks>The class is abstract so that it is not used directly.<br/>Instead, it is expected to be derived, with a static constructor adding sortable properties through the <see cref="AddSortableProperty{TValue}"/> method</remarks>
     public abstract class SortableBindingList<T> : BindingList<T>
     {
-        public static Dictionary<string, Comparison<T>> PropertyComparers { get; } = new();
+        public static Dictionary<string, Comparison<T>> PropertyComparers { get; } = [];
 
         private List<T> Elements => (List<T>)Items;
 

--- a/GitUI/SpellChecker/EditNetSpell.cs
+++ b/GitUI/SpellChecker/EditNetSpell.cs
@@ -36,7 +36,7 @@ namespace GitUI.SpellChecker
         private static WordDictionary? _wordDictionary;
 
         private CancellationTokenSource _autoCompleteCancellationTokenSource = new();
-        private readonly List<IAutoCompleteProvider> _autoCompleteProviders = new();
+        private readonly List<IAutoCompleteProvider> _autoCompleteProviders = [];
         private AsyncLazy<IEnumerable<AutoCompleteWord>?>? _autoCompleteListTask;
         private bool _autoCompleteWasUserActivated;
         private bool _disableAutoCompleteTriggerOnTextUpdate = true; // only popup on key press

--- a/GitUI/SpellChecker/SpellCheckEditControl.cs
+++ b/GitUI/SpellChecker/SpellCheckEditControl.cs
@@ -10,8 +10,8 @@ namespace GitUI.SpellChecker
         public bool IsImeStartingComposition { get; private set; }
 
         private readonly RichTextBox _richTextBox;
-        public List<TextPos> IllFormedLines { get; } = new List<TextPos>();
-        public List<TextPos> Lines { get; } = new List<TextPos>();
+        public List<TextPos> IllFormedLines { get; } = [];
+        public List<TextPos> Lines { get; } = [];
         private Bitmap? _bitmap;
         private Graphics? _bufferGraphics;
         private int _lineHeight;
@@ -156,7 +156,7 @@ namespace GitUI.SpellChecker
             int waveHalfWidth = waveWidth >> 1;
             if ((end.X - start.X) > waveWidth)
             {
-                List<Point> pl = new();
+                List<Point> pl = [];
                 for (int i = start.X; i <= (end.X - waveHalfWidth); i += waveWidth)
                 {
                     pl.Add(new Point(i, start.Y));

--- a/GitUI/SplitterManager.cs
+++ b/GitUI/SplitterManager.cs
@@ -5,7 +5,7 @@ namespace GitUI
 {
     public sealed class SplitterManager
     {
-        private readonly List<SplitterData> _splitters = new();
+        private readonly List<SplitterData> _splitters = [];
         private readonly ISettingsSource _settings;
 
         public SplitterManager(ISettingsSource settings)

--- a/GitUI/Theming/Renderers/ThemeRenderer.cs
+++ b/GitUI/Theming/Renderers/ThemeRenderer.cs
@@ -20,7 +20,7 @@ namespace GitUI.Theming
         /// </summary>
         public const int Handled = 0;
 
-        private readonly HashSet<IntPtr> _themeDataHandles = new();
+        private readonly HashSet<IntPtr> _themeDataHandles = [];
 
         protected abstract string Clsid { get; }
 

--- a/GitUI/Theming/SystemBrushesCache.cs
+++ b/GitUI/Theming/SystemBrushesCache.cs
@@ -5,7 +5,7 @@ namespace GitUI.Theming
 {
     internal class SystemBrushesCache : IDisposable
     {
-        private readonly Dictionary<int, HandleRef> _cache = new();
+        private readonly Dictionary<int, HandleRef> _cache = [];
 
         public void Dispose()
         {

--- a/GitUI/Theming/ThemeLoader.cs
+++ b/GitUI/Theming/ThemeLoader.cs
@@ -163,9 +163,9 @@ namespace GitUI.Theming
 
         private class ThemeColors
         {
-            public readonly Dictionary<AppColor, Color> AppColors = new();
-            public readonly Dictionary<KnownColor, Color> SysColors = new();
-            public readonly Dictionary<string, int> SpecificityByColor = new();
+            public readonly Dictionary<AppColor, Color> AppColors = [];
+            public readonly Dictionary<KnownColor, Color> SysColors = [];
+            public readonly Dictionary<string, int> SpecificityByColor = [];
         }
     }
 }

--- a/GitUI/Theming/Win32ThemeHooks.cs
+++ b/GitUI/Theming/Win32ThemeHooks.cs
@@ -35,7 +35,7 @@ namespace GitUI.Theming
 
         internal static ThemeSettings ThemeSettings { private get; set; } = ThemeSettings.Default;
 
-        private static readonly HashSet<NativeListView> InitializingListViews = new();
+        private static readonly HashSet<NativeListView> InitializingListViews = [];
         private static ScrollBarRenderer? _scrollBarRenderer;
         private static readonly SystemBrushesCache _systemBrushesCache = new();
         private static ListViewRenderer? _listViewRenderer;

--- a/GitUI/UserControls/BlameControl.cs
+++ b/GitUI/UserControls/BlameControl.cs
@@ -363,9 +363,9 @@ namespace GitUI.Blame
             StringBuilder lineBuilder = new(lineLength + 2);
             StringBuilder gutter = new(capacity: lineBuilder.Capacity * _blame.Lines.Count);
             string emptyLine = new(' ', lineLength);
-            Dictionary<string, Image?> cacheAvatars = new();
+            Dictionary<string, Image?> cacheAvatars = [];
             Image noAuthorImage = (Image)new Bitmap(Images.User80, avatarSize, avatarSize);
-            Dictionary<ObjectId, string> authorLineCache = new();
+            Dictionary<ObjectId, string> authorLineCache = [];
             for (int index = 0; index < _blame.Lines.Count; index++)
             {
                 GitBlameLine line = _blame.Lines[index];

--- a/GitUI/UserControls/BranchSelector.cs
+++ b/GitUI/UserControls/BranchSelector.cs
@@ -71,7 +71,7 @@ namespace GitUI.UserControls
 
             string[] GetContainsRevisionBranches()
             {
-                HashSet<string> result = new();
+                HashSet<string> result = [];
 
                 if (_containRevisions.Count > 0)
                 {

--- a/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -40,7 +40,7 @@ namespace GitUI
             }
 
             GitModule module = GetModule();
-            List<FileStatusWithDescription> fileStatusDescs = new();
+            List<FileStatusWithDescription> fileStatusDescs = [];
             if (revisions.Count == 1)
             {
                 // If the grid is filtered, parents may be rewritten

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -56,7 +56,7 @@ namespace GitUI
         [DefaultValue(false)]
         public bool DisableSubmoduleMenuItemBold { get; set; }
 
-        private readonly Dictionary<string, int> _stateImageIndexDict = new();
+        private readonly Dictionary<string, int> _stateImageIndexDict = [];
 
         public FileStatusList()
         {
@@ -551,7 +551,7 @@ namespace GitUI
 
             ListViewItem? FindPrevItemInGroups()
             {
-                List<ListViewGroup> searchInGroups = new();
+                List<ListViewGroup> searchInGroups = [];
                 bool foundCurrentGroup = false;
                 for (int i = FileStatusListView.Groups.Count - 1; i >= 0; i--)
                 {
@@ -586,7 +586,7 @@ namespace GitUI
 
             ListViewItem? FindNextItemInGroups()
             {
-                List<ListViewGroup> searchInGroups = new();
+                List<ListViewGroup> searchInGroups = [];
                 bool foundCurrentGroup = false;
                 for (int i = 0; i < FileStatusListView.Groups.Count; i++)
                 {
@@ -1015,7 +1015,7 @@ namespace GitUI
             FileStatusListView.Groups.Clear();
             FileStatusListView.Items.Clear();
 
-            List<ListViewItem> list = new();
+            List<ListViewItem> list = [];
             foreach (FileStatusWithDescription i in GitItemStatusesWithDescription)
             {
                 string name = i.Statuses.Count == 1 && i.Statuses[0].IsRangeDiff
@@ -1628,7 +1628,7 @@ namespace GitUI
             {
                 if (SelectedItems.Any())
                 {
-                    StringCollection fileList = new();
+                    StringCollection fileList = [];
 
                     foreach (FileStatusItem item in SelectedItems)
                     {

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -66,7 +66,7 @@ namespace GitUI.UserControls
             string filter = tscboBranchFilter.Text == TranslatedStrings.NoResultsFound ? string.Empty : tscboBranchFilter.Text;
             if (checkBranch && !string.IsNullOrWhiteSpace(filter))
             {
-                List<string> newFilter = new();
+                List<string> newFilter = [];
                 IReadOnlyList<IGitRef> refs = _getRefs(RefsFilter.NoFilter);
 
                 // Split at whitespace (char[])null is default) but with split options.
@@ -345,13 +345,13 @@ namespace GitUI.UserControls
             tsbShowReflog.Checked = e.ShowReflogReferences;
             InitBranchSelectionFilter(e);
 
-            List<(string filter, ToolStripMenuItem menuItem)> revFilters = new()
-            {
+            List<(string filter, ToolStripMenuItem menuItem)> revFilters =
+            [
                 (e.MessageFilter, tsmiCommitFilter),
                 (e.CommitterFilter, tsmiCommitterFilter),
                 (e.AuthorFilter, tsmiAuthorFilter),
                 (e.DiffContentFilter, tsmiDiffContainsFilter),
-            };
+            ];
 
             // If there is no filter in filterInfo, clear text but retain checks
             tstxtRevisionFilter.Text = "";

--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -93,7 +93,7 @@ namespace GitUI
                 .Where(p => p.Length >= 3)
                 .ToArray();
 
-            List<PatchFile> patchFiles = new();
+            List<PatchFile> patchFiles = [];
             if (commitsInfos.Length == 0)
             {
                 return patchFiles;
@@ -110,7 +110,7 @@ namespace GitUI
             catch (OperationCanceledException)
             {
                 // If retrieve of commit range failed, fall back on getting data commit by commit
-                rebasedCommitsRevisions = new Dictionary<string, GitRevision>();
+                rebasedCommitsRevisions = [];
             }
 
             string? currentCommitShortHash = File.Exists(currentFilePath) ? File.ReadAllText(currentFilePath).Trim() : null;
@@ -190,7 +190,7 @@ namespace GitUI
 
         private IReadOnlyList<PatchFile> GetRebasePatchFiles()
         {
-            List<PatchFile> patchFiles = new();
+            List<PatchFile> patchFiles = [];
 
             string nextFile = GetNextRebasePatch();
 

--- a/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -43,7 +43,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         {
             MultilineIndicator indicator = new(e, revision);
             Rectangle messageBounds = indicator.RemainingCellBounds;
-            List<IGitRef> superprojectRefs = new();
+            List<IGitRef> superprojectRefs = [];
             int offset = ColumnLeftMargin;
 
             if (_grid.TryGetSuperProjectInfo(out SuperProjectInfo? spi))

--- a/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
@@ -98,8 +98,8 @@ namespace GitUI.UserControls.RevisionGrid
             DropDown.SuspendLayout();
             DropDownItems.Clear();
 
-            List<string> branchNames = new();
-            List<string> tagNames = new();
+            List<string> branchNames = [];
+            List<string> tagNames = [];
             foreach (GitRevision revision in revisions)
             {
                 GitRefListsForRevision refLists = new(revision);

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -297,7 +297,7 @@ namespace GitUI.UserControls.RevisionGrid
                 DebugHelpers.Fail("Not supported");
             }
 
-            ArgumentBuilder filter = new();
+            ArgumentBuilder filter = [];
 
             // Separate the filters in groups
             GetCommitRevisionFilter(filter);

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -33,7 +33,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         /// These revisions are only accessed from the update thread and are normally empty
         /// when the loading is completed.
         /// </summary>
-        private readonly Dictionary<ObjectId, RevisionGraphRevision> _incompleteRevisionByObjectId = new();
+        private readonly Dictionary<ObjectId, RevisionGraphRevision> _incompleteRevisionByObjectId = [];
 
         /// <summary>
         /// The loading is completed when all revisions are loaded from the log,

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphLaneColor.cs
@@ -22,7 +22,7 @@
 
         internal static Brush NonRelativeBrush { get; }
 
-        internal static readonly List<Brush> PresetGraphBrushes = new();
+        internal static readonly List<Brush> PresetGraphBrushes = [];
 
         static RevisionGraphLaneColor()
         {

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -276,7 +276,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 return;
             }
 
-            _gaps ??= new();
+            _gaps ??= [];
             _gaps.Add(fromLane);
             if (nextGap < int.MaxValue)
             {

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -27,7 +27,7 @@ namespace GitUI.UserControls.RevisionGrid
         private readonly Stopwatch _lastRepaint = Stopwatch.StartNew();
         private readonly Stopwatch _lastScroll = Stopwatch.StartNew();
         private readonly Stopwatch _consecutiveScroll = Stopwatch.StartNew();
-        private readonly List<ColumnProvider> _columnProviders = new();
+        private readonly List<ColumnProvider> _columnProviders = [];
 
         internal RevisionGraph _revisionGraph = new();
 
@@ -572,7 +572,7 @@ namespace GitUI.UserControls.RevisionGrid
             DebugHelpers.Assert(_loadedToBeSelectedRevisionsCount == ToBeSelectedObjectIds.Count,
                 $"{nameof(CalculateGraphIndices)}() was called before all expected revisions were loaded.");
 
-            List<int> toBeSelectedGraphIndexes = new();
+            List<int> toBeSelectedGraphIndexes = [];
             foreach (ObjectId objectId in ToBeSelectedObjectIds)
             {
                 if (_revisionGraph.TryGetRowIndex(objectId, out int rowIndexToBeSelected))

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -558,10 +558,10 @@ namespace GitUI
 
         public void LoadCustomDifftools()
         {
-            List<CustomDiffMergeTool> menus = new()
-            {
+            List<CustomDiffMergeTool> menus =
+            [
                 new(openCommitsWithDiffToolMenuItem, diffSelectedCommitsMenuItem_Click)
-            };
+            ];
 
             new CustomDiffMergeToolProvider().LoadCustomDiffMergeTools(Module, menus, components, isDiff: true, cancellationToken: _customDiffToolsSequence.Next());
         }
@@ -1175,7 +1175,7 @@ namespace GitUI
                     path
                 };
 
-                HashSet<string?> setOfFileNames = new();
+                HashSet<string?> setOfFileNames = [];
                 ExecutionResult result = Module.GitExecutable.Execute(args, outputEncoding: GitModule.LosslessEncoding, throwOnErrorExit: false);
                 LazyStringSplit lines = result.StandardOutput.LazySplit('\n');
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridToolTipProvider.cs
@@ -7,7 +7,7 @@ namespace GitUI
     internal sealed class RevisionGridToolTipProvider
     {
         private readonly ToolTip _toolTip = new();
-        private readonly Dictionary<Point, bool> _isTruncatedByCellPos = new();
+        private readonly Dictionary<Point, bool> _isTruncatedByCellPos = [];
         private readonly RevisionDataGridView _gridView;
         private int _previousRowIndex = -1;
         private int _previousColumnIndex = -1;

--- a/GitUI/UserControls/TreeViewExtensions.cs
+++ b/GitUI/UserControls/TreeViewExtensions.cs
@@ -35,7 +35,7 @@
         /// </summary>
         public static HashSet<string> GetExpandedNodesState(this TreeNode node)
         {
-            HashSet<string> result = new();
+            HashSet<string> result = [];
             node.DoGetExpandedNodesState(result);
             return result;
         }

--- a/GitUI/VisualStudioIntegration.cs
+++ b/GitUI/VisualStudioIntegration.cs
@@ -21,11 +21,11 @@ namespace GitUI
                 }
 
                 Executable executable = new(vswhere);
-                ArgumentBuilder arguments = new()
-                {
+                ArgumentBuilder arguments =
+                [
                     "-latest",
                     "-property productPath"
-                };
+                ];
                 _devEnvPath = await executable.GetOutputAsync(arguments);
             });
         }

--- a/GitUI/WindowPositionList.cs
+++ b/GitUI/WindowPositionList.cs
@@ -38,7 +38,7 @@ namespace GitUI
         private static readonly string ConfigFilePath = Path.Combine(AppSettings.LocalApplicationDataPath.Value, "WindowPositions.xml");
         private static readonly XmlSerializer _serializer = new(typeof(WindowPositionList));
 
-        public List<WindowPosition> WindowPositions { get; set; } = new List<WindowPosition>();
+        public List<WindowPosition> WindowPositions { get; set; } = [];
 
         protected WindowPositionList()
         {

--- a/GitUI/WindowsJumpListManager.cs
+++ b/GitUI/WindowsJumpListManager.cs
@@ -27,7 +27,7 @@ namespace GitUI
     /// <inheritdoc />
     public sealed class WindowsJumpListManager : IWindowsJumpListManager
     {
-        private static readonly Dictionary<Image, Icon> _iconByImage = new();
+        private static readonly Dictionary<Image, Icon> _iconByImage = [];
         private readonly IRepositoryDescriptionProvider _repositoryDescriptionProvider;
         private ThumbnailToolBarButton? _closeAllButton;
         private ThumbnailToolBarButton? _commitButton;

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FileStatusListTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FileStatusListTests.cs
@@ -38,7 +38,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             GitItemStatus item0 = new(name: "z.0");
             GitItemStatus item1 = new(name: "x.1");
             GitItemStatus item2 = new(name: "y.2");
-            List<GitItemStatus> items = new() { item0, item1, item2 };
+            List<GitItemStatus> items = [item0, item1, item2];
 
             // alphabetical order
             GitItemStatus itemAt0 = item1;

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.ReorderNodes.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.ReorderNodes.cs
@@ -23,7 +23,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         private bool _originalShowAuthorAvatarColumn;
         private bool _showAvailableDiffTools;
 
-        private List<bool> _originalRepoObjectsTreeShow = new();
+        private List<bool> _originalRepoObjectsTreeShow = [];
 
         private GitModuleTestHelper _repo1;
 

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SplitterPersistenceTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SplitterPersistenceTests.cs
@@ -160,7 +160,7 @@ namespace GitExtensions.UITests.CommandsDialogs
 
         private async Task RunFormTestAsync(Func<FormBrowse, Task> testDriverAsync)
         {
-            Dictionary<string, string> splitters = new();
+            Dictionary<string, string> splitters = [];
 
             UITest.RunForm(
                 showForm: () =>

--- a/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/GitUICommands/RunCommandTests.cs
@@ -176,7 +176,7 @@ namespace GitUITests.GitUICommandsTests
         {
             string expectedTab = command.Contains("blame") ? "Blame" : "Diff";
 
-            List<string> args = new() { "ge.exe", command, "filename" };
+            List<string> args = ["ge.exe", command, "filename"];
             if (commit)
             {
                 args.Add(_referenceRepository.CommitHash);

--- a/IntegrationTests/UI.IntegrationTests/GlobalServiceContainer.cs
+++ b/IntegrationTests/UI.IntegrationTests/GlobalServiceContainer.cs
@@ -20,7 +20,7 @@ namespace GitExtensions.UITests
             serviceContainer.AddService(Substitute.For<ILinkFactory>());
 
             IScriptsManager scriptsManager = Substitute.For<IScriptsManager>();
-            scriptsManager.GetScripts().Returns(new BindingList<ScriptInfo>());
+            scriptsManager.GetScripts().Returns([]);
             serviceContainer.AddService(scriptsManager);
 
             serviceContainer.AddService(Substitute.For<IScriptsRunner>());

--- a/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/CopyContextMenuItemTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/RevisionGrid/CopyContextMenuItemTests.cs
@@ -68,11 +68,11 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
         public void Should_show_info_if_commit_has_defined_branches()
         {
             GitRevision revision = new(ObjectId.Random());
-            List<IGitRef> refs = new()
-            {
+            List<IGitRef> refs =
+            [
                 new GitRef(null, revision.ObjectId, "refs/heads/branch1"),
                 new GitRef(null, revision.ObjectId, "refs/heads/branch2")
-            };
+            ];
             revision.Refs = refs;
             GitRevision[] revisions = new[] { revision };
             _copyContextMenuItem.SetRevisionFunc(() => revisions);
@@ -94,11 +94,11 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
         public void Should_show_info_if_commit_has_defined_tags()
         {
             GitRevision revision = new(ObjectId.Random());
-            List<IGitRef> refs = new()
-            {
+            List<IGitRef> refs =
+            [
                 new GitRef(null, revision.ObjectId, "refs/tags/tag1"),
                 new GitRef(null, revision.ObjectId, "refs/tags/tag2")
-            };
+            ];
             revision.Refs = refs;
             GitRevision[] revisions = new[] { revision };
             _copyContextMenuItem.SetRevisionFunc(() => revisions);
@@ -120,13 +120,13 @@ namespace GitExtensions.UITests.UserControls.RevisionGrid
         public void Should_show_info_if_commit_has_defined_branches_and_tags()
         {
             GitRevision revision = new(ObjectId.Random());
-            List<IGitRef> refs = new()
-            {
+            List<IGitRef> refs =
+            [
                 new GitRef(null, revision.ObjectId, "refs/tags/tag1"),
                 new GitRef(null, revision.ObjectId, "refs/heads/branch1"),
                 new GitRef(null, revision.ObjectId, "refs/tags/tag2"),
                 new GitRef(null, revision.ObjectId, "refs/heads/branch2"),
-            };
+            ];
             revision.Refs = refs;
             GitRevision[] revisions = new[] { revision };
             _copyContextMenuItem.SetRevisionFunc(() => revisions);

--- a/Plugins/Bitbucket/BitbucketPullRequestForm.cs
+++ b/Plugins/Bitbucket/BitbucketPullRequestForm.cs
@@ -23,7 +23,7 @@ namespace GitExtensions.Plugins.Bitbucket
         private readonly string _NO_TRANSLATE_LinkViewPull = "pull-requests";
 
         private readonly Settings? _settings;
-        private readonly BindingList<BitbucketUser> _reviewers = new();
+        private readonly BindingList<BitbucketUser> _reviewers = [];
 
         public BitbucketPullRequestForm(Settings? settings, IGitModule? module)
         {
@@ -83,7 +83,7 @@ namespace GitExtensions.Plugins.Bitbucket
                 Validates.NotNull(_settings.ProjectKey);
                 Validates.NotNull(_settings.RepoSlug);
 
-                List<Repository> list = new();
+                List<Repository> list = [];
                 GetRepoRequest getDefaultRepo = new(_settings.ProjectKey, _settings.RepoSlug, _settings);
                 BitbucketResponse<Repository> defaultRepo = await getDefaultRepo.SendAsync().ConfigureAwait(false);
                 if (defaultRepo.Success)
@@ -117,7 +117,7 @@ namespace GitExtensions.Plugins.Bitbucket
                 Validates.NotNull(_settings.ProjectKey);
                 Validates.NotNull(_settings.RepoSlug);
 
-                List<PullRequest> list = new();
+                List<PullRequest> list = [];
                 GetPullRequest getPullRequests = new(_settings.ProjectKey, _settings.RepoSlug, _settings);
                 BitbucketResponse<List<PullRequest>> result = await getPullRequests.SendAsync().ConfigureAwait(false);
                 if (result.Success)
@@ -166,7 +166,7 @@ namespace GitExtensions.Plugins.Bitbucket
             }
         }
 
-        private readonly Dictionary<Repository, IEnumerable<string>> _branches = new();
+        private readonly Dictionary<Repository, IEnumerable<string>> _branches = [];
         private async Task<IEnumerable<string>> GetBitbucketBranchesAsync(Repository selectedRepo)
         {
             lock (_branches)
@@ -179,7 +179,7 @@ namespace GitExtensions.Plugins.Bitbucket
 
             Validates.NotNull(_settings);
 
-            List<string> list = new();
+            List<string> list = [];
             GetBranchesRequest getBranches = new(selectedRepo, _settings);
             BitbucketResponse<Newtonsoft.Json.Linq.JObject> result = await getBranches.SendAsync().ConfigureAwait(false);
             if (result.Success)

--- a/Plugins/Bitbucket/BitbucketRequestBase.cs
+++ b/Plugins/Bitbucket/BitbucketRequestBase.cs
@@ -93,7 +93,7 @@ namespace GitExtensions.Plugins.Bitbucket
 
             if (json["errors"] is not null)
             {
-                List<string> messages = new();
+                List<string> messages = [];
                 BitbucketResponse<T> errorResponse = new() { Success = false };
                 foreach (JToken error in json["errors"])
                 {

--- a/Plugins/Bitbucket/CreatePullRequestRequest.cs
+++ b/Plugins/Bitbucket/CreatePullRequestRequest.cs
@@ -57,24 +57,30 @@ namespace GitExtensions.Plugins.Bitbucket
             Validates.NotNull(_info.TargetBranch);
             Validates.NotNull(_info.Reviewers);
 
-            JObject resource = new();
-            resource["title"] = _info.Title;
-            resource["description"] = _info.Description;
+            JObject resource = new()
+            {
+                ["title"] = _info.Title,
+                ["description"] = _info.Description,
 
-            resource["fromRef"] = CreatePullRequestRef(
+                ["fromRef"] = CreatePullRequestRef(
                 _info.SourceRepo.ProjectKey,
-                _info.SourceRepo.RepoName, _info.SourceBranch);
+                _info.SourceRepo.RepoName, _info.SourceBranch),
 
-            resource["toRef"] = CreatePullRequestRef(
+                ["toRef"] = CreatePullRequestRef(
                 _info.TargetRepo.ProjectKey,
-                _info.TargetRepo.RepoName, _info.TargetBranch);
+                _info.TargetRepo.RepoName, _info.TargetBranch)
+            };
 
-            JArray reviewers = new();
+            JArray reviewers = [];
             foreach (BitbucketUser reviewer in _info.Reviewers)
             {
-                JObject r = new();
-                r["user"] = new JObject();
-                r["user"]["name"] = reviewer.Slug;
+                JObject r = new()
+                {
+                    ["user"] = new JObject
+                    {
+                        ["name"] = reviewer.Slug
+                    }
+                };
 
                 reviewers.Add(r);
             }
@@ -86,12 +92,18 @@ namespace GitExtensions.Plugins.Bitbucket
 
         private static JObject CreatePullRequestRef(string projectKey, string repoName, string branchName)
         {
-            JObject reference = new();
-            reference["id"] = branchName;
-            reference["repository"] = new JObject();
-            reference["repository"]["slug"] = repoName;
-            reference["repository"]["project"] = new JObject();
-            reference["repository"]["project"]["key"] = projectKey;
+            JObject reference = new()
+            {
+                ["id"] = branchName,
+                ["repository"] = new JObject
+                {
+                    ["slug"] = repoName
+                }
+            };
+            reference["repository"]["project"] = new JObject
+            {
+                ["key"] = projectKey
+            };
             return reference;
         }
     }

--- a/Plugins/Bitbucket/GetInBetweenCommitsRequest.cs
+++ b/Plugins/Bitbucket/GetInBetweenCommitsRequest.cs
@@ -31,7 +31,7 @@ namespace GitExtensions.Plugins.Bitbucket
 
         protected override List<Commit> ParseResponse(JObject json)
         {
-            List<Commit> result = new();
+            List<Commit> result = [];
             foreach (JObject commit in json["values"])
             {
                 result.Add(Commit.Parse(commit));

--- a/Plugins/Bitbucket/GetPullRequest.cs
+++ b/Plugins/Bitbucket/GetPullRequest.cs
@@ -107,7 +107,7 @@ namespace GitExtensions.Plugins.Bitbucket
 
         protected override List<PullRequest> ParseResponse(JObject json)
         {
-            List<PullRequest> result = new();
+            List<PullRequest> result = [];
             foreach (JObject val in json["values"])
             {
                 result.Add(PullRequest.Parse(val));

--- a/Plugins/Bitbucket/GetRelatedRepoRequest.cs
+++ b/Plugins/Bitbucket/GetRelatedRepoRequest.cs
@@ -39,7 +39,7 @@ namespace GitExtensions.Plugins.Bitbucket
 
         protected override List<Repository> ParseResponse(JObject json)
         {
-            List<Repository> result = new();
+            List<Repository> result = [];
             foreach (JObject val in json["values"])
             {
                 result.Add(Repository.Parse(val));

--- a/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/Plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -48,7 +48,7 @@ namespace AppVeyorIntegration
 
         private HttpClient? _httpClientAppVeyor;
 
-        private List<AppVeyorBuildInfo>? _allBuilds = new();
+        private List<AppVeyorBuildInfo>? _allBuilds = [];
         private HashSet<ObjectId>? _fetchBuilds;
         private Func<ObjectId, bool>? _isCommitInRevisionGrid;
         private bool _shouldLoadTestResults;
@@ -70,7 +70,7 @@ namespace AppVeyorIntegration
             string? accountToken = config.GetString("AppVeyorAccountToken", null);
             _shouldLoadTestResults = config.GetBool("AppVeyorLoadTestsResults", false);
 
-            _fetchBuilds = new HashSet<ObjectId>();
+            _fetchBuilds = [];
 
             _httpClientAppVeyor = GetHttpClient(WebSiteUrl, accountToken);
 
@@ -136,7 +136,7 @@ namespace AppVeyorIntegration
 
             List<AppVeyorBuildInfo> FilterBuilds(IEnumerable<AppVeyorBuildInfo> allBuilds)
             {
-                List<AppVeyorBuildInfo> filteredBuilds = new();
+                List<AppVeyorBuildInfo> filteredBuilds = [];
                 foreach (AppVeyorBuildInfo build in allBuilds.OrderByDescending(b => b.StartDate))
                 {
                     Validates.NotNull(build.CommitId);
@@ -185,7 +185,7 @@ namespace AppVeyorIntegration
             string baseWebUrl = $"{WebSiteUrl}/project/{projectId}/build/";
             string baseApiUrl = $"{ApiBaseUrl}{projectId}/";
 
-            List<AppVeyorBuildInfo> buildDetails = new();
+            List<AppVeyorBuildInfo> buildDetails = [];
             foreach (JToken b in builds)
             {
                 try

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/BuildsCache.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/BuildsCache.cs
@@ -6,7 +6,7 @@ namespace AzureDevOpsIntegration
     {
         public string? Id { get; set; }
         public string? BuildDefinitions { get; init; }
-        public List<BuildInfo> FinishedBuilds { get; } = new List<BuildInfo>();
+        public List<BuildInfo> FinishedBuilds { get; } = [];
         public DateTime LastCall { get; set; } = DateTime.MinValue;
     }
 }

--- a/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
+++ b/Plugins/BuildServerIntegration/JenkinsIntegration/JenkinsAdapter.cs
@@ -52,7 +52,7 @@ namespace JenkinsIntegration
         private HttpClient? _httpClient;
 
         // last known build per project
-        private readonly Dictionary<string, long> _lastProjectBuildTime = new();
+        private readonly Dictionary<string, long> _lastProjectBuildTime = [];
         private Regex? _ignoreBuilds;
 
         public void Initialize(IBuildServerWatcher buildServerWatcher, ISettingsSource config, Action openSettings, Func<ObjectId, bool>? isCommitInRevisionGrid = null)
@@ -206,8 +206,8 @@ namespace JenkinsIntegration
         {
             try
             {
-                List<JoinableTask<ResponseInfo>> allBuildInfos = new();
-                List<JoinableTask<ResponseInfo>> latestBuildInfos = new();
+                List<JoinableTask<ResponseInfo>> allBuildInfos = [];
+                List<JoinableTask<ResponseInfo>> latestBuildInfos = [];
 
                 foreach (string projectUrl in _lastProjectBuildTime.Keys)
                 {
@@ -246,7 +246,7 @@ namespace JenkinsIntegration
                     return;
                 }
 
-                Dictionary<ObjectId, BuildInfo.BuildStatus> builds = new();
+                Dictionary<ObjectId, BuildInfo.BuildStatus> builds = [];
                 foreach (JoinableTask<ResponseInfo> build in allBuildInfos)
                 {
                     if (build.Task.IsFaulted)
@@ -381,7 +381,7 @@ namespace JenkinsIntegration
             string webUrl = buildDescription["url"].ToObject<string>();
 
             JToken action = buildDescription["actions"];
-            List<ObjectId> commitHashList = new();
+            List<ObjectId> commitHashList = [];
             string testResults = string.Empty;
             foreach (JToken element in action)
             {

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/TeamCityAdapter.cs
@@ -56,7 +56,7 @@ namespace TeamCityIntegration
 
         private string? _httpClientHostSuffix;
 
-        private readonly List<JoinableTask<IEnumerable<string>>> _getBuildTypesTask = new();
+        private readonly List<JoinableTask<IEnumerable<string>>> _getBuildTypesTask = [];
 
         private CookieContainer? _teamCityNtlmAuthCookie;
 
@@ -547,7 +547,7 @@ namespace TeamCityIntegration
 
         private Task<XDocument> GetFilteredBuildsXmlResponseAsync(string buildTypeId, CancellationToken cancellationToken, DateTime? sinceDate = null, bool? running = null)
         {
-            List<string> values = new() { "branch:(default:any)" };
+            List<string> values = [ "branch:(default:any)"];
 
             if (sinceDate.HasValue)
             {

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -28,7 +28,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
         private readonly TranslationString _branchesSelected = new("{0}/{1} branches selected.");
         private readonly DeleteUnusedBranchesFormSettings _settings;
 
-        private readonly SortableBranchesList _branches = new();
+        private readonly SortableBranchesList _branches = [];
         private readonly IGitModule _gitCommands;
         private readonly IGitUICommands? _gitUiCommands;
         private readonly IGitPlugin _gitPlugin;

--- a/Plugins/FindLargeFiles/FindLargeFilesForm.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesForm.cs
@@ -17,8 +17,8 @@ namespace GitExtensions.Plugins.FindLargeFiles
         private readonly GitUIEventArgs _gitUiCommands;
         private readonly IGitModule _gitCommands;
         private string[] _revList = Array.Empty<string>();
-        private readonly Dictionary<string, GitObject> _list = new();
-        private readonly SortableObjectsList _gitObjects = new();
+        private readonly Dictionary<string, GitObject> _list = [];
+        private readonly SortableObjectsList _gitObjects = [];
 
         public FindLargeFilesForm(float threshold, GitUIEventArgs gitUiEventArgs)
         {
@@ -55,7 +55,7 @@ namespace GitExtensions.Plugins.FindLargeFiles
             try
             {
                 IEnumerable<GitObject> data = GetLargeFiles(_threshold);
-                Dictionary<string, DateTime> revData = new();
+                Dictionary<string, DateTime> revData = [];
                 foreach (GitObject d in data)
                 {
                     string commit = d.Commit.First();

--- a/Plugins/FindLargeFiles/GitObject.cs
+++ b/Plugins/FindLargeFiles/GitObject.cs
@@ -8,7 +8,7 @@
             Path = path;
             SizeInBytes = size;
             CompressedSizeInBytes = -1;
-            Commit = new HashSet<string> { commit };
+            Commit = [commit];
         }
 
         public string SHA { get; set; }

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -17,7 +17,7 @@ namespace GitExtensions.Plugins.GitFlow
 
         private readonly GitUIEventArgs _gitUiCommands;
 
-        private Dictionary<string, IReadOnlyList<string>> Branches { get; } = new Dictionary<string, IReadOnlyList<string>>();
+        private Dictionary<string, IReadOnlyList<string>> Branches { get; } = [];
 
         private readonly AsyncLoader _task = new();
 
@@ -89,8 +89,7 @@ namespace GitExtensions.Plugins.GitFlow
                 btnPull.Enabled = btnPublish.Enabled = remotes.Any();
 
                 cbType.DataSource = BranchTypes;
-                List<string> types = new() { string.Empty };
-                types.AddRange(BranchTypes);
+                List<string> types = [string.Empty, .. BranchTypes];
                 cbManageType.DataSource = types;
 
                 cbBasedOn.Checked = false;

--- a/Plugins/GitHub3/GitHub3Plugin.cs
+++ b/Plugins/GitHub3/GitHub3Plugin.cs
@@ -230,7 +230,7 @@ namespace GitExtensions.Plugins.GitHub3
 
             IEnumerable<IHostedRemote> Remotes()
             {
-                HashSet<IHostedRemote> set = new();
+                HashSet<IHostedRemote> set = [];
 
                 foreach (string remote in gitModule.GetRemoteNames())
                 {

--- a/Plugins/GitHub3/GitHubPullRequestDiscussion.cs
+++ b/Plugins/GitHub3/GitHubPullRequestDiscussion.cs
@@ -10,7 +10,7 @@ namespace GitExtensions.Plugins.GitHub3
         public GitHubPullRequestDiscussion(PullRequest pullRequest)
         {
             _pullRequest = pullRequest;
-            Entries = new List<IDiscussionEntry>();
+            Entries = [];
             ForceReload();
         }
 

--- a/Plugins/GitUIPluginInterfaces/Remote.cs
+++ b/Plugins/GitUIPluginInterfaces/Remote.cs
@@ -12,7 +12,7 @@
             FetchUrl = fetchUrl ?? throw new ArgumentNullException(nameof(fetchUrl));
 
             // At least one push URL must be added
-            PushUrls = firstPushUrl is not null ? new List<string>() { firstPushUrl } : throw new ArgumentNullException(nameof(firstPushUrl));
+            PushUrls = firstPushUrl is not null ? [firstPushUrl] : throw new ArgumentNullException(nameof(firstPushUrl));
         }
     }
 }

--- a/Plugins/ReleaseNotesGenerator/GitLogLineParser.cs
+++ b/Plugins/ReleaseNotesGenerator/GitLogLineParser.cs
@@ -31,7 +31,7 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
 
         public IEnumerable<LogLine> Parse(IEnumerable<string>? lines)
         {
-            List<LogLine> resultList = new();
+            List<LogLine> resultList = [];
             if (lines is null)
             {
                 return resultList;

--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -18,25 +18,25 @@ namespace GitExtensions.Plugins.GitImpact
         private ImpactLoader? _impactLoader;
 
         // <Author, <Commits, Added Lines, Deleted Lines>>
-        private readonly Dictionary<string, ImpactLoader.DataPoint> _authors = new();
+        private readonly Dictionary<string, ImpactLoader.DataPoint> _authors = [];
 
         // <First weekday of commit date, <Author, <Commits, Added Lines, Deleted Lines>>>
-        private SortedDictionary<DateTime, Dictionary<string, ImpactLoader.DataPoint>> _impact = new();
+        private SortedDictionary<DateTime, Dictionary<string, ImpactLoader.DataPoint>> _impact = [];
 
         // List of authors that determines the drawing order
-        private readonly List<string> _authorStack = new();
+        private readonly List<string> _authorStack = [];
 
         // The paths for each author
-        private readonly Dictionary<string, GraphicsPath> _paths = new();
+        private readonly Dictionary<string, GraphicsPath> _paths = [];
 
         // The brush for each author
-        private readonly Dictionary<string, SolidBrush> _brushes = new();
+        private readonly Dictionary<string, SolidBrush> _brushes = [];
 
         // The changed-lines-labels for each author
-        private readonly Dictionary<string, List<(PointF point, int size)>> _lineLabels = new();
+        private readonly Dictionary<string, List<(PointF point, int size)>> _lineLabels = [];
 
         // The week-labels
-        private readonly List<(PointF point, DateTime date)> _weekLabels = new();
+        private readonly List<(PointF point, DateTime date)> _weekLabels = [];
 
         public ImpactControl()
         {
@@ -100,7 +100,7 @@ namespace GitExtensions.Plugins.GitImpact
                 if (!_impact.ContainsKey(commit.Week))
                 {
                     // Create it
-                    _impact.Add(commit.Week, new Dictionary<string, ImpactLoader.DataPoint>());
+                    _impact.Add(commit.Week, []);
                 }
 
                 // If author does not exist yet for this week in the impact dictionary
@@ -285,7 +285,7 @@ namespace GitExtensions.Plugins.GitImpact
         {
             int h_max = 0;
             int x = 0;
-            Dictionary<string, List<(Rectangle, int changeCount)>> author_points_dict = new();
+            Dictionary<string, List<(Rectangle, int changeCount)>> author_points_dict = [];
 
             lock (_dataLock)
             {

--- a/Plugins/Statistics/GitImpact/ImpactLoader.cs
+++ b/Plugins/Statistics/GitImpact/ImpactLoader.cs
@@ -111,15 +111,15 @@ namespace GitExtensions.Plugins.GitImpact
             string authorName = RespectMailmap ? "%aN" : "%an";
             string command = $"log --pretty=tformat:\"--- %ad --- {authorName}\" --numstat --date=iso -C --all --no-merges";
 
-            List<JoinableTask> tasks = new()
-            {
+            List<JoinableTask> tasks =
+            [
                 ThreadHelper.JoinableTaskFactory.RunAsync(
                     async () =>
                     {
                         await TaskScheduler.Default.SwitchTo(alwaysYield: true);
                         LoadModuleInfo(command, _module, token);
                     })
-            };
+            ];
 
             if (ShowSubmodules)
             {

--- a/Plugins/Statistics/GitStatistics/LineCounter.cs
+++ b/Plugins/Statistics/GitStatistics/LineCounter.cs
@@ -11,7 +11,7 @@
         public int BlankLineCount { get; private set; }
         public int CodeLineCount { get; private set; }
 
-        public Dictionary<string, int> LinesOfCodePerExtension { get; } = new Dictionary<string, int>();
+        public Dictionary<string, int> LinesOfCodePerExtension { get; } = [];
 
         public void FindAndAnalyzeCodeFiles(string filePattern, string directoriesToIgnore, IEnumerable<string> filesToCheck)
         {

--- a/Plugins/Statistics/GitStatistics/PieChart/PieChart3D.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/PieChart3D.cs
@@ -22,7 +22,7 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
         /// <summary>
         ///   Collection of reordered pie slices mapped to original order.
         /// </summary>
-        protected List<int> PieSlicesMapping { get; } = new List<int>();
+        protected List<int> PieSlicesMapping { get; } = [];
 
         /// <summary>
         ///   Array of colors used for rendering.
@@ -645,7 +645,7 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
             SizeF largestDisplacementEllipseSize = LargestDisplacementEllipseSize;
             int maxDisplacementIndex = SliceRelativeDisplacements.Length - 1;
             float largestDisplacement = LargestDisplacement;
-            List<PieSlice> listPieSlices = new();
+            List<PieSlice> listPieSlices = [];
             PieSlicesMapping.Clear();
             int colorIndex = 0;
             int backPieIndex = -1;

--- a/Plugins/Statistics/GitStatistics/PieChart/PieSlice.cs
+++ b/Plugins/Statistics/GitStatistics/PieChart/PieSlice.cs
@@ -981,7 +981,7 @@ namespace GitExtensions.Plugins.GitStatistics.PieChart
         /// </returns>
         private IEnumerable<PeripherySurfaceBounds> GetVisiblePeripherySurfaceBounds()
         {
-            List<PeripherySurfaceBounds> peripherySurfaceBounds = new();
+            List<PeripherySurfaceBounds> peripherySurfaceBounds = [];
 
             // outer periphery side is visible only when startAngle or endAngle
             // is between 0 and 180 degrees

--- a/ResourceManager/Translator.cs
+++ b/ResourceManager/Translator.cs
@@ -46,7 +46,7 @@ namespace ResourceManager
 
         public static string[] GetAllTranslations()
         {
-            List<string> translations = new();
+            List<string> translations = [];
             try
             {
                 string translationDir = GetTranslationDir();

--- a/ResourceManager/Xliff/TranslationBody.cs
+++ b/ResourceManager/Xliff/TranslationBody.cs
@@ -8,7 +8,7 @@ namespace ResourceManager.Xliff
     {
         public TranslationBody()
         {
-            TranslationItems = new List<TranslationItem>();
+            TranslationItems = [];
         }
 
         [XmlElement(ElementName = "trans-unit")]

--- a/ResourceManager/Xliff/TranslationFile.cs
+++ b/ResourceManager/Xliff/TranslationFile.cs
@@ -9,7 +9,7 @@ namespace ResourceManager.Xliff
         public TranslationFile()
         {
             Version = "1.0";
-            TranslationCategories = new List<TranslationCategory>();
+            TranslationCategories = [];
         }
 
         public TranslationFile(string gitExVersion, string sourceLanguage, string targetLanguage)

--- a/ResourceManager/Xliff/TranslationUtil.cs
+++ b/ResourceManager/Xliff/TranslationUtil.cs
@@ -15,7 +15,7 @@ namespace ResourceManager.Xliff
             = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static |
               BindingFlags.NonPublic | BindingFlags.SetField;
 
-        private static readonly HashSet<string> _processedAssemblies = new();
+        private static readonly HashSet<string> _processedAssemblies = [];
 
         private static readonly HashSet<string> _translatableItemInComponentNames = new(StringComparer.Ordinal)
         {
@@ -350,7 +350,7 @@ namespace ResourceManager.Xliff
 
         public static Dictionary<string, List<Type>> GetTranslatableTypes()
         {
-            Dictionary<string, List<Type>> dictionary = new();
+            Dictionary<string, List<Type>> dictionary = [];
             foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies().Where(p => !p.IsDynamic))
             {
                 if (_processedAssemblies.Contains(assembly.FullName))
@@ -370,7 +370,7 @@ namespace ResourceManager.Xliff
 
                 if (!dictionary.TryGetValue(key, out List<Type> list))
                 {
-                    list = new();
+                    list = [];
                     dictionary.Add(key, list);
                 }
 

--- a/TranslationApp/TranslationHelpers.cs
+++ b/TranslationApp/TranslationHelpers.cs
@@ -57,7 +57,7 @@ namespace TranslationApp
 
         public static IDictionary<string, List<TranslationItemWithCategory>> GetItemsDictionary(IDictionary<string, TranslationFile> translations)
         {
-            Dictionary<string, List<TranslationItemWithCategory>> items = new();
+            Dictionary<string, List<TranslationItemWithCategory>> items = [];
             foreach ((string key, TranslationFile file) in translations)
             {
                 IEnumerable<TranslationItemWithCategory> list = from item in file.TranslationCategories
@@ -73,7 +73,7 @@ namespace TranslationApp
         {
             if (!dictionary.TryGetValue(key, out List<T> list))
             {
-                list = new List<T>();
+                list = [];
                 dictionary.Add(key, list);
             }
 
@@ -83,7 +83,7 @@ namespace TranslationApp
         public static IDictionary<string, List<TranslationItemWithCategory>> LoadTranslation(
             IDictionary<string, TranslationFile> translation, IDictionary<string, List<TranslationItemWithCategory>> neutralItems)
         {
-            Dictionary<string, List<TranslationItemWithCategory>> translateItems = new();
+            Dictionary<string, List<TranslationItemWithCategory>> translateItems = [];
 
             IDictionary<string, List<TranslationItemWithCategory>> oldTranslationItems = GetItemsDictionary(translation);
 
@@ -91,7 +91,7 @@ namespace TranslationApp
             {
                 List<TranslationItemWithCategory> oldItems = oldTranslationItems.Find(key);
                 List<TranslationItemWithCategory> transItems = translateItems.Find(key);
-                Dictionary<string, string> dict = new();
+                Dictionary<string, string> dict = [];
                 foreach (TranslationItemWithCategory item in items)
                 {
                     IEnumerable<TranslationItemWithCategory> curItems = oldItems.Where(

--- a/UnitTests/CommonTestUtils/MEF/TestComposition.cs
+++ b/UnitTests/CommonTestUtils/MEF/TestComposition.cs
@@ -16,7 +16,7 @@ namespace CommonTestUtils.MEF
     public sealed partial class TestComposition
     {
         public static readonly TestComposition Empty = new(ImmutableHashSet<Assembly>.Empty, ImmutableHashSet<Type>.Empty, ImmutableHashSet<Type>.Empty);
-        private static readonly Dictionary<CacheKey, IExportProviderFactory> _factoryCache = new();
+        private static readonly Dictionary<CacheKey, IExportProviderFactory> _factoryCache = [];
 
         private readonly struct CacheKey : IEquatable<CacheKey>
         {

--- a/UnitTests/CommonTestUtils/MockExecutable.cs
+++ b/UnitTests/CommonTestUtils/MockExecutable.cs
@@ -11,7 +11,7 @@ namespace CommonTestUtils
     {
         private readonly ConcurrentDictionary<string, ConcurrentStack<(string output, int? exitCode, string? error)>> _outputStackByArguments = new();
         private readonly ConcurrentDictionary<string, int> _commandArgumentsSet = new();
-        private readonly List<MockProcess> _processes = new();
+        private readonly List<MockProcess> _processes = [];
         private int _nextCommandId;
 
         public IDisposable StageOutput(string arguments, string output, int? exitCode = 0, string? error = null)

--- a/UnitTests/GitCommands.Tests/ArgumentBuilderExtensionsTests.cs
+++ b/UnitTests/GitCommands.Tests/ArgumentBuilderExtensionsTests.cs
@@ -217,7 +217,7 @@ namespace GitCommandsTests
 
                 foreach (T member in Enum.GetValues(typeof(T)))
                 {
-                    ArgumentBuilder args = new();
+                    ArgumentBuilder args = [];
 
                     Assert.DoesNotThrow(() => method.Invoke(null, new object[] { args, member }));
                 }
@@ -244,10 +244,10 @@ namespace GitCommandsTests
         [TestCase(null)]
         public void Handle_null_objectid(ObjectId id)
         {
-            ArgumentBuilder args = new()
-            {
+            ArgumentBuilder args =
+            [
                 id
-            };
+            ];
             Assert.AreEqual(args.ToString(), "");
         }
 
@@ -257,10 +257,10 @@ namespace GitCommandsTests
             foreach (int mode in Enum.GetValues(typeof(ForcePushOptions)))
             {
                 // unimplemented switches will result in InvalidEnumArgumentException
-                ArgumentBuilder args = new()
-                {
+                ArgumentBuilder args =
+                [
                     (ForcePushOptions)mode
-                };
+                ];
             }
         }
 
@@ -270,10 +270,10 @@ namespace GitCommandsTests
             foreach (int mode in Enum.GetValues(typeof(GitBisectOption)))
             {
                 // unimplemented switches will result in InvalidEnumArgumentException
-                ArgumentBuilder args = new()
-                {
+                ArgumentBuilder args =
+                [
                     (GitBisectOption)mode
-                };
+                ];
             }
         }
 
@@ -283,10 +283,10 @@ namespace GitCommandsTests
             foreach (int mode in Enum.GetValues(typeof(IgnoreSubmodulesMode)))
             {
                 // unimplemented switches will result in InvalidEnumArgumentException
-                ArgumentBuilder args = new()
-                {
+                ArgumentBuilder args =
+                [
                     (IgnoreSubmodulesMode)mode
-                };
+                ];
             }
         }
 
@@ -296,10 +296,10 @@ namespace GitCommandsTests
             foreach (int mode in Enum.GetValues(typeof(CleanMode)))
             {
                 // unimplemented switches will result in InvalidEnumArgumentException
-                ArgumentBuilder args = new()
-                {
+                ArgumentBuilder args =
+                [
                     (CleanMode)mode
-                };
+                ];
             }
         }
 
@@ -309,10 +309,10 @@ namespace GitCommandsTests
             foreach (int mode in Enum.GetValues(typeof(ResetMode)))
             {
                 // unimplemented switches will result in InvalidEnumArgumentException
-                ArgumentBuilder args = new()
-                {
+                ArgumentBuilder args =
+                [
                     (ResetMode)mode
-                };
+                ];
             }
         }
 

--- a/UnitTests/GitCommands.Tests/AsyncLoaderTests.cs
+++ b/UnitTests/GitCommands.Tests/AsyncLoaderTests.cs
@@ -204,7 +204,7 @@ namespace GitCommandsTests
         {
             ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                List<Exception> observed = new();
+                List<Exception> observed = [];
 
                 _loader.LoadingError += (_, e) =>
                 {
@@ -239,7 +239,7 @@ namespace GitCommandsTests
         [Test]
         public void Error_raised_via_event_and_not_marked_as_handled_faults_task()
         {
-            List<Exception> observed = new();
+            List<Exception> observed = [];
 
             _loader.LoadingError += (_, e) =>
             {

--- a/UnitTests/GitCommands.Tests/ExternalLinks/ExternalLinkRevisionParserTests.cs
+++ b/UnitTests/GitCommands.Tests/ExternalLinks/ExternalLinkRevisionParserTests.cs
@@ -106,24 +106,24 @@ namespace GitCommandsTests.ExternalLinks
 
         private static BindingList<ConfigFileRemote> GetDefaultRemotes()
         {
-            BindingList<ConfigFileRemote> remotes = new();
-            remotes.Add(new ConfigFileRemote
-            {
-                Name = "origin",
-                Url = "https://github.com/jbialobr/gitextensions.git"
-            });
-
-            remotes.Add(new ConfigFileRemote
-            {
-                Name = "upstream",
-                Url = "https://github.com/gitextensions/gitextensions.git"
-            });
-
-            remotes.Add(new ConfigFileRemote
-            {
-                Name = "RussKie",
-                Url = "https://github.com/russkie/gitextensions.git"
-            });
+            BindingList<ConfigFileRemote> remotes =
+            [
+                new ConfigFileRemote
+                {
+                    Name = "origin",
+                    Url = "https://github.com/jbialobr/gitextensions.git"
+                },
+                new ConfigFileRemote
+                {
+                    Name = "upstream",
+                    Url = "https://github.com/gitextensions/gitextensions.git"
+                },
+                new ConfigFileRemote
+                {
+                    Name = "RussKie",
+                    Url = "https://github.com/russkie/gitextensions.git"
+                },
+            ];
 
             return remotes;
         }

--- a/UnitTests/GitCommands.Tests/Git/CommandsTests.DeleteBranch.cs
+++ b/UnitTests/GitCommands.Tests/Git/CommandsTests.DeleteBranch.cs
@@ -39,7 +39,7 @@ namespace GitCommandsTests_Git
                 const string name = "local_branch";
 
                 // Test local branches only
-                List<IGitRef> localRefs = new();
+                List<IGitRef> localRefs = [];
                 IGitModule localGitModule = Substitute.For<IGitModule>();
                 IConfigFileSettings localConfigFileSettings = Substitute.For<IConfigFileSettings>();
                 localConfigFileSettings.GetValue($"branch.local_branch.merge").Returns(string.Empty);
@@ -57,16 +57,13 @@ namespace GitCommandsTests_Git
                 string completeName = $"refs/remotes/{remoteName}/{name}";
                 GitRef remoteBranchRef = SetupRawRemoteRef(remoteName, completeName);
 
-                List<IGitRef> mixedRefs = new();
-                mixedRefs.Add(localBranchRef);
-                mixedRefs.Add(remoteBranchRef);
+                List<IGitRef> mixedRefs = [localBranchRef, remoteBranchRef];
 
                 yield return new TestCaseData(mixedRefs, /* force */ false, /* expected */ $"branch --delete --all \"{name}\" \"origin/{name}\"");
                 yield return new TestCaseData(mixedRefs, /* force */ true, /* expected */ $"branch --delete --force --all \"{name}\" \"origin/{name}\"");
 
                 // Test remote branches only
-                List<IGitRef> remoteRefs = new();
-                remoteRefs.Add(remoteBranchRef);
+                List<IGitRef> remoteRefs = [remoteBranchRef];
 
                 yield return new TestCaseData(remoteRefs, /* force */ false, /* expected */ $"branch --delete --remotes \"origin/{name}\"");
                 yield return new TestCaseData(remoteRefs, /* force */ true, /* expected */ $"branch --delete --force --remotes \"origin/{name}\"");

--- a/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ExecutableExtensionsTests.cs
@@ -95,7 +95,7 @@ namespace GitCommandsTests.Git
             // 9: 'reset -- '
             // 1: ' ' added after second Add in ArgumentBuilder
             int appLength = _appPath.Length + 3;
-            ArgumentBuilder builder = new() { "reset --" };
+            ArgumentBuilder builder = ["reset --"];
             int len = builder.ToString().Length;
             List<BatchArgumentItem> args = builder.BuildBatchArguments(new string[]
             {

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -547,7 +547,7 @@ namespace GitCommandsTests
         [Test]
         public void GetSubmodulesLocalPaths()
         {
-            List<GitModuleTestHelper> moduleTestHelpers = new();
+            List<GitModuleTestHelper> moduleTestHelpers = [];
             try
             {
                 const int numModules = 4;

--- a/UnitTests/GitCommands.Tests/Remote/ConfigFileRemoteSettingsManagerTests.cs
+++ b/UnitTests/GitCommands.Tests/Remote/ConfigFileRemoteSettingsManagerTests.cs
@@ -69,7 +69,7 @@ namespace GitCommandsTests.Remote
             const string remoteName1 = "name1";
             const string remoteName2 = "name2";
             _module.GetRemoteNames().Returns(x => new[] { null, "", " ", "    ", remoteName1, "\t" });
-            List<IConfigSection> sections = new() { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{remoteName2}", true) };
+            List<IConfigSection> sections = [new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{remoteName2}", true)];
             _configFile.GetConfigSections().Returns(x => sections);
 
             IEnumerable<ConfigFileRemote> remotes = _remotesManager.LoadRemotes(loadDisabled);
@@ -235,7 +235,7 @@ namespace GitCommandsTests.Remote
         [TestCase("name2", true)]
         public void SetRemoteState_should_call_ToggleRemoteState(string remoteName, bool remoteDisabled)
         {
-            List<IConfigSection> sections = new() { new ConfigSection("-remote.name1", true), new ConfigSection("remote.name2", true) };
+            List<IConfigSection> sections = [new ConfigSection("-remote.name1", true), new ConfigSection("remote.name2", true)];
             _configFile.GetConfigSections().Returns(x => sections);
 
             _remotesManager.ToggleRemoteState(remoteName, remoteDisabled);
@@ -356,7 +356,7 @@ namespace GitCommandsTests.Remote
 
             _module.GetRemoteNames().Returns(x => new[] { enabledRemoteName, });
 
-            List<IConfigSection> sections = new() { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true) };
+            List<IConfigSection> sections = [new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true)];
             _configFile.GetConfigSections().Returns(x => sections);
 
             IReadOnlyList<GitUIPluginInterfaces.Remote> disabledRemotes = _remotesManager.GetDisabledRemotes();
@@ -376,7 +376,7 @@ namespace GitCommandsTests.Remote
 
             _module.GetRemoteNames().Returns(x => new[] { enabledRemoteName, });
 
-            List<IConfigSection> sections = new() { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true) };
+            List<IConfigSection> sections = [new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true)];
             _configFile.GetConfigSections().Returns(x => sections);
 
             IReadOnlyList<string> enabledRemoteNames = _remotesManager.GetEnabledRemoteNames();
@@ -392,7 +392,7 @@ namespace GitCommandsTests.Remote
 
             _module.GetRemoteNames().Returns(x => new[] { enabledRemoteName, });
 
-            List<IConfigSection> sections = new() { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true) };
+            List<IConfigSection> sections = [new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true)];
             _configFile.GetConfigSections().Returns(x => sections);
 
             Assert.IsTrue(_remotesManager.EnabledRemoteExists(enabledRemoteName));
@@ -407,7 +407,7 @@ namespace GitCommandsTests.Remote
 
             _module.GetRemoteNames().Returns(x => new[] { enabledRemoteName, });
 
-            List<IConfigSection> sections = new() { new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true) };
+            List<IConfigSection> sections = [new ConfigSection($"{ConfigFileRemoteSettingsManager.DisabledSectionPrefix}{ConfigFileRemoteSettingsManager.SectionRemote}.{disabledRemoteName}", true)];
             _configFile.GetConfigSections().Returns(x => sections);
 
             Assert.IsTrue(_remotesManager.DisabledRemoteExists(disabledRemoteName));

--- a/UnitTests/GitCommands.Tests/UserRepositoryHistory/Legacy/RepositoryCategoryXmlSerialiserTests.cs
+++ b/UnitTests/GitCommands.Tests/UserRepositoryHistory/Legacy/RepositoryCategoryXmlSerialiserTests.cs
@@ -64,8 +64,8 @@ namespace GitCommandsTests.UserRepositoryHistory.Legacy
         [Test]
         public async Task Verify_backwards_compatibility_of_object_graph()
         {
-            List<RepositoryCategory> surrogate = new()
-            {
+            List<RepositoryCategory> surrogate =
+            [
                 new RepositoryCategory
                 {
                     Repositories = new List<Repository>(
@@ -87,7 +87,7 @@ namespace GitCommandsTests.UserRepositoryHistory.Legacy
                     CategoryType = "Repositories",
                     Description = "Test"
                 },
-            };
+            ];
 
             string xml;
             using StringWriter sw = new();

--- a/UnitTests/GitCommands.Tests/UserRepositoryHistory/Legacy/RepositoryStorageTests.cs
+++ b/UnitTests/GitCommands.Tests/UserRepositoryHistory/Legacy/RepositoryStorageTests.cs
@@ -42,8 +42,8 @@ namespace GitCommandsTests.UserRepositoryHistory.Legacy
         public void LoadLegacy_should_return_collection()
         {
             AppSettings.SetString("repositories", "repos");
-            List<RepositoryCategory> history = new()
-            {
+            List<RepositoryCategory> history =
+            [
                 new RepositoryCategory
                 {
                     Repositories = new List<Repository>(
@@ -65,7 +65,7 @@ namespace GitCommandsTests.UserRepositoryHistory.Legacy
                     CategoryType = "Repositories",
                     Description = "Test"
                 },
-            };
+            ];
             _repositoryCategorySerialiser.Deserialize(Arg.Any<string>()).Returns(x => history);
 
             IReadOnlyList<RepositoryCategory> repositories = _repositoryStorage.Load();

--- a/UnitTests/GitCommands.Tests/UserRepositoryHistory/LocalRepositoryManagerTests.cs
+++ b/UnitTests/GitCommands.Tests/UserRepositoryHistory/LocalRepositoryManagerTests.cs
@@ -40,13 +40,13 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_add_new_path_as_top_entry()
         {
             const string repoToAdd = "path to add\\";
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("path1\\"),
                 new Repository("path3\\"),
                 new Repository("path4\\"),
                 new Repository("path5\\"),
-            };
+            ];
             _repositoryStorage.Load(KeyRecentHistory).Returns(x => history);
 
             IList<Repository> newHistory = await _manager.AddAsMostRecentAsync(repoToAdd);
@@ -59,14 +59,14 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_move_existing_path_as_top_entry()
         {
             const string repoToAdd = "path to add\\";
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("path1\\"),
                 new Repository("path3\\"),
                 new Repository("path4\\"),
                 new Repository(repoToAdd),
                 new Repository("path5\\"),
-            };
+            ];
             _repositoryStorage.Load(KeyRecentHistory).Returns(x => history);
 
             IList<Repository> newHistory = await _manager.AddAsMostRecentAsync(repoToAdd);
@@ -79,15 +79,15 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_move_only_first_existing_path_as_top_entry()
         {
             const string repoToAdd = "path to add\\";
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("path1\\"),
                 new Repository("path3\\"),
                 new Repository(repoToAdd),
                 new Repository("path4\\"),
                 new Repository(repoToAdd),
                 new Repository("path5\\"),
-            };
+            ];
             _repositoryStorage.Load(KeyRecentHistory).Returns(x => history);
 
             IList<Repository> newHistory = await _manager.AddAsMostRecentAsync(repoToAdd);
@@ -101,14 +101,14 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_not_move_if_path_already_as_top_entry()
         {
             const string repoToAdd = "path to add\\";
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository(repoToAdd),
                 new Repository("path1\\"),
                 new Repository("path3\\"),
                 new Repository("path4\\"),
                 new Repository("path5\\"),
-            };
+            ];
             _repositoryStorage.Load(KeyRecentHistory).Returns(x => history);
 
             IList<Repository> newHistory = await _manager.AddAsMostRecentAsync(repoToAdd);
@@ -162,8 +162,8 @@ namespace GitCommandsTests.UserRepositoryHistory
         {
             const int size = 3;
             AppSettings.RecentRepositoriesHistorySize = size;
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("path1") { Category = "my" },
                 new Repository("path2"),
                 new Repository("path3"),
@@ -171,7 +171,7 @@ namespace GitCommandsTests.UserRepositoryHistory
                 new Repository("path5"),
                 new Repository("path6"),
                 new Repository("path7"),
-            };
+            ];
             _repositoryStorage.Load(KeyRecentHistory).Returns(x => history);
 
             IList<Repository> repositories = await _manager.LoadRecentHistoryAsync();
@@ -184,14 +184,14 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task RemoveRecentAsync_should_remove_if_exists()
         {
             const string repoToDelete = "path to delete";
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("path1"),
                 new Repository(repoToDelete),
                 new Repository("path3"),
                 new Repository("path4"),
                 new Repository("path5"),
-            };
+            ];
             _repositoryStorage.Load(KeyRecentHistory).Returns(x => history);
 
             IList<Repository> newHistory = await _manager.RemoveRecentAsync(repoToDelete);
@@ -207,14 +207,14 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task RemoveFavouriteAsync_should_not_crash_if_not_exists()
         {
             const string repoToDelete = "path to delete";
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("path1"),
                 new Repository("path2"),
                 new Repository("path3"),
                 new Repository("path4"),
                 new Repository("path5"),
-            };
+            ];
             _repositoryStorage.Load(KeyFavouriteHistory).Returns(x => history);
             _repositoryHistoryMigrator.MigrateAsync(Arg.Any<List<Repository>>()).Returns(x => (history, false));
 
@@ -234,14 +234,14 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task RemoveFavouriteAsync_should_remove_if_exists()
         {
             const string repoToDelete = "path to delete";
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("path1"),
                 new Repository(repoToDelete),
                 new Repository("path3"),
                 new Repository("path4"),
                 new Repository("path5"),
-            };
+            ];
             _repositoryStorage.Load(KeyFavouriteHistory).Returns(x => history);
             _repositoryHistoryMigrator.MigrateAsync(Arg.Any<List<Repository>>()).Returns(x => (history, false));
 
@@ -261,14 +261,14 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task RemoveRecentAsync_should_not_crash_if_not_exists()
         {
             const string repoToDelete = "path to delete";
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("path1"),
                 new Repository("path2"),
                 new Repository("path3"),
                 new Repository("path4"),
                 new Repository("path5"),
-            };
+            ];
             _repositoryStorage.Load(KeyRecentHistory).Returns(x => history);
 
             IList<Repository> newHistory = await _manager.RemoveRecentAsync(repoToDelete);
@@ -290,14 +290,14 @@ namespace GitCommandsTests.UserRepositoryHistory
         [Test]
         public async Task SaveFavouriteHistoryAsync_should_save()
         {
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("path1"),
                 new Repository("path2"),
                 new Repository("path3"),
                 new Repository("path4"),
                 new Repository("path5"),
-            };
+            ];
 
             await _manager.SaveFavouriteHistoryAsync(history);
 
@@ -316,14 +316,14 @@ namespace GitCommandsTests.UserRepositoryHistory
         {
             const int size = 3;
             AppSettings.RecentRepositoriesHistorySize = size;
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("path1"),
                 new Repository("path2"),
                 new Repository("path3"),
                 new Repository("path4"),
                 new Repository("path5"),
-            };
+            ];
 
             await _manager.SaveRecentHistoryAsync(history);
 
@@ -333,13 +333,13 @@ namespace GitCommandsTests.UserRepositoryHistory
         [Test]
         public async Task RemoveInvalidRepositoriesAsync_should_apply_predicate()
         {
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("Even"),
                 new Repository("Odd"),
                 new Repository("EvenEven"),
                 new Repository("AlsoOdd"),
-            };
+            ];
 
             _repositoryStorage.Load(KeyRecentHistory).Returns(x => history);
 
@@ -353,13 +353,13 @@ namespace GitCommandsTests.UserRepositoryHistory
         [Test]
         public async Task RemoveInvalidRepositoriesAsync_should_not_apply_predicate()
         {
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("Even"),
                 new Repository("Odd"),
                 new Repository("EvenEven"),
                 new Repository("AlsoOdd"),
-            };
+            ];
 
             _repositoryStorage.Load(KeyRecentHistory).Returns(x => history);
 
@@ -374,12 +374,12 @@ namespace GitCommandsTests.UserRepositoryHistory
         {
             const string repoToDelete = "different path";
 
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("path1"),
                 new Repository("path2"),
                 new Repository(repoToDelete),
-            };
+            ];
 
             _repositoryStorage.Load(KeyRecentHistory).Returns(x => history);
 
@@ -395,12 +395,12 @@ namespace GitCommandsTests.UserRepositoryHistory
         {
             const string repoToDelete = "different path";
 
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("path1"),
                 new Repository("path2"),
                 new Repository(repoToDelete),
-            };
+            ];
 
             _repositoryStorage.Load(KeyFavouriteHistory).Returns(x => history);
             _repositoryHistoryMigrator.MigrateAsync(Arg.Any<List<Repository>>()).Returns(x => (history, false));

--- a/UnitTests/GitCommands.Tests/UserRepositoryHistory/RemoteRepositoryManagerTests.cs
+++ b/UnitTests/GitCommands.Tests/UserRepositoryHistory/RemoteRepositoryManagerTests.cs
@@ -34,13 +34,13 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_add_new_path_as_top_entry()
         {
             const string repoToAdd = "https://path.to/add";
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("http://path1/"),
                 new Repository("http://path3/"),
                 new Repository("http://path4/"),
                 new Repository("http://path5/"),
-            };
+            ];
             _repositoryStorage.Load(Key).Returns(x => history);
 
             IList<Repository> newHistory = await _manager.AddAsMostRecentAsync(repoToAdd);
@@ -53,14 +53,14 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_move_existing_path_as_top_entry()
         {
             const string repoToAdd = "https://path.to/add";
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("git://path1/"),
                 new Repository("git://path3/"),
                 new Repository("git://path4/"),
                 new Repository(repoToAdd),
                 new Repository("git://path5/"),
-            };
+            ];
             _repositoryStorage.Load(Key).Returns(x => history);
 
             IList<Repository> newHistory = await _manager.AddAsMostRecentAsync(repoToAdd);
@@ -73,15 +73,15 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_move_only_first_existing_path_as_top_entry()
         {
             const string repoToAdd = "https://path.to/add";
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("ssh://path1/"),
                 new Repository("ssh://path3/"),
                 new Repository(repoToAdd),
                 new Repository("ssh://path4/"),
                 new Repository(repoToAdd),
                 new Repository("http://path5/"),
-            };
+            ];
             _repositoryStorage.Load(Key).Returns(x => history);
 
             IList<Repository> newHistory = await _manager.AddAsMostRecentAsync(repoToAdd);
@@ -95,14 +95,14 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task AddAsMostRecentAsync_should_not_move_if_path_already_as_top_entry()
         {
             const string repoToAdd = "https://path.to/add";
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository(repoToAdd),
                 new Repository("http://path1/"),
                 new Repository("http://path3/"),
                 new Repository("http://path4/"),
                 new Repository("http://path5/"),
-            };
+            ];
             _repositoryStorage.Load(Key).Returns(x => history);
 
             IList<Repository> newHistory = await _manager.AddAsMostRecentAsync(repoToAdd);
@@ -116,14 +116,14 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task RemoveRecentAsync_should_remove_if_exists()
         {
             const string repoToDelete = "path to delete";
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("path1"),
                 new Repository(repoToDelete),
                 new Repository("path3"),
                 new Repository("path4"),
                 new Repository("path5"),
-            };
+            ];
             _repositoryStorage.Load(Key).Returns(x => history);
 
             IList<Repository> newHistory = await _manager.RemoveRecentAsync(repoToDelete);
@@ -139,14 +139,14 @@ namespace GitCommandsTests.UserRepositoryHistory
         public async Task RemoveRecentAsync_should_not_crash_if_not_exists()
         {
             const string repoToDelete = "path to delete";
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("path1"),
                 new Repository("path2"),
                 new Repository("path3"),
                 new Repository("path4"),
                 new Repository("path5"),
-            };
+            ];
             _repositoryStorage.Load(Key).Returns(x => history);
 
             IList<Repository> newHistory = await _manager.RemoveRecentAsync(repoToDelete);
@@ -170,14 +170,14 @@ namespace GitCommandsTests.UserRepositoryHistory
         {
             const int size = 3;
             AppSettings.RecentRepositoriesHistorySize = size;
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository("path1"),
                 new Repository("path2"),
                 new Repository("path3"),
                 new Repository("path4"),
                 new Repository("path5"),
-            };
+            ];
 
             await _manager.SaveRecentHistoryAsync(history);
 

--- a/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryStorageTests.cs
+++ b/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryStorageTests.cs
@@ -48,8 +48,8 @@ namespace GitCommandsTests.UserRepositoryHistory
         public void Load_should_return_collection()
         {
             AppSettings.SetString("a", "repos");
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository(@"C:\Development\gitextensions\"),
                 new Repository(@"C:\Development\gitextensions\Externals\NBug\")
                 {
@@ -59,7 +59,8 @@ namespace GitCommandsTests.UserRepositoryHistory
                 {
                     Anchor = Repository.RepositoryAnchor.AllRecent,
                 }
-            };
+
+            ];
             _repositorySerialiser.Deserialize(Arg.Any<string>()).Returns(x => history);
 
             IReadOnlyList<Repository> repositories = _repositoryStorage.Load("a");

--- a/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryXmlSerialiserTests.cs
+++ b/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryXmlSerialiserTests.cs
@@ -101,8 +101,8 @@ namespace GitCommandsTests.UserRepositoryHistory
         [Test]
         public async Task Serialize_recent_repositories()
         {
-            List<Repository> history = new()
-            {
+            List<Repository> history =
+            [
                 new Repository(@"C:\Development\gitextensions\"),
                 new Repository(@"C:\Development\gitextensions\Externals\NBug\")
                 {
@@ -112,7 +112,8 @@ namespace GitCommandsTests.UserRepositoryHistory
                 {
                     Anchor = Repository.RepositoryAnchor.AllRecent,
                 }
-            };
+
+            ];
 
             string xml = _repositoryXmlSerialiser.Serialize(history);
             await Verifier.VerifyXml(xml);

--- a/UnitTests/GitExtUtils.Tests/ArgumentBuilderTests.cs
+++ b/UnitTests/GitExtUtils.Tests/ArgumentBuilderTests.cs
@@ -11,27 +11,27 @@ namespace GitExtUtilsTests
         {
             Test(
                 "",
-                new ArgumentBuilder());
+                []);
 
             Test(
                 "foo",
-                new ArgumentBuilder { "foo" });
+                ["foo"]);
 
             Test(
                 "foo bar",
-                new ArgumentBuilder { "foo", "bar" });
+                ["foo", "bar"]);
 
             Test(
                 "foo bar",
-                new ArgumentBuilder { "foo", null, "bar" });
+                ["foo", null, "bar"]);
 
             Test(
                 "foo bar",
-                new ArgumentBuilder { "foo", "", "bar" });
+                ["foo", "", "bar"]);
 
             Test(
                 "",
-                new ArgumentBuilder { null });
+                [null]);
 
             void Test(string expected, ArgumentBuilder command)
             {
@@ -42,7 +42,7 @@ namespace GitExtUtilsTests
         [Test]
         public void IsEmpty()
         {
-            ArgumentBuilder builder = new();
+            ArgumentBuilder builder = [];
             builder.IsEmpty.Should().BeTrue();
 
             builder.Add("test");
@@ -52,7 +52,7 @@ namespace GitExtUtilsTests
         [Test]
         public void Length()
         {
-            ArgumentBuilder builder = new();
+            ArgumentBuilder builder = [];
             builder.GetTestAccessor().Arguments.Length.Should().Be(0);
 
             builder.Add("test");
@@ -73,12 +73,7 @@ namespace GitExtUtilsTests
         [TestCase(new[] { "test", null, "test" }, 9, "test test")]
         public void Add(string[] args, int expectedLength, string expected)
         {
-            ArgumentBuilder builder = new();
-
-            foreach (string arg in args)
-            {
-                builder.Add(arg);
-            }
+            ArgumentBuilder builder = [.. args];
 
             builder.GetTestAccessor().Arguments.Length.Should().Be(expectedLength);
             builder.ToString().Should().Be(expected);

--- a/UnitTests/GitExtUtils.Tests/LazyStringSplitTests.cs
+++ b/UnitTests/GitExtUtils.Tests/LazyStringSplitTests.cs
@@ -34,12 +34,7 @@ namespace GitExtUtilsTests
             AssertEx.SequenceEqual(expected, actual);
 
             // Non boxing foreach
-            List<string> list = new();
-
-            foreach (string s in new LazyStringSplit(input, delimiter, StringSplitOptions.None))
-            {
-                list.Add(s);
-            }
+            List<string> list = [.. new LazyStringSplit(input, delimiter, StringSplitOptions.None)];
 
             AssertEx.SequenceEqual(expected, list);
 
@@ -75,12 +70,7 @@ namespace GitExtUtilsTests
             AssertEx.SequenceEqual(expected, actual);
 
             // Non boxing foreach
-            List<string> list = new();
-
-            foreach (string s in new LazyStringSplit(input, delimiter, StringSplitOptions.RemoveEmptyEntries))
-            {
-                list.Add(s);
-            }
+            List<string> list = [.. new LazyStringSplit(input, delimiter, StringSplitOptions.RemoveEmptyEntries)];
 
             AssertEx.SequenceEqual(expected, list);
 

--- a/UnitTests/GitUI.Tests/CommandsDialogs/FormRemotesControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/FormRemotesControllerTests.cs
@@ -20,11 +20,11 @@ namespace GitUITests.CommandsDialogs
         [TestCase("\t")]
         public void RemoteDelete_should_not_throw_or_mutate_list_of_remotes_if_oldRemoteUrl_null_or_empty(string oldRemoteUrl)
         {
-            List<Repository> remotes = new()
-            {
+            List<Repository> remotes =
+            [
                 new Repository("a"),
                 new Repository("b")
-            };
+            ];
 
             _controller.RemoteDelete(remotes, oldRemoteUrl);
 
@@ -34,11 +34,11 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void RemoteDelete_should_not_throw_or_mutate_list_of_remotes_if_oldRemoteUrl_not_in_list()
         {
-            List<Repository> remotes = new()
-            {
+            List<Repository> remotes =
+            [
                 new Repository("a"),
                 new Repository("b")
-            };
+            ];
 
             _controller.RemoteDelete(remotes, "foo");
 
@@ -48,11 +48,11 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void RemoteDelete_should_remove_remotes_matching_oldRemoteUrl()
         {
-            List<Repository> remotes = new()
-            {
+            List<Repository> remotes =
+            [
                 new Repository("a"),
                 new Repository("b")
-            };
+            ];
 
             _controller.RemoteDelete(remotes, "b");
 
@@ -65,11 +65,11 @@ namespace GitUITests.CommandsDialogs
         [TestCase("\t")]
         public void RemoteUpdate_should_not_throw_or_mutate_list_of_remotes_if_newRemoteUrl_null_or_empty(string newRemoteUrl)
         {
-            List<Repository> remotes = new()
-            {
+            List<Repository> remotes =
+            [
                 new Repository("a"),
                 new Repository("b")
-            };
+            ];
 
             _controller.RemoteUpdate(remotes, "who cares", newRemoteUrl);
 
@@ -81,11 +81,11 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void RemoteDelete_should_replace_matching_oldRemoteUrl()
         {
-            List<Repository> remotes = new()
-            {
+            List<Repository> remotes =
+            [
                 new Repository("a"),
                 new Repository("b")
-            };
+            ];
 
             _controller.RemoteUpdate(remotes, "a", "a1");
 
@@ -96,12 +96,12 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void RemoteDelete_should_place_newRemoteUrl_as_first()
         {
-            List<Repository> remotes = new()
-            {
+            List<Repository> remotes =
+            [
                 new Repository("a"),
                 new Repository("b"),
                 new Repository("c")
-            };
+            ];
 
             _controller.RemoteUpdate(remotes, "c", "a1");
 

--- a/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
+++ b/UnitTests/GitUI.Tests/CommandsDialogs/RevisionDiffControllerTests.cs
@@ -35,7 +35,7 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void SaveFiles_should_not_throw_if_userSelection_null_when_files_empty()
         {
-            List<FileStatusItem> files = new();
+            List<FileStatusItem> files = [];
 
             ((Action)(() => _controller.SaveFiles(files, userSelection: null))).Should().NotThrow();
         }
@@ -43,10 +43,10 @@ namespace GitUITests.CommandsDialogs
         [Test]
         public void SaveFiles_should_throw_if_userSelection_null_when_files_notnull()
         {
-            List<FileStatusItem> files = new()
-            {
+            List<FileStatusItem> files =
+            [
                 new(default, new(ObjectId.Random()), new(""))
-            };
+            ];
 
             ((Action)(() => _controller.SaveFiles(files, userSelection: null))).Should()
                 .Throw<ArgumentNullException>()
@@ -57,10 +57,10 @@ namespace GitUITests.CommandsDialogs
         public void SaveFiles_should_not_save_single_file_if_selection_cancelled()
         {
             FileStatusItem item = new(default, new(ObjectId.Random()), new(""));
-            List<FileStatusItem> files = new()
-            {
+            List<FileStatusItem> files =
+            [
                 item
-            };
+            ];
 
             // User cancelled the dialog
             Func<string, string?> userSelection = (_) => null;
@@ -75,10 +75,10 @@ namespace GitUITests.CommandsDialogs
         public void SaveFiles_should_save_single_file()
         {
             FileStatusItem item = new(default, new(ObjectId.Random()), new(""));
-            List<FileStatusItem> files = new()
-            {
+            List<FileStatusItem> files =
+            [
                 item
-            };
+            ];
 
             Func<string, string?> userSelection = (_) => "c:\\temp\\file.txt";
 
@@ -93,11 +93,11 @@ namespace GitUITests.CommandsDialogs
         {
             FileStatusItem item1 = new(default, new(ObjectId.Random()), new("item1"));
             FileStatusItem item2 = new(default, new(ObjectId.Random()), new("item2"));
-            List<FileStatusItem> files = new()
-            {
+            List<FileStatusItem> files =
+            [
                 item1,
                 item2
-            };
+            ];
 
             // User cancelled the dialog
             Func<string, string?> userSelection = (_) => null;
@@ -116,12 +116,12 @@ namespace GitUITests.CommandsDialogs
             FileStatusItem item1 = new(default, new(ObjectId.Random()), new("item1"));
             FileStatusItem item2 = new(default, new(ObjectId.Random()), new("item2"));
             FileStatusItem item3 = new(default, new(ObjectId.Random()), new("item3"));
-            List<FileStatusItem> files = new()
-            {
+            List<FileStatusItem> files =
+            [
                 item1,
                 item2,
                 item3,
-            };
+            ];
 
             _fullPathResolver.Resolve(item1.Item.Name).Returns(x => "c:\\temp\\item1.txt");
             _fullPathResolver.Resolve(item2.Item.Name).Returns(x => "c:\\temp\\folder1\\item2.txt");
@@ -147,12 +147,12 @@ namespace GitUITests.CommandsDialogs
             FileStatusItem item1 = new(default, new(ObjectId.Random()), new("item1"));
             FileStatusItem item2 = new(default, new(ObjectId.Random()), new("item2"));
             FileStatusItem item3 = new(default, new(ObjectId.Random()), new("item3"));
-            List<FileStatusItem> files = new()
-            {
+            List<FileStatusItem> files =
+            [
                 item1,
                 item2,
                 item3,
-            };
+            ];
 
             _fullPathResolver.Resolve(item1.Item.Name).Returns(x => "c:\\temp\\item1.txt");
             _fullPathResolver.Resolve(item2.Item.Name).Returns(x => "c:\\temp\\folder1\\item2.txt");

--- a/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
@@ -29,7 +29,7 @@ namespace GitUITests.Editor.Diff
         public void CanGetHeaders()
         {
             DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff);
-            List<int> headerLines = new() { 5, 17 };
+            List<int> headerLines = [5, 17];
             foreach (int header in headerLines)
             {
                 result.DiffLines[header].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);

--- a/UnitTests/GitUI.Tests/Editor/Diff/LinePrefixHelperFixture.cs
+++ b/UnitTests/GitUI.Tests/Editor/Diff/LinePrefixHelperFixture.cs
@@ -106,7 +106,7 @@ namespace GitUITests.Editor.Diff
 
         private static List<ISegment> GetSegmentsForDiffText(string diffText)
         {
-            List<ISegment> lineSegments = new();
+            List<ISegment> lineSegments = [];
             foreach (string diffLine in diffText.Split('\n'))
             {
                 ISegment seg = Substitute.For<ISegment>();

--- a/UnitTests/GitUI.Tests/Editor/FileViewerTextTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/FileViewerTextTests.cs
@@ -25,7 +25,7 @@ namespace GitUITests.Editor
         {
             ServiceContainer serviceContainer = new();
             IScriptsManager scriptsManager = Substitute.For<IScriptsManager>();
-            scriptsManager.GetScripts().Returns(new BindingList<ScriptInfo>());
+            scriptsManager.GetScripts().Returns([]);
             serviceContainer.AddService(scriptsManager);
             serviceContainer.AddService(Substitute.For<IHotkeySettingsLoader>());
             _serviceProvider = serviceContainer;

--- a/UnitTests/GitUI.Tests/Hotkey/HotkeySettingsManagerTests.cs
+++ b/UnitTests/GitUI.Tests/Hotkey/HotkeySettingsManagerTests.cs
@@ -17,7 +17,7 @@ namespace GitUITests.Hotkey
         public void SetUp()
         {
             IScriptsManager scriptsManager = Substitute.For<IScriptsManager>();
-            scriptsManager.GetScripts().Returns(new BindingList<ScriptInfo>());
+            scriptsManager.GetScripts().Returns([]);
 
             _settingsManager = new(scriptsManager);
         }

--- a/UnitTests/GitUI.Tests/LinqExtensionsTests.cs
+++ b/UnitTests/GitUI.Tests/LinqExtensionsTests.cs
@@ -13,7 +13,7 @@
         [Test]
         public void AsReadOnlyList_copies_to_new_list_if_required()
         {
-            HashSet<int> set = new() { 1, 2, 3 };
+            HashSet<int> set = [1, 2, 3];
 
             Assert.AreEqual(new[] { 1, 2, 3 }, set.AsReadOnlyList());
         }

--- a/UnitTests/GitUI.Tests/RepositoryHistoryUIServiceTests.cs
+++ b/UnitTests/GitUI.Tests/RepositoryHistoryUIServiceTests.cs
@@ -98,13 +98,13 @@ namespace GitUITests
         public void PopulateFavouriteRepositoriesMenu_should_order_favourites_alphabetically()
         {
             ToolStripMenuItem tsmiFavouriteRepositories = new();
-            List<Repository> repositoryHistory = new()
-            {
+            List<Repository> repositoryHistory =
+            [
                 new Repository(@"c:\") { Category = "D" },
                 new Repository(@"c:\") { Category = "A" },
                 new Repository(@"c:\") { Category = "C" },
                 new Repository(@"c:\") { Category = "B" }
-            };
+            ];
 
             using Form form = new();
             form.Show();

--- a/UnitTests/GitUI.Tests/ResourcesTests.cs
+++ b/UnitTests/GitUI.Tests/ResourcesTests.cs
@@ -66,7 +66,7 @@ namespace GitUITests
             // Skip header
             cursor = cursor[header.Length..];
 
-            List<string> sectionTypes = new();
+            List<string> sectionTypes = [];
 
             // Iterate sections
             while (cursor.Length > 0)

--- a/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
+++ b/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
@@ -225,7 +225,7 @@ namespace GitUITests.Script
         [Test]
         public void ParseScriptArguments_resolve_sRemotePathFromUrl_selectedRemotes_empty()
         {
-            List<string> noSelectedRemotes = new();
+            List<string> noSelectedRemotes = [];
 
             string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{openUrl} https://gitlab.com{sRemotePathFromUrl}/tree/{sBranch}", option: "sRemotePathFromUrl",
@@ -241,7 +241,7 @@ namespace GitUITests.Script
         public void ParseScriptArguments_resolve_sRemotePathFromUrl_currentRemote_set()
         {
             string currentRemote = "myRemote";
-            List<string> selectedRemotes = new() { currentRemote };
+            List<string> selectedRemotes = [currentRemote];
             _module.GetSetting(string.Format(SettingKeyString.RemoteUrl, currentRemote)).Returns("https://gitlab.com/gitlabhq/gitlabhq.git");
 
             string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
@@ -261,7 +261,7 @@ namespace GitUITests.Script
         {
             string option = "sRemoteBranch";
             string branch = remoteName + '/' + branchName;
-            List<IGitRef> remoteBranches = new() { new GitRef(null, null, branch) };
+            List<IGitRef> remoteBranches = [new GitRef(null, null, branch)];
 
             string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
@@ -280,7 +280,7 @@ namespace GitUITests.Script
         {
             string option = "sRemoteBranchName";
             string branch = remoteName + '/' + branchName;
-            List<IGitRef> remoteBranches = new() { new GitRef(null, null, branch) };
+            List<IGitRef> remoteBranches = [new GitRef(null, null, branch)];
 
             string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
@@ -299,7 +299,7 @@ namespace GitUITests.Script
         {
             string option = "cRemoteBranch";
             string branch = remoteName + '/' + branchName;
-            List<IGitRef> remoteBranches = new() { new GitRef(null, null, branch) };
+            List<IGitRef> remoteBranches = [new GitRef(null, null, branch)];
 
             string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,
@@ -318,7 +318,7 @@ namespace GitUITests.Script
         {
             string option = "cRemoteBranchName";
             string branch = remoteName + '/' + branchName;
-            List<IGitRef> remoteBranches = new() { new GitRef(null, null, branch) };
+            List<IGitRef> remoteBranches = [new GitRef(null, null, branch)];
 
             string result = ScriptOptionsParser.GetTestAccessor().ParseScriptArguments(
                 arguments: "{" + option + "}", option,

--- a/UnitTests/GitUI.Tests/TranslationTest.cs
+++ b/UnitTests/GitUI.Tests/TranslationTest.cs
@@ -30,7 +30,7 @@ namespace GitUITests
 
             Dictionary<string, List<Type>> translatableTypes = TranslationUtil.GetTranslatableTypes();
 
-            List<(string typeName, Exception exception)> problems = new();
+            List<(string typeName, Exception exception)> problems = [];
 
             foreach (List<Type> types in translatableTypes.Values)
             {

--- a/UnitTests/GitUI.Tests/UserControls/CommitInfo/BranchComparerTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/CommitInfo/BranchComparerTests.cs
@@ -13,8 +13,8 @@ namespace GitUITests.UserControls.CommitInfo
             AppSettings.PrioritizedBranchNames = "master;dummy;main[^/]*|master[^/]*;release/.*";
             AppSettings.PrioritizedRemoteNames = "zzz;origin|upstream";
 
-            List<string> expectedBranches = new()
-            {
+            List<string> expectedBranches =
+            [
                 currentBranch,
 
                 // local branch important
@@ -67,7 +67,7 @@ namespace GitUITests.UserControls.CommitInfo
                 "remotes/other/b2",
                 "remotes/z_other/b1",
                 "remotes/z_other/b2",
-            };
+            ];
 
             if (currentBranch is null)
             {

--- a/UnitTests/GitUI.Tests/UserControls/ConsoleEmulatorOutputControlFixture.cs
+++ b/UnitTests/GitUI.Tests/UserControls/ConsoleEmulatorOutputControlFixture.cs
@@ -68,7 +68,7 @@ namespace GitUITests.UserControls
                 "Receiving: 100%\nReceived data\n"
             };
 
-            List<string> received = new();
+            List<string> received = [];
 
             void FireDataReceived(TextEventArgs e)
             {
@@ -113,7 +113,7 @@ namespace GitUITests.UserControls
                 "Receiving: 100%\nReceived\r\ndata\n"
             };
 
-            List<string> received = new();
+            List<string> received = [];
 
             void FireDataReceived(TextEventArgs e)
             {

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
@@ -15,8 +15,8 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         /// for testing the LaneInfoProvider.References.MergeRegex
         /// "(?i)^merged? (pull request (.*) from )?(.*branch |tag )?'?([^ ']*[^ '.])'?( of [^ ]*[^ .])?( into (.*[^.]))?\\.?$"
         /// </summary>
-        private static readonly List<string> MergeSubjectsWithDecoding = new()
-        {
+        private static readonly List<string> MergeSubjectsWithDecoding =
+        [
             "Merge Branch xxx", // case-insignificance
             "xxx", "master",
 
@@ -79,7 +79,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
 
             "Merged tag yyy of remote/branch into zz.z.", // sentence with tag, remote and dot in into
             "yyy", "zz.z"
-        };
+        ];
 
         private RevisionGraphRevision _artificialCommitNode;
         private RevisionGraphRevision _realCommitNode;

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphMultiThreadingTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphMultiThreadingTests.cs
@@ -69,7 +69,7 @@ namespace GitUITests.UserControls.RevisionGrid
 
         private void LoadRandomRevisions()
         {
-            List<GitRevision> randomRevisions = new();
+            List<GitRevision> randomRevisions = [];
 
             for (int i = 0; i < _numberOfRevisionsAddedPerRun; i++)
             {

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphRowTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphRowTests.cs
@@ -14,7 +14,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         [Test]
         public void MoveLanesRight_should_do_nothing_if_empty([Values(-1, 0, 1)] int fromLane)
         {
-            List<RevisionGraphSegment> segments = new();
+            List<RevisionGraphSegment> segments = [];
             IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, previousRow: null, mergeGraphLanesHavingCommonParent: true);
             revisionGraphRow.GetLaneCount().Should().Be(1);
 
@@ -30,7 +30,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         [TestCase(2, 0)]
         public void MoveLanesRight_should_move_single_segment(int fromLane, int expectedLane)
         {
-            List<RevisionGraphSegment> segments = new() { _segment };
+            List<RevisionGraphSegment> segments = [_segment];
             IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, previousRow: null, mergeGraphLanesHavingCommonParent: true);
             revisionGraphRow.GetLaneCount().Should().Be(segments.Count);
 
@@ -48,7 +48,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         [TestCase(4, 0, 1, 2)]
         public void MoveLanesRight_should_move_segments(int fromLane, int expectedLane, int expectedLane1, int expectedLane2)
         {
-            List<RevisionGraphSegment> segments = new() { _segment, _segment1, _segment2 };
+            List<RevisionGraphSegment> segments = [_segment, _segment1, _segment2];
             IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, previousRow: null, mergeGraphLanesHavingCommonParent: true);
             revisionGraphRow.GetLaneCount().Should().Be(3);
 
@@ -82,7 +82,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         [TestCase(4, 3, 0, 1, 2)]
         public void MoveLanesRight_should_move_segments_twice(int fromLane1, int fromLane2, int expectedLane, int expectedLane1, int expectedLane2)
         {
-            List<RevisionGraphSegment> segments = new() { _segment, _segment1, _segment2 };
+            List<RevisionGraphSegment> segments = [_segment, _segment1, _segment2];
             IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, previousRow: null, mergeGraphLanesHavingCommonParent: true);
             revisionGraphRow.GetLaneCount().Should().Be(3);
 

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphTests.cs
@@ -311,8 +311,8 @@ namespace GitUITests.UserControls.RevisionGrid
         /// </summary>
         private static RevisionGraph CreateGraph(string commitSpecs)
         {
-            List<GitRevision> commits = new();
-            Dictionary<string, GitRevision> commitsById = new();
+            List<GitRevision> commits = [];
+            Dictionary<string, GitRevision> commitsById = [];
 
             // Parse and create commits
             foreach (string spec in commitSpecs.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
@@ -354,7 +354,7 @@ namespace GitUITests.UserControls.RevisionGrid
         /// </summary>
         private static List<string> AsciiGraphFor(RevisionGraph revisionGraph)
         {
-            List<string> graph = new();
+            List<string> graph = [];
 
             int rowIndex = 0;
             while (true)
@@ -386,7 +386,7 @@ namespace GitUITests.UserControls.RevisionGrid
                 line = Enumerable.Repeat(' ', (Math.Max(row.GetLaneCount(), nextRow.GetLaneCount()) * 2) + 1).ToArray();
 
                 // These drawing actions are done last, to appear on top
-                List<Action> actions = new();
+                List<Action> actions = [];
 
                 foreach (RevisionGraphSegment segment in row.Segments)
                 {

--- a/UnitTests/GitUI.Tests/UserControls/TreeViewExtensionsTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/TreeViewExtensionsTests.cs
@@ -61,7 +61,7 @@ namespace GitUITests.UserControls
         [Test]
         public void RestoreExpandedNodesState_should_restore_no_nodes()
         {
-            HashSet<string> expandedNodes = new();
+            HashSet<string> expandedNodes = [];
             _root.RestoreExpandedNodesState(expandedNodes);
 
             HashSet<string> expandedNodesPost = _root.GetExpandedNodesState();
@@ -71,7 +71,7 @@ namespace GitUITests.UserControls
         [Test]
         public void RestoreExpandedNodesState_should_restore_one_node()
         {
-            HashSet<string> expandedNodes = new() { @"Root\B" };
+            HashSet<string> expandedNodes = [@"Root\B"];
             _root.RestoreExpandedNodesState(expandedNodes);
 
             HashSet<string> expandedNodesPost = _root.GetExpandedNodesState();
@@ -82,8 +82,8 @@ namespace GitUITests.UserControls
         [Test]
         public void RestoreExpandedNodesState_should_restore_all_nodes()
         {
-            HashSet<string> expandedNodes = new()
-            {
+            HashSet<string> expandedNodes =
+            [
                 $"{_root.GetFullNamePath()}",
                 $"{_a.GetFullNamePath()}",
                 $"{_b.GetFullNamePath()}",
@@ -92,7 +92,7 @@ namespace GitUITests.UserControls
                 $"{_b2_1.GetFullNamePath()}",
                 $"{_b3.GetFullNamePath()}",
                 $"{_c.GetFullNamePath()}",
-            };
+            ];
 
             _root.RestoreExpandedNodesState(expandedNodes);
 

--- a/UnitTests/Plugins/BuildServerIntegration/GitlabIntegration.Tests/GitlabAdapterTestData.cs
+++ b/UnitTests/Plugins/BuildServerIntegration/GitlabIntegration.Tests/GitlabAdapterTestData.cs
@@ -8,10 +8,11 @@ namespace GitlabIntegrationTests
     {
         static GitlabAdapterTestData()
         {
-            Builds = new Dictionary<int, Tuple<BuildInfo, GitlabPipeline>>();
-
-            Builds.Add(1,
-                new Tuple<BuildInfo, GitlabPipeline>(
+            Builds = new Dictionary<int, Tuple<BuildInfo, GitlabPipeline>>
+            {
+                {
+                    1,
+                    new Tuple<BuildInfo, GitlabPipeline>(
                     new BuildInfo
                     {
                         Id = "1",
@@ -23,10 +24,11 @@ namespace GitlabIntegrationTests
                     {
                         Id = 1,
                         Sha = "ea6e12b9fbf6da0a558f62e1dc6eaf9d52c22f74"
-                    }));
-
-            Builds.Add(2,
-                new Tuple<BuildInfo, GitlabPipeline>(
+                    })
+                },
+                {
+                    2,
+                    new Tuple<BuildInfo, GitlabPipeline>(
                     new BuildInfo
                     {
                         Id = "2",
@@ -38,10 +40,11 @@ namespace GitlabIntegrationTests
                     {
                         Id = 2,
                         Sha = "0ecc29cbb3ceaa4d12411ceadae9c500e93c9255"
-                    }));
-
-            Builds.Add(3,
-                new Tuple<BuildInfo, GitlabPipeline>(
+                    })
+                },
+                {
+                    3,
+                    new Tuple<BuildInfo, GitlabPipeline>(
                     new BuildInfo
                     {
                         Id = "3",
@@ -53,10 +56,11 @@ namespace GitlabIntegrationTests
                     {
                         Id = 3,
                         Sha = "4ed8079785c070fdaf273771511901e4746c7164"
-                    }));
-
-            Builds.Add(4,
-                new Tuple<BuildInfo, GitlabPipeline>(
+                    })
+                },
+                {
+                    4,
+                    new Tuple<BuildInfo, GitlabPipeline>(
                     new BuildInfo
                     {
                         Id = "4",
@@ -68,10 +72,11 @@ namespace GitlabIntegrationTests
                     {
                         Id = 4,
                         Sha = "afe7fd31ae5156f1aff74874693c0fec7b8cd50a"
-                    }));
-
-            Builds.Add(5,
-                new Tuple<BuildInfo, GitlabPipeline>(
+                    })
+                },
+                {
+                    5,
+                    new Tuple<BuildInfo, GitlabPipeline>(
                     new BuildInfo
                     {
                         Id = "5",
@@ -83,10 +88,11 @@ namespace GitlabIntegrationTests
                     {
                         Id = 5,
                         Sha = "df0b59d03b11ee5d70c0db11bfcf99fc862df56f"
-                    }));
-
-            Builds.Add(6,
-                new Tuple<BuildInfo, GitlabPipeline>(
+                    })
+                },
+                {
+                    6,
+                    new Tuple<BuildInfo, GitlabPipeline>(
                     new BuildInfo
                     {
                         Id = "6",
@@ -98,10 +104,11 @@ namespace GitlabIntegrationTests
                     {
                         Id = 6,
                         Sha = "2b2fb529ba9f24646e5a3a6daf1c42a27940ac26"
-                    }));
-
-            Builds.Add(-7,
-                new Tuple<BuildInfo, GitlabPipeline>(
+                    })
+                },
+                {
+                    -7,
+                    new Tuple<BuildInfo, GitlabPipeline>(
                     new BuildInfo
                     {
                         Id = "7",
@@ -117,10 +124,11 @@ namespace GitlabIntegrationTests
                         Status = "running",
                         CreatedAt = new DateTime(2023, 7, 16, 13, 0, 0),
                         UpdatedAt = new DateTime(2023, 7, 16, 13, 1, 0)
-                    }));
-
-            Builds.Add(7,
-                new Tuple<BuildInfo, GitlabPipeline>(
+                    })
+                },
+                {
+                    7,
+                    new Tuple<BuildInfo, GitlabPipeline>(
                     new BuildInfo
                     {
                         Id = "7",
@@ -136,7 +144,9 @@ namespace GitlabIntegrationTests
                         Status = "success",
                         CreatedAt = new DateTime(2023, 7, 16, 13, 0, 0),
                         UpdatedAt = new DateTime(2023, 7, 16, 13, 1, 30)
-                    }));
+                    })
+                }
+            };
         }
 
         public static Dictionary<int, Tuple<BuildInfo, GitlabPipeline>> Builds;

--- a/UnitTests/Plugins/BuildServerIntegration/GitlabIntegration.Tests/GitlabAdapterTests.cs
+++ b/UnitTests/Plugins/BuildServerIntegration/GitlabIntegration.Tests/GitlabAdapterTests.cs
@@ -52,7 +52,7 @@ namespace GitlabIntegrationTests
                 Items = Array.Empty<GitlabPipeline>()
             };
 
-            List<BuildInfo> expected = new();
+            List<BuildInfo> expected = [];
 
             _apiClient.GetPipelinesAsync(Arg.Any<DateTime?>(), false, 1, Arg.Any<CancellationToken>())
                 .Returns(pagedResponse);
@@ -78,10 +78,10 @@ namespace GitlabIntegrationTests
                 }
             };
 
-            List<BuildInfo> expected = new()
-            {
+            List<BuildInfo> expected =
+            [
                 GitlabAdapterTestData.Builds[1].Item1,
-            };
+            ];
 
             _apiClient.GetPipelinesAsync(Arg.Any<DateTime?>(), false, 1, Arg.Any<CancellationToken>())
                 .Returns(pagedResponse);
@@ -107,10 +107,10 @@ namespace GitlabIntegrationTests
                 }
             };
 
-            List<BuildInfo> expected = new()
-            {
+            List<BuildInfo> expected =
+            [
                 GitlabAdapterTestData.Builds[-7].Item1,
-            };
+            ];
 
             _apiClient.GetPipelinesAsync(Arg.Any<DateTime?>(), true, 1, Arg.Any<CancellationToken>())
                 .Returns(pagedResponse);
@@ -152,15 +152,15 @@ namespace GitlabIntegrationTests
                 }
             };
 
-            List<BuildInfo> expected = new()
-            {
+            List<BuildInfo> expected =
+            [
                 GitlabAdapterTestData.Builds[6].Item1,
                 GitlabAdapterTestData.Builds[5].Item1,
                 GitlabAdapterTestData.Builds[4].Item1,
                 GitlabAdapterTestData.Builds[3].Item1,
                 GitlabAdapterTestData.Builds[2].Item1,
                 GitlabAdapterTestData.Builds[1].Item1
-            };
+            ];
 
             _apiClient.GetPipelinesAsync(Arg.Any<DateTime?>(), false, 1, Arg.Any<CancellationToken>())
                 .Returns(firstPagedResponse);
@@ -204,14 +204,14 @@ namespace GitlabIntegrationTests
                 }
             };
 
-            List<BuildInfo> expected = new()
-            {
+            List<BuildInfo> expected =
+            [
                 GitlabAdapterTestData.Builds[5].Item1,
                 GitlabAdapterTestData.Builds[4].Item1,
                 GitlabAdapterTestData.Builds[3].Item1,
                 GitlabAdapterTestData.Builds[2].Item1,
                 GitlabAdapterTestData.Builds[1].Item1,
-            };
+            ];
 
             _apiClient.GetPipelinesAsync(Arg.Any<DateTime?>(), false, 1, Arg.Any<CancellationToken>())
                 .Returns(firstPagedResponse);
@@ -240,10 +240,10 @@ namespace GitlabIntegrationTests
                 }
             };
 
-            List<BuildInfo> firstExpected = new()
-            {
+            List<BuildInfo> firstExpected =
+            [
                 GitlabAdapterTestData.Builds[1].Item1,
-            };
+            ];
 
             _apiClient.GetPipelinesAsync(Arg.Any<DateTime?>(), false, 1, Arg.Any<CancellationToken>())
                 .Returns(firstResponse);
@@ -266,10 +266,10 @@ namespace GitlabIntegrationTests
                 }
             };
 
-            List<BuildInfo> runningExpected = new()
-            {
+            List<BuildInfo> runningExpected =
+            [
                 GitlabAdapterTestData.Builds[-7].Item1,
-            };
+            ];
 
             _apiClient.GetPipelinesAsync(Arg.Any<DateTime?>(), true, 1, Arg.Any<CancellationToken>())
                 .Returns(runningResponse);
@@ -294,10 +294,10 @@ namespace GitlabIntegrationTests
             };
 
             // should receive only updated BuildInfo
-            List<BuildInfo> secondExpected = new()
-            {
+            List<BuildInfo> secondExpected =
+            [
                 GitlabAdapterTestData.Builds[7].Item1,
-            };
+            ];
 
             _apiClient.GetPipelinesAsync(Arg.Any<DateTime?>(), false, 1, Arg.Any<CancellationToken>())
                 .Returns(secondResponse);
@@ -385,7 +385,7 @@ namespace GitlabIntegrationTests
         private List<BuildInfo> ProcessGetFinishedBuildsRequest()
         {
             ManualResetEvent observableEvent = new(false);
-            List<BuildInfo> result = new();
+            List<BuildInfo> result = [];
 
             IObservable<BuildInfo> observable = _target.GetFinishedBuildsSince(_scheduler);
             observable.Subscribe(e =>
@@ -405,7 +405,7 @@ namespace GitlabIntegrationTests
         private List<BuildInfo> ProcessGetRunningBuildsRequest()
         {
             ManualResetEvent observableEvent = new(false);
-            List<BuildInfo> result = new();
+            List<BuildInfo> result = [];
 
             IObservable<BuildInfo> observable = _target.GetRunningBuilds(_scheduler);
             observable.Subscribe(e =>


### PR DESCRIPTION
Depends on #11240 
See also #11371

## Proposed changes

Use collection expressions: https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12#collection-expressions

Basically, it is an enhanced `new()`, like:
```
-            List<BatchArgumentItem> batches = new();
+            List<BatchArgumentItem> batches = [];
```

(This PR enables that syntax also where `new()` not applied previously.)

Also some conditional allowed (but I had to remove some added by the analyzer due to syntax failure).
*Error	CS0173	Type of conditional expression cannot be determined because there is no implicit conversion between 'collection expressions' and 'collection expressions'	UI.IntegrationTests	C:\dev\gc\gitextensions\IntegrationTests\UI.IntegrationTests\GitUICommands\RunCommandTests.cs	212	Active*

Not working
```
-            List<string> args = new() { "ge.exe", command, "filename" };
-            args.Add(commitValid ? _referenceRepository.CommitHash : "no-commit");
-            if (filter)
-            {
-                args.Add(filterValid ? "--filter-by-revision" : "invalid");
-            }
+            List<string> args =
+            [
+                "ge.exe", command, "filename",
+                commitValid ? _referenceRepository.CommitHash : "no-commit",
+                .. filter ? [filterValid ? "--filter-by-revision" : "invalid"] : [],
+            ];
```

OK
```
diff --git a/GitCommands/Git/Commands.Arguments.cs b/GitCommands/Git/Commands.Arguments.cs
index baff60..51f18 100644
--- a/GitCommands/Git/Commands.Arguments.cs
+++ b/GitCommands/Git/Commands.Arguments.cs
@@ -351,10 +351,12 @@ static ArgumentString GitRefsPattern(RefsFilter option)
                     return string.Empty;
                 }
 
-                ArgumentBuilder builder = new();
-                builder.Add((option & RefsFilter.Heads) != 0, "refs/heads/");
-                builder.Add((option & RefsFilter.Remotes) != 0, "refs/remotes/");
-                builder.Add((option & RefsFilter.Tags) != 0, "refs/tags/");
+                ArgumentBuilder builder = new()
+                {
+                    { (option & RefsFilter.Heads) != 0, "refs/heads/" },
+                    { (option & RefsFilter.Remotes) != 0, "refs/remotes/" },
+                    { (option & RefsFilter.Tags) != 0, "refs/tags/" }
+                };
 
                 return builder;
             }
```

Note that stylecop does not allow this syntax yet:
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3687
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1010.md

newline hade to be added

```
diff --git a/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryStorageTests.cs b/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryStorageTests.cs
index 0dc11..4bc47 100644
--- a/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryStorageTests.cs
+++ b/UnitTests/GitCommands.Tests/UserRepositoryHistory/RepositoryStorageTests.cs
@@ -59,6 +59,7 @@ public void Load_should_return_collection()
                 {
                     Anchor = Repository.RepositoryAnchor.AllRecent,
                 }
+
             ];
             _repositorySerialiser.Deserialize(Arg.Any<string>()).Returns(x => history);
```

## Test methodology <!-- How did you ensure quality? -->

Tests

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
