### PR TITLE
FileStatusList updates

### DIFF
--- a/GitUI/CommandsDialogs/FormStash.Designer.cs
+++ b/GitUI/CommandsDialogs/FormStash.Designer.cs
@@ -260,7 +260,7 @@ namespace GitUI.CommandsDialogs
             // 
             Stashed.ContextMenuStrip = contextMenuStripStashedFiles;
             Stashed.Dock = DockStyle.Fill;
-            Stashed.GroupByRevision = false;
+            Stashed.GroupByRevision = true;
             Stashed.Location = new Point(0, 0);
             Stashed.Margin = new Padding(0);
             Stashed.Name = "Stashed";

--- a/GitUI/CommandsDialogs/FormStash.cs
+++ b/GitUI/CommandsDialogs/FormStash.cs
@@ -165,7 +165,6 @@ namespace GitUI.CommandsDialogs
         {
             GitStash? gitStash = Stashes.SelectedItem as GitStash;
 
-            Stashed.GroupByRevision = false;
             Stashed.ClearDiffs();
 
             Loading.Visible = true;

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.Designer.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.Designer.cs
@@ -276,7 +276,6 @@ namespace GitUI.CommandsDialogs.RepoHosting
             // _fileStatusList
             // 
             _fileStatusList.Dock = DockStyle.Fill;
-            _fileStatusList.GroupByRevision = false;
             _fileStatusList.Location = new Point(0, 0);
             _fileStatusList.Margin = new Padding(3, 4, 3, 4);
             _fileStatusList.Name = "_fileStatusList";

--- a/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
@@ -96,8 +96,7 @@ namespace GitUI.CommandsDialogs
             // 
             DiffFiles.ContextMenuStrip = DiffContextMenu;
             DiffFiles.Dock = DockStyle.Fill;
-            DiffFiles.FilterVisible = true;
-            DiffFiles.GroupByRevision = false;
+            DiffFiles.GroupByRevision = true;
             DiffFiles.Location = new Point(0, 0);
             DiffFiles.Margin = new Padding(0);
             DiffFiles.Name = "DiffFiles";

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -53,7 +53,6 @@ namespace GitUI.CommandsDialogs
         public RevisionDiffControl()
         {
             InitializeComponent();
-            DiffFiles.GroupByRevision = true;
             InitializeComplete();
             HotkeysEnabled = true;
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);

--- a/GitUI/UserControls/FileStatusList.Designer.cs
+++ b/GitUI/UserControls/FileStatusList.Designer.cs
@@ -29,8 +29,8 @@
         private void InitializeComponent()
         {
             components = new System.ComponentModel.Container();
-            FileStatusListView = new GitUI.UserControls.NativeListView();
-            columnHeader = ((ColumnHeader)(new ColumnHeader()));
+            FileStatusListView = new UserControls.NativeListView();
+            columnHeader = new ColumnHeader();
             NoFiles = new Label();
             LoadingFiles = new Label();
             FilterComboBox = new ComboBox();
@@ -44,20 +44,18 @@
             // 
             FileStatusListView.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
             FileStatusListView.BorderStyle = BorderStyle.None;
-            FileStatusListView.Columns.AddRange(new ColumnHeader[] {
-            columnHeader});
+            FileStatusListView.Columns.AddRange(new ColumnHeader[] { columnHeader });
             FileStatusListView.FullRowSelect = true;
             FileStatusListView.HeaderStyle = ColumnHeaderStyle.None;
-            FileStatusListView.HideSelection = false;
             FileStatusListView.LabelWrap = false;
             FileStatusListView.Location = new Point(0, 21);
             FileStatusListView.Margin = new Padding(0);
             FileStatusListView.Name = "FileStatusListView";
             FileStatusListView.OwnerDraw = true;
             FileStatusListView.ShowItemToolTips = true;
-            FileStatusListView.Size = new Size(682, 464);
+            FileStatusListView.Size = new Size(682, 439);
             FileStatusListView.Sorting = SortOrder.Ascending;
-            FileStatusListView.TabIndex = 4;
+            FileStatusListView.TabIndex = 3;
             FileStatusListView.UseCompatibleStateImageBehavior = false;
             FileStatusListView.View = View.Details;
             FileStatusListView.DrawSubItem += FileStatusListView_DrawSubItem;
@@ -65,8 +63,8 @@
             FileStatusListView.DoubleClick += FileStatusListView_DoubleClick;
             FileStatusListView.KeyDown += FileStatusListView_KeyDown;
             FileStatusListView.MouseDown += FileStatusListView_MouseDown;
-            FileStatusListView.MouseUp += FileStatusListView_MouseUp;
             FileStatusListView.MouseMove += FileStatusListView_MouseMove;
+            FileStatusListView.MouseUp += FileStatusListView_MouseUp;
             FileStatusListView.Scroll += FileStatusListView_Scroll;
             // 
             // columnHeader
@@ -76,25 +74,27 @@
             // 
             // NoFiles
             // 
+            NoFiles.Anchor = AnchorStyles.Top | AnchorStyles.Left;
             NoFiles.AutoSize = true;
             NoFiles.BackColor = SystemColors.Window;
             NoFiles.ForeColor = SystemColors.GrayText;
-            NoFiles.Location = new Point(4, 4);
-            NoFiles.Margin = new Padding(0);
+            NoFiles.Location = new Point(0, 0);
             NoFiles.Name = "NoFiles";
-            NoFiles.Size = new Size(65, 13);
-            NoFiles.TabIndex = 5;
+            NoFiles.Padding = new Padding(4);
+            NoFiles.Size = new Size(65, 15);
+            NoFiles.TabIndex = 1;
             // 
             // LoadingFiles
             // 
+            LoadingFiles.Anchor = AnchorStyles.Top | AnchorStyles.Left;
             LoadingFiles.AutoSize = true;
             LoadingFiles.BackColor = SystemColors.Window;
             LoadingFiles.ForeColor = SystemColors.GrayText;
-            LoadingFiles.Location = new Point(4, 21);
-            LoadingFiles.Margin = new Padding(0);
+            LoadingFiles.Location = new Point(0, 24);
             LoadingFiles.Name = "LoadingFiles";
-            LoadingFiles.Size = new Size(65, 13);
-            LoadingFiles.TabIndex = 5;
+            LoadingFiles.Padding = new Padding(4);
+            LoadingFiles.Size = new Size(65, 15);
+            LoadingFiles.TabIndex = 0;
             // 
             // FilterComboBox
             // 
@@ -102,10 +102,10 @@
             FilterComboBox.FlatStyle = FlatStyle.Flat;
             FilterComboBox.FormattingEnabled = true;
             FilterComboBox.Location = new Point(0, 0);
-            FilterComboBox.Margin = new Padding(0, 0, 0, 1);
+            FilterComboBox.Margin = new Padding(0);
             FilterComboBox.Name = "FilterComboBox";
-            FilterComboBox.Size = new Size(682, 21);
-            FilterComboBox.TabIndex = 2;
+            FilterComboBox.Size = new Size(682, 23);
+            FilterComboBox.TabIndex = 1;
             FilterComboBox.SelectedIndexChanged += FilterComboBox_SelectedIndexChanged;
             FilterComboBox.TextUpdate += FilterComboBox_TextUpdate;
             FilterComboBox.SizeChanged += FilterComboBox_SizeChanged;
@@ -118,10 +118,11 @@
             FilterWatermarkLabel.AutoSize = true;
             FilterWatermarkLabel.BackColor = SystemColors.Window;
             FilterWatermarkLabel.ForeColor = SystemColors.GrayText;
-            FilterWatermarkLabel.Location = new Point(4, 4);
+            FilterWatermarkLabel.Location = new Point(0, 0);
             FilterWatermarkLabel.Name = "FilterWatermarkLabel";
-            FilterWatermarkLabel.Size = new Size(184, 13);
-            FilterWatermarkLabel.TabIndex = 0;
+            FilterWatermarkLabel.Padding = new Padding(4);
+            FilterWatermarkLabel.Size = new Size(206, 15);
+            FilterWatermarkLabel.TabIndex = 2;
             FilterWatermarkLabel.Text = "Filter files using a regular expression...";
             FilterWatermarkLabel.Click += FilterWatermarkLabel_Click;
             // 
@@ -137,10 +138,10 @@
             // lblSplitter
             // 
             lblSplitter.Dock = DockStyle.Top;
-            lblSplitter.Location = new Point(0, 21);
+            lblSplitter.Location = new Point(0, 23);
             lblSplitter.Name = "lblSplitter";
             lblSplitter.Size = new Size(682, 2);
-            lblSplitter.TabIndex = 3;
+            lblSplitter.TabIndex = 6;
             // 
             // DeleteFilterButton
             // 
@@ -148,28 +149,27 @@
             DeleteFilterButton.BackColor = SystemColors.Window;
             DeleteFilterButton.FlatStyle = FlatStyle.Flat;
             DeleteFilterButton.Image = Properties.Resources.DeleteText;
-            DeleteFilterButton.Location = new Point(646, 1);
+            DeleteFilterButton.Location = new Point(646, 0);
             DeleteFilterButton.Name = "DeleteFilterButton";
-            DeleteFilterButton.Size = new Size(18, 19);
-            DeleteFilterButton.TabIndex = 1;
+            DeleteFilterButton.Size = new Size(18, 23);
+            DeleteFilterButton.TabIndex = 5;
             DeleteFilterButton.Click += DeleteFilterButton_Click;
             // 
             // FileStatusList
             // 
             AutoScaleMode = AutoScaleMode.Inherit;
-            Controls.Add(DeleteFilterButton);
-            Controls.Add(FilterWatermarkLabel);
-            Controls.Add(NoFiles);
             Controls.Add(LoadingFiles);
+            Controls.Add(NoFiles);
+            Controls.Add(FilterWatermarkLabel);
+            Controls.Add(DeleteFilterButton);
             Controls.Add(FileStatusListView);
-            Controls.Add(lblSplitter);
             Controls.Add(FilterComboBox);
+            Controls.Add(lblSplitter);
             Margin = new Padding(3, 4, 3, 4);
             Name = "FileStatusList";
             Size = new Size(682, 485);
             ResumeLayout(false);
             PerformLayout();
-
         }
 
         #endregion

--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -25,15 +25,15 @@ namespace GitUI
         private readonly FileStatusDiffCalculator _diffCalculator;
         private readonly SortDiffListContextMenuItem _sortByContextMenu;
         private readonly IReadOnlyList<GitItemStatus> _noItemStatuses;
+        private readonly ToolStripItem _NO_TRANSLATE_openSubmoduleMenuItem;
+        private readonly ToolStripItem _openInVisualStudioSeparator = new ToolStripSeparator();
+        private readonly ToolStripItem _NO_TRANSLATE_openInVisualStudioMenuItem;
+        private readonly CancellationTokenSequence _reloadSequence = new();
 
         private int _nextIndexToSelect = -1;
         private bool _enableSelectedIndexChangeEvent = true;
         private bool _mouseEntered;
-        private readonly ToolStripItem _NO_TRANSLATE_openSubmoduleMenuItem;
-        private readonly ToolStripItem _openInVisualStudioSeparator = new ToolStripSeparator();
-        private readonly ToolStripItem _NO_TRANSLATE_openInVisualStudioMenuItem;
         private Rectangle _dragBoxFromMouseDown;
-        private IReadOnlyList<FileStatusWithDescription> _itemsWithDescription = new List<FileStatusWithDescription>();
         private IDisposable? _selectedIndexChangeSubscription;
         private IDisposable? _diffListSortSubscription;
 
@@ -72,22 +72,24 @@ namespace GitUI
             SetupUnifiedDiffListSorting();
             lblSplitter.Height = DpiUtil.Scale(1);
             InitializeComplete();
-            FilterVisible = true;
 
             SelectFirstItemOnSetItems = true;
 
             FileStatusListView.SmallImageList = CreateImageList();
             FileStatusListView.LargeImageList = FileStatusListView.SmallImageList;
 
-            HandleVisibility_NoFilesLabel_FilterComboBox(filesPresent: true);
             NoFiles.Text = TranslatedStrings.NoChanges;
             LoadingFiles.Text = TranslatedStrings.LoadingData;
             Controls.SetChildIndex(NoFiles, 0);
             Controls.SetChildIndex(LoadingFiles, 0);
+            Controls.SetChildIndex(DeleteFilterButton, 0);
+            Controls.SetChildIndex(FilterWatermarkLabel, 0);
+
             NoFiles.Font = new Font(NoFiles.Font, FontStyle.Italic);
             LoadingFiles.Font = new Font(LoadingFiles.Font, FontStyle.Italic);
             FilterWatermarkLabel.Font = new Font(FilterWatermarkLabel.Font, FontStyle.Italic);
             FilterComboBox.Font = new Font(FilterComboBox.Font, FontStyle.Bold);
+            SetFileStatusListVisibility(filesPresent: false);
 
             _diffCalculator = new FileStatusDiffCalculator(() => Module);
             _fullPathResolver = new FullPathResolver(() => Module.WorkingDir);
@@ -295,38 +297,18 @@ namespace GitUI
 
         public bool FilterFocused => FilterComboBox.Focused;
 
-        public bool FilterVisible
+        private void SetFileStatusListVisibility(bool filesPresent)
         {
-            get { return _filterVisible; }
-            set
-            {
-                if (value == _filterVisible)
-                {
-                    return;
-                }
+            LoadingFiles.Visible = false;
+            NoFiles.Visible = !filesPresent;
+            FilterComboBox.Visible = filesPresent;
 
-                _filterVisible = value;
-                FilterVisibleInternal = value;
-            }
-        }
+            SetDeleteFilterButtonVisibility();
+            SetFilterWatermarkLabelVisibility();
 
-        private bool FilterVisibleInternal
-        {
-            get => FilterComboBox.Visible;
-            set
-            {
-                FilterComboBox.Visible = value;
-                SetDeleteFilterButtonVisibility();
-                SetFilterWatermarkLabelVisibility();
-
-                int top = value
-                    ? FileStatusListView.Margin.Top + FilterComboBox.Bottom + FilterComboBox.Margin.Bottom
-                    : FileStatusListView.Margin.Top;
-
-                int height = ClientRectangle.Height - FileStatusListView.Margin.Bottom - top;
-
-                FileStatusListView.SetBounds(0, top, 0, height, BoundsSpecified.Y | BoundsSpecified.Height);
-            }
+            int top = FilterComboBox.Visible ? FilterComboBox.Bottom + FilterComboBox.Margin.Top + FilterComboBox.Margin.Bottom : 0;
+            int height = ClientRectangle.Height - top - FileStatusListView.Margin.Top - FileStatusListView.Margin.Bottom;
+            FileStatusListView.SetBounds(0, top, 0, height, BoundsSpecified.Y | BoundsSpecified.Height);
         }
 
         public override bool Focused => FileStatusListView.Focused;
@@ -346,17 +328,9 @@ namespace GitUI
             }
         }
 
-        private IReadOnlyList<FileStatusWithDescription> GitItemStatusesWithDescription
-        {
-            get => _itemsWithDescription;
-            set
-            {
-                _itemsWithDescription = value ?? throw new ArgumentNullException(nameof(value));
-                UpdateFileStatusListView();
-            }
-        }
+        private IReadOnlyList<FileStatusWithDescription> GitItemStatusesWithDescription { get; set; } = Array.Empty<FileStatusWithDescription>();
 
-        public bool GroupByRevision { get; set; }
+        public bool GroupByRevision { get; set; } = false;
 
         [Browsable(false)]
         [DefaultValue(true)]
@@ -750,8 +724,11 @@ namespace GitUI
 
         public void SetDiffs(IReadOnlyList<GitRevision> revisions)
         {
+            CancellationToken cancellationToken = _reloadSequence.Next();
+            FileStatusListLoading();
             _enableDisablingShowDiffForAllParents = true;
-            GitItemStatusesWithDescription = _diffCalculator.SetDiffs(revisions, headId: null, allowMultiDiff: false, cancellationToken: default);
+            _diffCalculator.SetDiff(revisions, headId: null, allowMultiDiff: false);
+            UpdateFileStatusListView(_diffCalculator.Calculate(cancellationToken));
         }
 
         public async Task SetDiffsAsync(IReadOnlyList<GitRevision> revisions, ObjectId? headId, CancellationToken cancellationToken)
@@ -762,11 +739,12 @@ namespace GitUI
 
             await TaskScheduler.Default;
             cancellationToken.ThrowIfCancellationRequested();
-            IReadOnlyList<FileStatusWithDescription> gitItemStatusesWithDescription = _diffCalculator.SetDiffs(revisions, headId, allowMultiDiff: true, cancellationToken);
+            _diffCalculator.SetDiff(revisions, headId, allowMultiDiff: true);
+            IReadOnlyList<FileStatusWithDescription> gitItemStatusesWithDescription = _diffCalculator.Calculate(cancellationToken);
 
             await this.SwitchToMainThreadAsync(cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
-            GitItemStatusesWithDescription = gitItemStatusesWithDescription;
+            UpdateFileStatusListView(gitItemStatusesWithDescription);
         }
 
         /// <summary>
@@ -787,8 +765,8 @@ namespace GitUI
             string workTreeDesc,
             IReadOnlyList<GitItemStatus> workTreeItems)
         {
-            GroupByRevision = true;
-            GitItemStatusesWithDescription = new List<FileStatusWithDescription>
+            FileStatusListLoading();
+            UpdateFileStatusListView(new List<FileStatusWithDescription>
             {
                 new(
                     firstRev: indexRev,
@@ -800,25 +778,25 @@ namespace GitUI
                     secondRev: indexRev,
                     summary: indexDesc,
                     statuses: indexItems)
-            };
+            });
         }
 
         public void SetDiffs(GitRevision? firstRev, GitRevision secondRev, IReadOnlyList<GitItemStatus> items)
         {
-            GroupByRevision = false;
-            GitItemStatusesWithDescription = new List<FileStatusWithDescription>
+            FileStatusListLoading();
+            UpdateFileStatusListView(new List<FileStatusWithDescription>
             {
                 new(
                     firstRev: firstRev,
                     secondRev: secondRev,
                     summary: TranslatedStrings.DiffWithParent + GetDescriptionForRevision(firstRev?.ObjectId),
                     statuses: items)
-            };
+            });
         }
 
         public void ClearDiffs()
         {
-            GitItemStatusesWithDescription = new List<FileStatusWithDescription>();
+            UpdateFileStatusListView([]);
         }
 
         private string? GetDescriptionForRevision(ObjectId? objectId) =>
@@ -967,18 +945,21 @@ namespace GitUI
 
         private void SetDeleteFilterButtonVisibility()
         {
-            DeleteFilterButton.Visible = FilterVisibleInternal && !string.IsNullOrEmpty(FilterComboBox.Text);
+            DeleteFilterButton.Visible = FilterComboBox.Visible && !string.IsNullOrEmpty(FilterComboBox.Text);
         }
 
         private void SetFilterWatermarkLabelVisibility()
         {
-            FilterWatermarkLabel.Visible = FilterVisibleInternal && !FilterComboBox.Focused && string.IsNullOrEmpty(FilterComboBox.Text);
+            FilterWatermarkLabel.Visible = FilterComboBox.Visible && !FilterComboBox.Focused && string.IsNullOrEmpty(FilterComboBox.Text);
         }
 
         private void FileStatusListLoading()
         {
-            LoadingFiles.Visible = true;
+            // Show "Files loading" below the filterbox
             NoFiles.Visible = false;
+            int top = FilterComboBox.Visible ? FilterComboBox.Bottom + FilterComboBox.Margin.Top + FilterComboBox.Margin.Bottom : 0;
+            LoadingFiles.Top = top;
+            LoadingFiles.Visible = true;
 
             FileStatusListView.BeginUpdate();
             FileStatusListView.Groups.Clear();
@@ -986,17 +967,14 @@ namespace GitUI
             FileStatusListView.EndUpdate();
         }
 
-        private void UpdateFileStatusListView(bool updateCausedByFilter = false)
+        private void UpdateFileStatusListView(IReadOnlyList<FileStatusWithDescription> items, bool updateCausedByFilter = false)
         {
-            bool hasChangesOrMultipleGroups = GitItemStatusesWithDescription.Count > 1 || GitItemStatusesWithDescription.Any(x => x.Statuses.Count > 0);
-            if (!hasChangesOrMultipleGroups)
-            {
-                HandleVisibility_NoFilesLabel_FilterComboBox(filesPresent: false);
-            }
-            else
+            GitItemStatusesWithDescription = items ?? throw new ArgumentNullException(nameof(items));
+            bool filesPresent = GitItemStatusesWithDescription.Any(x => x.Statuses.Count > 0);
+            bool hasChangesOrMultipleGroups = filesPresent || GitItemStatusesWithDescription.Count > 1;
+            if (filesPresent)
             {
                 EnsureSelectedIndexChangeSubscription();
-                HandleVisibility_NoFilesLabel_FilterComboBox(filesPresent: true);
             }
 
             HashSet<GitItemStatus>? previouslySelectedItems = null;
@@ -1011,6 +989,7 @@ namespace GitUI
             }
 
             FileStatusListView.BeginUpdate();
+            SetFileStatusListVisibility(filesPresent);
             FileStatusListView.ShowGroups = GitItemStatusesWithDescription.Count > 1 || GroupByRevision;
             FileStatusListView.Groups.Clear();
             FileStatusListView.Items.Clear();
@@ -1024,9 +1003,9 @@ namespace GitUI
                 ListViewGroup group = new(name)
                 {
                     // Collapse some groups for diffs with common BASE
-                    CollapsedState = i.Statuses.Count <= 7 || GitItemStatusesWithDescription.Count < 3 || i == GitItemStatusesWithDescription[0]
-                        ? ListViewGroupCollapsedState.Expanded
-                        : ListViewGroupCollapsedState.Collapsed,
+                    CollapsedState = (i.Statuses.Count <= 7 || GitItemStatusesWithDescription.Count < 3 || i == GitItemStatusesWithDescription[0])
+                            ? ListViewGroupCollapsedState.Expanded
+                            : ListViewGroupCollapsedState.Collapsed,
                     Tag = i.FirstRev
                 };
                 FileStatusListView.Groups.Add(group);
@@ -1269,13 +1248,6 @@ namespace GitUI
             }
         }
 
-        private void HandleVisibility_NoFilesLabel_FilterComboBox(bool filesPresent)
-        {
-            LoadingFiles.Visible = false;
-            NoFiles.Visible = !filesPresent;
-            FilterVisibleInternal = FilterVisible && filesPresent;
-        }
-
         public void SelectPreviousVisibleItem()
         {
             if (FileStatusListView.Items.Count <= 1)
@@ -1411,19 +1383,19 @@ namespace GitUI
             }
 
             // Show 'Show file differences for all parents' menu item if it is possible that there are multiple first revisions
-            bool mayBeMultipleRevs = _enableDisablingShowDiffForAllParents && _itemsWithDescription.Count > 1;
+            bool mayBeMultipleRevs = _enableDisablingShowDiffForAllParents && GitItemStatusesWithDescription.Count > 1;
 
             const string showAllDifferencesItemName = "ShowDiffForAllParentsText";
             ToolStripItem[] diffItem = cm.Items.Find(showAllDifferencesItemName, true);
             const string separatorKey = showAllDifferencesItemName + "Separator";
-            if (!diffItem.Any())
+            if (diffItem.Length == 0)
             {
                 cm.Items.Add(new ToolStripSeparator
                 {
                     Name = separatorKey,
                     Visible = mayBeMultipleRevs
                 });
-                ToolStripMenuItem showAllDiferencesItem = new(TranslatedStrings.ShowDiffForAllParentsText)
+                ToolStripMenuItem showAllDifferencesItem = new(TranslatedStrings.ShowDiffForAllParentsText)
                 {
                     Checked = AppSettings.ShowDiffForAllParents,
                     ToolTipText = TranslatedStrings.ShowDiffForAllParentsTooltip,
@@ -1431,20 +1403,21 @@ namespace GitUI
                     CheckOnClick = true,
                     Visible = mayBeMultipleRevs
                 };
-                showAllDiferencesItem.CheckedChanged += (s, e) =>
+                showAllDifferencesItem.CheckedChanged += (s, e) =>
                 {
-                    AppSettings.ShowDiffForAllParents = showAllDiferencesItem.Checked;
+                    AppSettings.ShowDiffForAllParents = showAllDifferencesItem.Checked;
+                    CancellationToken cancellationToken = _reloadSequence.Next();
                     FileStatusListLoading();
                     ThreadHelper.FileAndForget(async () =>
                     {
-                        IReadOnlyList<FileStatusWithDescription> gitItemStatusesWithDescription = _diffCalculator.Reload();
+                        IReadOnlyList<FileStatusWithDescription> gitItemStatusesWithDescription = _diffCalculator.Calculate(cancellationToken);
 
-                        await this.SwitchToMainThreadAsync();
-                        GitItemStatusesWithDescription = gitItemStatusesWithDescription;
+                        await this.SwitchToMainThreadAsync(cancellationToken);
+                        UpdateFileStatusListView(gitItemStatusesWithDescription);
                     });
                 };
 
-                cm.Items.Add(showAllDiferencesItem);
+                cm.Items.Add(showAllDifferencesItem);
             }
             else
             {
@@ -1725,7 +1698,6 @@ namespace GitUI
         private string _toolTipText = "";
         private readonly Subject<string> _filterSubject = new();
         private Regex? _filter;
-        private bool _filterVisible = false;
 
         public void SetFilter(string value)
         {
@@ -1742,7 +1714,8 @@ namespace GitUI
         {
             StoreFilter(value);
 
-            UpdateFileStatusListView(updateCausedByFilter: true);
+            // Feed back the current list of files
+            UpdateFileStatusListView(GitItemStatusesWithDescription, updateCausedByFilter: true);
             FilterChanged?.Invoke(this, EventArgs.Empty);
             return FileStatusListView.Items.Count;
         }
@@ -2009,6 +1982,7 @@ namespace GitUI
             internal Regex? Filter => _fileStatusList._filter;
             internal bool FilterWatermarkLabelVisible => _fileStatusList.FilterWatermarkLabel.Visible;
             internal void StoreFilter(string value) => _fileStatusList.StoreFilter(value);
+            internal void SetFileStatusListVisibility(bool filesPresent) => _fileStatusList.SetFileStatusListVisibility(filesPresent);
         }
     }
 }

--- a/GitUI/UserControls/FileStatusList.resx
+++ b/GitUI/UserControls/FileStatusList.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FileStatusListTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FileStatusListTests.cs
@@ -216,22 +216,19 @@ namespace GitExtensions.UITests.CommandsDialogs
         [Test]
         public void Test_FilterWatermarkLabelVisibility_on_FilterVisibleChange(
             [Values(null, "", "x")] string filterText,
-            [Values(true, false)] bool filterFocused,
-            [Values(true, false)] bool filterVisible)
+            [Values(true, false)] bool filterFocused)
         {
             FileStatusList.TestAccessor accessor = _fileStatusList.GetTestAccessor();
 
             accessor.FilterComboBox.Text = filterText; // must be set first because it does not need to update the visibility
-
-            _fileStatusList.FilterVisible = !filterVisible; // force a change
-            _fileStatusList.FilterVisible = filterVisible;
+            accessor.SetFileStatusListVisibility(filesPresent: true);
 
             if (filterFocused)
             {
                 accessor.FilterComboBox.Focus(); // must be done after FilterVisible = true
             }
 
-            accessor.FilterWatermarkLabelVisible.Should().Be(filterVisible && !filterFocused && string.IsNullOrEmpty(filterText));
+            accessor.FilterWatermarkLabelVisible.Should().Be(!filterFocused && string.IsNullOrEmpty(filterText));
         }
 
         [Test]
@@ -240,19 +237,15 @@ namespace GitExtensions.UITests.CommandsDialogs
             FileStatusList.TestAccessor accessor = _fileStatusList.GetTestAccessor();
 
             accessor.FilterComboBox.Text = "";
-
-            // FilterVisibleInternal has been reset because no items were added, toggle it
-            _fileStatusList.FilterVisible = false;
-            _fileStatusList.FilterVisible = true;
-
+            accessor.SetFileStatusListVisibility(filesPresent: true);
             accessor.FilterWatermarkLabelVisible.Should().BeTrue();
 
             accessor.FilterComboBox.Focus();
-
+            accessor.SetFileStatusListVisibility(filesPresent: true);
             accessor.FilterWatermarkLabelVisible.Should().BeFalse();
 
             accessor.FileStatusListView.Focus();
-
+            accessor.SetFileStatusListVisibility(filesPresent: true);
             accessor.FilterWatermarkLabelVisible.Should().BeTrue();
         }
 
@@ -267,12 +260,10 @@ namespace GitExtensions.UITests.CommandsDialogs
             string expectedRegex = string.IsNullOrEmpty(regex) ? null : regex;
 
             _fileStatusList.SetFilter(regex);
+            accessor.SetFileStatusListVisibility(filesPresent: true);
 
             CheckStoreFilter(expectedColor, expectedRegex, accessor);
 
-            // FilterVisibleInternal has been reset because no items were added, toggle it
-            _fileStatusList.FilterVisible = false;
-            _fileStatusList.FilterVisible = true;
             accessor.DeleteFilterButton.Visible.Should().Be(active);
         }
 


### PR DESCRIPTION
## Proposed changes

CancellationToken for diff calculation not only when
RevDiff updates.

Simplify internal handling with FilterVisible etc

Removed property for FilterVisible as it was always true, used in all lists.

Set property GroupByRevision to true only where needed

Revised taborder, tab to Filter box before list
(other sub controls are not tab enabled).

--
FileStatusList: Delay FileLoading label

Label appears as flickering.
~~Just clear the FileStatusList while calculating the data.~~

~~This is not required, but in most situations the FilesLoading... label is very quick, appears as flickering.~~
~~The change is in a separate commit, to simplify rejection.~~
~~The first commit hides the Filter Combobox too, maybe better to keep it visible if the FilesLoading label is kept~~

--
#11350 will require this change

## Screenshots <!-- Remove this section if PR does not change UI -->

In Linux repo
First two selected commits are f8678a336808f728ea2e0806cfc10362958ca4e5 7beae48301f7ca214939e522051007b9b4daf178
Slower than almost all GE commits, but much faster than third selection 51af5563423c6e8537da8b6bd485b46c2b0d6492 (even if that has a small diff)

### Before

![prev-list](https://github.com/gitextensions/gitextensions/assets/6248932/83e93ec4-019f-4413-9279-da9cb9eb89c7)

### After

![new-list2](https://github.com/gitextensions/gitextensions/assets/6248932/72d19ab7-a765-4287-9e24-90049a52f8a6)

## Test methodology <!-- How did you ensure quality? -->

Tests are updated

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
