### PR TITLE
Check for cancellation before accessing non-locals

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -996,6 +996,7 @@ namespace GitUI
                         ? getUnfilteredRefs.Value.Where(r => r.CompleteName != GitRefName.RefsStashPrefix)
                         : getUnfilteredRefs.Value)
                         .ToLookup(gitRef => gitRef.ObjectId);
+                    cancellationToken.ThrowIfCancellationRequested();
                     ResetNavigationHistory();
                     UpdateSelectedRef(capturedModule, getUnfilteredRefs.Value, headRef.Value);
                     _gridView.ToBeSelectedObjectIds = GetToBeSelectedRevisions(CurrentCheckout, currentlySelectedObjectIds);
@@ -1073,6 +1074,7 @@ namespace GitUI
                     {
                         RevisionReader reader = new(capturedModule);
                         string pathFilter = BuildPathFilter(_filterInfo.PathFilter);
+                        cancellationToken.ThrowIfCancellationRequested();
                         ParentsAreRewritten = _filterInfo.HasRevisionFilter;
 
                         cancellationToken.ThrowIfCancellationRequested();
@@ -1122,6 +1124,7 @@ namespace GitUI
 
             string BuildPathFilter(string? path)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 FilePathByObjectId?.Clear();
 
                 if (string.IsNullOrWhiteSpace(path))
@@ -1181,7 +1184,7 @@ namespace GitUI
 
                 HashSet<string?> setOfFileNames = [];
 
-                foreach (string fileName in ParseFileNames(args))
+                foreach (string fileName in ParseFileNames(args, cancellationToken))
                 {
                     setOfFileNames.Add(fileName);
                 }
@@ -1542,10 +1545,10 @@ namespace GitUI
                 path,
             };
 
-            return ParseFileNames(args).FirstOrDefault();
+            return ParseFileNames(args, cancellationToken: default).FirstOrDefault();
         }
 
-        private IEnumerable<string> ParseFileNames(GitArgumentBuilder args)
+        private IEnumerable<string> ParseFileNames(GitArgumentBuilder args, CancellationToken cancellationToken)
         {
             ExecutionResult result = Module.GitExecutable.Execute(args, outputEncoding: GitModule.LosslessEncoding, throwOnErrorExit: false);
 
@@ -1585,6 +1588,7 @@ namespace GitUI
                 }
 
                 // Add only the first file to the dictionary
+                cancellationToken.ThrowIfCancellationRequested();
                 FilePathByObjectId?.TryAdd(currentObjectId, line);
 
                 yield return line;


### PR DESCRIPTION
Fixes #11460

## Proposed changes

- RevisionGridControl: Check for cancellation before accessing non-locals

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).