### PR TITLE
Better delete branch checks

### DIFF
--- a/GitCommands/Git/CommandCache.cs
+++ b/GitCommands/Git/CommandCache.cs
@@ -102,5 +102,10 @@ namespace GitCommands
 
             Changed?.Invoke(this, EventArgs.Empty);
         }
+
+        internal void Clear()
+        {
+            _cache.Clear();
+        }
     }
 }

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -32,6 +32,7 @@ namespace GitCommands
 
         public static readonly string NoNewLineAtTheEnd = "\\ No newline at end of file";
         public static CommandCache GitCommandCache { get; } = new();
+        public static CommandCache GitCommandCacheBetweenRefresh { get; } = new();
 
         private readonly object _lock = new();
         private readonly IIndexLockManager _indexLockManager;
@@ -2938,7 +2939,7 @@ namespace GitCommands
                 "--contains",
                 objectId
             };
-            ExecutionResult exec = _gitExecutable.Execute(args, throwOnErrorExit: false, cancellationToken: cancellationToken);
+            ExecutionResult exec = _gitExecutable.Execute(args, throwOnErrorExit: false, cancellationToken: cancellationToken, cache: GitCommandCacheBetweenRefresh);
             if (!exec.ExitedSuccessfully)
             {
                 // Error occurred, no matches (no error presented to the user)
@@ -3986,6 +3987,11 @@ namespace GitCommands
                     ? $"{param}=\"{date:yyyy-MM-dd hh:mm:ss}\""
                     : "";
             }
+        }
+
+        public void ClearGitCommandBetweenRefreshCache()
+        {
+            GitCommandCacheBetweenRefresh.Clear();
         }
 
         internal TestAccessor GetTestAccessor() => new(this);

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2822,6 +2822,14 @@ namespace GitCommands
             return Array.Empty<IGitRef>();
         }
 
+        public IReadOnlyList<string> GetReflogHashes()
+        {
+            ExecutionResult result = _gitExecutable.Execute("reflog show HEAD --pretty=format:\"%H\"", throwOnErrorExit: false);
+            return result.ExitedSuccessfully
+                ? result.StandardOutput.Split('\n')
+                : Array.Empty<string>();
+        }
+
         /// <summary>
         /// Get the Git refs.
         /// </summary>

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -2822,12 +2823,12 @@ namespace GitCommands
             return Array.Empty<IGitRef>();
         }
 
-        public IReadOnlyList<string> GetReflogHashes()
+        public IReadOnlySet<string> GetReflogHashes()
         {
             ExecutionResult result = _gitExecutable.Execute("reflog show HEAD --pretty=format:\"%H\"", throwOnErrorExit: false);
             return result.ExitedSuccessfully
-                ? result.StandardOutput.Split('\n')
-                : Array.Empty<string>();
+                ? result.StandardOutput.Split('\n').ToHashSet()
+                : [];
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitRevisionGrid.cs
@@ -13,6 +13,11 @@ namespace GitUI.CommandsDialogs
             RevisionGrid.IndexWatcher.Changed += (_, args) =>
             {
                 bool indexChanged = args.IsIndexChanged;
+                if (indexChanged)
+                {
+                    UICommands.Module.ClearGitCommandBetweenRefreshCache();
+                }
+
                 this.InvokeAndForget(() =>
                     RefreshButton.Image = indexChanged && AppSettings.ShowGitStatusInBrowseToolbar && Module.IsValidGitWorkingDir()
                         ? Images.ReloadRevisionsDirty

--- a/GitUI/CommandsDialogs/FormDeleteBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.Designer.cs
@@ -32,6 +32,7 @@
             labelSelectBranches = new Label();
             Branches = new GitUI.BranchComboBox();
             tlpnlMain = new TableLayoutPanel();
+            labelWarning = new Label();
             MainPanel.SuspendLayout();
             ControlsPanel.SuspendLayout();
             tlpnlMain.SuspendLayout();
@@ -46,6 +47,7 @@
             // ControlsPanel
             // 
             ControlsPanel.Controls.Add(Delete);
+            ControlsPanel.Controls.Add(labelWarning);
             ControlsPanel.Location = new Point(0, 50);
             ControlsPanel.Size = new Size(412, 41);
             // 
@@ -85,6 +87,7 @@
             Branches.Name = "Branches";
             Branches.Size = new Size(299, 28);
             Branches.TabIndex = 1;
+            Branches.SelectedValueChanged += Branches_SelectedValueChanged;
             // 
             // tlpnlMain
             // 
@@ -104,6 +107,18 @@
             tlpnlMain.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
             tlpnlMain.Size = new Size(394, 32);
             tlpnlMain.TabIndex = 0;
+            // 
+            // labelWarning
+            // 
+            labelWarning.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left;
+            labelWarning.AutoSize = true;
+            labelWarning.ForeColor = Color.Red;
+            labelWarning.Location = new Point(272, 5);
+            labelWarning.Name = "labelWarning";
+            labelWarning.Size = new Size(46, 31);
+            labelWarning.TabIndex = 3;
+            labelWarning.Text = "             ";
+            labelWarning.TextAlign = ContentAlignment.MiddleLeft;
             // 
             // FormDeleteBranch
             // 
@@ -138,5 +153,6 @@
         private Label labelSelectBranches;
         private BranchComboBox Branches;
         private TableLayoutPanel tlpnlMain;
+        private Label labelWarning;
     }
 }

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -20,7 +20,7 @@ namespace GitUI.CommandsDialogs
 
         private readonly IEnumerable<string> _defaultBranches;
         private string? _currentBranch;
-        private IReadOnlyList<string> _reflogHashes;
+        private IReadOnlySet<string> _reflogHashes;
         private Dictionary<ObjectId, IReadOnlyList<string>> _containedInBranch = new();
 
         public FormDeleteBranch(GitUICommands commands, IEnumerable<string> defaultBranches)
@@ -68,7 +68,7 @@ namespace GitUI.CommandsDialogs
                 return;
             }
 
-            bool areAllInReflog = selectedBranches.All(b => _reflogHashes.Contains(b.ObjectId.ToString()));
+            bool areAllInReflog = selectedBranches.All(b => _reflogHashes.Any(b.ObjectId.Equals));
 
             // Detect if commits will be dangling (i.e. no remaining local refs left handling commit)
             string[] deletedCandidates = selectedBranches.Select(b => b.Name).ToArray();
@@ -170,7 +170,7 @@ namespace GitUI.CommandsDialogs
 
             foreach (IGitRef selectedBranch in selectedBranches)
             {
-                if (!_reflogHashes.Contains(selectedBranch.ObjectId.ToString()))
+                if (!_reflogHashes.Any(selectedBranch.ObjectId.Equals))
                 {
                     labelWarning.Text = _warningNotInReflog.Text;
                     labelWarning.ForeColor = Color.Orange;

--- a/GitUI/CommandsDialogs/FormDeleteBranch.cs
+++ b/GitUI/CommandsDialogs/FormDeleteBranch.cs
@@ -21,6 +21,7 @@ namespace GitUI.CommandsDialogs
         private readonly IEnumerable<string> _defaultBranches;
         private string? _currentBranch;
         private IReadOnlyList<string> _reflogHashes;
+        private Dictionary<ObjectId, IReadOnlyList<string>> _containedInBranch = new();
 
         public FormDeleteBranch(GitUICommands commands, IEnumerable<string> defaultBranches)
             : base(commands, enablePositionRestore: false)
@@ -50,7 +51,7 @@ namespace GitUI.CommandsDialogs
 
             Branches.Focus();
 
-            CheckSelectedBranches();
+            ProcessSelectedBranches();
         }
 
         private void Delete_Click(object sender, EventArgs e)
@@ -75,7 +76,7 @@ namespace GitUI.CommandsDialogs
 
             foreach (IGitRef selectedBranch in selectedBranches)
             {
-                atLeastOneHeadCommitWillBeDangling = !Module.GetAllBranchesWhichContainGivenCommit(selectedBranch.ObjectId, true, false) // include also remotes?
+                atLeastOneHeadCommitWillBeDangling = !GetAllBranchesWhichContainGivenCommit(selectedBranch.ObjectId)
                     .Any(b2 => !deletedCandidates.Contains(b2));
 
                 if (atLeastOneHeadCommitWillBeDangling)
@@ -115,14 +116,53 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        private void Branches_SelectedValueChanged(object sender, EventArgs e)
+        private IReadOnlyList<string> GetAllBranchesWhichContainGivenCommit(ObjectId commitId)
         {
-            CheckSelectedBranches();
+            lock (_containedInBranch)
+            {
+                if (_containedInBranch.TryGetValue(commitId, out IReadOnlyList<string> branches))
+                {
+                    return branches;
+                }
+
+                branches = Module.GetAllBranchesWhichContainGivenCommit(commitId, true, false); // include also remotes?
+
+                _containedInBranch.Add(commitId, branches);
+                return branches;
+            }
         }
 
-        private void CheckSelectedBranches()
+        private void BuildContainedInBranchData(IGitRef[] selectedBranches)
+        {
+            if (!selectedBranches.Any())
+            {
+                return;
+            }
+
+            foreach (IGitRef selectedBranch in selectedBranches)
+            {
+                GetAllBranchesWhichContainGivenCommit(selectedBranch.ObjectId);
+            }
+        }
+
+        private void Branches_SelectedValueChanged(object sender, EventArgs e)
+        {
+            ProcessSelectedBranches();
+        }
+
+        private void ProcessSelectedBranches()
         {
             IGitRef[] selectedBranches = Branches.GetSelectedBranches().ToArray();
+            CheckSelectedBranches(selectedBranches);
+
+            Task.Run(() =>
+            {
+                BuildContainedInBranchData(selectedBranches);
+            });
+        }
+
+        private void CheckSelectedBranches(IGitRef[] selectedBranches)
+        {
             if (!selectedBranches.Any())
             {
                 return;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -4312,7 +4312,8 @@ You can unset the template:
         <target />
       </trans-unit>
       <trans-unit id="_deleteBranchQuestion.Text">
-        <source>The selected branch(es) have not been merged into HEAD.
+        <source>The selected branch(es) have not been merged into any local branch.
+
 Proceed?</source>
         <target />
       </trans-unit>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -4311,14 +4311,34 @@ You can unset the template:
         <source>Delete Confirmation</source>
         <target />
       </trans-unit>
+      <trans-unit id="_deleteBranchNotInReflogQuestion.Text">
+        <source>The selected branch(es) have not been merged into any local branch
+ and is(are) not in the reflog so you won't be able to recover the commit(s) easily.
+
+Proceed?</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_deleteBranchQuestion.Text">
         <source>The selected branch(es) have not been merged into any local branch.
 
 Proceed?</source>
         <target />
       </trans-unit>
+      <trans-unit id="_restoreUsingReflogAvailable.Text">
+        <source>This branch can be restored using the reflog</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_useRecoverLostObjectsHint.Text">
+        <source>This commit will only be recoverable using "Recover lost objects" feature but could be cleaned by git at any time!</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_useReflogHint.Text">
-        <source>Did you know you can use reflog to restore deleted branches?</source>
+        <source>This commit is available from the reflog that you could use to restore this deleted branches</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_warningNotInReflog.Text">
+        <source>Warning! The head of this branch is not in the reflog!
+Commits won't be recoverable easily!!</source>
         <target />
       </trans-unit>
       <trans-unit id="labelSelectBranches.Text">

--- a/GitUI/UserControls/BranchComboBox.Designer.cs
+++ b/GitUI/UserControls/BranchComboBox.Designer.cs
@@ -41,6 +41,8 @@
             branches.Location = new Point(0, 3);
             branches.Name = "branches";
             branches.Size = new Size(304, 23);
+            branches.TabIndex = 0;
+            branches.SelectedValueChanged += branches_SelectedValueChanged;
             // 
             // selectMultipleBranchesButton
             // 
@@ -49,6 +51,7 @@
             selectMultipleBranchesButton.Location = new Point(308, 1);
             selectMultipleBranchesButton.Margin = new Padding(0);
             selectMultipleBranchesButton.Name = "selectMultipleBranchesButton";
+            selectMultipleBranchesButton.TabIndex = 1;
             selectMultipleBranchesButton.Size = new Size(23, 23);
             selectMultipleBranchesButton.UseVisualStyleBackColor = true;
             selectMultipleBranchesButton.Click += selectMultipleBranchesButton_Click;

--- a/GitUI/UserControls/BranchComboBox.cs
+++ b/GitUI/UserControls/BranchComboBox.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.ComponentModel;
+using GitCommands;
 using GitExtUtils;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
@@ -18,6 +19,11 @@ namespace GitUI
 
             branches.DisplayMember = nameof(IGitRef.Name);
         }
+
+        [Browsable(true)]
+        [Category("Action")]
+        [Description("Invoked when branch selection changed")]
+        public event EventHandler SelectedValueChanged;
 
         private IReadOnlyList<IGitRef>? _branchesToSelect;
         public IReadOnlyList<IGitRef>? BranchesToSelect
@@ -95,6 +101,13 @@ namespace GitUI
             }
 
             branches.Text = branchesText;
+
+            SelectedValueChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void branches_SelectedValueChanged(object sender, EventArgs e)
+        {
+            SelectedValueChanged?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -445,5 +445,6 @@ namespace GitUIPluginInterfaces
         string RenameBranch(string name, string newName);
 
         GitBlame Blame(string? fileName, string from, Encoding encoding, string? lines = null, CancellationToken cancellationToken = default);
+        IReadOnlyList<string> GetReflogHashes();
     }
 }

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -445,6 +445,6 @@ namespace GitUIPluginInterfaces
         string RenameBranch(string name, string newName);
 
         GitBlame Blame(string? fileName, string from, Encoding encoding, string? lines = null, CancellationToken cancellationToken = default);
-        IReadOnlyList<string> GetReflogHashes();
+        IReadOnlySet<string> GetReflogHashes();
     }
 }

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -7,6 +7,7 @@ namespace GitUIPluginInterfaces
     /// <summary>Provides manipulation with git module.</summary>
     public interface IGitModule
     {
+        void ClearGitCommandBetweenRefreshCache();
         IConfigFileSettings LocalConfigFile { get; }
 
         string AddRemote(string remoteName, string? path);

--- a/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
@@ -306,5 +306,14 @@ namespace GitCommandsTests.Git
             Assert.IsFalse(ObjectId.Parse(objectIdString) == ObjectId.Random());
             Assert.IsTrue(ObjectId.Parse(objectIdString) != ObjectId.Random());
         }
+
+        [Test]
+        public void Equals_against_hash_string()
+        {
+            string objectIdString = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+            Assert.IsTrue(ObjectId.Parse(objectIdString).Equals(objectIdString));
+            Assert.IsFalse(ObjectId.Parse(objectIdString).Equals("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"));
+            Assert.IsFalse(ObjectId.Parse(objectIdString).Equals("baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Better way to find if a branch could be securely deleted: check if branch deletion will make tip commit dangling (i.e. branch really merged in any **local** branch).
- Check that the tip of the deleted branch is in the reflog:
    * Add immediate feedback to the user (is or is not in reflog)
    * Better hint when not recoverable by reflog
    * Override user confirmation setting **if commit is not in the reflog** to prevent user to **really** loose commits

Summary of cases:
* **If the tip of the branch to delete is merged in any local branch, it won't create a dangling commit (i.e. the DAG won't change) and so no confirmation is asked anymore to the user** => more cases (that changes nothing) doesn't require confirmation...
* A confirmation is requested or not depending on user setting when branch is unmerged and tip is in reflog => when commit is easily recoverable, let the user decide if he wants a confirmation or not.
* A confirmation is **always** requested when branch is unmerged and tip is in **not** reflog (even if user doesn't want a confirmation) => when commit won't be recoverable easily (only through "Recover lost objects"), force the user to confirm (more secured because he is now aware of the case!!)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

(I don't have a local version behaving like that anymore so can't really provide screenshots)
There are downsides:
* If the branch to delete is not merged into the currently checked out branch, you will have a (boring!) message telling you that the branch is not merged and the user don't really know if he will lose commits or not without carefully checking (or checking out another branch --which make the delete process painful--)
* if exceptionally you are in detached head, the check could accept to delete even if you will loose the commits: user is not really aware of the risk.
* there is a tip on using reflog to recover even if it could happen that the tip is not in the reflog and so won't be recoverable like that

### After

* Branch is in the reflog:

![image](https://github.com/gitextensions/gitextensions/assets/460196/8b859331-e0bc-4b35-a604-954b91f8d08f)

* Branch is not in the reflog:
 
![image](https://github.com/gitextensions/gitextensions/assets/460196/1ccf6154-f157-437b-bb00-53db6193151e)

* Branch not merged and tip not in the reflog (UI is not the more beautiful but should happen very rarely and should be "surprising"):

![image](https://github.com/gitextensions/gitextensions/assets/460196/bc7ab881-5251-42c2-b4f6-82caf8f4cafa)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 7585fee4bd8edeef329f44377ea6dd1a0ba75198
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 8.0.0
- DPI 96dpi (no scaling)
- Portable: False



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer rebase merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
