### PR TITLE
GetObsoleteBranches: Restore linefeed in arguments

### DIFF
--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -97,7 +97,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
 
                 GitArgumentBuilder args = new("log")
                 {
-                    @"--pretty=""format:%ci\n%an\n%s""",
+                    "--pretty=\"format:%ci\n%an\n%s\"",
                     "--max-count=1",
                     branchName,
                     "--"


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/pull/11470#discussion_r1436984453

## Proposed changes

- Restore the linefeeds used in the command line before #11470

## Test methodology <!-- How did you ensure quality? -->

- open plugin

### Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).