### PR TITLE
Fixup graph performance

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -468,10 +468,16 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 for (int currentIndex = startIndex; currentIndex <= lastStraightenIndex;)
                 {
                     goBackLimit = Math.Max(goBackLimit, currentIndex - _straightenLanesLookAhead);
-                    bool moved = false;
                     IRevisionGraphRow currentRow = localOrderedRowCache[currentIndex];
+                    if (currentRow.Segments.Count >= MaxLanes)
+                    {
+                        ++currentIndex;
+                        continue;
+                    }
+
+                    bool moved = false;
                     IRevisionGraphRow previousRow = localOrderedRowCache[currentIndex - 1];
-                    foreach (RevisionGraphSegment revisionGraphSegment in currentRow.Segments.Take(MaxLanes))
+                    foreach (RevisionGraphSegment revisionGraphSegment in currentRow.Segments)
                     {
                         Lane currentRowLane = currentRow.GetLaneForSegment(revisionGraphSegment);
                         if (currentRowLane.Sharing != LaneSharing.ExclusiveOrPrimary)


### PR DESCRIPTION
Fixes #11292

## Proposed changes

Revert commit c621412b43f96686c230377abbb4a83c3ac91f3b
because (implicitly) calling `RevisionGraphRow.BuildSegmentLanes` for every revision is too much in the Linux repo f.i.

For vNext, I am going to make this limit configurable.

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual: open Linux repo and go to the initial commit when "Loading..." disappears, wait for the graph

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).