### PR TITLE
FormFileHistory: Do not refresh revision grid twice on load

### DIFF
--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -214,7 +214,6 @@ namespace GitUI.CommandsDialogs
             FileName = FileName.ToPosixPath();
 
             RevisionGrid.SetAndApplyPathFilter(FileName);
-            RevisionGrid.Load();
         }
 
         private string? GetFileNameForRevision(GitRevision rev)


### PR DESCRIPTION
## Proposed changes

- FormFileHistory: Do not refresh revision grid twice on load
  which is ignored before #11205

Found with #11460
that both `RevisionGrid.SetAndApplyPathFilter` and `RevisionGrid.Load` call `PerformRefreshRevisions`:

```
        public new void Load()
        {
            if (!DesignMode)
            {
                PerformRefreshRevisions();
            }
        }
```

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).