### PR TITLE
CommitCount: Use HEAD for artificial

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -874,8 +874,9 @@ namespace GitCommands
             return (null, null);
         }
 
-        public string GetCommitCountString(string from, string to)
+        public string GetCommitCountString(ObjectId fromId, string to)
         {
+            string from = fromId.IsArtificial ? "HEAD" : fromId.ToString();
             int? removed = GetCommitCount(from, to);
             int? added = GetCommitCount(to, from);
 

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -480,7 +480,7 @@ namespace GitUI.CommandsDialogs
                         ObjectId? currentCheckout = Module.GetCurrentCheckout();
                         if (currentCheckout is not null)
                         {
-                            aheadBehindInfo = Module.GetCommitCountString(currentCheckout.ToString(), branch);
+                            aheadBehindInfo = Module.GetCommitCountString(currentCheckout, branch);
                         }
 
                         await this.SwitchToMainThreadAsync();

--- a/GitUI/UserControls/BranchSelector.cs
+++ b/GitUI/UserControls/BranchSelector.cs
@@ -119,7 +119,7 @@ namespace GitUI.UserControls
 
                 ThreadHelper.FileAndForget(async () =>
                     {
-                        string text = Module.GetCommitCountString(currentCheckout.ToString(), branchName);
+                        string text = Module.GetCommitCountString(currentCheckout, branchName);
                         await this.SwitchToMainThreadAsync();
                         lbChanges.Text = text;
                     });

--- a/GitUI/UserControls/CommitPickerSmallControl.cs
+++ b/GitUI/UserControls/CommitPickerSmallControl.cs
@@ -57,7 +57,8 @@ namespace GitUI.UserControls
 
                         Validates.NotNull(currentCheckout);
 
-                        string text = Module.GetCommitCountString(currentCheckout.ToString(), SelectedObjectId.ToString());
+                        string toRef = SelectedObjectId.IsArtificial ? "HEAD" : SelectedObjectId.ToString();
+                        string text = Module.GetCommitCountString(currentCheckout, toRef);
 
                         await this.SwitchToMainThreadAsync();
 

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -300,7 +300,7 @@ namespace GitUIPluginInterfaces
         /// <returns>true if <paramref name="branchName"/> is valid reference name, otherwise false.</returns>
         bool CheckBranchFormat(string branchName);
         string? GetLocalTrackingBranchName(string remoteName, string branch);
-        string GetCommitCountString(string from, string to);
+        string GetCommitCountString(ObjectId fromId, string to);
         IReadOnlyList<GitItemStatus> GetAllChangedFilesWithSubmodulesStatus(CancellationToken cancellationToken);
         IReadOnlyList<GitItemStatus> GetAllChangedFilesWithSubmodulesStatus(bool excludeIgnoredFiles, bool excludeAssumeUnchangedFiles, bool excludeSkipWorktreeFiles, UntrackedFilesMode untrackedFiles, CancellationToken cancellationToken);
         bool ResetChanges(ObjectId? resetId, IReadOnlyList<GitItemStatus> selectedItems, bool resetAndDelete, IFullPathResolver fullPathResolver, out StringBuilder output, Action<BatchProgressEventArgs>? progressAction);


### PR DESCRIPTION
Fixes #11562

## Proposed changes

Ahead/Behind are shown in branch picker for instance for Compare,, just for information. If an artificial command is compared, git-rev-list must use HEAD instead.

## Screenshots <!-- Remove this section if PR does not change UI -->

### After

![image](https://github.com/gitextensions/gitextensions/assets/6248932/d186676b-ece9-4182-8d5a-03a75fd65945)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
