### PR TITLE
Refactor `ColumnProvider.Refresh`

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/AuthorNameColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/AuthorNameColumnProvider.cs
@@ -27,7 +27,10 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             };
         }
 
-        public override void Refresh(int rowHeight, in VisibleRowRange range) => Column.Visible = AppSettings.ShowAuthorNameColumn;
+        public override void ApplySettings()
+        {
+            Column.Visible = AppSettings.ShowAuthorNameColumn;
+        }
 
         public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {

--- a/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/AvatarColumnProvider.cs
@@ -37,7 +37,10 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             };
         }
 
-        public override void Refresh(int rowHeight, in VisibleRowRange range) => Column.Visible = AppSettings.ShowAuthorAvatarColumn;
+        public override void ApplySettings()
+        {
+            Column.Visible = AppSettings.ShowAuthorAvatarColumn;
+        }
 
         public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {

--- a/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/BuildStatusColumnProvider.cs
@@ -37,7 +37,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             };
         }
 
-        public override void Refresh(int rowHeight, in VisibleRowRange range)
+        public override void ApplySettings()
         {
             bool showIcon = AppSettings.ShowBuildStatusIconColumn;
             bool showText = AppSettings.ShowBuildStatusTextColumn;

--- a/GitUI/UserControls/RevisionGrid/Columns/ColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/ColumnProvider.cs
@@ -17,11 +17,17 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         /// <summary>The display friendly name of this column.</summary>
         public string Name { get; }
 
-        protected ColumnProvider(string name) => Name = name;
-
-        public virtual void Refresh(int rowHeight, in VisibleRowRange range) => Column.Visible = true;
-
         public int Index => Column.Index;
+
+        protected ColumnProvider(string name)
+        {
+            Name = name;
+        }
+
+        public virtual void ApplySettings()
+        {
+            Column.Visible = true;
+        }
 
         public virtual void Clear()
         {
@@ -48,7 +54,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         /// <remarks>Returning <c>false</c> here will not stop a tool tip being automatically displayed for truncated text.</remarks>
         public virtual bool TryGetToolTip(DataGridViewCellMouseEventArgs e, GitRevision revision, [NotNullWhen(returnValue: true)] out string? toolTip)
         {
-            toolTip = default;
+            toolTip = null;
             return false;
         }
     }

--- a/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/CommitIdColumnProvider.cs
@@ -28,7 +28,10 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             };
         }
 
-        public override void Refresh(int rowHeight, in VisibleRowRange range) => Column.Visible = AppSettings.ShowObjectIdColumn;
+        public override void ApplySettings()
+        {
+            Column.Visible = AppSettings.ShowObjectIdColumn;
+        }
 
         public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {

--- a/GitUI/UserControls/RevisionGrid/Columns/DateColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/DateColumnProvider.cs
@@ -26,7 +26,10 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             };
         }
 
-        public override void Refresh(int rowHeight, in VisibleRowRange range) => Column.Visible = AppSettings.ShowDateColumn;
+        public override void ApplySettings()
+        {
+            Column.Visible = AppSettings.ShowDateColumn;
+        }
 
         public override void OnCellPainting(DataGridViewCellPaintingEventArgs e, GitRevision revision, int rowHeight, in CellStyle style)
         {

--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -194,22 +194,14 @@ namespace GitUI.UserControls.RevisionGrid.Columns
             }
         }
 
+        public override void ApplySettings()
+        {
+            Column.Visible = AppSettings.ShowRevisionGridGraphColumn;
+        }
+
         public override void Clear()
         {
             _graphCache.Reset();
-        }
-
-        public override void Refresh(int rowHeight, in VisibleRowRange range)
-        {
-            // Hide graph column when there it is disabled
-            Column.Visible = AppSettings.ShowRevisionGridGraphColumn;
-            if (!Column.Visible)
-            {
-                return;
-            }
-
-            _graphCache.Reset();
-            Column.Width = CalculateGraphColumnWidth(range);
         }
 
         public override void OnColumnWidthChanged(DataGridViewColumnEventArgs e)
@@ -231,6 +223,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
 
             // Keep an extra page in the cache
             _graphCache.AdjustCapacity((range.Count * 2) + 1);
+
             int width = CalculateGraphColumnWidth(range);
             if (Column.Width != width)
             {

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -119,23 +119,7 @@ namespace GitUI.UserControls.RevisionGrid
                 }
             };
 
-            _revisionGraph.Updated += () =>
-            {
-                // We have to post this since the thread owns a lock on GraphData that we'll
-                // need in order to re-draw the graph.
-                this.InvokeAndForget(() =>
-                    {
-                        DebugHelpers.Assert(_rowHeight != 0, "_rowHeight != 0");
-
-                        // Refresh column providers
-                        foreach (ColumnProvider columnProvider in _columnProviders)
-                        {
-                            columnProvider.Refresh(_rowHeight, _visibleRowRange);
-                        }
-
-                        Invalidate();
-                    });
-            };
+            _revisionGraph.Updated += () => this.InvokeAndForget(Invalidate);
 
             VirtualMode = true;
             Clear();
@@ -663,19 +647,26 @@ namespace GitUI.UserControls.RevisionGrid
                 return;
             }
 
+            if (_forceRefresh)
+            {
+                // Always set _backgroundScrollTo in order to stop the background thread
+                _backgroundScrollTo = -1;
+
+                // The graph cache must be cleared at once
+                foreach (ColumnProvider columnProvider in _columnProviders)
+                {
+                    columnProvider.Clear();
+                }
+            }
+
             _backgroundUpdater.ScheduleExcecution();
         }
 
         private async Task UpdateVisibleRowRangeInternalAsync()
         {
             int fromIndex = Math.Max(0, FirstDisplayedScrollingRowIndex);
-            int visibleRowCount = _rowHeight <= 0 ? 0 : (Height + _rowHeight - 1) / _rowHeight; // Rounding up integer division: (a+b-1)/b = ceil(a/b)
+            int visibleRowCount = DisplayedRowCount(includePartialRow: true);
             visibleRowCount = Math.Min(_revisionGraph.Count - fromIndex, visibleRowCount);
-
-            if (_forceRefresh)
-            {
-                _backgroundScrollTo = -1;
-            }
 
             if (_forceRefresh || _visibleRowRange.FromIndex != fromIndex || _visibleRowRange.Count != visibleRowCount)
             {
@@ -741,18 +732,23 @@ namespace GitUI.UserControls.RevisionGrid
             }
         }
 
-        public override void Refresh()
+        public void ApplySettings()
         {
             InitFonts();
-
             UpdateRowHeight();
-            UpdateVisibleRowRange();
 
-            // Refresh column providers
             foreach (ColumnProvider columnProvider in _columnProviders)
             {
-                columnProvider.Refresh(_rowHeight, _visibleRowRange);
+                columnProvider.ApplySettings();
             }
+
+            Refresh();
+        }
+
+        public override void Refresh()
+        {
+            _forceRefresh = true;
+            UpdateVisibleRowRange();
 
             base.Refresh();
         }

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -524,7 +524,7 @@ namespace GitUI
                 _lastVisibleResizableColumn.Resizable = DataGridViewTriState.True;
             }
 
-            _gridView.Refresh(); // columns could change their Resizable state, e.g. the BuildStatusColumnProvider
+            _gridView.ApplySettings(); // columns could change their Resizable state, e.g. the BuildStatusColumnProvider
 
             base.Refresh();
 


### PR DESCRIPTION
## Proposed changes

- Split `ColumnProvider.Refresh` into `ApplySettings` and `Clear`
  because the former conglomerate resulted in redundancies with `RevisionGraphColumnProvider.OnVisibleRowsChanged`
- Extract `RevisionDataGridView.ApplySettings` from `Refresh`
  because there is no need to re-apply all `ColumnProvider` settings on every graph loading update. (This saves lots of accesses to `AppSettings` and `GetEffectiveSettings`.)

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).