### PR TITLE
perfs: better perf for ObjectId.ToShortString()

### DIFF
--- a/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
@@ -288,7 +288,7 @@ namespace GitCommandsTests.Git
             const string s = "0102030405060708091011121314151617181920";
             ObjectId id = ObjectId.Parse(s);
 
-            for (int length = 0; length < ObjectId.Sha1CharCount; length++)
+            for (int length = 1; length < ObjectId.Sha1CharCount; length++)
             {
                 Assert.AreEqual(s[..length], id.ToShortString(length));
             }


### PR DESCRIPTION
by allocating and less processing when needed
and (later) using `.ToHexStringLower()` that will be provided by .net9 https://github.com/dotnet/runtime/pull/92483

## Test methodology <!-- How did you ensure quality? -->

- unit tests
- manual

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
