### PR TITLE
GitCommandLog: Hide '-c option="value with space"'

### DIFF
--- a/GitCommands/Logging/CommandLog.cs
+++ b/GitCommands/Logging/CommandLog.cs
@@ -66,7 +66,7 @@ namespace GitCommands.Logging
 
     public sealed partial class CommandLogEntry
     {
-        [GeneratedRegex(@"((-c +[^ ]+)|(--no-optional-locks)) *", RegexOptions.ExplicitCapture)]
+        [GeneratedRegex(@"((-c +[^ ""]+(""[^""]*"")?)|(--no-optional-locks)) *", RegexOptions.ExplicitCapture)]
         private static partial Regex GitArgumentsWithoutConfigurationRegex();
 
         public string FileName { get; }

--- a/GitCommands/Logging/CommandLog.cs
+++ b/GitCommands/Logging/CommandLog.cs
@@ -102,12 +102,12 @@ namespace GitCommands.Logging
                 if (FileName.StartsWith("wsl "))
                 {
                     fileName = "wsl";
-                    arguments = GitArgumentsWithoutConfigurationRegex().Replace(Arguments, "");
+                    arguments = GitArgumentsWithoutConfigurationRegex().Replace(Arguments, "").TrimEnd();
                 }
                 else if (FileName.EndsWith("git.exe"))
                 {
                     fileName = "git";
-                    arguments = GitArgumentsWithoutConfigurationRegex().Replace(Arguments, "");
+                    arguments = GitArgumentsWithoutConfigurationRegex().Replace(Arguments, "").TrimEnd();
                 }
                 else
                 {

--- a/UnitTests/GitCommands.Tests/CommandLogTests.cs
+++ b/UnitTests/GitCommands.Tests/CommandLogTests.cs
@@ -1,0 +1,24 @@
+﻿using FluentAssertions;
+using GitCommands.Logging;
+
+namespace GitCommandsTests;
+
+[TestFixture]
+public class CommandLogTests
+{
+    [TestCase("", "")]
+    [TestCase(@"verb -c config", "verb")]
+    [TestCase(@"-c config verb", "verb")]
+    [TestCase(@"-c config --no-optional-locks verb", "verb")]
+    [TestCase(@"-c config1 -c config2=x verb", "verb")]
+    [TestCase(@"-c config1 -c config2 x verb", "x verb")]
+    [TestCase(@"-c config=""value with space"" verb", "verb")]
+    // Not needed and not implemented yet. It just removes '-c core.xxx=""something with \""' at the moment.
+    [TestCase(@"-c core.xxx=""something with \""value1 in escaped quotes\"" \""value2\"""" verb", @"value1 in escaped quotes\"" \""value2\"""" verb")]
+    public void CommanLogEntry_ColumnLine(string arguments, string expectedMainArguments)
+    {
+        const string gitExecutable = "somegit.exe";
+        CommandLogEntry commandLogEntry = new(gitExecutable, arguments, workingDir: "", startedAt: DateTime.MinValue, isOnMainThread: true);
+        commandLogEntry.ColumnLine.Should().Be($"00:00:00.000   running         UI     git {expectedMainArguments}");
+    }
+}


### PR DESCRIPTION
## Proposed changes

- GitCommandLog: Detect git configuration options like '-c option="value with space"' and hide them in the list (as other configuration options, too)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/36601201/7840ab12-9e85-4d17-9e00-2a395eaf51ff)

### After

![image](https://github.com/gitextensions/gitextensions/assets/36601201/9db4aa96-9fab-40c7-b464-14cd9ae20c19)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).