### PR TITLE
Cancellation token for Git commands in CommitInfo

### DIFF
--- a/GitCommands/Git/GitDescribeProvider.cs
+++ b/GitCommands/Git/GitDescribeProvider.cs
@@ -10,8 +10,9 @@ namespace GitCommands.Git
         /// of additional commits on top of the tagged object and the abbreviated object name of the most recent commit.
         /// </summary>
         /// <param name="revision">A revision to describe.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>Describe information.</returns>
-        (string precedingTag, string commitCount) Get(ObjectId revision);
+        (string precedingTag, string commitCount) Get(ObjectId revision, CancellationToken cancellationToken = default);
     }
 
     public sealed class GitDescribeProvider : IGitDescribeProvider
@@ -24,9 +25,9 @@ namespace GitCommands.Git
         }
 
         /// <inheritdoc />
-        public (string precedingTag, string commitCount) Get(ObjectId revision)
+        public (string precedingTag, string commitCount) Get(ObjectId revision, CancellationToken cancellationToken = default)
         {
-            string? description = GetModule().GetDescribe(revision);
+            string? description = GetModule().GetDescribe(revision, cancellationToken);
             if (string.IsNullOrEmpty(description))
             {
                 return (string.Empty, string.Empty);

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2838,10 +2838,10 @@ namespace GitCommands
                 : Array.Empty<IGitRef>();
         }
 
-        public async Task<string[]> GetMergedBranchesAsync(bool includeRemote = false, bool fullRefname = false, string? commit = null)
+        public async Task<string[]> GetMergedBranchesAsync(bool includeRemote, bool fullRefname, string? commit, CancellationToken cancellationToken)
         {
             ExecutionResult result = await _gitExecutable
-                .ExecuteAsync(Commands.MergedBranches(includeRemote, fullRefname, commit), throwOnErrorExit: false)
+                .ExecuteAsync(Commands.MergedBranches(includeRemote, fullRefname, commit), throwOnErrorExit: false, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
             ////TODO: Handle non-empty result.StandardError
             return result.StandardOutput.Split(Delimiters.LineFeed, StringSplitOptions.RemoveEmptyEntries);
@@ -2910,7 +2910,7 @@ namespace GitCommands
             return gitRefs;
         }
 
-        public IReadOnlyList<string> GetAllBranchesWhichContainGivenCommit(ObjectId objectId, bool getLocal, bool getRemote)
+        public IReadOnlyList<string> GetAllBranchesWhichContainGivenCommit(ObjectId objectId, bool getLocal, bool getRemote, CancellationToken cancellationToken = default)
         {
             if (!getLocal && !getRemote)
             {
@@ -2924,7 +2924,7 @@ namespace GitCommands
                 "--contains",
                 objectId
             };
-            ExecutionResult exec = _gitExecutable.Execute(args, throwOnErrorExit: false);
+            ExecutionResult exec = _gitExecutable.Execute(args, throwOnErrorExit: false, cancellationToken: cancellationToken);
             if (!exec.ExitedSuccessfully)
             {
                 // Error occurred, no matches (no error presented to the user)
@@ -2959,9 +2959,9 @@ namespace GitCommands
             return result;
         }
 
-        public IReadOnlyList<string> GetAllTagsWhichContainGivenCommit(ObjectId objectId)
+        public IReadOnlyList<string> GetAllTagsWhichContainGivenCommit(ObjectId objectId, CancellationToken cancellationToken)
         {
-            ExecutionResult exec = _gitExecutable.Execute($"tag --contains {objectId}", throwOnErrorExit: false);
+            ExecutionResult exec = _gitExecutable.Execute($"tag --contains {objectId}", throwOnErrorExit: false, cancellationToken: cancellationToken);
             if (!exec.ExitedSuccessfully)
             {
                 // Error occurred, no matches (no error presented to the user)
@@ -2971,7 +2971,7 @@ namespace GitCommands
             return exec.StandardOutput.Split(new[] { '\r', '\n', '*', ' ' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
-        public string? GetTagMessage(string? tag)
+        public string? GetTagMessage(string? tag, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(tag))
             {
@@ -2980,7 +2980,7 @@ namespace GitCommands
 
             tag = tag.Trim();
 
-            ExecutionResult exec = _gitExecutable.Execute($"cat-file -p {tag}", throwOnErrorExit: false);
+            ExecutionResult exec = _gitExecutable.Execute($"cat-file -p {tag}", throwOnErrorExit: false, cancellationToken: cancellationToken);
             if (!exec.ExitedSuccessfully)
             {
                 // Error occurred, no message (no error presented to the user)
@@ -3900,7 +3900,7 @@ namespace GitCommands
         /// </summary>
         /// <param name="commitId">The commit where to start searching</param>
         /// <returns>Tag name if it exists, otherwise null</returns>
-        public string? GetDescribe(ObjectId commitId)
+        public string? GetDescribe(ObjectId commitId, CancellationToken cancellationToken = default)
         {
             GitArgumentBuilder args = new("describe")
             {

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -503,7 +503,7 @@ namespace GitUI.CommitInfo
 
                             if (gitRef is { IsTag: true, IsDereference: true })
                             {
-                                string? content = WebUtility.HtmlEncode(Module.GetTagMessage(gitRef.LocalName));
+                                string? content = WebUtility.HtmlEncode(Module.GetTagMessage(gitRef.LocalName, cancellationToken));
                                 if (content is not null)
                                 {
                                     result.Add(gitRef.LocalName, content);
@@ -519,7 +519,7 @@ namespace GitUI.CommitInfo
                 {
                     await TaskScheduler.Default;
 
-                    List<string> tags = Module.GetAllTagsWhichContainGivenCommit(objectId).ToList();
+                    List<string> tags = Module.GetAllTagsWhichContainGivenCommit(objectId, cancellationToken).ToList();
 
                     await this.SwitchToMainThreadAsync(cancellationToken);
                     _tags = tags;
@@ -536,7 +536,7 @@ namespace GitUI.CommitInfo
                     // Include remote branches if requested
                     bool getRemote = AppSettings.CommitInfoShowContainedInBranchesRemote ||
                                      AppSettings.CommitInfoShowContainedInBranchesRemoteIfNoLocal;
-                    List<string> branches = Module.GetAllBranchesWhichContainGivenCommit(revision, getLocal, getRemote).ToList();
+                    List<string> branches = Module.GetAllBranchesWhichContainGivenCommit(revision, getLocal, getRemote, cancellationToken).ToList();
 
                     await this.SwitchToMainThreadAsync(cancellationToken);
                     _branches = branches;
@@ -562,7 +562,7 @@ namespace GitUI.CommitInfo
 
                     string GetDescribeInfoForRevision()
                     {
-                        (string precedingTag, string commitCount) = _gitDescribeProvider.Get(commitId);
+                        (string precedingTag, string commitCount) = _gitDescribeProvider.Get(commitId, cancellationToken);
 
                         StringBuilder gitDescribeInfo = new();
                         if (!string.IsNullOrEmpty(precedingTag))

--- a/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -309,7 +309,7 @@ namespace GitUI.LeftPanel
                 cancellationToken.ThrowIfCancellationRequested();
                 HashSet<string> mergedBranches = selectedGuid is null
                     ? []
-                    : (await Module.GetMergedBranchesAsync(includeRemote: true, fullRefname: true, commit: selectedGuid)).ToHashSet();
+                    : (await Module.GetMergedBranchesAsync(includeRemote: true, fullRefname: true, commit: selectedGuid, cancellationToken)).ToHashSet();
 
                 selectedRevision?.Refs.ForEach(gitRef => mergedBranches.Remove(gitRef.CompleteName));
 

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -212,7 +212,7 @@ namespace GitUIPluginInterfaces
 
         string ReEncodeCommitMessage(string s);
 
-        string? GetDescribe(ObjectId commitId);
+        string? GetDescribe(ObjectId commitId, CancellationToken cancellationToken = default);
 
         (int totalCount, Dictionary<string, int> countByName) GetCommitsByContributor(DateTime? since = null, DateTime? until = null);
 
@@ -230,6 +230,7 @@ namespace GitUIPluginInterfaces
         /// This normally requires long time (up to tenths of seconds)
         /// </summary>
         /// <param name="isDiff">diff or merge.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>the Git output.</returns>
         string GetCustomDiffMergeTools(bool isDiff, CancellationToken cancellationToken);
         Task<(Patch? patch, string? errorMessage)> GetSingleDiffAsync(ObjectId? firstId, ObjectId? secondId, string? fileName, string? oldFileName, string extraDiffArguments, Encoding encoding, bool cacheResult, bool isTracked);
@@ -280,7 +281,8 @@ namespace GitUIPluginInterfaces
         /// <param name="objectId">The sha1.</param>
         /// <param name="getLocal">Pass true to include local branches.</param>
         /// <param name="getRemote">Pass true to include remote branches.</param>
-        IReadOnlyList<string> GetAllBranchesWhichContainGivenCommit(ObjectId objectId, bool getLocal, bool getRemote);
+        /// <param name="cancellationToken">A cancellation token.</param>
+        IReadOnlyList<string> GetAllBranchesWhichContainGivenCommit(ObjectId objectId, bool getLocal, bool getRemote, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Uses check-ref-format to ensure that a branch name is well formed.
@@ -305,7 +307,7 @@ namespace GitUIPluginInterfaces
         /// Returns tag's message. If the lightweight tag is passed, corresponding commit message
         /// is returned.
         /// </summary>
-        string? GetTagMessage(string? tag);
+        string? GetTagMessage(string? tag, CancellationToken cancellationToken = default);
         void UnstageFile(string file);
         bool UnstageFiles(IReadOnlyList<GitItemStatus> files, out string allOutput);
         bool StageFile(string file);
@@ -392,7 +394,7 @@ namespace GitUIPluginInterfaces
         string? GetCombinedDiffContent(ObjectId revisionOfMergeCommit, string filePath, string extraArgs, Encoding encoding);
         bool IsMerge(ObjectId objectId);
         IEnumerable<string> GetMergedBranches(bool includeRemote = false);
-        Task<string[]> GetMergedBranchesAsync(bool includeRemote = false, bool fullRefname = false, string? commit = null);
+        Task<string[]> GetMergedBranchesAsync(bool includeRemote, bool fullRefname, string? commit, CancellationToken cancellationToken);
         IReadOnlyList<string> GetMergedRemoteBranches();
         IReadOnlyList<IGitRef> GetRemoteServerRefs(string remote, bool tags, bool branches, out string? errorOutput, CancellationToken cancellationToken);
 
@@ -420,7 +422,8 @@ namespace GitUIPluginInterfaces
         /// Gets all tags which contain the given commit.
         /// </summary>
         /// <param name="objectId">The sha1.</param>
-        IReadOnlyList<string> GetAllTagsWhichContainGivenCommit(ObjectId objectId);
+        /// <param name="cancellationToken">A cancellation token.</param>
+        IReadOnlyList<string> GetAllTagsWhichContainGivenCommit(ObjectId objectId, CancellationToken cancellationToken);
 
         /// <summary>
         ///  Gets the remote branch.


### PR DESCRIPTION
Discussed in https://github.com/gitextensions/gitextensions/pull/11472#discussion_r1439656333

## Proposed changes

Cancel longer Git operations when selecting a new commit in CommitInfo and left panel.
The commands were running to completion, using CPU (probably not blocking UI thread as discussed in #11472).

This PR adds the cancellationToken to the most common and long running commands in CommitInfo.
(git-describe and git-cat-file is normally quick but included as no refactoring was needed.)
There are a few other Git commands in CommitInfo that are not interrupted.
These are either fast or not executed often, some more refactoring would be required to handle the cancellation in invokes etc.

## Screenshots <!-- Remove this section if PR does not change UI -->

No diff for the user, just showing the command log when stepping in the linux repo.

### Before

One cancellation for the diff in RevDiff

![image](https://github.com/gitextensions/gitextensions/assets/6248932/10fdfe49-1877-486e-b8be-bbe148f191fb)

### After

The git-tag command that requires close to 10 s is started after git-branch and would have been cancelled if I had timed the cancellation.

![image](https://github.com/gitextensions/gitextensions/assets/6248932/eef4fc7d-6fe9-4f61-b977-b13b29852f51)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
