### PR TITLE
Git diff coloring

### DIFF
--- a/GitCommands/Git/SubmoduleHelpers.cs
+++ b/GitCommands/Git/SubmoduleHelpers.cs
@@ -14,7 +14,7 @@ namespace GitCommands.Git
 
         public static async Task<GitSubmoduleStatus?> GetCurrentSubmoduleChangesAsync(IGitModule module, string? fileName, string? oldFileName, ObjectId? firstId, ObjectId? secondId, CancellationToken cancellationToken)
         {
-            (Patch? patch, string? errorMessage) = await module.GetSingleDiffAsync(firstId, secondId, fileName, oldFileName, "", GitModule.SystemEncoding, cacheResult: true, isTracked: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+            (Patch? patch, string? errorMessage) = await module.GetSingleDiffAsync(firstId, secondId, fileName, oldFileName, "", GitModule.SystemEncoding, cacheResult: true, isTracked: true, useGitColoring: false, commandConfiguration: null, cancellationToken: cancellationToken).ConfigureAwait(false);
             return patch is null
                 ? new GitSubmoduleStatus(errorMessage ?? "", null, false, null, null, null, null)
                 : ParseSubmodulePatchStatus(patch, module, fileName);

--- a/GitCommands/Patches/PatchProcessor.cs
+++ b/GitCommands/Patches/PatchProcessor.cs
@@ -15,13 +15,13 @@ namespace GitCommands.Patches
             OutsidePatch
         }
 
-        [GeneratedRegex(@"^diff --(?<type>git|cc|combined)\s", RegexOptions.ExplicitCapture)]
+        [GeneratedRegex(@"^(\u001b\[.*?m)?diff --(?<type>git|cc|combined)\s", RegexOptions.ExplicitCapture)]
         private static partial Regex PatchHeaderRegex();
-        [GeneratedRegex(@"^diff --git [""]?[abiwco12]/(?<filenamea>.*)[""]? [""]?[abiwco12]/(?<filenameb>.*)[""]?$", RegexOptions.ExplicitCapture)]
+        [GeneratedRegex(@"^(\u001b\[.*?m)?diff --git [""]?[abiwco12]/(?<filenamea>.*)[""]? [""]?[abiwco12]/(?<filenameb>.*?)[""]?(\u001b\[.*?m)?$", RegexOptions.ExplicitCapture)]
         private static partial Regex DiffCommandRegex();
-        [GeneratedRegex(@"^diff --(cc|combined) [""]?(?<filenamea>.*)[""]?$", RegexOptions.ExplicitCapture)]
+        [GeneratedRegex(@"^(\u001b\[.*?m)?diff --(cc|combined) [""]?(?<filenamea>.*?)[""]?(\u001b\[.*?m)?$", RegexOptions.ExplicitCapture)]
         private static partial Regex CombinedDiffCommandRegex();
-        [GeneratedRegex(@"[-+]{3} [""]?[abiwco12]/(?<filename>.*)[""]?", RegexOptions.ExplicitCapture)]
+        [GeneratedRegex(@"(\u001b\[.*?m)?[-+]{3} [""]?[abiwco12]/(?<filename>.*)[""]?(\u001b\[.*?m)?", RegexOptions.ExplicitCapture)]
         private static partial Regex FileNameRegex();
 
         /// <summary>

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -1567,6 +1567,16 @@ namespace GitCommands
             set => SetBool("RememberShowEntireFilePreference", value);
         }
 
+        /// <summary>
+        /// Enable git-word-diff instead of normal "patch" viewer.
+        /// </summary>
+        public static BoolRuntimeSetting ShowGitWordColoring { get; } = new(RootSettingsPath, nameof(ShowGitWordColoring), false);
+
+        /// <summary>
+        /// Gets or sets whether to remember the preference for showing git word coloring.
+        /// </summary>
+        public static ISetting<bool> RememberShowGitWordColoring { get; } = Setting.Create(AppearanceSettingsPath, nameof(RememberShowGitWordColoring), false);
+
         public static int NumberOfContextLines
         {
             get

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -408,6 +408,16 @@ namespace GitCommands
             set => SetBool("usepatiencediffalgorithm", value);
         }
 
+        /// <summary>
+        /// Use Git coloring for selected commands
+        /// </summary>
+        public static ISetting<bool> UseGitColoring { get; } = Setting.Create(AppearanceSettingsPath, nameof(UseGitColoring), true);
+
+        /// <summary>
+        /// Use GE theme colors with Git diff coloring
+        /// </summary>
+        public static ISetting<bool> UseGEThemeGitColoring { get; } = Setting.Create(AppearanceSettingsPath, nameof(UseGEThemeGitColoring), true);
+
         public static bool ShowErrorsWhenStagingFiles
         {
             get => GetBool("showerrorswhenstagingfiles", true);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.Designer.cs
@@ -48,6 +48,10 @@
             tsmiUserFolder = new ToolStripMenuItem();
             _NO_TRANSLATE_cbSelectTheme = new ComboBox();
             lblRestartNeeded = new Label();
+            gbDiffColoring = new GroupBox();
+            tlpnlDiffColoring = new TableLayoutPanel();
+            chkUseGitColoring = new CheckBox();
+            chkUseGEThemeGitColoring = new CheckBox();
             tlpnlMain = new TableLayoutPanel();
             tlpnlMain.SuspendLayout();
             gbRevisionGraph.SuspendLayout();
@@ -55,6 +59,8 @@
             gbTheme.SuspendLayout();
             tableLayoutPanel1.SuspendLayout();
             cmsOpenThemeFolders.SuspendLayout();
+            gbDiffColoring.SuspendLayout();
+            tlpnlDiffColoring.SuspendLayout();
             SuspendLayout();
             // 
             // tlpnlMain
@@ -65,10 +71,12 @@
             tlpnlMain.ColumnStyles.Add(new ColumnStyle());
             tlpnlMain.Controls.Add(gbRevisionGraph, 0, 0);
             tlpnlMain.Controls.Add(gbTheme, 0, 2);
+            tlpnlMain.Controls.Add(gbDiffColoring, 0, 3);
             tlpnlMain.Dock = DockStyle.Fill;
             tlpnlMain.Location = new Point(8, 8);
             tlpnlMain.Name = "tlpnlMain";
-            tlpnlMain.RowCount = 4;
+            tlpnlMain.RowCount = 5;
+            tlpnlMain.RowStyles.Add(new RowStyle());
             tlpnlMain.RowStyles.Add(new RowStyle());
             tlpnlMain.RowStyles.Add(new RowStyle());
             tlpnlMain.RowStyles.Add(new RowStyle());
@@ -305,6 +313,62 @@
             lblRestartNeeded.Text = "Restart required to apply changes";
             lblRestartNeeded.TextAlign = ContentAlignment.MiddleRight;
             // 
+            // gbDiffColoring
+            // 
+            gbDiffColoring.AutoSize = true;
+            gbDiffColoring.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            gbDiffColoring.Controls.Add(tlpnlDiffColoring);
+            gbDiffColoring.Dock = DockStyle.Fill;
+            gbDiffColoring.Location = new Point(3, 3);
+            gbDiffColoring.Name = "gbDiffColoring";
+            gbDiffColoring.Padding = new Padding(8);
+            gbDiffColoring.Size = new Size(1505, 182);
+            gbDiffColoring.TabIndex = 0;
+            gbDiffColoring.TabStop = false;
+            gbDiffColoring.Text = "Diff coloring";
+            // 
+            // tlpnlDiffColoring
+            // 
+            tlpnlDiffColoring.AutoSize = true;
+            tlpnlDiffColoring.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            tlpnlDiffColoring.ColumnCount = 2;
+            tlpnlDiffColoring.ColumnStyles.Add(new ColumnStyle());
+            tlpnlDiffColoring.ColumnStyles.Add(new ColumnStyle());
+            tlpnlDiffColoring.Controls.Add(chkUseGitColoring, 0, 0);
+            tlpnlDiffColoring.Controls.Add(chkUseGEThemeGitColoring, 0, 1);
+            tlpnlDiffColoring.Dock = DockStyle.Fill;
+            tlpnlDiffColoring.Location = new Point(8, 24);
+            tlpnlDiffColoring.Name = "tlpnlDiffColoring";
+            tlpnlDiffColoring.RowCount = 3;
+            tlpnlDiffColoring.RowStyles.Add(new RowStyle());
+            tlpnlDiffColoring.RowStyles.Add(new RowStyle());
+            tlpnlDiffColoring.RowStyles.Add(new RowStyle());
+            tlpnlDiffColoring.Size = new Size(1489, 150);
+            tlpnlDiffColoring.TabIndex = 0;
+            // 
+            // chkUseGitColoring
+            // 
+            chkUseGitColoring.AutoSize = true;
+            chkUseGitColoring.Dock = DockStyle.Fill;
+            chkUseGitColoring.Location = new Point(3, 3);
+            chkUseGitColoring.Name = "chkUseGitColoring";
+            chkUseGitColoring.Size = new Size(183, 19);
+            chkUseGitColoring.TabIndex = 1;
+            chkUseGitColoring.Text = "Git coloring";
+            chkUseGitColoring.UseVisualStyleBackColor = true;
+            chkUseGitColoring.CheckedChanged += chkUseGitColoring_CheckedChanged;
+            // 
+            // chkUseGEThemeGitColoring
+            // 
+            chkUseGEThemeGitColoring.AutoSize = true;
+            chkUseGEThemeGitColoring.Dock = DockStyle.Fill;
+            chkUseGEThemeGitColoring.Location = new Point(3, 28);
+            chkUseGEThemeGitColoring.Name = "chkUseGEThemeGitColoring";
+            chkUseGEThemeGitColoring.Size = new Size(183, 19);
+            chkUseGEThemeGitColoring.TabIndex = 2;
+            chkUseGEThemeGitColoring.Text = "Use theme coloring";
+            chkUseGEThemeGitColoring.UseVisualStyleBackColor = true;
+            // 
             // ColorsSettingsPage
             // 
             AutoScaleDimensions = new SizeF(96F, 96F);
@@ -325,13 +389,17 @@
             tableLayoutPanel1.ResumeLayout(false);
             tableLayoutPanel1.PerformLayout();
             cmsOpenThemeFolders.ResumeLayout(false);
+            gbDiffColoring.ResumeLayout(false);
+            gbDiffColoring.PerformLayout();
+            tlpnlDiffColoring.ResumeLayout(false);
+            tlpnlDiffColoring.PerformLayout();
             ResumeLayout(false);
             PerformLayout();
 
         }
 
         #endregion
-    
+
         private GroupBox gbRevisionGraph;
         private CheckBox DrawNonRelativesTextGray;
         private CheckBox DrawNonRelativesGray;
@@ -350,5 +418,9 @@
         private ComboBox _NO_TRANSLATE_cbSelectTheme;
         private Label lblRestartNeeded;
         private CheckBox chkFillRefLabels;
+        private GroupBox gbDiffColoring;
+        private TableLayoutPanel tlpnlDiffColoring;
+        private CheckBox chkUseGitColoring;
+        private CheckBox chkUseGEThemeGitColoring;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ColorsSettings/ColorsSettingsPage.cs
@@ -114,6 +114,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             DrawNonRelativesTextGray.Checked = AppSettings.RevisionGraphDrawNonRelativesTextGray;
             chkHighlightAuthored.Checked = AppSettings.HighlightAuthoredRevisions;
             chkFillRefLabels.Checked = AppSettings.FillRefLabels;
+            chkUseGitColoring.Checked = AppSettings.UseGitColoring.Value;
+            chkUseGEThemeGitColoring.Checked = AppSettings.UseGEThemeGitColoring.Value;
+            chkUseGEThemeGitColoring.Enabled = chkUseGitColoring.Checked;
             _controller.ShowThemeSettings();
 
             base.SettingsToPage();
@@ -127,6 +130,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.RevisionGraphDrawNonRelativesTextGray = DrawNonRelativesTextGray.Checked;
             AppSettings.HighlightAuthoredRevisions = chkHighlightAuthored.Checked;
             AppSettings.FillRefLabels = chkFillRefLabels.Checked;
+            AppSettings.UseGitColoring.Value = chkUseGitColoring.Checked;
+            AppSettings.UseGEThemeGitColoring.Value = chkUseGEThemeGitColoring.Checked;
             _controller.ApplyThemeSettings();
 
             base.PageToSettings();
@@ -156,6 +161,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
         private void tsmiUserFolder_Click(object sender, EventArgs e) =>
             _controller.ShowUserThemesDirectory();
+
+        private void chkUseGitColoring_CheckedChanged(object sender, EventArgs e)
+            => chkUseGEThemeGitColoring.Enabled = chkUseGitColoring.Checked;
 
         private struct FormattedThemeId
         {

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.Designer.cs
@@ -32,6 +32,7 @@
             chkRememberIgnoreWhiteSpacePreference = new CheckBox();
             chkRememberShowNonPrintingCharsPreference = new CheckBox();
             chkRememberShowEntireFilePreference = new CheckBox();
+            chkRememberShowGitWordColoringPreference = new CheckBox();
             chkRememberNumberOfContextLines = new CheckBox();
             chkRememberShowSyntaxHighlightingInDiff = new CheckBox();
             chkOmitUninterestingDiff = new CheckBox();
@@ -60,19 +61,21 @@
             tlpnlGeneral.Controls.Add(chkRememberIgnoreWhiteSpacePreference, 0, 0);
             tlpnlGeneral.Controls.Add(chkRememberShowNonPrintingCharsPreference, 0, 1);
             tlpnlGeneral.Controls.Add(chkRememberShowEntireFilePreference, 0, 2);
-            tlpnlGeneral.Controls.Add(chkRememberNumberOfContextLines, 0, 3);
-            tlpnlGeneral.Controls.Add(chkRememberShowSyntaxHighlightingInDiff, 0, 4);
-            tlpnlGeneral.Controls.Add(chkOmitUninterestingDiff, 0, 5);
-            tlpnlGeneral.Controls.Add(chkContScrollToNextFileOnlyWithAlt, 0, 6);
-            tlpnlGeneral.Controls.Add(chkOpenSubmoduleDiffInSeparateWindow, 0, 7);
-            tlpnlGeneral.Controls.Add(chkShowDiffForAllParents, 0, 8);
-            tlpnlGeneral.Controls.Add(chkShowAllCustomDiffTools, 0, 9);
-            tlpnlGeneral.Controls.Add(label1, 0, 10);
-            tlpnlGeneral.Controls.Add(VerticalRulerPosition, 1, 10);
+            tlpnlGeneral.Controls.Add(chkRememberShowGitWordColoringPreference, 0, 3);
+            tlpnlGeneral.Controls.Add(chkRememberNumberOfContextLines, 0, 4);
+            tlpnlGeneral.Controls.Add(chkRememberShowSyntaxHighlightingInDiff, 0, 5);
+            tlpnlGeneral.Controls.Add(chkOmitUninterestingDiff, 0, 6);
+            tlpnlGeneral.Controls.Add(chkContScrollToNextFileOnlyWithAlt, 0, 7);
+            tlpnlGeneral.Controls.Add(chkOpenSubmoduleDiffInSeparateWindow, 0, 8);
+            tlpnlGeneral.Controls.Add(chkShowDiffForAllParents, 0, 9);
+            tlpnlGeneral.Controls.Add(chkShowAllCustomDiffTools, 0, 10);
+            tlpnlGeneral.Controls.Add(label1, 0, 11);
+            tlpnlGeneral.Controls.Add(VerticalRulerPosition, 1, 11);
             tlpnlGeneral.Dock = DockStyle.Fill;
             tlpnlGeneral.Location = new Point(8, 24);
             tlpnlGeneral.Name = "tlpnlGeneral";
-            tlpnlGeneral.RowCount = 11;
+            tlpnlGeneral.RowCount = 12;
+            tlpnlGeneral.RowStyles.Add(new RowStyle());
             tlpnlGeneral.RowStyles.Add(new RowStyle());
             tlpnlGeneral.RowStyles.Add(new RowStyle());
             tlpnlGeneral.RowStyles.Add(new RowStyle());
@@ -116,6 +119,16 @@
             chkRememberShowEntireFilePreference.Size = new Size(325, 19);
             chkRememberShowEntireFilePreference.Text = "Remember the \'Show entire file\' preference";
             chkRememberShowEntireFilePreference.UseVisualStyleBackColor = true;
+            // 
+            // chkRememberShowGitWordColoringPreference
+            // 
+            chkRememberShowGitWordColoringPreference.AutoSize = true;
+            chkRememberShowGitWordColoringPreference.Dock = DockStyle.Fill;
+            chkRememberShowGitWordColoringPreference.Location = new Point(3, 53);
+            chkRememberShowGitWordColoringPreference.Name = "chkRememberShowGitWordColoringPreference";
+            chkRememberShowGitWordColoringPreference.Size = new Size(325, 19);
+            chkRememberShowGitWordColoringPreference.Text = "Remember the \'Show Git word coloring\' preference";
+            chkRememberShowGitWordColoringPreference.UseVisualStyleBackColor = true;
             // 
             // chkRememberNumberOfContextLines
             // 
@@ -271,6 +284,7 @@
         private CheckBox chkRememberIgnoreWhiteSpacePreference;
         private CheckBox chkRememberShowNonPrintingCharsPreference;
         private CheckBox chkRememberShowEntireFilePreference;
+        private CheckBox chkRememberShowGitWordColoringPreference;
         private CheckBox chkRememberNumberOfContextLines;
         private CheckBox chkRememberShowSyntaxHighlightingInDiff;
         private CheckBox chkOmitUninterestingDiff;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DiffViewerSettingsPage.cs
@@ -20,6 +20,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             chkRememberIgnoreWhiteSpacePreference.Checked = AppSettings.RememberIgnoreWhiteSpacePreference;
             chkOmitUninterestingDiff.Checked = AppSettings.OmitUninterestingDiff;
             chkRememberShowEntireFilePreference.Checked = AppSettings.RememberShowEntireFilePreference;
+            chkRememberShowGitWordColoringPreference.Checked = AppSettings.RememberShowGitWordColoring.Value;
             chkRememberShowNonPrintingCharsPreference.Checked = AppSettings.RememberShowNonPrintingCharsPreference;
             chkRememberNumberOfContextLines.Checked = AppSettings.RememberNumberOfContextLines;
             chkRememberShowSyntaxHighlightingInDiff.Checked = AppSettings.RememberShowSyntaxHighlightingInDiff;
@@ -37,6 +38,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             AppSettings.RememberIgnoreWhiteSpacePreference = chkRememberIgnoreWhiteSpacePreference.Checked;
             AppSettings.OmitUninterestingDiff = chkOmitUninterestingDiff.Checked;
             AppSettings.RememberShowEntireFilePreference = chkRememberShowEntireFilePreference.Checked;
+            AppSettings.RememberShowGitWordColoring.Value = chkRememberShowGitWordColoringPreference.Checked;
             AppSettings.RememberShowNonPrintingCharsPreference = chkRememberShowNonPrintingCharsPreference.Checked;
             AppSettings.RememberNumberOfContextLines = chkRememberNumberOfContextLines.Checked;
             AppSettings.RememberShowSyntaxHighlightingInDiff = chkRememberShowSyntaxHighlightingInDiff.Checked;

--- a/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
+++ b/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
@@ -1,0 +1,465 @@
+﻿using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using GitExtUtils;
+using GitExtUtils.GitUI.Theming;
+using GitUI.Theming;
+using ICSharpCode.TextEditor.Document;
+
+namespace GitUI.Editor.Diff;
+
+public partial class AnsiEscapeUtilities
+{
+    [GeneratedRegex(@"\u001b\[((?<escNo>\d+)\s*[:;]?\s*)*m", RegexOptions.ExplicitCapture)]
+    private static partial Regex EscapeRegex();
+
+    // Offset for faint/dim is escapeCodes workaround to handle dim in Get8bitColor()
+    private const int _dimOffset = 0x0001_0000;
+    private const int _boldOffset = 8;
+
+    /// <summary>
+    /// Override Git colors from GE theme color.
+    /// </summary>
+    /// <param name="key">The Git config key: https://git-scm.com/docs/git-config#Documentation/git-config.txt-colordiffltslotgt.</param>
+    /// <param name="appBackColor">The back color to add, fore color to be derived from it.</param>
+    /// <returns>The GitConfigItem.</returns>
+    public static GitConfigItem SetUnsetGitColor(
+                    string key,
+                    AppColor appBackColor)
+    {
+        // Override the Git default coloring (mask the alpha for Git)
+        Color backColor = appBackColor.GetThemeColor();
+        int back = backColor.ToArgb() & 0xffffff;
+        Color foreColor = ColorHelper.GetForeColorForBackColor(backColor);
+        int fore = foreColor.ToArgb() & 0xffffff;
+
+        return new GitConfigItem(key, $"#{fore:x6} #{back:x6}");
+    }
+
+#if DEBUG
+    /// <summary>
+    /// Debug print colors similar to https://github.com/robertknight/konsole/raw/master/tests/color-spaces.pl
+    /// </summary>
+    public static void PrintColors(StringBuilder sb, List<TextMarker> textMarkers)
+    {
+        int currentColorId = 0;
+        sb.Append('\n');
+
+        // color id (standard) colors
+        foreach (bool fore in new List<bool>() { true, false })
+        {
+            foreach (int offset in new List<int>() { 0, _boldOffset, _dimOffset })
+            {
+                sb.Append($"{offset:d5} ");
+                for (int i = 0; i < 8; i++)
+                {
+                    sb.Append("@!");
+                    int colorId = i + offset;
+                    TryGetColorsFromEscapeSequence(new List<int>() { 38 + (fore ? 0 : 10), 5, colorId }, out Color? backColor, out Color? foreColor, ref currentColorId);
+                    if (TryGetTextMarker(new()
+                            {
+                                DocOffset = sb.Length - 2,
+                                Length = 2,
+                                BackColor = backColor,
+                                ForeColor = foreColor
+                            },
+                            out TextMarker tm))
+                    {
+                        textMarkers.Add(tm);
+                    }
+                }
+
+                sb.Append('\n');
+            }
+
+            sb.Append('\n');
+        }
+
+        // GE theme colors - primarily used as background color with adjusted foreground
+        foreach (List<Color?> cs in new List<List<Color?>>()
+            {
+            new() { null, AppColor.DiffRemoved.GetThemeColor(), AppColor.DiffAdded.GetThemeColor(), null, null, null, null, AppColor.DiffSection.GetThemeColor(), },
+            new() { null, AppColor.DiffRemovedExtra.GetThemeColor(), AppColor.DiffAddedExtra.GetThemeColor(), }
+            })
+        {
+            sb.Append($"{" ",6}");
+            foreach (Color? color in cs)
+            {
+                sb.Append(color is null ? "  " : "@!");
+                if (color is not null)
+                {
+                    if (TryGetTextMarker(new()
+                    {
+                        DocOffset = sb.Length - 2,
+                        Length = 2,
+                        BackColor = color,
+                        ForeColor = ColorHelper.GetForeColorForBackColor((Color)color)
+                    },
+                        out TextMarker tm))
+                    {
+                        textMarkers.Add(tm);
+                    }
+                }
+            }
+
+            sb.Append('\n');
+        }
+    }
+#endif
+
+    /// <summary>
+    /// Parse the text and convert ansi console escape sequences to highlight info applicable to the FileViewer.
+    /// </summary>
+    /// <param name="text">The text to parse.</param>
+    /// <param name="sb">StringBuilder to appened the text with with the escape sequences removed.</param>
+    /// <param name="textMarkers">Detected and current started highlight info for the document.</param>
+    public static void ParseEscape(string text, StringBuilder sb, List<TextMarker> textMarkers)
+    {
+        int prevLineOffset = 0;
+        int currentColorId = 0; // current color, used when just bold etc is set
+        HighlightInfo currentHighlight = new()
+        {
+            DocOffset = sb.Length,
+            Length = -1,
+            BackColor = Color.White,
+            ForeColor = Color.Black
+        };
+
+        for (Match match = EscapeRegex().Match(text); match.Success; match = match.NextMatch())
+        {
+            sb.Append(text[prevLineOffset..match.Index]);
+            prevLineOffset = match.Index + match.Length;
+
+            // An escape sequence can include several attributes (empty/unparsable is break).
+            List<int> escapeCodes = match.Groups["escNo"].Captures.Select(i => int.TryParse(i.ToString(), out int attribute) ? attribute : 0).ToList();
+
+            if (TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId))
+            {
+                if (currentHighlight.Length >= 0)
+                {
+                    // End current match so new can be started, this is expected but normally not used by Git (?).
+                    // Also assume that the new colors are "complete", not just overlay.
+                    Trace.WriteLine($"New start marker without end for grep {text} ({sb.Length})");
+
+                    currentHighlight.Length = sb.Length - currentHighlight.DocOffset;
+                    if (TryGetTextMarker(currentHighlight, out TextMarker tm))
+                    {
+                        textMarkers.Add(tm);
+                    }
+                }
+
+                // Start of new segment
+                currentHighlight.DocOffset = sb.Length;
+                currentHighlight.Length = 0;
+                currentHighlight.BackColor = backColor;
+                currentHighlight.ForeColor = foreColor;
+            }
+            else
+            {
+                // Reset escape sequence, end of segment
+
+                if (currentHighlight.Length < 0)
+                {
+                    // Previous was a reset, just ignore.
+                    continue;
+                }
+
+                if (currentHighlight.Length > 0)
+                {
+                    // This could be escapeCodes setting without any effect,
+                    // Git also ends "configured with empty" (like diff context set in GE) without start with end segment.
+                    Debug.WriteLineIf(sb.Length < 256, $"Debug: Unexpected no ongoing marker at {sb.Length}.");
+                    continue;
+                }
+
+                currentHighlight.Length = sb.Length - currentHighlight.DocOffset;
+                if (TryGetTextMarker(currentHighlight, out TextMarker tm))
+                {
+                    textMarkers.Add(tm);
+                }
+
+                currentHighlight.Length = -1;
+            }
+        }
+
+        sb.Append(text.AsSpan(prevLineOffset));
+        sb.Append('\n');
+    }
+
+    /// <summary>
+    /// Try to get the back/forecolor from the array of ANSI escape sequences defined in
+    /// https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+    /// </summary>
+    /// <param name="escapeCodes">Array of escape codes to interpret.</param>
+    /// <param name="backColor">Background color if set.</param>
+    /// <param name="foreColor">Foreground color if set.</param>
+    /// <param name="currentColorId">The fore color ANSI id (not argb color) if it was set. Can be used in follow-up sequences.</param>
+    /// <returns><see langword="true"/> if a color was set; otherwise <see langword="false"/>.</returns>
+    private static bool TryGetColorsFromEscapeSequence(IList<int> escapeCodes, out Color? backColor, out Color? foreColor, ref int currentColorId)
+    {
+        bool result = false;
+        backColor = null;
+        foreColor = null;
+
+        // A subset of attributes supported, most are ignored, other handled as bold/dim
+        bool bold = false; // Git bright, increased intensity
+        bool dim = false; // faint, decreased intensity
+        bool reverse = false; // swap isFore/back
+        for (int i = 0; i < escapeCodes.Count; ++i)
+        {
+            switch (escapeCodes[i])
+            {
+                case 0: // Reset or normal, all attributes become turned off
+                    result = false;
+                    bold = false;
+                    dim = false;
+                    reverse = false;
+                    backColor = null;
+                    foreColor = null;
+                    currentColorId = 0; // default black
+                    break;
+                case 1: // bold
+                case 4: // underline/ul
+                case 5: // slow blink
+                case 6: // fast blink
+                case 9: // strike
+                    bold = true;
+                    foreColor = Get8bitColor(currentColorId + GetBoldDimOffset(), out _);
+                    break;
+                case 2: // dim
+                case 3: // italic
+                    dim = true;
+                    foreColor = Get8bitColor(currentColorId + GetBoldDimOffset(), out _);
+                    break;
+                case 7: // reverse
+                    reverse = true;
+                    break;
+                case 39: // Default foreground color
+                    foreColor = null;
+                    currentColorId = 0;
+                    break;
+                case 49: // Default background color
+                    backColor = null;
+                    break;
+                case >= 30 and <= 37: // Set foreground color
+                case >= 90 and <= 97: // Set bright foreground color
+                    bold = escapeCodes[i] >= 90;
+                    currentColorId = escapeCodes[i] - (bold ? 90 : 30);
+                    foreColor = Get8bitColor(currentColorId + GetBoldDimOffset(), out _);
+                    break;
+                case >= 40 and <= 47: // Set background color
+                case >= 100 and <= 107: // Set bright background color
+                    bold = escapeCodes[i] >= 100;
+                    int backColorId = escapeCodes[i] - (bold ? 100 : 40);
+                    backColor = Get8bitColor(backColorId + GetBoldDimOffset(), out _);
+                    break;
+                case 38: // Set foreground color with sequence
+                case 48: // Set background color with sequence
+                    if (i >= escapeCodes.Count - 2)
+                    {
+                        Trace.WriteLine($"Unexpected too few arguments for {i} {escapeCodes}");
+                        DebugHelpers.Fail($"Unexpected too few arguments for {i} {escapeCodes}");
+                        break;
+                    }
+
+                    Color color;
+                    bool isFore = escapeCodes[i] == 38;
+                    ++i;
+
+                    if (escapeCodes[i] == 5)
+                    {
+                        // ESC[38:5:⟨n⟩m Select foreground color
+                        ++i;
+                        bold = escapeCodes[i] is >= _boldOffset and < 2 * _boldOffset;
+                        color = Get8bitColor(escapeCodes[i], out currentColorId);
+                    }
+                    else if (escapeCodes[i] == 2)
+                    {
+                        // ESC[38;2;⟨r⟩;⟨g⟩;⟨b⟩ m Select RGB foreground color
+                        ++i;
+                        if (i >= escapeCodes.Count - 2)
+                        {
+                            Trace.WriteLine($"Unexpected too few arguments for {i} {escapeCodes}");
+                            DebugHelpers.Fail($"Unexpected too few arguments for {i} {escapeCodes}");
+                            break;
+                        }
+
+                        color = Color.FromArgb(escapeCodes[i], escapeCodes[i + 1], escapeCodes[i + 2]);
+
+                        // Unknown fixed identifier, reset id
+                        // Reset also for background to avoid CS0165
+                        currentColorId = 0;
+                    }
+                    else
+                    {
+                        Trace.WriteLine($"Unexpected argument for {i} {escapeCodes}");
+                        DebugHelpers.Fail($"Unexpected argument for {i} {escapeCodes}");
+                        break;
+                    }
+
+                    if (isFore)
+                    {
+                        foreColor = color;
+                    }
+                    else
+                    {
+                        backColor = color;
+                    }
+
+                    break;
+                default: // Ignore unhandled sequences
+                    break;
+            }
+        }
+
+        if (reverse)
+        {
+            (backColor, foreColor) = (foreColor, backColor);
+        }
+
+        if (backColor is not null && foreColor is null)
+        {
+            foreColor = ColorHelper.GetForeColorForBackColor((Color)backColor);
+        }
+
+        // Set result if there are changes
+        // No action if there are only attribute changes like bold/dim/reverse
+        // (not generated by Git but could be set by the user)
+        if (backColor is not null || foreColor is not null)
+        {
+            result = true;
+        }
+
+        return result;
+
+        int GetBoldDimOffset()
+        {
+            if (dim)
+            {
+                // bold has no effect when dim
+                return (int)_dimOffset;
+            }
+
+            return bold ? (int)_boldOffset : 0;
+        }
+    }
+
+    /// <summary>
+    /// Decode 3, 4, and 8-bit colors from https://en.wikipedia.org/wiki/ANSI_escape_code#24-bit
+    /// Named 3/4 bit colors from the "theme" at https://github.com/mintty/mintty/blob/master/themes/helmholtz (could be integrated with GE colors)
+    /// (Dimmed/faint colors are not in the theme, extracted printing to terminal.)
+    /// Note: A difference from at least mintty handles sequences like "30;5;1" differently from "31",
+    /// as well as background and foreground differs occasionally.
+    /// </summary>
+    /// <param name="colorCode">The color code to decode.</param>
+    /// <param name="colorId">ANSI color id if known, otherwise default black.</param>
+    /// <returns>The 24-bit RGB color.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Unexpected value.</exception>
+    private static Color Get8bitColor(int colorCode, out int colorId)
+    {
+        // Color code definitions
+        const int blackId = 0;
+        const int redId = 1;
+        const int greenId = 2;
+        const int yellowId = 3;
+        const int blueId = 4;
+        const int magentaId = 5;
+        const int cyanId = 6;
+        const int whiteId = 7;
+
+        if (colorCode is >= blackId and <= whiteId
+            or >= blackId + _boldOffset and <= whiteId + _boldOffset
+            or >= blackId + _dimOffset and <= whiteId + _dimOffset)
+        {
+            // Mask bold or dim, last three bits
+            colorId = colorCode & 7;
+        }
+        else
+        {
+            // Reset to default (black)
+            colorId = 0;
+        }
+
+        return colorCode switch
+        {
+            blackId => Color.Black,
+            blackId + _boldOffset => Color.FromArgb(96, 96, 96),
+            blackId + _dimOffset => Color.FromArgb(127, 127, 127),
+
+            redId => Color.FromArgb(212, 44, 58),
+            redId + _boldOffset => Color.FromArgb(255, 118, 118),
+            redId + _dimOffset => Color.FromArgb(208, 142, 147),
+
+            greenId => Color.FromArgb(137, 190, 127),
+            greenId + _boldOffset => Color.FromArgb(0, 242, 0),
+            greenId + _dimOffset => Color.FromArgb(137, 190, 127),
+
+            yellowId => Color.FromArgb(192, 160, 0),
+            yellowId + _boldOffset => Color.FromArgb(242, 242, 0),
+            yellowId + _dimOffset => Color.FromArgb(199, 187, 127),
+
+            blueId => Color.FromArgb(0, 93, 255),
+            blueId + _boldOffset => Color.FromArgb(125, 151, 255),
+            blueId + _dimOffset => Color.FromArgb(127, 143, 233),
+
+            magentaId => Color.FromArgb(177, 72, 198),
+            magentaId + _boldOffset => Color.FromArgb(255, 112, 255),
+            magentaId + _dimOffset => Color.FromArgb(194, 154, 202),
+
+            cyanId => Color.FromArgb(0, 168, 154),
+            cyanId + _boldOffset => Color.FromArgb(0, 240, 240),
+            cyanId + _dimOffset => Color.FromArgb(127, 190, 184),
+
+            whiteId => Color.FromArgb(191, 191, 191),
+            whiteId + _boldOffset => Color.FromArgb(255, 255, 255),
+            whiteId + _dimOffset => Color.FromArgb(222, 222, 222),
+
+            >= 16 and < 232 => Get216Colors(colorCode),
+            >= 232 and <= 255 => Get24StepGray(colorCode),
+            _ => throw new ArgumentOutOfRangeException(nameof(colorCode), colorCode, $"Unexpected value for ANSI color.")
+        };
+
+        static Color Get216Colors(int level)
+        {
+            int i = level - 16;
+            int blue = i % 6;
+            int green = i % 36;
+            int red = i / 36;
+
+            return Color.FromArgb(red, green, blue);
+        }
+
+        static Color Get24StepGray(int level)
+        {
+            int i = 8 + ((level - 232) * 10);
+            return Color.FromArgb(i, i, i);
+        }
+    }
+
+    /// <summary>
+    /// Add pre-parsed highlight info (parsed ANSI escape sequences) as markers in the document.
+    /// </summary>
+    /// <param name="hl">Info to set.</param>
+    private static bool TryGetTextMarker(HighlightInfo hl, out TextMarker? textMarker)
+    {
+        if (hl.DocOffset < 0 || hl.Length < 0)
+        {
+            Trace.WriteLine($"Unexpected no docOffset or backColor ({hl})");
+            DebugHelpers.Fail($"Unexpected no docOffset or backColor ({hl})");
+            textMarker = null;
+            return false;
+        }
+
+        if (hl.BackColor is null)
+        {
+            // BackColor must always be set
+            // TODO get default back color, guess if the user has not set the value
+            hl.BackColor = Color.White; // document.LineSegmentCollection.FirstOrDefault().GetColorForPosition(0).BackgroundColor;
+        }
+
+        textMarker = hl.ForeColor is null
+            ? new TextMarker(hl.DocOffset, hl.Length, TextMarkerType.SolidBlock, (Color)hl.BackColor)
+            : new TextMarker(hl.DocOffset, hl.Length, TextMarkerType.SolidBlock, (Color)hl.BackColor, (Color)hl.ForeColor);
+        return true;
+    }
+}

--- a/GitUI/Editor/Diff/CombinedDiffHighlightService.cs
+++ b/GitUI/Editor/Diff/CombinedDiffHighlightService.cs
@@ -1,5 +1,7 @@
+using GitExtUtils;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Theming;
+using GitUIPluginInterfaces;
 using ICSharpCode.TextEditor;
 using ICSharpCode.TextEditor.Document;
 
@@ -12,7 +14,8 @@ public class CombinedDiffHighlightService : DiffHighlightService
     private static readonly string[] _removedLinePrefixes = ["-", " -"];
     private static readonly string[] _diffSearchPrefixes = [.. _addedLinePrefixes, .. _removedLinePrefixes];
 
-    public CombinedDiffHighlightService()
+    public CombinedDiffHighlightService(ref string text, bool useGitColoring)
+        : base(ref text, useGitColoring)
     {
     }
 
@@ -21,6 +24,9 @@ public class CombinedDiffHighlightService : DiffHighlightService
         DiffLinesInfo result = new DiffLineNumAnalyzer().Analyze(textEditor.Text, isCombinedDiff: true);
         lineNumbersControl.DisplayLineNum(result);
     }
+
+    public static GitCommandConfiguration GetGitCommandConfiguration(IGitModule module, bool useGitColoring)
+        => GetGitCommandConfiguration(module, useGitColoring, "diff-tree");
 
     public override string[] GetFullDiffPrefixes() => _diffFullPrefixes;
 

--- a/GitUI/Editor/Diff/CombinedDiffHighlightService.cs
+++ b/GitUI/Editor/Diff/CombinedDiffHighlightService.cs
@@ -1,54 +1,45 @@
 using GitExtUtils.GitUI.Theming;
 using GitUI.Theming;
+using ICSharpCode.TextEditor;
 using ICSharpCode.TextEditor.Document;
 
-namespace GitUI.Editor.Diff
+namespace GitUI.Editor.Diff;
+
+public class CombinedDiffHighlightService : DiffHighlightService
 {
-    public class CombinedDiffHighlightService : DiffHighlightService
+    private static readonly string[] _diffFullPrefixes = ["  ", "++", "+ ", " +", "--", "- ", " -"];
+    private static readonly string[] _addedLinePrefixes = ["+", " +"];
+    private static readonly string[] _removedLinePrefixes = ["-", " -"];
+    private static readonly string[] _diffSearchPrefixes = [.. _addedLinePrefixes, .. _removedLinePrefixes];
+
+    public CombinedDiffHighlightService()
     {
-        private static readonly string[] _diffFullPrefixes = { "  ", "++", "+ ", " +", "--", "- ", " -" };
-        private static readonly string[] _diffSearchPrefixes = { "+", "-", " +", " -" };
+    }
 
-        public static new CombinedDiffHighlightService Instance { get; } = new();
+    public override void SetLineControl(DiffViewerLineNumberControl lineNumbersControl, TextEditorControl textEditor)
+    {
+        DiffLinesInfo result = new DiffLineNumAnalyzer().Analyze(textEditor.Text, isCombinedDiff: true);
+        lineNumbersControl.DisplayLineNum(result);
+    }
 
-        protected CombinedDiffHighlightService()
-        {
-        }
+    public override string[] GetFullDiffPrefixes() => _diffFullPrefixes;
 
-        protected override int GetDiffContentOffset()
-        {
-            return 2;
-        }
+    public override bool IsSearchMatch(string line) => line.StartsWithAny(_diffSearchPrefixes);
 
-        public override string[] GetFullDiffPrefixes()
-        {
-            return _diffFullPrefixes;
-        }
+    protected override List<ISegment> GetAddedLines(IDocument document, ref int line, ref bool found)
+        => LinePrefixHelper.GetLinesStartingWith(document, ref line, _addedLinePrefixes, ref found);
 
-        public override bool IsSearchMatch(string line)
-        {
-            return line.StartsWithAny(_diffSearchPrefixes);
-        }
+    protected override List<ISegment> GetRemovedLines(IDocument document, ref int line, ref bool found)
+        => LinePrefixHelper.GetLinesStartingWith(document, ref line, _removedLinePrefixes, ref found);
 
-        protected override int TryHighlightAddedAndDeletedLines(IDocument document, int line, LineSegment lineSegment)
-        {
-            ProcessLineSegment(document, ref line, lineSegment, "++", AppColor.DiffAdded.GetThemeColor());
-            ProcessLineSegment(document, ref line, lineSegment, "+ ", AppColor.DiffAdded.GetThemeColor());
-            ProcessLineSegment(document, ref line, lineSegment, " +", AppColor.DiffAdded.GetThemeColor());
-            ProcessLineSegment(document, ref line, lineSegment, "--", AppColor.DiffRemoved.GetThemeColor());
-            ProcessLineSegment(document, ref line, lineSegment, "- ", AppColor.DiffRemoved.GetThemeColor());
-            ProcessLineSegment(document, ref line, lineSegment, " -", AppColor.DiffRemoved.GetThemeColor());
-            return line;
-        }
-
-        protected override List<ISegment> GetAddedLines(IDocument document, ref int line, ref bool found)
-        {
-            return LinePrefixHelper.GetLinesStartingWith(document, ref line, new[] { "+", " +" }, ref found);
-        }
-
-        protected override List<ISegment> GetRemovedLines(IDocument document, ref int line, ref bool found)
-        {
-            return LinePrefixHelper.GetLinesStartingWith(document, ref line, new[] { "-", " -" }, ref found);
-        }
+    protected override int TryHighlightAddedAndDeletedLines(IDocument document, int line, LineSegment lineSegment)
+    {
+        ProcessLineSegment(document, ref line, lineSegment, "++", AppColor.DiffAdded.GetThemeColor());
+        ProcessLineSegment(document, ref line, lineSegment, "+ ", AppColor.DiffAdded.GetThemeColor());
+        ProcessLineSegment(document, ref line, lineSegment, " +", AppColor.DiffAdded.GetThemeColor());
+        ProcessLineSegment(document, ref line, lineSegment, "--", AppColor.DiffRemoved.GetThemeColor());
+        ProcessLineSegment(document, ref line, lineSegment, "- ", AppColor.DiffRemoved.GetThemeColor());
+        ProcessLineSegment(document, ref line, lineSegment, " -", AppColor.DiffRemoved.GetThemeColor());
+        return line;
     }
 }

--- a/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -2,217 +2,192 @@
 using GitUI.Theming;
 using ICSharpCode.TextEditor.Document;
 
-namespace GitUI.Editor.Diff
+namespace GitUI.Editor.Diff;
+
+/// <summary>
+/// Common class for highlighting of diff style files.
+/// </summary>
+public abstract class DiffHighlightService : TextHighlightService
 {
-    public class DiffHighlightService : TextHighlightService
+    public DiffHighlightService()
     {
-        // Patterns to check for patches in diff files
-        private static readonly string[] _diffFullPrefixes = { " ", "+", "-" };
-        private static readonly string[] _diffSearchPrefixes = { "+", "-" };
+    }
 
-        public static new DiffHighlightService Instance { get; } = new();
+    public override void AddTextHighlighting(IDocument document)
+    {
+        bool forceAbort = false;
 
-        protected readonly LinePrefixHelper LinePrefixHelper = new(new LineSegmentGetter());
+        AddExtraPatchHighlighting(document);
 
-        protected DiffHighlightService()
+        for (int line = 0; line < document.TotalNumberOfLines && !forceAbort; line++)
         {
-        }
+            LineSegment lineSegment = document.GetLineSegment(line);
 
-        protected virtual int GetDiffContentOffset()
-        {
-            return 1;
-        }
-
-        public virtual string[] GetFullDiffPrefixes()
-        {
-            return _diffFullPrefixes;
-        }
-
-        public virtual bool IsSearchMatch(string line)
-        {
-            return line.StartsWithAny(_diffSearchPrefixes);
-        }
-
-        private static void MarkDifference(IDocument document, List<ISegment> linesRemoved, List<ISegment> linesAdded, int beginOffset)
-        {
-            int count = Math.Min(linesRemoved.Count, linesAdded.Count);
-
-            for (int i = 0; i < count; i++)
+            if (lineSegment.TotalLength == 0)
             {
-                MarkDifference(document, linesRemoved[i], linesAdded[i], beginOffset);
-            }
-        }
-
-        private static void MarkDifference(IDocument document, ISegment lineRemoved,
-            ISegment lineAdded, int beginOffset)
-        {
-            int lineRemovedEndOffset = lineRemoved.Length;
-            int lineAddedEndOffset = lineAdded.Length;
-            int endOffsetMin = Math.Min(lineRemovedEndOffset, lineAddedEndOffset);
-            int reverseOffset = 0;
-
-            while (beginOffset < endOffsetMin)
-            {
-                char a = document.GetCharAt(lineAdded.Offset + beginOffset);
-                char r = document.GetCharAt(lineRemoved.Offset + beginOffset);
-
-                if (a != r)
-                {
-                    break;
-                }
-
-                beginOffset++;
+                continue;
             }
 
-            while (lineAddedEndOffset > beginOffset && lineRemovedEndOffset > beginOffset)
+            if (line == document.TotalNumberOfLines - 1)
             {
-                reverseOffset = lineAdded.Length - lineAddedEndOffset;
-
-                char a = document.GetCharAt(lineAdded.Offset + lineAdded.Length - 1 - reverseOffset);
-                char r = document.GetCharAt(lineRemoved.Offset + lineRemoved.Length - 1 - reverseOffset);
-
-                if (a != r)
-                {
-                    break;
-                }
-
-                lineRemovedEndOffset--;
-                lineAddedEndOffset--;
+                forceAbort = true;
             }
 
-            Color color;
-            MarkerStrategy markerStrategy = document.MarkerStrategy;
+            line = TryHighlightAddedAndDeletedLines(document, line, lineSegment);
 
-            if (lineAdded.Length - beginOffset - reverseOffset > 0)
-            {
-                color = AppColor.DiffAddedExtra.GetThemeColor();
-                markerStrategy.AddMarker(new TextMarker(lineAdded.Offset + beginOffset,
-                                                        lineAdded.Length - beginOffset - reverseOffset,
-                                                        TextMarkerType.SolidBlock, color,
-                                                        ColorHelper.GetForeColorForBackColor(color)));
-            }
-
-            if (lineRemoved.Length - beginOffset - reverseOffset > 0)
-            {
-                color = AppColor.DiffRemovedExtra.GetThemeColor();
-                markerStrategy.AddMarker(new TextMarker(lineRemoved.Offset + beginOffset,
-                                                        lineRemoved.Length - beginOffset - reverseOffset,
-                                                        TextMarkerType.SolidBlock, color,
-                                                        ColorHelper.GetForeColorForBackColor(color)));
-            }
+            ProcessLineSegment(document, ref line, lineSegment, "@", AppColor.DiffSection.GetThemeColor());
+            ProcessLineSegment(document, ref line, lineSegment, "\\", AppColor.DiffSection.GetThemeColor());
         }
+    }
 
-        private void AddExtraPatchHighlighting(IDocument document)
+    public abstract string[] GetFullDiffPrefixes();
+
+    public abstract bool IsSearchMatch(string line);
+
+    protected readonly LinePrefixHelper LinePrefixHelper = new(new LineSegmentGetter());
+
+    protected abstract List<ISegment> GetAddedLines(IDocument document, ref int line, ref bool found);
+
+    protected abstract List<ISegment> GetRemovedLines(IDocument document, ref int line, ref bool found);
+
+    protected abstract int TryHighlightAddedAndDeletedLines(IDocument document, int line, LineSegment lineSegment);
+
+    protected void ProcessLineSegment(IDocument document, ref int line,
+        LineSegment lineSegment, string prefixStr, Color color, bool invertMatch = false)
+    {
+        if (!DoesLineStartWith(document, lineSegment.Offset, prefixStr, invertMatch))
         {
-            int line = 0;
-
-            bool found = false;
-            int diffContentOffset;
-            List<ISegment> linesRemoved = GetRemovedLines(document, ref line, ref found);
-            List<ISegment> linesAdded = GetAddedLines(document, ref line, ref found);
-            if (linesAdded.Count == 1 && linesRemoved.Count == 1)
-            {
-                ISegment lineA = linesRemoved[0];
-                ISegment lineB = linesAdded[0];
-                if (lineA.Length > 4 && lineB.Length > 4 &&
-                    document.GetCharAt(lineA.Offset + 4) == 'a' &&
-                    document.GetCharAt(lineB.Offset + 4) == 'b')
-                {
-                    diffContentOffset = 5;
-                }
-                else
-                {
-                    diffContentOffset = 4;
-                }
-
-                MarkDifference(document, linesRemoved, linesAdded, diffContentOffset);
-            }
-
-            diffContentOffset = GetDiffContentOffset();
-            while (line < document.TotalNumberOfLines)
-            {
-                found = false;
-                linesRemoved = GetRemovedLines(document, ref line, ref found);
-                linesAdded = GetAddedLines(document, ref line, ref found);
-
-                MarkDifference(document, linesRemoved, linesAdded, diffContentOffset);
-            }
-        }
-
-        protected virtual List<ISegment> GetAddedLines(IDocument document, ref int line, ref bool found)
-        {
-            return LinePrefixHelper.GetLinesStartingWith(document, ref line, "+", ref found);
-        }
-
-        protected virtual List<ISegment> GetRemovedLines(IDocument document, ref int line, ref bool found)
-        {
-            return LinePrefixHelper.GetLinesStartingWith(document, ref line, "-", ref found);
-        }
-
-        protected void ProcessLineSegment(IDocument document, ref int line,
-            LineSegment lineSegment, string prefixStr, Color color, bool invertMatch = false)
-        {
-            if (!DoesLineStartWith(document, lineSegment.Offset, prefixStr, invertMatch))
-            {
-                return;
-            }
-
-            LineSegment endLine = document.GetLineSegment(line);
-
-            for (;
-                line < document.TotalNumberOfLines
-                && DoesLineStartWith(document, endLine.Offset, prefixStr, invertMatch);
-                line++)
-            {
-                endLine = document.GetLineSegment(line);
-            }
-
-            line = Math.Max(0, line - 2);
-            endLine = document.GetLineSegment(line);
-
-            document.MarkerStrategy.AddMarker(new TextMarker(lineSegment.Offset,
-                (endLine.Offset + endLine.TotalLength) -
-                lineSegment.Offset, TextMarkerType.SolidBlock, color,
-                ColorHelper.GetForeColorForBackColor(color)));
-
             return;
-
-            bool DoesLineStartWith(IDocument document, int offset, string prefixStr, bool invertMatch)
-                => invertMatch ^ LinePrefixHelper.DoesLineStartWith(document, offset, prefixStr);
         }
 
-        public override void AddTextHighlighting(IDocument document)
+        LineSegment endLine = document.GetLineSegment(line);
+
+        for (;
+            line < document.TotalNumberOfLines
+            && DoesLineStartWith(document, endLine.Offset, prefixStr, invertMatch);
+            line++)
         {
-            bool forceAbort = false;
+            endLine = document.GetLineSegment(line);
+        }
 
-            AddExtraPatchHighlighting(document);
+        line = Math.Max(0, line - 2);
+        endLine = document.GetLineSegment(line);
 
-            for (int line = 0; line < document.TotalNumberOfLines && !forceAbort; line++)
+        document.MarkerStrategy.AddMarker(new TextMarker(lineSegment.Offset,
+            (endLine.Offset + endLine.TotalLength) -
+            lineSegment.Offset, TextMarkerType.SolidBlock, color,
+            ColorHelper.GetForeColorForBackColor(color)));
+
+        return;
+
+        bool DoesLineStartWith(IDocument document, int offset, string prefixStr, bool invertMatch)
+            => invertMatch ^ LinePrefixHelper.DoesLineStartWith(document, offset, prefixStr);
+    }
+
+    private static void MarkDifference(IDocument document, List<ISegment> linesRemoved, List<ISegment> linesAdded, int beginOffset)
+    {
+        int count = Math.Min(linesRemoved.Count, linesAdded.Count);
+
+        for (int i = 0; i < count; i++)
+        {
+            MarkDifference(document, linesRemoved[i], linesAdded[i], beginOffset);
+        }
+    }
+
+    private static void MarkDifference(IDocument document, ISegment lineRemoved,
+        ISegment lineAdded, int beginOffset)
+    {
+        int lineRemovedEndOffset = lineRemoved.Length;
+        int lineAddedEndOffset = lineAdded.Length;
+        int endOffsetMin = Math.Min(lineRemovedEndOffset, lineAddedEndOffset);
+        int reverseOffset = 0;
+
+        while (beginOffset < endOffsetMin)
+        {
+            char a = document.GetCharAt(lineAdded.Offset + beginOffset);
+            char r = document.GetCharAt(lineRemoved.Offset + beginOffset);
+
+            if (a != r)
             {
-                LineSegment lineSegment = document.GetLineSegment(line);
-
-                if (lineSegment.TotalLength == 0)
-                {
-                    continue;
-                }
-
-                if (line == document.TotalNumberOfLines - 1)
-                {
-                    forceAbort = true;
-                }
-
-                line = TryHighlightAddedAndDeletedLines(document, line, lineSegment);
-
-                ProcessLineSegment(document, ref line, lineSegment, "@", AppColor.DiffSection.GetThemeColor());
-                ProcessLineSegment(document, ref line, lineSegment, "\\", AppColor.DiffSection.GetThemeColor());
+                break;
             }
+
+            beginOffset++;
         }
 
-        protected virtual int TryHighlightAddedAndDeletedLines(IDocument document, int line, LineSegment lineSegment)
+        while (lineAddedEndOffset > beginOffset && lineRemovedEndOffset > beginOffset)
         {
-            ProcessLineSegment(document, ref line, lineSegment, "+", AppColor.DiffAdded.GetThemeColor());
-            ProcessLineSegment(document, ref line, lineSegment, "-", AppColor.DiffRemoved.GetThemeColor());
-            return line;
+            reverseOffset = lineAdded.Length - lineAddedEndOffset;
+
+            char a = document.GetCharAt(lineAdded.Offset + lineAdded.Length - 1 - reverseOffset);
+            char r = document.GetCharAt(lineRemoved.Offset + lineRemoved.Length - 1 - reverseOffset);
+
+            if (a != r)
+            {
+                break;
+            }
+
+            lineRemovedEndOffset--;
+            lineAddedEndOffset--;
+        }
+
+        Color color;
+        MarkerStrategy markerStrategy = document.MarkerStrategy;
+
+        if (lineAdded.Length - beginOffset - reverseOffset > 0)
+        {
+            color = AppColor.DiffAddedExtra.GetThemeColor();
+            markerStrategy.AddMarker(new TextMarker(lineAdded.Offset + beginOffset,
+                                                    lineAdded.Length - beginOffset - reverseOffset,
+                                                    TextMarkerType.SolidBlock, color,
+                                                    ColorHelper.GetForeColorForBackColor(color)));
+        }
+
+        if (lineRemoved.Length - beginOffset - reverseOffset > 0)
+        {
+            color = AppColor.DiffRemovedExtra.GetThemeColor();
+            markerStrategy.AddMarker(new TextMarker(lineRemoved.Offset + beginOffset,
+                                                    lineRemoved.Length - beginOffset - reverseOffset,
+                                                    TextMarkerType.SolidBlock, color,
+                                                    ColorHelper.GetForeColorForBackColor(color)));
+        }
+    }
+
+    private void AddExtraPatchHighlighting(IDocument document)
+    {
+        int line = 0;
+
+        bool found = false;
+        int diffContentOffset;
+        List<ISegment> linesRemoved = GetRemovedLines(document, ref line, ref found);
+        List<ISegment> linesAdded = GetAddedLines(document, ref line, ref found);
+        if (linesAdded.Count == 1 && linesRemoved.Count == 1)
+        {
+            ISegment lineA = linesRemoved[0];
+            ISegment lineB = linesAdded[0];
+            if (lineA.Length > 4 && lineB.Length > 4 &&
+                document.GetCharAt(lineA.Offset + 4) == 'a' &&
+                document.GetCharAt(lineB.Offset + 4) == 'b')
+            {
+                diffContentOffset = 5;
+            }
+            else
+            {
+                diffContentOffset = 4;
+            }
+
+            MarkDifference(document, linesRemoved, linesAdded, diffContentOffset);
+        }
+
+        // overlap when marking
+        diffContentOffset = 1;
+        while (line < document.TotalNumberOfLines)
+        {
+            found = false;
+            linesRemoved = GetRemovedLines(document, ref line, ref found);
+            linesAdded = GetAddedLines(document, ref line, ref found);
+
+            MarkDifference(document, linesRemoved, linesAdded, diffContentOffset);
         }
     }
 }

--- a/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -50,6 +50,13 @@ public abstract class DiffHighlightService : TextHighlightService
             commandConfiguration.Add(new GitConfigItem("diff.colorMovedWS", "no"), command);
         }
 
+        if (string.IsNullOrEmpty(module.GetEffectiveSetting("diff.wordRegex")))
+        {
+            // https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-diffwordRegex
+            // Set to "minimal" diff unless configured.
+            commandConfiguration.Add(new GitConfigItem("diff.wordRegex", "."), command);
+        }
+
         // Override Git default coloring to "theme" colors for those that are defined
         if (AppSettings.UseGEThemeGitColoring.Value)
         {
@@ -70,6 +77,12 @@ public abstract class DiffHighlightService : TextHighlightService
     {
         if (_useGitColoring)
         {
+            // Apply GE wordhighlighting unless Git coloring is already applied
+            if (!AppSettings.ShowGitWordColoring.Value)
+            {
+                AddExtraPatchHighlighting(document);
+            }
+
             foreach (TextMarker tm in _textMarkers)
             {
                 document.MarkerStrategy.AddMarker(tm);

--- a/GitUI/Editor/Diff/DiffLineInfo.cs
+++ b/GitUI/Editor/Diff/DiffLineInfo.cs
@@ -1,11 +1,10 @@
-﻿namespace GitUI.Editor.Diff
+﻿namespace GitUI.Editor.Diff;
+
+public class DiffLineInfo
 {
-    public class DiffLineInfo
-    {
-        public static readonly int NotApplicableLineNum = -1;
-        public int LineNumInDiff { get; set; }
-        public int LeftLineNumber { get; set; }
-        public int RightLineNumber { get; set; }
-        public DiffLineType LineType { get; set; }
-    }
+    public static readonly int NotApplicableLineNum = -1;
+    public int LineNumInDiff { get; set; }
+    public int LeftLineNumber { get; set; }
+    public int RightLineNumber { get; set; }
+    public DiffLineType LineType { get; set; }
 }

--- a/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
+++ b/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
@@ -1,150 +1,147 @@
 ﻿using System.Text.RegularExpressions;
 using GitCommands;
-using GitCommands.Patches;
 
-namespace GitUI.Editor.Diff
+namespace GitUI.Editor.Diff;
+
+public partial class DiffLineNumAnalyzer
 {
-    public partial class DiffLineNumAnalyzer
+    [GeneratedRegex(@"\-(?<leftStart>\d{1,})\,{0,}(?<leftCount>\d{0,})\s\+(?<rightStart>\d{1,})\,{0,}(?<rightCount>\d{0,})", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture)]
+    private static partial Regex DiffRegex();
+
+    public DiffLinesInfo Analyze(string diffContent, bool isCombinedDiff)
     {
-        [GeneratedRegex(@"\-(?<leftStart>\d{1,})\,{0,}(?<leftCount>\d{0,})\s\+(?<rightStart>\d{1,})\,{0,}(?<rightCount>\d{0,})", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture)]
-        private static partial Regex DiffRegex();
-
-        public DiffLinesInfo Analyze(string diffContent)
+        DiffLinesInfo ret = new();
+        int lineNumInDiff = 0;
+        int leftLineNum = DiffLineInfo.NotApplicableLineNum;
+        int rightLineNum = DiffLineInfo.NotApplicableLineNum;
+        bool isHeaderLineLocated = false;
+        string[] lines = diffContent.Split(Delimiters.LineFeed);
+        for (int i = 0; i < lines.Length; i++)
         {
-            DiffLinesInfo ret = new();
-            bool isCombinedDiff = PatchProcessor.IsCombinedDiff(diffContent);
-            int lineNumInDiff = 0;
-            int leftLineNum = DiffLineInfo.NotApplicableLineNum;
-            int rightLineNum = DiffLineInfo.NotApplicableLineNum;
-            bool isHeaderLineLocated = false;
-            string[] lines = diffContent.Split(Delimiters.LineFeed);
-            for (int i = 0; i < lines.Length; i++)
+            string line = lines[i];
+            if (i == lines.Length - 1 && string.IsNullOrEmpty(line))
             {
-                string line = lines[i];
-                if (i == lines.Length - 1 && string.IsNullOrEmpty(line))
-                {
-                    break;
-                }
-
-                lineNumInDiff++;
-                if (line.StartsWith("@"))
-                {
-                    DiffLineInfo meta = new()
-                    {
-                        LineNumInDiff = lineNumInDiff,
-                        LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
-                        RightLineNumber = DiffLineInfo.NotApplicableLineNum,
-                        LineType = DiffLineType.Header
-                    };
-
-                    Match lineNumbers = DiffRegex().Match(line);
-                    leftLineNum = int.Parse(lineNumbers.Groups["leftStart"].Value);
-                    rightLineNum = int.Parse(lineNumbers.Groups["rightStart"].Value);
-
-                    ret.Add(meta);
-                    isHeaderLineLocated = true;
-                }
-                else if (isHeaderLineLocated && isCombinedDiff)
-                {
-                    DiffLineInfo meta = new()
-                    {
-                        LineNumInDiff = lineNumInDiff,
-                        LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
-                        RightLineNumber = DiffLineInfo.NotApplicableLineNum,
-                    };
-
-                    if (IsMinusLineInCombinedDiff(line))
-                    {
-                        meta.LineType = DiffLineType.Minus;
-                    }
-                    else if (IsPlusLineInCombinedDiff(line))
-                    {
-                        meta.LineType = DiffLineType.Plus;
-                        meta.RightLineNumber = rightLineNum;
-                        rightLineNum++;
-                    }
-                    else
-                    {
-                        meta.LineType = DiffLineType.Context;
-                        meta.RightLineNumber = rightLineNum;
-                        rightLineNum++;
-                    }
-
-                    ret.Add(meta);
-                }
-                else if (isHeaderLineLocated && IsMinusLine(line))
-                {
-                    DiffLineInfo meta = new()
-                    {
-                        LineNumInDiff = lineNumInDiff,
-                        LeftLineNumber = leftLineNum,
-                        RightLineNumber = DiffLineInfo.NotApplicableLineNum,
-                        LineType = DiffLineType.Minus
-                    };
-                    ret.Add(meta);
-
-                    leftLineNum++;
-                }
-                else if (isHeaderLineLocated && IsPlusLine(line))
-                {
-                    DiffLineInfo meta = new()
-                    {
-                        LineNumInDiff = lineNumInDiff,
-                        LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
-                        RightLineNumber = rightLineNum,
-                        LineType = DiffLineType.Plus,
-                    };
-                    ret.Add(meta);
-                    rightLineNum++;
-                }
-                else if (line.StartsWith(GitModule.NoNewLineAtTheEnd))
-                {
-                    DiffLineInfo meta = new()
-                    {
-                        LineNumInDiff = lineNumInDiff,
-                        LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
-                        RightLineNumber = DiffLineInfo.NotApplicableLineNum,
-                        LineType = DiffLineType.Header
-                    };
-                    ret.Add(meta);
-                }
-                else if (isHeaderLineLocated)
-                {
-                    DiffLineInfo meta = new()
-                    {
-                        LineNumInDiff = lineNumInDiff,
-                        LeftLineNumber = leftLineNum,
-                        RightLineNumber = rightLineNum,
-                        LineType = DiffLineType.Context,
-                    };
-                    ret.Add(meta);
-
-                    leftLineNum++;
-                    rightLineNum++;
-                }
+                break;
             }
 
-            return ret;
+            lineNumInDiff++;
+            if (line.StartsWith('@'))
+            {
+                DiffLineInfo meta = new()
+                {
+                    LineNumInDiff = lineNumInDiff,
+                    LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
+                    RightLineNumber = DiffLineInfo.NotApplicableLineNum,
+                    LineType = DiffLineType.Header
+                };
+
+                Match lineNumbers = DiffRegex().Match(line);
+                leftLineNum = int.Parse(lineNumbers.Groups["leftStart"].Value);
+                rightLineNum = int.Parse(lineNumbers.Groups["rightStart"].Value);
+
+                ret.Add(meta);
+                isHeaderLineLocated = true;
+            }
+            else if (isHeaderLineLocated && isCombinedDiff)
+            {
+                DiffLineInfo meta = new()
+                {
+                    LineNumInDiff = lineNumInDiff,
+                    LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
+                    RightLineNumber = DiffLineInfo.NotApplicableLineNum,
+                };
+
+                if (IsMinusLineInCombinedDiff(line))
+                {
+                    meta.LineType = DiffLineType.Minus;
+                }
+                else if (IsPlusLineInCombinedDiff(line))
+                {
+                    meta.LineType = DiffLineType.Plus;
+                    meta.RightLineNumber = rightLineNum;
+                    rightLineNum++;
+                }
+                else
+                {
+                    meta.LineType = DiffLineType.Context;
+                    meta.RightLineNumber = rightLineNum;
+                    rightLineNum++;
+                }
+
+                ret.Add(meta);
+            }
+            else if (isHeaderLineLocated && IsMinusLine(line))
+            {
+                DiffLineInfo meta = new()
+                {
+                    LineNumInDiff = lineNumInDiff,
+                    LeftLineNumber = leftLineNum,
+                    RightLineNumber = DiffLineInfo.NotApplicableLineNum,
+                    LineType = DiffLineType.Minus
+                };
+                ret.Add(meta);
+
+                leftLineNum++;
+            }
+            else if (isHeaderLineLocated && IsPlusLine(line))
+            {
+                DiffLineInfo meta = new()
+                {
+                    LineNumInDiff = lineNumInDiff,
+                    LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
+                    RightLineNumber = rightLineNum,
+                    LineType = DiffLineType.Plus,
+                };
+                ret.Add(meta);
+                rightLineNum++;
+            }
+            else if (line.StartsWith(GitModule.NoNewLineAtTheEnd))
+            {
+                DiffLineInfo meta = new()
+                {
+                    LineNumInDiff = lineNumInDiff,
+                    LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
+                    RightLineNumber = DiffLineInfo.NotApplicableLineNum,
+                    LineType = DiffLineType.Header
+                };
+                ret.Add(meta);
+            }
+            else if (isHeaderLineLocated)
+            {
+                DiffLineInfo meta = new()
+                {
+                    LineNumInDiff = lineNumInDiff,
+                    LeftLineNumber = leftLineNum,
+                    RightLineNumber = rightLineNum,
+                    LineType = DiffLineType.Context,
+                };
+                ret.Add(meta);
+
+                leftLineNum++;
+                rightLineNum++;
+            }
         }
 
-        private static bool IsMinusLine(string line)
-        {
-            return line.StartsWith("-");
-        }
+        return ret;
+    }
 
-        private static bool IsPlusLine(string line)
-        {
-            return line.StartsWith("+");
-        }
+    private static bool IsMinusLine(string line)
+    {
+        return line.StartsWith('-');
+    }
 
-        private static bool IsPlusLineInCombinedDiff(string line)
-        {
-            return line.StartsWith("++") || line.StartsWith("+ ") || line.StartsWith(" +");
-        }
+    private static bool IsPlusLine(string line)
+    {
+        return line.StartsWith('+');
+    }
 
-        private static bool IsMinusLineInCombinedDiff(string line)
-        {
-            return line.StartsWith("--") || line.StartsWith("- ") || line.StartsWith(" -");
-        }
+    private static bool IsPlusLineInCombinedDiff(string line)
+    {
+        return line.StartsWith("++") || line.StartsWith("+ ") || line.StartsWith(" +");
+    }
+
+    private static bool IsMinusLineInCombinedDiff(string line)
+    {
+        return line.StartsWith("--") || line.StartsWith("- ") || line.StartsWith(" -");
     }
 }

--- a/GitUI/Editor/Diff/DiffLineType.cs
+++ b/GitUI/Editor/Diff/DiffLineType.cs
@@ -1,10 +1,9 @@
-﻿namespace GitUI.Editor.Diff
+﻿namespace GitUI.Editor.Diff;
+
+public enum DiffLineType
 {
-    public enum DiffLineType
-    {
-        Header,
-        Plus,
-        Minus,
-        Context
-    }
+    Header,
+    Plus,
+    Minus,
+    Context,
 }

--- a/GitUI/Editor/Diff/DiffLinesInfo.cs
+++ b/GitUI/Editor/Diff/DiffLinesInfo.cs
@@ -1,21 +1,20 @@
-﻿namespace GitUI.Editor.Diff
+﻿namespace GitUI.Editor.Diff;
+
+public sealed class DiffLinesInfo
 {
-    public sealed class DiffLinesInfo
+    private readonly Dictionary<int, DiffLineInfo> _diffLines = [];
+
+    public IReadOnlyDictionary<int, DiffLineInfo> DiffLines => _diffLines;
+
+    /// <summary>
+    /// Gets the maximum line number from either left or right version.
+    /// </summary>
+    public int MaxLineNumber { get; private set; }
+
+    public void Add(DiffLineInfo diffLine)
     {
-        private readonly Dictionary<int, DiffLineInfo> _diffLines = [];
-
-        public IReadOnlyDictionary<int, DiffLineInfo> DiffLines => _diffLines;
-
-        /// <summary>
-        /// Gets the maximum line number from either left or right version.
-        /// </summary>
-        public int MaxLineNumber { get; private set; }
-
-        public void Add(DiffLineInfo diffLine)
-        {
-            _diffLines.Add(diffLine.LineNumInDiff, diffLine);
-            MaxLineNumber = Math.Max(MaxLineNumber,
-                Math.Max(diffLine.LeftLineNumber, diffLine.RightLineNumber));
-        }
+        _diffLines.Add(diffLine.LineNumInDiff, diffLine);
+        MaxLineNumber = Math.Max(MaxLineNumber,
+            Math.Max(diffLine.LeftLineNumber, diffLine.RightLineNumber));
     }
 }

--- a/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
+++ b/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
@@ -3,132 +3,130 @@ using GitExtUtils.GitUI.Theming;
 using GitUI.Theming;
 using ICSharpCode.TextEditor;
 
-namespace GitUI.Editor.Diff
+namespace GitUI.Editor.Diff;
+
+public class DiffViewerLineNumberControl : AbstractMargin
 {
-    internal class DiffViewerLineNumberControl : AbstractMargin
+    private const int TextHorizontalMargin = 4;
+    private static readonly IReadOnlyDictionary<int, DiffLineInfo> Empty = new Dictionary<int, DiffLineInfo>();
+    private IReadOnlyDictionary<int, DiffLineInfo> _diffLines = Empty;
+    private bool _visible = true;
+
+    public DiffViewerLineNumberControl(TextArea textArea)
+        : base(textArea)
     {
-        private const int TextHorizontalMargin = 4;
-        private static readonly IReadOnlyDictionary<int, DiffLineInfo> Empty = new Dictionary<int, DiffLineInfo>();
-        private IReadOnlyDictionary<int, DiffLineInfo> _diffLines = Empty;
-        private bool _visible = true;
+    }
 
-        public DiffViewerLineNumberControl(TextArea textArea)
-            : base(textArea)
+    /// <summary>
+    /// Gets the maximum line number from either left or right version.
+    /// </summary>
+    public int MaxLineNumber { get; private set; }
+
+    public override int Width
+    {
+        get
         {
-        }
-
-        /// <summary>
-        /// Gets the maximum line number from either left or right version.
-        /// </summary>
-        public int MaxLineNumber { get; private set; }
-
-        public override int Width
-        {
-            get
+            if (_visible && _diffLines.Any())
             {
-                if (_visible && _diffLines.Any())
-                {
-                    int maxDigits = MaxLineNumber > 0 ? ((int)Math.Log10(MaxLineNumber) + 1) : 0;
-                    return TextHorizontalMargin + (textArea.TextView.WideSpaceWidth * ((2 * maxDigits) + /* a space behind each number */ 2));
-                }
+                int maxDigits = MaxLineNumber > 0 ? ((int)Math.Log10(MaxLineNumber) + 1) : 0;
+                return TextHorizontalMargin + (textArea.TextView.WideSpaceWidth * ((2 * maxDigits) + /* a space behind each number */ 2));
+            }
 
-                return 0;
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// returns the according line numbers or null if the caretLine is not mapped.
+    /// </summary>
+    /// <param name="caretLine">0-based (in contrast to the displayed line numbers which are 1-based).</param>
+    public DiffLineInfo GetLineInfo(int caretLine)
+    {
+        DiffLineInfo diffLine;
+        _diffLines.TryGetValue(caretLine + 1, out diffLine);
+        return diffLine;
+    }
+
+    public override void Paint(Graphics g, Rectangle rect)
+    {
+        int numbersWidth = Width - TextHorizontalMargin;
+        int leftWidth = TextHorizontalMargin + (numbersWidth / 2);
+        int rightWidth = rect.Width - leftWidth;
+
+        int fontHeight = textArea.TextView.FontHeight;
+        ICSharpCode.TextEditor.Document.HighlightColor lineNumberPainterColor = textArea.Document.HighlightingStrategy.GetColorFor("LineNumbers");
+        Brush fillBrush = textArea.Enabled ? BrushRegistry.GetBrush(lineNumberPainterColor.BackgroundColor) : SystemBrushes.InactiveBorder;
+        Brush drawBrush = BrushRegistry.GetBrush(lineNumberPainterColor.Color);
+
+        for (int y = 0; y < ((DrawingPosition.Height + textArea.TextView.VisibleLineDrawingRemainder) / fontHeight) + 1; ++y)
+        {
+            int ypos = drawingPosition.Y + (fontHeight * y) - textArea.TextView.VisibleLineDrawingRemainder;
+            Rectangle backgroundRectangle = new(drawingPosition.X, ypos, drawingPosition.Width, fontHeight);
+            if (!rect.IntersectsWith(backgroundRectangle))
+            {
+                continue;
+            }
+
+            g.FillRectangle(fillBrush, backgroundRectangle);
+            int curLine = textArea.Document.GetFirstLogicalLine(textArea.Document.GetVisibleLine(textArea.TextView.FirstVisibleLine) + y);
+
+            if (curLine >= textArea.Document.TotalNumberOfLines)
+            {
+                continue;
+            }
+
+            if (!_diffLines.ContainsKey(curLine + 1))
+            {
+                continue;
+            }
+
+            DiffLineInfo diffLine = _diffLines[curLine + 1];
+            if (diffLine.LineType != DiffLineType.Context)
+            {
+                using Brush brush = diffLine.LineType switch
+                {
+                    DiffLineType.Plus => new SolidBrush(AppColor.DiffAdded.GetThemeColor()),
+                    DiffLineType.Minus => new SolidBrush(AppColor.DiffRemoved.GetThemeColor()),
+                    DiffLineType.Header => new SolidBrush(AppColor.DiffSection.GetThemeColor()),
+                    _ => default(Brush)
+                };
+
+                DebugHelpers.Assert(brush is not null, string.Format("brush is not null, unknow diff line style {0}", diffLine.LineType));
+                g.FillRectangle(brush, new Rectangle(0, backgroundRectangle.Top, leftWidth, backgroundRectangle.Height));
+                g.FillRectangle(brush, new Rectangle(leftWidth, backgroundRectangle.Top, rightWidth, backgroundRectangle.Height));
+            }
+
+            if (diffLine.LeftLineNumber != DiffLineInfo.NotApplicableLineNum)
+            {
+                g.DrawString(diffLine.LeftLineNumber.ToString(),
+                    lineNumberPainterColor.GetFont(TextEditorProperties.FontContainer),
+                    drawBrush,
+                    new Point(TextHorizontalMargin, backgroundRectangle.Top));
+            }
+
+            if (diffLine.RightLineNumber != DiffLineInfo.NotApplicableLineNum)
+            {
+                g.DrawString(diffLine.RightLineNumber.ToString(),
+                    lineNumberPainterColor.GetFont(TextEditorProperties.FontContainer),
+                    drawBrush,
+                    new Point(leftWidth, backgroundRectangle.Top));
             }
         }
+    }
 
-        /// <summary>
-        /// returns the according line numbers or null if the caretLine is not mapped.
-        /// </summary>
-        /// <param name="caretLine">0-based (in contrast to the displayed line numbers which are 1-based).</param>
-        public DiffLineInfo GetLineInfo(int caretLine)
-        {
-            DiffLineInfo diffLine;
-            _diffLines.TryGetValue(caretLine + 1, out diffLine);
-            return diffLine;
-        }
+    public void DisplayLineNum(DiffLinesInfo result)
+    {
+        _diffLines = result.DiffLines;
+        MaxLineNumber = result.MaxLineNumber;
+    }
 
-        public override void Paint(Graphics g, Rectangle rect)
-        {
-            int numbersWidth = Width - TextHorizontalMargin;
-            int leftWidth = TextHorizontalMargin + (numbersWidth / 2);
-            int rightWidth = rect.Width - leftWidth;
+    public void Clear(bool forDiff)
+    {
+        _diffLines = Empty;
+    }
 
-            int fontHeight = textArea.TextView.FontHeight;
-            ICSharpCode.TextEditor.Document.HighlightColor lineNumberPainterColor = textArea.Document.HighlightingStrategy.GetColorFor("LineNumbers");
-            Brush fillBrush = textArea.Enabled ? BrushRegistry.GetBrush(lineNumberPainterColor.BackgroundColor) : SystemBrushes.InactiveBorder;
-            Brush drawBrush = BrushRegistry.GetBrush(lineNumberPainterColor.Color);
-
-            for (int y = 0; y < ((DrawingPosition.Height + textArea.TextView.VisibleLineDrawingRemainder) / fontHeight) + 1; ++y)
-            {
-                int ypos = drawingPosition.Y + (fontHeight * y) - textArea.TextView.VisibleLineDrawingRemainder;
-                Rectangle backgroundRectangle = new(drawingPosition.X, ypos, drawingPosition.Width, fontHeight);
-                if (!rect.IntersectsWith(backgroundRectangle))
-                {
-                    continue;
-                }
-
-                g.FillRectangle(fillBrush, backgroundRectangle);
-                int curLine = textArea.Document.GetFirstLogicalLine(textArea.Document.GetVisibleLine(textArea.TextView.FirstVisibleLine) + y);
-
-                if (curLine >= textArea.Document.TotalNumberOfLines)
-                {
-                    continue;
-                }
-
-                if (!_diffLines.ContainsKey(curLine + 1))
-                {
-                    continue;
-                }
-
-                DiffLineInfo diffLine = _diffLines[curLine + 1];
-                if (diffLine.LineType != DiffLineType.Context)
-                {
-                    using Brush brush = diffLine.LineType switch
-                    {
-                        DiffLineType.Plus => new SolidBrush(AppColor.DiffAdded.GetThemeColor()),
-                        DiffLineType.Minus => new SolidBrush(AppColor.DiffRemoved.GetThemeColor()),
-                        DiffLineType.Header => new SolidBrush(AppColor.DiffSection.GetThemeColor()),
-                        _ => default(Brush)
-                    };
-
-                    DebugHelpers.Assert(brush is not null, string.Format("brush is not null, unknow diff line style {0}", diffLine.LineType));
-                    g.FillRectangle(brush, new Rectangle(0, backgroundRectangle.Top, leftWidth, backgroundRectangle.Height));
-                    g.FillRectangle(brush, new Rectangle(leftWidth, backgroundRectangle.Top, rightWidth, backgroundRectangle.Height));
-                }
-
-                if (diffLine.LeftLineNumber != DiffLineInfo.NotApplicableLineNum)
-                {
-                    g.DrawString(diffLine.LeftLineNumber.ToString(),
-                        lineNumberPainterColor.GetFont(TextEditorProperties.FontContainer),
-                        drawBrush,
-                        new Point(TextHorizontalMargin, backgroundRectangle.Top));
-                }
-
-                if (diffLine.RightLineNumber != DiffLineInfo.NotApplicableLineNum)
-                {
-                    g.DrawString(diffLine.RightLineNumber.ToString(),
-                        lineNumberPainterColor.GetFont(TextEditorProperties.FontContainer),
-                        drawBrush,
-                        new Point(leftWidth, backgroundRectangle.Top));
-                }
-            }
-        }
-
-        public void DisplayLineNumFor(string diff)
-        {
-            DiffLinesInfo result = new DiffLineNumAnalyzer().Analyze(diff);
-            _diffLines = result.DiffLines;
-            MaxLineNumber = result.MaxLineNumber;
-        }
-
-        public void Clear(bool forDiff)
-        {
-            _diffLines = Empty;
-        }
-
-        public void SetVisibility(bool visible)
-        {
-            _visible = visible;
-        }
+    public void SetVisibility(bool visible)
+    {
+        _visible = visible;
     }
 }

--- a/GitUI/Editor/Diff/HighlightInfo.cs
+++ b/GitUI/Editor/Diff/HighlightInfo.cs
@@ -1,0 +1,9 @@
+﻿namespace GitUI.Editor.Diff;
+
+public struct HighlightInfo
+{
+    public int DocOffset { get; set; }
+    public int Length { get; set; }
+    public Color? BackColor { get; set; }
+    public Color? ForeColor { get; set; }
+}

--- a/GitUI/Editor/Diff/ITextHighlightService.cs
+++ b/GitUI/Editor/Diff/ITextHighlightService.cs
@@ -1,15 +1,25 @@
-﻿using ICSharpCode.TextEditor.Document;
+﻿using ICSharpCode.TextEditor;
+using ICSharpCode.TextEditor.Document;
 using JetBrains.Annotations;
 
-namespace GitUI.Editor.Diff
+namespace GitUI.Editor.Diff;
+
+public interface ITextHighlightService
 {
-    public interface ITextHighlightService
-    {
-        /// <summary>
-        /// Add text highlighting to the document.
-        /// This is primarily used to highlight changed files for diffs
-        /// </summary>
-        /// <param name="document">The document to highlight.</param>
-        void AddTextHighlighting([NotNull] IDocument document);
-    }
+    /// <summary>
+    /// Add text highlighting to the document.
+    /// This is primarily used to highlight changed files for diffs.
+    /// Called when the text is changed.
+    /// </summary>
+    /// <param name="document">The document to highlight.</param>
+    void AddTextHighlighting([NotNull] IDocument document);
+
+    /// <summary>
+    /// Set info in line number control for e.g. Patch/Diff views
+    /// where the line number is non sequential.
+    /// Other views (like normal text) do not use this control.
+    /// </summary>
+    /// <param name="lineNumbersControl">The line number control</param>
+    /// <param name="textEditor">The textEditor contol with text to adjust for.</param>
+    void SetLineControl(DiffViewerLineNumberControl lineNumbersControl, TextEditorControl textEditor);
 }

--- a/GitUI/Editor/Diff/LinePrefixHelper.cs
+++ b/GitUI/Editor/Diff/LinePrefixHelper.cs
@@ -1,76 +1,75 @@
 using ICSharpCode.TextEditor.Document;
 
-namespace GitUI.Editor.Diff
+namespace GitUI.Editor.Diff;
+
+public class LinePrefixHelper
 {
-    public class LinePrefixHelper
+    private readonly LineSegmentGetter _segmentGetter;
+
+    public LinePrefixHelper(LineSegmentGetter segmentGetter)
     {
-        private readonly LineSegmentGetter _segmentGetter;
+        _segmentGetter = segmentGetter;
+    }
 
-        public LinePrefixHelper(LineSegmentGetter segmentGetter)
+    public List<ISegment> GetLinesStartingWith(IDocument document, ref int beginIndex, string prefixStr, ref bool found)
+    {
+        return GetLinesStartingWith(document, ref beginIndex, new[] { prefixStr }, ref found);
+    }
+
+    public List<ISegment> GetLinesStartingWith(IDocument document, ref int beginIndex, string[] prefixStrs, ref bool found)
+    {
+        List<ISegment> result = [];
+
+        while (beginIndex < document.TotalNumberOfLines)
         {
-            _segmentGetter = segmentGetter;
-        }
+            ISegment lineSegment = _segmentGetter.GetSegment(document, beginIndex);
 
-        public List<ISegment> GetLinesStartingWith(IDocument document, ref int beginIndex, string prefixStr, ref bool found)
-        {
-            return GetLinesStartingWith(document, ref beginIndex, new[] { prefixStr }, ref found);
-        }
-
-        public List<ISegment> GetLinesStartingWith(IDocument document, ref int beginIndex, string[] prefixStrs, ref bool found)
-        {
-            List<ISegment> result = [];
-
-            while (beginIndex < document.TotalNumberOfLines)
+            if (lineSegment.Length > 0
+                && DoesLineStartWith(document, lineSegment.Offset, prefixStrs))
             {
-                ISegment lineSegment = _segmentGetter.GetSegment(document, beginIndex);
-
-                if (lineSegment.Length > 0
-                    && DoesLineStartWith(document, lineSegment.Offset, prefixStrs))
-                {
-                    found = true;
-                    result.Add(lineSegment);
-                    beginIndex++;
-                }
-                else
-                {
-                    if (found)
-                    {
-                        break;
-                    }
-
-                    beginIndex++;
-                }
+                found = true;
+                result.Add(lineSegment);
+                beginIndex++;
             }
+            else
+            {
+                if (found)
+                {
+                    break;
+                }
 
-            return result;
+                beginIndex++;
+            }
         }
 
-        public bool DoesLineStartWith(IDocument document, int lineOffset, string prefixStr)
-        {
-            if (prefixStr.Length == 1)
-            {
-                return document.GetCharAt(lineOffset) == prefixStr[0];
-            }
+        return result;
+    }
 
-            if (document.TextLength <= lineOffset + 1)
+    public bool DoesLineStartWith(IDocument document, int lineOffset, string prefixStr)
+    {
+        if (prefixStr.Length == 1)
+        {
+            return document.GetCharAt(lineOffset) == prefixStr[0];
+        }
+
+        if (document.TextLength <= lineOffset + 1)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < prefixStr.Length; i++)
+        {
+            if (document.GetCharAt(lineOffset + i) != prefixStr[i])
             {
                 return false;
             }
-
-            for (int i = 0; i < prefixStr.Length; i++)
-            {
-                if (document.GetCharAt(lineOffset + i) != prefixStr[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
         }
 
-        public bool DoesLineStartWith(IDocument document, int lineOffset, string[] prefixStrs)
-        {
-            return prefixStrs.Any(pre => DoesLineStartWith(document, lineOffset, pre));
-        }
+        return true;
+    }
+
+    public bool DoesLineStartWith(IDocument document, int lineOffset, string[] prefixStrs)
+    {
+        return prefixStrs.Any(pre => DoesLineStartWith(document, lineOffset, pre));
     }
 }

--- a/GitUI/Editor/Diff/LineSegmentGetter.cs
+++ b/GitUI/Editor/Diff/LineSegmentGetter.cs
@@ -1,12 +1,11 @@
 using ICSharpCode.TextEditor.Document;
 
-namespace GitUI.Editor.Diff
+namespace GitUI.Editor.Diff;
+
+public class LineSegmentGetter
 {
-    public class LineSegmentGetter
+    public virtual ISegment GetSegment(IDocument doc, int lineNumber)
     {
-        public virtual ISegment GetSegment(IDocument doc, int lineNumber)
-        {
-            return doc.GetLineSegment(lineNumber);
-        }
+        return doc.GetLineSegment(lineNumber);
     }
 }

--- a/GitUI/Editor/Diff/PatchHighlightService.cs
+++ b/GitUI/Editor/Diff/PatchHighlightService.cs
@@ -1,5 +1,7 @@
-﻿using GitExtUtils.GitUI.Theming;
+﻿using GitExtUtils;
+using GitExtUtils.GitUI.Theming;
 using GitUI.Theming;
+using GitUIPluginInterfaces;
 using ICSharpCode.TextEditor;
 using ICSharpCode.TextEditor.Document;
 
@@ -16,7 +18,8 @@ public class PatchHighlightService : DiffHighlightService
     private static readonly string[] _diffFullPrefixes = [" ", _addedLinePrefix, _removedLinePrefix];
     private static readonly string[] _diffSearchPrefixes = [_addedLinePrefix, _removedLinePrefix];
 
-    public PatchHighlightService()
+    public PatchHighlightService(ref string text, bool useGitColoring)
+        : base(ref text, useGitColoring)
     {
     }
 
@@ -26,6 +29,9 @@ public class PatchHighlightService : DiffHighlightService
         DiffLinesInfo result = new DiffLineNumAnalyzer().Analyze(textEditor.Text, isCombinedDiff: false);
         lineNumbersControl.DisplayLineNum(result);
     }
+
+    public static GitCommandConfiguration GetGitCommandConfiguration(IGitModule module, bool useGitColoring)
+        => GetGitCommandConfiguration(module, useGitColoring, "diff");
 
     public override string[] GetFullDiffPrefixes() => _diffFullPrefixes;
 

--- a/GitUI/Editor/Diff/PatchHighlightService.cs
+++ b/GitUI/Editor/Diff/PatchHighlightService.cs
@@ -1,0 +1,46 @@
+﻿using GitExtUtils.GitUI.Theming;
+using GitUI.Theming;
+using ICSharpCode.TextEditor;
+using ICSharpCode.TextEditor.Document;
+
+namespace GitUI.Editor.Diff;
+
+/// <summary>
+/// Highlight for "patches", normal diff files.
+/// </summary>
+public class PatchHighlightService : DiffHighlightService
+{
+    // Patterns to check for patches in diff files
+    private const string _addedLinePrefix = "+";
+    private const string _removedLinePrefix = "-";
+    private static readonly string[] _diffFullPrefixes = [" ", _addedLinePrefix, _removedLinePrefix];
+    private static readonly string[] _diffSearchPrefixes = [_addedLinePrefix, _removedLinePrefix];
+
+    public PatchHighlightService()
+    {
+    }
+
+    public override void SetLineControl(DiffViewerLineNumberControl lineNumbersControl, TextEditorControl textEditor)
+    {
+        // Note: This is the fourth time the text is parsed...
+        DiffLinesInfo result = new DiffLineNumAnalyzer().Analyze(textEditor.Text, isCombinedDiff: false);
+        lineNumbersControl.DisplayLineNum(result);
+    }
+
+    public override string[] GetFullDiffPrefixes() => _diffFullPrefixes;
+
+    public override bool IsSearchMatch(string line) => line.StartsWithAny(_diffSearchPrefixes);
+
+    protected override List<ISegment> GetAddedLines(IDocument document, ref int line, ref bool found)
+        => LinePrefixHelper.GetLinesStartingWith(document, ref line, _addedLinePrefix, ref found);
+
+    protected override List<ISegment> GetRemovedLines(IDocument document, ref int line, ref bool found)
+        => LinePrefixHelper.GetLinesStartingWith(document, ref line, _removedLinePrefix, ref found);
+
+    protected override int TryHighlightAddedAndDeletedLines(IDocument document, int line, LineSegment lineSegment)
+    {
+        ProcessLineSegment(document, ref line, lineSegment, _addedLinePrefix, AppColor.DiffAdded.GetThemeColor());
+        ProcessLineSegment(document, ref line, lineSegment, _removedLinePrefix, AppColor.DiffRemoved.GetThemeColor());
+        return line;
+    }
+}

--- a/GitUI/Editor/Diff/RangeDiffHighlightService.cs
+++ b/GitUI/Editor/Diff/RangeDiffHighlightService.cs
@@ -1,5 +1,7 @@
+using GitExtUtils;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Theming;
+using GitUIPluginInterfaces;
 using ICSharpCode.TextEditor.Document;
 
 namespace GitUI.Editor.Diff;
@@ -14,12 +16,27 @@ public class RangeDiffHighlightService : DiffHighlightService
     private static readonly string[] _addedLinePrefixes = ["+", " +"];
     private static readonly string[] _removedLinePrefixes = ["-", " -"];
 
-    public RangeDiffHighlightService()
+    public RangeDiffHighlightService(ref string text, bool useGitColoring)
+        : base(ref text, useGitColoring)
     {
     }
 
+    // git-range-diff has an extended subset of git-diff options, base is the same
+    public static GitCommandConfiguration GetGitCommandConfiguration(IGitModule module, bool useGitColoring)
+        => GetGitCommandConfiguration(module, useGitColoring, "range-diff");
+
     public override void AddTextHighlighting(IDocument document)
     {
+        if (_useGitColoring)
+        {
+            foreach (TextMarker tm in _textMarkers)
+            {
+                document.MarkerStrategy.AddMarker(tm);
+            }
+
+            return;
+        }
+
         bool forceAbort = false;
 
         for (int line = 0; line < document.TotalNumberOfLines && !forceAbort; line++)

--- a/GitUI/Editor/Diff/TextHighlightService.cs
+++ b/GitUI/Editor/Diff/TextHighlightService.cs
@@ -1,22 +1,24 @@
-﻿using GitExtUtils.GitUI.Theming;
-using GitUI.Theming;
+﻿using ICSharpCode.TextEditor;
 using ICSharpCode.TextEditor.Document;
 
-namespace GitUI.Editor.Diff
+namespace GitUI.Editor.Diff;
+
+public class TextHighlightService : ITextHighlightService
 {
-    public class TextHighlightService : ITextHighlightService
+    /// <summary>
+    /// Base class for highlighting, not adding any highlighting.
+    /// </summary>
+    public static TextHighlightService Instance { get; } = new();
+
+    protected TextHighlightService()
     {
-        /// <summary>
-        /// Base class for highlighting, not adding any highlighting.
-        /// </summary>
-        public static TextHighlightService Instance { get; } = new();
+    }
 
-        protected TextHighlightService()
-        {
-        }
+    public virtual void SetLineControl(DiffViewerLineNumberControl lineNumbersControl, TextEditorControl textEditor)
+    {
+    }
 
-        public virtual void AddTextHighlighting(IDocument document)
-        {
-        }
+    public virtual void AddTextHighlighting(IDocument document)
+    {
     }
 }

--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -36,6 +36,7 @@ namespace GitUI.Editor
             decreaseNumberOfLinesToolStripMenuItem = new ToolStripMenuItem();
             showEntireFileToolStripMenuItem = new ToolStripMenuItem();
             showSyntaxHighlightingToolStripMenuItem = new ToolStripMenuItem();
+            showGitWordColoringToolStripMenuItem = new ToolStripMenuItem();
             toolStripSeparator2 = new ToolStripSeparator();
             treatAllFilesAsTextToolStripMenuItem = new ToolStripMenuItem();
             automaticContinuousScrollToolStripMenuItem = new ToolStripMenuItem();
@@ -83,6 +84,7 @@ namespace GitUI.Editor
             ignoreWhitespaceAtEolToolStripMenuItem,
             ignoreWhitespaceChangesToolStripMenuItem,
             ignoreAllWhitespaceChangesToolStripMenuItem,
+            showGitWordColoringToolStripMenuItem,
             toolStripSeparator2,
             treatAllFilesAsTextToolStripMenuItem,
             automaticContinuousScrollToolStripMenuItem,
@@ -218,6 +220,14 @@ namespace GitUI.Editor
             showSyntaxHighlightingToolStripMenuItem.Size = new Size(243, 22);
             showSyntaxHighlightingToolStripMenuItem.Text = "Show synta&x highlighting";
             showSyntaxHighlightingToolStripMenuItem.Click += ShowSyntaxHighlighting_Click;
+            // 
+            // showGitWordColoringToolStripMenuItem
+            // 
+            showGitWordColoringToolStripMenuItem.Image = Properties.Images.Colors;
+            showGitWordColoringToolStripMenuItem.Name = "showGitWordColoringToolStripMenuItem";
+            showGitWordColoringToolStripMenuItem.Size = new Size(243, 22);
+            showGitWordColoringToolStripMenuItem.Text = "Show Git wor&d coloring";
+            showGitWordColoringToolStripMenuItem.Click += ShowGitWordColoringToolStripMenuItemClick;
             // 
             // toolStripSeparator2
             // 
@@ -482,6 +492,7 @@ namespace GitUI.Editor
         private ToolStripMenuItem decreaseNumberOfLinesToolStripMenuItem;
         private ToolStripMenuItem showEntireFileToolStripMenuItem;
         private ToolStripMenuItem showSyntaxHighlightingToolStripMenuItem;
+        private ToolStripMenuItem showGitWordColoringToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator2;
         private ToolStripMenuItem treatAllFilesAsTextToolStripMenuItem;
         private ToolStripMenuItem copyToolStripMenuItem;

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -412,11 +412,11 @@ namespace GitUI.Editor
         /// <param name="text">The patch text.</param>
         /// <param name="line">The line to display.</param>
         /// <param name="openWithDifftool">The action to open the difftool.</param>
-        public Task ViewPatchAsync(FileStatusItem item, string text, int? line, Action? openWithDifftool)
-            => ViewPrivateAsync(item, item?.Item?.Name, text, line, openWithDifftool, ViewMode.Diff);
+        public Task ViewPatchAsync(FileStatusItem item, string text, int? line, Action? openWithDifftool, bool useGitColoring)
+            => ViewPrivateAsync(item, item?.Item?.Name, text, line, openWithDifftool, ViewMode.Diff, useGitColoring);
 
-        public Task ViewCombinedDiffAsync(FileStatusItem item, string text, int? line, Action? openWithDifftool)
-            => ViewPrivateAsync(item, item?.Item?.Name, text, line, openWithDifftool, ViewMode.CombinedDiff);
+        public Task ViewCombinedDiffAsync(FileStatusItem item, string text, int? line, Action? openWithDifftool, bool useGitColoring)
+            => ViewPrivateAsync(item, item?.Item?.Name, text, line, openWithDifftool, ViewMode.CombinedDiff, useGitColoring);
 
         /// <summary>
         /// Present the text as a patch in the file viewer, for GitHub.
@@ -435,8 +435,8 @@ namespace GitUI.Editor
                 () => ViewFixedPatchAsync(fileName, text, openWithDifftool));
         }
 
-        public Task ViewRangeDiffAsync(string fileName, string text)
-            => ViewPrivateAsync(item: null, fileName, text, line: null, openWithDifftool: null, ViewMode.RangeDiff);
+        public Task ViewRangeDiffAsync(string fileName, string text, bool useGitColoring)
+            => ViewPrivateAsync(item: null, fileName, text, line: null, openWithDifftool: null, ViewMode.RangeDiff, useGitColoring);
 
         public void ViewText(string? fileName,
             string text,
@@ -747,14 +747,14 @@ namespace GitUI.Editor
 
         // Private methods
 
-        private Task ViewPrivateAsync(FileStatusItem? item, string? fileName, string text, int? line, Action? openWithDifftool, ViewMode viewMode)
+        private Task ViewPrivateAsync(FileStatusItem? item, string? fileName, string text, int? line, Action? openWithDifftool, ViewMode viewMode, bool useGitColoring = false)
         {
             return ShowOrDeferAsync(
                 text.Length,
                 () =>
                 {
                     ResetView(viewMode, fileName, item: item, text: text);
-                    internalFileViewer.SetText(text, openWithDifftool, _viewMode);
+                    internalFileViewer.SetText(text, openWithDifftool, _viewMode, useGitColoring);
                     if (line is not null)
                     {
                         GoToLine(line.Value);
@@ -1925,7 +1925,7 @@ namespace GitUI.Editor
                     new GitItemStatus(name: fileName ?? ""));
                 FileViewer fileViewer = _fileViewer;
                 ThreadHelper.JoinableTaskFactory.Run(
-                    () => fileViewer.ViewPatchAsync(f, text, line: null, openWithDifftool));
+                    () => fileViewer.ViewPatchAsync(f, text, line: null, openWithDifftool, useGitColoring: false));
             }
         }
     }

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -1,5 +1,4 @@
 ﻿using GitCommands;
-using GitCommands.Patches;
 using GitCommands.Settings;
 using GitExtUtils;
 using GitExtUtils.GitUI;
@@ -235,7 +234,7 @@ namespace GitUI.Editor
         /// <param name="openWithDifftool">The command to open the difftool.</param>
         public void SetText(string text, Action? openWithDifftool)
         {
-            SetText(text, openWithDifftool, viewMode: ViewMode.Text);
+            SetText(text, openWithDifftool, viewMode: ViewMode.Text, useGitColoring: false);
         }
 
         /// <summary>
@@ -244,7 +243,7 @@ namespace GitUI.Editor
         /// <param name="text">The text to set in the editor.</param>
         /// <param name="openWithDifftool">The command to open the difftool.</param>
         /// <param name="viewMode">the view viewMode in the file viewer, the kind of info shown</param>
-        public void SetText(string text, Action? openWithDifftool, ViewMode viewMode)
+        public void SetText(string text, Action? openWithDifftool, ViewMode viewMode, bool useGitColoring)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
@@ -256,10 +255,10 @@ namespace GitUI.Editor
             _textHighlightService = viewMode switch
             {
                 ViewMode.Text => TextHighlightService.Instance,
-                ViewMode.Diff or ViewMode.FixedDiff => new PatchHighlightService(),
-                ViewMode.CombinedDiff => new CombinedDiffHighlightService(),
-                ViewMode.RangeDiff => new RangeDiffHighlightService(),
-               _ => throw new ArgumentException($"Unexpected viewMode: {viewMode}", nameof(viewMode))
+                ViewMode.Diff or ViewMode.FixedDiff => new PatchHighlightService(ref text, useGitColoring),
+                ViewMode.CombinedDiff => new CombinedDiffHighlightService(ref text, useGitColoring),
+                ViewMode.RangeDiff => new RangeDiffHighlightService(ref text, useGitColoring),
+                _ => throw new ArgumentException($"Unexpected viewMode: {viewMode}", nameof(viewMode))
             };
 
             TextEditor.Text = text;

--- a/GitUI/Editor/ViewMode.cs
+++ b/GitUI/Editor/ViewMode.cs
@@ -1,0 +1,26 @@
+namespace GitUI.Editor;
+
+/// <summary>
+/// The type of information currently shown in the file viewer.
+/// </summary>
+public enum ViewMode
+{
+    // Plain text
+    Text,
+
+    // Diff or patch
+    Diff,
+
+    // Diffs that will not be affected by diff arguments like white space etc (limited options)
+    FixedDiff,
+
+    // range-diff output
+    RangeDiff,
+
+    // Get if the given diff is a combined diff, with changes from all parents.
+    // <see href="https://git-scm.com/docs/git-diff#_combined_diff_format"/> for more information.
+    CombinedDiff,
+
+    // Image viewer
+    Image
+}

--- a/GitUI/Editor/ViewModeExtension.cs
+++ b/GitUI/Editor/ViewModeExtension.cs
@@ -1,0 +1,18 @@
+namespace GitUI.Editor;
+
+public static class ViewModeExtension
+{
+    public static bool IsNormalDiffView(this ViewMode viewMode)
+        => viewMode is (ViewMode.Diff or ViewMode.FixedDiff or ViewMode.CombinedDiff);
+
+    public static bool IsDiffView(this ViewMode viewMode)
+        => viewMode.IsNormalDiffView() || viewMode is ViewMode.RangeDiff;
+
+    /// <summary>
+    /// The document is partial, the line numbers ar (normally) non-continuous.
+    /// </summary>
+    /// <param name="viewMode">The current view mode in the editor.</param>
+    /// <returns><c>true</c> if the view is partial, <c>false</c> if the complete contents is shown.</returns>
+    public static bool IsPartialTextView(this ViewMode viewMode)
+        => viewMode.IsDiffView();
+}

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -80,6 +80,8 @@ namespace GitUI
                         item.BaseB,
                         fileViewer.GetExtraDiffArguments(isRangeDiff: true),
                         additionalCommandInfo,
+                        useGitColoring: AppSettings.UseGitColoring.Value,
+                        commandConfiguration: RangeDiffHighlightService.GetGitCommandConfiguration(fileViewer.Module, AppSettings.UseGitColoring.Value),
                         cancellationToken);
 
                 if (!result.ExitedSuccessfully)
@@ -95,7 +97,8 @@ namespace GitUI
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                await fileViewer.ViewRangeDiffAsync(filename, result.StandardOutput);
+                await fileViewer.ViewRangeDiffAsync(filename, result.StandardOutput, AppSettings.UseGitColoring.Value);
+
                 return;
             }
 
@@ -105,6 +108,8 @@ namespace GitUI
                     fileViewer.GetExtraDiffArguments(),
                     fileViewer.Encoding,
                     out string diffOfConflict,
+                    useGitColoring: AppSettings.UseGitColoring.Value,
+                    commandConfiguration: CombinedDiffHighlightService.GetGitCommandConfiguration(fileViewer.Module, AppSettings.UseGitColoring.Value),
                     cancellationToken);
 
                 cancellationToken.ThrowIfCancellationRequested();
@@ -122,7 +127,7 @@ namespace GitUI
                     return;
                 }
 
-                await fileViewer.ViewCombinedDiffAsync(item, text: diffOfConflict, line: line, openWithDifftool: openWithDiffTool);
+                await fileViewer.ViewCombinedDiffAsync(item, text: diffOfConflict, line: line, openWithDifftool: openWithDiffTool, useGitColoring: AppSettings.UseGitColoring.Value);
                 return;
             }
 
@@ -137,7 +142,7 @@ namespace GitUI
             }
             else
             {
-                await fileViewer.ViewPatchAsync(item, text: selectedPatch, line: line, openWithDifftool: openWithDiffTool);
+                await fileViewer.ViewPatchAsync(item, text: selectedPatch, line: line, openWithDifftool: openWithDiffTool, useGitColoring: AppSettings.UseGitColoring.Value);
             }
 
             return;
@@ -193,6 +198,8 @@ namespace GitUI
                     bool isTracked = file.IsTracked || (file.TreeGuid is not null && secondId is not null);
 
                     return await module.GetSingleDiffAsync(firstId, secondId, file.Name, file.OldName, diffArgs, encoding, true, isTracked,
+                        AppSettings.UseGitColoring.Value,
+                        PatchHighlightService.GetGitCommandConfiguration(module, AppSettings.UseGitColoring.Value),
                         cancellationToken);
                 }
             }

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -332,6 +332,7 @@ namespace GitUI.Hotkey
                     Hk(FileViewer.Command.PreviousChange, Keys.Alt | Keys.Up),
                     Hk(FileViewer.Command.ShowEntireFile, Keys.Control | Keys.E),
                     Hk(FileViewer.Command.ShowSyntaxHighlighting, Keys.X),
+                    Hk(FileViewer.Command.ShowGitWordColoring, Keys.Control | Keys.Shift | Keys.D),
                     Hk(FileViewer.Command.TreatFileAsText, Keys.None),
                     Hk(FileViewer.Command.NextOccurrence, Keys.Alt | Keys.Right),
                     Hk(FileViewer.Command.PreviousOccurrence, Keys.Alt | Keys.Left),

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1385,6 +1385,10 @@ Please make sure that Git for Windows is installed or set the correct command ma
         <source>Remember the 'Show entire file' preference</source>
         <target />
       </trans-unit>
+      <trans-unit id="chkRememberShowGitWordColoringPreference.Text">
+        <source>Remember the 'Show Git word coloring' preference</source>
+        <target />
+      </trans-unit>
       <trans-unit id="chkRememberShowNonPrintingCharsPreference.Text">
         <source>Remember the 'Show nonprinting characters' preference</source>
         <target />
@@ -1616,6 +1620,10 @@ The primary difftool can still be selected by clicking the main menu entry.</sou
       </trans-unit>
       <trans-unit id="showEntireFileToolStripMenuItem.Text">
         <source>Show &amp;entire file</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="showGitWordColoringToolStripMenuItem.Text">
+        <source>Show Git wor&amp;d coloring</source>
         <target />
       </trans-unit>
       <trans-unit id="showNonPrintChars.ToolTipText">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -828,8 +828,20 @@ Please make sure that Git for Windows is installed or set the correct command ma
         <source>Highlight authored revisions</source>
         <target />
       </trans-unit>
+      <trans-unit id="chkUseGEThemeGitColoring.Text">
+        <source>Use theme coloring</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="chkUseGitColoring.Text">
+        <source>Git coloring</source>
+        <target />
+      </trans-unit>
       <trans-unit id="chkUseSystemVisualStyle.Text">
         <source>Use system-defined visual style (looks bad with dark colors)</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="gbDiffColoring.Text">
+        <source>Diff coloring</source>
         <target />
       </trans-unit>
       <trans-unit id="gbRevisionGraph.Text">

--- a/Plugins/GitUIPluginInterfaces/IGitModule.cs
+++ b/Plugins/GitUIPluginInterfaces/IGitModule.cs
@@ -242,7 +242,7 @@ namespace GitUIPluginInterfaces
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>the Git output.</returns>
         string GetCustomDiffMergeTools(bool isDiff, CancellationToken cancellationToken);
-        Task<(Patch? patch, string? errorMessage)> GetSingleDiffAsync(ObjectId? firstId, ObjectId? secondId, string? fileName, string? oldFileName, string extraDiffArguments, Encoding encoding, bool cacheResult, bool isTracked, CancellationToken cancellationToken);
+        Task<(Patch? patch, string? errorMessage)> GetSingleDiffAsync(ObjectId? firstId, ObjectId? secondId, string? fileName, string? oldFileName, string extraDiffArguments, Encoding encoding, bool cacheResult, bool isTracked, bool useGitColoring, GitCommandConfiguration commandConfiguration, CancellationToken cancellationToken);
         int? GetCommitCount(string parent, string child, bool cache, bool throwOnErrorExit);
 
         /// <summary>
@@ -259,7 +259,7 @@ namespace GitUIPluginInterfaces
         bool InTheMiddleOfBisect();
         IReadOnlyList<GitItemStatus> GetDiffFilesWithUntracked(string? firstRevision, string? secondRevision, StagedStatus stagedStatus, bool noCache, CancellationToken cancellationToken);
         bool IsDirtyDir();
-        Task<ExecutionResult> GetRangeDiffAsync(ObjectId firstId, ObjectId secondId, ObjectId? firstBase, ObjectId? secondBase, string extraDiffArguments, string? pathFilter, CancellationToken cancellationToken);
+        Task<ExecutionResult> GetRangeDiffAsync(ObjectId firstId, ObjectId secondId, ObjectId? firstBase, ObjectId? secondBase, string extraDiffArguments, string? pathFilter, bool useGitColoring, GitCommandConfiguration commandConfiguration, CancellationToken cancellationToken);
         bool InTheMiddleOfPatch();
         bool InTheMiddleOfConflictedMerge(bool throwOnErrorExit = true);
         bool InTheMiddleOfAction();
@@ -400,7 +400,7 @@ namespace GitUIPluginInterfaces
         /// </summary>
         IGitVersion GitVersion { get; }
 
-        bool GetCombinedDiffContent(ObjectId revisionOfMergeCommit, string filePath, string extraArgs, Encoding encoding, out string diffOfConflict, CancellationToken cancellationToken);
+        bool GetCombinedDiffContent(ObjectId revisionOfMergeCommit, string filePath, string extraArgs, Encoding encoding, out string diffOfConflict, bool useGitColoring, GitCommandConfiguration commandConfiguration, CancellationToken cancellationToken);
         bool IsMerge(ObjectId objectId);
         IEnumerable<string> GetMergedBranches(bool includeRemote = false);
         Task<string[]> GetMergedBranchesAsync(bool includeRemote, bool fullRefname, string? commit, CancellationToken cancellationToken);

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -171,6 +171,8 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.ApplyPatchIgnoreWhitespace)], false, false, false);
                 yield return (properties[nameof(AppSettings.ApplyPatchSignOff)], true, false, false);
                 yield return (properties[nameof(AppSettings.UseHistogramDiffAlgorithm)], false, false, false);
+                yield return (properties[nameof(AppSettings.UseGitColoring)], true, false, true);
+                yield return (properties[nameof(AppSettings.UseGEThemeGitColoring)], true, false, true);
                 yield return (properties[nameof(AppSettings.ShowErrorsWhenStagingFiles)], true, false, false);
                 yield return (properties[nameof(AppSettings.EnsureCommitMessageSecondLineEmpty)], true, false, false);
                 yield return (properties[nameof(AppSettings.LastCommitMessage)], string.Empty, true, false);

--- a/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
+++ b/UnitTests/GitCommands.Tests/Settings/AppSettingsTests.cs
@@ -310,6 +310,8 @@ namespace GitCommandsTests.Settings
                 yield return (properties[nameof(AppSettings.RememberShowNonPrintingCharsPreference)], false, false, false);
                 yield return (properties[nameof(AppSettings.ShowEntireFile)], false, false, true);
                 yield return (properties[nameof(AppSettings.RememberShowEntireFilePreference)], false, false, false);
+                yield return (properties[nameof(AppSettings.ShowGitWordColoring)], false, false, true);
+                yield return (properties[nameof(AppSettings.RememberShowGitWordColoring)], false, false, true);
                 yield return (properties[nameof(AppSettings.RememberNumberOfContextLines)], false, false, false);
                 yield return (properties[nameof(AppSettings.ShowSyntaxHighlightingInDiff)], true, false, true);
                 yield return (properties[nameof(AppSettings.RememberShowSyntaxHighlightingInDiff)], true, false, false);

--- a/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTest.Get8bitColor.cs
+++ b/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTest.Get8bitColor.cs
@@ -1,0 +1,127 @@
+using FluentAssertions;
+using GitUI.Editor.Diff;
+
+namespace GitUITests.Editor.Diff;
+
+[TestFixture]
+public class AnsiEscapeUtilitiesTest_Get8bitColor
+{
+    private const int _blackId = 0;
+    private const int _redId = 1;
+    private readonly Color _normalRedAnsiTheme = Color.FromArgb(212, 44, 58);
+    private readonly Color _boldRedAnsiTheme = Color.FromArgb(255, 118, 118);
+    private readonly Color _dimRedAnsiTheme = Color.FromArgb(208, 142, 147);
+
+    [Test]
+    public void Get8bitColor_ShouldReturnNamedColors()
+    {
+        List<int> offsets = [0, AnsiEscapeUtilities.TestAccessor.GetBoldOffset(), AnsiEscapeUtilities.TestAccessor.GetDimOffset()];
+        for (int colorId = 0; colorId < 8; ++colorId)
+        {
+            foreach (int offset in offsets)
+            {
+                // Only check the result for red, the other should just get a value and set the id
+                // (No need to maintain all ANSI theme colors in parallel)
+                Color result = AnsiEscapeUtilities.TestAccessor.Get8bitColor(colorId + offset, out int seenColorId);
+                colorId.Should().Be(seenColorId);
+                if (colorId == _redId)
+                {
+                    if (offset == 0)
+                    {
+                        result.Should().Be(_normalRedAnsiTheme);
+                    }
+                    else if (offset == AnsiEscapeUtilities.TestAccessor.GetBoldOffset())
+                    {
+                        result.Should().Be(_boldRedAnsiTheme);
+                    }
+                    else if (offset == AnsiEscapeUtilities.TestAccessor.GetDimOffset())
+                    {
+                        result.Should().Be(_dimRedAnsiTheme);
+                    }
+                }
+            }
+        }
+    }
+
+    [Test]
+    public void Get8bitColor_ShouldReturnCorrect6bitColor()
+    {
+        // currentColorId is always reset, no named color
+        const int currentColorId = _blackId;
+
+        for (int i = 16; i < 232; ++i)
+        {
+            Color result = AnsiEscapeUtilities.TestAccessor.Get8bitColor(i, out int colorId);
+            result.Should().Be(GetExpectedColor(i));
+            colorId.Should().Be(currentColorId);
+
+            // sample colors
+            if (i == 196)
+            {
+                result.Should().Be(Color.FromArgb(255, 0, 0));
+            }
+            else if (i == 231)
+            {
+                result.Should().Be(Color.FromArgb(255, 255, 255));
+            }
+        }
+
+        return;
+
+        static Color GetExpectedColor(int level)
+        {
+            int i = level - 16;
+            int blue = Get8bitFrom6over3bit(i % 6);
+            int green = Get8bitFrom6over3bit((i % 36) / 6);
+            int red = Get8bitFrom6over3bit(i / 36);
+
+            return Color.FromArgb(red, green, blue);
+
+            static int Get8bitFrom6over3bit(int color)
+                => color * 51;
+        }
+    }
+
+    [Test]
+    public void Get8bitColor_ShouldReturnCorrect4bitGrey()
+    {
+        // currentColorId is always rest, no named color
+        const int currentColorId = _blackId;
+
+        for (int i = 232; i <= 255; ++i)
+        {
+            Color result = AnsiEscapeUtilities.TestAccessor.Get8bitColor(i, out int colorId);
+            result.Should().Be(Get24StepGray(i));
+            colorId.Should().Be(currentColorId);
+
+            // border
+            if (i == 232)
+            {
+                result.Should().Be(Color.FromArgb(0, 0, 0));
+            }
+            else if (i == 255)
+            {
+                result.Should().Be(Color.FromArgb(253, 253, 253));
+            }
+        }
+
+        return;
+
+        static Color Get24StepGray(int level)
+        {
+            int i = (level - 232) * 11;
+            return Color.FromArgb(i, i, i);
+        }
+    }
+
+    [Test]
+    public void Get8bitColor_ShouldThrowException_WhenColorCodeIsOutOfRange()
+    {
+        int colorCode = 256;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            AnsiEscapeUtilities.TestAccessor.Get8bitColor(colorCode, out int colorId);
+        });
+    }
+}

--- a/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTest.ParseEscape.cs
+++ b/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTest.ParseEscape.cs
@@ -1,0 +1,133 @@
+using System.Text;
+using FluentAssertions;
+using GitUI.Editor.Diff;
+using ICSharpCode.TextEditor.Document;
+
+namespace GitUITests.Editor.Diff;
+
+[TestFixture]
+public class AnsiEscapeUtilitiesTest_ParseEscape
+{
+    private string _escape_sequence = "\u001b[";
+    private readonly Color _normalRedAnsiTheme = Color.FromArgb(212, 44, 58);
+    private readonly Color _boldRedAnsiTheme = Color.FromArgb(255, 118, 118);
+    private readonly Color _dimRedAnsiTheme = Color.FromArgb(208, 142, 147);
+
+    [Test]
+    public void ParseEscape_ShouldAppendTextWithoutEscapeSequence_WhenNoEscapeSequenceIsPresent()
+    {
+        string text = "No escape sequence  ";
+        StringBuilder sb = new();
+        List<TextMarker> textMarkers = [];
+
+        AnsiEscapeUtilities.ParseEscape(text, sb, textMarkers);
+
+        sb.ToString().Should().Be(text);
+        textMarkers.Should().BeEmpty();
+    }
+
+    [Test]
+    public void ParseEscape_ShouldAppendTextWithCorrectEscapeSequence_WhenEscapeSequenceIsPresent()
+    {
+        string in_text = $"""
+            Text with {_escape_sequence}31mred{_escape_sequence}0m escape sequence
+            extra line
+            Some {_escape_sequence}0;1;31mbold red{_escape_sequence}0m
+            Now {_escape_sequence}101mbold reverse red{_escape_sequence}0m
+            and some {_escape_sequence}2:31mdim red{_escape_sequence}0m
+            and some {_escape_sequence}mdefault{_escape_sequence}0m
+              
+            """.ReplaceLineEndings("\n");
+        string expected = """
+            Text with red escape sequence
+            extra line
+            Some bold red
+            Now bold reverse red
+            and some dim red
+            and some default
+              
+            """.ReplaceLineEndings("\n");
+        StringBuilder sb = new();
+        List<TextMarker> textMarkers = [];
+
+        AnsiEscapeUtilities.ParseEscape(in_text, sb, textMarkers);
+
+        // sb.ToString().Should().Be("Text with red escape sequence\nextra line\nSome bold red\nNow bold reverse red\nand some dim red\nand some default\n  \n  ");
+        sb.ToString().Should().Be(expected);
+        textMarkers.Should().HaveCount(4);
+
+        textMarkers[0].Offset.Should().Be(10);
+        textMarkers[0].Length.Should().Be(3);
+        textMarkers[0].Color.Should().Be(Color.White);
+        textMarkers[0].ForeColor.Should().Be(_normalRedAnsiTheme);
+
+        textMarkers[1].Offset.Should().Be(46);
+        textMarkers[1].Length.Should().Be(8);
+        textMarkers[1].Color.Should().Be(Color.White);
+        textMarkers[1].ForeColor.Should().Be(_boldRedAnsiTheme);
+
+        textMarkers[2].Offset.Should().Be(59);
+        textMarkers[2].Length.Should().Be(16);
+        textMarkers[2].Color.Should().Be(_boldRedAnsiTheme);
+        textMarkers[2].ForeColor.ToArgb().Should().Be(Color.Black.ToArgb());
+
+        textMarkers[3].Offset.Should().Be(85);
+        textMarkers[3].Length.Should().Be(7);
+        textMarkers[3].Color.Should().Be(Color.White);
+        textMarkers[3].ForeColor.Should().Be(_dimRedAnsiTheme);
+    }
+
+    [Test]
+    public void ParseEscape_ShouldHandleNonConformingEscapes()
+    {
+        string in_text = $"""
+            Text with {_escape_sequence}38;5;196mred without end
+            extra line
+            then {_escape_sequence}0;48:5:46:1;31mreverse green,
+            then {_escape_sequence}38;2;0;0;255mblue,
+            {_escape_sequence}999mcode out of range,
+            {_escape_sequence}99munused code,
+            {_escape_sequence}30mblack to the end
+            {_escape_sequence}incomplete escape1,
+            {_escape_sequence}1xmincomplete escape2
+            """.ReplaceLineEndings("\n");
+        string expected_text = $"""
+            Text with red without end
+            extra line
+            then reverse green,
+            then blue,
+            code out of range,
+            unused code,
+            black to the end
+            {_escape_sequence}incomplete escape1,
+            {_escape_sequence}1xmincomplete escape2
+            """.ReplaceLineEndings("\n");
+        StringBuilder sb = new();
+        List<TextMarker> textMarkers = [];
+
+        AnsiEscapeUtilities.ParseEscape(in_text, sb, textMarkers);
+
+        sb.ToString().Should().Be(expected_text);
+        textMarkers.Should().HaveCount(4);
+
+        textMarkers[0].Offset.Should().Be(10);
+        textMarkers[0].Length.Should().Be(32);
+        textMarkers[0].Color.Should().Be(Color.White);
+        textMarkers[0].ForeColor.Should().Be(Color.FromArgb(255, 255, 0, 0));
+
+        textMarkers[1].Offset.Should().Be(42);
+        textMarkers[1].Length.Should().Be(20);
+        textMarkers[1].Color.Should().Be(Color.FromArgb(255, 0, 255, 0));
+        textMarkers[1].ForeColor.Should().Be(Color.FromArgb(255, 255, 118, 118)); // selected from backcolor
+
+        textMarkers[2].Offset.Should().Be(62);
+        textMarkers[2].Length.Should().Be(6);
+        textMarkers[2].Color.Should().Be(Color.White);
+        textMarkers[2].ForeColor.Should().Be(Color.FromArgb(255, 0, 0, 255));
+
+        textMarkers[3].Offset.Should().Be(100);
+        textMarkers[3].Length.Should().Be(62);
+        textMarkers[3].Color.Should().Be(Color.White);
+        textMarkers[3].ForeColor.ToArgb().Should().Be(Color.Black.ToArgb());
+    }
+}

--- a/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTest.TryGetColors.cs
+++ b/UnitTests/GitUI.Tests/Editor/Diff/AnsiEscapeUtilitiesTest.TryGetColors.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using GitUI.Editor.Diff;
+
+namespace GitUITests.Editor.Diff;
+
+[TestFixture]
+public class AnsiEscapeUtilitiesTest_TryGetColors
+{
+    private const int _blackId = 0;
+    private const int _redId = 1;
+    private const int _yellowId = 3;
+    private readonly Color _normalRedAnsiTheme = Color.FromArgb(212, 44, 58);
+    private readonly Color _boldRedAnsiTheme = Color.FromArgb(255, 118, 118);
+    private readonly Color _dimRedAnsiTheme = Color.FromArgb(208, 142, 147);
+
+    [Test]
+    public void TryGetColorsFromEscapeSequence_ShouldReturnFalse_WhenEscapeCodesIsEmpty()
+    {
+        // currentColorId should be preserved
+        IList<int> escapeCodes = new List<int>();
+        int currentColorId = _yellowId;
+
+        bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId);
+
+        result.Should().BeFalse();
+        backColor.Should().BeNull();
+        foreColor.Should().BeNull();
+        currentColorId.Should().Be(_yellowId);
+    }
+
+    [Test]
+    public void TryGetColorsFromEscapeSequence_ShouldSetBackColorAndForeColorToNull_WhenEscapeCodeIs0()
+    {
+        // currentColorId should be reset
+        IList<int> escapeCodes = new List<int> { 0 };
+        int currentColorId = _yellowId;
+
+        bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId);
+
+        result.Should().BeFalse();
+        backColor.Should().BeNull();
+        foreColor.Should().BeNull();
+        currentColorId.Should().Be(_blackId);
+    }
+
+    [Test]
+    public void TryGetColorsFromEscapeSequence_ShouldSetBoldAndForeColor_WhenEscapeCodeIs1()
+    {
+        // currentColorId should be unchanged, just bold
+        IList<int> escapeCodes = new List<int> { 1 };
+        int currentColorId = _redId;
+
+        bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId);
+
+        result.Should().BeTrue();
+        backColor.Should().BeNull();
+        foreColor.Should().Be(_boldRedAnsiTheme);
+        currentColorId.Should().Be(_redId);
+    }
+
+    [Test]
+    public void TryGetColorsFromEscapeSequence_ShouldSetBoldAndForeColor_WhenEscapeCodeIsx1()
+    {
+        // currentColorId should be unchanged, just bold
+        IList<int> escapeCodes = new List<int> { 1 };
+        int currentColorId = _redId;
+
+        bool result = AnsiEscapeUtilities.TestAccessor.TryGetColorsFromEscapeSequence(escapeCodes, out Color? backColor, out Color? foreColor, ref currentColorId);
+
+        result.Should().BeTrue();
+        backColor.Should().BeNull();
+        foreColor.Should().Be(_boldRedAnsiTheme);
+        currentColorId.Should().Be(_redId);
+    }
+}

--- a/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
@@ -28,7 +28,7 @@ namespace GitUITests.Editor.Diff
         [Test]
         public void CanGetHeaders()
         {
-            DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff);
+            DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: false);
             List<int> headerLines = [5, 17];
             foreach (int header in headerLines)
             {
@@ -40,7 +40,7 @@ namespace GitUITests.Editor.Diff
         [Test]
         public void CanGetContextLines()
         {
-            DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff);
+            DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: false);
 
             result.DiffLines[6].LeftLineNumber.Should().Be(9);
             result.DiffLines[6].RightLineNumber.Should().Be(9);
@@ -58,7 +58,7 @@ namespace GitUITests.Editor.Diff
         [Test]
         public void CanGetMinusLines()
         {
-            DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff);
+            DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: false);
 
             result.DiffLines[9].LeftLineNumber.Should().Be(12);
             result.DiffLines[9].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
@@ -70,7 +70,7 @@ namespace GitUITests.Editor.Diff
         [Test]
         public void CanGetPlusLines()
         {
-            DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff);
+            DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: false);
 
             result.DiffLines[12].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
             result.DiffLines[12].RightLineNumber.Should().Be(14);
@@ -85,7 +85,7 @@ namespace GitUITests.Editor.Diff
         [Test]
         public void CanGetLineNumbersForCombinedDiff()
         {
-            DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleCombinedDiff);
+            DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleCombinedDiff, isCombinedDiff: true);
 
             result.DiffLines[6].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
             result.DiffLines[6].RightLineNumber.Should().Be(70);

--- a/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
@@ -1,115 +1,114 @@
 ﻿using FluentAssertions;
 using GitUI.Editor.Diff;
 
-namespace GitUITests.Editor.Diff
+namespace GitUITests.Editor.Diff;
+
+[TestFixture]
+public class DiffLineNumAnalyzerTests
 {
-    [TestFixture]
-    public class DiffLineNumAnalyzerTests
+    private static readonly string TestDataDir = Path.Combine(TestContext.CurrentContext.TestDirectory, "Editor", "Diff");
+    private readonly string _sampleDiff;
+    private readonly string _sampleCombinedDiff;
+    private DiffLineNumAnalyzer _lineNumAnalyzer;
+
+    public DiffLineNumAnalyzerTests()
     {
-        private static readonly string TestDataDir = Path.Combine(TestContext.CurrentContext.TestDirectory, "Editor", "Diff");
-        private readonly string _sampleDiff;
-        private readonly string _sampleCombinedDiff;
-        private DiffLineNumAnalyzer _lineNumAnalyzer;
+        // File copied from https://github.com/libgit2/libgit2sharp/pull/1034/files
+        _sampleDiff = File.ReadAllText(Path.Combine(TestDataDir, "Sample.diff"));
 
-        public DiffLineNumAnalyzerTests()
+        _sampleCombinedDiff = File.ReadAllText(Path.Combine(TestDataDir, "SampleCombined.diff"));
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        _lineNumAnalyzer = new DiffLineNumAnalyzer();
+    }
+
+    [Test]
+    public void CanGetHeaders()
+    {
+        DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: true);
+        List<int> headerLines = [5, 17];
+        foreach (int header in headerLines)
         {
-            // File copied from https://github.com/libgit2/libgit2sharp/pull/1034/files
-            _sampleDiff = File.ReadAllText(Path.Combine(TestDataDir, "Sample.diff"));
-
-            _sampleCombinedDiff = File.ReadAllText(Path.Combine(TestDataDir, "SampleCombined.diff"));
+            result.DiffLines[header].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+            result.DiffLines[header].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
         }
+    }
 
-        [SetUp]
-        public void SetUp()
-        {
-            _lineNumAnalyzer = new DiffLineNumAnalyzer();
-        }
+    [Test]
+    public void CanGetContextLines()
+    {
+        DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: false);
 
-        [Test]
-        public void CanGetHeaders()
-        {
-            DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: false);
-            List<int> headerLines = [5, 17];
-            foreach (int header in headerLines)
-            {
-                result.DiffLines[header].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-                result.DiffLines[header].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-            }
-        }
+        result.DiffLines[6].LeftLineNumber.Should().Be(9);
+        result.DiffLines[6].RightLineNumber.Should().Be(9);
 
-        [Test]
-        public void CanGetContextLines()
-        {
-            DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: false);
+        result.DiffLines[14].LeftLineNumber.Should().Be(15);
+        result.DiffLines[14].RightLineNumber.Should().Be(16);
 
-            result.DiffLines[6].LeftLineNumber.Should().Be(9);
-            result.DiffLines[6].RightLineNumber.Should().Be(9);
+        result.DiffLines[18].LeftLineNumber.Should().Be(33);
+        result.DiffLines[18].RightLineNumber.Should().Be(34);
 
-            result.DiffLines[14].LeftLineNumber.Should().Be(15);
-            result.DiffLines[14].RightLineNumber.Should().Be(16);
+        result.DiffLines[25].LeftLineNumber.Should().Be(39);
+        result.DiffLines[25].RightLineNumber.Should().Be(40);
+    }
 
-            result.DiffLines[18].LeftLineNumber.Should().Be(33);
-            result.DiffLines[18].RightLineNumber.Should().Be(34);
+    [Test]
+    public void CanGetMinusLines()
+    {
+        DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: false);
 
-            result.DiffLines[25].LeftLineNumber.Should().Be(39);
-            result.DiffLines[25].RightLineNumber.Should().Be(40);
-        }
+        result.DiffLines[9].LeftLineNumber.Should().Be(12);
+        result.DiffLines[9].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
 
-        [Test]
-        public void CanGetMinusLines()
-        {
-            DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: false);
+        result.DiffLines[21].LeftLineNumber.Should().Be(36);
+        result.DiffLines[21].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+    }
 
-            result.DiffLines[9].LeftLineNumber.Should().Be(12);
-            result.DiffLines[9].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+    [Test]
+    public void CanGetPlusLines()
+    {
+        DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: false);
 
-            result.DiffLines[21].LeftLineNumber.Should().Be(36);
-            result.DiffLines[21].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-        }
+        result.DiffLines[12].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[12].RightLineNumber.Should().Be(14);
 
-        [Test]
-        public void CanGetPlusLines()
-        {
-            DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: false);
+        result.DiffLines[13].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[13].RightLineNumber.Should().Be(15);
 
-            result.DiffLines[12].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-            result.DiffLines[12].RightLineNumber.Should().Be(14);
+        result.DiffLines[22].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[22].RightLineNumber.Should().Be(37);
+    }
 
-            result.DiffLines[13].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-            result.DiffLines[13].RightLineNumber.Should().Be(15);
+    [Test]
+    public void CanGetLineNumbersForCombinedDiff()
+    {
+        DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleCombinedDiff, isCombinedDiff: true);
 
-            result.DiffLines[22].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-            result.DiffLines[22].RightLineNumber.Should().Be(37);
-        }
+        result.DiffLines[6].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[6].RightLineNumber.Should().Be(70);
+        result.DiffLines[6].LineType.Should().Be(DiffLineType.Context);
 
-        [Test]
-        public void CanGetLineNumbersForCombinedDiff()
-        {
-            DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleCombinedDiff, isCombinedDiff: true);
+        result.DiffLines[9].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[9].RightLineNumber.Should().Be(73);
+        result.DiffLines[9].LineType.Should().Be(DiffLineType.Plus);
 
-            result.DiffLines[6].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-            result.DiffLines[6].RightLineNumber.Should().Be(70);
-            result.DiffLines[6].LineType.Should().Be(DiffLineType.Context);
+        result.DiffLines[19].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[19].RightLineNumber.Should().Be(83);
+        result.DiffLines[19].LineType.Should().Be(DiffLineType.Plus);
 
-            result.DiffLines[9].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-            result.DiffLines[9].RightLineNumber.Should().Be(73);
-            result.DiffLines[9].LineType.Should().Be(DiffLineType.Plus);
+        result.DiffLines[34].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[34].RightLineNumber.Should().Be(100);
+        result.DiffLines[34].LineType.Should().Be(DiffLineType.Context);
 
-            result.DiffLines[19].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-            result.DiffLines[19].RightLineNumber.Should().Be(83);
-            result.DiffLines[19].LineType.Should().Be(DiffLineType.Plus);
+        result.DiffLines[37].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[37].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[37].LineType.Should().Be(DiffLineType.Minus);
 
-            result.DiffLines[34].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-            result.DiffLines[34].RightLineNumber.Should().Be(100);
-            result.DiffLines[34].LineType.Should().Be(DiffLineType.Context);
-
-            result.DiffLines[37].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-            result.DiffLines[37].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-            result.DiffLines[37].LineType.Should().Be(DiffLineType.Minus);
-
-            result.DiffLines[38].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-            result.DiffLines[38].RightLineNumber.Should().Be(103);
-            result.DiffLines[38].LineType.Should().Be(DiffLineType.Plus);
-        }
+        result.DiffLines[38].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[38].RightLineNumber.Should().Be(103);
+        result.DiffLines[38].LineType.Should().Be(DiffLineType.Plus);
     }
 }

--- a/UnitTests/GitUI.Tests/Editor/Diff/LinePrefixHelperFixture.cs
+++ b/UnitTests/GitUI.Tests/Editor/Diff/LinePrefixHelperFixture.cs
@@ -3,128 +3,127 @@ using GitUI.Editor.Diff;
 using ICSharpCode.TextEditor.Document;
 using NSubstitute;
 
-namespace GitUITests.Editor.Diff
+namespace GitUITests.Editor.Diff;
+
+[TestFixture]
+internal class LinePrefixHelperFixture
 {
-    [TestFixture]
-    internal class LinePrefixHelperFixture
+    [Test]
+    public void CanFindAddedLines()
     {
-        [Test]
-        public void CanFindAddedLines()
-        {
-            const string diffText = @"+added line 1
+        const string diffText = @"+added line 1
 +added line 2
 -removed line
 -removed line";
 
-            LineSegmentGetter lineSegmentGetter = PrepareLineSegmentGetter(diffText);
+        LineSegmentGetter lineSegmentGetter = PrepareLineSegmentGetter(diffText);
 
-            IDocument doc = PreDocumentForDiffText(diffText);
+        IDocument doc = PreDocumentForDiffText(diffText);
 
-            int beginIndex = 0;
-            bool found = false;
+        int beginIndex = 0;
+        bool found = false;
 
-            List<ISegment> lines = new LinePrefixHelper(lineSegmentGetter)
-                .GetLinesStartingWith(doc, ref beginIndex, "+", ref found);
+        List<ISegment> lines = new LinePrefixHelper(lineSegmentGetter)
+            .GetLinesStartingWith(doc, ref beginIndex, "+", ref found);
 
-            lines.Count.Should().Be(2);
-            beginIndex.Should().Be(2);
-            found.Should().BeTrue();
-        }
+        lines.Count.Should().Be(2);
+        beginIndex.Should().Be(2);
+        found.Should().BeTrue();
+    }
 
-        [Test]
-        public void CanFindDeletedLines()
-        {
-            const string diffText = @"+added line 1
+    [Test]
+    public void CanFindDeletedLines()
+    {
+        const string diffText = @"+added line 1
 +added line 2
 -removed line1
 -removed line2";
 
-            LineSegmentGetter lineSegmentGetter = PrepareLineSegmentGetter(diffText);
+        LineSegmentGetter lineSegmentGetter = PrepareLineSegmentGetter(diffText);
 
-            IDocument doc = PreDocumentForDiffText(diffText);
+        IDocument doc = PreDocumentForDiffText(diffText);
 
-            int beginIndex = 0;
-            bool found = false;
+        int beginIndex = 0;
+        bool found = false;
 
-            List<ISegment> lines = new LinePrefixHelper(lineSegmentGetter)
-                .GetLinesStartingWith(doc, ref beginIndex, "-", ref found);
+        List<ISegment> lines = new LinePrefixHelper(lineSegmentGetter)
+            .GetLinesStartingWith(doc, ref beginIndex, "-", ref found);
 
-            lines.Count.Should().Be(2);
-            beginIndex.Should().Be(4);
-            found.Should().BeTrue();
-        }
+        lines.Count.Should().Be(2);
+        beginIndex.Should().Be(4);
+        found.Should().BeTrue();
+    }
 
-        [TestCase("++ diffline", "++")]
-        [TestCase("+  diffline", "+ ")]
-        [TestCase(" + diffline", " +")]
+    [TestCase("++ diffline", "++")]
+    [TestCase("+  diffline", "+ ")]
+    [TestCase(" + diffline", " +")]
 
-        [TestCase("-- diffline", "--")]
-        [TestCase("-  diffline", "- ")]
-        [TestCase(" - diffline", " -")]
+    [TestCase("-- diffline", "--")]
+    [TestCase("-  diffline", "- ")]
+    [TestCase(" - diffline", " -")]
 
-        [TestCase("+ diffline", "+")]
-        [TestCase("- diffline", "-")]
-        public void CanCheckIfTheLineStartsWithSpecificPrefix(string diffText, string prefix)
+    [TestCase("+ diffline", "+")]
+    [TestCase("- diffline", "-")]
+    public void CanCheckIfTheLineStartsWithSpecificPrefix(string diffText, string prefix)
+    {
+        LineSegmentGetter lineSegmentGetter = PrepareLineSegmentGetter(diffText);
+
+        IDocument doc = PreDocumentForDiffText(diffText);
+
+        LinePrefixHelper helper = new(lineSegmentGetter);
+        helper.DoesLineStartWith(doc, 0, prefix).Should().BeTrue();
+    }
+
+    [TestCase("+")]
+    [TestCase("-")]
+    public void GivenThatTheDocDoesNotHaveEnoughChars_ShouldReturnFalseWhenCheckPrefix(string diffText)
+    {
+        LineSegmentGetter lineSegmentGetter = PrepareLineSegmentGetter(diffText);
+
+        IDocument doc = PreDocumentForDiffText(diffText);
+
+        LinePrefixHelper helper = new(lineSegmentGetter);
+        helper.DoesLineStartWith(doc, 0, "++").Should().BeFalse();
+    }
+
+    private static IDocument PreDocumentForDiffText(string diffText)
+    {
+        IDocument doc = Substitute.For<IDocument>();
+        doc.GetCharAt(Arg.Any<int>()).Returns(args => diffText[(int)args[0]]);
+        doc.TotalNumberOfLines.Returns(diffText.Split('\n').Length);
+        doc.TextLength.Returns(diffText.Length);
+        return doc;
+    }
+
+    private static LineSegmentGetter PrepareLineSegmentGetter(string diffText)
+    {
+        List<ISegment> lineSegments = GetSegmentsForDiffText(diffText);
+        LineSegmentGetter lineSegmentGetter = Substitute.For<LineSegmentGetter>();
+        lineSegmentGetter.GetSegment(Arg.Any<IDocument>(), Arg.Any<int>())
+            .Returns(args => lineSegments[(int)args[1]]);
+        return lineSegmentGetter;
+    }
+
+    private static List<ISegment> GetSegmentsForDiffText(string diffText)
+    {
+        List<ISegment> lineSegments = [];
+        foreach (string diffLine in diffText.Split('\n'))
         {
-            LineSegmentGetter lineSegmentGetter = PrepareLineSegmentGetter(diffText);
-
-            IDocument doc = PreDocumentForDiffText(diffText);
-
-            LinePrefixHelper helper = new(lineSegmentGetter);
-            helper.DoesLineStartWith(doc, 0, prefix).Should().BeTrue();
-        }
-
-        [TestCase("+")]
-        [TestCase("-")]
-        public void GivenThatTheDocDoesNotHaveEnoughChars_ShouldReturnFalseWhenCheckPrefix(string diffText)
-        {
-            LineSegmentGetter lineSegmentGetter = PrepareLineSegmentGetter(diffText);
-
-            IDocument doc = PreDocumentForDiffText(diffText);
-
-            LinePrefixHelper helper = new(lineSegmentGetter);
-            helper.DoesLineStartWith(doc, 0, "++").Should().BeFalse();
-        }
-
-        private static IDocument PreDocumentForDiffText(string diffText)
-        {
-            IDocument doc = Substitute.For<IDocument>();
-            doc.GetCharAt(Arg.Any<int>()).Returns(args => diffText[(int)args[0]]);
-            doc.TotalNumberOfLines.Returns(diffText.Split('\n').Length);
-            doc.TextLength.Returns(diffText.Length);
-            return doc;
-        }
-
-        private static LineSegmentGetter PrepareLineSegmentGetter(string diffText)
-        {
-            List<ISegment> lineSegments = GetSegmentsForDiffText(diffText);
-            LineSegmentGetter lineSegmentGetter = Substitute.For<LineSegmentGetter>();
-            lineSegmentGetter.GetSegment(Arg.Any<IDocument>(), Arg.Any<int>())
-                .Returns(args => lineSegments[(int)args[1]]);
-            return lineSegmentGetter;
-        }
-
-        private static List<ISegment> GetSegmentsForDiffText(string diffText)
-        {
-            List<ISegment> lineSegments = [];
-            foreach (string diffLine in diffText.Split('\n'))
+            ISegment seg = Substitute.For<ISegment>();
+            seg.Length.Returns(diffLine.Length);
+            if (!lineSegments.Any())
             {
-                ISegment seg = Substitute.For<ISegment>();
-                seg.Length.Returns(diffLine.Length);
-                if (!lineSegments.Any())
-                {
-                    seg.Offset = 0;
-                }
-                else
-                {
-                    ISegment lastSegment = lineSegments[^1];
-                    seg.Offset = lastSegment.Offset + lastSegment.Length + 1;
-                }
-
-                lineSegments.Add(seg);
+                seg.Offset = 0;
+            }
+            else
+            {
+                ISegment lastSegment = lineSegments[^1];
+                seg.Offset = lastSegment.Offset + lastSegment.Length + 1;
             }
 
-            return lineSegments;
+            lineSegments.Add(seg);
         }
+
+        return lineSegments;
     }
 }

--- a/UnitTests/GitUI.Tests/Editor/FileViewerInternal.CurrentViewPositionCacheTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/FileViewerInternal.CurrentViewPositionCacheTests.cs
@@ -117,7 +117,8 @@ namespace GitUITests.Editor
             test.TextEditor.ActiveTextAreaControl.TextArea.ScrollToCaret();
             test.TextEditor.ActiveTextAreaControl.TextArea.TextView.FirstVisibleLine = 18;
             test.LineNumberControl = new DiffViewerLineNumberControl(test.TextEditor.ActiveTextAreaControl.TextArea);
-            test.LineNumberControl.DisplayLineNumFor(test.TextEditor.Text);
+            DiffLinesInfo result = new DiffLineNumAnalyzer().Analyze(test.TextEditor.Text, isCombinedDiff: true);
+            test.LineNumberControl.DisplayLineNum(result);
 
             _viewPositionCache.Capture();
 

--- a/UnitTests/GitUI.Tests/Editor/FileViewerInternal.CurrentViewPositionCacheTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/FileViewerInternal.CurrentViewPositionCacheTests.cs
@@ -117,7 +117,7 @@ namespace GitUITests.Editor
             test.TextEditor.ActiveTextAreaControl.TextArea.ScrollToCaret();
             test.TextEditor.ActiveTextAreaControl.TextArea.TextView.FirstVisibleLine = 18;
             test.LineNumberControl = new DiffViewerLineNumberControl(test.TextEditor.ActiveTextAreaControl.TextArea);
-            DiffLinesInfo result = new DiffLineNumAnalyzer().Analyze(test.TextEditor.Text, isCombinedDiff: true);
+            DiffLinesInfo result = new DiffLineNumAnalyzer().Analyze(test.TextEditor.Text, isCombinedDiff: false);
             test.LineNumberControl.DisplayLineNum(result);
 
             _viewPositionCache.Capture();


### PR DESCRIPTION
Fixes #11464
Fixes #11517

## Proposed changes

TBD, opened to get feedback.
Description will be improved too, as well as screenshots.

--
FileViewer: Restructure HighlightService

Move handling of "normal" patches from the shared
DiffHighlightService to PatchHighlightService.

Various code cleanups.

This commit is a preparation for Git coloring and git-grep.

--
Git diff coloring

Use the coloring by git-diff instead of GE internal algorithm,
by using Git ANSI terminal escape sequences.
This enables for instance view moved code.

Configuration: Git coloring is set by default, the existing engine is still available.
The GE theme colors for added/removed code (reverse green/red) is applied by default (default Git to just set foreground text is can be configured).
Git by default warns about white space, this is disabled by default (diff.colorMovedWS).
A user can override the Git colors for each "slot" (see below), but this is not available in GE UI.

--
Git word diff coloring

Enable Git word diff coloring view.
This is an alternative view for diff, not in patch format.
The differences are coded on the same line.

Configuration: "GE word highlighting" is the default, "Git diff highlighting" can be enabled.
By default Git highlights changed words. If the user has not set diff.wordRegex, change by character is used ('.').

--

What is not in this PR:
- Documentation for the changes, how colors etc can be changed by Git config
- Tests are added for the "decoding escape sequence handling". The status for other parts is the same as before (there are no major benefits for adding tests)
- Tuned colors fully matching theming
- A more generic way to display diff in other ways, like using diff-so-fancy or delta. That is probably a different view, similar to Blame in diff (but using the same FileViewer).

## Screenshots <!-- Remove this section if PR does not change UI -->

TBD, see #11464 for now

### moved

The third is "Git default", no GE theme override, whitespace errors
![image](https://github.com/gitextensions/gitextensions/assets/6248932/7f714ef3-9978-43c7-a2c8-899ca18509f3) ![image](https://github.com/gitextensions/gitextensions/assets/6248932/93e0afac-5543-43dd-9a15-056eb6624a1f) ![image](https://github.com/gitextensions/gitextensions/assets/6248932/1df174ee-c9c6-47e5-898c-805c076503ea)

![image](https://github.com/gitextensions/gitextensions/assets/6248932/d5a19320-d69b-44a3-b244-c2047233a81d) ![image](https://github.com/gitextensions/gitextensions/assets/6248932/3f06316f-41d7-428e-b4d6-0d7b4ff4af6b) 

![image](https://github.com/gitextensions/gitextensions/assets/6248932/0bd536ca-40c0-4cb0-adb8-cdd1326e9759) ![image](https://github.com/gitextensions/gitextensions/assets/6248932/56571c0c-e47b-4840-87d5-396b8bdbf020)

### range diff - the GE coloring is very limited

![image](https://github.com/gitextensions/gitextensions/assets/6248932/5a8dae94-99b4-4c2b-beba-a7ced1ef053c) ![image](https://github.com/gitextensions/gitextensions/assets/6248932/6866e09a-ff40-459e-8006-ac34d4416880)

A missed merge (color should have been yellow, I have modified it). Dual color makes these diffs easier to read.
![image](https://github.com/gitextensions/gitextensions/assets/6248932/81d6b8ac-3d67-439d-bcc5-7d502cffb5e6)  ![image](https://github.com/gitextensions/gitextensions/assets/6248932/6f938777-fe50-4d76-9765-2f7d7415fa6e)


### Git word diff

![image](https://github.com/gitextensions/gitextensions/assets/6248932/7f714ef3-9978-43c7-a2c8-899ca18509f3) ![image](https://github.com/gitextensions/gitextensions/assets/6248932/79c67130-2351-49d5-9ba0-85648afcb969)

The word diff is best used to toggle the view back and forward to see details, only worddiff is confusing

![image](https://github.com/gitextensions/gitextensions/assets/6248932/94d09ba5-c2e9-436d-abfa-0ca4c1f8295a) ![image](https://github.com/gitextensions/gitextensions/assets/6248932/79863312-bc05-4d53-a605-51c28473dea4)

### ANSI Color theme

Git uses "slots" like old, new, oldMoved etc to set situations.
https://git-scm.com/docs/git-config#Documentation/git-config.txt-colordiffltslotgt
The slots are translated to named colors (8) that can be normal/bright/dim (and more, not really used in Git) as well as background/foreground. A terminal uses a "theme" to translate these colors.
The "theme" for these colors in this PR is displayed below as well as the GE theme colors overriding the default. (Note that the GE colors DiffAddedExtra and DiffRemovedExtra has no direct fit in the ANSI colors, maybe bright is the closest).
  
![image](https://github.com/gitextensions/gitextensions/assets/6248932/25f4824c-40c8-4aba-ab69-d57ca8d886fb)

## Test methodology <!-- How did you ensure quality? -->

Manual, tests to be added, maybe in a followup PR

## Merge strategy

- Rebase merge (PR submitter must change the commit message for the last commit).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
