### PR TITLE
Do not update graph cache if row unavailable

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -61,13 +61,20 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
             bool PaintGraphCell(int rowIndex, Rectangle cellBounds, Graphics graphics)
             {
-                // Draws the required row into _graphBitmap, or retrieves an equivalent one from the cache.
+                // Renders the required row into _graphCache.GraphBitmap if the row is available and not yet cached, and draws it from the cache.
 
                 int height = _graphCache.Capacity * rowHeight;
                 int width = Column.Width;
 
                 if (width <= 0 || height <= 0)
                 {
+                    // Nothing to be drawn
+                    return true;
+                }
+
+                if (_revisionGraph.GetSegmentsForRow(rowIndex) is null)
+                {
+                    // Needs to be refreshed when available
                     return false;
                 }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -306,7 +306,12 @@ namespace GitUI.UserControls.RevisionGrid
                 provider.OnCellPainting(e, revision, _rowHeight, cellStyle);
             }
 
-            e.Handled = true;
+            if (!e.Handled)
+            {
+                e.Handled = true;
+                _forceRefresh = true;
+                UpdateVisibleRowRange();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes regression from #11463
Fixes #9223 (at least, it worked well a few times)

## Proposed changes

- Do not update graph cache if the row is unavailable yet
- Trigger refresh when loaded
- Set `DataGridViewCellPaintingEventArgs.Handled = true` if the cell has zero size (in order to avoid endless refreshes)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

missing graph or some rows drawn from outdated cache

### After

correct graph

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).