### PR TITLE
Avoid popup resetting new file to index

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1377,6 +1377,12 @@ namespace GitCommands
 
                 if (resetId == ObjectId.IndexId)
                 {
+                    if (!postUnstageStatus.Value.Any(i => i.Name == item.Name))
+                    {
+                        // Already removed (for instance new file)
+                        continue;
+                    }
+
                     if (UnmergedIndex(item, postUnstageStatus))
                     {
                         filesCannotCheckout.Add(item.Name);


### PR DESCRIPTION
Fixes #11391

## Proposed changes

Avoid a popup when resetting worktree files

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
