### PR TITLE
Avoid test hangs due to grid background task

### DIFF
--- a/GitExtUtils/GitUI/TaskManager.cs
+++ b/GitExtUtils/GitUI/TaskManager.cs
@@ -131,7 +131,14 @@ namespace GitUI
 
         public async Task JoinPendingOperationsAsync(CancellationToken cancellationToken)
         {
-            await _joinableTaskCollection.JoinTillEmptyAsync(cancellationToken);
+            try
+            {
+                await _joinableTaskCollection.JoinTillEmptyAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine(ex);
+            }
         }
 
         public void JoinPendingOperations()
@@ -141,7 +148,7 @@ namespace GitUI
 
             // Note that JoinableTaskContext.Factory must be used to bypass the default behavior of JoinableTaskFactory
             // since the latter adds new tasks to the collection and would therefore never complete.
-            JoinableTaskContext.Factory.Run(() => _joinableTaskCollection.JoinTillEmptyAsync(cancellationTokenSource.Token));
+            JoinableTaskContext.Factory.Run(() => JoinPendingOperationsAsync(cancellationTokenSource.Token));
         }
 
         /// <summary>

--- a/GitExtUtils/GitUI/TaskManager.cs
+++ b/GitExtUtils/GitUI/TaskManager.cs
@@ -136,9 +136,12 @@ namespace GitUI
 
         public void JoinPendingOperations()
         {
+            const int maxWaitMilliseconds = 60_000;
+            using CancellationTokenSource cancellationTokenSource = new(maxWaitMilliseconds);
+
             // Note that JoinableTaskContext.Factory must be used to bypass the default behavior of JoinableTaskFactory
             // since the latter adds new tasks to the collection and would therefore never complete.
-            JoinableTaskContext.Factory.Run(_joinableTaskCollection.JoinTillEmptyAsync);
+            JoinableTaskContext.Factory.Run(() => _joinableTaskCollection.JoinTillEmptyAsync(cancellationTokenSource.Token));
         }
 
         /// <summary>

--- a/GitExtUtils/GitUI/ThreadHelper.cs
+++ b/GitExtUtils/GitUI/ThreadHelper.cs
@@ -22,6 +22,9 @@ namespace GitUI
 
         public static JoinableTaskFactory JoinableTaskFactory => _taskManager.JoinableTaskFactory;
 
+        internal static void CancelSwitchToMainThread()
+            => TaskManager.CancelSwitchToMainThread();
+
         public static ExclusiveTaskRunner CreateExclusiveTaskRunner()
             => new(_taskManager);
 

--- a/GitExtUtils/GitUI/ThreadHelper.cs
+++ b/GitExtUtils/GitUI/ThreadHelper.cs
@@ -105,9 +105,6 @@ namespace GitUI
         public static async Task JoinPendingOperationsAsync(CancellationToken cancellationToken)
             => await _taskManager.JoinPendingOperationsAsync(cancellationToken);
 
-        public static void JoinPendingOperations()
-            => _taskManager.JoinPendingOperations();
-
         public static T CompletedResult<T>(this Task<T> task)
         {
             if (!task.IsCompleted)

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -522,6 +522,7 @@ namespace GitUI.CommandsDialogs
         protected override void OnClosed(EventArgs e)
         {
             PluginRegistry.Unregister(UICommands);
+            RevisionGrid.CancelBackgroundTasks();
             base.OnClosed(e);
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -254,6 +254,13 @@ namespace GitUI
                 .FirstOrDefault(column => column.Resizable == DataGridViewTriState.True && column.AutoSizeMode == DataGridViewAutoSizeColumnMode.Fill);
         }
 
+        internal void CancelBackgroundTasks()
+        {
+            _customDiffToolsSequence.CancelCurrent();
+            _refreshRevisionsSequence.CancelCurrent();
+            _gridView.CancelBackgroundTasks();
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.Remotes.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.Remotes.cs
@@ -178,7 +178,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             Assert.IsFalse(form.MainSplitContainer.Panel1Collapsed);
 
             // Await all async operation such as load of branches and remotes in the left panel
-            ThreadHelper.JoinPendingOperations();
+            AsyncTestHelper.JoinPendingOperations();
 
             GitUI.UserControls.NativeTreeView treeView = form.GetTestAccessor().RepoObjectsTree.GetTestAccessor().TreeView;
             TreeNode remotesNode = treeView.Nodes.OfType<TreeNode>().FirstOrDefault(n => n.Text == TranslatedStrings.Remotes);

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -271,20 +271,14 @@ namespace GitExtensions.UITests.CommandsDialogs
 
             RunFormTest(async form =>
             {
-                using (CancellationTokenSource cts = new(AsyncTestHelper.UnexpectedTimeout))
-                {
-                    await ThreadHelper.JoinPendingOperationsAsync(cts.Token);
-                }
+                await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
 
                 Assert.AreEqual("Stage all", form.GetTestAccessor().StageAllToolItem.ToolTipText);
             });
 
             RunFormTest(async form =>
             {
-                using (CancellationTokenSource cts = new(AsyncTestHelper.UnexpectedTimeout))
-                {
-                    await ThreadHelper.JoinPendingOperationsAsync(cts.Token);
-                }
+                await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
 
                 FormCommit.TestAccessor testform = form.GetTestAccessor();
 
@@ -314,20 +308,14 @@ namespace GitExtensions.UITests.CommandsDialogs
 
             RunFormTest(async form =>
             {
-                using (CancellationTokenSource cts = new(AsyncTestHelper.UnexpectedTimeout))
-                {
-                    await ThreadHelper.JoinPendingOperationsAsync(cts.Token);
-                }
+                await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
 
                 Assert.AreEqual("Unstage all", form.GetTestAccessor().UnstageAllToolItem.ToolTipText);
             });
 
             RunFormTest(async form =>
             {
-                using (CancellationTokenSource cts = new(AsyncTestHelper.UnexpectedTimeout))
-                {
-                    await ThreadHelper.JoinPendingOperationsAsync(cts.Token);
-                }
+                await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
 
                 FormCommit.TestAccessor testform = form.GetTestAccessor();
 

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -493,7 +493,7 @@ namespace GitExtensions.UITests.CommandsDialogs
 
                 // update the form
                 Application.DoEvents();
-                ThreadHelper.JoinPendingOperations();
+                AsyncTestHelper.JoinPendingOperations();
 
                 _commands.Module.RevParse("HEAD").Should().Be(previousCommitId);
                 ta.Amend.Enabled.Should().BeFalse();
@@ -508,7 +508,7 @@ namespace GitExtensions.UITests.CommandsDialogs
 
                 // update the form
                 Application.DoEvents();
-                ThreadHelper.JoinPendingOperations();
+                AsyncTestHelper.JoinPendingOperations();
 
                 ta.Amend.Enabled.Should().BeTrue();
                 ta.Amend.Checked.Should().BeFalse();
@@ -613,7 +613,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                 _referenceRepository.CreateRepoFile("original2.txt", contents);
 
                 ta.RescanChanges();
-                ThreadHelper.JoinPendingOperations();
+                AsyncTestHelper.JoinPendingOperations();
 
                 ta.UnstagedList.SelectedItems = ta.UnstagedList.AllItems;
                 ta.UnstagedList.Focus();
@@ -622,7 +622,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                 ta.StagedList.SelectedGitItem = ta.StagedList.AllItems.Single(i => i.Item.Name.Contains("original2.txt")).Item;
 
                 selectedDiffInternal.Focus();
-                ThreadHelper.JoinPendingOperations();
+                AsyncTestHelper.JoinPendingOperations();
 
                 selectedDiffInternal.GetTestAccessor().TextEditor.ActiveTextAreaControl.SelectionManager.SetSelection(
                     new TextLocation(2, 11), new TextLocation(5, 12));
@@ -637,7 +637,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                 selectedDiff.ExecuteCommand(FileViewer.Command.ResetLines);
 
                 ta.RescanChanges();
-                ThreadHelper.JoinPendingOperations();
+                AsyncTestHelper.JoinPendingOperations();
 
                 int textLengthAfterReset = selectedDiffInternal.GetTestAccessor().TextEditor.ActiveTextAreaControl.Document.TextLength;
 
@@ -685,7 +685,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                     });
 
                     // Await updated FileViewer
-                    ThreadHelper.JoinPendingOperations();
+                    AsyncTestHelper.JoinPendingOperations();
                 },
                 testDriverAsync);
         }

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SplitterPersistenceTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/SplitterPersistenceTests.cs
@@ -219,7 +219,7 @@ namespace GitExtensions.UITests.CommandsDialogs
             UITest.ProcessUntil("Loading Revisions", () => revisionGridControl.GetTestAccessor().IsDataLoadComplete);
             try
             {
-                await AsyncTestHelper.JoinPendingOperationsAsync(TimeSpan.FromSeconds(5));
+                await AsyncTestHelper.JoinPendingOperationsAsync(AsyncTestHelper.UnexpectedTimeout);
             }
             catch
             {

--- a/UnitTests/CommonTestUtils/AsyncTestHelper.cs
+++ b/UnitTests/CommonTestUtils/AsyncTestHelper.cs
@@ -22,5 +22,12 @@ namespace CommonTestUtils
             using CancellationTokenSource cancellationTokenSource = new(timeout);
             await ThreadHelper.JoinPendingOperationsAsync(cancellationTokenSource.Token);
         }
+
+        public static void JoinPendingOperations()
+        {
+            // Note that JoinableTaskContext.Factory must be used to bypass the default behavior of JoinableTaskFactory
+            // since the latter adds new tasks to the collection and would therefore never complete.
+            ThreadHelper.JoinableTaskContext.Factory.Run(() => JoinPendingOperationsAsync(UnexpectedTimeout));
+        }
     }
 }

--- a/UnitTests/CommonTestUtils/ConfigureJoinableTaskFactoryAttribute.cs
+++ b/UnitTests/CommonTestUtils/ConfigureJoinableTaskFactoryAttribute.cs
@@ -67,6 +67,8 @@ namespace CommonTestUtils
                     using CancellationTokenSource cts = new(AsyncTestHelper.UnexpectedTimeout);
                     try
                     {
+                        ThreadHelper.CancelSwitchToMainThread();
+
                         // Note that ThreadHelper.JoinableTaskContext.Factory must be used to bypass the default behavior of
                         // ThreadHelper.JoinableTaskFactory since the latter adds new tasks to the collection and would therefore
                         // never complete.

--- a/UnitTests/GitUI.Tests/RepositoryHistoryUIServiceTests.cs
+++ b/UnitTests/GitUI.Tests/RepositoryHistoryUIServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using CommonTestUtils;
+using FluentAssertions;
 using GitCommands.UserRepositoryHistory;
 using GitUI;
 using GitUI.CommandsDialogs;
@@ -71,7 +72,7 @@ namespace GitUITests
             _service.GetTestAccessor().AddRecentRepositories(containerMenu, repository, caption);
 
             // await adding branch name in ShortcutKeyDisplayString, done async
-            ThreadHelper.JoinableTaskContext.Factory.Run(() => ThreadHelper.JoinPendingOperationsAsync(default));
+            AsyncTestHelper.JoinPendingOperations();
 
             ToolStripMenuItem item = (ToolStripMenuItem)containerMenu.DropDownItems[0];
             item.ShortcutKeyDisplayString.Should().Be(branch);


### PR DESCRIPTION
## Proposed changes

- Await cancellation of RevisionGridControl tasks on close of FormBrowse
- Handle exceptions in UpdateGraphAsync
- Cancel SwitchToMainThreadAsync on AfterTest
- Move JoinPendingOperations to AsyncTestHelper and add timeout
- Tests: Avoid direct use of ThreadHelper.JoinPendingOperationsAsync
- TaskManager.JoinPendingOperations with timeout of 1 minute
- Catch exceptions in TaskManager.JoinPendingOperations[Async]

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).