### PR TITLE
Workaround ImageList transparent image regression introduced in .NET 8

### DIFF
--- a/GitExtUtils/GitUI/ImageListExtensions.cs
+++ b/GitExtUtils/GitUI/ImageListExtensions.cs
@@ -1,23 +1,15 @@
-﻿using System.Runtime.InteropServices;
+﻿namespace GitUI;
 
-namespace GitUI
+public static class ImageListExtensions
 {
-    public static class ImageListExtensions
+    /// <summary>
+    /// A regression was introduced in .NET 8 which causes an incorrect background color to be set
+    /// which manifests when using transparent images. See https://github.com/dotnet/winforms/issues/10462
+    /// This method should be removed once the underlying issue is fixed.
+    /// </summary>
+    public static ImageList FixImageTransparencyRegression(this ImageList imageList)
     {
-        internal const int ComCtl32CLRNone = unchecked((int)0xFFFFFFFF);
-
-        [DllImport("comctl32.dll", EntryPoint = "ImageList_SetBkColor")]
-        internal static extern int ImageListSetBkColor(IntPtr himl, int clrBk);
-
-        /// <summary>
-        /// A regression was introduced in .net8 which causes an incorrect background color to be set
-        /// which manifests when using transparent images. See https://github.com/dotnet/winforms/issues/10462
-        /// This metod should be removed once the underlying issue is fixed.
-        /// </summary>
-        public static ImageList FixImageTransparencyRegression(this ImageList imageList)
-        {
-            ImageListSetBkColor(imageList.Handle, ComCtl32CLRNone);
-            return imageList;
-        }
+        NativeMethods.ImageListSetBkColor(imageList.Handle, NativeMethods.ComCtl32CLRNone);
+        return imageList;
     }
 }

--- a/GitExtUtils/GitUI/ImageListExtensions.cs
+++ b/GitExtUtils/GitUI/ImageListExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System.Runtime.InteropServices;
+
+namespace GitUI
+{
+    public static class ImageListExtensions
+    {
+        internal const int ComCtl32CLRNone = unchecked((int)0xFFFFFFFF);
+
+        [DllImport("comctl32.dll", EntryPoint = "ImageList_SetBkColor")]
+        internal static extern int ImageListSetBkColor(IntPtr himl, int clrBk);
+
+        /// <summary>
+        /// A regression was introduced in .net8 which causes an incorrect background color to be set
+        /// which manifests when using transparent images. See https://github.com/dotnet/winforms/issues/10462
+        /// This metod should be removed once the underlying issue is fixed.
+        /// </summary>
+        public static ImageList FixImageTransparencyRegression(this ImageList imageList)
+        {
+            ImageListSetBkColor(imageList.Handle, ComCtl32CLRNone);
+            return imageList;
+        }
+    }
+}

--- a/GitExtUtils/GitUI/Interops/ComCtl32/ImageListSetBkColor.cs
+++ b/GitExtUtils/GitUI/Interops/ComCtl32/ImageListSetBkColor.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices;
+
+namespace System;
+
+internal static class NativeMethods
+{
+    internal const int ComCtl32CLRNone = unchecked((int)0xFFFFFFFF);
+
+    [DllImport("comctl32.dll", EntryPoint = "ImageList_SetBkColor")]
+    internal static extern int ImageListSetBkColor(IntPtr himl, int clrBk);
+}

--- a/GitUI/CommandsDialogs/FormBrowse.InitCommitDetails.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitCommitDetails.cs
@@ -25,7 +25,8 @@ namespace GitUI.CommandsDialogs
                     { nameof(Images.Key), Images.Key },
                     { nameof(Images.Console), Images.Console }
                 }
-            };
+            }
+            .FixImageTransparencyRegression();
 
             CommitInfoTabPage.ImageKey = nameof(Images.CommitSummary);
             DiffTabPage.ImageKey = nameof(Images.Diff);

--- a/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -141,7 +141,9 @@ namespace GitUI.CommandsDialogs
                         Images.ViewFile,
                         Images.Blame
                     }
-                };
+                }
+                .FixImageTransparencyRegression();
+
                 tabControl1.TabPages[0].ImageIndex = 0;
                 tabControl1.TabPages[1].ImageIndex = 1;
                 tabControl1.TabPages[2].ImageIndex = 2;


### PR DESCRIPTION
Fixes #11506

A root cause was found to be an incorrect setting of the image background during `ImageList` handle creation https://github.com/dotnet/winforms/issues/10462#issuecomment-1880068488

This also suggests a clear fix:

## Proposed changes

- Set ImageList background to a value used before this regression got introduced
- Add comment instructing to remove this workaround once the fix is implemented in .NET 9 (most likely) 

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

FormBrowse > Commit Info
![image](https://github.com/gitextensions/gitextensions/assets/483659/0e1dbe69-d3e8-49b7-b123-dfd8496dfc98)

FormFileHistory
![image](https://github.com/gitextensions/gitextensions/assets/483659/a4b851e8-1b94-44bc-9bdf-ef9aa64aacde)

### After

![image](https://github.com/gitextensions/gitextensions/assets/483659/9696add8-8232-4d4a-8280-9318dc1e70e9)
![image](https://github.com/gitextensions/gitextensions/assets/483659/342c2cc7-ad12-4b49-a408-d4e9cd440cad)


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

- Squash merge (there is just a single commit but this maintains PR number in a commit message)

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
