### PR TITLE
FileViewer Replace

### DIFF
--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -27,6 +27,7 @@ namespace GitUI.Editor
             copyNewVersionToolStripMenuItem = new ToolStripMenuItem();
             copyOldVersionToolStripMenuItem = new ToolStripMenuItem();
             findToolStripMenuItem = new ToolStripMenuItem();
+            replaceToolStripMenuItem = new ToolStripMenuItem();
             toolStripSeparator1 = new ToolStripSeparator();
             ignoreWhitespaceAtEolToolStripMenuItem = new ToolStripMenuItem();
             ignoreWhitespaceChangesToolStripMenuItem = new ToolStripMenuItem();
@@ -84,6 +85,7 @@ namespace GitUI.Editor
             automaticContinuousScrollToolStripMenuItem,
             showNonprintableCharactersToolStripMenuItem,
             findToolStripMenuItem,
+            replaceToolStripMenuItem,
             goToLineToolStripMenuItem});
             contextMenu.Name = "ContextMenu";
             contextMenu.Size = new Size(244, 346);
@@ -147,6 +149,13 @@ namespace GitUI.Editor
             findToolStripMenuItem.Size = new Size(243, 22);
             findToolStripMenuItem.Text = "Find";
             findToolStripMenuItem.Click += FindToolStripMenuItemClick;
+            // 
+            // replaceToolStripMenuItem
+            // 
+            replaceToolStripMenuItem.Name = "replaceToolStripMenuItem";
+            replaceToolStripMenuItem.Size = new Size(243, 22);
+            replaceToolStripMenuItem.Text = "Replace";
+            replaceToolStripMenuItem.Click += FindToolStripMenuItemClick;
             // 
             // toolStripSeparator1
             // 
@@ -453,6 +462,7 @@ namespace GitUI.Editor
 
         private ContextMenuStrip contextMenu;
         private ToolStripMenuItem findToolStripMenuItem;
+        private ToolStripMenuItem replaceToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator1;
         private ToolStripMenuItem ignoreWhitespaceAtEolToolStripMenuItem;
         private ToolStripMenuItem ignoreWhitespaceChangesToolStripMenuItem;

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -220,7 +220,11 @@ namespace GitUI.Editor
         public bool IsReadOnly
         {
             get => internalFileViewer.IsReadOnly;
-            set => internalFileViewer.IsReadOnly = value;
+            set
+            {
+                internalFileViewer.IsReadOnly = value;
+                replaceToolStripMenuItem.Visible = !value;
+            }
         }
 
         [DefaultValue(true)]
@@ -333,6 +337,7 @@ namespace GitUI.Editor
         {
             LoadHotkeys(HotkeySettingsName);
             findToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.Find);
+            replaceToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.Replace);
             stageSelectedLinesToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.StageLines);
             unstageSelectedLinesToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.UnstageLines);
             resetSelectedLinesToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.ResetLines);
@@ -1744,7 +1749,7 @@ namespace GitUI.Editor
 
         private void FindToolStripMenuItemClick(object sender, EventArgs e)
         {
-            internalFileViewer.Find();
+            internalFileViewer.Find(sender == replaceToolStripMenuItem && !IsReadOnly);
         }
 
         private void encodingToolStripComboBox_SelectedIndexChanged(object sender, EventArgs e)
@@ -1796,6 +1801,7 @@ namespace GitUI.Editor
         internal enum Command
         {
             Find = 0,
+            Replace = 16,
             FindNextOrOpenWithDifftool = 8,
             FindPrevious = 9,
             GoToLine = 1,
@@ -1819,7 +1825,14 @@ namespace GitUI.Editor
 
             switch (command)
             {
-                case Command.Find: internalFileViewer.Find(); break;
+                case Command.Find: internalFileViewer.Find(replace: false); break;
+                case Command.Replace:
+                    if (!IsReadOnly)
+                    {
+                        internalFileViewer.Find(replace: true);
+                    }
+
+                    break;
                 case Command.FindNextOrOpenWithDifftool: internalFileViewer.InvokeAndForget(() => internalFileViewer.FindNextAsync(searchForwardOrOpenWithDifftool: true)); break;
                 case Command.FindPrevious: internalFileViewer.InvokeAndForget(() => internalFileViewer.FindNextAsync(searchForwardOrOpenWithDifftool: false)); break;
                 case Command.GoToLine: return PerformClickIfAvailable(goToLineToolStripMenuItem);

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -187,9 +187,9 @@ namespace GitUI.Editor
             }
         }
 
-        public void Find()
+        public void Find(bool replace)
         {
-            _findAndReplaceForm.ShowFor(TextEditor, false);
+            _findAndReplaceForm.ShowFor(TextEditor, replace && !IsReadOnly);
             OnVScrollPositionChanged(EventArgs.Empty);
         }
 

--- a/GitUI/Editor/IFileViewer.cs
+++ b/GitUI/Editor/IFileViewer.cs
@@ -26,7 +26,7 @@ namespace GitUI.Editor
         event EventHandler DoubleClick;
 
         void EnableScrollBars(bool enable);
-        void Find();
+        void Find(bool replace);
         Task FindNextAsync(bool searchForwardOrOpenWithDifftool);
 
         string GetText();

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -322,6 +322,7 @@ namespace GitUI.Hotkey
                 new HotkeySettings(
                     FileViewer.HotkeySettingsName,
                     Hk(FileViewer.Command.Find, Keys.Control | Keys.F),
+                    Hk(FileViewer.Command.Replace, Keys.Control | Keys.H),
                     Hk(FileViewer.Command.FindNextOrOpenWithDifftool, OpenWithDifftoolHotkey),
                     Hk(FileViewer.Command.FindPrevious, Keys.Shift | OpenWithDifftoolHotkey),
                     Hk(FileViewer.Command.GoToLine, Keys.Control | Keys.G),

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1578,6 +1578,10 @@ The primary difftool can still be selected by clicking the main menu entry.</sou
         <source>Previous change</source>
         <target />
       </trans-unit>
+      <trans-unit id="replaceToolStripMenuItem.Text">
+        <source>Replace</source>
+        <target />
+      </trans-unit>
       <trans-unit id="resetSelectedLinesToolStripMenuItem.Text">
         <source>Reset selected line(s)</source>
         <target />


### PR DESCRIPTION
## Proposed changes

Enable the existing Replace popup for files that are writable.
For multiple files (including context menu in  file status list), Ctrl-H is ignored

This functionality was already implemented in FindAndReplaceForm.cs

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Find is unchanged for readonly (no replace) or when starting Find

![image](https://github.com/gitextensions/gitextensions/assets/6248932/b7f0c7f1-afb2-4d28-b3a4-ba57bc477eb6)

### After

Explicitly starting replace

![image](https://github.com/gitextensions/gitextensions/assets/6248932/f6a500fa-aff5-461e-8515-1d28f2a5e1af)

Added to file context menu.

![image](https://github.com/gitextensions/gitextensions/assets/6248932/37c29171-b48f-4969-a49c-5124a79e6c62)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
