### PR TITLE
Ignore ListViewGroup accessibility exception

### DIFF
--- a/GitUI/NBugReports/BugReportInvoker.cs
+++ b/GitUI/NBugReports/BugReportInvoker.cs
@@ -109,6 +109,13 @@ namespace GitUI.NBugReports
                 return;
             }
 
+            // Ignore accessibility-specific exception (refer to https://github.com/gitextensions/gitextensions/issues/11385)
+            if (exception is InvalidOperationException && exception.StackTrace?.Contains("ListViewGroup.get_AccessibilityObject") is true)
+            {
+                Trace.WriteLine(exception);
+                return;
+            }
+
             ExternalOperationException externalOperationException = exception as ExternalOperationException;
 
             if (externalOperationException?.InnerException?.Message?.Contains(ExecutableExtensions.DubiousOwnershipSecurityConfigString) is true)


### PR DESCRIPTION
Fixes #11385
(workaround)

## Proposed changes

- Ignore exception from `ListViewGroup.get_AccessibilityObject` which occasionally occurs on `GetFocus` after `OnApplicationActivated` with .NET 8.0.1 yet

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).