### PR TITLE
GPG: don't crash on artificial commits

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1263,6 +1263,22 @@ namespace GitUI.CommandsDialogs
 
         private async Task FillGpgInfoAsync(GitRevision? revision)
         {
+            // Don't show the "GPG" tab for artificial commits
+            bool showGpgInfoTab = revision?.IsArtificial is false && AppSettings.ShowGpgInformation.Value;
+
+            if (!showGpgInfoTab)
+            {
+                GpgInfoTabPage.Parent = null;
+                return;
+            }
+
+            if (GpgInfoTabPage.Parent is null)
+            {
+                int index = CommitInfoTabControl.TabPages.IndexOf(TreeTabPage);
+                Debug.Assert(index != -1, "TabControl should contain file tree tab page");
+                CommitInfoTabControl.TabPages.Insert(index + 1, GpgInfoTabPage);
+            }
+
             if (!AppSettings.ShowGpgInformation.Value || CommitInfoTabControl.SelectedTab != GpgInfoTabPage)
             {
                 return;


### PR DESCRIPTION
and hide the tab

Fixes #11388

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Crash

### After

We don't see the tab anymore:
![image](https://github.com/gitextensions/gitextensions/assets/460196/f644b100-f32b-44b6-a34d-993e8d36da69)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 6dd05e51f3540f6d9d0ee2c8b12e780230c8c1c6 (Dirty)
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 6.0.25
- DPI 96dpi (no scaling)
- Portable: False


<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
