### PR TITLE
Improve flaky LeftPanelTests.Submodules

### DIFF
--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.Submodules.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowse.LeftPanelTests.Submodules.cs
@@ -5,9 +5,7 @@ using GitCommands;
 using GitCommands.Submodules;
 using GitUI;
 using GitUI.CommandsDialogs;
-using GitUI.ScriptsEngine;
 using GitUIPluginInterfaces;
-using NSubstitute;
 
 namespace GitExtensions.UITests.CommandsDialogs
 {
@@ -83,7 +81,7 @@ namespace GitExtensions.UITests.CommandsDialogs
         [TearDown]
         public void TearDown()
         {
-            // _provider is a singleton and must not be disposed
+            _provider.Dispose();
             _repo1.Dispose();
             _repo2.Dispose();
             _repo3.Dispose();
@@ -93,14 +91,14 @@ namespace GitExtensions.UITests.CommandsDialogs
         public void RepoObjectTree_should_show_all_submodules()
         {
             RunFormTest(
-                async form =>
+                form =>
                 {
-                    // act
-                    await SubmoduleTestHelpers.UpdateSubmoduleStructureAndWaitForResultAsync(_provider, _repo1Module);
-
-                    // assert
                     TreeNode submodulesNode = GetSubmoduleNode(form);
 
+                    // act: wait until loaded by left panel
+                    UITest.ProcessUntil("Loading submodules", () => submodulesNode.Nodes.Count == 1);
+
+                    // assert
                     submodulesNode.Nodes.Count.Should().Be(1);
 
                     TreeNode repo1Node = submodulesNode.Nodes[0];
@@ -114,6 +112,8 @@ namespace GitExtensions.UITests.CommandsDialogs
                     TreeNode repo3Node = repo2Node.Nodes[0];
                     repo3Node.Name.Should().StartWith("repo3");
                     repo3Node.Nodes.Count.Should().Be(0);
+
+                    return Task.CompletedTask;
                 });
         }
 


### PR DESCRIPTION
Should avoid `OperationCanceledException` as https://ci.appveyor.com/project/gitextensions/gitextensions/builds/49289921#L341

## Proposed changes

- Just wait for finished submodule update triggered by left panel
- Correctly dispose the per-test provider instance

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- run the test (on AppVeyor)

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).