### PR TITLE
RevDiff Find file clarification

### DIFF
--- a/GitUI/CommandsDialogs/FormDiff.Designer.cs
+++ b/GitUI/CommandsDialogs/FormDiff.Designer.cs
@@ -418,11 +418,9 @@ namespace GitUI.CommandsDialogs
             // 
             // findInDiffToolStripMenuItem
             // 
-            findInDiffToolStripMenuItem.Image = Properties.Images.Preview;
             findInDiffToolStripMenuItem.Name = "findInDiffToolStripMenuItem";
-            findInDiffToolStripMenuItem.ShortcutKeys = ((Keys)((Keys.Control | Keys.F)));
             findInDiffToolStripMenuItem.Size = new Size(210, 22);
-            findInDiffToolStripMenuItem.Text = "Find";
+            findInDiffToolStripMenuItem.Text = "Find file...";
             findInDiffToolStripMenuItem.Click += findInDiffToolStripMenuItem_Click;
             // 
             // FormDiff

--- a/GitUI/CommandsDialogs/FormDiff.Designer.cs
+++ b/GitUI/CommandsDialogs/FormDiff.Designer.cs
@@ -353,7 +353,7 @@ namespace GitUI.CommandsDialogs
             openWithDifftoolToolStripMenuItem.Image = Properties.Images.Diff;
             openWithDifftoolToolStripMenuItem.Name = "openWithDifftoolToolStripMenuItem";
             openWithDifftoolToolStripMenuItem.Size = new Size(210, 22);
-            openWithDifftoolToolStripMenuItem.Text = "Open with difftool";
+            openWithDifftoolToolStripMenuItem.Text = "Open with &difftool";
             openWithDifftoolToolStripMenuItem.DropDownOpening += openWithDifftoolToolStripMenuItem_DropDownOpening;
             // 
             // firstToSelectedToolStripMenuItem
@@ -392,7 +392,7 @@ namespace GitUI.CommandsDialogs
             openContainingFolderToolStripMenuItem.Image = Properties.Images.BrowseFileExplorer;
             openContainingFolderToolStripMenuItem.Name = "openContainingFolderToolStripMenuItem";
             openContainingFolderToolStripMenuItem.Size = new Size(210, 22);
-            openContainingFolderToolStripMenuItem.Text = "Show in folder";
+            openContainingFolderToolStripMenuItem.Text = "Show &in folder";
             openContainingFolderToolStripMenuItem.Click += openContainingFolderToolStripMenuItem_Click;
             // 
             // toolStripSeparator33
@@ -405,7 +405,7 @@ namespace GitUI.CommandsDialogs
             fileHistoryDiffToolstripMenuItem.Image = Properties.Images.FileHistory;
             fileHistoryDiffToolstripMenuItem.Name = "fileHistoryDiffToolstripMenuItem";
             fileHistoryDiffToolstripMenuItem.Size = new Size(210, 22);
-            fileHistoryDiffToolstripMenuItem.Text = "File history";
+            fileHistoryDiffToolstripMenuItem.Text = "File &history";
             fileHistoryDiffToolstripMenuItem.Click += fileHistoryDiffToolStripMenuItem_Click;
             // 
             // blameToolStripMenuItem
@@ -413,14 +413,14 @@ namespace GitUI.CommandsDialogs
             blameToolStripMenuItem.Image = Properties.Images.Blame;
             blameToolStripMenuItem.Name = "blameToolStripMenuItem";
             blameToolStripMenuItem.Size = new Size(210, 22);
-            blameToolStripMenuItem.Text = "Blame";
+            blameToolStripMenuItem.Text = "&Blame";
             blameToolStripMenuItem.Click += blameToolStripMenuItem_Click;
             // 
             // findInDiffToolStripMenuItem
             // 
             findInDiffToolStripMenuItem.Name = "findInDiffToolStripMenuItem";
             findInDiffToolStripMenuItem.Size = new Size(210, 22);
-            findInDiffToolStripMenuItem.Text = "Find file...";
+            findInDiffToolStripMenuItem.Text = "&Find file...";
             findInDiffToolStripMenuItem.Click += findInDiffToolStripMenuItem_Click;
             // 
             // FormDiff

--- a/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.Designer.cs
@@ -429,10 +429,9 @@ namespace GitUI.CommandsDialogs
             // 
             // findInDiffToolStripMenuItem
             // 
-            findInDiffToolStripMenuItem.Image = Properties.Images.Preview;
             findInDiffToolStripMenuItem.Name = "findInDiffToolStripMenuItem";
             findInDiffToolStripMenuItem.Size = new Size(262, 22);
-            findInDiffToolStripMenuItem.Text = "&Find";
+            findInDiffToolStripMenuItem.Text = "&Find file...";
             findInDiffToolStripMenuItem.Click += findInDiffToolStripMenuItem_Click;
             // 
             // DiffText

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.Designer.cs
@@ -135,7 +135,7 @@ namespace GitUI.CommandsDialogs
             openWithDifftoolToolStripMenuItem.Image = Properties.Images.Diff;
             openWithDifftoolToolStripMenuItem.Name = "openWithDifftoolToolStripMenuItem";
             openWithDifftoolToolStripMenuItem.Size = new Size(325, 22);
-            openWithDifftoolToolStripMenuItem.Text = "Open with difftool";
+            openWithDifftoolToolStripMenuItem.Text = "Open with &difftool";
             openWithDifftoolToolStripMenuItem.Click += openWithDifftoolToolStripMenuItem_Click;
             // 
             // diffWithRememberedFileToolStripMenuItem
@@ -148,7 +148,7 @@ namespace GitUI.CommandsDialogs
             // 
             rememberFileStripMenuItem.Name = "rememberFileStripMenuItem";
             rememberFileStripMenuItem.Size = new Size(296, 22);
-            rememberFileStripMenuItem.Text = "Remember file for diff";
+            rememberFileStripMenuItem.Text = "Re&member file for diff";
             rememberFileStripMenuItem.Click += rememberFileToolStripMenuItem_Click;
             // 
             // saveAsToolStripMenuItem
@@ -156,7 +156,7 @@ namespace GitUI.CommandsDialogs
             saveAsToolStripMenuItem.Image = Properties.Images.SaveAs;
             saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
             saveAsToolStripMenuItem.Size = new Size(325, 22);
-            saveAsToolStripMenuItem.Text = "Save as...";
+            saveAsToolStripMenuItem.Text = "S&ave as...";
             saveAsToolStripMenuItem.Click += saveAsToolStripMenuItem_Click;
             // 
             // resetToThisRevisionToolStripMenuItem
@@ -164,7 +164,7 @@ namespace GitUI.CommandsDialogs
             resetToThisRevisionToolStripMenuItem.Image = Properties.Images.ResetFileTo;
             resetToThisRevisionToolStripMenuItem.Name = "resetToThisRevisionToolStripMenuItem";
             resetToThisRevisionToolStripMenuItem.Size = new Size(325, 22);
-            resetToThisRevisionToolStripMenuItem.Text = "Reset to selected revision";
+            resetToThisRevisionToolStripMenuItem.Text = "&Reset to selected revision";
             resetToThisRevisionToolStripMenuItem.Click += resetToThisRevisionToolStripMenuItem_Click;
             // 
             // toolStripSeparatorFileSystemActions
@@ -189,7 +189,7 @@ namespace GitUI.CommandsDialogs
             fileTreeOpenContainingFolderToolStripMenuItem.Image = Properties.Images.BrowseFileExplorer;
             fileTreeOpenContainingFolderToolStripMenuItem.Name = "fileTreeOpenContainingFolderToolStripMenuItem";
             fileTreeOpenContainingFolderToolStripMenuItem.Size = new Size(325, 22);
-            fileTreeOpenContainingFolderToolStripMenuItem.Text = "Show in folder";
+            fileTreeOpenContainingFolderToolStripMenuItem.Text = "Show &in folder";
             fileTreeOpenContainingFolderToolStripMenuItem.Click += fileTreeOpenContainingFolderToolStripMenuItem_Click;
             // 
             // fileTreeArchiveToolStripMenuItem
@@ -197,7 +197,7 @@ namespace GitUI.CommandsDialogs
             fileTreeArchiveToolStripMenuItem.Image = Properties.Images.ArchiveRevision;
             fileTreeArchiveToolStripMenuItem.Name = "fileTreeArchiveToolStripMenuItem";
             fileTreeArchiveToolStripMenuItem.Size = new Size(325, 22);
-            fileTreeArchiveToolStripMenuItem.Text = "Archive...";
+            fileTreeArchiveToolStripMenuItem.Text = "Archi&ve...";
             fileTreeArchiveToolStripMenuItem.Click += fileTreeArchiveToolStripMenuItem_Click;
             // 
             // fileTreeCleanWorkingTreeToolStripMenuItem
@@ -205,7 +205,7 @@ namespace GitUI.CommandsDialogs
             fileTreeCleanWorkingTreeToolStripMenuItem.Image = Properties.Images.CleanupRepo;
             fileTreeCleanWorkingTreeToolStripMenuItem.Name = "fileTreeCleanWorkingTreeToolStripMenuItem";
             fileTreeCleanWorkingTreeToolStripMenuItem.Size = new Size(325, 22);
-            fileTreeCleanWorkingTreeToolStripMenuItem.Text = "Clean this folder in the working directory...";
+            fileTreeCleanWorkingTreeToolStripMenuItem.Text = "&Clean this folder in the working directory...";
             fileTreeCleanWorkingTreeToolStripMenuItem.Click += fileTreeCleanWorkingTreeToolStripMenuItem_Click;
             // 
             // toolStripSeparatorFileNameActions
@@ -225,7 +225,7 @@ namespace GitUI.CommandsDialogs
             fileHistoryToolStripMenuItem.Image = Properties.Images.FileHistory;
             fileHistoryToolStripMenuItem.Name = "fileHistoryToolStripMenuItem";
             fileHistoryToolStripMenuItem.Size = new Size(325, 22);
-            fileHistoryToolStripMenuItem.Text = "View history";
+            fileHistoryToolStripMenuItem.Text = "View &history";
             fileHistoryToolStripMenuItem.Click += fileHistoryItem_Click;
             // 
             // blameToolStripMenuItem1
@@ -233,7 +233,7 @@ namespace GitUI.CommandsDialogs
             blameToolStripMenuItem1.Image = Properties.Images.Blame;
             blameToolStripMenuItem1.Name = "blameToolStripMenuItem1";
             blameToolStripMenuItem1.Size = new Size(325, 22);
-            blameToolStripMenuItem1.Text = "Blame";
+            blameToolStripMenuItem1.Text = "&Blame";
             blameToolStripMenuItem1.Click += blameMenuItem_Click;
             // 
             // toolStripSeparatorTopActions
@@ -246,7 +246,7 @@ namespace GitUI.CommandsDialogs
             editCheckedOutFileToolStripMenuItem.Image = Properties.Images.EditFile;
             editCheckedOutFileToolStripMenuItem.Name = "editCheckedOutFileToolStripMenuItem";
             editCheckedOutFileToolStripMenuItem.Size = new Size(325, 22);
-            editCheckedOutFileToolStripMenuItem.Text = "Edit working directory file";
+            editCheckedOutFileToolStripMenuItem.Text = "&Edit working directory file";
             editCheckedOutFileToolStripMenuItem.Click += editCheckedOutFileToolStripMenuItem_Click;
             // 
             // openWithToolStripMenuItem
@@ -254,7 +254,7 @@ namespace GitUI.CommandsDialogs
             openWithToolStripMenuItem.Image = Properties.Images.EditFile;
             openWithToolStripMenuItem.Name = "openWithToolStripMenuItem";
             openWithToolStripMenuItem.Size = new Size(325, 22);
-            openWithToolStripMenuItem.Text = "Open working directory file with...";
+            openWithToolStripMenuItem.Text = "&Open working directory file with...";
             openWithToolStripMenuItem.Click += openWithToolStripMenuItem_Click;
             // 
             // openFileToolStripMenuItem
@@ -262,7 +262,7 @@ namespace GitUI.CommandsDialogs
             openFileToolStripMenuItem.Image = Properties.Images.ViewFile;
             openFileToolStripMenuItem.Name = "openFileToolStripMenuItem";
             openFileToolStripMenuItem.Size = new Size(325, 22);
-            openFileToolStripMenuItem.Text = "Open this revision (temp file)";
+            openFileToolStripMenuItem.Text = "Ope&n this revision (temp file)";
             openFileToolStripMenuItem.Click += openFileToolStripMenuItem_Click;
             // 
             // openFileWithToolStripMenuItem
@@ -270,7 +270,7 @@ namespace GitUI.CommandsDialogs
             openFileWithToolStripMenuItem.Image = Properties.Images.ViewFile;
             openFileWithToolStripMenuItem.Name = "openFileWithToolStripMenuItem";
             openFileWithToolStripMenuItem.Size = new Size(325, 22);
-            openFileWithToolStripMenuItem.Text = "Open this revision with... (temp file)";
+            openFileWithToolStripMenuItem.Text = "Open this revision &with... (temp file)";
             openFileWithToolStripMenuItem.Click += openFileWithToolStripMenuItem_Click;
             // 
             // toolStripSeparatorGitActions
@@ -283,7 +283,7 @@ namespace GitUI.CommandsDialogs
             stopTrackingThisFileToolStripMenuItem.Image = Properties.Images.StopTrackingFile;
             stopTrackingThisFileToolStripMenuItem.Name = "stopTrackingThisFileToolStripMenuItem";
             stopTrackingThisFileToolStripMenuItem.Size = new Size(325, 22);
-            stopTrackingThisFileToolStripMenuItem.Text = "Stop tracking this file";
+            stopTrackingThisFileToolStripMenuItem.Text = "Stop &tracking this file";
             stopTrackingThisFileToolStripMenuItem.Click += stopTrackingToolStripMenuItem_Click;
             // 
             // assumeUnchangedTheFileToolStripMenuItem
@@ -291,7 +291,7 @@ namespace GitUI.CommandsDialogs
             assumeUnchangedTheFileToolStripMenuItem.Image = Properties.Images.AddToGitIgnore;
             assumeUnchangedTheFileToolStripMenuItem.Name = "assumeUnchangedTheFileToolStripMenuItem";
             assumeUnchangedTheFileToolStripMenuItem.Size = new Size(325, 22);
-            assumeUnchangedTheFileToolStripMenuItem.Text = "Assume unchanged this file";
+            assumeUnchangedTheFileToolStripMenuItem.Text = "Assume &unchanged this file";
             assumeUnchangedTheFileToolStripMenuItem.Click += assumeUnchangedToolStripMenuItem_Click;
             // 
             // toolStripSeparatorGitTrackingActions
@@ -301,10 +301,10 @@ namespace GitUI.CommandsDialogs
             // 
             // findToolStripMenuItem
             // 
-            findToolStripMenuItem.Image = Properties.Images.Preview;
+            findToolStripMenuItem.Image = Properties.Images.FileTree;
             findToolStripMenuItem.Name = "findToolStripMenuItem";
             findToolStripMenuItem.Size = new Size(325, 22);
-            findToolStripMenuItem.Text = "Find in file tree...";
+            findToolStripMenuItem.Text = "&Find file...";
             findToolStripMenuItem.Click += findToolStripMenuItem_Click;
             // 
             // expandSubtreeToolStripMenuItem
@@ -312,7 +312,7 @@ namespace GitUI.CommandsDialogs
             expandToolStripMenuItem.Image = Properties.Images.TreeExpandSubtree;
             expandToolStripMenuItem.Name = "expandToolStripMenuItem";
             expandToolStripMenuItem.Size = new Size(325, 22);
-            expandToolStripMenuItem.Text = "Expand";
+            expandToolStripMenuItem.Text = "&Expand";
             expandToolStripMenuItem.Click += expandToolStripMenuItem_Click;
             // 
             // collapseAllToolStripMenuItem
@@ -320,7 +320,7 @@ namespace GitUI.CommandsDialogs
             collapseAllToolStripMenuItem.Image = Properties.Images.TreeCollapseAll;
             collapseAllToolStripMenuItem.Name = "collapseAllToolStripMenuItem";
             collapseAllToolStripMenuItem.Size = new Size(325, 22);
-            collapseAllToolStripMenuItem.Text = "Collapse All";
+            collapseAllToolStripMenuItem.Text = "Co&llapse all";
             collapseAllToolStripMenuItem.Click += collapseAllToolStripMenuItem_Click;
             // 
             // FileText

--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -150,14 +150,14 @@ namespace GitUI.Editor
             findToolStripMenuItem.Image = Properties.Images.Preview;
             findToolStripMenuItem.Name = "findToolStripMenuItem";
             findToolStripMenuItem.Size = new Size(243, 22);
-            findToolStripMenuItem.Text = "&Find";
+            findToolStripMenuItem.Text = "&Find...";
             findToolStripMenuItem.Click += FindToolStripMenuItemClick;
             // 
             // replaceToolStripMenuItem
             // 
             replaceToolStripMenuItem.Name = "replaceToolStripMenuItem";
             replaceToolStripMenuItem.Size = new Size(243, 22);
-            replaceToolStripMenuItem.Text = "&Replace";
+            replaceToolStripMenuItem.Text = "&Replace...";
             replaceToolStripMenuItem.Click += FindToolStripMenuItemClick;
             // 
             // toolStripSeparator1

--- a/GitUI/Editor/FileViewer.Designer.cs
+++ b/GitUI/Editor/FileViewer.Designer.cs
@@ -147,6 +147,7 @@ namespace GitUI.Editor
             // 
             // findToolStripMenuItem
             // 
+            findToolStripMenuItem.Image = Properties.Images.Preview;
             findToolStripMenuItem.Name = "findToolStripMenuItem";
             findToolStripMenuItem.Size = new Size(243, 22);
             findToolStripMenuItem.Text = "&Find";

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -4438,7 +4438,7 @@ Deleting a branch can cause commits to be deleted too!</source>
         <target />
       </trans-unit>
       <trans-unit id="findInDiffToolStripMenuItem.Text">
-        <source>Find</source>
+        <source>Find file...</source>
         <target />
       </trans-unit>
       <trans-unit id="firstCommitGroup.Text">
@@ -8822,7 +8822,7 @@ Reset the filter via View &gt; Show all branches.</source>
         <target />
       </trans-unit>
       <trans-unit id="findInDiffToolStripMenuItem.Text">
-        <source>&amp;Find</source>
+        <source>&amp;Find file...</source>
         <target />
       </trans-unit>
       <trans-unit id="firstToLocalToolStripMenuItem.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -1539,7 +1539,7 @@ The primary difftool can still be selected by clicking the main menu entry.</sou
         <target />
       </trans-unit>
       <trans-unit id="findToolStripMenuItem.Text">
-        <source>&amp;Find</source>
+        <source>&amp;Find...</source>
         <target />
       </trans-unit>
       <trans-unit id="goToLineToolStripMenuItem.Text">
@@ -1587,7 +1587,7 @@ The primary difftool can still be selected by clicking the main menu entry.</sou
         <target />
       </trans-unit>
       <trans-unit id="replaceToolStripMenuItem.Text">
-        <source>&amp;Replace</source>
+        <source>&amp;Replace...</source>
         <target />
       </trans-unit>
       <trans-unit id="resetSelectedLinesToolStripMenuItem.Text">
@@ -4418,7 +4418,7 @@ Deleting a branch can cause commits to be deleted too!</source>
         <target />
       </trans-unit>
       <trans-unit id="blameToolStripMenuItem.Text">
-        <source>Blame</source>
+        <source>&amp;Blame</source>
         <target />
       </trans-unit>
       <trans-unit id="btnCompareDirectoriesWithDiffTool.Text">
@@ -4434,11 +4434,11 @@ Deleting a branch can cause commits to be deleted too!</source>
         <target />
       </trans-unit>
       <trans-unit id="fileHistoryDiffToolstripMenuItem.Text">
-        <source>File history</source>
+        <source>File &amp;history</source>
         <target />
       </trans-unit>
       <trans-unit id="findInDiffToolStripMenuItem.Text">
-        <source>Find file...</source>
+        <source>&amp;Find file...</source>
         <target />
       </trans-unit>
       <trans-unit id="firstCommitGroup.Text">
@@ -4454,11 +4454,11 @@ Deleting a branch can cause commits to be deleted too!</source>
         <target />
       </trans-unit>
       <trans-unit id="openContainingFolderToolStripMenuItem.Text">
-        <source>Show in folder</source>
+        <source>Show &amp;in folder</source>
         <target />
       </trans-unit>
       <trans-unit id="openWithDifftoolToolStripMenuItem.Text">
-        <source>Open with difftool</source>
+        <source>Open with &amp;difftool</source>
         <target />
       </trans-unit>
       <trans-unit id="secondCommitGroup.Text">
@@ -8944,15 +8944,15 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="assumeUnchangedTheFileToolStripMenuItem.Text">
-        <source>Assume unchanged this file</source>
+        <source>Assume &amp;unchanged this file</source>
         <target />
       </trans-unit>
       <trans-unit id="blameToolStripMenuItem1.Text">
-        <source>Blame</source>
+        <source>&amp;Blame</source>
         <target />
       </trans-unit>
       <trans-unit id="collapseAllToolStripMenuItem.Text">
-        <source>Collapse All</source>
+        <source>Co&amp;llapse all</source>
         <target />
       </trans-unit>
       <trans-unit id="copyPathsToolStripMenuItem.Text">
@@ -8960,27 +8960,27 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="editCheckedOutFileToolStripMenuItem.Text">
-        <source>Edit working directory file</source>
+        <source>&amp;Edit working directory file</source>
         <target />
       </trans-unit>
       <trans-unit id="expandToolStripMenuItem.Text">
-        <source>Expand</source>
+        <source>&amp;Expand</source>
         <target />
       </trans-unit>
       <trans-unit id="fileHistoryToolStripMenuItem.Text">
-        <source>View history</source>
+        <source>View &amp;history</source>
         <target />
       </trans-unit>
       <trans-unit id="fileTreeArchiveToolStripMenuItem.Text">
-        <source>Archive...</source>
+        <source>Archi&amp;ve...</source>
         <target />
       </trans-unit>
       <trans-unit id="fileTreeCleanWorkingTreeToolStripMenuItem.Text">
-        <source>Clean this folder in the working directory...</source>
+        <source>&amp;Clean this folder in the working directory...</source>
         <target />
       </trans-unit>
       <trans-unit id="fileTreeOpenContainingFolderToolStripMenuItem.Text">
-        <source>Show in folder</source>
+        <source>Show &amp;in folder</source>
         <target />
       </trans-unit>
       <trans-unit id="filterFileInGridToolStripMenuItem.Text">
@@ -8988,15 +8988,15 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="findToolStripMenuItem.Text">
-        <source>Find in file tree...</source>
+        <source>&amp;Find file...</source>
         <target />
       </trans-unit>
       <trans-unit id="openFileToolStripMenuItem.Text">
-        <source>Open this revision (temp file)</source>
+        <source>Ope&amp;n this revision (temp file)</source>
         <target />
       </trans-unit>
       <trans-unit id="openFileWithToolStripMenuItem.Text">
-        <source>Open this revision with... (temp file)</source>
+        <source>Open this revision &amp;with... (temp file)</source>
         <target />
       </trans-unit>
       <trans-unit id="openSubmoduleMenuItem.Text">
@@ -9004,27 +9004,27 @@ See the changes in the commit form.</source>
         <target />
       </trans-unit>
       <trans-unit id="openWithDifftoolToolStripMenuItem.Text">
-        <source>Open with difftool</source>
+        <source>Open with &amp;difftool</source>
         <target />
       </trans-unit>
       <trans-unit id="openWithToolStripMenuItem.Text">
-        <source>Open working directory file with...</source>
+        <source>&amp;Open working directory file with...</source>
         <target />
       </trans-unit>
       <trans-unit id="rememberFileStripMenuItem.Text">
-        <source>Remember file for diff</source>
+        <source>Re&amp;member file for diff</source>
         <target />
       </trans-unit>
       <trans-unit id="resetToThisRevisionToolStripMenuItem.Text">
-        <source>Reset to selected revision</source>
+        <source>&amp;Reset to selected revision</source>
         <target />
       </trans-unit>
       <trans-unit id="saveAsToolStripMenuItem.Text">
-        <source>Save as...</source>
+        <source>S&amp;ave as...</source>
         <target />
       </trans-unit>
       <trans-unit id="stopTrackingThisFileToolStripMenuItem.Text">
-        <source>Stop tracking this file</source>
+        <source>Stop &amp;tracking this file</source>
         <target />
       </trans-unit>
     </body>


### PR DESCRIPTION
## Proposed changes

Find file (in list) was just displayed as "Find" with the preview icon, mostly related to searching.
(Find file is a variation to the filter.)
(To search the files in the commit Find in the FileViewer must be used, by default Ctrl-F will work too).
Similar change in Compare form.

Added the preview (magnifier) icon to FileViewer find.

## Screenshots <!-- Remove this section if PR does not change UI -->

RevDiff
![image](https://github.com/gitextensions/gitextensions/assets/6248932/34760c9e-87b7-4001-8c2c-13442fd77a4b) ![image](https://github.com/gitextensions/gitextensions/assets/6248932/c1029097-ac43-42e9-a35c-5e6b5f1c67de)

Compare
![image](https://github.com/gitextensions/gitextensions/assets/6248932/03edad3a-f84e-4bd2-9fc8-1628a64db93b) ![image](https://github.com/gitextensions/gitextensions/assets/6248932/87db2509-8ea5-4c90-a6ed-60b31c560fee)

FileViewer
(left is master, there has been other cleanups recently.)
![image](https://github.com/gitextensions/gitextensions/assets/6248932/3b599b57-84cb-47ff-9576-0bca3dd31644)  ![image](https://github.com/gitextensions/gitextensions/assets/6248932/d30db686-d88d-44b9-bb4a-80dd83712f8b)

FileTree
![image](https://github.com/gitextensions/gitextensions/assets/6248932/d7b4ef97-87d4-45dc-8cba-8e66ff773d65) ![image](https://github.com/gitextensions/gitextensions/assets/6248932/e8bf0b08-21da-4ee7-962b-2fef3df65f4d)

![image](https://github.com/gitextensions/gitextensions/assets/6248932/f6249d88-73a1-420c-b101-8e312ee18054)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
