### PR TITLE
Remove bad shortcut association (rebase on pull-rebase)

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1029,7 +1029,6 @@ namespace GitUI.CommandsDialogs
             pullToolStripMenuItem1.ShortcutKeyDisplayString = GetShortcutKeys(Command.PullOrFetch).ToShortcutKeyDisplayString();
             pushToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.Push).ToShortcutKeyDisplayString();
             rebaseToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.Rebase).ToShortcutKeyDisplayString();
-            rebaseToolStripMenuItem1.ShortcutKeyDisplayString = GetShortcutKeys(Command.Rebase).ToShortcutKeyDisplayString();
 
             helpToolStripMenuItem.RefreshShortcutKeys(Hotkeys);
             toolsToolStripMenuItem.RefreshShortcutKeys(Hotkeys);


### PR DESCRIPTION
## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/df1f0cc7-acda-49e6-8a1a-096a86152c5e)

### After
![image](https://github.com/gitextensions/gitextensions/assets/460196/d3e6e010-d39b-4f1d-97cc-5a0d3757923c)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 69d17129d78cefd5c98d5ada53ee7bc643c51456
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 8.0.0
- DPI 96dpi (no scaling)
- Portable: False


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
