### PR TITLE
Do not straighten graph if it is too wide

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1512,6 +1512,14 @@ namespace GitCommands
 
         public static ISetting<bool> MergeGraphLanesHavingCommonParent { get; } = Setting.Create(RevisionGraphSettingsPath, nameof(MergeGraphLanesHavingCommonParent), true);
 
+        /// <summary>
+        ///  The limit when to skip the straightening of revision graph segments.
+        /// </summary>
+        /// <remarks>
+        ///  Straightening needs to call the expensive RevisionGraphRow.BuildSegmentLanes function.<br></br>
+        ///  Straightening inserts gaps making the graph wider. If it already has to display many segments, i.e. parallel branches, there would be a low benefit of straightening.<br></br>
+        ///  So rather skip the - in this case particularly expensive - RevisionGraphRow.BuildSegmentLanes function and call it only if the row is visible.
+        /// </remarks>
         public static ISetting<int> StraightenGraphSegmentsLimit { get; } = Setting.Create(RevisionGraphSettingsPath, nameof(StraightenGraphSegmentsLimit), 80);
 
         public static string LastFormatPatchDir

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1512,6 +1512,8 @@ namespace GitCommands
 
         public static ISetting<bool> MergeGraphLanesHavingCommonParent { get; } = Setting.Create(RevisionGraphSettingsPath, nameof(MergeGraphLanesHavingCommonParent), true);
 
+        public static ISetting<int> StraightenGraphSegmentsLimit { get; } = Setting.Create(RevisionGraphSettingsPath, nameof(StraightenGraphSegmentsLimit), 80);
+
         public static string LastFormatPatchDir
         {
             get => GetString("lastformatpatchdir", "");

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphConfig.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphConfig.cs
@@ -8,6 +8,9 @@ internal readonly struct RevisionGraphConfig
 
     public bool ReduceGraphCrossings => !MergeGraphLanesHavingCommonParent;
 
+    /// <summary>
+    ///  <see cref="AppSettings.StraightenGraphSegmentsLimit"/>
+    /// </summary>
     public int StraightenGraphSegmentsLimit { get; }
 
     public RevisionGraphConfig()

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphConfig.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraphConfig.cs
@@ -8,8 +8,11 @@ internal readonly struct RevisionGraphConfig
 
     public bool ReduceGraphCrossings => !MergeGraphLanesHavingCommonParent;
 
+    public int StraightenGraphSegmentsLimit { get; }
+
     public RevisionGraphConfig()
     {
         MergeGraphLanesHavingCommonParent = AppSettings.MergeGraphLanesHavingCommonParent.Value;
+        StraightenGraphSegmentsLimit = AppSettings.StraightenGraphSegmentsLimit.Value;
     }
 }

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -298,6 +298,7 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.HighlightAuthoredRevisions)], true, false, false);
                 yield return (properties[nameof(AppSettings.FillRefLabels)], false, false, false);
                 yield return (properties[nameof(AppSettings.MergeGraphLanesHavingCommonParent)], true, false, true);
+                yield return (properties[nameof(AppSettings.StraightenGraphSegmentsLimit)], 80, false, true);
                 yield return (properties[nameof(AppSettings.LastFormatPatchDir)], string.Empty, true, false);
                 yield return (properties[nameof(AppSettings.IgnoreWhitespaceKind)], IgnoreWhitespaceKind.None, false, true);
                 yield return (properties[nameof(AppSettings.RememberIgnoreWhiteSpacePreference)], true, false, false);


### PR DESCRIPTION
Contributes to #11292
#11451 for vNext with AppSetting 

## Proposed changes

- Do not straighten graph if it is too wide with configurable limit

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).