### PR TITLE
Ignore fetch/push options in configuration of remote repos

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2327,7 +2327,7 @@ namespace GitCommands
                 .ToList();
         }
 
-        private static readonly Regex _remoteVerboseLineRegex = new(@"^(?<name>[^	]+)\t(?<url>.+?) \((?<direction>fetch|push)\)$", RegexOptions.Compiled);
+        private static readonly Regex _remoteVerboseLineRegex = new(@"^(?<name>[^	]+)\t(?<url>.+?) \((?<direction>fetch|push)\)(?<option>\s*\[[^\]]*])?$", RegexOptions.Compiled);
 
         public async Task<IReadOnlyList<Remote>> GetRemotesAsync()
         {

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2327,7 +2327,8 @@ namespace GitCommands
                 .ToList();
         }
 
-        private static readonly Regex _remoteVerboseLineRegex = new(@"^(?<name>[^	]+)\t(?<url>.+?) \((?<direction>fetch|push)\)(?<option>\s*\[[^\]]*])?$", RegexOptions.Compiled);
+        // Ignore trailing options
+        private static readonly Regex _remoteVerboseLineRegex = new(@"^(?<name>[^	]+)\t(?<url>.+?) \((?<direction>fetch|push)\)(?:\s*\[[^\]]*])?$", RegexOptions.Compiled);
 
         public async Task<IReadOnlyList<Remote>> GetRemotesAsync()
         {

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -499,14 +499,17 @@ namespace GitCommandsTests
                     "ignoreunknown\tgit@github.com:drewnoakes/gitextensions.git (unknownType)",
                     "ignorenotab git@github.com:drewnoakes/gitextensions.git (fetch)",
                     "ignoremissingtype\tgit@gitlab.com:drewnoakes/gitextensions.git",
-                    "git@gitlab.com:drewnoakes/gitextensions.git"
+                    "git@gitlab.com:drewnoakes/gitextensions.git",
+
+                    "with_option\thttps://github.com/flannelhead/jsmn-stream.git (fetch) [blob:none]",
+                    "with_option\thttps://github.com/flannelhead/jsmn-stream.git (push) [ignored]"
                 };
 
                 using (_executable.StageOutput("remote -v", string.Join("\n", lines)))
                 {
                     var remotes = await _gitModule.GetRemotesAsync();
 
-                    Assert.AreEqual(6, remotes.Count);
+                    Assert.AreEqual(7, remotes.Count);
 
                     Assert.AreEqual("RussKie", remotes[0].Name);
                     Assert.AreEqual("git://github.com/RussKie/gitextensions.git", remotes[0].FetchUrl);
@@ -538,6 +541,11 @@ namespace GitCommandsTests
                     Assert.AreEqual(2, remotes[5].PushUrls.Count);
                     Assert.AreEqual("git@github.com:drewnoakes/gitextensions.git", remotes[5].PushUrls[0]);
                     Assert.AreEqual("git@gitlab.com:drewnoakes/gitextensions.git", remotes[5].PushUrls[1]);
+
+                    Assert.AreEqual("with_option", remotes[6].Name);
+                    Assert.AreEqual("https://github.com/flannelhead/jsmn-stream.git", remotes[6].FetchUrl);
+                    Assert.AreEqual(1, remotes[6].PushUrls.Count);
+                    Assert.AreEqual("https://github.com/flannelhead/jsmn-stream.git", remotes[6].PushUrls[0]);
                 }
             });
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11424

## Proposed changes

- Ignore fetch/push options in `GetRemotesAsync`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- extended testcase

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).