### PR TITLE
Add a default shortcut for "CreateSquashCommit"

### DIFF
--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -283,7 +283,7 @@ namespace GitUI.Hotkey
                     Hk(RevisionGridControl.Command.CompareToWorkingDirectory, Keys.Control | Keys.D),
                     Hk(RevisionGridControl.Command.CreateAmendCommit, Keys.None),
                     Hk(RevisionGridControl.Command.CreateFixupCommit, Keys.Control | Keys.X),
-                    Hk(RevisionGridControl.Command.CreateSquashCommit, Keys.None),
+                    Hk(RevisionGridControl.Command.CreateSquashCommit, Keys.Control | Keys.Shift | Keys.X),
                     Hk(RevisionGridControl.Command.DeleteRef, Keys.Delete),
                     Hk(RevisionGridControl.Command.GoToChild, Keys.Control | Keys.N),
                     Hk(RevisionGridControl.Command.GoToCommit, Keys.Control | Keys.Shift | Keys.G),


### PR DESCRIPTION
## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

(no shortcut)

### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/c2da8ae5-898a-40c3-9164-a6a57a7ed042)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build ebc7f90a509b388f0939e8f6ecac6524fd036adb
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
