### PR TITLE
Quote Git reference names

### DIFF
--- a/GitCommands/CommitDataManager.cs
+++ b/GitCommands/CommitDataManager.cs
@@ -124,7 +124,7 @@ namespace GitCommands
             {
                 "-1",
                 $"--pretty=\"format:{format}\"",
-                commitId
+                commitId.Quote()
             };
 
             // This command can be cached if commitId is a git sha and Notes are ignored

--- a/GitCommands/Git/Commands.Arguments.cs
+++ b/GitCommands/Git/Commands.Arguments.cs
@@ -396,7 +396,7 @@ namespace GitCommands.Git
                 { fullRefname, @"--format=""%(refname)""" },
                 { includeRemote, "-a" },
                 "--merged",
-                commit.Quote()
+                { !string.IsNullOrWhiteSpace(commit), commit.QuoteNE() }
             };
         }
 

--- a/GitCommands/Git/Commands.Arguments.cs
+++ b/GitCommands/Git/Commands.Arguments.cs
@@ -396,7 +396,7 @@ namespace GitCommands.Git
                 { fullRefname, @"--format=""%(refname)""" },
                 { includeRemote, "-a" },
                 "--merged",
-                { !string.IsNullOrWhiteSpace(commit), commit.QuoteNE() }
+                commit.QuoteNE()
             };
         }
 

--- a/GitCommands/Git/Commands.Arguments.cs
+++ b/GitCommands/Git/Commands.Arguments.cs
@@ -396,7 +396,7 @@ namespace GitCommands.Git
                 { fullRefname, @"--format=""%(refname)""" },
                 { includeRemote, "-a" },
                 "--merged",
-                commit
+                commit.Quote()
             };
         }
 

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -816,7 +816,7 @@ namespace GitCommands
         {
             GitArgumentBuilder args = new("ls-tree")
             {
-                refName,
+                refName.Quote(),
                 { !string.IsNullOrWhiteSpace(filename), "--" },
                 filename.QuoteNE()
             };
@@ -834,8 +834,8 @@ namespace GitCommands
 
             GitArgumentBuilder args = new("rev-list")
             {
-                parent,
-                $"^{child}",
+                parent.Quote(),
+                $"^{child}".Quote(),
                 "--count",
                 "--"
             };
@@ -859,7 +859,7 @@ namespace GitCommands
 
             GitArgumentBuilder args = new("rev-list")
             {
-                $"{firstId}...{secondId}",
+                $"{firstId}...{secondId}".Quote(),
                 "--count",
                 "--left-right"
             };
@@ -995,7 +995,7 @@ namespace GitCommands
 
             GitArgumentBuilder args = new("rev-parse")
             {
-                $"{objectId}^@"
+                $"{objectId}^@".Quote()
             };
             return _gitExecutable.Execute(args, cache: GitCommandCache)
                 .StandardOutput
@@ -1053,7 +1053,7 @@ namespace GitCommands
             {
                 "--verify",
                 "--quiet",
-                $"{objectIdPrefix}^{{commit}}"
+                $"{objectIdPrefix}^{{commit}}".Quote()
             };
             ExecutionResult result = _gitExecutable.Execute(args, throwOnErrorExit: false);
             string output = result.StandardOutput.Trim();
@@ -1111,7 +1111,7 @@ namespace GitCommands
                 "--parents",
                 "--no-walk",
                 "--min-parents=2",
-                $"{startRev}..{endRev}"
+                $"{startRev}..{endRev}".Quote(),
             };
 
             // Could fail if pulling interactively from remote where the specified branch does not exist
@@ -2397,7 +2397,7 @@ namespace GitCommands
             // add - optionally stashed - untracked files
             GitArgumentBuilder args = new("log")
             {
-                $"{stashName}^3",
+                $"{stashName}^3".Quote(),
                 "--pretty=format:\"%T\"",
                 "--max-count=1"
             };
@@ -3050,7 +3050,7 @@ namespace GitCommands
         public IReadOnlyList<string> GetFullTree(string id)
         {
             return _gitExecutable.GetOutput(
-                    $"ls-tree -z -r --name-only {id}",
+                    $"ls-tree -z -r --name-only {id.Quote()}",
                     cache: GitCommandCache)
                 .Split(Delimiters.NullAndLineFeed);
         }
@@ -3419,7 +3419,7 @@ namespace GitCommands
             {
                 "-z",
                 $"-n {count}",
-                revision,
+                revision.Quote(),
                 @"--pretty=""format:%B""",
                 { !string.IsNullOrEmpty(authorPattern), string.Concat("--author=\"", authorPattern, "\"") }
             };
@@ -3507,7 +3507,7 @@ namespace GitCommands
             {
                 "--quiet",
                 "--verify",
-                $"\"{revisionExpression}~0\""
+                $"{revisionExpression}~0".Quote()
             };
             ExecutionResult result = _gitExecutable.Execute(args, throwOnErrorExit: false);
 

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -140,7 +140,7 @@ namespace GitCommands
             {
                 "-z",
                 $"--pretty=format:\"{GetLogFormat()}\"",
-                $"{olderCommitHash}~..{newerCommitHash}"
+                $"{olderCommitHash}~..{newerCommitHash}".Quote()
             };
 
             return GetRevisionsFromArguments(arguments, cancellationToken);
@@ -160,7 +160,7 @@ namespace GitCommands
                 "-z",
                 "-1",
                 $"--pretty=format:\"{GetLogFormat(hasNotes: hasNotes)}\"",
-                commitHash
+                commitHash.Quote()
             };
 
             // output can be cached if Git Notes is not included
@@ -275,7 +275,7 @@ namespace GitCommands
                 { AppSettings.RevisionSortOrder == RevisionSortOrder.AuthorDate, "--author-date-order" },
                 { AppSettings.RevisionSortOrder == RevisionSortOrder.Topology, "--topo-order" },
 
-                revisionFilter,
+                revisionFilter.Quote(),
                 "--",
                 { !string.IsNullOrWhiteSpace(pathFilter), pathFilter }
             };

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -275,7 +275,7 @@ namespace GitCommands
                 { AppSettings.RevisionSortOrder == RevisionSortOrder.AuthorDate, "--author-date-order" },
                 { AppSettings.RevisionSortOrder == RevisionSortOrder.Topology, "--topo-order" },
 
-                revisionFilter.Quote(),
+                revisionFilter,
                 "--",
                 { !string.IsNullOrWhiteSpace(pathFilter), pathFilter }
             };

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -2381,7 +2381,7 @@ namespace GitUI.CommandsDialogs
                     {
                         "--pretty=format:\"    %m %h - %s\"",
                         "--no-merges",
-                        $"{from}...{to}"
+                        $"{from}...{to}".Quote()
                     };
 
                     string log = module.GitExecutable.GetOutput(args);

--- a/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
+++ b/Plugins/DeleteUnusedBranches/DeleteUnusedBranchesForm.cs
@@ -99,7 +99,7 @@ namespace GitExtensions.Plugins.DeleteUnusedBranches
                 {
                     "--pretty=\"format:%ci\n%an\n%s\"",
                     "--max-count=1",
-                    branchName,
+                    branchName.Quote(),
                     "--"
                 };
 

--- a/Plugins/FindLargeFiles/FindLargeFilesForm.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesForm.cs
@@ -182,7 +182,7 @@ namespace GitExtensions.Plugins.FindLargeFiles
                 GitArgumentBuilder args = new("ls-tree")
                 {
                     "-zrl",
-                    rev
+                    rev.Quote()
                 };
                 string[] objects = _gitCommands.GitExecutable.GetOutput(args).Split(new[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (string objData in objects)

--- a/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
@@ -375,7 +375,7 @@ namespace GitCommandsTests_Git
 
         [Test]
         public void MergedBranchesCmd([Values(true, false)] bool includeRemote, [Values(true, false)] bool fullRefname,
-             [Values(null, "", " ", "HEAD", "1234567890")] string commit)
+             [Values(null, "", "HEAD", "1234567890")] string commit)
         {
             string formatArg = fullRefname ? @" --format=""%(refname)""" : string.Empty;
             string remoteArg = includeRemote ? " -a" : string.Empty;

--- a/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
+++ b/UnitTests/GitCommands.Tests/Git/CommandsTests.cs
@@ -379,7 +379,7 @@ namespace GitCommandsTests_Git
         {
             string formatArg = fullRefname ? @" --format=""%(refname)""" : string.Empty;
             string remoteArg = includeRemote ? " -a" : string.Empty;
-            string commitArg = string.IsNullOrWhiteSpace(commit) ? string.Empty : $" {commit}";
+            string commitArg = string.IsNullOrWhiteSpace(commit) ? string.Empty : $" {commit.Quote()}";
             string expected = $"branch{formatArg}{remoteArg} --merged{commitArg}";
 
             Assert.AreEqual(expected, Commands.MergedBranches(includeRemote, fullRefname, commit).Arguments);

--- a/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -436,7 +436,7 @@ namespace GitCommandsTests
         {
             GitArgumentBuilder args = new("rev-parse")
             {
-                $"{Sha1}^@"
+                $"{Sha1}^@".Quote()
             };
 
             using (_executable.StageOutput(


### PR DESCRIPTION
Fixes #11567

## Proposed changes

Quote reference names for several commands handling Git references that has quite open rules for references, including quotes and parenthesis.
https://git-scm.com/docs/git-check-ref-format#_description

I scanned for some commands I could think of in addition to ls-tree, but there could be more. Most occurrences should be handled already.
ObjectId does not need quoting.

## Test methodology <!-- How did you ensure quality? -->

Minimal manual tests.
Note that tests did not have to be updated.
## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
