### PR TITLE
UseWaitCursor when waiting for Impact Graph results (#11409)

### DIFF
--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -202,8 +202,13 @@ namespace GitExtensions.Plugins.GitImpact
                 // Nothing to draw
                 if (_impact.Count == 0)
                 {
+                    // Show this cursor until we get some results painted
+                    UseWaitCursor = true;
                     return;
                 }
+
+                // Now we have results, don't show waiting cursor
+                UseWaitCursor = false;
 
                 // Activate AntiAliasing
                 e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;

--- a/contributors.txt
+++ b/contributors.txt
@@ -201,3 +201,4 @@ YYYY/MM/DD, github id, Full name, email
 2023/08/30, SlugFiller, Saar Korren, slugfiller(at)gmail.com
 2023/07/16, e-stadnik, Evgeny Stadnik ev.stadnik(at)outlook.com
 2023/10/20, dmitrybozhenok, Dmitry Bozhenok, dmitry.bozhenok(at)gmail.com
+2023/11/30, snelltheta, Steve Samons, snelltheta(at)gmail.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11409 

## Proposed changes
Add waiting cursor when mouse is over the form to be painted.
- 

## Test methodology 

- Built and ran.

## Test environment(s) 

- GIT 2.42windows2
- Windows 10 22H2

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Rebase merge (PR submitter must change the commit message for the last commit).

The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
