### PR TITLE
ProxySwitcher Do not fail if http.proxy is not set

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2117,9 +2117,9 @@ namespace GitCommands
             return ((ConfigFileSettings)EffectiveConfigFile).ByPath(path);
         }
 
-        public string? GetEffectiveGitSetting(string setting, bool cache = true)
+        public string? GetGitSetting(string setting, string scopeArg, bool cache = false)
         {
-            GitArgumentBuilder args = new("config") { "--includes", "--get", setting };
+            GitArgumentBuilder args = new("config") { "--includes", scopeArg, "--get", setting };
             ExecutionResult result = GitExecutable.Execute(args, cache: cache ? GitCommandCache : null, throwOnErrorExit: false);
 
             // Handle no value set, is error code 1: https://git-scm.com/docs/git-config#_description
@@ -2130,6 +2130,11 @@ namespace GitCommands
                 ConfigKeyInvalidOrNotSet => null,
                 _ => throw new ExternalOperationException("git", args.ToString(), WorkingDir, result.ExitCode, new InvalidOperationException("Error getting config value"))
             };
+        }
+
+        public string? GetEffectiveGitSetting(string setting, bool cache = false)
+        {
+            return GetGitSetting(setting, scopeArg: "", cache);
         }
 
         public void UnsetSetting(string setting)

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2714,7 +2714,7 @@ namespace GitUI.CommandsDialogs
                     return;
 
                     // Do not cache results in order to update the info on FormActivate
-                    string GetSetting(string key) => Module.GetEffectiveGitSetting(key, cache: false) ?? $"/{string.Format(TranslatedStrings.NotConfigured, key)}/";
+                    string GetSetting(string key) => Module.GetEffectiveGitSetting(key) ?? $"/{string.Format(TranslatedStrings.NotConfigured, key)}/";
                 });
         }
 

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -182,12 +182,21 @@ namespace GitUIPluginInterfaces
         T? GetEffectiveSetting<T>(string setting) where T : struct;
 
         /// <summary>
+        /// Get the config setting from git according to the scope.
+        /// </summary>
+        /// <param name="setting">The setting key.</param>
+        /// <param name="scopeArg">The scope for the config like "--global" according to https://git-scm.com/docs/git-config#_description. An empty string is the effective settings.</param>
+        /// <param name="cache"><see langword="true"/> if the result shall be cached.</param>
+        /// <returns>The value of the setting or <see langword="null"/> if the value is not set.</returns>
+        string? GetGitSetting(string setting, string scopeArg, bool cache = false);
+
+        /// <summary>
         /// Get the effective config setting from git.
         /// </summary>
         /// <param name="setting">The setting key.</param>
         /// <param name="cache"><see langword="true"/> if the result shall be cached.</param>
         /// <returns>The value of the setting or <see langword="null"/> if the value is not set.</returns>
-        string? GetEffectiveGitSetting(string setting, bool cache = true);
+        string? GetEffectiveGitSetting(string setting, bool cache = false);
 
         SettingsSource GetEffectiveSettingsByPath(string path);
 

--- a/Plugins/ProxySwitcher/ProxySwitcherForm.cs
+++ b/Plugins/ProxySwitcher/ProxySwitcherForm.cs
@@ -61,19 +61,8 @@ namespace GitExtensions.Plugins.ProxySwitcher
 
         private void RefreshProxy()
         {
-            GitArgumentBuilder args = new("config")
-            {
-                "--get",
-                "http.proxy"
-            };
-            LocalHttpProxy_TextBox.Text = HidePassword(_gitCommands.GitExecutable.GetOutput(args));
-            args = new GitArgumentBuilder("config")
-            {
-                "--global",
-                "--get",
-                "http.proxy"
-            };
-            GlobalHttpProxy_TextBox.Text = HidePassword(_gitCommands.GitExecutable.GetOutput(args));
+            LocalHttpProxy_TextBox.Text = HidePassword(_gitCommands.GetEffectiveGitSetting("http.proxy") ?? "");
+            GlobalHttpProxy_TextBox.Text = HidePassword(_gitCommands.GetGitSetting("http.proxy", "--global") ?? "");
             ApplyGlobally_CheckBox.Checked = string.Equals(LocalHttpProxy_TextBox.Text, GlobalHttpProxy_TextBox.Text);
         }
 


### PR DESCRIPTION
fixes #11490

## Proposed changes

Do not raise errors if Git config setting http.proxy is not set.

* GetGitSetting() for scoped git-config
Make it possible to get get git-config with a scope, like "--global"

* GetEffectiveGitSetting() should not cache by default

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
