### PR TITLE
Refresh after checking out tag using Left Panel

### DIFF
--- a/GitUI/LeftPanel/TagNode.cs
+++ b/GitUI/LeftPanel/TagNode.cs
@@ -63,9 +63,7 @@ namespace GitUI.LeftPanel
 
         public bool Checkout()
         {
-            using FormCheckoutRevision form = new(UICommands);
-            form.SetRevision(FullPath);
-            return form.ShowDialog(TreeViewNode.TreeView) != DialogResult.Cancel;
+            return UICommands.StartCheckoutRevisionDialog(TreeViewNode.TreeView, FullPath);
         }
     }
 }


### PR DESCRIPTION
Fixes #11427

## Proposed changes

- Open the `FormCheckoutRevision` using the `UICommands.StartCheckoutRevisionDialog`,
  which wraps the call with `DoActionOnRepo`, runs pre/post scripts and notifies about the repo change 

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).