### PR TITLE
Fix FormCommit "splitRight" moving down on each FormCommit open

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -495,7 +495,7 @@ namespace GitUI.CommandsDialogs
             //
             // The problem is likely caused by 'splitRight.FixedPanel = FixedPanel.Panel2' fact, but other forms
             // have the same setting, and don't appear to suffer from the same bug.
-            splitRight.SplitterDistance -= 6;
+            splitRight.SplitterDistance -= DpiUtil.Scale(6);
         }
 
         protected override void OnShown(EventArgs e)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Take Dpi scaling into account when adjusting `FormCommit` horizontal splitter position

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
https://github.com/gitextensions/gitextensions/assets/483659/19173dfc-9d30-40af-93f8-4b5022f0b627

### After

Sorry, didn't record after, but the splitter doesn't move down with this fix.

## Test methodology <!-- How did you ensure quality? -->

- Manually with 200% scaling

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11
- 200% scaling

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
