### PR TITLE
DeleteObsoleteBranches: Parse symbolic references

### DIFF
--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -120,7 +120,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
             GitArgumentBuilder args = new("branch")
             {
                  "--list",
-                 { context.IncludeRemotes, "-r" },
+                 { context.RemoteBranches, "-r" },
                  { !context.IncludeUnmerged, $"--merged {context.ReferenceBranch}" }
             };
 
@@ -133,9 +133,9 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
             }
 
             bool withoutRegexFilter = string.IsNullOrEmpty(context.RegexFilter);
-            return _commandOutputParser.GetBranchNames(result.StandardOutput)
+            return _commandOutputParser.GetBranchNames(result.StandardOutput, context.RemoteBranches)
                                         .Where(branchName => branchName != curBranch && branchName != context.ReferenceBranch)
-                                        .Where(branchName => (!context.IncludeRemotes || branchName.StartsWith(context.RemoteRepositoryName + "/"))
+                                        .Where(branchName => (!context.RemoteBranches || branchName.StartsWith(context.RemoteRepositoryName + "/"))
                                                             && (withoutRegexFilter || Regex.IsMatch(branchName, context.RegexFilter, options) == regexMustMatch));
         }
 
@@ -374,7 +374,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
                 TimeSpan obsolescenceDuration, CancellationToken cancellationToken)
             {
                 Commands = commands;
-                IncludeRemotes = includeRemotes;
+                RemoteBranches = includeRemotes;
                 IncludeUnmerged = includeUnmerged;
                 ReferenceBranch = referenceBranch;
                 RemoteRepositoryName = remoteRepositoryName;
@@ -386,7 +386,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
             }
 
             public IGitModule Commands { get; }
-            public bool IncludeRemotes { get; }
+            public bool RemoteBranches { get; }
             public bool IncludeUnmerged { get; }
             public string ReferenceBranch { get; }
             public string RemoteRepositoryName { get; }

--- a/Plugins/DeleteUnusedBranches/GitBranchOutputCommandParser.cs
+++ b/Plugins/DeleteUnusedBranches/GitBranchOutputCommandParser.cs
@@ -1,24 +1,41 @@
-﻿namespace GitExtensions.Plugins.DeleteUnusedBranches
+﻿namespace GitExtensions.Plugins.DeleteUnusedBranches;
+
+public class GitBranchOutputCommandParser
 {
-    public class GitBranchOutputCommandParser
+    public IEnumerable<string> GetBranchNames(string commandOutput, bool isRemote)
     {
-        public IEnumerable<string> GetBranchNames(string commandOutput)
+        if (commandOutput is null)
         {
-            if (commandOutput is null)
+            yield break;
+        }
+
+        foreach (string line in commandOutput.Split('\n').Where(line => !string.IsNullOrWhiteSpace(line) && line.Length > 2))
+        {
+            // Removing first 2 chars: 1st is '*' for current branch or '+' for a worktree branch followed by a space
+            // Symbolic refs are listed like "  origin/HEAD -> origin/master" (see also below), just use the branch name.
+            string branchName = line[2..].Trim(' ', '\r').Split(' ')[0];
+
+            if (branchName.StartsWith('(') || branchName.Length == 0)
             {
-                yield break;
+                continue;
             }
 
-            foreach (string line in commandOutput.Split('\n').Where(line => !string.IsNullOrWhiteSpace(line) && line.Length > 2))
+            if (isRemote)
             {
-                // Removing first 2 chars: 1st is '*' for current branch or '+' for a worktree branch followed by a space
-                string branchName = line[2..].Trim(' ', '\n', '\r');
-
-                if (branchName != "HEAD" && !branchName.StartsWith("(") && branchName.Length != 0)
+                // Remote HEAD, included from e.g. GitLab as a symbolic link
+                string[] remotes = branchName.Split('/');
+                if (remotes.Length == 2 && remotes[1] == "HEAD")
                 {
-                    yield return branchName;
+                    continue;
                 }
             }
+            else if (branchName == "HEAD")
+            {
+                // Local HEAD should normally be in .git/HEAD (rather than .git/refs/heads/HEAD)
+                continue;
+            }
+
+            yield return branchName;
         }
     }
 }

--- a/UnitTests/Plugins/DeleteUnusedBranches.Tests/GitBranchOutputCommandParserTests.cs
+++ b/UnitTests/Plugins/DeleteUnusedBranches.Tests/GitBranchOutputCommandParserTests.cs
@@ -14,12 +14,12 @@ namespace DeleteUnusedBranchesTests
             _parser = new GitBranchOutputCommandParser();
         }
 
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase("    ")]
-        public void GetBranchNames_should_return_empty_list(string commandOutput)
+        [Test]
+        public void GetBranchNames_should_return_empty_list(
+            [Values(null, "", "   ")] string commandOutput,
+            [Values(true, false)] bool isRemote)
         {
-            _parser.GetBranchNames(commandOutput).Should().BeEmpty();
+            _parser.GetBranchNames(commandOutput, isRemote).Should().BeEmpty();
         }
 
         [TestCase]
@@ -31,11 +31,30 @@ namespace DeleteUnusedBranchesTests
   HEAD
 * (HEAD detached at dce3f9f)
   +_valid_branch_name_starting_with_+
+  space/after 
+  symbolic_ref -> origin/master
 ";
 
-            _parser.GetBranchNames(commandOutput)
+            _parser.GetBranchNames(commandOutput, isRemote: false)
                    .Should()
-                   .BeEquivalentTo("feature/branch-1", "fix/branch-2", "master", "+_valid_branch_name_starting_with_+");
+                   .BeEquivalentTo("feature/branch-1", "fix/branch-2", "master", "+_valid_branch_name_starting_with_+", "space/after", "symbolic_ref");
+        }
+
+        [TestCase]
+        public void GetBranchNames_parse_for_remote()
+        {
+            string commandOutput = @"  just_remote_that_should_not_occur_but_is_tested
+  myremote/mybranch
+  other_remote/+_valid_branch_name_starting_with_+
+  +remote/+branch+
+  space/after 
+  origin/symbolic_ref -> origin/master
+  ignore_remote_HEAD/HEAD
+";
+
+            _parser.GetBranchNames(commandOutput, isRemote: true)
+                   .Should()
+                   .BeEquivalentTo("just_remote_that_should_not_occur_but_is_tested", "myremote/mybranch", "other_remote/+_valid_branch_name_starting_with_+", "+remote/+branch+", "space/after", "origin/symbolic_ref");
         }
 
         [TestCase]
@@ -46,7 +65,7 @@ namespace DeleteUnusedBranchesTests
 + +_valid_branch_name_starting_with_+
 ";
 
-            _parser.GetBranchNames(commandOutput)
+            _parser.GetBranchNames(commandOutput, isRemote: false)
                    .Should()
                    .BeEquivalentTo("branch_in_worktree", "master", "+_valid_branch_name_starting_with_+");
         }


### PR DESCRIPTION
Fixes #11357

## Proposed changes

Symbolic references were not parsed correctly

## Test methodology <!-- How did you ensure quality? -->

Added test case, as well as for trailing spaces

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
