### PR TITLE
FormResolveConflicts: Improve help when merging/rebasing

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1948,14 +1948,14 @@ namespace GitCommands
             return File.Exists(Path.Combine(GetGitDirectory(), "BISECT_START"));
         }
 
-        public bool InTheMiddleOfRebase()
-        {
-            return !File.Exists(GetRebaseDir() + "applying") && Directory.Exists(GetRebaseDir());
-        }
+        public bool InTheMiddleOfRebase() => InTheMiddleOfGitOperation("applying");
 
-        public bool InTheMiddleOfPatch()
+        public bool InTheMiddleOfPatch() => InTheMiddleOfGitOperation("rebasing");
+
+        private bool InTheMiddleOfGitOperation(string filename)
         {
-            return !File.Exists(GetRebaseDir() + "rebasing") && Directory.Exists(GetRebaseDir());
+            string rebaseDir = GetRebaseDir();
+            return !File.Exists(rebaseDir + filename) && Directory.Exists(rebaseDir);
         }
 
         public bool InTheMiddleOfMerge()

--- a/GitExtUtils/DisplayWithSuffixUpdater.cs
+++ b/GitExtUtils/DisplayWithSuffixUpdater.cs
@@ -1,0 +1,16 @@
+﻿namespace GitExtUtils;
+
+public static class DisplayWithSuffixUpdater
+{
+    public static string UpdateSuffix(this string currentText, string suffix)
+    {
+        // NO-BREAK SPACE
+        const string specialSpaceSeparator = "\u00A0";
+        int indexSuffix = currentText.LastIndexOf(specialSpaceSeparator);
+        string textWithoutSuffix = indexSuffix < 0 ? currentText : currentText[..indexSuffix];
+        return string.IsNullOrWhiteSpace(suffix) ? textWithoutSuffix : $"{textWithoutSuffix}{specialSpaceSeparator}{suffix}";
+    }
+
+    public static string UpdateSuffixWithinParenthesis(this string currentText, string suffix)
+        => currentText.UpdateSuffix($"({suffix})");
+}

--- a/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
@@ -46,11 +46,11 @@ namespace GitUI.CommandsDialogs
             fileHistoryToolStripMenuItem = new ToolStripMenuItem();
             gitItemBindingSource = new BindingSource(components);
             tableLayoutPanel1 = new TableLayoutPanel();
-            label7 = new Label();
+            labelLocalCurrent = new Label();
             localFileName = new Label();
             baseFileName = new Label();
-            label2 = new Label();
-            label5 = new Label();
+            labelBase = new Label();
+            labelRemoteIncoming = new Label();
             remoteFileName = new Label();
             tableLayoutPanel3 = new TableLayoutPanel();
             merge = new Button();
@@ -66,6 +66,7 @@ namespace GitUI.CommandsDialogs
             gotoUserManualControl1 = new GitUI.UserControls.GotoUserManualControl();
             progressBar = new ProgressBar();
             ((System.ComponentModel.ISupportInitialize)(ConflictedFiles)).BeginInit();
+            toolTip = new ToolTip(components);
             ConflictedFilesContextMenu.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(gitItemBindingSource)).BeginInit();
             tableLayoutPanel1.SuspendLayout();
@@ -303,13 +304,14 @@ namespace GitUI.CommandsDialogs
             // 
             tableLayoutPanel1.AutoSize = true;
             tableLayoutPanel1.ColumnCount = 2;
+            tableLayoutPanel4.SetColumnSpan(tableLayoutPanel1, 2);
             tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle());
             tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-            tableLayoutPanel1.Controls.Add(label7, 0, 0);
+            tableLayoutPanel1.Controls.Add(labelLocalCurrent, 0, 0);
             tableLayoutPanel1.Controls.Add(localFileName, 1, 0);
             tableLayoutPanel1.Controls.Add(baseFileName, 1, 1);
-            tableLayoutPanel1.Controls.Add(label2, 0, 1);
-            tableLayoutPanel1.Controls.Add(label5, 0, 2);
+            tableLayoutPanel1.Controls.Add(labelBase, 0, 1);
+            tableLayoutPanel1.Controls.Add(labelRemoteIncoming, 0, 2);
             tableLayoutPanel1.Controls.Add(remoteFileName, 1, 2);
             tableLayoutPanel1.Dock = DockStyle.Fill;
             tableLayoutPanel1.Location = new Point(0, 296);
@@ -322,16 +324,16 @@ namespace GitUI.CommandsDialogs
             tableLayoutPanel1.Size = new Size(467, 66);
             tableLayoutPanel1.TabIndex = 0;
             // 
-            // label7
+            // labelLocalCurrent
             // 
-            label7.Anchor = AnchorStyles.Left;
-            label7.AutoSize = true;
-            label7.Location = new Point(3, 0);
-            label7.Name = "label7";
-            label7.Padding = new Padding(0, 3, 0, 3);
-            label7.Size = new Size(37, 22);
-            label7.TabIndex = 1;
-            label7.Text = "Local";
+            labelLocalCurrent.Anchor = AnchorStyles.Left;
+            labelLocalCurrent.AutoSize = true;
+            labelLocalCurrent.Location = new Point(3, 0);
+            labelLocalCurrent.Name = "labelLocalCurrent";
+            labelLocalCurrent.Padding = new Padding(0, 3, 0, 3);
+            labelLocalCurrent.Size = new Size(80, 21);
+            labelLocalCurrent.TabIndex = 1;
+            labelLocalCurrent.Text = "Local/current";
             // 
             // localFileName
             // 
@@ -353,27 +355,27 @@ namespace GitUI.CommandsDialogs
             baseFileName.TabIndex = 4;
             baseFileName.Text = "...";
             // 
-            // label2
+            // labelBase
             // 
-            label2.Anchor = AnchorStyles.Left;
-            label2.AutoSize = true;
-            label2.Location = new Point(3, 22);
-            label2.Name = "label2";
-            label2.Padding = new Padding(0, 3, 0, 3);
-            label2.Size = new Size(35, 22);
-            label2.TabIndex = 2;
-            label2.Text = "Base";
+            labelBase.Anchor = AnchorStyles.Left;
+            labelBase.AutoSize = true;
+            labelBase.Location = new Point(3, 22);
+            labelBase.Name = "labelBase";
+            labelBase.Padding = new Padding(0, 3, 0, 3);
+            labelBase.Size = new Size(35, 22);
+            labelBase.TabIndex = 2;
+            labelBase.Text = "Base";
             // 
-            // label5
+            // labelRemoteIncoming
             // 
-            label5.Anchor = AnchorStyles.Left;
-            label5.AutoSize = true;
-            label5.Location = new Point(3, 44);
-            label5.Name = "label5";
-            label5.Padding = new Padding(0, 3, 0, 3);
-            label5.Size = new Size(52, 22);
-            label5.TabIndex = 5;
-            label5.Text = "Remote";
+            labelRemoteIncoming.Anchor = AnchorStyles.Left;
+            labelRemoteIncoming.AutoSize = true;
+            labelRemoteIncoming.Location = new Point(3, 44);
+            labelRemoteIncoming.Name = "labelRemoteIncoming";
+            labelRemoteIncoming.Padding = new Padding(0, 3, 0, 3);
+            labelRemoteIncoming.Size = new Size(104, 21);
+            labelRemoteIncoming.TabIndex = 5;
+            labelRemoteIncoming.Text = "Remote/incoming";
             // 
             // remoteFileName
             // 
@@ -609,12 +611,12 @@ namespace GitUI.CommandsDialogs
         private ToolStripMenuItem openWithToolStripMenuItem;
         private ToolStripMenuItem openToolStripMenuItem;
         private ToolStripMenuItem openFolderToolStripMenuItem;
-        private Label label7;
+        private Label labelLocalCurrent;
         private TableLayoutPanel tableLayoutPanel1;
-        private Label label2;
+        private Label labelBase;
         private Label localFileName;
         private Label baseFileName;
-        private Label label5;
+        private Label labelRemoteIncoming;
         private Label remoteFileName;
         private Label conflictDescription;
         private DataGridView ConflictedFiles;
@@ -634,5 +636,6 @@ namespace GitUI.CommandsDialogs
         private TableLayoutPanel tableLayoutPanel5;
         private UserControls.GotoUserManualControl gotoUserManualControl1;
         private ProgressBar progressBar;
+        private ToolTip toolTip;
     }
 }

--- a/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.Designer.cs
@@ -549,8 +549,8 @@ namespace GitUI.CommandsDialogs
             gotoUserManualControl1.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
             gotoUserManualControl1.AutoSize = true;
             gotoUserManualControl1.Location = new Point(3, 369);
-            gotoUserManualControl1.ManualSectionAnchorName = null;
-            gotoUserManualControl1.ManualSectionSubfolder = "merge_conflicts";
+            gotoUserManualControl1.ManualSectionAnchorName = "handle-merge-conflicts";
+            gotoUserManualControl1.ManualSectionSubfolder = "modify_history";
             gotoUserManualControl1.MinimumSize = new Size(70, 20);
             gotoUserManualControl1.Name = "gotoUserManualControl1";
             gotoUserManualControl1.Size = new Size(70, 20);

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -65,11 +65,18 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _openMergeToolItemText = new("Open in");
         private readonly TranslationString _button1Text = new("Open in");
 
-        private readonly TranslationString _contextChooseLocalRebaseText = new("Choose local (theirs)");
-        private readonly TranslationString _contextChooseRemoteRebaseText = new("Choose remote (ours)");
+        private readonly TranslationString _contextChooseLocalRebaseText = new("Choose local/current (theirs)");
+        private readonly TranslationString _takeOnly = new("Take only");
+        private readonly TranslationString _changesLocalRebaseTooltip = new("the changes from the branch you are rebasing onto");
+        private readonly TranslationString _contextChooseRemoteRebaseText = new("Choose remote/incoming (ours)");
+        private readonly TranslationString _changesRemoteRebaseTooltip = new("the changes from the branch you are rebasing");
 
-        private readonly TranslationString _contextChooseLocalMergeText = new("Choose local (ours)");
-        private readonly TranslationString _contextChooseRemoteMergeText = new("Choose remote (theirs)");
+        private readonly TranslationString _contextChooseLocalMergeText = new("Choose local/current (ours)");
+        private readonly TranslationString _changesLocalMergeTooltip = new("the changes from the current branch");
+        private readonly TranslationString _contextChooseRemoteMergeText = new("Choose remote/incoming (theirs)");
+        private readonly TranslationString _changesRemoteMergeTooltip = new("the changes from the branch you are merging");
+
+        private readonly TranslationString _contextChooseBaseTooltip = new("Take no changes and revert to base content!");
 
         private readonly TranslationString _noBaseFileMergeCaption = new("Merge");
 
@@ -242,13 +249,29 @@ namespace GitUI.CommandsDialogs
                 if (_inTheMiddleOfRebase)
                 {
                     ContextChooseLocal.Text = _contextChooseLocalRebaseText.Text;
+                    ContextChooseLocal.ToolTipText = _takeOnly.Text + " " + _changesLocalRebaseTooltip.Text;
+                    labelLocalCurrent.Text = labelLocalCurrent.Text.UpdateSuffixWithinParenthesis(_theirs.Text);
+                    toolTip.SetToolTip(labelLocalCurrent, _changesLocalRebaseTooltip.Text);
+
                     ContextChooseRemote.Text = _contextChooseRemoteRebaseText.Text;
+                    ContextChooseRemote.ToolTipText = _takeOnly.Text + " " + _changesRemoteRebaseTooltip.Text;
+                    labelRemoteIncoming.Text = labelRemoteIncoming.Text.UpdateSuffixWithinParenthesis(_ours.Text);
+                    toolTip.SetToolTip(labelRemoteIncoming, _changesRemoteRebaseTooltip.Text);
                 }
                 else
                 {
                     ContextChooseLocal.Text = _contextChooseLocalMergeText.Text;
+                    ContextChooseLocal.ToolTipText = _takeOnly.Text + " " + _changesLocalMergeTooltip.Text;
+                    labelLocalCurrent.Text = labelLocalCurrent.Text.UpdateSuffixWithinParenthesis(_ours.Text);
+                    toolTip.SetToolTip(labelLocalCurrent, _changesLocalMergeTooltip.Text);
+
                     ContextChooseRemote.Text = _contextChooseRemoteMergeText.Text;
+                    ContextChooseRemote.ToolTipText = _takeOnly.Text + " " + _changesRemoteMergeTooltip.Text;
+                    labelRemoteIncoming.Text = labelRemoteIncoming.Text.UpdateSuffixWithinParenthesis(_theirs.Text);
+                    toolTip.SetToolTip(labelRemoteIncoming, _changesRemoteMergeTooltip.Text);
                 }
+
+                ContextChooseBase.ToolTipText = _contextChooseBaseTooltip.Text;
 
                 if (!Module.InTheMiddleOfConflictedMerge() && _thereWhereMergeConflicts)
                 {

--- a/GitUI/CommandsDialogs/FormResolveConflicts.resx
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -125,5 +125,8 @@
   </metadata>
   <metadata name="gitItemBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
+  </metadata>
+  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>391, 17</value>
   </metadata>
 </root>

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6728,6 +6728,22 @@ Is the merge conflict solved?</source>
         <source>Open in</source>
         <target />
       </trans-unit>
+      <trans-unit id="_changesLocalMergeTooltip.Text">
+        <source>the changes from the current branch</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_changesLocalRebaseTooltip.Text">
+        <source>the changes from the branch you are rebasing onto</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_changesRemoteMergeTooltip.Text">
+        <source>the changes from the branch you are merging</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_changesRemoteRebaseTooltip.Text">
+        <source>the changes from the branch you are rebasing</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_chooseBaseFileFailedText.Text">
         <source>Choose base file failed.</source>
         <target />
@@ -6752,20 +6768,24 @@ Is the merge conflict solved?</source>
         <source>Solve</source>
         <target />
       </trans-unit>
+      <trans-unit id="_contextChooseBaseTooltip.Text">
+        <source>Take no changes and revert to base content!</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_contextChooseLocalMergeText.Text">
-        <source>Choose local (ours)</source>
+        <source>Choose local/current (ours)</source>
         <target />
       </trans-unit>
       <trans-unit id="_contextChooseLocalRebaseText.Text">
-        <source>Choose local (theirs)</source>
+        <source>Choose local/current (theirs)</source>
         <target />
       </trans-unit>
       <trans-unit id="_contextChooseRemoteMergeText.Text">
-        <source>Choose remote (theirs)</source>
+        <source>Choose remote/incoming (theirs)</source>
         <target />
       </trans-unit>
       <trans-unit id="_contextChooseRemoteRebaseText.Text">
-        <source>Choose remote (ours)</source>
+        <source>Choose remote/incoming (ours)</source>
         <target />
       </trans-unit>
       <trans-unit id="_currentFormatFilter.Text">
@@ -6928,6 +6948,10 @@ Please go to settings and configure the mergetool!</source>
         <source>Stage {0}</source>
         <target />
       </trans-unit>
+      <trans-unit id="_takeOnly.Text">
+        <source>Take only</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_theirs.Text">
         <source>theirs</source>
         <target />
@@ -6958,16 +6982,16 @@ Do you want to use this custom merge script?</source>
         <source>Unresolved merge conflicts</source>
         <target />
       </trans-unit>
-      <trans-unit id="label2.Text">
+      <trans-unit id="labelBase.Text">
         <source>Base</source>
         <target />
       </trans-unit>
-      <trans-unit id="label5.Text">
-        <source>Remote</source>
+      <trans-unit id="labelLocalCurrent.Text">
+        <source>Local/current</source>
         <target />
       </trans-unit>
-      <trans-unit id="label7.Text">
-        <source>Local</source>
+      <trans-unit id="labelRemoteIncoming.Text">
+        <source>Remote/incoming</source>
         <target />
       </trans-unit>
       <trans-unit id="merge.Text">

--- a/ResourceManager/Hotkey/KeysExtensions.cs
+++ b/ResourceManager/Hotkey/KeysExtensions.cs
@@ -1,11 +1,10 @@
 ﻿using System.Globalization;
+using GitExtUtils;
 
 namespace ResourceManager.Hotkey
 {
     public static class KeysExtensions
     {
-        private const string TooltipSeparator = "\u00A0";
-
         /// <summary>
         /// Strips the modifier from KeyData.
         /// </summary>
@@ -84,11 +83,7 @@ namespace ResourceManager.Hotkey
             => key == Keys.None ? "" : $"({key.ToShortcutKeyDisplayString()})";
 
         public static string UpdateTooltipWithShortcut(this string currentTooltipText, string shortcut)
-        {
-            int indexShortcut = currentTooltipText.LastIndexOf(TooltipSeparator);
-            string toolTip = indexShortcut < 0 ? currentTooltipText : currentTooltipText[..indexShortcut];
-            return string.IsNullOrWhiteSpace(shortcut) ? toolTip : $"{toolTip}{TooltipSeparator}{shortcut}";
-        }
+            => currentTooltipText.UpdateSuffix(shortcut);
 
         private static string? ToCultureSpecificString(this Keys key)
         {

--- a/UnitTests/GitExtUtils.Tests/DisplayWithSuffixUpdaterTests.cs
+++ b/UnitTests/GitExtUtils.Tests/DisplayWithSuffixUpdaterTests.cs
@@ -1,0 +1,20 @@
+﻿using GitExtUtils;
+
+namespace GitExtUtilsTests
+{
+    [TestFixture]
+    public sealed class DisplayWithSuffixUpdaterTests
+    {
+        [Test]
+        public void FromInitialValue()
+        {
+            Assert.AreEqual(DisplayWithSuffixUpdater.UpdateSuffixWithinParenthesis("a", "b"), "a\u00A0(b)");
+        }
+
+        [Test]
+        public void FromValueContainingAlreadyTheSuffix()
+        {
+            Assert.AreEqual(DisplayWithSuffixUpdater.UpdateSuffixWithinParenthesis("a (b)", "c"), "a\u00A0(c)");
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

When conflicts during merge/rebase, it is not always easy to what is "local" or "remote" ( See [here](https://jvns.ca/blog/2023/11/01/confusing-git-terminology/#ours-and-theirs-while-merging-or-rebasing) and [here](https://nitaym.github.io/ourstheirs/) )


- Add also terms "current"/"incoming" (that I found a little more explicit) and that user could be used to see if merging with "vscode"
- Add more explicit help as tooltips

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

* Merge:

![image](https://github.com/gitextensions/gitextensions/assets/460196/8b8b1b32-8e7e-404b-9636-c187b49bc1c5)

* Rebase:

![image](https://github.com/gitextensions/gitextensions/assets/460196/6d91dc51-d179-44a2-b9bd-d216e50ef58f)


### After

* Merge:

![image](https://github.com/gitextensions/gitextensions/assets/460196/caee38bf-32d5-4b09-82a2-d15f76e1e012)

* Rebase:

![image](https://github.com/gitextensions/gitextensions/assets/460196/edaa6ff2-739e-4917-afb2-5210daec1538)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 199b9935fa10cea107ffcff6d2d14c54d85cc2f4
- Git 2.44.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer **rebase** merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
