### PR TITLE
Improve graph performance (vNext)

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -445,11 +445,8 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 // The list containing the segments is created later. We can set the correct capacity then, to prevent resizing
                 List<RevisionGraphSegment> segments;
 
-                RevisionGraphRow? previousRevisionGraphRow;
                 if (nextIndex == 0)
                 {
-                    previousRevisionGraphRow = null;
-
                     // This is the first row. Start with only the startsegments of this row
                     segments = new List<RevisionGraphSegment>(revisionStartSegments);
 
@@ -463,7 +460,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 else
                 {
                     // Copy lanes from last row
-                    previousRevisionGraphRow = localOrderedRowCache[nextIndex - 1];
+                    RevisionGraphRow previousRevisionGraphRow = localOrderedRowCache[nextIndex - 1];
 
                     // Create segments list with the correct capacity
                     segments = new List<RevisionGraphSegment>(previousRevisionGraphRow.Segments.Count + revisionStartSegments.Length);
@@ -528,7 +525,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                     }
                 }
 
-                localOrderedRowCache.Add(new RevisionGraphRow(revision, segments, previousRevisionGraphRow, Config.MergeGraphLanesHavingCommonParent));
+                localOrderedRowCache.Add(new RevisionGraphRow(revision, segments, Config.MergeGraphLanesHavingCommonParent));
             }
 
             // Straightening does not apply to the first and the last row. The single node there shall not be moved.

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphRow.cs
@@ -1,9 +1,4 @@
-﻿// Disabled hotfix of #11292 for release 4.2: Due to heavy performance issues with the Linux repo, do not determine the kind of LaneSharing of secondary segments.
-// This deactivated #10915 which avoided the multiple drawing of shared graph segments.
-// This reactivated a minor hyperactivity of line-straightening over commits (#11059).
-////#define ALL_PRIMARY_LANES
-
-using Microsoft;
+﻿using Microsoft;
 
 namespace GitUI.UserControls.RevisionGrid.Graph
 {
@@ -130,11 +125,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                         }
                         else
                         {
-#if ALL_PRIMARY_LANES
-                            laneSharing = LaneSharing.ExclusiveOrPrimary;
-#else
                             laneSharing = LaneSharing.DifferentEnd;
-#endif
                         }
 
                         return new Lane(_revisionLane, laneSharing);
@@ -203,16 +194,12 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
                     LaneSharing GetSecondarySharingOfContinuedSegment()
                     {
-#if ALL_PRIMARY_LANES
-                        return LaneSharing.ExclusiveOrPrimary;
-#else
                         return _previousRow.GetLaneForSegment(segment).Sharing switch
                         {
                             LaneSharing.ExclusiveOrPrimary or LaneSharing.DifferentEnd => LaneSharing.DifferentStart,
                             LaneSharing.Entire or LaneSharing.DifferentStart => LaneSharing.Entire,
                             _ => throw new NotImplementedException()
                         };
-#endif
                     }
                 }
 

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphSegment.cs
@@ -26,6 +26,11 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             Child = child;
         }
 
+        /// <summary>
+        ///  Used by <see cref="RevisionGraphRow.BuildSegmentLanes"/> in order to remember whether this segment has already shared a lane with another segment.
+        /// </summary>
+        internal bool IsSecondarySharedLane { get; set; }
+
         public LaneInfo? LaneInfo { get; set; }
 
         public RevisionGraphRevision Parent { get; }

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphRowTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphRowTests.cs
@@ -15,7 +15,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         public void MoveLanesRight_should_do_nothing_if_empty([Values(-1, 0, 1)] int fromLane)
         {
             List<RevisionGraphSegment> segments = [];
-            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, previousRow: null, mergeGraphLanesHavingCommonParent: true);
+            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, mergeGraphLanesHavingCommonParent: true);
             revisionGraphRow.GetLaneCount().Should().Be(1);
 
             revisionGraphRow.MoveLanesRight(fromLane);
@@ -31,7 +31,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         public void MoveLanesRight_should_move_single_segment(int fromLane, int expectedLane)
         {
             List<RevisionGraphSegment> segments = [_segment];
-            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, previousRow: null, mergeGraphLanesHavingCommonParent: true);
+            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, mergeGraphLanesHavingCommonParent: true);
             revisionGraphRow.GetLaneCount().Should().Be(segments.Count);
 
             revisionGraphRow.MoveLanesRight(fromLane);
@@ -49,7 +49,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         public void MoveLanesRight_should_move_segments(int fromLane, int expectedLane, int expectedLane1, int expectedLane2)
         {
             List<RevisionGraphSegment> segments = [_segment, _segment1, _segment2];
-            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, previousRow: null, mergeGraphLanesHavingCommonParent: true);
+            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, mergeGraphLanesHavingCommonParent: true);
             revisionGraphRow.GetLaneCount().Should().Be(3);
 
             revisionGraphRow.MoveLanesRight(fromLane);
@@ -83,7 +83,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
         public void MoveLanesRight_should_move_segments_twice(int fromLane1, int fromLane2, int expectedLane, int expectedLane1, int expectedLane2)
         {
             List<RevisionGraphSegment> segments = [_segment, _segment1, _segment2];
-            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, previousRow: null, mergeGraphLanesHavingCommonParent: true);
+            IRevisionGraphRow revisionGraphRow = new RevisionGraphRow(_segment.Child, segments, mergeGraphLanesHavingCommonParent: true);
             revisionGraphRow.GetLaneCount().Should().Be(3);
 
             revisionGraphRow.MoveLanesRight(fromLane1);


### PR DESCRIPTION
#11450 for vNext
Contributes to #11292
Replaces (the already deactivated) #11294

## Proposed changes

- Calculate `LaneSharing` without previous row, but add `RevisionGraphSegment.IsSecondarySharedLane` in order to store the sharing state
- Revert #11294

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).