### PR TITLE
Diff for filtered file between selected commits

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1938,7 +1938,8 @@ namespace GitUI.CommandsDialogs
             OpenCommitsWithDifftool = 35,
             ToggleBetweenArtificialAndHeadCommits = 36,
             GoToChild = 37,
-            GoToParent = 38
+            GoToParent = 38,
+            OpenFilterPathInCommitsWithDifftool = 49,
 
             /* deprecated: RotateApplicationIcon = 14, */
         }
@@ -2055,6 +2056,7 @@ namespace GitUI.CommandsDialogs
                 case Command.StashStaged: UICommands.StashStaged(this); break;
                 case Command.StashPop: UICommands.StashPop(this); break;
                 case Command.OpenCommitsWithDifftool: RevisionGrid.DiffSelectedCommitsWithDifftool(); break;
+                case Command.OpenFilterPathInCommitsWithDifftool: RevisionGrid.DiffFilterPathInSelectedCommitsWithDifftool(); break;
                 case Command.OpenWithDifftool: OpenWithDifftool(); break;
                 case Command.OpenWithDifftoolFirstToLocal: OpenWithDifftoolFirstToLocal(); break;
                 case Command.OpenWithDifftoolSelectedToLocal: OpenWithDifftoolSelectedToLocal(); break;

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -9407,6 +9407,10 @@ See the changes in the commit form.</source>
         <source>Open selected commits with &amp;difftool</source>
         <target />
       </trans-unit>
+      <trans-unit id="openFilterPathInCommitsWithDiffToolMenuItem.Text">
+        <source>Open &amp;filtered file in selected commits with difftool</source>
+        <target />
+      </trans-unit>
       <trans-unit id="openPullRequestPageStripMenuItem.Text">
         <source>Vie&amp;w pull request in a browser</source>
         <target />

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Command.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Command.cs
@@ -49,6 +49,7 @@
             RenameRef = 42,
             CreateSquashCommit = 43,
             CreateAmendCommit = 44,
+            OpenFilterPathInCommitsWithDifftool = 45,
         }
     }
 }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -324,7 +324,7 @@ namespace GitUI
             // 
             openFilterPathInCommitsWithDiffToolMenuItem.Name = "openFilterPathInCommitsWithDiffToolMenuItem";
             openFilterPathInCommitsWithDiffToolMenuItem.Size = new Size(230, 22);
-            openFilterPathInCommitsWithDiffToolMenuItem.Text = "Open filtered file/folder in selected commits with &difftool";
+            openFilterPathInCommitsWithDiffToolMenuItem.Text = "Open &filtered file in selected commits with difftool";
             openFilterPathInCommitsWithDiffToolMenuItem.Click += diffFilterPathInSelectedCommitsMenuItem_Click;
             // 
             // compareStripSeparator

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.Designer.cs
@@ -45,6 +45,7 @@ namespace GitUI
             renameBranchToolStripMenuItem = new ToolStripMenuItem();
             toolStripSeparator4 = new ToolStripSeparator();
             openCommitsWithDiffToolMenuItem = new ToolStripMenuItem();
+            openFilterPathInCommitsWithDiffToolMenuItem = new ToolStripMenuItem();
             compareStripSeparator = new ToolStripSeparator();
             compareToBranchToolStripMenuItem = new ToolStripMenuItem();
             compareToolStripMenuItem = new ToolStripMenuItem();
@@ -319,6 +320,13 @@ namespace GitUI
             openCommitsWithDiffToolMenuItem.Text = "Open selected commits with &difftool";
             openCommitsWithDiffToolMenuItem.Click += diffSelectedCommitsMenuItem_Click;
             // 
+            // openFilterPathInCommitsWithDiffToolMenuItem
+            // 
+            openFilterPathInCommitsWithDiffToolMenuItem.Name = "openFilterPathInCommitsWithDiffToolMenuItem";
+            openFilterPathInCommitsWithDiffToolMenuItem.Size = new Size(230, 22);
+            openFilterPathInCommitsWithDiffToolMenuItem.Text = "Open filtered file/folder in selected commits with &difftool";
+            openFilterPathInCommitsWithDiffToolMenuItem.Click += diffFilterPathInSelectedCommitsMenuItem_Click;
+            // 
             // compareStripSeparator
             // 
             compareStripSeparator.Name = "compareStripSeparator";
@@ -376,6 +384,7 @@ namespace GitUI
             compareToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[]
             {
                 openCommitsWithDiffToolMenuItem,
+                openFilterPathInCommitsWithDiffToolMenuItem,
                 compareStripSeparator,
                 compareToBranchToolStripMenuItem,
                 compareWithCurrentBranchToolStripMenuItem,
@@ -615,6 +624,7 @@ namespace GitUI
         private ToolStripMenuItem bisectSkipRevisionToolStripMenuItem;
         private ToolStripMenuItem viewToolStripMenuItem;
         private ToolStripMenuItem openCommitsWithDiffToolMenuItem;
+        private ToolStripMenuItem openFilterPathInCommitsWithDiffToolMenuItem;
         private ToolStripMenuItem compareToBranchToolStripMenuItem;
         private ToolStripMenuItem compareToolStripMenuItem;
         private ToolStripMenuItem compareWithCurrentBranchToolStripMenuItem;

--- a/contributors.txt
+++ b/contributors.txt
@@ -205,3 +205,4 @@ YYYY/MM/DD, github id, Full name, email
 2023/11/30, snelltheta, Steve Samons, snelltheta(at)gmail.com
 2023/12/01, pmgiant, Pawel Marchewka, ppmmggiiaanntt(at)gmail.com
 2024/01/01, qgppl, Grzegorz Pachocki, g.pachocki(at)wp.pl
+2024/01/26, nikolaosginos, Nikolaos Ginos, nikolaos.gkinos@googlemail.com


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11548

## Proposed changes

- Add button in revision grid context menu to compare the filtered file between two selected commits

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="942" alt="Screenshot 2024-01-26 212646" src="https://github.com/gitextensions/gitextensions/assets/4991936/8abcb8f2-5afd-45be-8398-d6de92b110cd">

### After

<img width="942" alt="Screenshot 2024-01-26 212808" src="https://github.com/gitextensions/gitextensions/assets/4991936/b66a60cb-c832-49f8-b7a7-496b418c4f7d">


## Test methodology <!-- How did you ensure quality? -->

- Manually tested
- Tested with no filtering -> nothing happens
- Tested with only one selected commit -> diff to parent

## Test environment(s) <!-- Remove any that don't apply -->

- GIT 2.43.0.windows.1
- Windows 11 23H2

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
