### PR TITLE
Correctly rethrow exception from revision reader

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Runtime.ExceptionServices;
 using GitCommands;
 using GitCommands.Config;
 using GitCommands.Git;
@@ -1340,7 +1341,7 @@ namespace GitUI
                 _isRefreshingRevisions = false;
 
                 // Rethrow the exception on the UI thread
-                ThreadHelper.FileAndForget(() => throw exception);
+                ThreadHelper.FileAndForget(() => ExceptionDispatchInfo.Throw(exception));
             }
 
             void OnRevisionReadCompleted()


### PR DESCRIPTION
Recommended in https://github.com/gitextensions/gitextensions/issues/11460#issuecomment-1865099903

## Proposed changes

- Correctly rethrow exception from revision reader with the original stack trace

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

```
System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
   at void GitUI.RevisionGridControl.PerformRefreshRevisions(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs, bool forceRefreshRefs)+() => { } in D:/Build/gitextensions3/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs:line 1352
   at async Task GitUI.TaskManager.HandleExceptionsAsync(Func<Task> asyncAction, Func<Exception, Task> handleExceptionAsync) in D:/Build/gitextensions3/GitExtUtils/GitUI/TaskManager.cs:line 28
```

### After

```
System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
   at bool System.Collections.Generic.Dictionary<TKey, TValue>.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at string GitUI.RevisionGridControl+<>c__DisplayClass145_0.<PerformRefreshRevisions>g__BuildPathFilter|5(?)+BuildPathFilter(string path) in D:/Build/gitextensions3/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs:line 1222
   at void GitUI.RevisionGridControl.PerformRefreshRevisions(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs, bool forceRefreshRefs)+() => { } in D:/Build/gitextensions3/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs:line 1079
   at void GitUI.TaskManager.HandleExceptions(Action action, Action<Exception> handleException) in D:/Build/gitextensions3/GitExtUtils/GitUI/TaskManager.cs:line 47
   at void GitUI.RevisionGridControl.PerformRefreshRevisions(Func<RefsFilter, IReadOnlyList<IGitRef>> getRefs, bool forceRefreshRefs)+() => { } in D:/Build/gitextensions3/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs:line 1357
   at Func<Task> GitUI.TaskManager.AsyncAction(Action action)+() => { } in D:/Build/gitextensions3/GitExtUtils/GitUI/TaskManager.cs:line 63
   at async Task GitUI.TaskManager.HandleExceptionsAsync(Func<Task> asyncAction, Func<Exception, Task> handleExceptionAsync) in D:/Build/gitextensions3/GitExtUtils/GitUI/TaskManager.cs:line 28
```

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).