### PR TITLE
Simplify RevisionDataGridView.LoadingCompleted

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -437,54 +437,52 @@ namespace GitUI.UserControls.RevisionGrid
             if (_revisionGraph.Count == 0)
             {
                 MarkAsDataLoadingComplete();
+                return;
             }
-            else
+
+            // Rows have not been selected yet
+            this.InvokeAndForget(async () =>
             {
-                // Rows have not been selected yet
-                this.InvokeAndForget(async () =>
+                SetRowCountAndSelectRowsIfReady();
+
+                if (_toBeSelectedGraphIndexesCache.Value.Count == 0)
                 {
-                    SetRowCountAndSelectRowsIfReady();
-
-                    if (_toBeSelectedGraphIndexesCache.Value.Count == 0)
-                    {
-                        // Nothing to select or interrupted
-                        MarkAsDataLoadingComplete();
-                        return;
-                    }
-
-                    int scrollTo = _toBeSelectedGraphIndexesCache.Value.Max();
-                    int firstGraphIndex = _toBeSelectedGraphIndexesCache.Value[0];
-                    if (RowCount - 1 < scrollTo)
-                    {
-                        // Wait for the periodic background thread to load all rows in the grid
-                        while (RowCount - 1 < scrollTo && firstGraphIndex >= Rows.Count)
-                        {
-                            // Force loading of rows
-                            int maxScroll = Math.Min(RowCount - 1, scrollTo);
-                            EnsureRowVisible(maxScroll);
-
-                            // Wait for background thread to update grid rows
-                            UpdateVisibleRowRange();
-                            await Task.Delay(BackgroundThreadUpdatePeriod);
-                            if (_loadedToBeSelectedRevisionsCount == 0)
-                            {
-                                // Selection done or aborted
-                                break;
-                            }
-                        }
-                    }
-
-                    // Scroll to first selected only if selection is not changed
-                    if (firstGraphIndex >= 0 && firstGraphIndex < Rows.Count && Rows[firstGraphIndex].Selected)
-                    {
-                        EnsureRowVisible(firstGraphIndex);
-                    }
-
+                    // Nothing to select or interrupted
                     MarkAsDataLoadingComplete();
-                });
-            }
+                    return;
+                }
 
-            return;
+                int scrollTo = _toBeSelectedGraphIndexesCache.Value.Max();
+
+                int rowCount;
+
+                // Wait for the periodic background thread to load the first selected grid row, stop if aborted
+                int firstGraphIndex = _toBeSelectedGraphIndexesCache.Value[0];
+                do
+                {
+                    rowCount = RowCount;
+                    if (scrollTo < rowCount || firstGraphIndex < rowCount)
+                    {
+                        break;
+                    }
+
+                    // Force loading of rows
+                    EnsureRowVisible(rowCount - 1);
+
+                    // Wait for background thread to load grid rows
+                    UpdateVisibleRowRange();
+                    await Task.Delay(BackgroundThreadUpdatePeriod);
+                }
+                while (_loadedToBeSelectedRevisionsCount > 0);
+
+                // Scroll to first selected only if selection is not changed
+                if (firstGraphIndex >= 0 && firstGraphIndex < rowCount && Rows[firstGraphIndex].Selected)
+                {
+                    EnsureRowVisible(firstGraphIndex);
+                }
+
+                MarkAsDataLoadingComplete();
+            });
         }
 
         public void MarkAsDataLoadingComplete()

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -452,8 +452,6 @@ namespace GitUI.UserControls.RevisionGrid
                     return;
                 }
 
-                int scrollTo = _toBeSelectedGraphIndexesCache.Value.Max();
-
                 int rowCount;
 
                 // Wait for the periodic background thread to load the first selected grid row, stop if aborted
@@ -461,12 +459,12 @@ namespace GitUI.UserControls.RevisionGrid
                 do
                 {
                     rowCount = RowCount;
-                    if (scrollTo < rowCount || firstGraphIndex < rowCount)
+                    if (firstGraphIndex < rowCount)
                     {
                         break;
                     }
 
-                    // Force loading of rows
+                    // Scroll to currently last loaded row
                     EnsureRowVisible(rowCount - 1);
 
                     // Wait for background thread to load grid rows


### PR DESCRIPTION
## Proposed changes

Simplify `RevisionDataGridView.LoadingCompleted`:
- remove pointless `srollTo`
- avoid repeated evaluation of `RowCount `

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).