### PR TITLE
SubmoduleInfo: Do not quote empty ref

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -160,7 +160,7 @@ namespace GitCommands
                 "-z",
                 "-1",
                 $"--pretty=format:\"{GetLogFormat(hasNotes: hasNotes)}\"",
-                commitHash.Quote()
+                commitHash.QuoteNE()
             };
 
             // output can be cached if Git Notes is not included


### PR DESCRIPTION
## Proposed changes

Commit could be empty for directories not yet added or removed submodule directories.

Regression in #11570 b82e637d37a3a467f083c0b320b05a7b74171e94
(to handle refs with characters that the shell may change).

I reviewed the other changes, did not see any more potential issues.

## Test methodology <!-- How did you ensure quality? -->

Manual 

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
