### PR TITLE
Do not migrate empty settings

### DIFF
--- a/GitCommands/UserRepositoryHistory/Legacy/RepositoryStorage.cs
+++ b/GitCommands/UserRepositoryHistory/Legacy/RepositoryStorage.cs
@@ -44,7 +44,7 @@ namespace GitCommands.UserRepositoryHistory.Legacy
         public IReadOnlyList<RepositoryCategory> Load()
         {
             string? legacySetting = AppSettings.GetString(KeyHistory, null);
-            if (legacySetting is null)
+            if (string.IsNullOrWhiteSpace(legacySetting))
             {
                 return Array.Empty<RepositoryCategory>();
             }

--- a/UnitTests/GitCommands.Tests/UserRepositoryHistory/Legacy/RepositoryStorageTests.cs
+++ b/UnitTests/GitCommands.Tests/UserRepositoryHistory/Legacy/RepositoryStorageTests.cs
@@ -19,10 +19,14 @@ namespace GitCommandsTests.UserRepositoryHistory.Legacy
             _repositoryStorage = new RepositoryStorage(_repositoryCategorySerialiser);
         }
 
-        [Test]
-        public void LoadLegacy_should_return_empty_collection_if_settings_value_null()
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void LoadLegacy_should_return_empty_collection_if_settings_empty(string setting)
         {
-            var repositories = _repositoryStorage.Load();
+            AppSettings.SetString("repositories", setting);
+            RepositoryStorage repositoryStorage = new();
+            var repositories = repositoryStorage.Load();
 
             repositories.Should().BeEmpty();
         }


### PR DESCRIPTION
Fixes #11383

## Proposed changes

Do not migrate empty settings

## Test methodology <!-- How did you ensure quality? -->

manual edit the settings file

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
