### PR TITLE
Fix FormRebase DPI issues

### DIFF
--- a/GitExtUtils/GitUI/DpiUtil.cs
+++ b/GitExtUtils/GitUI/DpiUtil.cs
@@ -174,7 +174,7 @@ namespace GitExtUtils.GitUI
             using Graphics g = Graphics.FromImage(bitmap);
 
             // NearestNeighbor is better for 200% and above
-            // http://blogs.msdn.com/b/visualstudio/archive/2014/03/19/improving-high-dpi-support-for-visual-studio-2013.aspx
+            // https://devblogs.microsoft.com/visualstudio/improving-high-dpi-support-for-visual-studio-2013/
 
             g.InterpolationMode = ScaleX >= 2
                 ? InterpolationMode.NearestNeighbor

--- a/GitUI/CommandsDialogs/FormRebase.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRebase.Designer.cs
@@ -120,8 +120,10 @@ namespace GitUI.CommandsDialogs
             // btnAddFiles
             // 
             btnAddFiles.AutoSize = true;
+            btnAddFiles.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             btnAddFiles.Image = Properties.Images.BulletAdd;
             btnAddFiles.Location = new Point(3, 3);
+            btnAddFiles.MinimumSize = new Size(79, 25);
             btnAddFiles.Name = "btnAddFiles";
             btnAddFiles.Size = new Size(79, 25);
             btnAddFiles.TabIndex = 34;
@@ -133,8 +135,10 @@ namespace GitUI.CommandsDialogs
             // btnCommit
             // 
             btnCommit.AutoSize = true;
+            btnCommit.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             btnCommit.Image = Properties.Images.RepoStateStaged;
             btnCommit.Location = new Point(88, 3);
+            btnCommit.MinimumSize = new Size(86, 25);
             btnCommit.Name = "btnCommit";
             btnCommit.Size = new Size(86, 25);
             btnCommit.TabIndex = 35;
@@ -146,8 +150,10 @@ namespace GitUI.CommandsDialogs
             // btnEditTodo
             // 
             btnEditTodo.AutoSize = true;
+            btnEditTodo.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             btnEditTodo.Image = Properties.Images.EditFile;
             btnEditTodo.Location = new Point(180, 3);
+            btnEditTodo.MinimumSize = new Size(90, 25);
             btnEditTodo.Name = "btnEditTodo";
             btnEditTodo.Size = new Size(90, 25);
             btnEditTodo.TabIndex = 36;
@@ -172,7 +178,9 @@ namespace GitUI.CommandsDialogs
             // btnSkip
             // 
             btnSkip.AutoSize = true;
+            btnSkip.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             btnSkip.Location = new Point(163, 3);
+            btnSkip.MinimumSize = new Size(183, 25);
             btnSkip.Name = "btnSkip";
             btnSkip.Size = new Size(183, 25);
             btnSkip.TabIndex = 39;
@@ -247,7 +255,9 @@ namespace GitUI.CommandsDialogs
             // btnContinueRebase
             // 
             btnContinueRebase.AutoSize = true;
+            btnContinueRebase.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             btnContinueRebase.Location = new Point(837, 8);
+            btnContinueRebase.MinimumSize = new Size(103, 25);
             btnContinueRebase.Name = "btnContinueRebase";
             btnContinueRebase.Size = new Size(103, 25);
             btnContinueRebase.TabIndex = 38;
@@ -258,7 +268,9 @@ namespace GitUI.CommandsDialogs
             // btnAbort
             // 
             btnAbort.AutoSize = true;
+            btnAbort.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             btnAbort.Location = new Point(946, 8);
+            btnAbort.MinimumSize = new Size(75, 25);
             btnAbort.Name = "btnAbort";
             btnAbort.Size = new Size(75, 25);
             btnAbort.TabIndex = 40;
@@ -269,9 +281,10 @@ namespace GitUI.CommandsDialogs
             // btnSolveConflicts
             // 
             btnSolveConflicts.AutoSize = true;
+            btnSolveConflicts.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             btnSolveConflicts.Location = new Point(0, 2);
             btnSolveConflicts.Margin = new Padding(1);
-            btnSolveConflicts.MinimumSize = new Size(100, 0);
+            btnSolveConflicts.MinimumSize = new Size(100, 25);
             btnSolveConflicts.Name = "btnSolveConflicts";
             btnSolveConflicts.Size = new Size(100, 25);
             btnSolveConflicts.TabIndex = 32;
@@ -428,9 +441,11 @@ namespace GitUI.CommandsDialogs
             // btnChooseFromRevision
             // 
             btnChooseFromRevision.Anchor = AnchorStyles.Left;
+            btnChooseFromRevision.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             btnChooseFromRevision.Enabled = false;
             btnChooseFromRevision.Image = Properties.Images.SelectRevision;
             btnChooseFromRevision.Location = new Point(268, 3);
+            btnChooseFromRevision.MinimumSize = new Size(25, 24);
             btnChooseFromRevision.Name = "btnChooseFromRevision";
             btnChooseFromRevision.Size = new Size(25, 24);
             btnChooseFromRevision.TabIndex = 22;
@@ -501,6 +516,7 @@ namespace GitUI.CommandsDialogs
             btnSolveMergeconflicts.BackColor = Color.Salmon;
             btnSolveMergeconflicts.FlatStyle = FlatStyle.Flat;
             btnSolveMergeconflicts.Location = new Point(12, 426);
+            btnSolveMergeconflicts.MinimumSize = new Size(213, 27);
             btnSolveMergeconflicts.Name = "btnSolveMergeconflicts";
             btnSolveMergeconflicts.Size = new Size(213, 27);
             btnSolveMergeconflicts.TabIndex = 42;
@@ -615,9 +631,10 @@ namespace GitUI.CommandsDialogs
             // btnRebase
             // 
             btnRebase.AutoSize = true;
+            btnRebase.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             btnRebase.Image = Properties.Images.Rebase;
             btnRebase.Location = new Point(628, 8);
-            btnRebase.MinimumSize = new Size(100, 0);
+            btnRebase.MinimumSize = new Size(100, 25);
             btnRebase.Name = "btnRebase";
             btnRebase.Size = new Size(100, 25);
             btnRebase.TabIndex = 29;
@@ -630,8 +647,8 @@ namespace GitUI.CommandsDialogs
             // FormRebase
             // 
             AcceptButton = btnRebase;
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             BackgroundImageLayout = ImageLayout.Center;
             ClientSize = new Size(1034, 461);
             Controls.Add(btnSolveMergeconflicts);
@@ -643,6 +660,7 @@ namespace GitUI.CommandsDialogs
             Controls.SetChildIndex(MainPanel, 0);
             Controls.SetChildIndex(btnSolveMergeconflicts, 0);
             MainPanel.ResumeLayout(false);
+            MainPanel.PerformLayout();
             ControlsPanel.ResumeLayout(false);
             ControlsPanel.PerformLayout();
             flowLayoutPanel1.ResumeLayout(false);

--- a/GitUI/CommandsDialogs/FormRebase.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRebase.Designer.cs
@@ -60,12 +60,12 @@ namespace GitUI.CommandsDialogs
             lblRangeTo = new Label();
             cboTo = new ComboBox();
             llblShowOptions = new LinkLabel();
-            PatchGrid = new GitUI.PatchGrid();
+            PatchGrid = new PatchGrid();
             lblCommitsToReapply = new Label();
             btnSolveMergeconflicts = new Button();
             MergeToolPanel = new Panel();
             MainLayout = new TableLayoutPanel();
-            PanelLeftImage = new GitUI.Help.HelpImageDisplayUserControl();
+            PanelLeftImage = new Help.HelpImageDisplayUserControl();
             PanelMiddle = new TableLayoutPanel();
             rebasePanel = new FlowLayoutPanel();
             tlpnlSecondaryControls = new TableLayoutPanel();
@@ -149,11 +149,11 @@ namespace GitUI.CommandsDialogs
             btnEditTodo.Image = Properties.Images.EditFile;
             btnEditTodo.Location = new Point(180, 3);
             btnEditTodo.Name = "btnEditTodo";
-            btnEditTodo.Size = new Size(79, 25);
+            btnEditTodo.Size = new Size(90, 25);
             btnEditTodo.TabIndex = 36;
             btnEditTodo.Text = "&Edit todo...";
-            btnEditTodo.UseVisualStyleBackColor = true;
             btnEditTodo.TextImageRelation = TextImageRelation.ImageBeforeText;
+            btnEditTodo.UseVisualStyleBackColor = true;
             btnEditTodo.Click += EditTodoClick;
             // 
             // flowLayoutPanel2
@@ -292,7 +292,7 @@ namespace GitUI.CommandsDialogs
             flpnlOptionsPanelTop.Dock = DockStyle.Fill;
             flpnlOptionsPanelTop.Location = new Point(3, 78);
             flpnlOptionsPanelTop.Name = "flpnlOptionsPanelTop";
-            flpnlOptionsPanelTop.Size = new Size(709, 25);
+            flpnlOptionsPanelTop.Size = new Size(709, 50);
             flpnlOptionsPanelTop.TabIndex = 11;
             // 
             // chkInteractive
@@ -351,8 +351,7 @@ namespace GitUI.CommandsDialogs
             chkIgnoreDate.Size = new Size(86, 19);
             chkIgnoreDate.TabIndex = 16;
             chkIgnoreDate.Text = "Ignore &date";
-            toolTip1.SetToolTip(chkIgnoreDate, "Sets the author date to the current date (same as\r\ncommit date), ignoring the ori" +
-        "ginal author date.");
+            toolTip1.SetToolTip(chkIgnoreDate, "Sets the author date to the current date (same as\r\ncommit date), ignoring the original author date.");
             chkIgnoreDate.UseVisualStyleBackColor = true;
             chkIgnoreDate.CheckedChanged += chkIgnoreDate_CheckedChanged;
             // 
@@ -360,7 +359,7 @@ namespace GitUI.CommandsDialogs
             // 
             chkCommitterDateIsAuthorDate.Anchor = AnchorStyles.Left;
             chkCommitterDateIsAuthorDate.AutoSize = true;
-            chkCommitterDateIsAuthorDate.Location = new Point(523, 3);
+            chkCommitterDateIsAuthorDate.Location = new Point(3, 28);
             chkCommitterDateIsAuthorDate.Name = "chkCommitterDateIsAuthorDate";
             chkCommitterDateIsAuthorDate.Size = new Size(185, 19);
             chkCommitterDateIsAuthorDate.TabIndex = 17;
@@ -372,7 +371,7 @@ namespace GitUI.CommandsDialogs
             // checkBoxUpdateRefs
             // 
             checkBoxUpdateRefs.AutoSize = true;
-            checkBoxUpdateRefs.Location = new Point(714, 3);
+            checkBoxUpdateRefs.Location = new Point(194, 28);
             checkBoxUpdateRefs.Name = "checkBoxUpdateRefs";
             checkBoxUpdateRefs.Size = new Size(146, 19);
             checkBoxUpdateRefs.TabIndex = 18;
@@ -389,7 +388,7 @@ namespace GitUI.CommandsDialogs
             flpnlOptionsPanelBottom.Controls.Add(lblRangeTo);
             flpnlOptionsPanelBottom.Controls.Add(cboTo);
             flpnlOptionsPanelBottom.Dock = DockStyle.Fill;
-            flpnlOptionsPanelBottom.Location = new Point(3, 109);
+            flpnlOptionsPanelBottom.Location = new Point(3, 134);
             flpnlOptionsPanelBottom.Name = "flpnlOptionsPanelBottom";
             flpnlOptionsPanelBottom.Size = new Size(709, 30);
             flpnlOptionsPanelBottom.TabIndex = 18;
@@ -477,17 +476,17 @@ namespace GitUI.CommandsDialogs
             PatchGrid.AutoSize = true;
             PatchGrid.Dock = DockStyle.Fill;
             PatchGrid.IsManagingRebase = true;
-            PatchGrid.Location = new Point(3, 177);
+            PatchGrid.Location = new Point(3, 192);
             PatchGrid.Margin = new Padding(3, 2, 3, 2);
             PatchGrid.MinimumSize = new Size(0, 100);
             PatchGrid.Name = "PatchGrid";
-            PatchGrid.Size = new Size(709, 174);
+            PatchGrid.Size = new Size(709, 159);
             PatchGrid.TabIndex = 26;
             // 
             // lblCommitsToReapply
             // 
             lblCommitsToReapply.AutoSize = true;
-            lblCommitsToReapply.Location = new Point(3, 150);
+            lblCommitsToReapply.Location = new Point(3, 175);
             lblCommitsToReapply.Name = "lblCommitsToReapply";
             lblCommitsToReapply.Padding = new Padding(0, 10, 0, 0);
             lblCommitsToReapply.Size = new Size(120, 25);
@@ -668,7 +667,6 @@ namespace GitUI.CommandsDialogs
             tlpnlSecondaryControls.PerformLayout();
             ResumeLayout(false);
             PerformLayout();
-
         }
 
         #endregion

--- a/GitUI/CommandsDialogs/FormRebase.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRebase.Designer.cs
@@ -486,10 +486,10 @@ namespace GitUI.CommandsDialogs
             // lblCommitsToReapply
             // 
             lblCommitsToReapply.AutoSize = true;
+            lblCommitsToReapply.Dock = DockStyle.Fill;
             lblCommitsToReapply.Location = new Point(3, 175);
             lblCommitsToReapply.Name = "lblCommitsToReapply";
-            lblCommitsToReapply.Padding = new Padding(0, 10, 0, 0);
-            lblCommitsToReapply.Size = new Size(120, 25);
+            lblCommitsToReapply.Size = new Size(709, 15);
             lblCommitsToReapply.TabIndex = 25;
             lblCommitsToReapply.Text = "Commits to re-apply:";
             // 

--- a/GitUI/CommandsDialogs/FormRebase.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRebase.Designer.cs
@@ -630,8 +630,8 @@ namespace GitUI.CommandsDialogs
             // FormRebase
             // 
             AcceptButton = btnRebase;
-            AutoScaleDimensions = new SizeF(96F, 96F);
-            AutoScaleMode = AutoScaleMode.Dpi;
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
             BackgroundImageLayout = ImageLayout.Center;
             ClientSize = new Size(1034, 461);
             Controls.Add(btnSolveMergeconflicts);

--- a/GitUI/UserControls/HelpImageDisplayUserControl.cs
+++ b/GitUI/UserControls/HelpImageDisplayUserControl.cs
@@ -1,4 +1,5 @@
 ﻿using GitCommands;
+using GitExtUtils.GitUI;
 using ResourceManager;
 
 namespace GitUI.Help
@@ -91,7 +92,7 @@ namespace GitUI.Help
             get { return _image1; }
             set
             {
-                _image1 = value;
+                _image1 = value is null ? value : DpiUtil.Scale(value);
                 UpdateImageDisplay();
                 if (IsExpanded)
                 {
@@ -105,7 +106,7 @@ namespace GitUI.Help
             get { return _image2; }
             set
             {
-                _image2 = value;
+                _image2 = value is null ? value : DpiUtil.Scale(value);
                 UpdateImageDisplay();
                 if (IsExpanded)
                 {

--- a/GitUI/UserControls/PatchGrid.Designer.cs
+++ b/GitUI/UserControls/PatchGrid.Designer.cs
@@ -117,7 +117,7 @@
             // CommitHash
             // 
             CommitHash.AutoSizeMode = DataGridViewAutoSizeColumnMode.ColumnHeader;
-            CommitHash.HeaderText = "Hash";
+            CommitHash.HeaderText = "Commit hash";
             CommitHash.Name = "CommitHash";
             CommitHash.ReadOnly = true;
             CommitHash.SortMode = DataGridViewColumnSortMode.NotSortable;

--- a/GitUI/UserControls/PatchGrid.Designer.cs
+++ b/GitUI/UserControls/PatchGrid.Designer.cs
@@ -93,7 +93,7 @@
             // 
             // CommitHash
             // 
-            CommitHash.AutoSizeMode = DataGridViewAutoSizeColumnMode.None;
+            CommitHash.AutoSizeMode = DataGridViewAutoSizeColumnMode.ColumnHeader;
             CommitHash.HeaderText = "Commit hash";
             CommitHash.Name = "CommitHash";
             CommitHash.ReadOnly = true;

--- a/GitUI/UserControls/PatchGrid.Designer.cs
+++ b/GitUI/UserControls/PatchGrid.Designer.cs
@@ -33,10 +33,10 @@
             patchFileBindingSource = new BindingSource(components);
             Action = new DataGridViewTextBoxColumn();
             FileName = new DataGridViewTextBoxColumn();
-            CommitHash = new DataGridViewTextBoxColumn();
             subjectDataGridViewTextBoxColumn = new DataGridViewTextBoxColumn();
             authorDataGridViewTextBoxColumn = new DataGridViewTextBoxColumn();
             dateDataGridViewTextBoxColumn = new DataGridViewTextBoxColumn();
+            CommitHash = new DataGridViewTextBoxColumn();
             Status = new DataGridViewTextBoxColumn();
             ((System.ComponentModel.ISupportInitialize)(Patches)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(patchFileBindingSource)).BeginInit();
@@ -55,10 +55,10 @@
             Status,
             Action,
             FileName,
-            CommitHash,
             subjectDataGridViewTextBoxColumn,
             authorDataGridViewTextBoxColumn,
-            dateDataGridViewTextBoxColumn});
+            dateDataGridViewTextBoxColumn,
+            CommitHash});
             Patches.DataSource = patchFileBindingSource;
             Patches.Dock = DockStyle.Fill;
             Patches.Location = new Point(0, 0);
@@ -91,14 +91,6 @@
             Action.ReadOnly = true;
             Action.SortMode = DataGridViewColumnSortMode.NotSortable;
             // 
-            // CommitHash
-            // 
-            CommitHash.AutoSizeMode = DataGridViewAutoSizeColumnMode.ColumnHeader;
-            CommitHash.HeaderText = "Commit hash";
-            CommitHash.Name = "CommitHash";
-            CommitHash.ReadOnly = true;
-            CommitHash.SortMode = DataGridViewColumnSortMode.NotSortable;
-            // 
             // subjectDataGridViewTextBoxColumn
             // 
             subjectDataGridViewTextBoxColumn.HeaderText = "Subject";
@@ -121,6 +113,14 @@
             dateDataGridViewTextBoxColumn.Name = "dateDataGridViewTextBoxColumn";
             dateDataGridViewTextBoxColumn.ReadOnly = true;
             dateDataGridViewTextBoxColumn.SortMode = DataGridViewColumnSortMode.NotSortable;
+            // 
+            // CommitHash
+            // 
+            CommitHash.AutoSizeMode = DataGridViewAutoSizeColumnMode.ColumnHeader;
+            CommitHash.HeaderText = "Hash";
+            CommitHash.Name = "CommitHash";
+            CommitHash.ReadOnly = true;
+            CommitHash.SortMode = DataGridViewColumnSortMode.NotSortable;
             // 
             // Status
             // 
@@ -149,10 +149,10 @@
         private BindingSource patchFileBindingSource;
         private DataGridViewTextBoxColumn Action;
         private DataGridViewTextBoxColumn FileName;
-        private DataGridViewTextBoxColumn CommitHash;
         private DataGridViewTextBoxColumn subjectDataGridViewTextBoxColumn;
         private DataGridViewTextBoxColumn authorDataGridViewTextBoxColumn;
         private DataGridViewTextBoxColumn dateDataGridViewTextBoxColumn;
+        private DataGridViewTextBoxColumn CommitHash;
         private DataGridViewTextBoxColumn Status;
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11606

## Proposed changes

- Use `Font` scaling. Tests with .net framework 4.7.2, .net6 and .net8 have shown that `Dpi` scaling mode doesn't work properly for controls which are placed in container controls. This [SO question](https://stackoverflow.com/questions/22735174/how-to-write-winforms-code-that-auto-scales-to-system-font-and-dpi-settings) has helped a lot.
- Adjust `Commit hash` column to fit the header text without wrapping
- Fix Help image scaling.. And as for `FormMerge` it was sad to find out that even the text above the image turns out has always been clipped

## Screenshots

### Before

100% scaling
![FormRebase-100p-master](https://github.com/gitextensions/gitextensions/assets/483659/e6e0f75d-0813-4ce2-854e-21fafe21681d)

200% scaling
![FormRebase-200p-master](https://github.com/gitextensions/gitextensions/assets/483659/60877ff0-2bcd-44aa-8bc9-a1c30042f124)


### After
100% scaling
![FormRebase-100p-fixed](https://github.com/gitextensions/gitextensions/assets/483659/a8f33fe1-0a1d-4952-9bca-14bb76282c34)

200% scaling
![FormRebase-200p-fixed](https://github.com/gitextensions/gitextensions/assets/483659/470ffb13-6c3e-486b-a472-1453aca08b46)



## Test methodology <!-- How did you ensure quality? -->

- Checked `FormRebase` and `FormMerge` manually at 100% 150% and 200% scaling

#### FormMerge

### Before
200% scaling
![FormMerge-200p-master](https://github.com/gitextensions/gitextensions/assets/483659/ed662c7d-3558-4286-a441-42b0b2be42a7)

### After
200% scaling
![FormMerge-200p-fixed](https://github.com/gitextensions/gitextensions/assets/483659/5fc006be-d676-440a-928f-9c013e000492)


## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11
- 100% 150% and 200% scaling

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
