### PR TITLE
Improve Form remotes UX

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1655,6 +1655,12 @@ namespace GitCommands
             set => SetInt("history size", value);
         }
 
+        // (Currently) hidden configuration
+        public static int RemotesCacheLength
+        {
+            get => GetInt("RemotesCacheLength", 30);
+        }
+
         public static int RecentReposComboMinWidth
         {
             get => GetInt("RecentReposComboMinWidth", 0);

--- a/GitCommands/UserRepositoryHistory/RemoteRepositoryManager.cs
+++ b/GitCommands/UserRepositoryHistory/RemoteRepositoryManager.cs
@@ -72,16 +72,8 @@ namespace GitCommands.UserRepositoryHistory
         {
             await TaskScheduler.Default;
 
-            // BUG: this must be a separate settings
-            // TODO: to be addressed separately
-            int size = AppSettings.RecentRepositoriesHistorySize;
             IReadOnlyList<Repository> history = _repositoryStorage.Load(KeyRemoteHistory);
-            if (history is null)
-            {
-                return Array.Empty<Repository>();
-            }
-
-            return AdjustHistorySize(history, size).ToList();
+            return history is null ? Array.Empty<Repository>() : AdjustHistorySize(history, AppSettings.RemotesCacheLength).ToList();
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormOpenDirectory.cs
@@ -21,6 +21,8 @@ namespace GitUI.CommandsDialogs.BrowseDialog
 
             IList<Repository> repositoryHistory = ThreadHelper.JoinableTaskFactory.Run(RepositoryHistoryManager.Locals.LoadRecentHistoryAsync);
             _NO_TRANSLATE_Directory.DataSource = GetDirectories(currentModule, repositoryHistory);
+            _NO_TRANSLATE_Directory.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
+
             Load.Select();
             _NO_TRANSLATE_Directory.Focus();
             _NO_TRANSLATE_Directory.Select();

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -247,10 +247,12 @@ Inactive remote is completely invisible to git.");
                 Url.DataSource = repositoryHistory.ToList();
                 Url.DisplayMember = nameof(Repository.Path);
                 Url.SelectedItem = null;
+                Url.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
 
                 comboBoxPushUrl.DataSource = repositoryHistory.ToList();
                 comboBoxPushUrl.DisplayMember = nameof(Repository.Path);
                 comboBoxPushUrl.SelectedItem = null;
+                comboBoxPushUrl.DropDownWidth = Url.DropDownWidth;
 
                 BindRemotes(preselectRemote);
             }

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -24,9 +24,8 @@ namespace GitUI.UserControls
             // Select an option until we get a filter bound.
             SelectShowBranchesFilterOption(selectedIndex: 0);
 
-            tscboBranchFilter.ComboBox.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
-            tstxtRevisionFilter.ComboBox.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
             tstxtRevisionFilter.Items.AddRange(AppSettings.RevisionFilterDropdowns);
+            tstxtRevisionFilter.ComboBox.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
         }
 
         private IRevisionGridFilter RevisionGridFilter
@@ -329,6 +328,7 @@ namespace GitUI.UserControls
                 tscboBranchFilter.Items.Clear();
                 tscboBranchFilter.Items.AddRange(matches);
                 tscboBranchFilter.SelectionStart = index;
+                tscboBranchFilter.ComboBox.ResizeDropDownWidth(AppSettings.BranchDropDownMinWidth, AppSettings.BranchDropDownMaxWidth);
             }
         }
 


### PR DESCRIPTION
## Proposed changes

- increase size of opened dropdowns to be readable
- history should not be dependent of local repo history setting (which is absolutely not related). Hard code a value is enough.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/4f549f84-c171-46f4-9570-b1bb52844cb5)

### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/64b22dfa-138a-4f3d-b088-04f54c7733d7)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 2c067ca81a355d7358514cf6cde9933dd1778996
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer rebase merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
