### PR TITLE
Improve and fix plugins loading

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -151,6 +151,7 @@ namespace GitUI.CommandsDialogs
             _addUpstreamRemoteToolStripMenuItem = new ToolStripMenuItem();
             ToolStripFilters = new GitUI.UserControls.FilterToolBar();
             ToolStripScripts = new GitUI.ToolStripEx();
+            pluginsLoadingToolStripMenuItem = new ToolStripMenuItem();
             toolStripSeparator14 = new ToolStripSeparator();
             toolStripSeparator11 = new ToolStripSeparator();
             ToolStripMain.SuspendLayout();
@@ -1280,9 +1281,7 @@ namespace GitUI.CommandsDialogs
             // 
             // pluginsToolStripMenuItem
             // 
-            pluginsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] {
-            toolStripSeparator15,
-            pluginSettingsToolStripMenuItem});
+            pluginsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { pluginsLoadingToolStripMenuItem, toolStripSeparator15, pluginSettingsToolStripMenuItem });
             pluginsToolStripMenuItem.Name = "pluginsToolStripMenuItem";
             pluginsToolStripMenuItem.Size = new Size(58, 20);
             pluginsToolStripMenuItem.Text = "&Plugins";
@@ -1385,6 +1384,13 @@ namespace GitUI.CommandsDialogs
             ToolStripScripts.Size = new Size(43, 25);
             ToolStripScripts.TabIndex = 2;
             ToolStripScripts.Text = "Scripts";
+            // 
+            // pluginsLoadingToolStripMenuItem
+            // 
+            pluginsLoadingToolStripMenuItem.Enabled = false;
+            pluginsLoadingToolStripMenuItem.Name = "pluginsLoadingToolStripMenuItem";
+            pluginsLoadingToolStripMenuItem.Size = new Size(180, 22);
+            pluginsLoadingToolStripMenuItem.Text = "Loading...";
             // 
             // FormBrowse
             // 
@@ -1567,5 +1573,6 @@ namespace GitUI.CommandsDialogs
         private Panel RevisionGridContainer;
         private UserControls.InteractiveGitActionControl notificationBarBisectInProgress;
         private UserControls.InteractiveGitActionControl notificationBarGitActionInProgress;
+        private ToolStripMenuItem pluginsLoadingToolStripMenuItem;
     }
 }

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -272,13 +272,6 @@ namespace GitUI.CommandsDialogs
             MainSplitContainer.Visible = false;
             MainSplitContainer.SplitterDistance = DpiUtil.Scale(260);
 
-            ThreadHelper.FileAndForget(async () =>
-            {
-                PluginRegistry.Initialize();
-                await this.SwitchToMainThreadAsync();
-                RegisterPlugins();
-            });
-
             InitCountArtificial(out _gitStatusMonitor);
 
             _formBrowseMenus = new FormBrowseMenus(mainMenuStrip);
@@ -474,6 +467,13 @@ namespace GitUI.CommandsDialogs
 
             // All app init is done, make all repo related similar to switching repos
             SetGitModule(this, new GitModuleEventArgs(new GitModule(Module.WorkingDir)));
+
+            ThreadHelper.FileAndForget(async () =>
+            {
+                PluginRegistry.Initialize();
+                await this.SwitchToMainThreadAsync();
+                RegisterPlugins();
+            });
         }
 
         protected override void OnActivated(EventArgs e)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -716,6 +716,10 @@ namespace GitUI.CommandsDialogs
             _dashboard.Visible = true;
             _dashboard.BringToFront();
 
+            _createPullRequestsToolStripMenuItem.Enabled = false;
+            _viewPullRequestsToolStripMenuItem.Enabled = false;
+            _addUpstreamRemoteToolStripMenuItem.Enabled = false;
+
             DiagnosticsClient.TrackPageView("Dashboard");
         }
 
@@ -902,6 +906,7 @@ namespace GitUI.CommandsDialogs
                 toolStripSplitStash.Enabled = validBrowseDir && !bareRepository;
                 _createPullRequestsToolStripMenuItem.Enabled = validBrowseDir;
                 _viewPullRequestsToolStripMenuItem.Enabled = validBrowseDir;
+                _addUpstreamRemoteToolStripMenuItem.Enabled = validBrowseDir;
 
                 // repositoryToolStripMenuItem.Visible
                 if (validBrowseDir)

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -1,4 +1,6 @@
+using System;
 using System.ComponentModel.Design;
+using System.Diagnostics;
 using System.Text;
 using GitCommands;
 using GitCommands.Git;
@@ -524,48 +526,64 @@ namespace GitUI
                 return false;
             }
 
+            // Commit dialog can be opened on its own without the main form
+            // If it is opened by itself, we need to ensure plugins are loaded because some of them
+            // may have hooks into the commit flow
+            bool werePluginsRegistered = PluginRegistry.PluginsRegistered;
+
+            try
+            {
+                // Load plugins synchronously
+                // if the commit dialog is opened from the main form, all plugins are already loaded and we return instantly,
+                // if the dialog is loaded on its own, plugins need to be loaded before we load the form
+                if (!werePluginsRegistered)
+                {
+                    PluginRegistry.InitializeForCommitForm();
+                    PluginRegistry.Register(this);
+                }
+            }
+            catch (Exception exception)
+            {
+                // Nothing: we don't want plugin loading to crash the application here
+                Trace.WriteLine(exception);
+            }
+
             bool Action()
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
 
-                // Commit dialog can be opened on its own without the main form
-                // If it is opened by itself, we need to ensure plugins are loaded because some of them
-                // may have hooks into the commit flow
-                bool werePluginsRegistered = PluginRegistry.PluginsRegistered;
-
-                try
+                using FormCommit form = new(this, commitMessage: commitMessage);
+                if (showOnlyWhenChanges)
                 {
-                    // Load plugins synchronously
-                    // if the commit dialog is opened from the main form, all plugins are already loaded and we return instantly,
-                    // if the dialog is loaded on its own, plugins need to be loaded before we load the form
-                    if (!werePluginsRegistered)
-                    {
-                        PluginRegistry.InitializeForCommitForm();
-                        PluginRegistry.Register(this);
-                    }
-
-                    using FormCommit form = new(this, commitMessage: commitMessage);
-                    if (showOnlyWhenChanges)
-                    {
-                        form.ShowDialogWhenChanges(owner);
-                    }
-                    else
-                    {
-                        form.ShowDialog(owner);
-                    }
+                    form.ShowDialogWhenChanges(owner);
                 }
-                finally
+                else
+                {
+                    form.ShowDialog(owner);
+                }
+
+                return true;
+            }
+
+            try
+            {
+                return DoActionOnRepo(owner, Action, changesRepo: false, preEvent: PreCommit, postEvent: PostCommit);
+            }
+            finally
+            {
+                try
                 {
                     if (!werePluginsRegistered)
                     {
                         PluginRegistry.Unregister(this);
                     }
                 }
-
-                return true;
+                catch (Exception exception)
+                {
+                    // Nothing: we don't want plugin loading to crash the application here
+                    Trace.WriteLine(exception);
+                }
             }
-
-            return DoActionOnRepo(owner, Action, changesRepo: false, preEvent: PreCommit, postEvent: PostCommit);
         }
 
         public bool StartInitializeDialog(IWin32Window? owner = null, string? dir = null, EventHandler<GitModuleEventArgs>? gitModuleChanged = null)

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -540,7 +540,7 @@ namespace GitUI
                     // if the dialog is loaded on its own, plugins need to be loaded before we load the form
                     if (!werePluginsRegistered)
                     {
-                        PluginRegistry.Initialize();
+                        PluginRegistry.InitializeAll();
                         PluginRegistry.Register(this);
                     }
 

--- a/GitUI/GitUICommands.cs
+++ b/GitUI/GitUICommands.cs
@@ -540,7 +540,7 @@ namespace GitUI
                     // if the dialog is loaded on its own, plugins need to be loaded before we load the form
                     if (!werePluginsRegistered)
                     {
-                        PluginRegistry.InitializeAll();
+                        PluginRegistry.InitializeForCommitForm();
                         PluginRegistry.Register(this);
                     }
 

--- a/GitUI/Plugin/PluginRegistry.cs
+++ b/GitUI/Plugin/PluginRegistry.cs
@@ -19,7 +19,7 @@ namespace GitUI
 
         public static void InitializeGitHostersOnly()
         {
-            LoadPlugin<IRepositoryHostPlugin>();
+            LoadPlugins<IRepositoryHostPlugin>();
         }
 
         /// <summary>
@@ -33,10 +33,21 @@ namespace GitUI
             }
 
             _isLoaded = true;
-            LoadPlugin<IGitPlugin>();
+            LoadPlugins<IGitPlugin>();
         }
 
-        private static void LoadPlugin<T>() where T : IGitPlugin
+        public static void InitializeForCommitForm()
+        {
+            if (_isLoaded)
+            {
+                return;
+            }
+
+            _isLoaded = true;
+            LoadPlugins<IGitPluginForCommit>();
+        }
+
+        private static void LoadPlugins<T>() where T : IGitPlugin
         {
             try
             {

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2681,6 +2681,10 @@ Do you want to continue?</source>
         <source>Plugin &amp;Settings</source>
         <target />
       </trans-unit>
+      <trans-unit id="pluginsLoadingToolStripMenuItem.Text">
+        <source>Loading...</source>
+        <target />
+      </trans-unit>
       <trans-unit id="pluginsToolStripMenuItem.Text">
         <source>&amp;Plugins</source>
         <target />

--- a/Plugins/GitHub3/GitHub3Plugin.cs
+++ b/Plugins/GitHub3/GitHub3Plugin.cs
@@ -65,6 +65,7 @@ namespace GitExtensions.Plugins.GitHub3
     }
 
     [Export(typeof(IGitPlugin))]
+    [Export(typeof(IRepositoryHostPlugin))]
     public class GitHub3Plugin : GitPluginBase, IRepositoryHostPlugin
     {
         private readonly TranslationString _viewInWebSite = new("View in {0}");

--- a/Plugins/GitUIPluginInterfaces/IGitPluginForCommit.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitPluginForCommit.cs
@@ -1,0 +1,8 @@
+namespace GitUIPluginInterfaces;
+
+/// <summary>
+///  Plugin that will be loaded when FormCommit is opened
+/// </summary>
+public interface IGitPluginForCommit : IGitPluginForRepository
+{
+}

--- a/Plugins/GitUIPluginInterfaces/RepositoryHosts/IRepositoryHostPlugin.cs
+++ b/Plugins/GitUIPluginInterfaces/RepositoryHosts/IRepositoryHostPlugin.cs
@@ -1,21 +1,25 @@
-﻿namespace GitUIPluginInterfaces.RepositoryHosts
+﻿namespace GitUIPluginInterfaces.RepositoryHosts;
+
+/// <summary>
+///  Define that the plugin provides features (clone, ...) related to an online git hosting service.
+///  A plugin implementing this interface **must** have the `Export` attribute declared this way:
+///  [Export(typeof(IRepositoryHostPlugin))]
+/// </summary>
+public interface IRepositoryHostPlugin : IGitPlugin
 {
-    public interface IRepositoryHostPlugin : IGitPlugin
-    {
-        IReadOnlyList<IHostedRepository> SearchForRepository(string search);
-        IReadOnlyList<IHostedRepository> GetRepositoriesOfUser(string user);
-        IHostedRepository GetRepository(string user, string repositoryName);
+    IReadOnlyList<IHostedRepository> SearchForRepository(string search);
+    IReadOnlyList<IHostedRepository> GetRepositoriesOfUser(string user);
+    IHostedRepository GetRepository(string user, string repositoryName);
 
-        IReadOnlyList<IHostedRepository> GetMyRepos();
+    IReadOnlyList<IHostedRepository> GetMyRepos();
 
-        void ConfigureContextMenu(ContextMenuStrip contextMenu);
+    void ConfigureContextMenu(ContextMenuStrip contextMenu);
 
-        bool ConfigurationOk { get; }
+    bool ConfigurationOk { get; }
 
-        bool GitModuleIsRelevantToMe();
-        IReadOnlyList<IHostedRemote> GetHostedRemotesForModule();
-        string? OwnerLogin { get; }
+    bool GitModuleIsRelevantToMe();
+    IReadOnlyList<IHostedRemote> GetHostedRemotesForModule();
+    string? OwnerLogin { get; }
 
-        Task<string?> AddUpstreamRemoteAsync();
-    }
+    Task<string?> AddUpstreamRemoteAsync();
 }

--- a/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
+++ b/Plugins/JiraCommitHintPlugin/JiraCommitHintPlugin.cs
@@ -16,7 +16,8 @@ using RestSharp.Authenticators;
 namespace GitExtensions.Plugins.JiraCommitHintPlugin
 {
     [Export(typeof(IGitPlugin))]
-    public class JiraCommitHintPlugin : GitPluginBase, IGitPluginForRepository
+    [Export(typeof(IGitPluginForCommit))]
+    public class JiraCommitHintPlugin : GitPluginBase, IGitPluginForCommit
     {
         private static readonly TranslationString JiraFieldsLabel = new("Jira fields");
         private static readonly TranslationString QueryHelperLinkText = new("Open the query helper inside Jira");

--- a/TranslationApp/Program.cs
+++ b/TranslationApp/Program.cs
@@ -30,7 +30,7 @@ namespace TranslationApp
             ManagedExtensibility.Initialise();
 
             // Required for translation
-            PluginRegistry.Initialize();
+            PluginRegistry.InitializeAll();
 
             // We will be instantiating a number of forms using their default constructors.
             // This would lead to InvalidOperationException thrown in GitModuleForm().


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Improve on "However, since the startup time of GitExtensions is so long, this feature is ruined for me." of https://github.com/gitextensions/gitextensions/issues/11518#issue-2081522202 (especially the first cold start)

## Proposed changes

- FormBrowse & Dashboard: Plugins start to be loaded a little later so that revision grid loading is not blocked anymore and is displayed more quickly (revision grid displayed around 4s earlier on a cold start)
- Dashboard: 
    - Load only the git hosters plugin (and later the others) making that "Clone GitHub repository" feature appears much more quickly (for that plugins need to export also "IRepositoryHostPlugin" interface)
    - fix state of GitHub menu items
- Form Commit **stand alone** (i.e. launched directly from file explorer): 
    - fix registering of plugins (that never worked)
    - improve performance by loading only "form commit" plugins (plugins need to export also new "IGitPluginForCommit" interface)

## Screenshots <!-- Remove this section if PR does not change UI -->

## Revision grid is not blocked by plugin loading

#### Before

Blank screen in the revision grid during 4 or 5s

![plugins_startup_before_slow](https://github.com/gitextensions/gitextensions/assets/460196/ea0597a2-417b-4119-b382-7f6051c16fd5)

#### After

Revision grid content appears immediately and the plugins are loaded after

Note: Here, to explain the principle, I was "lucky" because in this specific case the cold start was exceptionally long (around 15s to load the plugins) whereas normally it took around 5s. With current plugin loading, I would have waited more than 15s before seeing the revision grid loaded.
![plugins_startup_quick_best](https://github.com/gitextensions/gitextensions/assets/460196/d3ba98d4-3485-42e2-9bfa-d5b3cbdc7c12)

Same but with a usual time:

![plugins_startup_quick_normal](https://github.com/gitextensions/gitextensions/assets/460196/e9f57679-03c8-45db-aace-3a11b4565d62)

## Dashboard: Git provider loading

#### Before

![plugins_dashboard_slow](https://github.com/gitextensions/gitextensions/assets/460196/2016fda2-aea1-4bb6-8300-219c7c6bd894)

Note: I just discovered during the gif that it even slow down retrieving the checked out branches of all the repositories

#### After

![plugins_dashboard_quick](https://github.com/gitextensions/gitextensions/assets/460196/b9c84a5f-86c6-4cf9-bad7-051e44b1d656)


## Dashboard: fix state of GitHub menu items

#### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/337f388f-d4fd-4edc-9359-78d63dfaa0bc)

#### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/9151f4c4-410f-4ac9-a576-9ee7855b4e5b)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 00049fdc9fc67ad0749232d84c886cbf9fb982fe
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22621.0
- .NET 8.0.0
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.21 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 6.0.25 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.14 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.0 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer **rebase** merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
