### PR TITLE
Add option to set category to FormClone/FormInit

### DIFF
--- a/GitUI/CommandsDialogs/FormClone.Designer.cs
+++ b/GitUI/CommandsDialogs/FormClone.Designer.cs
@@ -41,6 +41,8 @@
             tpnlMain = new TableLayoutPanel();
             optionsPanel = new FlowLayoutPanel();
             ttHints = new ToolTip(components);
+            cbAddCategory = new CheckBox();
+            categories = new ComboBox();
             MainPanel.SuspendLayout();
             ControlsPanel.SuspendLayout();
             tableLayoutPanel1.SuspendLayout();
@@ -353,12 +355,34 @@
             optionsPanel.AutoSize = true;
             optionsPanel.Controls.Add(cbIntializeAllSubmodules);
             optionsPanel.Controls.Add(cbDownloadFullHistory);
+            optionsPanel.Controls.Add(cbAddCategory);
+            optionsPanel.Controls.Add(categories);
             optionsPanel.Dock = DockStyle.Fill;
             optionsPanel.Location = new Point(0, 272);
             optionsPanel.Margin = new Padding(0, 10, 0, 0);
             optionsPanel.Name = "optionsPanel";
             optionsPanel.Size = new Size(623, 25);
             optionsPanel.TabIndex = 2;
+            // 
+            // cbAddCategory
+            // 
+            cbAddCategory.AutoSize = true;
+            cbAddCategory.Location = new Point(342, 3);
+            cbAddCategory.Name = "cbAddCategory";
+            cbAddCategory.Size = new Size(100, 19);
+            cbAddCategory.TabIndex = 5;
+            cbAddCategory.Text = "Add category:";
+            cbAddCategory.UseVisualStyleBackColor = true;
+            cbAddCategory.CheckStateChanged += cbAddCategory_CheckStateChanged;
+            // 
+            // categories
+            // 
+            categories.Enabled = false;
+            categories.FormattingEnabled = true;
+            categories.Location = new Point(448, 3);
+            categories.Name = "categories";
+            categories.Size = new Size(172, 23);
+            categories.TabIndex = 6;
             // 
             // FormClone
             // 
@@ -420,5 +444,7 @@
         private TableLayoutPanel tpnlMain;
         private ToolTip ttHints;
         private FlowLayoutPanel optionsPanel;
+        private CheckBox cbAddCategory;
+        private ComboBox categories;
     }
 }

--- a/GitUI/CommandsDialogs/FormInit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormInit.Designer.cs
@@ -35,6 +35,8 @@
             Central = new RadioButton();
             Personal = new RadioButton();
             Init = new Button();
+            cbAddCategory = new CheckBox();
+            categories = new ComboBox();
             MainPanel.SuspendLayout();
             ControlsPanel.SuspendLayout();
             groupBox1.SuspendLayout();
@@ -42,16 +44,18 @@
             // 
             // MainPanel
             // 
+            MainPanel.Controls.Add(categories);
+            MainPanel.Controls.Add(cbAddCategory);
             MainPanel.Controls.Add(groupBox1);
             MainPanel.Controls.Add(Browse);
             MainPanel.Controls.Add(_NO_TRANSLATE_Directory);
             MainPanel.Controls.Add(label1);
-            MainPanel.Size = new Size(542, 132);
+            MainPanel.Size = new Size(542, 153);
             // 
             // ControlsPanel
             // 
             ControlsPanel.Controls.Add(Init);
-            ControlsPanel.Location = new Point(0, 132);
+            ControlsPanel.Location = new Point(0, 153);
             ControlsPanel.Size = new Size(542, 41);
             // 
             // label1
@@ -128,12 +132,32 @@
             Init.UseVisualStyleBackColor = true;
             Init.Click += InitClick;
             // 
+            // cbAddCategory
+            // 
+            cbAddCategory.AutoSize = true;
+            cbAddCategory.Location = new Point(257, 125);
+            cbAddCategory.Name = "cbAddCategory";
+            cbAddCategory.Size = new Size(100, 19);
+            cbAddCategory.TabIndex = 4;
+            cbAddCategory.Text = "Add category:";
+            cbAddCategory.UseVisualStyleBackColor = true;
+            cbAddCategory.CheckStateChanged += cbAddCategory_CheckStateChanged;
+            // 
+            // categories
+            // 
+            categories.Enabled = false;
+            categories.FormattingEnabled = true;
+            categories.Location = new Point(363, 124);
+            categories.Name = "categories";
+            categories.Size = new Size(167, 23);
+            categories.TabIndex = 5;
+            // 
             // FormInit
             // 
             AcceptButton = Init;
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
-            ClientSize = new Size(542, 173);
+            ClientSize = new Size(542, 194);
             FormBorderStyle = FormBorderStyle.FixedDialog;
             HelpButton = true;
             ManualSectionAnchorName = "create-new-repository";
@@ -163,5 +187,7 @@
         private RadioButton Central;
         private RadioButton Personal;
         private Button Init;
+        private ComboBox categories;
+        private CheckBox cbAddCategory;
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11312 

## Proposed changes
Add an option to assign a category on creating or cloning a repository via an editable combobox (disabled by default). I don't think it makes sense from UX point of view to add it also to FormOpen. 

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://github.com/gitextensions/gitextensions/assets/23001472/b9e5c634-eaab-4f3c-974d-87044983ddae)
![image](https://github.com/gitextensions/gitextensions/assets/23001472/91de93d9-503c-42f1-bcfa-9c76fba2344e)

### After
![image](https://github.com/gitextensions/gitextensions/assets/23001472/d1aceba5-1d5c-4528-8212-5582c18f7099)
![image](https://github.com/gitextensions/gitextensions/assets/23001472/2f6ebb3e-dea5-4cfb-bf09-81aaa3d65061)
![image](https://github.com/gitextensions/gitextensions/assets/23001472/0f0a3628-a9cb-4175-9f1f-4f7c516d84b0)
![image](https://github.com/gitextensions/gitextensions/assets/23001472/e481ebd1-3b4b-4963-9a64-1b268764fe1d)

## Test methodology <!-- How did you ensure quality? -->

Manual testing.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.43.0
- Microsoft Windows NT 10.0.22621.0

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
