### PR TITLE
Fix FormCherryPick sizing

### DIFF
--- a/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.Designer.cs
@@ -55,6 +55,8 @@ namespace GitUI.CommandsDialogs
             // 
             // MainPanel
             // 
+            MainPanel.AutoSize = true;
+            MainPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             MainPanel.Controls.Add(tlpnlMain);
             MainPanel.Size = new Size(614, 379);
             MainPanel.TabIndex = 0;

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -28,6 +28,12 @@ namespace GitUI.CommandsDialogs
         {
             Revision = revision;
             InitializeComponent();
+
+            columnHeader1.Width = DpiUtil.Scale(columnHeader1.Width);
+            columnHeader2.Width = DpiUtil.Scale(columnHeader2.Width);
+            columnHeader3.Width = DpiUtil.Scale(columnHeader3.Width);
+            columnHeader4.Width = DpiUtil.Scale(columnHeader4.Width);
+
             InitializeComplete();
 
             _lblParentsControlHeight = lblParents.Size.Height;

--- a/GitUI/CommandsDialogs/FormCherryPick.cs
+++ b/GitUI/CommandsDialogs/FormCherryPick.cs
@@ -1,6 +1,7 @@
 ﻿using GitCommands;
 using GitCommands.Git;
 using GitExtUtils;
+using GitExtUtils.GitUI;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
 using ResourceManager;
@@ -15,6 +16,10 @@ namespace GitUI.CommandsDialogs
         #endregion
 
         private bool _isMerge;
+        private int _lblParentsControlHeight;
+        private int _lvParentsListControlHeight;
+
+        private const int _parentsListItemHeight = 18;
 
         public GitRevision? Revision { get; set; }
 
@@ -23,8 +28,10 @@ namespace GitUI.CommandsDialogs
         {
             Revision = revision;
             InitializeComponent();
-            Size = MinimumSize;
             InitializeComplete();
+
+            _lblParentsControlHeight = lblParents.Size.Height;
+            _lvParentsListControlHeight = lvParentsList.Size.Height;
         }
 
         private void Form_Load(object sender, EventArgs e)
@@ -57,7 +64,7 @@ namespace GitUI.CommandsDialogs
         {
             try
             {
-                tlpnlMain.SuspendLayout();
+                SuspendLayout();
 
                 commitSummaryUserControl1.Revision = Revision;
 
@@ -68,8 +75,22 @@ namespace GitUI.CommandsDialogs
                     _isMerge = Module.IsMerge(Revision.ObjectId);
                 }
 
-                lblParents.Visible = _isMerge;
-                lvParentsList.Visible = _isMerge;
+                // We need to hide these optional components first to get a correct base value of PreferredMinimumHeight
+                lblParents.Visible = false;
+                lvParentsList.Visible = false;
+
+                if (_isMerge)
+                {
+                    MinimumSize = new Size(MinimumSize.Width, PreferredMinimumHeight + _lblParentsControlHeight + _lvParentsListControlHeight);
+                    Size = MinimumSize;
+                    lblParents.Visible = true;
+                    lvParentsList.Visible = true;
+                }
+                else
+                {
+                    MinimumSize = new Size(MinimumSize.Width, PreferredMinimumHeight - _lblParentsControlHeight - _lvParentsListControlHeight);
+                    Size = MinimumSize;
+                }
 
                 if (_isMerge && Revision is not null)
                 {
@@ -80,23 +101,24 @@ namespace GitUI.CommandsDialogs
                         lvParentsList.Items.Add(new ListViewItem((i + 1).ToString())
                         {
                             SubItems =
-                        {
-                            parents[i].Subject,
-                            parents[i].Author,
-                            parents[i].CommitDate.ToShortDateString()
-                        }
+                            {
+                                parents[i].Subject,
+                                parents[i].Author,
+                                parents[i].CommitDate.ToShortDateString()
+                            }
                         });
                     }
 
                     lvParentsList.TopItem.Selected = true;
                     Size size = MinimumSize;
-                    size.Height += 100;
+                    size.Height += DpiUtil.Scale(_parentsListItemHeight * (parents.Count - 1));
+                    Size = size;
                     MinimumSize = size;
                 }
             }
             finally
             {
-                tlpnlMain.ResumeLayout(performLayout: true);
+                ResumeLayout(performLayout: true);
             }
         }
 

--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -8,7 +8,7 @@
 
     <!--
     For debug purposes uncomment these lines:
-    
+
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>
     -->
@@ -40,7 +40,7 @@
     <ProjectReference Include="..\ResourceManager\ResourceManager.csproj" />
     <ProjectReference Include="..\Plugins\GitUIPluginInterfaces\GitUIPluginInterfaces.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\GitExtensions.Analyzers.CSharp\GitExtensions.Analyzers.CSharp.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

FormCherryPick has at least two problems with high DPI screens. First, its default size hides one of the checkboxes and for merge-commits hides parent commit info. Second, parent commit info header width is not scaled.

- Fix form's height calculation to work with both 100% and other scaling factors.
- Scale column header width manually

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
https://github.com/gitextensions/gitextensions/assets/483659/fa51dbe7-d5e0-4130-962b-1c7d796c7805


### After
https://github.com/gitextensions/gitextensions/assets/483659/7e681e59-92dd-4b08-bffe-c363104ad67b


## Test methodology <!-- How did you ensure quality? -->

- Manually with 100% 125% 150% 200% scaling factors

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11
- Scaling: 100% 125% 150% 200%

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
