### PR TITLE
Blame: options to git-diff to get line in previous commit

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3066,10 +3066,9 @@ namespace GitCommands
             GitArgumentBuilder args = new("blame")
             {
                 "--porcelain",
-                $"--diff-algorithm={(AppSettings.UseHistogramDiffAlgorithm ? "histogram" : "default")}",
-                { AppSettings.DetectCopyInFileOnBlame, "-M" },
-                { AppSettings.DetectCopyInAllOnBlame, "-C" },
-                { AppSettings.IgnoreWhitespaceOnBlame, "-w" },
+                { AppSettings.DetectCopyInFileOnBlame, "-M" }, // as git-diff --find-renames
+                { AppSettings.DetectCopyInAllOnBlame, "-C" }, // as git-diff --find-copies
+                { AppSettings.IgnoreWhitespaceOnBlame, "-w" }, // as git-diff --ignore-all-space
                 "-l",
                 { lines is not null, $"-L {lines}" },
                 from.ToPosixPath().Quote(),

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -3066,6 +3066,7 @@ namespace GitCommands
             GitArgumentBuilder args = new("blame")
             {
                 "--porcelain",
+                $"--diff-algorithm={(AppSettings.UseHistogramDiffAlgorithm ? "histogram" : "default")}",
                 { AppSettings.DetectCopyInFileOnBlame, "-M" },
                 { AppSettings.DetectCopyInAllOnBlame, "-C" },
                 { AppSettings.IgnoreWhitespaceOnBlame, "-w" },

--- a/GitUI/UserControls/GitBlameParser.cs
+++ b/GitUI/UserControls/GitBlameParser.cs
@@ -36,13 +36,14 @@ internal partial class GitBlameParser : IGitBlameParser
         {
             // Get the git diff of changes introduced by the blamed selected commit
             // *without context lines* to make starting line value more accurate and possibly have more distincts chunks!
+            // git-config diff algorithm option must be overridden for user preferences and tests
             GitArgumentBuilder args = new("diff")
             {
                 $"-U0",
                 $"--diff-algorithm={(AppSettings.UseHistogramDiffAlgorithm ? "histogram" : "default")}",
-                { AppSettings.DetectCopyInFileOnBlame, "-M" },
-                { AppSettings.DetectCopyInAllOnBlame, "-C" },
-                { AppSettings.IgnoreWhitespaceOnBlame, "-w" },
+                { AppSettings.DetectCopyInFileOnBlame, "--find-renames" }, // git-blame only has -M
+                { AppSettings.DetectCopyInAllOnBlame, "--find-copies" }, // git-blame only has -C
+                { AppSettings.IgnoreWhitespaceOnBlame, "--ignore-all-space" }, // git-blame only has -w
                 parentId,
                 selectedBlamedRevision.ObjectId,
                 "--",

--- a/GitUI/UserControls/GitBlameParser.cs
+++ b/GitUI/UserControls/GitBlameParser.cs
@@ -36,7 +36,18 @@ internal partial class GitBlameParser : IGitBlameParser
         {
             // Get the git diff of changes introduced by the blamed selected commit
             // *without context lines* to make starting line value more accurate and possibly have more distincts chunks!
-            GitArgumentBuilder args = new("diff") { $"-U0", parentId, selectedBlamedRevision.ObjectId, "--", filename };
+            GitArgumentBuilder args = new("diff")
+            {
+                $"-U0",
+                $"--diff-algorithm={(AppSettings.UseHistogramDiffAlgorithm ? "histogram" : "default")}",
+                { AppSettings.DetectCopyInFileOnBlame, "-M" },
+                { AppSettings.DetectCopyInAllOnBlame, "-C" },
+                { AppSettings.IgnoreWhitespaceOnBlame, "-w" },
+                parentId,
+                selectedBlamedRevision.ObjectId,
+                "--",
+                filename
+            };
 
             string diffOutput = _getModule().GitExecutable.GetOutput(args, cache: GitModule.GitCommandCache);
 
@@ -51,7 +62,7 @@ internal partial class GitBlameParser : IGitBlameParser
                 }
 
                 int currentChunkStartingLine = int.Parse(match.Groups["CurrentLineNumber"].Value);
-                if (currentChunkStartingLine < selectedLine)
+                if (currentChunkStartingLine <= selectedLine)
                 {
                     // Calculate the offset thanks to the diff chunk header
                     int previousChunkStartingLine = int.Parse(match.Groups["PreviousLineNumber"].Value);

--- a/IntegrationTests/UI.IntegrationTests/UserControls/GitBlameParserTest.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/GitBlameParserTest.cs
@@ -9,18 +9,30 @@ public sealed class GitBlameParserTest
 {
     // Track the original setting value
     private bool _useHistogramDiffAlgorithm;
+    private bool _detectCopyInFileOnBlame;
+    private bool _detectCopyInAllOnBlame;
+    private bool _ignoreWhitespaceOnBlame;
 
     [OneTimeSetUp]
     public void OneTimeSetUp()
     {
         _useHistogramDiffAlgorithm = AppSettings.UseHistogramDiffAlgorithm;
+        _detectCopyInFileOnBlame = AppSettings.DetectCopyInFileOnBlame;
+        _detectCopyInAllOnBlame = AppSettings.DetectCopyInAllOnBlame;
+        _ignoreWhitespaceOnBlame = AppSettings.IgnoreWhitespaceOnBlame;
         AppSettings.UseHistogramDiffAlgorithm = false;
+        AppSettings.DetectCopyInFileOnBlame = false;
+        AppSettings.DetectCopyInAllOnBlame = false;
+        AppSettings.IgnoreWhitespaceOnBlame = true;
     }
 
     [OneTimeTearDown]
     public void OneTimeTearDown()
     {
         AppSettings.UseHistogramDiffAlgorithm = _useHistogramDiffAlgorithm;
+        AppSettings.DetectCopyInFileOnBlame = _detectCopyInFileOnBlame;
+        AppSettings.DetectCopyInAllOnBlame = _detectCopyInAllOnBlame;
+        AppSettings.IgnoreWhitespaceOnBlame = _ignoreWhitespaceOnBlame;
     }
 
     [Test]
@@ -40,14 +52,14 @@ public sealed class GitBlameParserTest
         // line content is still: internal bool ExecuteCommand(Command cmd)
         Assert.AreEqual(2192, GetOriginalLineInPreviousCommit(2281));
 
-        // line content from offset in diff
-        //   case Command.Stash: UICommands.StashSave(this, AppSettings.IncludeUntrackedFilesInManualStash); break;
-        //  ->
-        //   case Commands.QuickPull: UICommands.StartPullDialogAndPullImmediately(this); break;
-        Assert.AreEqual(2147, GetOriginalLineInPreviousCommit(2187));
-
         // line content is still around: internal enum Command -> internal enum Commands
         Assert.AreEqual(2085, GetOriginalLineInPreviousCommit(2090));
+
+        // line content from offset in diff
+        //   kGitToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Command.GitGitK).ToShortcutKeyDisplayString();
+        //  ->
+        //   kGitToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys(Commands.GitGitK).ToShortcutKeyDisplayString();
+        Assert.AreEqual(824, GetOriginalLineInPreviousCommit(824));
 
         int GetOriginalLineInPreviousCommit(int blamedLineNumber)
             => new GitBlameParser(() => gitModule)

--- a/IntegrationTests/UI.IntegrationTests/UserControls/GitBlameParserTest.cs
+++ b/IntegrationTests/UI.IntegrationTests/UserControls/GitBlameParserTest.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using CommonTestUtils;
+using GitCommands;
 using GitUI.UserControls;
 using GitUIPluginInterfaces;
 
@@ -6,6 +7,22 @@ namespace GitUITests.UserControls;
 
 public sealed class GitBlameParserTest
 {
+    // Track the original setting value
+    private bool _useHistogramDiffAlgorithm;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _useHistogramDiffAlgorithm = AppSettings.UseHistogramDiffAlgorithm;
+        AppSettings.UseHistogramDiffAlgorithm = false;
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        AppSettings.UseHistogramDiffAlgorithm = _useHistogramDiffAlgorithm;
+    }
+
     [Test]
     public void GetOriginalLineInPreviousCommit()
     {
@@ -14,16 +31,26 @@ public sealed class GitBlameParserTest
         // line content is: internal bool ExecuteCommand(Command cmd)
 
         string gitExtensionsRepoPath = Path.GetFullPath(@"..\..\..\..\..\..\..");
-        Assert.IsTrue(gitExtensionsRepoPath.EndsWith("gitextensions"));
 
         GitModule gitModule = new(gitExtensionsRepoPath);
 
         // Revision corresponding to line 2281
         GitRevision selectedBlamedRevision = gitModule.GetRevision(ObjectId.Parse("52476f30670ba5338756b606841fb0a346fd6460"));
 
-        int matchingBlameLineNumber = new GitBlameParser(() => gitModule)
-            .GetOriginalLineInPreviousCommit(selectedBlamedRevision, "GitUI/CommandsDialogs/FormBrowse.cs", 2281);
+        // line content is still: internal bool ExecuteCommand(Command cmd)
+        Assert.AreEqual(2192, GetOriginalLineInPreviousCommit(2281));
 
-        Assert.AreEqual(2192, matchingBlameLineNumber); // line content is still: internal bool ExecuteCommand(Command cmd)
+        // line content from offset in diff
+        //   case Command.Stash: UICommands.StashSave(this, AppSettings.IncludeUntrackedFilesInManualStash); break;
+        //  ->
+        //   case Commands.QuickPull: UICommands.StartPullDialogAndPullImmediately(this); break;
+        Assert.AreEqual(2147, GetOriginalLineInPreviousCommit(2187));
+
+        // line content is still around: internal enum Command -> internal enum Commands
+        Assert.AreEqual(2085, GetOriginalLineInPreviousCommit(2090));
+
+        int GetOriginalLineInPreviousCommit(int blamedLineNumber)
+            => new GitBlameParser(() => gitModule)
+                    .GetOriginalLineInPreviousCommit(selectedBlamedRevision, "GitUI/CommandsDialogs/FormBrowse.cs", blamedLineNumber);
     }
 }


### PR DESCRIPTION
## Proposed changes

GetOriginalLineInPreviousCommit() (to get line number in the previous commit)
must override the git diff option from git-config to follow the user preference
and to give predictable options for tests.
Similar, rename and whitespace options must be the same for git-diff
and git-blame.

* Include current section in checks
Better matching.

* BlameParserTest should not assume clone folder name

--

was

BlameParserTest should not assume clone folder

Follow up to #11434 Test fals if clonefolder is not gitextensions. I use various worktree folders with other names, so the test fails.
There is no reason to test the name of the clone folder.

Tests also fails locally due to matchingBlameLineNumber=2291, separate isue. (blame UI is OK, so are AppVeyor tests)

## Test methodology <!-- How did you ensure quality? -->

Removed incorrect test case

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
