### PR TITLE
fix(CommitPickerSmallControl): fix commit count crash

### DIFF
--- a/GitUI/UserControls/CommitPickerSmallControl.cs
+++ b/GitUI/UserControls/CommitPickerSmallControl.cs
@@ -43,10 +43,11 @@ namespace GitUI.UserControls
 
             bool isArtificialCommitForEmptyRepo = commitHash == "HEAD";
 
+            lbCommits.Text = "";
+
             if (SelectedObjectId is null || isArtificialCommitForEmptyRepo)
             {
                 textBoxCommitHash.Text = "";
-                lbCommits.Text = "";
             }
             else
             {
@@ -55,7 +56,10 @@ namespace GitUI.UserControls
                     {
                         ObjectId currentCheckout = Module.GetCurrentCheckout();
 
-                        Validates.NotNull(currentCheckout);
+                        if (currentCheckout is null)
+                        {
+                            return;
+                        }
 
                         string toRef = SelectedObjectId.IsArtificial ? "HEAD" : SelectedObjectId.ToString();
                         string text = Module.GetCommitCountString(currentCheckout, toRef);


### PR DESCRIPTION
when nothing is checked out

Fixes #11609

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/d571bee4-5e39-480f-a580-f5fcbf3d3e72)

### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/2bb0521f-ec46-4989-8318-74ff6daec7a7)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build a6bfcb6dcff5447d313dab39dcab628fcb86b6a5
- Git 2.44.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
