### PR TITLE
Improve performance of push form (when a lot of local branches)

### DIFF
--- a/GitUI/CommandsDialogs/FormPush.Designer.cs
+++ b/GitUI/CommandsDialogs/FormPush.Designer.cs
@@ -207,6 +207,7 @@
             _NO_TRANSLATE_Branch.TabIndex = 0;
             _NO_TRANSLATE_Branch.SelectedIndexChanged += _NO_TRANSLATE_Branch_SelectedIndexChanged;
             _NO_TRANSLATE_Branch.SelectedValueChanged += BranchSelectedValueChanged;
+            _NO_TRANSLATE_Branch.Enter += _NO_TRANSLATE_Branch_Enter;
             // 
             // labelTo
             // 

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -701,10 +701,7 @@ namespace GitUI.CommandsDialogs
                 }
             }
 
-            foreach (IGitRef head in GetLocalBranches())
-            {
-                _NO_TRANSLATE_Branch.Items.Add(head);
-            }
+            _NO_TRANSLATE_Branch.Items.AddRange(GetLocalBranches().ToArray());
 
             _NO_TRANSLATE_Branch.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
 
@@ -737,24 +734,12 @@ namespace GitUI.CommandsDialogs
 
             if (_selectedRemote is not null)
             {
-                foreach (IGitRef head in GetRemoteBranches(_selectedRemote.Name))
-                {
-                    if (_NO_TRANSLATE_Branch.Text != head.LocalName)
-                    {
-                        RemoteBranch.Items.Add(head.LocalName);
-                    }
-                }
+                RemoteBranch.Items.AddRange(GetRemoteBranches(_selectedRemote.Name).Select(head => head.LocalName).Where(head => _NO_TRANSLATE_Branch.Text != head).ToArray());
 
                 HashSet<string> remoteBranchesSet = GetRemoteBranches(_selectedRemote.Name).Select(b => b.LocalName).ToHashSet();
                 IEnumerable<IGitRef> onlyLocalBranches = GetLocalBranches().Where(b => !remoteBranchesSet.Contains(b.LocalName));
 
-                foreach (IGitRef head in onlyLocalBranches)
-                {
-                    if (_NO_TRANSLATE_Branch.Text != head.LocalName)
-                    {
-                        RemoteBranch.Items.Add(head.LocalName);
-                    }
-                }
+                RemoteBranch.Items.AddRange(onlyLocalBranches.Select(head => head.LocalName).Where(head => _NO_TRANSLATE_Branch.Text != head).ToArray());
             }
 
             RemoteBranch.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);

--- a/GitUI/CommandsDialogs/FormPush.cs
+++ b/GitUI/CommandsDialogs/FormPush.cs
@@ -735,11 +735,6 @@ namespace GitUI.CommandsDialogs
             if (_selectedRemote is not null)
             {
                 RemoteBranch.Items.AddRange(GetRemoteBranches(_selectedRemote.Name).Select(head => head.LocalName).Where(head => _NO_TRANSLATE_Branch.Text != head).ToArray());
-
-                HashSet<string> remoteBranchesSet = GetRemoteBranches(_selectedRemote.Name).Select(b => b.LocalName).ToHashSet();
-                IEnumerable<IGitRef> onlyLocalBranches = GetLocalBranches().Where(b => !remoteBranchesSet.Contains(b.LocalName));
-
-                RemoteBranch.Items.AddRange(onlyLocalBranches.Select(head => head.LocalName).Where(head => _NO_TRANSLATE_Branch.Text != head).ToArray());
             }
 
             RemoteBranch.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
@@ -781,6 +776,11 @@ namespace GitUI.CommandsDialogs
                             }
                         }
                     }
+                }
+
+                if (!RemoteBranch.Items.Contains(_NO_TRANSLATE_Branch.Text))
+                {
+                    RemoteBranch.Items.Add(_NO_TRANSLATE_Branch.Text);
                 }
 
                 RemoteBranch.Text = _NO_TRANSLATE_Branch.Text;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Helps when there are lot of branches (like in #11441)

## Proposed changes

Most of the times, user open push form to push the current branch (and so don't change the dropdown values). So prevent to load all the branches when opening the form making the form opening immediately (instead of having to wait 16s for example when having 20k branches) by deferring loading:

- Load only the current branch in "Branch to push" combobox and load and fill  **all** local branches only when the user open it (opening time of 4s when 20k branches and less than 1s when 4k. Imperceptible otherwise)
- Don't add **all** local branches in the "to" combo box but prefer adding local branch in remote combobox on the fly when pushing a new branch.
- use `AddRange()` to add a big number of branches in remotes

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build a57c649dbe97e235729b9867be66a8cac084449f
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 8.0.0
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer **rebase** merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
