### PR TITLE
Plugins: Fail to load a plugin no more prevent loading of all others

### DIFF
--- a/GitUI/Plugin/FailedPluginWrapper.cs
+++ b/GitUI/Plugin/FailedPluginWrapper.cs
@@ -1,0 +1,65 @@
+﻿using System.Diagnostics;
+using System.Text.RegularExpressions;
+using GitUI.Properties;
+using GitUIPluginInterfaces;
+
+namespace GitUI;
+
+internal partial class FailedPluginWrapper : IGitPlugin
+{
+    [GeneratedRegex("\\\"GitExtensions.([^\"]+)\\\"")]
+    private static partial Regex PluginNameRegex();
+
+    private readonly string _exception;
+    private string _pluginName;
+
+    public FailedPluginWrapper(Exception loadingException)
+    {
+        ArgumentNullException.ThrowIfNull(loadingException);
+
+        _exception = loadingException.Demystify().ToString();
+        try
+        {
+            // Try to extract plugin name from exception
+            Match match = PluginNameRegex().Match(_exception);
+            if (match.Success)
+            {
+                _pluginName = match.Value;
+                Name = $"{TranslatedStrings.FailedToLoadPlugin}: {_pluginName.Substring(0, Math.Min(50, match.Value.Length))}";
+            }
+        }
+        catch (Exception)
+        {
+            // no-op: best effort
+        }
+    }
+
+    public Guid Id { get; } = Guid.NewGuid();
+    public string? Name { get; init; } = TranslatedStrings.FailedToLoadPlugin;
+    public string? Description { get; } = TranslatedStrings.FailedToLoadPlugin;
+    public Image? Icon { get; } = Resources.bug;
+    public IGitPluginSettingsContainer? SettingsContainer { get; set; }
+    public bool HasSettings { get; } = false;
+
+    public bool Execute(GitUIEventArgs args)
+    {
+        DialogResult result = MessageBox.Show(string.Format(TranslatedStrings.FailedToLoadPluginPopupText, _exception),
+            TranslatedStrings.FailedToLoadPlugin, MessageBoxButtons.OKCancel, MessageBoxIcon.Error);
+        if (result == DialogResult.OK)
+        {
+            Clipboard.SetText(_exception);
+        }
+
+        return false;
+    }
+
+    public IEnumerable<ISetting> GetSettings() => Array.Empty<ISetting>();
+
+    public void Register(IGitUICommands gitUiCommands)
+    {
+    }
+
+    public void Unregister(IGitUICommands gitUiCommands)
+    {
+    }
+}

--- a/GitUI/TranslatedStrings.cs
+++ b/GitUI/TranslatedStrings.cs
@@ -178,6 +178,13 @@ following command.
         private readonly TranslationString _failedToLoadFileOrAssemblyText = new("Most of the times the error is temporary, likely caused by Windows Update.");
         private readonly TranslationString _notConfigured = new("{0} not configured");
 
+        private readonly TranslationString _failedToLoadPlugin = new("Plugin loading failure");
+        private readonly TranslationString _failedToLoadPluginPopupText = new(@"Fail to load a plugin. Error:
+
+{0}
+
+Copy error details to clipboard?");
+
         // public only because of FormTranslate
         public TranslatedStrings()
         {
@@ -366,5 +373,7 @@ following command.
         public static string FailedToLoadFileOrAssemblyFormat => _instance.Value._failedToLoadFileOrAssemblyFormat.Text;
         public static string FailedToLoadFileOrAssemblyText => _instance.Value._failedToLoadFileOrAssemblyText.Text;
         public static string NotConfigured => _instance.Value._notConfigured.Text;
+        public static string FailedToLoadPlugin => _instance.Value._failedToLoadPlugin.Text;
+        public static string FailedToLoadPluginPopupText => _instance.Value._failedToLoadPluginPopupText.Text;
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -10115,6 +10115,18 @@ Select this commit to populate the full message.</source>
         <source>Most of the times the error is temporary, likely caused by Windows Update.</source>
         <target />
       </trans-unit>
+      <trans-unit id="_failedToLoadPlugin.Text">
+        <source>Plugin loading failure</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_failedToLoadPluginPopupText.Text">
+        <source>Fail to load a plugin. Error:
+
+{0}
+
+Copy error details to clipboard?</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_filterFileInGrid.Text">
         <source>Filter file in &amp;grid</source>
         <target />


### PR DESCRIPTION
When a plugin fail to load and an exception is raised, no plugin was added to the `Plugins` collection
and so none was added to the menu in the UI.

Will mitigate the case where external plugins not (yet) compatible won't prevent internal plugins to load.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/657c722a-5ee8-4fd3-ac78-8596f2f7c5cb)

### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/229d417c-501e-417e-8464-1cb259219c14)

![image](https://github.com/gitextensions/gitextensions/assets/460196/099eb0e1-d361-485c-ab5d-3d8947ddbe2e)


## Test methodology <!-- How did you ensure quality? -->

- Manual ( test a current `master` with #11397 )

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build b98f9600d6dd6de04644191a64b2881fff057fd9 (Dirty)
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 8.0.0
- DPI 96dpi (no scaling)
- Portable: False


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
