### PR TITLE
Browse FileHistory mode: Open diff by default

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.BrowseArguments.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.BrowseArguments.cs
@@ -27,9 +27,9 @@ namespace GitUI.CommandsDialogs
             public ObjectId? FirstId { get; init; }
 
             /// <summary>
-            /// If to start in "FileHistory mode" with blame view
+            /// If to start in "FileHistory mode", hiding left panel.
             /// </summary>
-            public bool IsFileBlameHistory { get; init; }
+            public bool IsFileHistoryMode { get; init; }
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -8,7 +8,7 @@ namespace GitUI.CommandsDialogs
     {
         // This file is dedicated to init logic for FormBrowse revisiong grid control
 
-        private void InitRevisionGrid(ObjectId? selectedId, ObjectId? firstId, bool isBlame)
+        private void InitRevisionGrid(ObjectId? selectedId, ObjectId? firstId, bool isFileHistory)
         {
             RevisionGrid.IndexWatcher.Changed += (_, args) =>
             {
@@ -39,11 +39,10 @@ namespace GitUI.CommandsDialogs
 
             RevisionGrid.RevisionsLoading += (sender, e) =>
             {
-                // The FileTree tab should be shown at first start, in "filehistory" mode
-                if (isBlame)
+                // Open diff in "filehistory" mode
+                if (isFileHistory)
                 {
-                    CommitInfoTabControl.SelectedTab = TreeTabPage;
-                    isBlame = false;
+                    CommitInfoTabControl.SelectedTab = DiffTabPage;
                 }
 
                 if (sender is null || MainSplitContainer.Panel1Collapsed)

--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -8,7 +8,7 @@ namespace GitUI.CommandsDialogs
     {
         // This file is dedicated to init logic for FormBrowse revisiong grid control
 
-        private void InitRevisionGrid(ObjectId? selectedId, ObjectId? firstId, bool isFileHistory)
+        private void InitRevisionGrid(ObjectId? selectedId, ObjectId? firstId, bool isFileHistoryMode)
         {
             RevisionGrid.IndexWatcher.Changed += (_, args) =>
             {
@@ -37,11 +37,13 @@ namespace GitUI.CommandsDialogs
                 fileTree.FallbackFollowedFile = path;
             };
 
+            bool firstTimeInFileHistoryMode = isFileHistoryMode;
             RevisionGrid.RevisionsLoading += (sender, e) =>
             {
                 // Open diff in "filehistory" mode
-                if (isFileHistory)
+                if (firstTimeInFileHistoryMode)
                 {
+                    firstTimeInFileHistoryMode = false;
                     CommitInfoTabControl.SelectedTab = DiffTabPage;
                 }
 

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -219,7 +219,7 @@ namespace GitUI.CommandsDialogs
         private readonly RepositoryHistoryUIService _repositoryHistoryUIService = new();
         private ConEmuControl? _terminal;
         private Dashboard? _dashboard;
-        private bool _isFileBlameHistory;
+        private bool _isFileHistoryMode;
         private bool _fileBlameHistoryLeftPanelStartupState;
 
         private TabPage? _consoleTabPage;
@@ -250,7 +250,7 @@ namespace GitUI.CommandsDialogs
 
             SystemEvents.SessionEnding += (sender, args) => SaveApplicationSettings();
 
-            _isFileBlameHistory = args.IsFileBlameHistory;
+            _isFileHistoryMode = args.IsFileHistoryMode;
             InitializeComponent();
 
             fileToolStripMenuItem.Initialize(() => UICommands);
@@ -288,7 +288,7 @@ namespace GitUI.CommandsDialogs
             ToolStripFilters.Bind(() => Module, RevisionGrid);
             InitMenusAndToolbars(args.RevFilter, args.PathFilter.ToPosixPath());
 
-            InitRevisionGrid(args.SelectedId, args.FirstId, args.IsFileBlameHistory);
+            InitRevisionGrid(args.SelectedId, args.FirstId, args.IsFileHistoryMode);
             InitCommitDetails();
 
             InitializeComplete();
@@ -318,8 +318,7 @@ namespace GitUI.CommandsDialogs
             repoObjectsTree.Initialize(_aheadBehindDataProvider, filterRevisionGridBySpaceSeparatedRefs: ToolStripFilters.SetBranchFilter, refsSource: RevisionGrid, revisionGridInfo: RevisionGrid);
             revisionDiff.Bind(revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, revisionFileTree: fileTree, () => RevisionGrid.CurrentFilter.PathFilter, RefreshGitStatusMonitor);
 
-            // Show blame by default if not started from command line
-            fileTree.Bind(revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, RefreshGitStatusMonitor, _isFileBlameHistory);
+            fileTree.Bind(revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, RefreshGitStatusMonitor);
             RevisionGrid.ResumeRefreshRevisions();
 
             // Application is init, the repo related operations are triggered in OnLoad()
@@ -511,7 +510,7 @@ namespace GitUI.CommandsDialogs
         protected override void OnClosing(CancelEventArgs e)
         {
             // Restore state at startup if file history mode, ignore the forced setting
-            if (_isFileBlameHistory)
+            if (_isFileHistoryMode)
             {
                 MainSplitContainer.Panel1Collapsed = _fileBlameHistoryLeftPanelStartupState;
             }
@@ -2221,7 +2220,7 @@ namespace GitUI.CommandsDialogs
 
             _splitterManager.RestoreSplitters();
             RefreshLayoutToggleButtonStates();
-            if (_isFileBlameHistory)
+            if (_isFileHistoryMode)
             {
                 _fileBlameHistoryLeftPanelStartupState = MainSplitContainer.Panel1Collapsed;
                 MainSplitContainer.Panel1Collapsed = true;

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -318,7 +318,8 @@ namespace GitUI.CommandsDialogs
             repoObjectsTree.Initialize(_aheadBehindDataProvider, filterRevisionGridBySpaceSeparatedRefs: ToolStripFilters.SetBranchFilter, refsSource: RevisionGrid, revisionGridInfo: RevisionGrid);
             revisionDiff.Bind(revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, revisionFileTree: fileTree, () => RevisionGrid.CurrentFilter.PathFilter, RefreshGitStatusMonitor);
 
-            fileTree.Bind(revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, RefreshGitStatusMonitor);
+            // Show blame by default in file tree if not started from command line
+            fileTree.Bind(revisionGridInfo: RevisionGrid, revisionGridUpdate: RevisionGrid, RefreshGitStatusMonitor, _isFileHistoryMode);
             RevisionGrid.ResumeRefreshRevisions();
 
             // Application is init, the repo related operations are triggered in OnLoad()

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -69,11 +69,12 @@ See the changes in the commit form.");
             copyPathsToolStripMenuItem.Initialize(() => UICommands, () => new string[] { (tvGitTree.SelectedNode?.Tag as GitItem)?.FileName });
         }
 
-        public void Bind(IRevisionGridInfo revisionGridInfo, IRevisionGridUpdate revisionGridUpdate, Action? refreshGitStatus)
+        public void Bind(IRevisionGridInfo revisionGridInfo, IRevisionGridUpdate revisionGridUpdate, Action? refreshGitStatus, bool isBlame)
         {
             _revisionGridInfo = revisionGridInfo;
             _revisionGridUpdate = revisionGridUpdate;
             _refreshGitStatus = refreshGitStatus;
+            blameToolStripMenuItem1.Checked = isBlame;
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -69,12 +69,11 @@ See the changes in the commit form.");
             copyPathsToolStripMenuItem.Initialize(() => UICommands, () => new string[] { (tvGitTree.SelectedNode?.Tag as GitItem)?.FileName });
         }
 
-        public void Bind(IRevisionGridInfo revisionGridInfo, IRevisionGridUpdate revisionGridUpdate, Action? refreshGitStatus, bool isBlame)
+        public void Bind(IRevisionGridInfo revisionGridInfo, IRevisionGridUpdate revisionGridUpdate, Action? refreshGitStatus)
         {
             _revisionGridInfo = revisionGridInfo;
             _revisionGridUpdate = revisionGridUpdate;
             _refreshGitStatus = refreshGitStatus;
-            blameToolStripMenuItem1.Checked = isBlame;
         }
 
         /// <summary>

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1590,7 +1590,7 @@ namespace GitUI
                     {
                         RevFilter = GetParameterOrEmptyStringAsDefault(args, "-filter"),
                         PathFilter = GetParameterOrEmptyStringAsDefault(args, PathFilterArg),
-                        IsFileBlameHistory = args.Any(arg => arg.StartsWith(PathFilterArg))
+                        IsFileHistoryMode = args.Any(arg => arg.StartsWith(PathFilterArg))
                     });
             }
 
@@ -1603,7 +1603,7 @@ namespace GitUI
                         PathFilter = GetParameterOrEmptyStringAsDefault(args, PathFilterArg),
                         SelectedId = selectedId,
                         FirstId = firstId,
-                        IsFileBlameHistory = args.Any(arg => arg.StartsWith(PathFilterArg))
+                        IsFileHistoryMode = args.Any(arg => arg.StartsWith(PathFilterArg))
                     });
             }
 
@@ -1761,7 +1761,7 @@ namespace GitUI
                                      RevFilter = filterByRevision ? revision?.ObjectId.ToString() : null,
                                      PathFilter = fileHistoryFileName,
                                      SelectedId = revision?.ObjectId,
-                                     IsFileBlameHistory = true
+                                     IsFileHistoryMode = true
                                  }));
             }
             else


### PR DESCRIPTION
Mentioned in #11440 

## Proposed changes

#9865/38e700fae4259e71ba2a2f8e8d03ed719abe4392 opened FileHistory tab with blame enabled to improve discoverability of blame. View (instead of blame) was set as default in
#10453/d9bd1c64e0aca88235006f7e2e5d371164ca26c9

The default tab should be Diff if Blame is not shown.

Left panel is still hidden in filehstory mode
#9865/edb2a5d2d1e729ffad6c1308d00cee9a4f018a38

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
