### PR TITLE
CI: allow click on status cell to open build report

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -232,6 +232,7 @@ namespace GitUI
             _gridView.MouseDoubleClick += OnGridViewDoubleClick;
             _gridView.MouseClick += OnGridViewMouseClick;
             _gridView.CellMouseMove += (_, e) => _toolTipProvider.OnCellMouseMove(e);
+            _gridView.CellMouseEnter += _gridView_CellMouseEnter;
 
             // Allow to drop patch file on revision grid
             _gridView.AllowDrop = true;
@@ -1742,10 +1743,29 @@ namespace GitUI
             }
         }
 
+        private void _gridView_CellMouseEnter(object? sender, DataGridViewCellEventArgs e)
+        {
+            if (e.ColumnIndex == _buildServerWatcher.ColumnProvider.Index)
+            {
+                GitRevision revision = GetRevision(e.RowIndex);
+                _gridView.Cursor = string.IsNullOrWhiteSpace(revision?.BuildStatus?.Url) ? Cursors.Default : Cursors.Hand;
+            }
+            else
+            {
+                _gridView.Cursor = Cursors.Default;
+            }
+        }
+
         private void OnGridViewCellMouseDown(object sender, DataGridViewCellMouseEventArgs e)
         {
             try
             {
+                if (e.Button == MouseButtons.Left && e.ColumnIndex == _buildServerWatcher.ColumnProvider.Index)
+                {
+                    OpenBuildReport(GetRevision(e.RowIndex));
+                    return;
+                }
+
                 if (e.Button != MouseButtons.Right)
                 {
                     return;
@@ -2983,7 +3003,11 @@ namespace GitUI
 
         private void openBuildReportToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            GitRevision? revision = GetSelectedRevisionOrDefault();
+            OpenBuildReport(GetSelectedRevisionOrDefault());
+        }
+
+        private void OpenBuildReport(GitRevision? revision)
+        {
             if (string.IsNullOrWhiteSpace(revision?.BuildStatus?.Url))
             {
                 return;


### PR DESCRIPTION

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Nothing

### After

![ci_open_report](https://github.com/gitextensions/gitextensions/assets/460196/8daad16f-c021-403c-888b-8150544a62ea)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 3c3c8460a9d95508a188d5e3f415350c98eee676 (Dirty)
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 8.0.0
- DPI 96dpi (no scaling)
- Portable: False


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
