### PR TITLE
Fixup limits by RevisionGraph.Count

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -122,7 +122,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         public int GetCachedCount()
         {
             ImmutableArray<RevisionGraphRow> localOrderedRowCache = _orderedRowCache;
-            if (localOrderedRowCache.Length == 0 || IsRowCacheDirty(localOrderedRowCache, BuildOrderedNodesCache(Count)))
+            if (localOrderedRowCache.Length == 0 || IsRowCacheDirty(localOrderedRowCache, BuildOrderedNodesCache(int.MaxValue)))
             {
                 return 0;
             }
@@ -201,7 +201,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 }
             }
 
-            index = BuildOrderedNodesCache(Count).IndexOf(revision);
+            index = BuildOrderedNodesCache(int.MaxValue).IndexOf(revision);
             return index >= 0;
         }
 
@@ -209,7 +209,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         {
             // Use a local variable, because the cached list can be reset
             ImmutableArray<RevisionGraphRevision> localOrderedNodesCache = BuildOrderedNodesCache(row);
-            if (row >= localOrderedNodesCache.Length)
+            if (row < 0 || row >= localOrderedNodesCache.Length)
             {
                 return null;
             }
@@ -221,7 +221,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         {
             ImmutableArray<RevisionGraphRevision> localOrderedNodesCache = BuildOrderedNodesCache(row);
             ImmutableArray<RevisionGraphRow> localOrderedRowCache = _orderedRowCache;
-            if (IsRowCacheDirty(localOrderedRowCache, localOrderedNodesCache) || localOrderedRowCache.Length == 0 || row < 0 || row >= localOrderedRowCache.Length)
+            if (IsRowCacheDirty(localOrderedRowCache, localOrderedNodesCache) || row < 0 || row >= localOrderedRowCache.Length)
             {
                 return null;
             }
@@ -693,11 +693,11 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         /// <summary>
         /// Build the ordered list of nodes from the revisions.
         /// </summary>
-        /// <param name="currentRowIndex">The min node index for the row.</param>
+        /// <param name="currentRowIndex">The min node index for the row; is automatically limited using <see cref="Count"/>.</param>
         /// <returns>The ordered revision cache.</returns>
         private ImmutableArray<RevisionGraphRevision> BuildOrderedNodesCache(int currentRowIndex)
         {
-            if (!_orderedNodesCacheInvalid && _orderedNodesCache.Length >= Math.Min(Count, currentRowIndex))
+            if (!_orderedNodesCacheInvalid && _orderedNodesCache.Length > Math.Min(Count - 1, currentRowIndex))
             {
                 return _orderedNodesCache;
             }
@@ -711,7 +711,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 {
                     // Reset flags to ensure the cache isn't marked dirty before we even got to rebuilding it.
                     _orderedNodesCacheInvalid = false;
-                    _orderedNodesCache = ImmutableArray<RevisionGraphRevision>.Empty;
+                    _orderedNodesCache = [];
 
                     _orderedNodesCache = _revisionByObjectId.Values.OrderBy(n => n.Score).ToImmutableArray();
 

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -361,7 +361,7 @@ namespace GitUI.UserControls.RevisionGrid
 
         public void Clear()
         {
-            _backgroundScrollTo = 0;
+            _backgroundScrollTo = -1;
             _forceRefresh = false;
 
             // Set rowcount to 0 first, to ensure it is not possible to select or redraw, since we are about to delete the data
@@ -662,8 +662,8 @@ namespace GitUI.UserControls.RevisionGrid
         {
             int fromIndex = Math.Max(0, FirstDisplayedScrollingRowIndex);
             int visibleRowCount = _rowHeight <= 0 ? 0 : (Height + _rowHeight - 1) / _rowHeight; // Rounding up integer division: (a+b-1)/b = ceil(a/b)
-
             visibleRowCount = Math.Min(_revisionGraph.Count - fromIndex, visibleRowCount);
+
             if (_forceRefresh)
             {
                 _backgroundScrollTo = -1;
@@ -695,14 +695,15 @@ namespace GitUI.UserControls.RevisionGrid
                                 // Take changes to _backgroundScrollTo and IsDataLoadComplete by another thread into account
                                 if (IsDataLoadComplete)
                                 {
-                                    _backgroundScrollTo = Math.Min(_backgroundScrollTo, _revisionGraph.Count);
+                                    _backgroundScrollTo = Math.Min(_backgroundScrollTo, _revisionGraph.Count - 1);
                                 }
                             }
-                            while (curCount < _backgroundScrollTo);
+                            while (curCount <= _backgroundScrollTo);
                         }
                         else
                         {
-                            await UpdateGraphAsync(fromIndex: _revisionGraph.Count, toIndex: _revisionGraph.Count);
+                            int maxRowIndex = _revisionGraph.Count - 1;
+                            await UpdateGraphAsync(fromIndex: maxRowIndex, toIndex: maxRowIndex);
                         }
                     }
 


### PR DESCRIPTION
## Proposed changes

- Fixup violations of "A row index must be less than `RevisionGraph.Count`."

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).