### PR TITLE
Fix avatars not loading behind a corporate proxy

### DIFF
--- a/GitUI/Avatars/AvatarDownloader.cs
+++ b/GitUI/Avatars/AvatarDownloader.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Net;
 using Microsoft.VisualStudio.Threading;
 
 namespace GitUI.Avatars
@@ -13,7 +14,7 @@ namespace GitUI.Avatars
 
         private static readonly SemaphoreSlim _downloadSemaphore = new(initialCount: _maxConcurrentDownloads);
         private static readonly ConcurrentDictionary<Uri, (DateTime, Task<Image?>)> _downloads = new();
-        private static readonly HttpClient _client = new(new HttpClientHandler() { UseProxy = true });
+        private static readonly HttpClient _client = new(new HttpClientHandler() { UseProxy = true, DefaultProxyCredentials = CredentialCache.DefaultCredentials });
 
         public async Task<Image?> DownloadImageAsync(Uri? imageUrl)
         {

--- a/contributors.txt
+++ b/contributors.txt
@@ -1,4 +1,4 @@
-Git Extensions Project Contributors Certification of Origin and Rights
+`Git Extensions Project Contributors Certification of Origin and Rights
 
 All contributors to Git Extensions must formally agree to abide by this
 certificate of origin by signing on the bottom with their github
@@ -205,3 +205,5 @@ YYYY/MM/DD, github id, Full name, email
 2023/11/30, snelltheta, Steve Samons, snelltheta(at)gmail.com
 2023/12/01, pmgiant, Pawel Marchewka, ppmmggiiaanntt(at)gmail.com
 2024/01/01, qgppl, Grzegorz Pachocki, g.pachocki(at)wp.pl
+2024/02/21, superhoang, Aymeric Nguyen, aymeric.nguyen(at)gmail.com
+

--- a/contributors.txt
+++ b/contributors.txt
@@ -1,4 +1,4 @@
-`Git Extensions Project Contributors Certification of Origin and Rights
+Git Extensions Project Contributors Certification of Origin and Rights
 
 All contributors to Git Extensions must formally agree to abide by this
 certificate of origin by signing on the bottom with their github


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/gitextensions/gitextensions/issues/11595

## Proposed changes

- Use Default credentials for proxy access when loading avatars

## Test methodology
- Testing before : no avatar displayed when behind corporate proxy
- Testing after : avatar displayed

## Test environment(s)

- GitExtensions version: 4.2.1
- GIT version: 2.43.2
- OS version: Windows 10 22H2
- .NET version: .NET 6.0.27

## Merge strategy

- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).

I agree that the maintainer squash merge this PR (if the commit message is clear).

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
