### PR TITLE
Improve editors detection

### DIFF
--- a/GitCommands/PathUtil.cs
+++ b/GitCommands/PathUtil.cs
@@ -500,13 +500,9 @@ namespace GitCommands
                     continue;
                 }
 
-                fullName = FindFileInEnvVarFolder("ProgramFiles", location, fileName);
-                if (fullName is not null)
-                {
-                    return fullName;
-                }
-
-                fullName = FindFileInEnvVarFolder("ProgramW6432", location, fileName);
+                fullName = FindFileInEnvVarFolder("LOCALAPPDATA", Path.Combine("Programs", location), fileName)
+                    ?? FindFileInEnvVarFolder("ProgramFiles", location, fileName)
+                    ?? FindFileInEnvVarFolder("ProgramW6432", location, fileName);
                 if (fullName is not null)
                 {
                     return fullName;

--- a/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
@@ -1,56 +1,49 @@
 using GitCommands;
 
-namespace GitUI.CommandsDialogs.SettingsDialog.Pages
+namespace GitUI.CommandsDialogs.SettingsDialog.Pages;
+
+public static class EditorHelper
 {
-    public static class EditorHelper
+    public static string FileEditorCommand
+        => $"\"{AppSettings.GetGitExtensionsFullPath()}\" fileeditor";
+
+    public static string[] GetEditors()
     {
-        public static string FileEditorCommand
-            => $"\"{AppSettings.GetGitExtensionsFullPath()}\" fileeditor";
-
-        public static string[] GetEditors()
+        return new[]
         {
-            return new[]
-            {
-                FileEditorCommand,
-                "vi",
-                "notepad",
-                GetNotepadPP(),
-                GetSublimeText3(),
-                GetVsCode(),
-            };
+            FileEditorCommand,
+            "vi",
+            "notepad",
+            GetNotepadPlusPlus(),
+            GetSublimeText3(),
+            GetVsCode(),
+        };
+    }
+
+    private static string GetNotepadPlusPlus()
+        => GetEditorCommandLine("notepad++.exe", "-multiInst -nosession", "notepad++");
+
+    private static string GetVsCode()
+        => GetEditorCommandLine("code.exe", "--new-window --wait", "Microsoft VS Code");
+
+    // http://stackoverflow.com/questions/8951275/git-config-core-editor-how-to-make-sublime-text-the-default-editor-for-git-on
+    private static string GetSublimeText3()
+        => GetEditorCommandLine("sublime_text.exe", "-w --multiinstance", "Sublime Text 3");
+
+    private static string GetEditorCommandLine(string executableName, string commandLineParameter, params string[] installFolders)
+    {
+        string exec = executableName.FindInFolders(installFolders);
+
+        if (string.IsNullOrEmpty(exec))
+        {
+            // hoping the tool is available in the PATH
+            exec = Path.GetExtension(executableName) == ".exe" ? Path.GetFileNameWithoutExtension(executableName) : executableName;
+        }
+        else
+        {
+            exec = $"\"{exec}\"";
         }
 
-        private static string GetNotepadPP()
-        {
-            return GetEditorCommandLine("notepad++.exe", " -multiInst -nosession", "notepad++");
-        }
-
-        private static string GetVsCode()
-        {
-            return GetEditorCommandLine("code.exe", " --new-window --wait", "Microsoft VS Code");
-        }
-
-        private static string GetSublimeText3()
-        {
-            // http://stackoverflow.com/questions/8951275/git-config-core-editor-how-to-make-sublime-text-the-default-editor-for-git-on
-            return GetEditorCommandLine("sublime_text.exe", " -w --multiinstance", "Sublime Text 3");
-        }
-
-        private static string GetEditorCommandLine(string executableName, string commandLineParameter, params string[] installFolders)
-        {
-            string exec = executableName.FindInFolders(installFolders);
-
-            if (string.IsNullOrEmpty(exec))
-            {
-                // hoping the tool is available in the PATH
-                exec = Path.GetExtension(executableName) == ".exe" ? Path.GetFileNameWithoutExtension(executableName) : executableName;
-            }
-            else
-            {
-                exec = $"\"{exec}\"";
-            }
-
-            return exec + commandLineParameter;
-        }
+        return $"{exec} {commandLineParameter}";
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
@@ -17,7 +17,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 GetNotepadPP(),
                 GetSublimeText3(),
                 GetVsCode(),
-                GetAtom()
             };
         }
 
@@ -29,11 +28,6 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         private static string GetVsCode()
         {
             return GetEditorCommandLine("Visual Studio Code", "code.exe", " --new-window --wait", "Microsoft VS Code");
-        }
-
-        private static string GetAtom()
-        {
-            return GetEditorCommandLine("Atom", "atom.exe", " --wait", "atom");
         }
 
         private static string GetSublimeText3()

--- a/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
@@ -15,7 +15,7 @@ public static class EditorHelper
             "vi",
             "notepad",
             GetNotepadPlusPlus(),
-            GetSublimeText3(),
+            GetSublimeText(),
             GetVsCode(),
         };
     }
@@ -27,8 +27,8 @@ public static class EditorHelper
         => GetEditorCommandLine("code.exe", "--new-window --wait", "Microsoft VS Code");
 
     // http://stackoverflow.com/questions/8951275/git-config-core-editor-how-to-make-sublime-text-the-default-editor-for-git-on
-    private static string GetSublimeText3()
-        => GetEditorCommandLine("sublime_text.exe", "-w --multiinstance", "Sublime Text 3");
+    private static string GetSublimeText()
+        => GetEditorCommandLine("sublime_text.exe", "--new-window --wait", "Sublime Text");
 
     private static string GetEditorCommandLine(string executableName, string commandLineParameter, params string[] installFolders)
     {

--- a/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/EditorHelper.cs
@@ -22,27 +22,28 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private static string GetNotepadPP()
         {
-            return GetEditorCommandLine("Notepad++", "notepad++.exe", " -multiInst -nosession", "notepad++");
+            return GetEditorCommandLine("notepad++.exe", " -multiInst -nosession", "notepad++");
         }
 
         private static string GetVsCode()
         {
-            return GetEditorCommandLine("Visual Studio Code", "code.exe", " --new-window --wait", "Microsoft VS Code");
+            return GetEditorCommandLine("code.exe", " --new-window --wait", "Microsoft VS Code");
         }
 
         private static string GetSublimeText3()
         {
             // http://stackoverflow.com/questions/8951275/git-config-core-editor-how-to-make-sublime-text-the-default-editor-for-git-on
-            return GetEditorCommandLine("SublimeText", "sublime_text.exe", " -w --multiinstance", "Sublime Text 3");
+            return GetEditorCommandLine("sublime_text.exe", " -w --multiinstance", "Sublime Text 3");
         }
 
-        private static string GetEditorCommandLine(string editorName, string executableName, string commandLineParameter, params string[] installFolders)
+        private static string GetEditorCommandLine(string executableName, string commandLineParameter, params string[] installFolders)
         {
             string exec = executableName.FindInFolders(installFolders);
 
             if (string.IsNullOrEmpty(exec))
             {
-                exec = editorName;
+                // hoping the tool is available in the PATH
+                exec = Path.GetExtension(executableName) == ".exe" ? Path.GetFileNameWithoutExtension(executableName) : executableName;
             }
             else
             {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11556

## Proposed changes

- Try to find current user install of a text editor
- Remove "Atom" editor that is no more maintained ( https://github.blog/2022-06-08-sunsetting-atom/ )
- better support for text editor in the PATH

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/b1fdfeb3-0138-499d-952d-cf7419999a80)

### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/9b002475-5710-4f27-a6d5-98226732722d)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 6d2996f15652e8c4cc65f75661e275b3832368c0 (Dirty)
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer **rebase** merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
