### PR TITLE
refactor: clean usage of delimiters

### DIFF
--- a/GitCommands/Git/GetAllChangedFilesOutputParser.cs
+++ b/GitCommands/Git/GetAllChangedFilesOutputParser.cs
@@ -348,9 +348,8 @@ namespace GitCommands.Git
         private static string RemoveWarnings(string statusString)
         {
             // The status string from git-diff can show warnings. See tests
-            char[] nl = new[] { '\n', '\r' };
             string trimmedStatus = statusString;
-            int lastNewLinePos = trimmedStatus.LastIndexOfAny(nl);
+            int lastNewLinePos = trimmedStatus.LastIndexOfAny(Delimiters.LineFeedAndCarriageReturn);
             while (lastNewLinePos >= 0)
             {
                 if (lastNewLinePos == 0)
@@ -360,10 +359,10 @@ namespace GitCommands.Git
                 }
 
                 // Error always end with \n and start at previous index
-                int ind = trimmedStatus.LastIndexOfAny(new[] { '\n', '\r', '\0' }, lastNewLinePos - 1);
+                int ind = trimmedStatus.LastIndexOfAny(Delimiters.LineFeedCarriageReturnAndNull, lastNewLinePos - 1);
 
                 trimmedStatus = trimmedStatus.Remove(ind + 1, lastNewLinePos - ind);
-                lastNewLinePos = trimmedStatus.LastIndexOfAny(nl);
+                lastNewLinePos = trimmedStatus.LastIndexOfAny(Delimiters.LineFeedAndCarriageReturn);
             }
 
             return trimmedStatus;

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2952,7 +2952,7 @@ namespace GitCommands
                 return Array.Empty<string>();
             }
 
-            string[] result = exec.StandardOutput.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] result = exec.StandardOutput.Split(Delimiters.LineFeedAndCarriageReturn, StringSplitOptions.RemoveEmptyEntries);
 
             // Remove symlink targets as in "origin/HEAD -> origin/master"
             for (int i = 0; i < result.Length; i++)
@@ -2989,7 +2989,7 @@ namespace GitCommands
                 return Array.Empty<string>();
             }
 
-            return exec.StandardOutput.Split(new[] { '\r', '\n', '*', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            return exec.StandardOutput.Split(Delimiters.GitOutput, StringSplitOptions.RemoveEmptyEntries);
         }
 
         public string? GetTagMessage(string? tag, CancellationToken cancellationToken = default)

--- a/GitCommands/Patches/PatchManager.cs
+++ b/GitCommands/Patches/PatchManager.cs
@@ -62,7 +62,7 @@ namespace GitCommands.Patches
 
         private static string CorrectHeaderForNewFile(string header)
         {
-            string[] headerLines = header.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] headerLines = header.Split('\n', StringSplitOptions.RemoveEmptyEntries);
             string? pppLine = null;
             foreach (string line in headerLines)
             {
@@ -108,7 +108,7 @@ namespace GitCommands.Patches
             // --- a/original2.txt
             // +++ b/original2.txt
 
-            string[] headerLines = header.Split(new[] { '\n' });
+            string[] headerLines = header.Split('\n');
             string? oldNameWithPrefix = null;
             string? newName = null;
             foreach (string line in headerLines)

--- a/GitExtUtils/Delimiters.cs
+++ b/GitExtUtils/Delimiters.cs
@@ -9,20 +9,23 @@ namespace System
     /// </remarks>
     internal static class Delimiters
     {
-        public static readonly char[] LineFeed = { '\n' };
-        public static readonly char[] LineAndVerticalFeed = { '\n', '\v' };
-        public static readonly char[] Space = { ' ' };
-        public static readonly char[] Tab = { '\t' };
-        public static readonly char[] Null = { '\0' };
-        public static readonly char[] TabAndSpace = { '\t', ' ' };
-        public static readonly char[] TabAndLineFeedAndCarriageReturn = { '\t', '\n', '\r' };
-        public static readonly char[] NullAndLineFeed = { '\0', '\n' };
-        public static readonly char[] LineFeedAndCarriageReturn = { '\n', '\r' };
-        public static readonly char[] ForwardSlash = { '/' };
-        public static readonly char[] Colon = { ':' };
-        public static readonly char[] Comma = { ',' };
-        public static readonly char[] Period = { '.' };
-        public static readonly char[] Hash = { '#' };
-        public static readonly char[] PathSeparators = { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+        public static readonly char[] LineFeed = ['\n'];
+        public static readonly char[] LineAndVerticalFeed = ['\n', '\v'];
+        public static readonly char[] Space = [' '];
+        public static readonly char[] Tab = ['\t'];
+        public static readonly char[] Null = ['\0'];
+        public static readonly char[] TabAndSpace = ['\t', ' '];
+        public static readonly char[] TabAndLineFeedAndCarriageReturn = ['\t', '\n', '\r'];
+        public static readonly char[] NullAndLineFeed = ['\0', '\n'];
+        public static readonly char[] LineFeedAndCarriageReturn = ['\n', '\r'];
+        public static readonly char[] LineFeedCarriageReturnAndNull = ['\n', '\r', '\0'];
+        public static readonly string[] NewLines = ["\r\n", "\n"];
+        public static readonly char[] GitOutput = ['*', ' ', '\n', '\r'];
+        public static readonly char[] ForwardSlash = ['/'];
+        public static readonly char[] Colon = [':'];
+        public static readonly char[] Comma = [','];
+        public static readonly char[] Period = ['.'];
+        public static readonly char[] Hash = ['#'];
+        public static readonly char[] PathSeparators = [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar];
     }
 }

--- a/GitUI/Avatars/InitialsAvatarProvider.cs
+++ b/GitUI/Avatars/InitialsAvatarProvider.cs
@@ -136,7 +136,7 @@ namespace GitUI.Avatars
             return $"{name[0]}{names[^1][0]}".ToUpper();
         }
 
-        private readonly (Brush foregroundBrush, Color backgroundColor)[] _avatarColors = AppSettings.AvatarAuthorInitialsPalette.Split(",").Select(GetAvatarDrawingMaterial).ToArray();
+        private readonly (Brush foregroundBrush, Color backgroundColor)[] _avatarColors = AppSettings.AvatarAuthorInitialsPalette.Split(',').Select(GetAvatarDrawingMaterial).ToArray();
 
         private static (Brush foregroundBrush, Color backgroundColor) GetAvatarDrawingMaterial(string colorCode)
         {

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1447,7 +1447,7 @@ namespace GitUI.CommandsDialogs
                 {
                     if (AppSettings.CommitValidationMaxCntCharsFirstLine > 0)
                     {
-                        string firstLine = Message.Text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries)[0];
+                        string firstLine = Message.Text.Split(Delimiters.NewLines, StringSplitOptions.RemoveEmptyEntries)[0];
                         if (firstLine.Length > AppSettings.CommitValidationMaxCntCharsFirstLine &&
                             MessageBox.Show(this, _commitMsgFirstLineInvalid.Text, _commitValidationCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Asterisk) == DialogResult.No)
                         {
@@ -1457,7 +1457,7 @@ namespace GitUI.CommandsDialogs
 
                     if (AppSettings.CommitValidationMaxCntCharsPerLine > 0)
                     {
-                        string[] lines = Message.Text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+                        string[] lines = Message.Text.Split(Delimiters.NewLines, StringSplitOptions.RemoveEmptyEntries);
                         foreach (string line in lines)
                         {
                             if (line.Length > AppSettings.CommitValidationMaxCntCharsPerLine &&
@@ -1470,7 +1470,7 @@ namespace GitUI.CommandsDialogs
 
                     if (AppSettings.CommitValidationSecondLineMustBeEmpty)
                     {
-                        string[] lines = Message.Text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+                        string[] lines = Message.Text.Split(Delimiters.NewLines, StringSplitOptions.None);
                         if (lines.Length > 2 &&
                             lines[1].Length != 0 &&
                             MessageBox.Show(this, _commitMsgSecondLineNotEmpty.Text, _commitValidationCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Asterisk) == DialogResult.No)
@@ -1501,7 +1501,7 @@ namespace GitUI.CommandsDialogs
 
                 static string GetTextToValidate(string text)
                 {
-                    string[] lines = text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+                    string[] lines = text.Split(Delimiters.NewLines, StringSplitOptions.None);
                     if (text.StartsWith(CommitKind.Amend.GetPrefix()) && lines.Length > 2 && lines[1].Length == 0)
                     {
                         return string.Join(Environment.NewLine, lines.Skip(2));

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -275,7 +275,7 @@ namespace GitUI.CommandsDialogs
                 _lostObjects.Clear();
                 _lostObjects.AddRange(
                     cmdOutput
-                        .Split('\r', '\n')
+                        .Split(Delimiters.LineFeedAndCarriageReturn)
                         .Where(s => !string.IsNullOrEmpty(s))
                         .Select(s => LostObject.TryParse(Module, s))
                         .WhereNotNull()

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -845,10 +845,10 @@ namespace GitUI.CommitInfo
             {
                 _currentBranch = currentBranch;
                 _isDetachedHead = DetachedHeadParser.IsDetachedHead(currentBranch);
-                string[] branchRegexes = AppSettings.PrioritizedBranchNames.Split(";", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                string[] branchRegexes = AppSettings.PrioritizedBranchNames.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
                 string[] localBranchRegexes = branchRegexes.Select(regex => $"^({regex})$").ToArray();
                 string[] remoteBranchRegexes = branchRegexes.Select(regex => $"^{_remoteBranchPrefix}[^/]+/({regex})$").ToArray();
-                string[] remoteRegexes = AppSettings.PrioritizedRemoteNames.Split(";", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                string[] remoteRegexes = AppSettings.PrioritizedRemoteNames.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                     .Select(regex => $"^{_remoteBranchPrefix}({regex})/").ToArray();
 
                 foreach (string branch in branches)

--- a/GitUI/HelperDialogs/FormProcess.cs
+++ b/GitUI/HelperDialogs/FormProcess.cs
@@ -221,8 +221,6 @@ namespace GitUI.HelperDialogs
         }
 
         public static bool IsOperationAborted(string dialogResult)
-        {
-            return dialogResult.Trim('\r', '\n') == "Aborted";
-        }
+            => dialogResult.Trim(Delimiters.LineFeedAndCarriageReturn) == "Aborted";
     }
 }

--- a/GitUI/LeftPanel/BaseRefTree.cs
+++ b/GitUI/LeftPanel/BaseRefTree.cs
@@ -101,7 +101,7 @@ namespace GitUI.LeftPanel
         private static IEnumerable<T> OrderByPriority<T>(IReadOnlyList<T> references, Func<T, string> keySelector, string setting)
         {
             // Sort prio branches first (if set) with the compile cache (no need to instantiate)
-            string[] regexes = setting.Split(";", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            string[] regexes = setting.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .Select(regex => $"^({regex})$")
                 .ToArray();
 

--- a/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
+++ b/GitUI/UserControls/RevisionGrid/CopyContextMenuItem.cs
@@ -57,7 +57,7 @@ namespace GitUI.UserControls.RevisionGrid
 
             ToolStripMenuItem item = new()
             {
-                Text = displayText.TrimEnd('\r', '\n'),
+                Text = displayText.TrimEnd(Delimiters.LineFeedAndCarriageReturn),
                 ShowShortcutKeys = true,
                 Image = image
             };

--- a/GitUI/UserControls/TextBoxSilencer.cs
+++ b/GitUI/UserControls/TextBoxSilencer.cs
@@ -7,8 +7,6 @@
     /// because they are implemented using SendMessage calls.
     internal sealed class TextBoxSilencer
     {
-        private static readonly char[] _lineEndChars = { '\r', '\n' };
-
         private RichTextBox _textBox;
 
         private bool _isAtFirstColumn;
@@ -51,12 +49,12 @@
             _isAtFirstColumn = position == _textBox.GetFirstCharIndexOfCurrentLine();
             _isAtEndColumn = position == GetLineEnd(text, startIndex: position);
             _isAtFirstLine = position <= GetLineEnd(text, startIndex: 0);
-            _isAtLastLine = text.IndexOfAny(_lineEndChars, startIndex: position) < 0;
+            _isAtLastLine = text.IndexOfAny(Delimiters.LineFeedAndCarriageReturn, startIndex: position) < 0;
         }
 
         private static int GetLineEnd(string text, int startIndex)
         {
-            int eol = text.IndexOfAny(_lineEndChars, startIndex);
+            int eol = text.IndexOfAny(Delimiters.LineFeedAndCarriageReturn, startIndex);
             return eol >= startIndex ? eol : text.Length;
         }
     }

--- a/Plugins/CreateLocalBranches/CreateLocalBranchesForm.cs
+++ b/Plugins/CreateLocalBranches/CreateLocalBranchesForm.cs
@@ -20,7 +20,7 @@ namespace GitExtensions.Plugins.CreateLocalBranches
         {
             GitArgumentBuilder args = new("branch") { "-a" };
             string[] references = _gitUiCommands.GitModule.GitExecutable.GetOutput(args)
-                .Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
             if (references.Length == 0)
             {
@@ -33,7 +33,7 @@ namespace GitExtensions.Plugins.CreateLocalBranches
             {
                 try
                 {
-                    string branchName = reference.Trim('*', ' ', '\n', '\r');
+                    string branchName = reference.Trim(Delimiters.GitOutput);
 
                     if (branchName.StartsWith("remotes/" + _NO_TRANSLATE_Remote.Text + "/"))
                     {

--- a/Plugins/CreateLocalBranches/GitExtensions.Plugins.CreateLocalBranches.csproj
+++ b/Plugins/CreateLocalBranches/GitExtensions.Plugins.CreateLocalBranches.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <Compile Include="..\..\GitExtUtils\Delimiters.cs" Link="Delimiters.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\GitExtUtils\GitExtUtils.csproj">
       <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
       <Private>false</Private>

--- a/Plugins/FindLargeFiles/FindLargeFilesForm.cs
+++ b/Plugins/FindLargeFiles/FindLargeFilesForm.cs
@@ -161,7 +161,7 @@ namespace GitExtensions.Plugins.FindLargeFiles
             base.OnLoad(e);
 
             GitArgumentBuilder args = new("rev-list") { "HEAD" };
-            _revList = _gitCommands.GitExecutable.GetOutput(args).Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            _revList = _gitCommands.GitExecutable.GetOutput(args).Split('\n', StringSplitOptions.RemoveEmptyEntries);
             pbRevisions.Maximum = (int)(_revList.Length * 1.1f);
             BranchesGrid.DataSource = _gitObjects;
             Thread thread = new(FindLargeFilesFunction);

--- a/Plugins/GitFlow/GitExtensions.Plugins.GitFlow.csproj
+++ b/Plugins/GitFlow/GitExtensions.Plugins.GitFlow.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <Compile Include="..\..\GitExtUtils\Delimiters.cs" Link="Delimiters.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\GitCommands\GitCommands.csproj">
       <PrivateAssets>build;buildTransitive;compile</PrivateAssets>
       <Private>false</Private>

--- a/Plugins/GitFlow/GitFlowForm.cs
+++ b/Plugins/GitFlow/GitFlowForm.cs
@@ -159,8 +159,8 @@ namespace GitExtensions.Plugins.GitFlow
             }
 
             return result.StandardOutput
-                .Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(e => e.Trim('*', ' ', '\n', '\r'))
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Select(e => e.Trim(Delimiters.GitOutput))
                 .ToList();
         }
 
@@ -203,7 +203,8 @@ namespace GitExtensions.Plugins.GitFlow
                 GitArgumentBuilder args = new("branch");
                 return _gitUiCommands.GitModule
                     .GitExecutable.GetOutput(args)
-                    .Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(e => e.Trim('*', ' ', '\n', '\r'))
+                    .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(e => e.Trim(Delimiters.GitOutput))
                     .ToList();
             }
         }
@@ -407,7 +408,7 @@ namespace GitExtensions.Plugins.GitFlow
             ExecutionResult result = _gitUiCommands.GitModule.GitExecutable.Execute(args, throwOnErrorExit: false);
 
             string head = result.ExitedSuccessfully
-                ? result.StandardOutput.Trim('*', ' ', '\n', '\r')
+                ? result.StandardOutput.Trim(Delimiters.GitOutput)
                 : "";
 
             lblHead.Text = head;

--- a/ResourceManager/LocalizationHelpers.cs
+++ b/ResourceManager/LocalizationHelpers.cs
@@ -156,8 +156,7 @@ namespace ResourceManager
                     {
                         sb.AppendLine("\t\t\t\t\t" + GetRelativeDateString(DateTime.UtcNow, oldCommitData.CommitDate.UtcDateTime) + " (" +
                                       GetFullDateString(oldCommitData.CommitDate) + ")");
-                        char[] delimiter = new[] { '\n', '\r' };
-                        string[] lines = oldCommitData.Body.Trim(delimiter).Split(new[] { "\r\n" }, StringSplitOptions.None);
+                        string[] lines = oldCommitData.Body.Trim(Delimiters.LineFeedAndCarriageReturn).Split("\r\n", StringSplitOptions.None);
                         foreach (string line in lines)
                         {
                             sb.AppendLine("\t\t" + line);


### PR DESCRIPTION
## Proposed changes

- No behavior change, just refactoring.

## Test methodology <!-- How did you ensure quality? -->

- Unit tests & manual

## Test environment(s) <!-- Remove any that don't apply -->

- GIT <!-- Add version 2.11 or above -->
- Windows <!-- Add version 7 SP1 or above -->

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
