### PR TITLE
Improve (hugely!) impact graph performance

### DIFF
--- a/Plugins/Statistics/GitImpact/FormImpact.cs
+++ b/Plugins/Statistics/GitImpact/FormImpact.cs
@@ -34,7 +34,7 @@ namespace GitExtensions.Plugins.GitImpact
                 async () =>
                 {
                     await this.SwitchToMainThreadAsync();
-                    UpdateAuthorInfo(Impact.GetSelectedAuthor());
+                    UpdateAuthorInfo(Impact.SelectedAuthor);
                 });
         }
 
@@ -55,13 +55,8 @@ namespace GitExtensions.Plugins.GitImpact
 
         private void Impact_MouseMove(object sender, MouseEventArgs e)
         {
-            // Are we hovering above an author path?
-            string author = Impact.GetAuthorByScreenPosition(e.X, e.Y);
-            if (!string.IsNullOrEmpty(author))
+            if (Impact.TrySetAuthorByScreenPosition(e.X, e.Y))
             {
-                // Push that author to the top of the stack
-                // -> Draw it above all others
-                Impact.SelectAuthor(author);
                 Impact.Invalidate();
             }
         }

--- a/Plugins/Statistics/GitImpact/FormImpact.cs
+++ b/Plugins/Statistics/GitImpact/FormImpact.cs
@@ -26,6 +26,8 @@ namespace GitExtensions.Plugins.GitImpact
             Impact.Stop();
 
             base.OnClosed(e);
+
+            Impact.Dispose();
         }
 
         private void Impact_Invalidated(object sender, InvalidateEventArgs e)

--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -90,56 +90,59 @@ namespace GitExtensions.Plugins.GitImpact
             Invalidate();
         }
 
-        private void OnImpactUpdate(ImpactLoader.Commit commit)
+        private void OnImpactUpdate(IList<ImpactLoader.Commit> commits)
         {
             lock (_dataLock)
             {
-                // UPDATE IMPACT
+                foreach (ImpactLoader.Commit commit in commits)
+                {
+                    // UPDATE IMPACT
 
-                // If week does not exist yet in the impact dictionary
-                if (!_impact.ContainsKey(commit.Week))
-                {
-                    // Create it
-                    _impact.Add(commit.Week, []);
-                }
+                    // If week does not exist yet in the impact dictionary
+                    if (!_impact.ContainsKey(commit.Week))
+                    {
+                        // Create it
+                        _impact.Add(commit.Week, []);
+                    }
 
-                // If author does not exist yet for this week in the impact dictionary
-                if (!_impact[commit.Week].ContainsKey(commit.Author))
-                {
-                    // Create it
-                    _impact[commit.Week].Add(commit.Author, commit.Data);
-                }
-                else
-                {
-                    // Otherwise just add the changes
-                    _impact[commit.Week][commit.Author] += commit.Data;
-                }
+                    // If author does not exist yet for this week in the impact dictionary
+                    if (!_impact[commit.Week].ContainsKey(commit.Author))
+                    {
+                        // Create it
+                        _impact[commit.Week].Add(commit.Author, commit.Data);
+                    }
+                    else
+                    {
+                        // Otherwise just add the changes
+                        _impact[commit.Week][commit.Author] += commit.Data;
+                    }
 
-                // UPDATE AUTHORS
+                    // UPDATE AUTHORS
 
-                // If author does not exist yet in the authors dictionary
-                if (!_authors.ContainsKey(commit.Author))
-                {
-                    // Create it
-                    _authors.Add(commit.Author, commit.Data);
-                }
-                else
-                {
-                    // Otherwise just add the changes
-                    _authors[commit.Author] += commit.Data;
+                    // If author does not exist yet in the authors dictionary
+                    if (!_authors.ContainsKey(commit.Author))
+                    {
+                        // Create it
+                        _authors.Add(commit.Author, commit.Data);
+                    }
+                    else
+                    {
+                        // Otherwise just add the changes
+                        _authors[commit.Author] += commit.Data;
+                    }
+
+                    // UPDATE AUTHOR STACK
+
+                    // If author does not exist yet in the author_stack
+                    if (!_authorStack.Contains(commit.Author))
+                    {
+                        // Add it to the front (drawn first)
+                        _authorStack.Insert(0, commit.Author);
+                    }
                 }
 
                 // Add authors to intermediate weeks where they didn't create commits
                 ImpactLoader.AddIntermediateEmptyWeeks(ref _impact, _authors.Keys);
-
-                // UPDATE AUTHOR STACK
-
-                // If author does not exist yet in the author_stack
-                if (!_authorStack.Contains(commit.Author))
-                {
-                    // Add it to the front (drawn first)
-                    _authorStack.Insert(0, commit.Author);
-                }
             }
 
             UpdatePathsAndLabels();

--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -21,7 +21,7 @@ namespace GitExtensions.Plugins.GitImpact
         private readonly Dictionary<string, ImpactLoader.DataPoint> _authors = [];
 
         // <First weekday of commit date, <Author, <Commits, Added Lines, Deleted Lines>>>
-        private SortedDictionary<DateTime, Dictionary<string, ImpactLoader.DataPoint>> _impact = [];
+        private SortedDictionary<DateOnly, Dictionary<string, ImpactLoader.DataPoint>> _impact = [];
 
         // List of authors that determines the drawing order
         private readonly List<string> _authorStack = [];
@@ -36,7 +36,7 @@ namespace GitExtensions.Plugins.GitImpact
         private readonly Dictionary<string, List<(PointF point, int size)>> _lineLabels = [];
 
         // The week-labels
-        private readonly List<(PointF point, DateTime date)> _weekLabels = [];
+        private readonly List<(PointF point, DateOnly date)> _weekLabels = [];
 
         private readonly Font _weekFont = new("Arial", WeekFontSize);
         private readonly Brush _weekBrush = Brushes.Gray;
@@ -286,7 +286,7 @@ namespace GitExtensions.Plugins.GitImpact
         {
             lock (_dataLock)
             {
-                foreach ((PointF point, DateTime date) in _weekLabels)
+                foreach ((PointF point, DateOnly date) in _weekLabels)
                 {
                     string formatedDate = date.ToShortDateString();
                     SizeF sz = g.MeasureString(formatedDate, _weekFont);
@@ -315,7 +315,7 @@ namespace GitExtensions.Plugins.GitImpact
                 _weekLabels.Clear();
 
                 // Iterate through weeks
-                foreach ((DateTime weekDate, Dictionary<string, ImpactLoader.DataPoint> dataByAuthor) in _impact)
+                foreach ((DateOnly weekDate, Dictionary<string, ImpactLoader.DataPoint> dataByAuthor) in _impact)
                 {
                     int y = 0;
 
@@ -361,7 +361,7 @@ namespace GitExtensions.Plugins.GitImpact
                 // Scale week label coordinates
                 for (int i = 0; i < _weekLabels.Count; i++)
                 {
-                    (PointF point, DateTime date) = _weekLabels[i];
+                    (PointF point, DateOnly date) = _weekLabels[i];
 
                     PointF adjustedPoint = new(point.X, point.Y * (float)height_factor);
 

--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -8,7 +8,9 @@ namespace GitExtensions.Plugins.GitImpact
     public partial class ImpactControl : UserControl
     {
         private static readonly int BlockWidth = DpiUtil.Scale(60);
+        private static readonly int BlockHalfWidth = BlockWidth / 2;
         private static readonly int TransitionWidth = DpiUtil.Scale(50);
+        private static readonly int TransitionHalfWidth = TransitionWidth / 2;
 
         private const int LinesFontSize = 10;
         private const int WeekFontSize = 8;
@@ -350,7 +352,7 @@ namespace GitExtensions.Plugins.GitImpact
                     h_max = Math.Max(h_max, y);
 
                     // Add week date label
-                    _weekLabels.Add((new PointF(x + (BlockWidth / 2f), y), weekDate));
+                    _weekLabels.Add((new PointF(x + BlockHalfWidth, y), weekDate));
 
                     // Increase x for next week
                     x += BlockWidth + TransitionWidth;
@@ -396,7 +398,7 @@ namespace GitExtensions.Plugins.GitImpact
 
                         if (rect.Height > LinesFontSize * 1.5)
                         {
-                            PointF adjustedPoint = new(rect.Left + (BlockWidth / 2), rect.Top + (rect.Height / 2));
+                            PointF adjustedPoint = new(rect.Left + BlockHalfWidth, rect.Top + (rect.Height / 2));
 
                             authorLineLabels.Add((adjustedPoint, num));
                         }
@@ -418,26 +420,24 @@ namespace GitExtensions.Plugins.GitImpact
                         (Rectangle rect, int _) = points[i];
 
                         authorGraphicsPath.AddLine(rect.Left, rect.Top,
-                                               rect.Right, rect.Top);
+                                                   rect.Right, rect.Top);
 
                         if (i < points.Count - 1)
                         {
                             (Rectangle nextRect, int _) = points[i + 1];
 
                             authorGraphicsPath.AddBezier(rect.Right, rect.Top,
-                                                     rect.Right + (TransitionWidth / 2), rect.Top,
-                                                     rect.Right + (TransitionWidth / 2), nextRect.Top,
-                                                     nextRect.Left, nextRect.Top);
+                                                         rect.Right + TransitionHalfWidth, rect.Top,
+                                                         rect.Right + TransitionHalfWidth, nextRect.Top,
+                                                         nextRect.Left, nextRect.Top);
                         }
                     }
 
                     (Rectangle lastRect, int _) = points[^1];
 
                     // Right border
-                    authorGraphicsPath.AddLine(lastRect.Right,
-                                           lastRect.Top,
-                                           lastRect.Right,
-                                           lastRect.Bottom);
+                    authorGraphicsPath.AddLine(lastRect.Right, lastRect.Top,
+                                               lastRect.Right, lastRect.Bottom);
 
                     // Bottom borders
                     for (int i = points.Count - 1; i >= 0; i--)
@@ -445,15 +445,15 @@ namespace GitExtensions.Plugins.GitImpact
                         (Rectangle rect, int _) = points[i];
 
                         authorGraphicsPath.AddLine(rect.Right, rect.Bottom,
-                                               rect.Left, rect.Bottom);
+                                                   rect.Left, rect.Bottom);
 
                         if (i > 0)
                         {
                             (Rectangle prevRect, int _) = points[i - 1];
 
                             authorGraphicsPath.AddBezier(rect.Left, rect.Bottom,
-                                                     rect.Left - (TransitionWidth / 2), rect.Bottom,
-                                                     rect.Left - (TransitionWidth / 2), prevRect.Bottom,
+                                                     rect.Left - TransitionHalfWidth, rect.Bottom,
+                                                     rect.Left - TransitionHalfWidth, prevRect.Bottom,
                                                      prevRect.Right, prevRect.Bottom);
                         }
                     }

--- a/Plugins/Statistics/GitImpact/ImpactControl.cs
+++ b/Plugins/Statistics/GitImpact/ImpactControl.cs
@@ -57,6 +57,7 @@ namespace GitExtensions.Plugins.GitImpact
                 ControlStyles.UserPaint | ControlStyles.DoubleBuffer, true);
 
             MouseWheel += ImpactControl_MouseWheel;
+            Disposed += ImpactControl_Disposed;
         }
 
         public void Init(IGitModule module)
@@ -78,8 +79,8 @@ namespace GitExtensions.Plugins.GitImpact
                 _impact.Clear();
 
                 _authorStack.Clear();
-                _paths.Clear();
-                _brushes.Clear();
+                ClearPaths();
+                ClearBrushes();
                 _lineLabels.Clear();
                 _weekLabels.Clear();
             }
@@ -369,7 +370,7 @@ namespace GitExtensions.Plugins.GitImpact
                 }
 
                 // Clear previous paths
-                _paths.Clear();
+                ClearPaths();
 
                 // Clear previous labels
                 _lineLabels.Clear();
@@ -401,6 +402,7 @@ namespace GitExtensions.Plugins.GitImpact
                         }
                     }
 
+                    // Will be disposed when ClearPaths() is called
                     GraphicsPath authorGraphicsPath = new();
                     _paths.Add(author, authorGraphicsPath);
 
@@ -534,6 +536,37 @@ namespace GitExtensions.Plugins.GitImpact
 
                 return new ImpactLoader.DataPoint(0, 0, 0);
             }
+        }
+
+        private void ImpactControl_Disposed(object? sender, EventArgs e)
+        {
+            lock (_dataLock)
+            {
+                _impactLoader?.Dispose();
+
+                ClearBrushes();
+                ClearPaths();
+            }
+        }
+
+        private void ClearBrushes()
+        {
+            foreach (SolidBrush brush in _brushes.Values)
+            {
+                brush.Dispose();
+            }
+
+            _brushes.Clear();
+        }
+
+        private void ClearPaths()
+        {
+            foreach (GraphicsPath path in _paths.Values)
+            {
+                path.Dispose();
+            }
+
+            _paths.Clear();
         }
     }
 }

--- a/Plugins/Statistics/GitImpact/ImpactLoader.cs
+++ b/Plugins/Statistics/GitImpact/ImpactLoader.cs
@@ -164,7 +164,7 @@ namespace GitExtensions.Plugins.GitImpact
         private List<Commit> LoadModuleInfoData(IGitModule module, CancellationToken token)
         {
             string authorName = RespectMailmap ? "%aN" : "%an";
-            string command = $"log --pretty=tformat:\"--- %ad --- {authorName}\" --numstat --date=short -C --all --no-merges";
+            string command = $"log --pretty=tformat:\"--- %ad --- {authorName}\" --numstat --date=short --find-copies --all --no-merges";
             ExecutionResult result = module.GitExecutable.Execute(command, cancellationToken: token);
             List<string> lines = result.StandardOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries).ToList();
 

--- a/Plugins/Statistics/GitImpact/ImpactLoader.cs
+++ b/Plugins/Statistics/GitImpact/ImpactLoader.cs
@@ -236,8 +236,8 @@ namespace GitExtensions.Plugins.GitImpact
             foreach (string author in authors)
             {
                 // Determine first and last commit week of each author
-                DateTime start = new();
-                DateTime end = new();
+                DateTime start = DateTime.MinValue;
+                DateTime end = DateTime.MinValue;
                 bool startFound = false;
 
                 foreach ((DateTime weekDate, Dictionary<string, DataPoint> weekDataByAuthor) in impact)

--- a/Plugins/Statistics/GitImpact/ImpactLoader.cs
+++ b/Plugins/Statistics/GitImpact/ImpactLoader.cs
@@ -75,6 +75,7 @@ namespace GitExtensions.Plugins.GitImpact
             _closingPluginCancellationToken.Cancel();
             Stop();
             _cancellationTokenSequence.Dispose();
+            _closingPluginCancellationToken.Dispose();
         }
 
         public void Stop()

--- a/Plugins/Statistics/GitImpact/ImpactLoader.cs
+++ b/Plugins/Statistics/GitImpact/ImpactLoader.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.Globalization;
+using GitCommands;
 using GitUI;
 using GitUIPluginInterfaces;
 using Microsoft.VisualStudio.Threading;
@@ -58,6 +59,7 @@ namespace GitExtensions.Plugins.GitImpact
         private readonly IGitModule _module;
         private readonly JoinableTask _mainModuleLoadingTask;
         private readonly Dictionary<string, List<Commit>> _modulesCommits = new(1);
+        private readonly int _firstDayOfWeek = (int)CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek;
 
         public ImpactLoader(IGitModule module)
         {
@@ -208,7 +210,7 @@ namespace GitExtensions.Plugins.GitImpact
                 DateOnly date = DateOnly.Parse(header[0]);
 
                 // Calculate first day of the commit week
-                DateOnly week = date.AddDays(-(int)date.DayOfWeek);
+                DateOnly week = date.AddDays(_firstDayOfWeek - (int)date.DayOfWeek);
 
                 // Reset commit data
                 int commits = 1;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11411

## Proposed changes

1. Rendering now takes less than 1s (whereas it was taking minutes on big repositories like GitExtensions --around 7min-- or Git --around 1h08min--ones).

So now the time to build the impact graph correspond only to the time to retrieve data from repo. 

I did one benchmark on git repository for the rendering:
* before: 1h8min
* after: 0.76s (around x5300 times quicker!!)

Retrieving data still takes around 30s, so overall process was before 1h9min and after 30s (x130 times quicker!)

GitExtensions repo: now total time 23s (200ms of rendering)

2. Submodule checkbox change doesn't cancel the long main data retrieve and data are put in a cache so that switch is immediate (instead of fetching the data again every times)
3. Display is done depending on 1st day of the week culture setting


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 72f0d419fcce299752cc26c96009c6dab53aba89 (Dirty)
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 8.0.0
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to rebase (preferred) or squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer rebase (preferred) or squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
