### PR TITLE
GitExtSshAskPass: Ensure chars are outputed as UTF8 chars

### DIFF
--- a/GitExtSshAskPass/SshAskPass.cpp
+++ b/GitExtSshAskPass/SshAskPass.cpp
@@ -32,6 +32,8 @@
 #include <tchar.h>
 
 #include <atlbase.h>
+#include <io.h>
+#include <fcntl.h>
 
 #include <commctrl.h>
 #pragma comment(linker, "\"/manifestdependency:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
@@ -63,6 +65,11 @@ int APIENTRY _tWinMain(HINSTANCE	/*hInstance*/,
 	SetDllDirectory(L"");
 
 	InitCommonControls();
+
+    // !!! Ensure windows console display characters as unicode/UTF8
+    // https://stackoverflow.com/a/15450250/717372
+    // https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setmode?view=msvc-170&redirectedfrom=MSDN#example-use-_setmode-to-change-stdout
+    _setmode(_fileno(stdout), _O_U8TEXT);
 
 	if( _tcslen(lpCmdLine) == 0 )
 	{


### PR DESCRIPTION
because "By default, windows console does not process wide characters."

See https://stackoverflow.com/a/15450250/717372
    & https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setmode?view=msvc-170&redirectedfrom=MSDN

Fixes #11379

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Test methodology <!-- How did you ensure quality? -->

- Manual (and it's a pain!)
    - Run `./GitExtSshAskPass.exe` **from git bash** (the others consoles don't display outputs or display it wrong!!)
    - or run `.\GitExtSshAskPass.exe > output.txt` and check file content

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
