### PR TITLE
FormResetAnotherBranch: remove useless failing assert on posix path

### DIFF
--- a/GitCommands/Git/Commands.Arguments.cs
+++ b/GitCommands/Git/Commands.Arguments.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using GitCommands.Config;
 using GitCommands.Utils;
 using GitExtUtils;
@@ -473,14 +472,11 @@ namespace GitCommands.Git
         /// </summary>
         /// <param name="gitRef">The branch to move.</param>
         /// <param name="targetId">The commit to move to.</param>
-        /// <param name="repoDir">Directory to the current repo in Posix format.</param>
+        /// <param name="repoDir">Directory to the current repo.</param>
         /// <param name="force">Push the reference also if commits are lost.</param>
         /// <returns>The Git command to execute.</returns>
         public static ArgumentString PushLocal(string gitRef, ObjectId targetId, string repoDir, Func<string, string?> getPathForGitExecution, bool force = false)
         {
-            DebugHelpers.Assert(!EnvUtils.RunningOnWindows() || repoDir.IndexOf(PathUtil.NativeDirectorySeparatorChar) < 0,
-                $"'PushLocalCmd' must be called with 'repoDir' in Posix format");
-
             return new GitArgumentBuilder("push")
             {
                 $@"""file://{getPathForGitExecution(repoDir)}""",


### PR DESCRIPTION
to prevent a Debug failure to be raised (and opening a VS instance on debug builds)

Made useless following a refactoring of the api that now accept all path format and convert it in posix

## Screenshots <!-- Remove this section if PR does not change UI -->

No UI change

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 33.33.33
- Build 403278735fbbfe378600e73b4c7e13e6b49957c9 (Dirty)
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 8.0.0
- DPI 96dpi (no scaling)
- Portable: False

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
