### PR TITLE
Tests runnable under dotnet 8 and latest R# - allow dotnet.exe as host

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1815,6 +1815,7 @@ namespace GitCommands
                     _applicationExecutablePath.EndsWith("testhost.x86.exe", StringComparison.InvariantCultureIgnoreCase) ||
 
                     _applicationExecutablePath.EndsWith("ReSharperTestRunner.exe", StringComparison.InvariantCultureIgnoreCase) ||
+                    _applicationExecutablePath.EndsWith("dotnet.exe", StringComparison.InvariantCultureIgnoreCase) ||
 
                     // Translations
                     _applicationExecutablePath.EndsWith("TranslationApp.exe", StringComparison.InvariantCultureIgnoreCase);

--- a/contributors.txt
+++ b/contributors.txt
@@ -202,3 +202,4 @@ YYYY/MM/DD, github id, Full name, email
 2023/07/16, e-stadnik, Evgeny Stadnik ev.stadnik(at)outlook.com
 2023/10/20, dmitrybozhenok, Dmitry Bozhenok, dmitry.bozhenok(at)gmail.com
 2023/11/30, snelltheta, Steve Samons, snelltheta(at)gmail.com
+2023/12/01, pmgiant, Pawel Marchewka, ppmmggiiaanntt(at)gmail.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

I`m compiling (and happily running) GE for dotnet 8, using latest VS2022 Enterprise and R#. 
Unit tests fail one assertion, because the host exe is not on the short whitelist. 

This PR simply adds dotnet.exe to this list.

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
