### PR TITLE
Calculate ahead-behind on worker thread

### DIFF
--- a/GitCommands/Git/AheadBehindData.cs
+++ b/GitCommands/Git/AheadBehindData.cs
@@ -1,24 +1,18 @@
-﻿namespace GitCommands.Git
-{
-    public struct AheadBehindData
-    {
-        // gone: "plumbing" expression, see https://git-scm.com/docs/git-for-each-ref#Documentation/git-for-each-ref.txt-upstream
-        public static readonly string Gone = "gone";
-        public string Branch { get; set; }
-        public string RemoteRef { get; set; }
-        public string AheadCount { get; set; }
-        public string BehindCount { get; set; }
+﻿namespace GitCommands.Git;
 
-        public string ToDisplay()
-        {
-            return AheadCount == Gone
-                ? AheadBehindData.Gone
-                : AheadCount == "0" && string.IsNullOrEmpty(BehindCount)
-                ? "0↑↓"
-                : (!string.IsNullOrEmpty(AheadCount) && AheadCount != "0"
-                    ? AheadCount + "↑" + (!string.IsNullOrEmpty(BehindCount) ? " " : string.Empty)
-                    : string.Empty)
-                + (!string.IsNullOrEmpty(BehindCount) ? BehindCount + "↓" : string.Empty);
-        }
+public readonly record struct AheadBehindData(string Branch,  string RemoteRef, string AheadCount, string BehindCount)
+{
+    // gone: "plumbing" expression, see https://git-scm.com/docs/git-for-each-ref#Documentation/git-for-each-ref.txt-upstream
+    public static readonly string Gone = "gone";
+    public string ToDisplay()
+    {
+        return AheadCount == Gone
+            ? Gone
+            : AheadCount == "0" && string.IsNullOrEmpty(BehindCount)
+            ? "0↑↓"
+            : (!string.IsNullOrEmpty(AheadCount) && AheadCount != "0"
+                ? AheadCount + "↑" + (!string.IsNullOrEmpty(BehindCount) ? " " : string.Empty)
+                : string.Empty)
+            + (!string.IsNullOrEmpty(BehindCount) ? BehindCount + "↓" : string.Empty);
     }
 }

--- a/GitUI/CommandsDialogs/ToolStripPushButton.cs
+++ b/GitUI/CommandsDialogs/ToolStripPushButton.cs
@@ -16,29 +16,18 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _behindCommitsTointegrateOrForcePush =
             new("{0} commit(s) should be integrated (or will be lost if force pushed)");
 
-        private IAheadBehindDataProvider? _aheadBehindDataProvider;
-
-        public void Initialize(IAheadBehindDataProvider? aheadBehindDataProvider)
-        {
-            _aheadBehindDataProvider = aheadBehindDataProvider;
-            ResetToDefaultState();
-        }
-
         public void DisplayAheadBehindInformation(IDictionary<string, AheadBehindData>? aheadBehindData, string branchName)
         {
-            ResetToDefaultState();
-
-            if (string.IsNullOrWhiteSpace(branchName) || !AppSettings.ShowAheadBehindData)
+            if (string.IsNullOrWhiteSpace(branchName)
+                || !AppSettings.ShowAheadBehindData
+                || aheadBehindData?.TryGetValue(branchName, out AheadBehindData data) is not true)
             {
+                ResetToDefaultState();
                 return;
             }
 
-            if (aheadBehindData?.ContainsKey(branchName) is not true)
-            {
-                return;
-            }
-
-            AheadBehindData data = aheadBehindData[branchName];
+            ImageAlign = ContentAlignment.MiddleLeft;
+            AutoSize = true;
             Text = data.ToDisplay();
             DisplayStyle = ToolStripItemDisplayStyle.ImageAndText;
             ToolTipText = GetToolTipText(data);
@@ -49,8 +38,19 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void ResetToDefaultState()
+        /// <summary>
+        /// Reset the contents keeping the size the same, to avoid toolbar resizing.
+        /// </summary>
+        public void ResetBeforeUpdate()
         {
+            AutoSize = false;
+            Text = "";
+            ToolTipText = _push.Text;
+        }
+
+        public void ResetToDefaultState()
+        {
+            AutoSize = true;
             DisplayStyle = ToolStripItemDisplayStyle.Image;
             Image = Images.Push.AdaptLightness();
             ToolTipText = _push.Text;
@@ -89,7 +89,8 @@ namespace GitUI.CommandsDialogs
                 _button = button;
             }
 
-            public string? GetToolTipText(AheadBehindData data) => _button.GetToolTipText(data);
+            public string GetButtonText() => _button.Text;
+            public int GetButtonWidth() => _button.Width;
         }
     }
 }

--- a/UnitTests/GitUI.Tests/UserControls/ToolStripPushButtonTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/ToolStripPushButtonTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using Castle.Core.Internal;
+using FluentAssertions;
 using GitCommands;
 using GitCommands.Git;
 using GitUI.CommandsDialogs;
@@ -25,7 +26,7 @@ namespace GitUITests.UserControls
             _aheadBehindDataProvider = Substitute.For<IAheadBehindDataProvider>();
 
             _sut = new ToolStripPushButton();
-            _sut.Initialize(_aheadBehindDataProvider);
+            _sut.ResetToDefaultState();
         }
 
         [TearDown]
@@ -37,7 +38,7 @@ namespace GitUITests.UserControls
         [Test]
         public void DisplayAheadBehindInformation_should_not_display_anything_if_does_not_support_ahead_behind()
         {
-            _sut.Initialize(null);
+            _sut.ResetToDefaultState();
 
             _sut.DisplayAheadBehindInformation(_aheadBehindDataProvider?.GetData(), "any-branchName");
 
@@ -154,6 +155,24 @@ namespace GitUITests.UserControls
             _sut.ToolTipText.Should().NotContain("99 new commit(s) will be pushed");
             _sut.ToolTipText.Should().NotContain("3 commit(s) should be integrated");
             _sut.Image.RawFormat.GetHashCode().Should().Be(Images.Unstage.RawFormat.GetHashCode());
+        }
+
+        [Test]
+        public void PushButton_should_keep_size_before_update_and_decrease_if_fewer_changes()
+        {
+            string branchName = "my-branch";
+            Dictionary<string, AheadBehindData> data = new()
+            {
+                { branchName, new AheadBehindData { AheadCount = "99", BehindCount = "33", Branch = branchName } }
+            };
+            _aheadBehindDataProvider.GetData(branchName).Returns(x => data);
+
+            _sut.DisplayAheadBehindInformation(_aheadBehindDataProvider?.GetData(branchName), branchName);
+            int updatedSize = _sut.GetTestAccessor().GetButtonWidth();
+            _sut.ResetBeforeUpdate();
+            _sut.GetTestAccessor().GetButtonWidth().Should().Be(updatedSize);
+            _sut.GetTestAccessor().GetButtonText().IsNullOrEmpty().Should().BeTrue();
+            _sut.DisplayStyle.Should().Be(ToolStripItemDisplayStyle.ImageAndText);
         }
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/gitextensions/gitextensions/pull/11445#issuecomment-1861751454

## Proposed changes

Update after spinner is closed

Sidepanel calls are unchanged, FormBrowse is normally start first from what I see.

A second part could be to delay the start of the command until git-log delivers revisions.

## Test methodology <!-- How did you ensure quality? -->

Manual - inserted delay to the Git command

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
