### PR TITLE
Splitters: Fix crash when restoring size

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -2231,7 +2231,14 @@ namespace GitUI.CommandsDialogs
             // Account for this shift. This is a workaround at best in the same way as for FormCommit.
             if (!RevisionsSplitContainer.Panel2Collapsed && RevisionsSplitContainer.FixedPanel == FixedPanel.Panel2)
             {
-                RevisionsSplitContainer.SplitterDistance -= 4;
+                try
+                {
+                    RevisionsSplitContainer.SplitterDistance -= 4;
+                }
+                catch (Exception)
+                {
+                    // Catching because bad value can raise an exception
+                }
             }
         }
 


### PR DESCRIPTION
(Should) Fixes #11085

## Test methodology <!-- How did you ensure quality? -->

- None (because I don't have a crash). Looking at stacktrace.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
