### PR TITLE
FormBrowse: Avoid toolbar resize while refreshing

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
@@ -310,14 +310,13 @@ namespace GitUI.CommandsDialogs
             toolStripButtonPull.ToolTipText += GetShortcutKeys(Command.QuickPullOrFetch).ToShortcutKeyToolTipString();
         }
 
-        private Brush? UpdateCommitButtonAndGetBrush(IReadOnlyList<GitItemStatus>? status, bool showCount)
+        private Brush UpdateCommitButtonAndGetBrush(IReadOnlyList<GitItemStatus>? status, bool showCount)
         {
-            Brush brush = null;
             try
             {
                 ToolStripMain.SuspendLayout();
                 RepoStateVisualiser repoStateVisualiser = new();
-                (Image image, brush) = repoStateVisualiser.Invoke(status);
+                (Image image, Brush brush) = repoStateVisualiser.Invoke(status);
 
                 if (showCount)
                 {
@@ -346,13 +345,13 @@ namespace GitUI.CommandsDialogs
                     toolStripButtonCommit.Text = _commitButtonText.Text;
                     toolStripButtonCommit.AutoSize = true;
                 }
+
+                return brush;
             }
             finally
             {
                 ToolStripMain.ResumeLayout();
             }
-
-            return brush;
         }
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
@@ -310,41 +310,48 @@ namespace GitUI.CommandsDialogs
             toolStripButtonPull.ToolTipText += GetShortcutKeys(Command.QuickPullOrFetch).ToShortcutKeyToolTipString();
         }
 
-        private Brush UpdateCommitButtonAndGetBrush(IReadOnlyList<GitItemStatus>? status, bool showCount)
+        private Brush? UpdateCommitButtonAndGetBrush(IReadOnlyList<GitItemStatus>? status, bool showCount)
         {
-            ToolStripMain.SuspendLayout();
-            RepoStateVisualiser repoStateVisualiser = new();
-            (Image image, Brush brush) = repoStateVisualiser.Invoke(status);
-
-            if (showCount)
+            Brush brush = null;
+            try
             {
-                toolStripButtonCommit.Image = image;
+                ToolStripMain.SuspendLayout();
+                RepoStateVisualiser repoStateVisualiser = new();
+                (Image image, brush) = repoStateVisualiser.Invoke(status);
 
-                if (status is not null)
+                if (showCount)
                 {
-                    toolStripButtonCommit.Text = string.Format("{0} ({1})", _commitButtonText, status.Count);
-                    toolStripButtonCommit.AutoSize = true;
+                    toolStripButtonCommit.Image = image;
+
+                    if (status is not null)
+                    {
+                        toolStripButtonCommit.Text = string.Format("{0} ({1})", _commitButtonText, status.Count);
+                        toolStripButtonCommit.AutoSize = true;
+                    }
+                    else
+                    {
+                        int width = toolStripButtonCommit.Width;
+                        toolStripButtonCommit.Text = _commitButtonText.Text;
+                        if (width > toolStripButtonCommit.Width)
+                        {
+                            toolStripButtonCommit.AutoSize = false;
+                            toolStripButtonCommit.Width = width;
+                        }
+                    }
                 }
                 else
                 {
-                    int width = toolStripButtonCommit.Width;
+                    toolStripButtonCommit.Image = repoStateVisualiser.Invoke(new List<GitItemStatus>()).image;
+
                     toolStripButtonCommit.Text = _commitButtonText.Text;
-                    if (width > toolStripButtonCommit.Width)
-                    {
-                        toolStripButtonCommit.AutoSize = false;
-                        toolStripButtonCommit.Width = width;
-                    }
+                    toolStripButtonCommit.AutoSize = true;
                 }
             }
-            else
+            finally
             {
-                toolStripButtonCommit.Image = repoStateVisualiser.Invoke(new List<GitItemStatus>()).image;
-
-                toolStripButtonCommit.Text = _commitButtonText.Text;
-                toolStripButtonCommit.AutoSize = true;
+                ToolStripMain.ResumeLayout();
             }
 
-            ToolStripMain.ResumeLayout();
             return brush;
         }
     }

--- a/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
@@ -312,6 +312,7 @@ namespace GitUI.CommandsDialogs
 
         private Brush UpdateCommitButtonAndGetBrush(IReadOnlyList<GitItemStatus>? status, bool showCount)
         {
+            ToolStripMain.SuspendLayout();
             RepoStateVisualiser repoStateVisualiser = new();
             (Image image, Brush brush) = repoStateVisualiser.Invoke(status);
 
@@ -343,6 +344,7 @@ namespace GitUI.CommandsDialogs
                 toolStripButtonCommit.AutoSize = true;
             }
 
+            ToolStripMain.ResumeLayout();
             return brush;
         }
     }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -359,7 +359,7 @@ namespace GitUI.CommandsDialogs
                     bool countToolbar = AppSettings.ShowGitStatusInBrowseToolbar;
                     bool countArtificial = AppSettings.ShowGitStatusForArtificialCommits && AppSettings.RevisionGraphShowArtificialCommits;
 
-                    Brush brush = UpdateCommitButtonAndGetBrush(status, countToolbar);
+                    Brush? brush = UpdateCommitButtonAndGetBrush(status, countToolbar);
 
                     RevisionGrid.UpdateArtificialCommitCount(countArtificial ? status : null);
 
@@ -390,7 +390,7 @@ namespace GitUI.CommandsDialogs
 
                     void UpdateStatusInTaskbar()
                     {
-                        if (!EnvUtils.RunningOnWindowsWithMainWindow())
+                        if (!EnvUtils.RunningOnWindowsWithMainWindow() || brush is null)
                         {
                             return;
                         }
@@ -940,10 +940,10 @@ namespace GitUI.CommandsDialogs
                 OnActivate();
 
                 LoadUserMenu();
+                toolStripButtonLevelUp.Image = validBrowseDir && Module.SuperprojectModule is not null ? Images.NavigateUp : Images.SubmodulesManage;
 
                 if (validBrowseDir)
                 {
-                    toolStripButtonLevelUp.Image = Module.SuperprojectModule is not null ? Images.NavigateUp : Images.SubmodulesManage;
                     _windowsJumpListManager.AddToRecent(Module.WorkingDir);
 
                     // add Navigate and View menu

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -359,7 +359,7 @@ namespace GitUI.CommandsDialogs
                     bool countToolbar = AppSettings.ShowGitStatusInBrowseToolbar;
                     bool countArtificial = AppSettings.ShowGitStatusForArtificialCommits && AppSettings.RevisionGraphShowArtificialCommits;
 
-                    Brush? brush = UpdateCommitButtonAndGetBrush(status, countToolbar);
+                    Brush brush = UpdateCommitButtonAndGetBrush(status, countToolbar);
 
                     RevisionGrid.UpdateArtificialCommitCount(countArtificial ? status : null);
 
@@ -390,7 +390,7 @@ namespace GitUI.CommandsDialogs
 
                     void UpdateStatusInTaskbar()
                     {
-                        if (!EnvUtils.RunningOnWindowsWithMainWindow() || brush is null)
+                        if (!EnvUtils.RunningOnWindowsWithMainWindow())
                         {
                             return;
                         }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -362,7 +362,6 @@ namespace GitUI.CommandsDialogs
                     Brush brush = UpdateCommitButtonAndGetBrush(status, countToolbar);
 
                     RevisionGrid.UpdateArtificialCommitCount(countArtificial ? status : null);
-                    toolStripButtonLevelUp.Image = Module.SuperprojectModule is not null ? Images.NavigateUp : Images.SubmodulesManage;
 
                     if (countToolbar || countArtificial)
                     {
@@ -944,6 +943,7 @@ namespace GitUI.CommandsDialogs
 
                 if (validBrowseDir)
                 {
+                    toolStripButtonLevelUp.Image = Module.SuperprojectModule is not null ? Images.NavigateUp : Images.SubmodulesManage;
                     _windowsJumpListManager.AddToRecent(Module.WorkingDir);
 
                     // add Navigate and View menu


### PR DESCRIPTION
## Proposed changes

Annoying resizing of the toolbar when git status updates
Not solved, but improved.
((The remaining flicker is after first update is done and before git-status reports changes.)

## Screenshots <!-- Remove this section if PR does not change UI -->

Explicit refresh

### Before

![old-refresh](https://github.com/gitextensions/gitextensions/assets/6248932/68fd8e61-e5c1-4aa5-830e-da0e193db590)

### After

![new-refresh](https://github.com/gitextensions/gitextensions/assets/6248932/9a3fc702-5630-4f82-ac5a-785298c30519)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
