### PR TITLE
Do not get stash count in bare repos

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1065,7 +1065,7 @@ namespace GitUI.CommandsDialogs
 
         private void UpdateStashCount()
         {
-            if (AppSettings.ShowStashCount)
+            if (AppSettings.ShowStashCount && !Module.IsBareRepository())
             {
                 ThreadHelper.FileAndForget(async () =>
                 {


### PR DESCRIPTION
Fixes #11467

## Proposed changes

Another command to disable in bare repos

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
