### PR TITLE
Delete unused branch plugin: Makes GetBranchNames() support worktrees

### DIFF
--- a/Plugins/DeleteUnusedBranches/GitBranchOutputCommandParser.cs
+++ b/Plugins/DeleteUnusedBranches/GitBranchOutputCommandParser.cs
@@ -9,11 +9,12 @@
                 yield break;
             }
 
-            foreach (var line in commandOutput.Split('\n').Where(line => !string.IsNullOrWhiteSpace(line)))
+            foreach (string line in commandOutput.Split('\n').Where(line => !string.IsNullOrWhiteSpace(line) && line.Length > 2))
             {
-                var branchName = line.Trim('*', ' ', '\n', '\r');
+                // Removing first 2 chars: 1st is '*' for current branch or '+' for a worktree branch followed by a space
+                string branchName = line[2..].Trim(' ', '\n', '\r');
 
-                if (branchName != "HEAD")
+                if (branchName != "HEAD" && !branchName.StartsWith("(") && branchName.Length != 0)
                 {
                     yield return branchName;
                 }

--- a/UnitTests/Plugins/DeleteUnusedBranches.Tests/GitBranchOutputCommandParserTests.cs
+++ b/UnitTests/Plugins/DeleteUnusedBranches.Tests/GitBranchOutputCommandParserTests.cs
@@ -28,12 +28,27 @@ namespace DeleteUnusedBranchesTests
             var commandOutput = @"  feature/branch-1
 * fix/branch-2
   master
-
+  HEAD
+* (HEAD detached at dce3f9f)
+  +_valid_branch_name_starting_with_+
 ";
 
             _parser.GetBranchNames(commandOutput)
                    .Should()
-                   .BeEquivalentTo("feature/branch-1", "fix/branch-2", "master");
+                   .BeEquivalentTo("feature/branch-1", "fix/branch-2", "master", "+_valid_branch_name_starting_with_+");
+        }
+
+        [TestCase]
+        public void GetBranchNames_should_support_worktrees()
+        {
+            string commandOutput = @"+ branch_in_worktree
+* master
++ +_valid_branch_name_starting_with_+
+";
+
+            _parser.GetBranchNames(commandOutput)
+                   .Should()
+                   .BeEquivalentTo("branch_in_worktree", "master", "+_valid_branch_name_starting_with_+");
         }
     }
 }


### PR DESCRIPTION
by parsing correctly the output of the command
`git branch --list --merged HEAD`
that contains "+ " prefix in front of branch names checked out in git worktrees

+ add support of some other edge cases

Fixes #11375

+ makes git log command a little more resilient by appending '--' like done in #11277 (if it will fail in the future, it will be with a little better error message)

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/f23cbed7-2bdf-4f5d-8f4e-27d4a4b1810f)

### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/21aed0c5-0d11-478b-bd04-3720985c3ddb)

## Test methodology <!-- How did you ensure quality? -->

- unit tests
- manual

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
