### PR TITLE
Remove assert in CalculateGraphIndices()

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -559,29 +559,23 @@ namespace GitUI.UserControls.RevisionGrid
         private void ResetGraphIndices()
         {
             _toBeSelectedGraphIndexesCache = new(() => CalculateGraphIndices());
-        }
+            return;
 
-        /// <summary>
-        /// Get the revision graph row indexes for the ToBeSelectedObjectIds.
-        /// (In filtering situations, all may no longer be in the grid).
-        /// </summary>
-        private IList<int> CalculateGraphIndices()
-        {
-            // This will assert if switching from one repo with no checkout but with a revision selected
-            // to a repo also without a checkout. This is handled below.
-            DebugHelpers.Assert(_loadedToBeSelectedRevisionsCount == ToBeSelectedObjectIds.Count,
-                $"{nameof(CalculateGraphIndices)}() was called before all expected revisions were loaded.");
-
-            List<int> toBeSelectedGraphIndexes = [];
-            foreach (ObjectId objectId in ToBeSelectedObjectIds)
+            // Get the revision graph row indexes for the ToBeSelectedObjectIds.
+            // (In filtering situations, all previous commits may no longer be in the grid).
+            IList<int> CalculateGraphIndices()
             {
-                if (_revisionGraph.TryGetRowIndex(objectId, out int rowIndexToBeSelected))
+                List<int> toBeSelectedGraphIndexes = [];
+                foreach (ObjectId objectId in ToBeSelectedObjectIds)
                 {
-                    toBeSelectedGraphIndexes.Add(rowIndexToBeSelected);
+                    if (_revisionGraph.TryGetRowIndex(objectId, out int rowIndexToBeSelected))
+                    {
+                        toBeSelectedGraphIndexes.Add(rowIndexToBeSelected);
+                    }
                 }
-            }
 
-            return toBeSelectedGraphIndexes;
+                return toBeSelectedGraphIndexes;
+            }
         }
 
         private void SelectRowsIfReady(int rowCount)


### PR DESCRIPTION
## Proposed changes

As we try to retain selections when switching repos, this assert is often incorrect.

A more proper assert would require more logic and info from RevGrid, just complicating.

## Test methodology <!-- How did you ensure quality? -->

Manual removal.

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
