### PR TITLE
Clarify revision loading

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -189,7 +189,6 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
         public override void Clear()
         {
-            _revisionGraph.Clear();
             _graphCache.Reset();
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.BackgroundUpdater.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.BackgroundUpdater.cs
@@ -28,7 +28,7 @@
                     {
                         // if not running, start it
                         _executing = true;
-                        Task.Run(WrappedOperationAsync);
+                        ThreadHelper.FileAndForget(WrappedOperationAsync);
                     }
                     else
                     {
@@ -55,7 +55,7 @@
                     {
                         if (_rerunRequested)
                         {
-                            Task.Run(WrappedOperationAsync);
+                            ThreadHelper.FileAndForget(WrappedOperationAsync);
                             _rerunRequested = false;
                         }
                         else


### PR DESCRIPTION
## Proposed changes

- Remove redundant call of `_revisionGraph.Clear`
- Separate `TriggerRowCountUpdate` from `UpdateVisibleRowRange`,
  which will be really split in a follow up
- use C#'s unconditional logical operator `|=`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).