### PR TITLE
Improve avatar handling perfs

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -598,7 +598,7 @@ namespace GitCommands
 
         public static int AvatarCacheSize
         {
-            get => GetInt("Appearance.AvatarCacheSize", 50);
+            get => GetInt("Appearance.AvatarCacheSize", 200);
             set => SetInt("Appearance.AvatarCacheSize", value);
         }
 

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -558,7 +558,7 @@ namespace GitCommands
 
         #region Avatars
 
-        public static string AvatarImageCachePath => Path.Combine(ApplicationDataPath.Value, "Images\\");
+        public static string AvatarImageCachePath => Path.Combine(LocalApplicationDataPath.Value, "Images\\");
 
         public static AvatarFallbackType AvatarFallbackType
         {

--- a/GitCommands/Settings/AvatarProvider.cs
+++ b/GitCommands/Settings/AvatarProvider.cs
@@ -3,8 +3,8 @@ namespace GitCommands
     public enum AvatarProvider
     {
         // DO NOT RENAME THESE -- doing so will break user preferences
-        Default = 0,
-        Custom,
-        None,
+        Default = 0, // External providers: Gravatar & Github
+        Custom, // External provider: user defined
+        None, // Only fallback are used: result is always the same
     }
 }

--- a/GitUI/Avatars/AvatarDownloader.cs
+++ b/GitUI/Avatars/AvatarDownloader.cs
@@ -65,6 +65,11 @@ namespace GitUI.Avatars
             try
             {
                 using HttpResponseMessage response = await _client.GetAsync(imageUrl);
+                if (!response.IsSuccessStatusCode)
+                {
+                    return null;
+                }
+
                 using Stream imageStream = await response.Content.ReadAsStreamAsync();
                 return Image.FromStream(imageStream);
             }

--- a/GitUI/Avatars/AvatarMemoryCache.cs
+++ b/GitUI/Avatars/AvatarMemoryCache.cs
@@ -21,6 +21,8 @@ namespace GitUI.Avatars
             _cache = new MruCache<(string email, int imageSize), Image>(capacity);
         }
 
+        public bool PerformsIo => false;
+
         /// <inheritdoc />
         public event EventHandler? CacheCleared;
 

--- a/GitUI/Avatars/AvatarMemoryCache.cs
+++ b/GitUI/Avatars/AvatarMemoryCache.cs
@@ -102,6 +102,14 @@ namespace GitUI.Avatars
         {
             lock (_cache)
             {
+                foreach ((string email, int imageSize) key in _cache.Keys)
+                {
+                    if (_cache.TryGetValue(key, out Image cachedImage))
+                    {
+                        cachedImage.Dispose();
+                    }
+                }
+
                 _cache.Clear();
             }
 

--- a/GitUI/Avatars/AvatarService.cs
+++ b/GitUI/Avatars/AvatarService.cs
@@ -112,7 +112,7 @@ namespace GitUI.Avatars
             FileSystemAvatarCache persistentCacheProvider = new(HotSwapProvider);
             AvatarMemoryCache memoryCachedProvider = new(persistentCacheProvider, AppSettings.AvatarCacheSize);
 
-            MultiCacheCleaner cacheCleaner = new(persistentCacheProvider, memoryCachedProvider);
+            MultiCacheCleaner cacheCleaner = new(memoryCachedProvider, persistentCacheProvider);
 
             SafetynetAvatarProvider mainProvider
                 = new(

--- a/GitUI/Avatars/AvatarService.cs
+++ b/GitUI/Avatars/AvatarService.cs
@@ -122,5 +122,10 @@ namespace GitUI.Avatars
 
             return (mainProvider, cacheCleaner);
         }
+
+        public static void UpdateAvatarInitialFontsSettings()
+        {
+            InitialsAvatarProvider.UpdateFontsSettings();
+        }
     }
 }

--- a/GitUI/Avatars/ChainedAvatarProvider.cs
+++ b/GitUI/Avatars/ChainedAvatarProvider.cs
@@ -7,6 +7,8 @@
     {
         private readonly IAvatarProvider[] _avatarProviders;
 
+        public bool PerformsIo => _avatarProviders.Length == 0 ? false : _avatarProviders.Any(p => p.PerformsIo);
+
         public ChainedAvatarProvider(params IAvatarProvider[] avatarProviders)
         {
             _avatarProviders = avatarProviders ?? throw new ArgumentNullException(nameof(avatarProviders));

--- a/GitUI/Avatars/CustomAvatarProvider.UriTemplateResolver.cs
+++ b/GitUI/Avatars/CustomAvatarProvider.UriTemplateResolver.cs
@@ -19,6 +19,8 @@ namespace GitUI.Avatars
         {
             private readonly Func<UriTemplateData, string> _templateResolver;
 
+            public bool PerformsIo => false;
+
             public UriTemplateResolver(string uriTemplate)
             {
                 // create a formatter, so we only have to parse the template once

--- a/GitUI/Avatars/CustomAvatarProvider.cs
+++ b/GitUI/Avatars/CustomAvatarProvider.cs
@@ -21,6 +21,8 @@ namespace GitUI.Avatars
             _subProvider = subProvider ?? throw new ArgumentNullException(nameof(subProvider));
         }
 
+        public bool PerformsIo => true;
+
         /// <inheritdoc/>
         public async Task<Image?> GetAvatarAsync(string email, string? name, int imageSize)
         {

--- a/GitUI/Avatars/FileSystemAvatarCache.cs
+++ b/GitUI/Avatars/FileSystemAvatarCache.cs
@@ -37,9 +37,16 @@ namespace GitUI.Avatars
         /// <inheritdoc />
         public event EventHandler? CacheCleared;
 
+        public bool PerformsIo => true;
+
         /// <inheritdoc />
         public async Task<Image?> GetAvatarAsync(string email, string? name, int imageSize)
         {
+            if (!_inner.PerformsIo)
+            {
+                return await _inner.GetAvatarAsync(email, name, imageSize);
+            }
+
             string path = Path.Combine(_cacheDir, $"{email}.{imageSize}px.png");
 
             Image image = ReadImage();

--- a/GitUI/Avatars/FileSystemAvatarCache.cs
+++ b/GitUI/Avatars/FileSystemAvatarCache.cs
@@ -54,24 +54,14 @@ namespace GitUI.Avatars
 
                 try
                 {
+                    // Workaround to avoid the "A generic error occurred in GDI+." exception when saving
+                    // where copying the image in a new one allows the save on disk to be successful...
+                    using Bitmap newImage = new(image);
                     using Stream output = _fileSystem.File.OpenWrite(path);
-                    image.Save(output, ImageFormat.Png);
+                    newImage.Save(output, ImageFormat.Png);
                 }
                 catch
                 {
-                    // Workaround to avoid the "A generic error occurred in GDI+." exception when saving
-                    // where copying the image in a new one allows the save on disk to be successful...
-                    try
-                    {
-                        using (Bitmap newImage = new(image))
-                        {
-                            using Stream output = _fileSystem.File.OpenWrite(path);
-                            newImage.Save(output, ImageFormat.Png);
-                        }
-                    }
-                    catch
-                    {
-                    }
                 }
             }
 

--- a/GitUI/Avatars/GithubAvatarProvider.cs
+++ b/GitUI/Avatars/GithubAvatarProvider.cs
@@ -29,6 +29,8 @@ namespace GitUI.Avatars
             _onlySupplyNoReply = onlySupplyNoReply;
         }
 
+        public bool PerformsIo => true;
+
         public async Task<Image?> GetAvatarAsync(string email, string? name, int imageSize)
         {
             Uri uri = await BuildAvatarUriAsync(email, imageSize);

--- a/GitUI/Avatars/GravatarProvider.cs
+++ b/GitUI/Avatars/GravatarProvider.cs
@@ -39,6 +39,8 @@ namespace GitUI.Avatars
             _queryString += "&s=";
         }
 
+        public bool PerformsIo => true;
+
         public static bool IsFallbackSupportedByGravatar(AvatarFallbackType fallback)
         {
             return SerializeFallbackType(fallback) is not null;

--- a/GitUI/Avatars/HotSwapAvatarProvider.cs
+++ b/GitUI/Avatars/HotSwapAvatarProvider.cs
@@ -16,6 +16,8 @@ namespace GitUI.Avatars
         /// </summary>
         public IAvatarProvider? Provider { get; set; }
 
+        public bool PerformsIo => Provider?.PerformsIo ?? false;
+
         public Task<Image?> GetAvatarAsync(string email, string? name, int imageSize)
         {
             try

--- a/GitUI/Avatars/IAvatarProvider.cs
+++ b/GitUI/Avatars/IAvatarProvider.cs
@@ -9,5 +9,11 @@
         /// Provides the avatar image for the associated email at the requested size.
         /// </summary>
         Task<Image?> GetAvatarAsync(string email, string? name, int imageSize);
+
+        /// <summary>
+        /// Provider doesn't perform any I/O and can generate an avatar quicker then getting it from a filesystem cache
+        /// and so the filesystem cache can be bypassed.
+        /// </summary>
+        bool PerformsIo { get; }
     }
 }

--- a/GitUI/Avatars/InitialsAvatarProvider.cs
+++ b/GitUI/Avatars/InitialsAvatarProvider.cs
@@ -33,6 +33,8 @@ namespace GitUI.Avatars
             return Task.FromResult<Image?>(avatar);
         }
 
+        public bool PerformsIo => false;
+
         /// <summary>
         /// Calculate the most simpler non-cryptographic deterministic hash (to get the same result every times it is calculated for the same string)
         /// We just need an inexpensive way to convert a string to an integer, and calculating a hash is a good way to do it.

--- a/GitUI/Avatars/InitialsAvatarProvider.cs
+++ b/GitUI/Avatars/InitialsAvatarProvider.cs
@@ -25,9 +25,9 @@ namespace GitUI.Avatars
         /// <inheritdoc/>
         public Task<Image?> GetAvatarAsync(string email, string? name, int imageSize)
         {
-            (string initials, int hashCode) = GetInitialsAndHashCode(email, name);
+            (string initials, int colorIndex) = GetInitialsAndColorIndex(email, name);
 
-            (Brush foregroundBrush, Color backgroundColor) = _avatarColors[hashCode];
+            (Brush foregroundBrush, Color backgroundColor) = _avatarColors[colorIndex];
             Image avatar = DrawText(initials, foregroundBrush, backgroundColor, imageSize);
 
             return Task.FromResult<Image?>(avatar);
@@ -55,7 +55,7 @@ namespace GitUI.Avatars
             }
         }
 
-        protected internal (string? initials, int hashCode) GetInitialsAndHashCode(string email, string? name)
+        protected internal (string? initials, int hashCode) GetInitialsAndColorIndex(string email, string? name)
         {
             (string selectedName, char[] separator) = NameSelector(name, email);
 

--- a/GitUI/Avatars/SafetynetAvatarProvider.cs
+++ b/GitUI/Avatars/SafetynetAvatarProvider.cs
@@ -24,6 +24,8 @@ namespace GitUI.Avatars
             _avatarProvider = avatarProvider ?? throw new ArgumentNullException(nameof(avatarProvider));
         }
 
+        public bool PerformsIo => _avatarProvider.PerformsIo;
+
         public async Task<Image?> GetAvatarAsync(string email, string? name, int imageSize)
         {
             if (imageSize < 1)

--- a/GitUI/Avatars/StaticImageAvatarProvider.cs
+++ b/GitUI/Avatars/StaticImageAvatarProvider.cs
@@ -26,7 +26,7 @@
                     return image;
                 }
 
-                Bitmap resizedImage = new(_image, new Size(imageSize, imageSize));
+                Bitmap resizedImage = new(_image, imageSize, imageSize);
                 _sizeCache.Add(imageSize, resizedImage);
 
                 return resizedImage;

--- a/GitUI/Avatars/StaticImageAvatarProvider.cs
+++ b/GitUI/Avatars/StaticImageAvatarProvider.cs
@@ -11,6 +11,8 @@
             _sizeCache.Add(_image.Height, image);
         }
 
+        public bool PerformsIo => false;
+
         /// <inheritdoc />
         public Task<Image?> GetAvatarAsync(string email, string? name, int imageSize)
         {

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -14,6 +14,7 @@ using GitCommands.Utils;
 using GitExtUtils;
 using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
+using GitUI.Avatars;
 using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.CommandsDialogs.BrowseDialog.DashboardControl;
 using GitUI.CommandsDialogs.WorktreeDialog;
@@ -1492,6 +1493,7 @@ namespace GitUI.CommandsDialogs
             revisionDiff.ReloadHotkeys();
             repoObjectsTree.ReloadHotkeys();
             SetShortcutKeyDisplayStringsFromHotkeySettings();
+            AvatarService.UpdateAvatarInitialFontsSettings();
 
             // Clear the separate caches for diff/merge tools
             ThreadHelper.FileAndForget(() => new CustomDiffMergeToolProvider().ClearAsync(isDiff: false));

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -195,7 +195,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void ClearImageCache_Click(object sender, EventArgs e)
         {
-            ThreadHelper.JoinableTaskFactory.Run(AvatarService.CacheCleaner.ClearCacheAsync);
+            ThreadHelper.FileAndForget(AvatarService.CacheCleaner.ClearCacheAsync);
         }
 
         private void helpTranslate_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/GitUI/UserControls/AvatarControl.cs
+++ b/GitUI/UserControls/AvatarControl.cs
@@ -59,11 +59,11 @@ namespace GitUI
 
         public void ClearCache()
         {
-            this.InvokeAndForget(async () =>
+            ThreadHelper.FileAndForget(async () =>
                     {
                         AvatarService.UpdateAvatarProvider();
-                        await _avatarCacheCleaner.ClearCacheAsync().ConfigureAwait(true);
-                        await UpdateAvatarAsync().ConfigureAwait(false);
+                        await _avatarCacheCleaner.ClearCacheAsync();
+                        await UpdateAvatarAsync();
                     });
         }
 

--- a/GitUI/UserControls/AvatarControl.cs
+++ b/GitUI/UserControls/AvatarControl.cs
@@ -19,8 +19,6 @@ namespace GitUI
             InitializeComponent();
             InitializeComplete();
 
-            clearImagecacheToolStripMenuItem.Click += delegate { ClearCache(); };
-
             foreach (AvatarProvider avatarProvider in EnumHelper.GetValues<AvatarProvider>())
             {
                 ToolStripMenuItem item = new()
@@ -141,13 +139,6 @@ namespace GitUI
 
         private void OnClearCacheClick(object sender, EventArgs e)
         {
-            string email = Email;
-
-            if (string.IsNullOrWhiteSpace(email))
-            {
-                return;
-            }
-
             ClearCache();
         }
 

--- a/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
@@ -63,18 +63,6 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
             if (imageTask.Status != TaskStatus.RanToCompletion)
             {
-                // First time, draw at the good size the placeholder image and cache it
-                if (_placeholderImage is null)
-                {
-                    _placeholderImage = new Bitmap(imageSize, imageSize);
-                    using Graphics g = Graphics.FromImage(_placeholderImage);
-                    g.InterpolationMode = InterpolationMode.HighQualityBicubic;
-                    g.DrawImage(Images.User80, 0, 0, imageSize, imageSize);
-                }
-
-                // and draw this placeholder for now
-                e.Graphics.DrawImageUnscaled(_placeholderImage, rect);
-
                 // Once the image has loaded, invalidate only the avatar area for repaint
                 imageTask.ContinueWith(
                     t =>
@@ -82,6 +70,20 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                         if (t.Status == TaskStatus.RanToCompletion)
                         {
                             _revisionGridView.Invalidate(rect);
+                        }
+                        else
+                        {
+                            // draw the placeholder
+                            // First time, draw at the good size the placeholder image and cache it
+                            if (_placeholderImage is null)
+                            {
+                                _placeholderImage = new Bitmap(imageSize, imageSize);
+                                using Graphics g = Graphics.FromImage(_placeholderImage);
+                                g.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                                g.DrawImage(Images.User80, 0, 0, imageSize, imageSize);
+                            }
+
+                            e.Graphics.DrawImageUnscaled(_placeholderImage, rect);
                         }
 
                         imageTask.Dispose();

--- a/UnitTests/GitUI.Tests/Avatars/AvatarTestBase.cs
+++ b/UnitTests/GitUI.Tests/Avatars/AvatarTestBase.cs
@@ -55,6 +55,7 @@ namespace GitUITests.Avatars
         {
             _inner = Substitute.For<IAvatarProvider>();
 
+            _inner.PerformsIo.Returns(true);
             _inner.GetAvatarAsync(_email1, _name1, _size).Returns(Task.FromResult(_img1));
             _inner.GetAvatarAsync(_email2, _name2, _size).Returns(Task.FromResult(_img2));
             _inner.GetAvatarAsync(_email3, _name3, _size).Returns(Task.FromResult(_img3));

--- a/UnitTests/GitUI.Tests/Avatars/InitialsAvatarGeneratorTests.cs
+++ b/UnitTests/GitUI.Tests/Avatars/InitialsAvatarGeneratorTests.cs
@@ -25,7 +25,7 @@ namespace GitUITests.Avatars
         [TestCase(null, null, "?")]
         public void GetInitialsAndHashCode_return_initials_of_a_user(string email, string name, string expected)
         {
-            (string initials, int _) = new InitialsAvatarProvider().GetInitialsAndHashCode(email, name);
+            (string initials, int _) = new InitialsAvatarProvider().GetInitialsAndColorIndex(email, name);
 
             Assert.AreEqual(expected, initials);
         }


### PR DESCRIPTION
## Proposed changes

- Improve quick scrolling avatar display (that could block UI when the avatar was not in cache due to some potential exceptions raised)
- Don't draw temporary placeholder avatar (less things to do and no visual blink)
- Fix "Clear image cache feature" (and remove double call to clear)
- Cache avatars in %LocalAppData% instead of %AppData% (no roaming for cache data)
- Bypass filesystem cache for initial avatar provider that is quicker that reading cache from filesystem (and so no need to write a file)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 5b7092d88f31ec36a53c000796a8cf2ddb813ab7
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer **rebase** merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
