### PR TITLE
Remove redundant GitUICommands.GitModule

### DIFF
--- a/GitCommands/Git/Tag/GitTagController.cs
+++ b/GitCommands/Git/Tag/GitTagController.cs
@@ -53,7 +53,7 @@ namespace GitCommands.Git.Tag
 
             try
             {
-                return _uiCommands.StartCommandLineProcessDialog(parentWindow, Commands.CreateTag(args, tagMessageFileName, _uiCommands.GitModule.GetPathForGitExecution));
+                return _uiCommands.StartCommandLineProcessDialog(parentWindow, Commands.CreateTag(args, tagMessageFileName, _uiCommands.Module.GetPathForGitExecution));
             }
             finally
             {
@@ -66,7 +66,7 @@ namespace GitCommands.Git.Tag
 
         private string GetWorkingDirPath()
         {
-            return _uiCommands.GitModule.WorkingDir;
+            return _uiCommands.Module.WorkingDir;
         }
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -128,7 +128,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             Init(commandsSource);
 
-            _getAllChangedFilesOutputParser = new GetAllChangedFilesOutputParser(() => commandsSource.UICommands.GitModule);
+            _getAllChangedFilesOutputParser = new GetAllChangedFilesOutputParser(() => commandsSource.UICommands.Module);
 
             return;
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -613,7 +613,7 @@ namespace GitUI.CommandsDialogs
         /// </summary>
         private void RefreshRevisions()
         {
-            RefreshRevisions(new FilteredGitRefsProvider(UICommands.GitModule).GetRefs);
+            RefreshRevisions(new FilteredGitRefsProvider(UICommands.Module).GetRefs);
         }
 
         /// <summary>
@@ -2735,9 +2735,9 @@ namespace GitUI.CommandsDialogs
                 Lazy<IReadOnlyCollection<GitRevision>> getStashRevs = new(() =>
                     !AppSettings.ShowStashes
                     ? Array.Empty<GitRevision>()
-                    : new RevisionReader(new GitModule(UICommands.GitModule.WorkingDir)).GetStashes(CancellationToken.None));
+                    : new RevisionReader(new GitModule(UICommands.Module.WorkingDir)).GetStashes(CancellationToken.None));
 
-                RefreshLeftPanel(new FilteredGitRefsProvider(UICommands.GitModule).GetRefs, getStashRevs, forceRefresh: true);
+                RefreshLeftPanel(new FilteredGitRefsProvider(UICommands.Module).GetRefs, getStashRevs, forceRefresh: true);
                 repoObjectsTree.RefreshRevisionsLoaded();
             }
         }

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -905,7 +905,7 @@ namespace GitUI.CommandsDialogs
 
         private void FillTagDropDown()
         {
-            // var tags = Module.GetTagHeads(GitModule.GetTagHeadsOption.OrderByCommitDateDescending); // comment out to sort by commit date
+            // var tags = Module.GetTagHeads(Module.GetTagHeadsOption.OrderByCommitDateDescending); // comment out to sort by commit date
             List<string> tags = Module.GetRefs(RefsFilter.Tags)
                                       .Select(tag => tag.Name)
                                       .ToList();

--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -381,7 +381,7 @@ namespace GitUI.CommandsDialogs
             try
             {
                 AppSettings.ShowStashes = false;
-                ObjectId firstParent = UICommands.GitModule.RevParse("HEAD~");
+                ObjectId firstParent = UICommands.Module.RevParse("HEAD~");
                 string preSelectedCommit = !string.IsNullOrWhiteSpace(txtFrom.Text) ? txtFrom.Text : firstParent?.ToString() ?? string.Empty;
                 using FormChooseCommit chooseForm = new(UICommands, preSelectedCommit, showCurrentBranchOnly: true);
                 if (chooseForm.ShowDialog(this) == DialogResult.OK && chooseForm.SelectedRevision is not null)

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -80,7 +80,7 @@ namespace GitUI.CommandsDialogs
                     "--no-abbrev",
                     item
                 };
-                string output = UICommands.GitModule.GitExecutable.GetOutput(arguments);
+                string output = UICommands.Module.GitExecutable.GetOutput(arguments);
                 List<RefLine> refLines = ConvertReflogOutput().ToList();
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 _lastHitRowIndex = 0;

--- a/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
+++ b/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
@@ -117,7 +117,7 @@ namespace GitUI.CommandsDialogs
         /// </summary>
         public FileInfo GetPathToSparseCheckoutFile()
         {
-            return new FileInfo(Path.Combine(_gitCommands.GitModule.ResolveGitInternalPath("info"), "sparse-checkout"));
+            return new FileInfo(Path.Combine(_gitCommands.Module.ResolveGitInternalPath("info"), "sparse-checkout"));
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormCreateWorktree.cs
@@ -32,7 +32,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
 
             void LoadBranchesAsync()
             {
-                string selectedBranch = UICommands.GitModule.GetSelectedBranch();
+                string selectedBranch = UICommands.Module.GetSelectedBranch();
                 ExistingBranches = Module.GetRefs(RefsFilter.Heads);
                 comboBoxBranches.Text = TranslatedStrings.LoadingData;
                 ThreadHelper.FileAndForget(async () =>

--- a/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
+++ b/GitUI/CommandsDialogs/WorktreeDialog/FormManageWorktree.cs
@@ -236,7 +236,7 @@ namespace GitUI.CommandsDialogs.WorktreeDialog
         }
 
         private bool IsCurrentlyOpenedWorktree(WorkTree workTree)
-            => new DirectoryInfo(UICommands.GitModule.WorkingDir).FullName.TrimEnd('\\') == new DirectoryInfo(workTree.Path).FullName.TrimEnd('\\');
+            => new DirectoryInfo(UICommands.Module.WorkingDir).FullName.TrimEnd('\\') == new DirectoryInfo(workTree.Path).FullName.TrimEnd('\\');
 
         private void buttonCreateNewWorktree_Click(object sender, EventArgs e)
         {

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -51,8 +51,6 @@ namespace GitUI
             _findFilePredicateProvider = new FindFilePredicateProvider();
         }
 
-        public IGitModule GitModule => Module;
-
         #region Events
 
         public event EventHandler<GitUIEventArgs>? PreCheckoutRevision;

--- a/GitUI/LeftPanel/RepoObjectsTree.ContextActions.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.ContextActions.cs
@@ -196,8 +196,8 @@ namespace GitUI.LeftPanel
             RegisterClick(mnubtnMoveDown, () => ReorderTreeNode(treeMain.SelectedNode, up: false));
 
             // Sort by / order
-            _sortByContextMenuItem = new GitRefsSortByContextMenuItem(() => ResortRefs(new FilteredGitRefsProvider(UICommands.GitModule).GetRefs));
-            _sortOrderContextMenuItem = new GitRefsSortOrderContextMenuItem(() => ResortRefs(new FilteredGitRefsProvider(UICommands.GitModule).GetRefs));
+            _sortByContextMenuItem = new GitRefsSortByContextMenuItem(() => ResortRefs(new FilteredGitRefsProvider(UICommands.Module).GetRefs));
+            _sortOrderContextMenuItem = new GitRefsSortOrderContextMenuItem(() => ResortRefs(new FilteredGitRefsProvider(UICommands.Module).GetRefs));
             menuMain.InsertItems(new ToolStripItem[] { new ToolStripSeparator(), _sortByContextMenuItem, _sortOrderContextMenuItem }, after: mnubtnMoveDown);
         }
 

--- a/GitUI/ScriptsEngine/ScriptOptionsParser.cs
+++ b/GitUI/ScriptsEngine/ScriptOptionsParser.cs
@@ -93,7 +93,7 @@ namespace GitUI.ScriptsEngine
             }
 
             ArgumentNullException.ThrowIfNull(uiCommands);
-            ArgumentNullException.ThrowIfNull(uiCommands.GitModule);
+            ArgumentNullException.ThrowIfNull(uiCommands.Module);
 
             GitRevision? selectedRevision = null;
             GitRevision? currentRevision = null;
@@ -119,7 +119,7 @@ namespace GitUI.ScriptsEngine
 
                 if (currentRevision is null && (option.StartsWith("c") || option == head))
                 {
-                    currentRevision = GetCurrentRevision(uiCommands.GitModule, currentTags, currentLocalBranches, currentRemoteBranches, currentBranches,
+                    currentRevision = GetCurrentRevision(uiCommands.Module, currentTags, currentLocalBranches, currentRemoteBranches, currentBranches,
                         loadBody: Contains(arguments, currentMessage));
                     if (currentRevision is null)
                     {
@@ -128,14 +128,14 @@ namespace GitUI.ScriptsEngine
 
                     if (currentLocalBranches.Count == 1)
                     {
-                        currentRemote = uiCommands.GitModule.GetSetting(string.Format(SettingKeyString.BranchRemote, currentLocalBranches[0].Name));
+                        currentRemote = uiCommands.Module.GetSetting(string.Format(SettingKeyString.BranchRemote, currentLocalBranches[0].Name));
                     }
                     else
                     {
-                        currentRemote = uiCommands.GitModule.GetCurrentRemote();
+                        currentRemote = uiCommands.Module.GetCurrentRemote();
                         if (string.IsNullOrEmpty(currentRemote))
                         {
-                            currentRemote = uiCommands.GitModule.GetSetting(string.Format(SettingKeyString.BranchRemote,
+                            currentRemote = uiCommands.Module.GetSetting(string.Format(SettingKeyString.BranchRemote,
                                 AskToSpecify(currentLocalBranches, uiCommands, owner)));
                         }
                     }
@@ -329,7 +329,7 @@ namespace GitUI.ScriptsEngine
                     if (!string.IsNullOrEmpty(newString))
                     {
                         remote = newString;
-                        newString = uiCommands.GitModule.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
+                        newString = uiCommands.Module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
                     }
 
                     break;
@@ -339,7 +339,7 @@ namespace GitUI.ScriptsEngine
                     if (!string.IsNullOrEmpty(newString))
                     {
                         remote = newString;
-                        url = uiCommands.GitModule.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
+                        url = uiCommands.Module.GetSetting(string.Format(SettingKeyString.RemoteUrl, remote));
                         newString = GetRemotePath(url);
                     }
 
@@ -378,7 +378,7 @@ namespace GitUI.ScriptsEngine
                     break;
 
                 case head:
-                    newString = uiCommands.GitModule.GetSelectedBranch(emptyIfDetached: true);
+                    newString = uiCommands.Module.GetSelectedBranch(emptyIfDetached: true);
                     if (string.IsNullOrEmpty(newString))
                     {
                         newString = currentRevision.Guid;
@@ -449,7 +449,7 @@ namespace GitUI.ScriptsEngine
                     }
                     else
                     {
-                        newString = uiCommands.GitModule.GetSetting(string.Format(SettingKeyString.RemoteUrl, currentRemote));
+                        newString = uiCommands.Module.GetSetting(string.Format(SettingKeyString.RemoteUrl, currentRemote));
                     }
 
                     break;
@@ -461,18 +461,18 @@ namespace GitUI.ScriptsEngine
                     }
                     else
                     {
-                        url = uiCommands.GitModule.GetSetting(string.Format(SettingKeyString.RemoteUrl, currentRemote));
+                        url = uiCommands.Module.GetSetting(string.Format(SettingKeyString.RemoteUrl, currentRemote));
                         newString = GetRemotePath(url);
                     }
 
                     break;
 
                 case "RepoName":
-                    newString = uiCommands.GetRequiredService<IRepositoryDescriptionProvider>().Get(uiCommands.GitModule.WorkingDir);
+                    newString = uiCommands.GetRequiredService<IRepositoryDescriptionProvider>().Get(uiCommands.Module.WorkingDir);
                     break;
 
                 case "WorkingDir":
-                    newString = uiCommands.GitModule.WorkingDir;
+                    newString = uiCommands.Module.WorkingDir;
                     break;
 
                 default:

--- a/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
+++ b/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
@@ -115,7 +115,7 @@ namespace GitUI.ScriptsEngine
                     if (optionDependingOnSelectedRevision is not null)
                     {
                         throw new UserExternalOperationException($"{TranslatedStrings.ScriptText}: '{script.Name}'{Environment.NewLine}'{optionDependingOnSelectedRevision}' {TranslatedStrings.ScriptErrorOptionWithoutRevisionGridText}",
-                            new ExternalOperationException(script.Command, arguments, uiCommands.GitModule.WorkingDir));
+                            new ExternalOperationException(script.Command, arguments, uiCommands.Module.WorkingDir));
                     }
                 }
 
@@ -142,15 +142,15 @@ namespace GitUI.ScriptsEngine
                 if (abort)
                 {
                     throw new UserExternalOperationException($"{TranslatedStrings.ScriptText}: '{script.Name}'{Environment.NewLine}{TranslatedStrings.ScriptErrorOptionWithoutRevisionText}",
-                        new ExternalOperationException(script.Command, arguments, uiCommands.GitModule.WorkingDir));
+                        new ExternalOperationException(script.Command, arguments, uiCommands.Module.WorkingDir));
                 }
 
                 string command = OverrideCommandWhenNecessary(originalCommand);
-                command = ExpandCommandVariables(command, uiCommands.GitModule);
+                command = ExpandCommandVariables(command, uiCommands.Module);
 
                 if (script.IsPowerShell)
                 {
-                    PowerShellHelper.RunPowerShell(command, argument, uiCommands.GitModule.WorkingDir, script.RunInBackground);
+                    PowerShellHelper.RunPowerShell(command, argument, uiCommands.Module.WorkingDir, script.RunInBackground);
 
                     // 'RunPowerShell' always runs the script detached (yet).
                     // Hence currently, it does not make sense to trigger the 'RepoChangedNotifier' if '!scriptInfo.RunInBackground'.
@@ -191,7 +191,7 @@ namespace GitUI.ScriptsEngine
                     command = command.Replace(NavigateToPrefix, string.Empty);
                     if (!string.IsNullOrEmpty(command))
                     {
-                        ExecutionResult result = new Executable(command, uiCommands.GitModule.WorkingDir).Execute(argument);
+                        ExecutionResult result = new Executable(command, uiCommands.Module.WorkingDir).Execute(argument);
                         string revisionRef = result.StandardOutput.Split('\n').FirstOrDefault();
 
                         if (revisionRef is not null)
@@ -206,7 +206,7 @@ namespace GitUI.ScriptsEngine
                 if (!script.RunInBackground)
                 {
                     // TODO: Remove downcast from IGitUICommands to GitUICommands after https://github.com/gitextensions/gitextensions/pull/11269
-                    bool success = FormProcess.ShowDialog(owner, uiCommands as GitUICommands, argument, uiCommands.GitModule.WorkingDir, null, true, process: command);
+                    bool success = FormProcess.ShowDialog(owner, uiCommands as GitUICommands, argument, uiCommands.Module.WorkingDir, null, true, process: command);
                     if (!success)
                     {
                         return false;
@@ -225,7 +225,7 @@ namespace GitUI.ScriptsEngine
                         // It is totally valid to have a command without an argument, e.g.:
                         //    Command  : myscript.cmd
                         //    Arguments: <blank>
-                        new Executable(command, uiCommands.GitModule.WorkingDir).Start(argument ?? string.Empty);
+                        new Executable(command, uiCommands.Module.WorkingDir).Start(argument ?? string.Empty);
                     }
                 }
 

--- a/GitUI/ScriptsEngine/ScriptsManager.cs
+++ b/GitUI/ScriptsEngine/ScriptsManager.cs
@@ -74,7 +74,7 @@ namespace GitUI.ScriptsEngine
             if (scriptInfo is null)
             {
                 throw new UserExternalOperationException($"{TranslatedStrings.ScriptErrorCantFind}: '{scriptId}'",
-                    new ExternalOperationException(workingDirectory: commands.GitModule.WorkingDir));
+                    new ExternalOperationException(workingDirectory: commands.Module.WorkingDir));
             }
 
             return ScriptRunner.RunScript(scriptInfo, owner, commands, scriptOptionsProvider);

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2723,7 +2723,7 @@ namespace GitUI
                 revisions
             };
 
-            string mergeBaseCommitId = UICommands.GitModule.GitExecutable.GetOutput(args).TrimEnd('\n');
+            string mergeBaseCommitId = UICommands.Module.GitExecutable.GetOutput(args).TrimEnd('\n');
             if (string.IsNullOrWhiteSpace(mergeBaseCommitId))
             {
                 MessageBox.Show(_noMergeBaseCommit.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/IntegrationTests/UI.IntegrationTests/ScriptEngine/ScriptRunnerTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/ScriptEngine/ScriptRunnerTests.cs
@@ -57,7 +57,7 @@ namespace GitExtensions.UITests.ScriptEngine
             _module.GetCurrentCheckout().ReturnsForAnyArgs(ObjectId.WorkTreeId);
 
             _commands = Substitute.For<IGitUICommands>();
-            _commands.GitModule.Returns(_module);
+            _commands.Module.Returns(_module);
 
             _mockForm = new(_commands);
 

--- a/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
+++ b/Plugins/BackgroundFetch/BackgroundFetchPlugin.cs
@@ -69,7 +69,7 @@ namespace GitExtensions.Plugins.BackgroundFetch
 
             Validates.NotNull(_currentGitUiCommands);
 
-            IGitModule gitModule = _currentGitUiCommands.GitModule;
+            IGitModule gitModule = _currentGitUiCommands.Module;
             if (fetchInterval > 0 && gitModule.IsValidGitWorkingDir())
             {
                 _cancellationToken =
@@ -108,7 +108,7 @@ namespace GitExtensions.Plugins.BackgroundFetch
 
                                           try
                                           {
-                                              _currentGitUiCommands.GitModule.GitExecutable.GetOutput(args);
+                                              _currentGitUiCommands.Module.GitExecutable.GetOutput(args);
                                           }
                                           catch
                                           {
@@ -130,7 +130,7 @@ namespace GitExtensions.Plugins.BackgroundFetch
                                           // git fetch is writing result details into standard error and not standard output, see:
                                           // https://github.com/gitextensions/gitextensions/pull/10793
                                           // https://lore.kernel.org/git/xmqq7cvqrdu6.fsf@gitster.g/
-                                          msg = _currentGitUiCommands.GitModule.GitExecutable.Execute(args).StandardError;
+                                          msg = _currentGitUiCommands.Module.GitExecutable.Execute(args).StandardError;
                                       }
                                       catch
                                       {

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -300,7 +300,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
             IsRefreshing = true;
             Validates.NotNull(_refreshCancellation);
 
-            string curBranch = _gitUiCommands.GitModule.GetSelectedBranch();
+            string curBranch = _gitUiCommands.Module.GetSelectedBranch();
             RefreshContext context = new(
                 _gitCommands,
                 IncludeRemoteBranches.Checked,

--- a/Plugins/GitHub3/GitHub3Plugin.cs
+++ b/Plugins/GitHub3/GitHub3Plugin.cs
@@ -189,7 +189,7 @@ namespace GitExtensions.Plugins.GitHub3
         {
             Validates.NotNull(_currentGitUiCommands);
 
-            IGitModule gitModule = _currentGitUiCommands.GitModule;
+            IGitModule gitModule = _currentGitUiCommands.Module;
             IHostedRemote hostedRemote = GetHostedRemotesForModule().FirstOrDefault(r => r.IsOwnedByMe);
             if (hostedRemote is null)
             {
@@ -221,12 +221,12 @@ namespace GitExtensions.Plugins.GitHub3
         /// </summary>
         public IReadOnlyList<IHostedRemote> GetHostedRemotesForModule()
         {
-            if (_currentGitUiCommands?.GitModule is null)
+            if (_currentGitUiCommands?.Module is null)
             {
                 return Array.Empty<IHostedRemote>();
             }
 
-            IGitModule gitModule = _currentGitUiCommands.GitModule;
+            IGitModule gitModule = _currentGitUiCommands.Module;
             return Remotes().ToList();
 
             IEnumerable<IHostedRemote> Remotes()

--- a/Plugins/GitUIPluginInterfaces/GitUIEventArgs.cs
+++ b/Plugins/GitUIPluginInterfaces/GitUIEventArgs.cs
@@ -25,7 +25,7 @@ namespace GitUIPluginInterfaces
 
         public IWin32Window? OwnerForm { get; }
 
-        public IGitModule GitModule => GitUICommands.GitModule;
+        public IGitModule GitModule => GitUICommands.Module;
 
         public IReadOnlyList<IGitRef> GetRefs(RefsFilter filter) => _getRefs.GetRefs(filter);
     }

--- a/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitUICommands.cs
@@ -14,7 +14,7 @@ namespace GitUIPluginInterfaces
 
         IBrowseRepo? BrowseRepo { get; set; }
 
-        IGitModule GitModule { get; }
+        IGitModule Module { get; }
 
         /// <summary>
         /// RepoChangedNotifier.Notify() should be called after each action that changes repo state

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -226,7 +226,7 @@ namespace GitExtensions.Plugins.JiraCommitHintPlugin
         public override void Register(IGitUICommands gitUiCommands)
         {
             base.Register(gitUiCommands);
-            _gitModule = gitUiCommands.GitModule;
+            _gitModule = gitUiCommands.Module;
             gitUiCommands.PostSettings += gitUiCommands_PostSettings;
             gitUiCommands.PreCommit += gitUiCommands_PreCommit;
             gitUiCommands.PostCommit += gitUiCommands_PostRepositoryChanged;

--- a/ResourceManager/GitPluginBase.cs
+++ b/ResourceManager/GitPluginBase.cs
@@ -56,7 +56,7 @@ namespace ResourceManager
         public virtual void Register(IGitUICommands gitUiCommands)
         {
             Validates.NotNull(SettingsContainer);
-            SettingsContainer.SetSettingsSource(gitUiCommands.GitModule.GetEffectiveSettings());
+            SettingsContainer.SetSettingsSource(gitUiCommands.Module.GetEffectiveSettings());
         }
 
         public virtual void Unregister(IGitUICommands gitUiCommands)

--- a/UnitTests/GitCommands.Tests/Git/Tag/GitTagControllerTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/Tag/GitTagControllerTest.cs
@@ -24,8 +24,8 @@ namespace GitCommandsTests.Git.Tag
             _fileSystem.File.Returns(Substitute.For<FileBase>());
 
             _uiCommands = Substitute.For<IGitUICommands>();
-            _uiCommands.GitModule.WorkingDir.Returns(_workingDir);
-            _uiCommands.GitModule.GetPathForGitExecution(_tagMessageFile).Returns(_tagMessageFile);
+            _uiCommands.Module.WorkingDir.Returns(_workingDir);
+            _uiCommands.Module.GetPathForGitExecution(_tagMessageFile).Returns(_tagMessageFile);
 
             _controller = new GitTagController(_uiCommands, _fileSystem);
         }

--- a/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
+++ b/UnitTests/GitUI.Tests/Script/ScriptOptionsParserTests.cs
@@ -26,7 +26,7 @@ namespace GitUITests.Script
             _scriptOptionsProvider = Substitute.For<IScriptOptionsProvider>();
 
             _commands = Substitute.For<IGitUICommands>();
-            _commands.GitModule.Returns(_module);
+            _commands.Module.Returns(_module);
         }
 
         [Test]

--- a/UnitTests/GitUI.Tests/Script/ScriptsManagerScriptRunnerTests.cs
+++ b/UnitTests/GitUI.Tests/Script/ScriptsManagerScriptRunnerTests.cs
@@ -22,7 +22,7 @@ public class ScriptsManagerScriptRunnerTests
         _scriptOptionsProvider = Substitute.For<IScriptOptionsProvider>();
 
         _commands = Substitute.For<IGitUICommands>();
-        _commands.GitModule.Returns(_module);
+        _commands.Module.Returns(_module);
     }
 
     [Test]


### PR DESCRIPTION
Fixes #11386

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).