### PR TITLE
cancellationToken for Git patch commands

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2175,8 +2175,8 @@ namespace GitCommands
             ObjectId? firstId, ObjectId? secondId,
             string? fileName, string? oldFileName,
             string extraDiffArguments, Encoding encoding,
-            bool cacheResult, bool isTracked = true,
-            CancellationToken cancellationToken = default)
+            bool cacheResult, bool isTracked,
+            CancellationToken cancellationToken)
         {
             // fix refs slashes
             fileName = fileName.ToPosixPath();
@@ -3867,7 +3867,7 @@ namespace GitCommands
                 }).ToList();
         }
 
-        public bool GetCombinedDiffContent(ObjectId revisionOfMergeCommit, string filePath, string extraArgs, Encoding encoding, out string diffOfConflict, CancellationToken cancellationToken = default)
+        public bool GetCombinedDiffContent(ObjectId revisionOfMergeCommit, string filePath, string extraArgs, Encoding encoding, out string diffOfConflict, CancellationToken cancellationToken)
         {
             GitArgumentBuilder args = new("diff-tree")
             {
@@ -3901,7 +3901,7 @@ namespace GitCommands
                 return false;
             }
 
-            diffOfConflict = GetPatch(patches, filePath, filePath).Text ?? "";
+            diffOfConflict = patch.Text ?? "";
             return true;
         }
 

--- a/GitCommands/Git/SubmoduleHelpers.cs
+++ b/GitCommands/Git/SubmoduleHelpers.cs
@@ -12,9 +12,9 @@ namespace GitCommands.Git
         [GeneratedRegex(@"diff --cc (?<filenamea>.+)", RegexOptions.ExplicitCapture)]
         private static partial Regex CombinedDiffCommandRegex();
 
-        public static async Task<GitSubmoduleStatus?> GetCurrentSubmoduleChangesAsync(IGitModule module, string? fileName, string? oldFileName, ObjectId? firstId, ObjectId? secondId)
+        public static async Task<GitSubmoduleStatus?> GetCurrentSubmoduleChangesAsync(IGitModule module, string? fileName, string? oldFileName, ObjectId? firstId, ObjectId? secondId, CancellationToken cancellationToken)
         {
-            (Patch? patch, string? errorMessage) = await module.GetSingleDiffAsync(firstId, secondId, fileName, oldFileName, "", GitModule.SystemEncoding, cacheResult: true, isTracked: true).ConfigureAwait(false);
+            (Patch? patch, string? errorMessage) = await module.GetSingleDiffAsync(firstId, secondId, fileName, oldFileName, "", GitModule.SystemEncoding, cacheResult: true, isTracked: true, cancellationToken: cancellationToken).ConfigureAwait(false);
             return patch is null
                 ? new GitSubmoduleStatus(errorMessage ?? "", null, false, null, null, null, null)
                 : ParseSubmodulePatchStatus(patch, module, fileName);

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -82,13 +82,13 @@ namespace GitUI
 
                 if (!result.ExitedSuccessfully)
                 {
-                    string output = $"{result.StandardError}{Environment.NewLine}Git command (exit code: {result.ExitCode}): {result}{Environment.NewLine}";
+                    string output = $"{result.StandardError}{Environment.NewLine}Git output (exit code: {result.ExitCode}): {Environment.NewLine}{result.StandardOutput}";
                     await fileViewer.ViewTextAsync(item?.Item?.Name, text: output);
                     return;
                 }
 
                 // Try set highlighting from first found filename
-                Match match = FileNameRegex().Match(result.StandardOutput ?? "");
+                Match match = FileNameRegex().Match(result.StandardOutput);
                 string filename = match.Groups["file"].Success ? match.Groups["file"].Value : item.Item.Name;
 
                 cancellationToken.ThrowIfCancellationRequested();

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -71,7 +71,7 @@ namespace GitUI
                     : $"{item.BaseA}..{firstId} {item.BaseB}..{item.SecondRevision.ObjectId}";
                 await fileViewer.ViewTextAsync("git-range-diff.sh", $"git range-diff {range} -- {additionalCommandInfo}");
 
-                string? output = await fileViewer.Module.GetRangeDiffAsync(
+                ExecutionResult result = await fileViewer.Module.GetRangeDiffAsync(
                         firstId,
                         item.SecondRevision.ObjectId,
                         item.BaseA,
@@ -80,13 +80,20 @@ namespace GitUI
                         additionalCommandInfo,
                         cancellationToken);
 
+                if (!result.ExitedSuccessfully)
+                {
+                    string output = $"{result.StandardError}{Environment.NewLine}Git command (exit code: {result.ExitCode}): {result}{Environment.NewLine}";
+                    await fileViewer.ViewTextAsync(item?.Item?.Name, text: output);
+                    return;
+                }
+
                 // Try set highlighting from first found filename
-                Match match = FileNameRegex().Match(output ?? "");
+                Match match = FileNameRegex().Match(result.StandardOutput ?? "");
                 string filename = match.Groups["file"].Success ? match.Groups["file"].Value : item.Item.Name;
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                await fileViewer.ViewRangeDiffAsync(filename, output ?? defaultText);
+                await fileViewer.ViewRangeDiffAsync(filename, result.StandardOutput);
                 return;
             }
 
@@ -116,7 +123,7 @@ namespace GitUI
                     isTracked: item.Item.IsTracked);
             }
 
-            static async Task<string?> GetSelectedPatchAsync(
+            async Task<string?> GetSelectedPatchAsync(
                 FileViewer fileViewer,
                 ObjectId firstId,
                 ObjectId selectedId,
@@ -125,13 +132,20 @@ namespace GitUI
             {
                 if (firstId == ObjectId.CombinedDiffId)
                 {
-                    string diffOfConflict = fileViewer.Module.GetCombinedDiffContent(selectedId, file.Name,
-                        fileViewer.GetExtraDiffArguments(), fileViewer.Encoding);
+                    bool result = fileViewer.Module.GetCombinedDiffContent(selectedId, file.Name,
+                        fileViewer.GetExtraDiffArguments(),
+                        fileViewer.Encoding,
+                        out string diffOfConflict,
+                        cancellationToken);
 
                     cancellationToken.ThrowIfCancellationRequested();
-                    return string.IsNullOrWhiteSpace(diffOfConflict)
-                        ? TranslatedStrings.UninterestingDiffOmitted
-                        : diffOfConflict;
+
+                    return result switch
+                    {
+                        false => defaultText,
+                        true when string.IsNullOrWhiteSpace(diffOfConflict) => TranslatedStrings.UninterestingDiffOmitted,
+                        _ => diffOfConflict
+                    };
                 }
 
                 Task<GitSubmoduleStatus?> task = file.GetSubmoduleStatusAsync();
@@ -148,7 +162,7 @@ namespace GitUI
                 }
 
                 (Patch? patch, string? errorMessage) = await GetItemPatchAsync(fileViewer.Module, file, firstId, selectedId,
-                    fileViewer.GetExtraDiffArguments(), fileViewer.Encoding);
+                    fileViewer.GetExtraDiffArguments(), fileViewer.Encoding, cancellationToken);
 
                 cancellationToken.ThrowIfCancellationRequested();
                 return file.IsSubmodule
@@ -161,12 +175,14 @@ namespace GitUI
                     ObjectId? firstId,
                     ObjectId? secondId,
                     string diffArgs,
-                    Encoding encoding)
+                    Encoding encoding,
+                    CancellationToken cancellationToken)
                 {
                     // Files with tree guid should be presented with normal diff
                     bool isTracked = file.IsTracked || (file.TreeGuid is not null && secondId is not null);
 
-                    return await module.GetSingleDiffAsync(firstId, secondId, file.Name, file.OldName, diffArgs, encoding, true, isTracked);
+                    return await module.GetSingleDiffAsync(firstId, secondId, file.Name, file.OldName, diffArgs, encoding, true, isTracked,
+                        cancellationToken);
                 }
             }
         }

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -242,7 +242,7 @@ namespace GitUIPluginInterfaces
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>the Git output.</returns>
         string GetCustomDiffMergeTools(bool isDiff, CancellationToken cancellationToken);
-        Task<(Patch? patch, string? errorMessage)> GetSingleDiffAsync(ObjectId? firstId, ObjectId? secondId, string? fileName, string? oldFileName, string extraDiffArguments, Encoding encoding, bool cacheResult, bool isTracked);
+        Task<(Patch? patch, string? errorMessage)> GetSingleDiffAsync(ObjectId? firstId, ObjectId? secondId, string? fileName, string? oldFileName, string extraDiffArguments, Encoding encoding, bool cacheResult, bool isTracked, CancellationToken cancellationToken = default);
         int? GetCommitCount(string parent, string child, bool cache, bool throwOnErrorExit);
 
         /// <summary>
@@ -259,7 +259,7 @@ namespace GitUIPluginInterfaces
         bool InTheMiddleOfBisect();
         IReadOnlyList<GitItemStatus> GetDiffFilesWithUntracked(string? firstRevision, string? secondRevision, StagedStatus stagedStatus, bool noCache, CancellationToken cancellationToken);
         bool IsDirtyDir();
-        Task<string> GetRangeDiffAsync(ObjectId firstId, ObjectId secondId, ObjectId? firstBase, ObjectId? secondBase, string extraDiffArguments, string? pathFilter, CancellationToken cancellationToken);
+        Task<ExecutionResult> GetRangeDiffAsync(ObjectId firstId, ObjectId secondId, ObjectId? firstBase, ObjectId? secondBase, string extraDiffArguments, string? pathFilter, CancellationToken cancellationToken);
         bool InTheMiddleOfPatch();
         bool InTheMiddleOfConflictedMerge(bool throwOnErrorExit = true);
         bool InTheMiddleOfAction();
@@ -400,7 +400,7 @@ namespace GitUIPluginInterfaces
         /// </summary>
         IGitVersion GitVersion { get; }
 
-        string? GetCombinedDiffContent(ObjectId revisionOfMergeCommit, string filePath, string extraArgs, Encoding encoding);
+        bool GetCombinedDiffContent(ObjectId revisionOfMergeCommit, string filePath, string extraArgs, Encoding encoding, out string diffOfConflict, CancellationToken cancellationToken = default);
         bool IsMerge(ObjectId objectId);
         IEnumerable<string> GetMergedBranches(bool includeRemote = false);
         Task<string[]> GetMergedBranchesAsync(bool includeRemote, bool fullRefname, string? commit, CancellationToken cancellationToken);

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -242,7 +242,7 @@ namespace GitUIPluginInterfaces
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>the Git output.</returns>
         string GetCustomDiffMergeTools(bool isDiff, CancellationToken cancellationToken);
-        Task<(Patch? patch, string? errorMessage)> GetSingleDiffAsync(ObjectId? firstId, ObjectId? secondId, string? fileName, string? oldFileName, string extraDiffArguments, Encoding encoding, bool cacheResult, bool isTracked, CancellationToken cancellationToken = default);
+        Task<(Patch? patch, string? errorMessage)> GetSingleDiffAsync(ObjectId? firstId, ObjectId? secondId, string? fileName, string? oldFileName, string extraDiffArguments, Encoding encoding, bool cacheResult, bool isTracked, CancellationToken cancellationToken);
         int? GetCommitCount(string parent, string child, bool cache, bool throwOnErrorExit);
 
         /// <summary>
@@ -400,7 +400,7 @@ namespace GitUIPluginInterfaces
         /// </summary>
         IGitVersion GitVersion { get; }
 
-        bool GetCombinedDiffContent(ObjectId revisionOfMergeCommit, string filePath, string extraArgs, Encoding encoding, out string diffOfConflict, CancellationToken cancellationToken = default);
+        bool GetCombinedDiffContent(ObjectId revisionOfMergeCommit, string filePath, string extraArgs, Encoding encoding, out string diffOfConflict, CancellationToken cancellationToken);
         bool IsMerge(ObjectId objectId);
         IEnumerable<string> GetMergedBranches(bool includeRemote = false);
         Task<string[]> GetMergedBranchesAsync(bool includeRemote, bool fullRefname, string? commit, CancellationToken cancellationToken);


### PR DESCRIPTION
Abort Git commands in Diff tab file viewer.

## Proposed changes

Git commands related to the Diff tab did not use cancellation tokens so there could be lingering commands running.

Related to #11494 but diff commands run much quicker so no major impact.

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
