### PR TITLE
Improve performance of left panel reload

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1656,6 +1656,8 @@ namespace GitUI.CommandsDialogs
             _gitStatusMonitor.InvalidateGitWorkingDirectoryStatus();
             _submoduleStatusProvider.Init();
 
+            repoObjectsTree.ClearTrees();
+
             UICommands = UICommands.WithGitModule(e.GitModule);
             if (Module.IsValidGitWorkingDir())
             {

--- a/GitUI/LeftPanel/BaseRevisionNode.cs
+++ b/GitUI/LeftPanel/BaseRevisionNode.cs
@@ -19,9 +19,18 @@ namespace GitUI.LeftPanel
                 throw new ArgumentNullException(nameof(fullPath));
             }
 
-            string[] dirs = fullPath.Split(PathSeparator);
-            Name = dirs[^1];
-            ParentPath = dirs.Take(dirs.Length - 1).Join(PathSeparator.ToString());
+            int nameIndex = fullPath.LastIndexOf(PathSeparator);
+            if (nameIndex == -1)
+            {
+                Name = fullPath;
+                ParentPath = null;
+            }
+            else
+            {
+                Name = fullPath.Substring(nameIndex + 1);
+                ParentPath = fullPath.Substring(0, nameIndex);
+            }
+
             Visible = visible;
         }
 

--- a/GitUI/LeftPanel/BaseRevisionNode.cs
+++ b/GitUI/LeftPanel/BaseRevisionNode.cs
@@ -19,6 +19,7 @@ namespace GitUI.LeftPanel
                 throw new ArgumentNullException(nameof(fullPath));
             }
 
+            FullPath = fullPath;
             int nameIndex = fullPath.LastIndexOf(PathSeparator);
             if (nameIndex == -1)
             {
@@ -44,7 +45,7 @@ namespace GitUI.LeftPanel
         /// <summary>
         /// Full path of the branch. <example>"issues/issue1344"</example>.
         /// </summary>
-        public string FullPath => ParentPath.Combine(PathSeparator.ToString(), Name)!;
+        public string FullPath { get; }
 
         /// <summary>
         /// ObjectId for nodes with a revision.

--- a/GitUI/LeftPanel/BaseRevisionTree.cs
+++ b/GitUI/LeftPanel/BaseRevisionTree.cs
@@ -30,7 +30,7 @@ namespace GitUI.LeftPanel
         {
             TreeView treeView = TreeViewNode.TreeView;
 
-            if (treeView is null || !IsAttached)
+            if (treeView is null || !IsAttached || IsLoading)
             {
                 return;
             }

--- a/GitUI/LeftPanel/Node.cs
+++ b/GitUI/LeftPanel/Node.cs
@@ -65,7 +65,13 @@ namespace GitUI.LeftPanel
             Validates.NotNull(_treeViewNode);
 
             _treeViewNode.Name = NodeName();
-            _treeViewNode.Text = DisplayText();
+
+            // Check before if value has changed because that's a costly operation
+            string updatedText = DisplayText();
+            if (updatedText != _treeViewNode.Text)
+            {
+                _treeViewNode.Text = updatedText;
+            }
         }
 
         internal virtual void OnSelected()

--- a/GitUI/LeftPanel/RepoObjectsTree.SettingsContextMenu.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.SettingsContextMenu.cs
@@ -85,6 +85,15 @@ namespace GitUI.LeftPanel
             ShowEnabledTrees();
         }
 
+        public void ClearTrees()
+        {
+            _branchesTree.ClearTree();
+            _remotesTree.ClearTree();
+            _tagTree.ClearTree();
+            _submoduleTree.ClearTree();
+            _stashTree.ClearTree();
+        }
+
         private void ShowEnabledTrees()
         {
             if (tsbShowBranches.Checked)

--- a/GitUI/LeftPanel/Tree.cs
+++ b/GitUI/LeftPanel/Tree.cs
@@ -72,6 +72,11 @@ namespace GitUI.LeftPanel
         {
         }
 
+        public void ClearTree()
+        {
+            TreeViewNode.Nodes.Clear();
+        }
+
         public IEnumerable<TNode> DepthEnumerator<TNode>() where TNode : NodeBase
             => Nodes.DepthEnumerator<TNode>();
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->
Improvement over https://github.com/gitextensions/gitextensions/discussions/11441#discussioncomment-7829262

## Proposed changes

- Improve performance when reloading left panel (with 20k refs in repository, treeview refresh block the UI now around 2.5s while it was around 6.5s before this fix). Note: the first loading is still slow but after it's much more usable.
- Fix a temporary bad state that is much more likely to occur when ahead/behind data are retrieved (which are slow)and now that treeview load quicker.
- Some other small performance improvements

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 4c9e8a8f933d2ba5aab92569b5c53bc17069f253
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 8.0.0
- DPI 96dpi (no scaling)
- Portable: False

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer *rebase* merge this PR (if the commit message is clear).
Note: better reviewed commit by commit

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).

