### PR TITLE
Improve blame feature

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -854,7 +854,7 @@ namespace GitCommands
 
         public static bool DetectCopyInFileOnBlame
         {
-            get => GetBool("DetectCopyInFileOnBlame", true);
+            get => GetBool("DetectCopyInFileOnBlame", false);
             set => SetBool("DetectCopyInFileOnBlame", value);
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -786,7 +786,7 @@ namespace GitUI.CommandsDialogs
 
             // switch to view (and fills the first level of file tree data model if not already done)
             string name = DiffFiles.SelectedItems.First().Item.Name;
-            int? line = DiffText.Visible ? DiffText.CurrentFileLine : BlameControl.CurrentFileLine;
+            int line = DiffText.Visible ? DiffText.CurrentFileLine : BlameControl.CurrentFileLine;
             (FindForm() as FormBrowse)?.ExecuteCommand(FormBrowse.Command.FocusFileTree);
             _revisionFileTree.ExpandToFile(name, line, requestBlame);
         }

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -419,9 +419,8 @@ See the changes in the commit form.");
 
             Task ViewItem()
             {
-                // new selection, start show at line 1
                 return e.Node?.Tag is GitItem gitItem
-                    ? ShowGitItemAsync(gitItem, 1)
+                    ? ShowGitItemAsync(gitItem, line: null)
                     : ClearOutputAsync();
             }
         }
@@ -440,7 +439,7 @@ See the changes in the commit form.");
                     {
                         if (!blameToolStripMenuItem1.Checked)
                         {
-                            return ViewGitItemAsync(gitItem, line);
+                            return ViewGitItemAsync(gitItem, line ?? 1);
                         }
 
                         FileText.Visible = false;
@@ -532,7 +531,7 @@ See the changes in the commit form.");
                 return;
             }
 
-            int? line = FileText.Visible ? FileText.CurrentFileLine : BlameControl.CurrentFileLine;
+            int line = FileText.Visible ? FileText.CurrentFileLine : BlameControl.CurrentFileLine;
             blameToolStripMenuItem1.Checked = !blameToolStripMenuItem1.Checked;
 
             this.InvokeAndForget(() => ShowGitItemAsync(gitItem, line));

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace GitUI.CommandsDialogs.SettingsDialog.Pages
+﻿using GitUI.UserControls.Settings;
+
+namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     partial class BlameViewerSettingsPage
     {
@@ -31,8 +33,8 @@
             groupBoxBlameSettings = new GroupBox();
             tableLayoutPanelBlameSettings = new TableLayoutPanel();
             cbIgnoreWhitespace = new CheckBox();
-            cbDetectMoveAndCopyInThisFile = new CheckBox();
-            cbDetectMoveAndCopyInAllFiles = new CheckBox();
+            cbDetectMoveAndCopyInThisFile = new SettingsCheckBox();
+            cbDetectMoveAndCopyInAllFiles = new SettingsCheckBox();
             groupBoxDisplayResult = new GroupBox();
             tableLayoutPanelDisplayResult = new TableLayoutPanel();
             cbDisplayAuthorFirst = new CheckBox();
@@ -91,22 +93,32 @@
             // cbDetectMoveAndCopyInThisFile
             // 
             cbDetectMoveAndCopyInThisFile.AutoSize = true;
+            cbDetectMoveAndCopyInThisFile.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            cbDetectMoveAndCopyInThisFile.Checked = false;
             cbDetectMoveAndCopyInThisFile.Dock = DockStyle.Fill;
             cbDetectMoveAndCopyInThisFile.Location = new Point(3, 28);
+            cbDetectMoveAndCopyInThisFile.Margin = new Padding(3, 3, 3, 3);
             cbDetectMoveAndCopyInThisFile.Name = "cbDetectMoveAndCopyInThisFile";
             cbDetectMoveAndCopyInThisFile.Size = new Size(297, 19);
             cbDetectMoveAndCopyInThisFile.TabIndex = 1;
             cbDetectMoveAndCopyInThisFile.Text = "Detect move and copy in this file";
+            cbDetectMoveAndCopyInThisFile.ToolTipText = null;
+            cbDetectMoveAndCopyInThisFile.ToolTipIcon = UserControls.Settings.ToolTipIcon.Warning;
             // 
             // cbDetectMoveAndCopyInAllFiles
             // 
             cbDetectMoveAndCopyInAllFiles.AutoSize = true;
+            cbDetectMoveAndCopyInAllFiles.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            cbDetectMoveAndCopyInAllFiles.Checked = false;
             cbDetectMoveAndCopyInAllFiles.Dock = DockStyle.Fill;
             cbDetectMoveAndCopyInAllFiles.Location = new Point(3, 53);
+            cbDetectMoveAndCopyInAllFiles.Margin = new Padding(3, 3, 3, 3);
             cbDetectMoveAndCopyInAllFiles.Name = "cbDetectMoveAndCopyInAllFiles";
             cbDetectMoveAndCopyInAllFiles.Size = new Size(297, 19);
             cbDetectMoveAndCopyInAllFiles.TabIndex = 2;
             cbDetectMoveAndCopyInAllFiles.Text = "Detect move and copy in all files";
+            cbDetectMoveAndCopyInAllFiles.ToolTipText = null;
+            cbDetectMoveAndCopyInAllFiles.ToolTipIcon = UserControls.Settings.ToolTipIcon.Warning;
             // 
             // groupBoxDisplayResult
             // 
@@ -242,8 +254,8 @@
         private GroupBox groupBoxBlameSettings;
         private TableLayoutPanel tableLayoutPanelBlameSettings;
         private CheckBox cbIgnoreWhitespace;
-        private CheckBox cbDetectMoveAndCopyInThisFile;
-        private CheckBox cbDetectMoveAndCopyInAllFiles;
+        private SettingsCheckBox cbDetectMoveAndCopyInThisFile;
+        private SettingsCheckBox cbDetectMoveAndCopyInAllFiles;
         private GroupBox groupBoxDisplayResult;
         private TableLayoutPanel tableLayoutPanelDisplayResult;
         private CheckBox cbDisplayAuthorFirst;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.Designer.cs
@@ -101,7 +101,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             cbDetectMoveAndCopyInThisFile.Name = "cbDetectMoveAndCopyInThisFile";
             cbDetectMoveAndCopyInThisFile.Size = new Size(297, 19);
             cbDetectMoveAndCopyInThisFile.TabIndex = 1;
-            cbDetectMoveAndCopyInThisFile.Text = "Detect move and copy in this file";
+            cbDetectMoveAndCopyInThisFile.Text = "Detect moved or copied lines within blamed file";
             cbDetectMoveAndCopyInThisFile.ToolTipText = null;
             cbDetectMoveAndCopyInThisFile.ToolTipIcon = UserControls.Settings.ToolTipIcon.Warning;
             // 
@@ -116,7 +116,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             cbDetectMoveAndCopyInAllFiles.Name = "cbDetectMoveAndCopyInAllFiles";
             cbDetectMoveAndCopyInAllFiles.Size = new Size(297, 19);
             cbDetectMoveAndCopyInAllFiles.TabIndex = 2;
-            cbDetectMoveAndCopyInAllFiles.Text = "Detect move and copy in all files";
+            cbDetectMoveAndCopyInAllFiles.Text = "Detect moved or copied lines from all files in same commit";
             cbDetectMoveAndCopyInAllFiles.ToolTipText = null;
             cbDetectMoveAndCopyInAllFiles.ToolTipIcon = UserControls.Settings.ToolTipIcon.Warning;
             // 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.cs
@@ -14,8 +14,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void SettingsToPage()
         {
             cbIgnoreWhitespace.Checked = AppSettings.IgnoreWhitespaceOnBlame;
-            cbDetectMoveAndCopyInAllFiles.Checked = AppSettings.DetectCopyInAllOnBlame;
             cbDetectMoveAndCopyInThisFile.Checked = AppSettings.DetectCopyInFileOnBlame;
+            cbDetectMoveAndCopyInAllFiles.Checked = AppSettings.DetectCopyInAllOnBlame;
 
             cbDisplayAuthorFirst.Checked = AppSettings.BlameDisplayAuthorFirst;
             cbShowAuthor.Checked = AppSettings.BlameShowAuthor;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BlameViewerSettingsPage.cs
@@ -1,14 +1,20 @@
 ﻿using GitCommands;
+using GitUI.UserControls.Settings;
+using ResourceManager;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
     public partial class BlameViewerSettingsPage : SettingsPageWithHeader
     {
+        private readonly TranslationString _blameWarningTooltip = new("Could prevent blame to calculate the accurate line number when blaming previous revisions.");
+
         public BlameViewerSettingsPage(IServiceProvider serviceProvider)
             : base(serviceProvider)
         {
             InitializeComponent();
             InitializeComplete();
+            cbDetectMoveAndCopyInThisFile.ToolTipText = _blameWarningTooltip.Text;
+            cbDetectMoveAndCopyInAllFiles.ToolTipText = _blameWarningTooltip.Text;
         }
 
         protected override void SettingsToPage()

--- a/GitUI/Properties/Resources.Designer.cs
+++ b/GitUI/Properties/Resources.Designer.cs
@@ -284,5 +284,15 @@ namespace GitUI.Properties {
                 return ResourceManager.GetString("Translators", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        internal static System.Drawing.Bitmap Warning {
+            get {
+                object obj = ResourceManager.GetObject("Warning", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
     }
 }

--- a/GitUI/Properties/Resources.resx
+++ b/GitUI/Properties/Resources.resx
@@ -184,4 +184,7 @@ Victor Shih, bygreencn, mrahn80, Alexander Eifler, Marcelo Ghelman, ghanique, ol
   <data name="DeleteText" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\Icons\DeleteText.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="Warning" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\Icons\Warning.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
 </root>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -308,6 +308,10 @@ Click this info icon for more details.</source>
         <source>Blame viewer</source>
         <target />
       </trans-unit>
+      <trans-unit id="_blameWarningTooltip.Text">
+        <source>Could prevent blame to calculate the accurate line number when blaming previous revisions.</source>
+        <target />
+      </trans-unit>
       <trans-unit id="cbDetectMoveAndCopyInAllFiles.Text">
         <source>Detect move and copy in all files</source>
         <target />

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -313,11 +313,11 @@ Click this info icon for more details.</source>
         <target />
       </trans-unit>
       <trans-unit id="cbDetectMoveAndCopyInAllFiles.Text">
-        <source>Detect move and copy in all files</source>
+        <source>Detect moved or copied lines from all files in same commit</source>
         <target />
       </trans-unit>
       <trans-unit id="cbDetectMoveAndCopyInThisFile.Text">
-        <source>Detect move and copy in this file</source>
+        <source>Detect moved or copied lines within blamed file</source>
         <target />
       </trans-unit>
       <trans-unit id="cbDisplayAuthorFirst.Text">

--- a/GitUI/UserControls/GitBlameParser.cs
+++ b/GitUI/UserControls/GitBlameParser.cs
@@ -1,0 +1,75 @@
+﻿using System.Diagnostics;
+using System.Text.RegularExpressions;
+using GitCommands;
+using GitExtUtils;
+using GitUIPluginInterfaces;
+
+namespace GitUI.UserControls;
+
+internal interface IGitBlameParser
+{
+    int GetOriginalLineInPreviousCommit(GitRevision selectedBlamedRevision, string filename, int selectedLine);
+}
+
+internal partial class GitBlameParser : IGitBlameParser
+{
+    private readonly Func<IGitModule> _getModule;
+
+    [GeneratedRegex(@"\@\@ -(?<PreviousLineNumber>\d+)(,(?<LineRemovedCount>\d+))? \+(?<CurrentLineNumber>\d+)(,(?<LineAddedCount>\d+))? \@\@", RegexOptions.ExplicitCapture)]
+    private static partial Regex ChunkHeaderRegex();
+
+    public GitBlameParser(Func<IGitModule> getModule)
+    {
+        _getModule = getModule;
+    }
+
+    public int GetOriginalLineInPreviousCommit(GitRevision selectedBlamedRevision, string filename, int selectedLine)
+    {
+        ObjectId? parentId = selectedBlamedRevision.FirstParentId;
+
+        if (parentId is null)
+        {
+            return selectedLine;
+        }
+
+        try
+        {
+            // Get the git diff of changes introduced by the blamed selected commit
+            // *without context lines* to make starting line value more accurate and possibly have more distincts chunks!
+            GitArgumentBuilder args = new("diff") { $"-U0", parentId, selectedBlamedRevision.ObjectId, "--", filename };
+
+            string diffOutput = _getModule().GitExecutable.GetOutput(args, cache: GitModule.GitCommandCache);
+
+            // Find the good chunk of code with current line number (starting from the end), skipping header
+            foreach (string chunk in diffOutput.Split("\n@@").Skip(1).Reverse())
+            {
+                Match match = ChunkHeaderRegex().Match($"@@{chunk}");
+                if (!match.Success)
+                {
+                    Trace.WriteLine($"Blame previous commit: chunk/regex not matching\n@@{chunk}");
+                    continue;
+                }
+
+                int currentChunkStartingLine = int.Parse(match.Groups["CurrentLineNumber"].Value);
+                if (currentChunkStartingLine < selectedLine)
+                {
+                    // Calculate the offset thanks to the diff chunk header
+                    int previousChunkStartingLine = int.Parse(match.Groups["PreviousLineNumber"].Value);
+                    int lineRemovedCount = match.Groups["LineRemovedCount"].Success ? int.Parse(match.Groups["LineRemovedCount"].Value) : 1;
+                    int lineAddedCount = match.Groups["LineAddedCount"].Success ? int.Parse(match.Groups["LineAddedCount"].Value) : 1;
+
+                    // calculate the new position based on changes made above in the file
+                    // and changes made in this chunk
+                    return Math.Max(previousChunkStartingLine,
+                        selectedLine - currentChunkStartingLine + previousChunkStartingLine - lineAddedCount + lineRemovedCount);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Trace.WriteLine("Blame previous commit: error when evaluating a better line number. Exception:" + ex);
+        }
+
+        return selectedLine;
+    }
+}

--- a/GitUI/UserControls/Settings/SettingsCheckBox.cs
+++ b/GitUI/UserControls/Settings/SettingsCheckBox.cs
@@ -5,6 +5,7 @@ namespace GitUI.UserControls.Settings
     public partial class SettingsCheckBox : UserControl
     {
         private string? _toolTipText;
+        private ToolTipIcon _toolTipIcon;
         private ToolTip? _tooltip;
 
         public SettingsCheckBox()
@@ -38,6 +39,21 @@ namespace GitUI.UserControls.Settings
                 _tooltip.SetToolTip(checkBox, _toolTipText);
                 _tooltip.SetToolTip(pictureBox, _toolTipText);
                 pictureBox.Visible = !string.IsNullOrEmpty(_toolTipText);
+            }
+        }
+
+        public ToolTipIcon ToolTipIcon
+        {
+            get => _toolTipIcon;
+            set
+            {
+                _toolTipIcon = value;
+                pictureBox.Image = _toolTipIcon switch
+                {
+                    ToolTipIcon.Warning => Properties.Resources.Warning,
+                    ToolTipIcon.Information => Properties.Resources.information,
+                    _ => throw new NotImplementedException(),
+                };
             }
         }
 

--- a/GitUI/UserControls/Settings/ToolTipIcon.cs
+++ b/GitUI/UserControls/Settings/ToolTipIcon.cs
@@ -1,0 +1,7 @@
+﻿namespace GitUI.UserControls.Settings;
+
+public enum ToolTipIcon
+{
+    Information,
+    Warning
+}

--- a/IntegrationTests/UI.IntegrationTests/UserControls/GitBlameParserTest.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/GitBlameParserTest.cs
@@ -1,0 +1,29 @@
+﻿using GitCommands;
+using GitUI.UserControls;
+using GitUIPluginInterfaces;
+
+namespace GitUITests.UserControls;
+
+public sealed class GitBlameParserTest
+{
+    [Test]
+    public void GetOriginalLineInPreviousCommit()
+    {
+        // Simulate "Blame previous revision" on line 2281
+        // when blaming file FormBrowse.cs on commit 7edc265403b54dd8ea2b8402f8790219d8d42077
+        // line content is: internal bool ExecuteCommand(Command cmd)
+
+        string gitExtensionsRepoPath = Path.GetFullPath(@"..\..\..\..\..\..\..");
+        Assert.IsTrue(gitExtensionsRepoPath.EndsWith("gitextensions"));
+
+        GitModule gitModule = new(gitExtensionsRepoPath);
+
+        // Revision corresponding to line 2281
+        GitRevision selectedBlamedRevision = gitModule.GetRevision(ObjectId.Parse("52476f30670ba5338756b606841fb0a346fd6460"));
+
+        int matchingBlameLineNumber = new GitBlameParser(() => gitModule)
+            .GetOriginalLineInPreviousCommit(selectedBlamedRevision, "GitUI/CommandsDialogs/FormBrowse.cs", 2281);
+
+        Assert.AreEqual(2192, matchingBlameLineNumber); // line content is still: internal bool ExecuteCommand(Command cmd)
+    }
+}

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -218,7 +218,7 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.SimplifyMergesInFileHistory)], false, false, false);
                 yield return (properties[nameof(AppSettings.LoadFileHistoryOnShow)], true, false, false);
                 yield return (properties[nameof(AppSettings.LoadBlameOnShow)], true, false, false);
-                yield return (properties[nameof(AppSettings.DetectCopyInFileOnBlame)], true, false, false);
+                yield return (properties[nameof(AppSettings.DetectCopyInFileOnBlame)], false, false, false);
                 yield return (properties[nameof(AppSettings.DetectCopyInAllOnBlame)], false, false, false);
                 yield return (properties[nameof(AppSettings.IgnoreWhitespaceOnBlame)], true, false, false);
                 yield return (properties[nameof(AppSettings.OpenSubmoduleDiffInSeparateWindow)], false, false, false);


### PR DESCRIPTION
## Proposed changes

- better default value for "change move detection" setting (because the "break" blame)
- Add a warning that these "change move detection" options doesn't work well with blame feature
- improve blame option labels
- better line selection when switching revision from revision grid during a blame
- better estimate line number for "blame previous commit"

(better reviewed commit by commit)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Setting

#### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/3aef252a-8642-488c-b818-daab31690361)

#### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/b50f50d5-1eb0-43a0-a019-ee2f83c12554)

### Change revision line

#### Before

return at the  begin of file:

![blame_other_revision_before](https://github.com/gitextensions/gitextensions/assets/460196/6ea79cef-cc69-42b2-8c83-2e930fc25973)

#### After

stay at the same line:

![blame_other_revision](https://github.com/gitextensions/gitextensions/assets/460196/713766e2-f5c4-47f1-a195-cddabba043e6)


### Blame previous revision

Scenario: go to commit 7edc265403b54dd8ea2b8402f8790219d8d42077 and blame FormBrowse.cs
then blame "previous revision" on line 2281
( the commit 52476f30670ba5338756b606841fb0a346fd6460 add a lot of lines --89-- before this line 2281 )

#### Before

(we end up at 89 lines of the right position and it's very difficult to find the good code --we need to search for some text--)
![blame_prefvious_revision_before](https://github.com/gitextensions/gitextensions/assets/460196/6e026a2b-926b-49d8-af85-ef9fb6a6822a)


#### After

(we end up at the right position, ready to blame again if needed)
![blame_prefvious_revision_after](https://github.com/gitextensions/gitextensions/assets/460196/fe87aad2-6fcb-41f5-b622-e0428710664e)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 33.33.33
- Build 2ae38fae7dcc7a269300d7c05a4cba3e8c79a02e
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 8.0.0
- DPI 96dpi (no scaling)
- Portable: False

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer **rebase** merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
