### PR TITLE
Scripts: Focus property grids when creating a new one

### DIFF
--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -270,6 +270,8 @@ Currently checked out revision:
             script.Enabled = true;
 
             BindScripts(_scripts, script);
+
+            propertyGrid1.Focus();
         }
 
         private void btnArgumentsHelp_Click(object sender, EventArgs e)


### PR DESCRIPTION
to be able to type the script name right away

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![script_new_broken](https://github.com/gitextensions/gitextensions/assets/460196/628eb96e-98ad-4d3a-92f9-7ea179e16982)


### After

![script_new](https://github.com/gitextensions/gitextensions/assets/460196/f3575109-66b8-4a16-a7f5-87e69886cbac)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->
- Git Extensions 33.33.33
- Build 05af8bf761f7ab5a578266b439e225cd29fd8b6b
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 8.0.0
- DPI 96dpi (no scaling)
- Portable: False

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
