### PR TITLE
Regex explicit capture

### DIFF
--- a/BugReporter/BugReportForm.cs
+++ b/BugReporter/BugReportForm.cs
@@ -40,7 +40,7 @@ Send report?");
         private string _exceptionInfo;
         private string? _environmentInfo;
 
-        [GeneratedRegex(@"\s|\r|\n")]
+        [GeneratedRegex(@"\s|\r|\n", RegexOptions.ExplicitCapture)]
         private static partial Regex WhitespaceRegex();
 
         static BugReportForm()

--- a/GitCommands/Git/DetachedHeadParser.cs
+++ b/GitCommands/Git/DetachedHeadParser.cs
@@ -9,7 +9,7 @@ namespace GitCommands.Git
 
         private static readonly string[] DetachedPrefixes = { "(no branch", "(detached from ", "(HEAD detached at " };
 
-        [GeneratedRegex(@"^\(.* (?<sha1>.*)\)$")]
+        [GeneratedRegex(@"^\(.* (?<sha1>.*)\)$", RegexOptions.ExplicitCapture)]
         private static partial Regex ShaRegex();
 
         public static bool IsDetachedHead(string branch)

--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -15,7 +15,7 @@ namespace GitCommands
         public const string DubiousOwnershipSecurityConfigString = "config --global --add safe.directory";
         private static readonly Lazy<Encoding> _defaultOutputEncoding = new(() => GitModule.SystemEncoding, false);
 
-        [GeneratedRegex(@"\u001B[\u0040-\u005F].*?[\u0040-\u007E]")]
+        [GeneratedRegex(@"\u001B[\u0040-\u005F].*?[\u0040-\u007E]", RegexOptions.ExplicitCapture)]
         private static partial Regex AnsiCodeRegex();
 
         /// <summary>

--- a/GitCommands/Git/GitBranchNameNormaliser.cs
+++ b/GitCommands/Git/GitBranchNameNormaliser.cs
@@ -66,21 +66,21 @@ namespace GitCommands.Git
     /// </summary>
     public sealed partial class GitBranchNameNormaliser : IGitBranchNameNormaliser
     {
-        [GeneratedRegex("^(\\.)*")]
+        [GeneratedRegex(@"^(\.)*", RegexOptions.ExplicitCapture)]
         private static partial Regex PeriodRegex();
-        [GeneratedRegex("(\\.lock)$")]
+        [GeneratedRegex(@"(\.lock)$", RegexOptions.ExplicitCapture)]
         private static partial Regex LockRegex();
-        [GeneratedRegex("\\.{2,}")]
+        [GeneratedRegex(@"\.{2,}", RegexOptions.ExplicitCapture)]
         private static partial Regex Rule03Regex();
-        [GeneratedRegex("(\\?|\\*|\\[)")]
+        [GeneratedRegex(@"(\?|\*|\[)", RegexOptions.ExplicitCapture)]
         private static partial Regex Rule05Regex();
-        [GeneratedRegex(@"(\/{2,})")]
+        [GeneratedRegex(@"(\/{2,})", RegexOptions.ExplicitCapture)]
         private static partial Regex Rule06Regex();
-        [GeneratedRegex("(\\.{1,})$")]
+        [GeneratedRegex(@"(\.{1,})$", RegexOptions.ExplicitCapture)]
         private static partial Regex Rule07Regex();
-        [GeneratedRegex("(@\\{)")]
+        [GeneratedRegex(@"(@\{)", RegexOptions.ExplicitCapture)]
         private static partial Regex Rule08Regex();
-        [GeneratedRegex(@"(\\{1,})")]
+        [GeneratedRegex(@"(\\{1,})", RegexOptions.ExplicitCapture)]
         private static partial Regex Rule10Regex();
 
         /// <summary>

--- a/GitCommands/Git/GitGpgController.cs
+++ b/GitCommands/Git/GitGpgController.cs
@@ -69,13 +69,13 @@ namespace GitCommands.Gpg
         private const string NoTagPubKey = "NO_PUBKEY";
         private const string NoSignatureFound = "error: no signature found";
 
-        [GeneratedRegex(ValidTagSign)]
+        [GeneratedRegex(ValidTagSign, RegexOptions.ExplicitCapture)]
         private static partial Regex ValidSignatureTagRegex();
-        [GeneratedRegex(GoodSignature)]
+        [GeneratedRegex(GoodSignature, RegexOptions.ExplicitCapture)]
         private static partial Regex GoodSignatureTagRegex();
-        [GeneratedRegex(NoTagPubKey)]
+        [GeneratedRegex(NoTagPubKey, RegexOptions.ExplicitCapture)]
         private static partial Regex NoPubKeyTagRegex();
-        [GeneratedRegex(NoSignatureFound)]
+        [GeneratedRegex(NoSignatureFound, RegexOptions.ExplicitCapture)]
         private static partial Regex NoSignatureFoundTagRegex();
 
         /// <summary>

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -52,22 +52,22 @@ namespace GitCommands
         // 366dfba1abf6cb98d2934455713f3d190df2ba34 refs/tags/2.51
         //
         // Lines may also use \t as a column delimiter, such as output of "ls-remote --heads origin".
-        [GeneratedRegex(@"^(?<objectid>[0-9a-f]{40})[ \t](?<refname>.+)$", RegexOptions.Multiline)]
+        [GeneratedRegex(@"^(?<objectid>[0-9a-f]{40})[ \t](?<refname>.+)$", RegexOptions.Multiline | RegexOptions.ExplicitCapture)]
         private static partial Regex RefRegex();
 
-        [GeneratedRegex(@"^(?<objectid>[0-9a-f]{40}) (?<origlinenum>\d+) (?<finallinenum>\d+)")]
+        [GeneratedRegex(@"^(?<objectid>[0-9a-f]{40}) (?<origlinenum>\d+) (?<finallinenum>\d+)", RegexOptions.ExplicitCapture)]
         private static partial Regex HeaderRegex();
 
-        [GeneratedRegex(@"^(?<name>[^\t]+)\t(?<url>.+?) \((?<direction>fetch|push)\)(?:(?# ignore trailing options)\s*\[[^\]]*])?$")]
+        [GeneratedRegex(@"^(?<name>[^\t]+)\t(?<url>.+?) \((?<direction>fetch|push)\)(?:(?# ignore trailing options)\s*\[[^\]]*])?$", RegexOptions.ExplicitCapture)]
         private static partial Regex RemoteVerboseLineRegex();
 
-        [GeneratedRegex(@"(\\([0-7]{3}))+")]
+        [GeneratedRegex(@"(\\(?<octal>[0-7]{3}))+", RegexOptions.ExplicitCapture)]
         private static partial Regex EscapedOctalCodePointRegex();
 
-        [GeneratedRegex(@"^([ -+U])([0-9a-f]{40}) (.+) \((.+)\)$")]
+        [GeneratedRegex(@"^(?<code>[ -+U])(?<sha>[0-9a-f]{40}) (?<path>.+) \((?<branch>.+)\)$", RegexOptions.ExplicitCapture)]
         private static partial Regex ShaRegex();
 
-        [GeneratedRegex(@"^\s*(?<count>\d+)\s+(?<name>.*)$")]
+        [GeneratedRegex(@"^\s*(?<count>\d+)\s+(?<name>.*)$", RegexOptions.ExplicitCapture)]
         private static partial Regex ShortlogRegex();
 
         /// <summary>
@@ -1224,11 +1224,11 @@ namespace GitCommands
                     return false;
                 }
 
-                char code = match.Groups[1].Value[0];
-                string localPath = match.Groups[3].Value;
-                string branch = match.Groups[4].Value;
+                char code = match.Groups["code"].Value[0];
+                string localPath = match.Groups["path"].Value;
+                string branch = match.Groups["branch"].Value;
 
-                if (!ObjectId.TryParse(match.Groups[2].Value, out ObjectId? currentCommitId))
+                if (!ObjectId.TryParse(match.Groups["sha"].Value, out ObjectId? currentCommitId))
                 {
                     info = default;
                     return false;
@@ -3706,7 +3706,7 @@ namespace GitCommands
                     try
                     {
                         return SystemEncoding.GetString(
-                            match.Groups[2]
+                            match.Groups["octal"]
                                 .Captures.Cast<Capture>()
                                 .Select(c => Convert.ToByte(c.Value, 8))
                                 .ToArray());

--- a/GitCommands/Git/GitRefName.cs
+++ b/GitCommands/Git/GitRefName.cs
@@ -8,9 +8,9 @@ namespace GitCommands
 {
     public static partial class GitRefName
     {
-        [GeneratedRegex(@"^refs/remotes/[^/]+/HEAD$")]
+        [GeneratedRegex(@"^refs/remotes/[^/]+/HEAD$", RegexOptions.ExplicitCapture)]
         private static partial Regex RemoteHeadRegex();
-        [GeneratedRegex(@"^refs/remotes/([^/]+)")]
+        [GeneratedRegex(@"^refs/remotes/(?<remote>[^/]+)", RegexOptions.ExplicitCapture)]
         private static partial Regex RemoteNameRegex();
 
         /// <summary>"refs/tags/".</summary>
@@ -47,7 +47,7 @@ namespace GitCommands
 
             if (match.Success)
             {
-                return match.Groups[1].Value;
+                return match.Groups["remote"].Value;
             }
 
             // This method requires the full form of the ref path, which begins with "refs/".

--- a/GitCommands/Git/GitTreeParser.cs
+++ b/GitCommands/Git/GitTreeParser.cs
@@ -12,7 +12,7 @@ namespace GitCommands.Git
 
     public sealed partial class GitTreeParser : IGitTreeParser
     {
-        [GeneratedRegex(@"^(?<mode>\d{6}) (?<type>(blob|tree|commit)+) (?<objectid>[0-9a-f]{40})\s+(?<name>.+)$")]
+        [GeneratedRegex(@"^(?<mode>\d{6}) (?<type>(blob|tree|commit)+) (?<objectid>[0-9a-f]{40})\s+(?<name>.+)$", RegexOptions.ExplicitCapture)]
         private static partial Regex TreeLineRegex();
 
         public IEnumerable<GitItem> Parse(string? tree)

--- a/GitCommands/Git/SubmoduleHelpers.cs
+++ b/GitCommands/Git/SubmoduleHelpers.cs
@@ -7,9 +7,9 @@ namespace GitCommands.Git
 {
     public static partial class SubmoduleHelpers
     {
-        [GeneratedRegex(@"diff --git [abic]/(.+)\s[abwi]/(.+)")]
+        [GeneratedRegex(@"diff --git [abic]/(?<filenamea>.+)\s[abwi]/(?<filenameb>.+)", RegexOptions.ExplicitCapture)]
         private static partial Regex DiffCommandRegex();
-        [GeneratedRegex(@"diff --cc (.+)")]
+        [GeneratedRegex(@"diff --cc (?<filenamea>.+)", RegexOptions.ExplicitCapture)]
         private static partial Regex CombinedDiffCommandRegex();
 
         public static async Task<GitSubmoduleStatus?> GetCurrentSubmoduleChangesAsync(IGitModule module, string? fileName, string? oldFileName, ObjectId? firstId, ObjectId? secondId)
@@ -68,16 +68,16 @@ namespace GitCommands.Git
                     Match match = DiffCommandRegex().Match(line);
                     if (match.Groups.Count > 1)
                     {
-                        name = match.Groups[1].Value;
-                        oldName = match.Groups[2].Value;
+                        name = match.Groups["filenamea"].Value;
+                        oldName = match.Groups["filenameb"].Value;
                     }
                     else
                     {
                         match = CombinedDiffCommandRegex().Match(line);
                         if (match.Groups.Count > 1)
                         {
-                            name = match.Groups[1].Value;
-                            oldName = match.Groups[1].Value;
+                            name = match.Groups["filenamea"].Value;
+                            oldName = match.Groups["filenamea"].Value;
                         }
                     }
                 }

--- a/GitCommands/Git/SubmoduleHelpers.cs
+++ b/GitCommands/Git/SubmoduleHelpers.cs
@@ -77,7 +77,7 @@ namespace GitCommands.Git
                         if (match.Groups.Count > 1)
                         {
                             name = match.Groups["filenamea"].Value;
-                            oldName = match.Groups["filenamea"].Value;
+                            oldName = name;
                         }
                     }
                 }

--- a/GitCommands/Logging/CommandLog.cs
+++ b/GitCommands/Logging/CommandLog.cs
@@ -66,7 +66,7 @@ namespace GitCommands.Logging
 
     public sealed partial class CommandLogEntry
     {
-        [GeneratedRegex(@"((-c +[^ ]+)|(--no-optional-locks)) *")]
+        [GeneratedRegex(@"((-c +[^ ]+)|(--no-optional-locks)) *", RegexOptions.ExplicitCapture)]
         private static partial Regex GitArgumentsWithoutConfigurationRegex();
 
         public string FileName { get; }

--- a/GitCommands/Patches/PatchManager.cs
+++ b/GitCommands/Patches/PatchManager.cs
@@ -515,7 +515,7 @@ namespace GitCommands.Patches
         private readonly List<SubChunk> _subChunks = [];
         private SubChunk? _currentSubChunk;
 
-        [GeneratedRegex(@".*-(\d+),")]
+        [GeneratedRegex(@".*-(?<startline>\d+),", RegexOptions.ExplicitCapture)]
         private static partial Regex HeaderRegex();
 
         private SubChunk CurrentSubChunk
@@ -578,7 +578,7 @@ namespace GitCommands.Patches
 
             if (match.Success)
             {
-                _startLine = int.Parse(match.Groups[1].Value);
+                _startLine = int.Parse(match.Groups["startline"].Value);
             }
         }
 

--- a/GitCommands/Patches/PatchProcessor.cs
+++ b/GitCommands/Patches/PatchProcessor.cs
@@ -15,13 +15,13 @@ namespace GitCommands.Patches
             OutsidePatch
         }
 
-        [GeneratedRegex(@"^diff --(?<type>git|cc|combined)\s")]
+        [GeneratedRegex(@"^diff --(?<type>git|cc|combined)\s", RegexOptions.ExplicitCapture)]
         private static partial Regex PatchHeaderRegex();
-        [GeneratedRegex("^diff --git [\\\"]?[abiwco12]/(.*)[\\\"]? [\\\"]?[abiwco12]/(.*)[\\\"]?$")]
+        [GeneratedRegex(@"^diff --git [""]?[abiwco12]/(?<filenamea>.*)[""]? [""]?[abiwco12]/(?<filenameb>.*)[""]?$", RegexOptions.ExplicitCapture)]
         private static partial Regex DiffCommandRegex();
-        [GeneratedRegex("^diff --(cc|combined) [\\\"]?(?<filenamea>.*)[\\\"]?$")]
+        [GeneratedRegex(@"^diff --(cc|combined) [""]?(?<filenamea>.*)[""]?$", RegexOptions.ExplicitCapture)]
         private static partial Regex CombinedDiffCommandRegex();
-        [GeneratedRegex("[-+]{3} [\\\"]?[abiwco12]/(.*)[\\\"]?")]
+        [GeneratedRegex(@"[-+]{3} [""]?[abiwco12]/(?<filename>.*)[""]?", RegexOptions.ExplicitCapture)]
         private static partial Regex FileNameRegex();
 
         /// <summary>
@@ -99,8 +99,8 @@ namespace GitCommands.Patches
                     throw new FormatException("Invalid patch header: " + header);
                 }
 
-                fileNameA = match.Groups[1].Value.Trim();
-                fileNameB = match.Groups[2].Value.Trim();
+                fileNameA = match.Groups["filenamea"].Value.Trim();
+                fileNameB = match.Groups["filenameb"].Value.Trim();
             }
             else
             {
@@ -123,7 +123,7 @@ namespace GitCommands.Patches
             patchText.Append(header);
             if (lineIndex < lines.Length - 1)
             {
-                patchText.Append("\n");
+                patchText.Append('\n');
             }
 
             bool done = false;
@@ -157,7 +157,7 @@ namespace GitCommands.Patches
                     patchText.Append(line);
                     if (i < lines.Length - 1)
                     {
-                        patchText.Append("\n");
+                        patchText.Append('\n');
                     }
 
                     continue;
@@ -222,7 +222,7 @@ namespace GitCommands.Patches
 
                     if (regexMatch.Success)
                     {
-                        fileNameA = regexMatch.Groups[1].Value.Trim();
+                        fileNameA = regexMatch.Groups["filename"].Value.Trim();
                     }
                     else
                     {
@@ -245,7 +245,7 @@ namespace GitCommands.Patches
 
                     if (regexMatch.Success)
                     {
-                        fileNameB = regexMatch.Groups[1].Value.Trim();
+                        fileNameB = regexMatch.Groups["filename"].Value.Trim();
                     }
                     else
                     {
@@ -257,7 +257,7 @@ namespace GitCommands.Patches
 
                 if (i < lines.Length - 1)
                 {
-                    patchText.Append("\n");
+                    patchText.Append('\n');
                 }
             }
 

--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -16,11 +16,11 @@ namespace GitCommands
         public static readonly char PosixDirectorySeparatorChar = '/';
         public static readonly char NativeDirectorySeparatorChar = Path.DirectorySeparatorChar;
 
-        [GeneratedRegex(@"^(\w+):\/\/([\S]+)")]
+        [GeneratedRegex(@"^(\w+):\/\/([\S]+)", RegexOptions.ExplicitCapture)]
         private static partial Regex DriveLetterRegex();
 
         /// <summary>Replaces native path separator with posix path separator (/).</summary>
-        [return: NotNullIfNotNull("path")]
+        [return: NotNullIfNotNull(nameof(path))]
         public static string? ToPosixPath(this string? path)
         {
             return path?.Replace(NativeDirectorySeparatorChar, PosixDirectorySeparatorChar);

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -40,7 +40,7 @@ namespace GitCommands
 
         private static Mutex _globalMutex;
 
-        [GeneratedRegex(@"^(\d+)\.(\d+)")]
+        [GeneratedRegex(@"^(?<major>\d+)\.(?<minor>\d+)", RegexOptions.ExplicitCapture)]
         private static partial Regex VersionRegex();
 
         public static readonly int BranchDropDownMinWidth = 300;
@@ -142,7 +142,7 @@ namespace GitCommands
                 Match match = VersionRegex().Match(version);
                 if (match.Success)
                 {
-                    docVersion = $"en/release-{match.Groups[1]}.{match.Groups[2]}/";
+                    docVersion = $"en/release-{match.Groups["major"]}.{match.Groups["minor"]}/";
                 }
             }
 

--- a/GitExtUtils/GitArgumentBuilder.cs
+++ b/GitExtUtils/GitArgumentBuilder.cs
@@ -38,7 +38,7 @@ namespace GitExtUtils
         private readonly ArgumentString _gitArgs;
         private readonly string _command;
 
-        [GeneratedRegex("^[a-z0-9_.-]+$")]
+        [GeneratedRegex(@"^[a-z0-9_.-]+$", RegexOptions.ExplicitCapture)]
         private static partial Regex CommandRegex();
 
         /// <summary>

--- a/GitUI/Avatars/GithubAvatarProvider.cs
+++ b/GitUI/Avatars/GithubAvatarProvider.cs
@@ -20,7 +20,7 @@ namespace GitUI.Avatars
         private readonly IAvatarDownloader _downloader;
         private readonly bool _onlySupplyNoReply;
 
-        [GeneratedRegex(@"^(\d+\+)?(?<username>[^@]+)@users\.noreply\.github\.com$", RegexOptions.IgnoreCase)]
+        [GeneratedRegex(@"^(\d+\+)?(?<username>[^@]+)@users\.noreply\.github\.com$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture)]
         private static partial Regex GitHubEmailRegex();
 
         public GithubAvatarProvider([NotNull] IAvatarDownloader downloader, bool onlySupplyNoReply = false)

--- a/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
+++ b/GitUI/CommandsDialogs/AboutBoxDialog/FormContributors.cs
@@ -13,7 +13,7 @@ namespace GitUI.CommandsDialogs.AboutBoxDialog
         private readonly TranslationString _contributors = new("Contributors");
         private readonly TranslationString _caption = new("The application would not be possible without...");
 
-        [GeneratedRegex(@"\r\n?|\n")]
+        [GeneratedRegex(@"\r\n?|\n", RegexOptions.ExplicitCapture)]
         private static partial Regex NewlineRegex();
 
         public FormContributors()

--- a/GitUI/CommandsDialogs/FormPull.cs
+++ b/GitUI/CommandsDialogs/FormPull.cs
@@ -122,7 +122,7 @@ namespace GitUI.CommandsDialogs
         private List<IGitRef>? _heads;
         private bool _bInternalUpdate;
 
-        [GeneratedRegex(@"Your configuration specifies to .* the ref '.*'[\r]?\nfrom the remote, but no such ref was fetched.")]
+        [GeneratedRegex(@"Your configuration specifies to .* the ref '.*'[\r]?\nfrom the remote, but no such ref was fetched.", RegexOptions.ExplicitCapture)]
         private static partial Regex IsRefRemoved();
 
         public bool ErrorOccurred { get; private set; }

--- a/GitUI/CommandsDialogs/FormReflog.cs
+++ b/GitUI/CommandsDialogs/FormReflog.cs
@@ -25,7 +25,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _continueResetCurrentBranchEvenWithChangesText = new("You have changes in your working directory that could be lost.\n\nDo you want to continue?");
         private readonly TranslationString _continueResetCurrentBranchCaptionText = new("Changes not committed...");
 
-        [GeneratedRegex("^([^ ]+) ([^:]+): (.+)$")]
+        [GeneratedRegex(@"^(?<sha>[^ ]+) (?<ref>[^:]+): (?<action>.+)$", RegexOptions.ExplicitCapture)]
         private static partial Regex ReflogRegex();
 
         private string? _currentBranch;
@@ -94,7 +94,7 @@ namespace GitUI.CommandsDialogs
                         select ReflogRegex().Match(line)
                         into match
                         where match.Success
-                        select new RefLine(ObjectId.Parse(match.Groups[1].Value), match.Groups[2].Value, match.Groups[3].Value);
+                        select new RefLine(ObjectId.Parse(match.Groups["sha"].Value), match.Groups["ref"].Value, match.Groups["action"].Value);
             }
         }
 

--- a/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -33,9 +33,9 @@ namespace GitUI.CommandsDialogs.RepoHosting
         private IReadOnlyList<IPullRequestInformation>? _pullRequestsInfo;
         private readonly AsyncLoader _loader = new();
 
-        [GeneratedRegex(@"(?:\n|^)diff --git ")]
+        [GeneratedRegex(@"(?:\n|^)diff --git ", RegexOptions.ExplicitCapture)]
         private static partial Regex DiffCommandRegex();
-        [GeneratedRegex(@"^a/([^\n]+) b/([^\n]+)\s*(.*)$", RegexOptions.Singleline)]
+        [GeneratedRegex(@"^a/([^\n]+) b/(?<name>[^\n]+)\s*(?<value>.*)$", RegexOptions.Singleline | RegexOptions.ExplicitCapture)]
         private static partial Regex FilePartRegex();
 
         public ViewPullRequestsForm(GitUICommands commands, IRepositoryHostPlugin gitHoster)
@@ -399,7 +399,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                     return;
                 }
 
-                GitItemStatus gis = new(name: match.Groups[2].Value.Trim())
+                GitItemStatus gis = new(name: match.Groups["name"].Value.Trim())
                 {
                     IsChanged = true,
                     IsNew = false,
@@ -409,7 +409,7 @@ namespace GitUI.CommandsDialogs.RepoHosting
                 };
 
                 giss.Add(gis);
-                _diffCache.Add(gis.Name, match.Groups[3].Value);
+                _diffCache.Add(gis.Name, match.Groups["value"].Value);
             }
 
             // Note: Commits in PR may not exist in the local repo

--- a/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
+++ b/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
@@ -6,7 +6,7 @@ namespace GitUI.Editor.Diff
 {
     public partial class DiffLineNumAnalyzer
     {
-        [GeneratedRegex(@"\-(?<leftStart>\d{1,})\,{0,}(?<leftCount>\d{0,})\s\+(?<rightStart>\d{1,})\,{0,}(?<rightCount>\d{0,})", RegexOptions.IgnoreCase)]
+        [GeneratedRegex(@"\-(?<leftStart>\d{1,})\,{0,}(?<leftCount>\d{0,})\s\+(?<rightStart>\d{1,})\,{0,}(?<rightCount>\d{0,})", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture)]
         private static partial Regex DiffRegex();
 
         public DiffLinesInfo Analyze(string diffContent)

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -74,7 +74,7 @@ namespace GitUI.Editor
         private FileStatusItem? _viewItem;
         private readonly TaskDialogPage _NO_TRANSLATE_resetSelectedLinesConfirmationDialog;
 
-        [GeneratedRegex("warning: .*has type .* expected .*")]
+        [GeneratedRegex(@"warning: .*has type .* expected .*", RegexOptions.ExplicitCapture)]
         private static partial Regex FileModeWarningRegex();
 
         public FileViewer()

--- a/GitUI/Plugin/FailedPluginWrapper.cs
+++ b/GitUI/Plugin/FailedPluginWrapper.cs
@@ -7,7 +7,7 @@ namespace GitUI;
 
 internal partial class FailedPluginWrapper : IGitPlugin
 {
-    [GeneratedRegex("\\\"GitExtensions.([^\"]+)\\\"")]
+    [GeneratedRegex(@"""GitExtensions.([^""]+)""", RegexOptions.ExplicitCapture)]
     private static partial Regex PluginNameRegex();
 
     private readonly string _exception;

--- a/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
+++ b/GitUI/ScriptsEngine/ScriptsManager.ScriptRunner.cs
@@ -18,9 +18,9 @@ namespace GitUI.ScriptsEngine
             private const string userFiles = "UserFiles";
 
             // Regex that ensure that in the default value, there is the same number of '{' than '}' to find the right end of the default value expression.
-            [GeneratedRegex(@"\{UserInput:(?<label>[^}=]+)(=(?<defaultValue>[^{}]*(({[^{}]+})+[^{}]*)*))?\}")]
+            [GeneratedRegex(@"\{UserInput:(?<label>[^}=]+)(=(?<defaultValue>[^{}]*(({[^{}]+})+[^{}]*)*))?\}", RegexOptions.ExplicitCapture)]
             private static partial Regex UserInputRegex();
-            [GeneratedRegex(@"\{plugin.(.+)\}", RegexOptions.IgnoreCase)]
+            [GeneratedRegex(@"\{plugin.(?<name>.+)\}", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture)]
             private static partial Regex PluginRegex();
 
             public static bool RunScript(ScriptInfo script, IWin32Window owner, IGitUICommands commands, IScriptOptionsProvider? scriptOptionsProvider = null)
@@ -263,7 +263,7 @@ namespace GitUI.ScriptsEngine
                 Match match = PluginRegex().Match(originalCommand);
                 if (match.Success && match.Groups.Count > 1)
                 {
-                    originalCommand = $"{PluginPrefix}{match.Groups[1].Value.ToLower()}";
+                    originalCommand = $"{PluginPrefix}{match.Groups["name"].Value.ToLower()}";
                 }
 
                 return originalCommand;

--- a/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
+++ b/GitUI/UserControls/ConsoleEmulatorOutputControl.cs
@@ -141,7 +141,7 @@ namespace GitUI.UserControls
         private int _commandLineCharsInOutput;
         private string? _lineChunk;
 
-        [GeneratedRegex(@"(?<=[\n\r])")]
+        [GeneratedRegex(@"(?<=[\n\r])", RegexOptions.ExplicitCapture)]
         private static partial Regex NewLineRegex();
 
         public ConsoleCommandLineOutputProcessor(int commandLineCharsInOutput, Action<TextEventArgs> fireDataReceived)

--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -19,9 +19,9 @@ namespace GitUI
         private IList<PatchFile> _skipped = Array.Empty<PatchFile>();
         private bool _isManagingRebase;
 
-        [GeneratedRegex(@"^(?<header_key>[-A-Za-z0-9]+)(?::[ \t]*)(?<header_value>.*)$")]
+        [GeneratedRegex(@"^(?<header_key>[-A-Za-z0-9]+)(?::[ \t]*)(?<header_value>.*)$", RegexOptions.ExplicitCapture)]
         private static partial Regex HeadersRegex();
-        [GeneratedRegex(@"=\?([\w-]+)\?q\?(.*)\?=$")]
+        [GeneratedRegex(@"=\?(?<qr1>[\w-]+)\?q\?(<qr2>.*)\?=$", RegexOptions.ExplicitCapture)]
         private static partial Regex QuotedRegex();
 
         public PatchGrid()
@@ -273,8 +273,8 @@ namespace GitUI
 
                         if (m.Success)
                         {
-                            key = m.Groups[1].Value;
-                            value = m.Groups[2].Value;
+                            key = m.Groups["header_key"].Value;
+                            value = m.Groups["header_value"].Value;
                         }
                         else if (!string.IsNullOrEmpty(line))
                         {
@@ -296,7 +296,7 @@ namespace GitUI
 
             return patchFiles;
 
-            string AppendQuotedString(string str1, string str2)
+            static string AppendQuotedString(string str1, string str2)
             {
                 Match m1 = QuotedRegex().Match(str1);
                 Match m2 = QuotedRegex().Match(str2);
@@ -305,8 +305,8 @@ namespace GitUI
                     return str1 + str2;
                 }
 
-                DebugHelpers.Assert(m1.Groups[1].Value == m2.Groups[1].Value, "m1.Groups[1].Value == m2.Groups[1].Value");
-                return str1[..^2] + m2.Groups[2].Value + "?=";
+                DebugHelpers.Assert(m1.Groups["qr1"].Value == m2.Groups["qr1"].Value, @"m1.Groups[""qr1""].Value == m2.Groups[""qr2""].Value");
+                return str1[..^2] + m2.Groups["qr2"].Value + "?=";
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid/Graph/BranchFinder.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/BranchFinder.cs
@@ -5,7 +5,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 {
     internal partial class BranchFinder
     {
-        [GeneratedRegex("(?i)^merged? (pull request (.*) from )?(.*branch |tag )?'?([^ ']*[^ '.])'?( of [^ ]*[^ .])?( into (.*[^.]))?\\.?$", RegexOptions.CultureInvariant)]
+        [GeneratedRegex(@"^merged? (pull request (?<pr>.*) from )?(.*branch |tag )?'?(?<with>[^ ']*[^ '.])'?( of [^ ]*[^ .])?( into (?<into>.*[^.]))?\.?$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture)]
         private static partial Regex MergeRegex();
 
         internal BranchFinder(RevisionGraphRevision node)
@@ -77,9 +77,9 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             Match match = MergeRegex().Match(commitSubject);
             if (match.Success)
             {
-                Group matchPullRequest = match.Groups[2];
-                Group matchWith = match.Groups[4];
-                Group matchInto = match.Groups[7];
+                Group matchPullRequest = match.Groups["pr"];
+                Group matchWith = match.Groups["with"];
+                Group matchInto = match.Groups["into"];
                 into = matchInto.Success ? matchInto.Value : "master";
                 with = matchWith.Success ? matchWith.Value : "?";
                 if (appendPullRequest && matchPullRequest.Success)

--- a/GitUI/UserEnvironmentInformation.cs
+++ b/GitUI/UserEnvironmentInformation.cs
@@ -14,9 +14,9 @@ namespace GitUI
         private static bool _dirty;
         private static string? _sha;
 
-        [GeneratedRegex(@"^(?=.*\bMicrosoft\.WindowsDesktop\.App\b)[^\n\r]*", RegexOptions.Multiline)]
+        [GeneratedRegex(@"^(?=.*\bMicrosoft\.WindowsDesktop\.App\b)[^\n\r]*", RegexOptions.Multiline | RegexOptions.ExplicitCapture)]
         private static partial Regex DesktopAppRegex();
-        [GeneratedRegex("^", RegexOptions.Multiline)]
+        [GeneratedRegex(@"^", RegexOptions.Multiline | RegexOptions.ExplicitCapture)]
         private static partial Regex LineStartRegex();
 
         public static void CopyInformation() => ClipboardUtil.TrySetText(GetInformation() + GetDotnetVersionInfo());

--- a/Plugins/Bitbucket/Settings.cs
+++ b/Plugins/Bitbucket/Settings.cs
@@ -6,9 +6,9 @@ namespace GitExtensions.Plugins.Bitbucket
 {
     public partial class Settings
     {
-        [GeneratedRegex(@"https?:\/\/([\w\.\:]+\@)?(?<url>([a-zA-Z0-9\.\-\/]+?)):?(\d+)?\/scm\/(?<project>~?([^\/]+?))\/(?<repo>(.*?)).git")]
+        [GeneratedRegex(@"https?:\/\/([\w\.\:]+\@)?(?<url>([a-zA-Z0-9\.\-\/]+?)):?(\d+)?\/scm\/(?<project>~?([^\/]+?))\/(?<repo>(.*?)).git", RegexOptions.ExplicitCapture)]
         private static partial Regex BitbucketHttpRegex();
-        [GeneratedRegex(@"ssh:\/\/([\w\.]+\@)(?<url>([a-zA-Z0-9\.\-]+)):?(\d+)?\/(?<project>~?([^\/]+))\/(?<repo>(.*?)).git")]
+        [GeneratedRegex(@"ssh:\/\/([\w\.]+\@)(?<url>([a-zA-Z0-9\.\-]+)):?(\d+)?\/(?<project>~?([^\/]+))\/(?<repo>(.*?)).git", RegexOptions.ExplicitCapture)]
         private static partial Regex BitbucketSshRegex();
 
         public static Settings? Parse(IGitModule module, SettingsSource settings, BitbucketPlugin plugin)

--- a/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/ProjectUrlHelper.cs
+++ b/Plugins/BuildServerIntegration/AzureDevOpsIntegration/Settings/ProjectUrlHelper.cs
@@ -8,29 +8,29 @@ namespace AzureDevOpsIntegration.Settings
     /// </summary>
     public partial class ProjectUrlHelper
     {
-        [GeneratedRegex(@"^(?<prot>(?:http|https))://(?<user>[^.@]+)(?:@[^.]*)?\.visualstudio\.com(?<port>:\d*)?(?:/DefaultCollection)?(?<project>(/[^/]+)?/[^/]+)/_(git|ssh)/(.+)$")]
+        [GeneratedRegex(@"^(?<prot>(?:http|https))://(?<user>[^.@]+)(?:@[^.]*)?\.visualstudio\.com(?<port>:\d*)?(?:/DefaultCollection)?(?<project>(/[^/]+)?/[^/]+)/_(git|ssh)/(.+)$", RegexOptions.ExplicitCapture)]
         private static partial Regex VsTeamHttpsRegex();
-        [GeneratedRegex(@"^(?<user>[^.@]+)@vs-ssh\.visualstudio.com:v3(?:/[^/]*)?(?<project>/[^/]+)")]
+        [GeneratedRegex(@"^(?<user>[^.@]+)@vs-ssh\.visualstudio.com:v3(?:/[^/]*)?(?<project>/[^/]+)", RegexOptions.ExplicitCapture)]
         private static partial Regex VsTeamSshRegex();
 
-        [GeneratedRegex(@"^(?<prot>(?:http|https))://(?:[^.@]+@)?dev\.azure\.com(?<port>:\d*)?(?<project>(?:/[^/]+)?/[^/]+)/_(?:git|ssh)/(?:.+)$")]
+        [GeneratedRegex(@"^(?<prot>(?:http|https))://(?:[^.@]+@)?dev\.azure\.com(?<port>:\d*)?(?<project>(?:/[^/]+)?/[^/]+)/_(?:git|ssh)/(?:.+)$", RegexOptions.ExplicitCapture)]
         private static partial Regex AzureDevopsHttpsRegex();
-        [GeneratedRegex(@"^[^.@]+@ssh\.dev\.azure\.com:v3(?<project>(?:/[^/]+)?/[^/]+)")]
+        [GeneratedRegex(@"^[^.@]+@ssh\.dev\.azure\.com:v3(?<project>(?:/[^/]+)?/[^/]+)", RegexOptions.ExplicitCapture)]
         private static partial Regex AzureDevopsSshRegex();
 
-        [GeneratedRegex(@"^(?<instanceurl>(?:http|https)://[^/]+(?::\d*)?(?:/[^/]+)+/DefaultCollection)(?<project>/[^/]+)/_(?:git|ssh)")]
+        [GeneratedRegex(@"^(?<instanceurl>(?:http|https)://[^/]+(?::\d*)?(?:/[^/]+)+/DefaultCollection)(?<project>/[^/]+)/_(?:git|ssh)", RegexOptions.ExplicitCapture)]
         private static partial Regex TfsSecondaryRegex();
-        [GeneratedRegex(@"^(?<instanceurl>(?:http|https)://[^/]+(?::\d*)?(?:/[^/]+)+/DefaultCollection)/_(?:git|ssh)(?<project>/[^/]+)")]
+        [GeneratedRegex(@"^(?<instanceurl>(?:http|https)://[^/]+(?::\d*)?(?:/[^/]+)+/DefaultCollection)/_(?:git|ssh)(?<project>/[^/]+)", RegexOptions.ExplicitCapture)]
         private static partial Regex TfsMainRegex();
 
-        [GeneratedRegex(@"^(?<instanceurl>(?:http|https)://[^.@]+(?:@[^.]*)?\.visualstudio\.com(?::\d*)?)")]
+        [GeneratedRegex(@"^(?<instanceurl>(?:http|https)://[^.@]+(?:@[^.]*)?\.visualstudio\.com(?::\d*)?)", RegexOptions.ExplicitCapture)]
         private static partial Regex VsTeamTokenRegex();
-        [GeneratedRegex(@"^(?<instanceurl>(?:http|https)://dev\.azure\.com(?::\d*)?/[^/]+)")]
+        [GeneratedRegex(@"^(?<instanceurl>(?:http|https)://dev\.azure\.com(?::\d*)?/[^/]+)", RegexOptions.ExplicitCapture)]
         private static partial Regex AzureDevopsTokenRegex();
-        [GeneratedRegex(@"^(?<instanceurl>(?:http|https)://[^/]+(?::\d*)?(?:/[^/]+)+)/[^/]+")]
+        [GeneratedRegex(@"^(?<instanceurl>(?:http|https)://[^/]+(?::\d*)?(?:/[^/]+)+)/[^/]+", RegexOptions.ExplicitCapture)]
         private static partial Regex TfsTokenRegex();
 
-        [GeneratedRegex(@"^(?<projecturl>(?:http|https)://[^/]+(?::\d*)?(?:/[^/]+)+)/_build.*(?:&|\?)buildId=(?<buildid>\d+)")]
+        [GeneratedRegex(@"^(?<projecturl>(?:http|https)://[^/]+(?::\d*)?(?:/[^/]+)+)/_build.*(?:&|\?)buildId=(?<buildid>\d+)", RegexOptions.ExplicitCapture)]
         private static partial Regex BuildUrlInfoRegex();
 
         private static readonly Dictionary<Regex, Func<Match, string>> RemoteToProjectUrlLookup = new()

--- a/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.cs
+++ b/Plugins/BuildServerIntegration/TeamCityIntegration/Settings/TeamCitySettingsUserControl.cs
@@ -20,7 +20,7 @@ namespace TeamCityIntegration.Settings
                 "(Should contain at least the \"buildTypeId\" parameter)");
         private readonly TranslationString _failToExtractDataFromClipboardCaption = new("Build url not valid");
 
-        [GeneratedRegex(@"(\?|\&)([^=]+)\=([^&]+)")]
+        [GeneratedRegex(@"(\?|\&)(?<buildtypeid>[^=]+)\=(?<buildtype>[^&]+)", RegexOptions.ExplicitCapture)]
         private static partial Regex TeamcityBuildUrl();
 
         public TeamCitySettingsUserControl()
@@ -122,9 +122,9 @@ namespace TeamCityIntegration.Settings
                 {
                     if (paramResult.Success)
                     {
-                        if (paramResult.Groups[2].Value == "buildTypeId")
+                        if (paramResult.Groups["buildtypeid"].Value == "buildTypeId")
                         {
-                            Build buildType = _teamCityAdapter.GetBuildType(paramResult.Groups[3].Value);
+                            Build buildType = _teamCityAdapter.GetBuildType(paramResult.Groups["buildtype"].Value);
                             TeamCityProjectName.Text = buildType.ParentProject;
                             TeamCityBuildIdFilter.Text = buildType.Id;
                             return;

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -25,7 +25,7 @@ namespace GitExtensions.Plugins.GitFlow
 
         private string? CurrentBranch { get; set; }
 
-        [GeneratedRegex(@"\r\n?|\n")]
+        [GeneratedRegex(@"\r\n?|\n", RegexOptions.ExplicitCapture)]
         private static partial Regex LineEndRegex();
 
         private enum Branch

--- a/Plugins/GitUIPluginInterfaces/GitRevision.cs
+++ b/Plugins/GitUIPluginInterfaces/GitRevision.cs
@@ -18,9 +18,9 @@ namespace GitUIPluginInterfaces
         /// Artificial commit for the combined diff</summary>
         public const string CombinedDiffGuid = "3333333333333333333333333333333333333333";
 
-        [GeneratedRegex(@"^[a-f\d]{40}$")]
+        [GeneratedRegex(@"^[a-f\d]{40}$", RegexOptions.ExplicitCapture)]
         public static partial Regex Sha1HashRegex();
-        [GeneratedRegex(@"\b[a-f\d]{7,40}\b(?![^@\s]*@)")]
+        [GeneratedRegex(@"\b[a-f\d]{7,40}\b(?![^@\s]*@)", RegexOptions.ExplicitCapture)]
         public static partial Regex Sha1HashShortRegex();
 
         private BuildInfo? _buildStatus;

--- a/Plugins/GitUIPluginInterfaces/GitStash.cs
+++ b/Plugins/GitUIPluginInterfaces/GitStash.cs
@@ -6,7 +6,7 @@ namespace GitUIPluginInterfaces
     /// <summary>Stored local modifications.</summary>
     public sealed partial class GitStash
     {
-        [GeneratedRegex(@"^stash@\{(?<index>\d+)\}: (?<message>.+)$")]
+        [GeneratedRegex(@"^stash@\{(?<index>\d+)\}: (?<message>.+)$", RegexOptions.ExplicitCapture)]
         private static partial Regex StashRegex();
 
         public static bool TryParse(string s, [NotNullWhen(returnValue: true)] out GitStash? stash)

--- a/Plugins/Gource/GourcePlugin.cs
+++ b/Plugins/Gource/GourcePlugin.cs
@@ -35,7 +35,7 @@ namespace GitExtensions.Plugins.Gource
 
         // find http://gource.googlecode.com/files/gource-0.26b.win32.zip
         // find http://gource.googlecode.com/files/gource-0.34-rc2.win32.zip
-        [GeneratedRegex(@"(?:<a .*href="")(.*gource-.{3,15}win32\.zip)""")]
+        [GeneratedRegex(@"(?:<a .*href="")(?<path>.*gource-.{3,15}win32\.zip)""", RegexOptions.ExplicitCapture)]
         private static partial Regex GourceRegex();
 
         public GourcePlugin() : base(true)
@@ -253,7 +253,7 @@ namespace GitExtensions.Plugins.Gource
 
                 foreach (Match match in matches)
                 {
-                    return "https://github.com" + match.Groups[1].Value;
+                    return "https://github.com" + match.Groups["path"].Value;
                 }
 
                 response = webClient.DownloadString(@"https://github.com/acaudwell/Gource/releases/tag/gource-0.42");
@@ -262,7 +262,7 @@ namespace GitExtensions.Plugins.Gource
 
                 foreach (Match match in matches)
                 {
-                    return "https://github.com" + match.Groups[1].Value;
+                    return "https://github.com" + match.Groups["path"].Value;
                 }
 
                 return string.Empty;

--- a/Plugins/ProxySwitcher/ProxySwitcherForm.cs
+++ b/Plugins/ProxySwitcher/ProxySwitcherForm.cs
@@ -18,7 +18,7 @@ namespace GitExtensions.Plugins.ProxySwitcher
         private readonly TranslationString _pleaseSetProxy = new("There is no proxy configured. Please set the proxy host in the plugin settings.");
         #endregion
 
-        [GeneratedRegex(":(.*)@")]
+        [GeneratedRegex(@":(.*)@", RegexOptions.ExplicitCapture)]
         private static partial Regex PasswordRegex();
 
         /// <summary>

--- a/Plugins/ReleaseNotesGenerator/GitLogLineParser.cs
+++ b/Plugins/ReleaseNotesGenerator/GitLogLineParser.cs
@@ -10,7 +10,7 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
 
     public sealed partial class GitLogLineParser : IGitLogLineParser
     {
-        [GeneratedRegex("^([a-zA-Z0-9]{1,})@(.*)")]
+        [GeneratedRegex(@"^(?<before>[a-zA-Z0-9]{1,})@(?<after>.*)", RegexOptions.ExplicitCapture)]
         private static partial Regex LogLineRegex();
 
         public LogLine? Parse(string line)
@@ -26,7 +26,7 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
                 return null;
             }
 
-            LogLine logLine = new(m.Groups[1].Value, m.Groups[2].Value);
+            LogLine logLine = new(m.Groups["before"].Value, m.Groups["after"].Value);
             return logLine;
         }
 

--- a/Plugins/ReleaseNotesGenerator/HtmlFragment.cs
+++ b/Plugins/ReleaseNotesGenerator/HtmlFragment.cs
@@ -13,7 +13,7 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
     /// </summary>
     internal partial class HtmlFragment
     {
-        [GeneratedRegex(@"([a-zA-Z]+):(.+?)[\r\n]", RegexOptions.IgnoreCase)]
+        [GeneratedRegex(@"(?<key>[a-zA-Z]+):(?<val>.+?)[\r\n]", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture)]
         private static partial Regex HtmlRegex();
 
         #region Read and decode from clipboard
@@ -54,8 +54,8 @@ namespace GitExtensions.Plugins.ReleaseNotesGenerator
 
             for (Match m = HtmlRegex().Match(rawClipboardText); m.Success; m = m.NextMatch())
             {
-                string key = m.Groups[1].Value.ToLower();
-                string val = m.Groups[2].Value;
+                string key = m.Groups["key"].Value.ToLower();
+                string val = m.Groups["val"].Value;
 
                 switch (key)
                 {

--- a/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
+++ b/ResourceManager/CommitDataRenders/CommitDataHeaderRenderer.cs
@@ -41,9 +41,9 @@ namespace ResourceManager.CommitDataRenders
         private readonly IHeaderRenderStyleProvider _headerRendererStyleProvider;
         private readonly ILinkFactory? _linkFactory;
 
-        [GeneratedRegex(@"[ \t]+")]
+        [GeneratedRegex(@"[ \t]+", RegexOptions.ExplicitCapture)]
         private static partial Regex SpacesRegex();
-        [GeneratedRegex(@"(\n[^:]+: ).* ago \(([^)]+)\)")]
+        [GeneratedRegex(@"(?<reltime>\n[^:]+: ).* ago \((?<unit>[^)]+)\)", RegexOptions.ExplicitCapture)]
         private static partial Regex RemoveAgoRegex();
 
         public CommitDataHeaderRenderer(IHeaderLabelFormatter labelFormatter, IDateFormatter dateFormatter, IHeaderRenderStyleProvider headerRendererStyleProvider, ILinkFactory? linkFactory)

--- a/UnitTests/BugReporter.Tests/SerializableExceptionTests.cs
+++ b/UnitTests/BugReporter.Tests/SerializableExceptionTests.cs
@@ -9,7 +9,7 @@ namespace BugReporterTests
     [SetUICulture("en-US")]
     public sealed partial class SerializableExceptionTests
     {
-        [GeneratedRegex(@"^(?<keep>.*)(?<codeLocationToBeRemoved>\sin\s.*)$")]
+        [GeneratedRegex(@"^(?<keep>.*)(?<codeLocationToBeRemoved>\sin\s.*)$", RegexOptions.ExplicitCapture)]
         private static partial Regex PathRegex();
 
         [Test, TestCaseSource(nameof(TestCases))]

--- a/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
@@ -10,11 +10,11 @@ namespace GitCommandsTests.Git
     [TestFixture]
     public sealed partial class ObjectIdTests
     {
-        [GeneratedRegex("[a-f0-9]{40}")]
+        [GeneratedRegex(@"[a-f0-9]{40}", RegexOptions.ExplicitCapture)]
         private static partial Regex Sha40Regex();
-        [GeneratedRegex("[a-f0-9]{39}")]
+        [GeneratedRegex(@"[a-f0-9]{39}", RegexOptions.ExplicitCapture)]
         private static partial Regex Sha39Regex();
-        [GeneratedRegex("[XYZa-f0-9]{39}")]
+        [GeneratedRegex(@"[XYZa-f0-9]{39}", RegexOptions.ExplicitCapture)]
         private static partial Regex ShaXYZRegex();
 
         [TestCase("0000000000000000000000000000000000000000")]

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/LaneInfoProviderTests.cs
@@ -12,8 +12,7 @@ namespace GitUITests.UserControls.RevisionGrid.Graph
     {
         /// <summary>
         /// triples of merge subject, merged branch and destination branch ("into")
-        /// for testing the LaneInfoProvider.References.MergeRegex
-        /// "(?i)^merged? (pull request (.*) from )?(.*branch |tag )?'?([^ ']*[^ '.])'?( of [^ ]*[^ .])?( into (.*[^.]))?\\.?$"
+        /// for testing the GitUI.UserControls.RevisionGrid.Graph.MergeRegex()
         /// </summary>
         private static readonly List<string> MergeSubjectsWithDecoding =
         [


### PR DESCRIPTION

## Proposed changes

Name all generated regex captures, to improve readability and enable the possibility to use explicit capture.

Enable the option for explicit capture for all generated regex. This improves performance slightly.

Use verbatim strings for regex.

A few VS suggested changes.

This in itself will likely not make any noticable improvements, but will simplify investigations and set a usage pattern.

## Test methodology <!-- How did you ensure quality? -->

Code review, tests

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
