### PR TITLE
Add remote a little more smarter completion

### DIFF
--- a/GitCommands/Remotes/AzureDevOpsRemoteParser.cs
+++ b/GitCommands/Remotes/AzureDevOpsRemoteParser.cs
@@ -1,19 +1,26 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 
 namespace GitCommands.Remotes
 {
-    public sealed class AzureDevOpsRemoteParser : RemoteParser
+    public sealed partial class AzureDevOpsRemoteParser : RemoteParser
     {
-        private static readonly string VstsHttpsRemoteRegex = @"^https:\/\/(?<owner>[^.]*)\.visualstudio\.com\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$";
-        private static readonly string VstsSshRemoteRegex = @"^[^@]*@vs-ssh\.visualstudio\.com:v\d\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/(?<repo>.*)$";
-        private static readonly string AzureDevopsHttpsRemoteRegex = @"^https:\/\/[^@]*@dev\.azure\.com\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$";
-        private static readonly string AzureDevopsSshRemoteRegex = @"^git@ssh\.dev\.azure\.com:v\d\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/(?<repo>.*)$";
-        private static readonly string[] AzureDevopsRegexes = { AzureDevopsHttpsRemoteRegex, AzureDevopsSshRemoteRegex, VstsHttpsRemoteRegex, VstsSshRemoteRegex };
+        [GeneratedRegex(@"^https:\/\/(?<owner>[^.]*)\.visualstudio\.com\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$")]
+        private static partial Regex VstsHttpsRemoteRegex();
+
+        [GeneratedRegex(@"^[^@]*@vs-ssh\.visualstudio\.com:v\d\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/(?<repo>.*)$")]
+        private static partial Regex VstsSshRemoteRegex();
+
+        [GeneratedRegex(@"^https:\/\/[^@]*@dev\.azure\.com\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$")]
+        private static partial Regex AzureDevopsHttpsRemoteRegex();
+
+        [GeneratedRegex(@"^git@ssh\.dev\.azure\.com:v\d\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/(?<repo>.*)$")]
+        private static partial Regex AzureDevopsSshRemoteRegex();
+
+        private static readonly Regex[] _azureDevopsRegexes = [ AzureDevopsHttpsRemoteRegex(), AzureDevopsSshRemoteRegex(), VstsHttpsRemoteRegex(), VstsSshRemoteRegex()];
 
         public bool IsValidRemoteUrl(string remoteUrl)
-        {
-            return TryExtractAzureDevopsDataFromRemoteUrl(remoteUrl, out _, out _, out _);
-        }
+            => TryExtractAzureDevopsDataFromRemoteUrl(remoteUrl, out _, out _, out _);
 
         public bool TryExtractAzureDevopsDataFromRemoteUrl(string remoteUrl, [NotNullWhen(returnValue: true)] out string? owner, [NotNullWhen(returnValue: true)] out string? project, [NotNullWhen(returnValue: true)] out string? repository)
         {
@@ -21,7 +28,7 @@ namespace GitCommands.Remotes
             project = null;
             repository = null;
 
-            System.Text.RegularExpressions.Match m = MatchRegExes(remoteUrl, AzureDevopsRegexes);
+            Match m = MatchRegExes(remoteUrl, _azureDevopsRegexes);
 
             if (m is null || !m.Success)
             {

--- a/GitCommands/Remotes/GitHostingRemoteParser.cs
+++ b/GitCommands/Remotes/GitHostingRemoteParser.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+
+namespace GitCommands.Remotes
+{
+    public partial class GitHostingRemoteParser : RemoteParser
+    {
+        [GeneratedRegex(@"^(ssh://)?git(?:@|://)(?<hosting>([^.]+\.)+[^.]+)[:/](?<owner>[^/]+)/(?<repo>[\w_\.\-]+)(?:.git)?")]
+        private static partial Regex GitHostingSshUrlRegex();
+
+        [GeneratedRegex(@"^https?://(?:[^@:]*?)?(?::[^/@:]*?)?@?(?<hosting>([^./]+\.)+[^./]+)/(?<owner>[^/]+)/(?<repo>[\w_\.\-]+)(?:.git)?$")]
+        private static partial Regex GitHostingHttpsUrlRegex();
+
+        private static readonly Regex[] _gitHostingRegexes = [GitHostingHttpsUrlRegex(), GitHostingSshUrlRegex()];
+
+        /// <summary>
+        /// Gets if an url is the one of a git hosted repository.
+        /// </summary>
+        /// <param name="remoteUrl">the url of a git repository.</param>
+        /// <returns>
+        /// true, if the url has been succefully parsed.
+        /// false otherwise.
+        /// </returns>
+        public bool IsValidRemoteUrl(string remoteUrl)
+            => TryExtractGitHostingDataFromRemoteUrl(remoteUrl, out _, out _, out _);
+
+        public bool TryExtractGitHostingDataFromRemoteUrl(string remoteUrl, [NotNullWhen(returnValue: true)] out string? gitHosting, [NotNullWhen(returnValue: true)] out string? owner, [NotNullWhen(returnValue: true)] out string? repository)
+        {
+            owner = null;
+            repository = null;
+            gitHosting = null;
+
+            Match m = MatchRegExes(remoteUrl, _gitHostingRegexes);
+
+            if (m is null || !m.Success)
+            {
+                return false;
+            }
+
+            gitHosting = m.Groups["hosting"].Value;
+            owner = m.Groups["owner"].Value;
+            repository = m.Groups["repo"].Value.Replace(".git", "");
+            return true;
+        }
+    }
+}

--- a/GitCommands/Remotes/GitHubRemoteParser.cs
+++ b/GitCommands/Remotes/GitHubRemoteParser.cs
@@ -3,11 +3,14 @@ using System.Text.RegularExpressions;
 
 namespace GitCommands.Remotes
 {
-    public sealed class GitHubRemoteParser : RemoteParser
+    public sealed partial class GitHubRemoteParser : RemoteParser
     {
-        private static readonly string GitHubSshUrlRegex = @"git(?:@|://)github.com[:/](?<owner>[^/]+)/(?<repo>[\w_\.\-]+)\.git";
-        private static readonly string GitHubHttpsUrlRegex = @"https?://(?:[^@:]+)?(?::[^/@:]+)?@?github.com/(?<owner>[^/]+)/(?<repo>[\w_\.\-]+)(?:.git)?";
-        private static readonly string[] GitHubRegexes = { GitHubHttpsUrlRegex, GitHubSshUrlRegex };
+        [GeneratedRegex(@"git(?:@|://)github.com[:/](?<owner>[^/]+)/(?<repo>[\w_\.\-]+)\.git")]
+        private static partial Regex GitHubSshUrlRegex();
+
+        [GeneratedRegex(@"https?://(?:[^@:]+)?(?::[^/@:]+)?@?github.com/(?<owner>[^/]+)/(?<repo>[\w_\.\-]+)(?:.git)?")]
+        private static partial Regex GitHubHttpsUrlRegex();
+        private static readonly Regex[] GitHubRegexes = { GitHubHttpsUrlRegex(), GitHubSshUrlRegex() };
 
         public bool IsValidRemoteUrl(string remoteUrl)
         {

--- a/GitCommands/Remotes/GitHubRemoteParser.cs
+++ b/GitCommands/Remotes/GitHubRemoteParser.cs
@@ -1,37 +1,13 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Text.RegularExpressions;
 
 namespace GitCommands.Remotes
 {
-    public sealed partial class GitHubRemoteParser : RemoteParser
+    public sealed partial class GitHubRemoteParser : GitHostingRemoteParser
     {
-        [GeneratedRegex(@"git(?:@|://)github.com[:/](?<owner>[^/]+)/(?<repo>[\w_\.\-]+)\.git")]
-        private static partial Regex GitHubSshUrlRegex();
-
-        [GeneratedRegex(@"https?://(?:[^@:]+)?(?::[^/@:]+)?@?github.com/(?<owner>[^/]+)/(?<repo>[\w_\.\-]+)(?:.git)?")]
-        private static partial Regex GitHubHttpsUrlRegex();
-        private static readonly Regex[] GitHubRegexes = { GitHubHttpsUrlRegex(), GitHubSshUrlRegex() };
-
-        public bool IsValidRemoteUrl(string remoteUrl)
-        {
-            return TryExtractGitHubDataFromRemoteUrl(remoteUrl, out _, out _);
-        }
+        public new bool IsValidRemoteUrl(string remoteUrl)
+            => TryExtractGitHubDataFromRemoteUrl(remoteUrl, out _, out _);
 
         public bool TryExtractGitHubDataFromRemoteUrl(string remoteUrl, [NotNullWhen(returnValue: true)] out string? owner, [NotNullWhen(returnValue: true)] out string? repository)
-        {
-            owner = null;
-            repository = null;
-
-            Match m = MatchRegExes(remoteUrl, GitHubRegexes);
-
-            if (m is null || !m.Success)
-            {
-                return false;
-            }
-
-            owner = m.Groups["owner"].Value;
-            repository = m.Groups["repo"].Value.Replace(".git", "");
-            return true;
-        }
+            => TryExtractGitHostingDataFromRemoteUrl(remoteUrl, out string gitHosting, out owner, out repository) && gitHosting == "github.com";
     }
 }

--- a/GitCommands/Remotes/RemoteParser.cs
+++ b/GitCommands/Remotes/RemoteParser.cs
@@ -4,12 +4,12 @@ namespace GitCommands.Remotes
 {
     public abstract class RemoteParser
     {
-        protected Match? MatchRegExes(string remoteUrl, string[] regExs)
+        protected Match? MatchRegExes(string remoteUrl, Regex[] regExs)
         {
             Match? m = null;
-            foreach (string regex in regExs)
+            foreach (Regex regex in regExs)
             {
-                m = Regex.Match(remoteUrl, regex);
+                m = regex.Match(remoteUrl);
                 if (m.Success)
                 {
                     break;

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -2015,6 +2015,11 @@ namespace GitCommands
             set => SetInt("DiffViewer.AutomaticContinuousScrollDelay", value);
         }
 
+        public static IEnumerable<string> CustomGenericRemoteNames
+        {
+            get => GetString("CustomGenericRemoteNames", string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries);
+        }
+
         public static bool LogCaptureCallStacks
         {
             get => GetBool("Log.CaptureCallStacks", false);

--- a/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -413,6 +413,7 @@ namespace GitUI.CommandsDialogs
             RemoteName.Size = new Size(248, 20);
             RemoteName.TabIndex = 1;
             RemoteName.TextChanged += RemoteName_TextChanged;
+            RemoteName.Enter += RemoteName_Enter;
             // 
             // pnlManagementContainer
             // 

--- a/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -347,6 +347,7 @@ namespace GitUI.CommandsDialogs
             comboBoxPushUrl.Size = new Size(248, 21);
             comboBoxPushUrl.TabIndex = 7;
             comboBoxPushUrl.Visible = false;
+            comboBoxPushUrl.Enter += ComboBoxPushUrl_Enter;
             // 
             // label2
             // 
@@ -368,6 +369,7 @@ namespace GitUI.CommandsDialogs
             Url.Name = "Url";
             Url.Size = new Size(248, 21);
             Url.TabIndex = 3;
+            Url.Enter += Url_Enter;
             // 
             // labelPushUrl
             // 

--- a/GitUI/CommandsDialogs/FormRemotes.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.cs
@@ -753,5 +753,20 @@ Inactive remote is completely invisible to git.");
                 }
             }
         }
+
+        private void RemoteName_Enter(object sender, EventArgs e)
+        {
+            if (!string.IsNullOrEmpty(RemoteName.Text) || string.IsNullOrEmpty(Url.Text))
+            {
+                return;
+            }
+
+            GitHostingRemoteParser gitHostingRemoteParser = new();
+            if (gitHostingRemoteParser.TryExtractGitHostingDataFromRemoteUrl(Url.Text, out _, out string owner, out _))
+            {
+                RemoteName.Text = owner;
+                RemoteName.SelectAll();
+            }
+        }
     }
 }

--- a/Plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabRemoteParser.cs
+++ b/Plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabRemoteParser.cs
@@ -4,16 +4,18 @@ using GitCommands.Remotes;
 
 namespace GitExtensions.Plugins.GitlabIntegration.Settings
 {
-    public class GitlabRemoteParser : RemoteParser
+    public partial class GitlabRemoteParser : RemoteParser
     {
-        private const string _gitlabSshUrlRegex = @"git(?:@|://)(?<host>[^/]+)[:/](?<owner>[^/]+)/(?<repo>[\w_\.\-]+)\.git";
-        private const string _gitlabHttpsUrlRegex = @"https?://(?<host>[^@]+)/(?<owner>[^/]+)/(?<repo>[\w_\.\-]+)(?:.git)?";
-        private static readonly string[] GitHubRegexes = { _gitlabHttpsUrlRegex, _gitlabSshUrlRegex };
+        [GeneratedRegex(@"git(?:@|://)(?<host>[^/]+)[:/](?<owner>[^/]+)/(?<repo>[\w_\.\-]+)\.git")]
+        private static partial Regex GitlabSshUrlRegex();
+
+        [GeneratedRegex(@"https?://(?<host>[^@]+)/(?<owner>[^/]+)/(?<repo>[\w_\.\-]+)(?:.git)?")]
+        private static partial Regex GitlabHttpsUrlRegex();
+
+        private static readonly Regex[] _gitLabRegexes = [GitlabHttpsUrlRegex(), GitlabSshUrlRegex()];
 
         public bool IsValidRemoteUrl(string remoteUrl)
-        {
-            return TryExtractGitlabDataFromRemoteUrl(remoteUrl, out _, out _, out _);
-        }
+            => TryExtractGitlabDataFromRemoteUrl(remoteUrl, out _, out _, out _);
 
         public bool TryExtractGitlabDataFromRemoteUrl(
             string remoteUrl,
@@ -25,7 +27,7 @@ namespace GitExtensions.Plugins.GitlabIntegration.Settings
             owner = null;
             repository = null;
 
-            Match m = MatchRegExes(remoteUrl, GitHubRegexes);
+            Match m = MatchRegExes(remoteUrl, _gitLabRegexes);
 
             if (m is null || !m.Success)
             {

--- a/UnitTests/GitCommands.Tests/Remote/GitHostingRemoteParserTests.cs
+++ b/UnitTests/GitCommands.Tests/Remote/GitHostingRemoteParserTests.cs
@@ -1,0 +1,43 @@
+﻿using FluentAssertions;
+using GitCommands.Remotes;
+
+namespace GitCommandsTests.Remote
+{
+    [TestFixture]
+    public class GitHostingRemoteParserTests
+    {
+        [TestCase("https://github.com/owner/repo.git", "github.com")]
+        [TestCase("http://github.com/owner/repo.git", "github.com")]
+        [TestCase("https://github.com/owner/repo", "github.com")]
+        [TestCase("ssh://git@github.com/owner/repo.git", "github.com")]
+        [TestCase("git@github.com/owner/repo.git", "github.com")]
+        [TestCase("git@framagit.org:owner/repo.git", "framagit.org")]
+        [TestCase("https://framagit.org/owner/repo.git", "framagit.org")]
+        [TestCase("https://github.com/owner/repo.git", "github.com")]
+        [TestCase("git@github.com:owner/repo.git", "github.com")]
+        [TestCase("https://git.sr.ht/owner/repo", "git.sr.ht")]
+        [TestCase("git@git.sr.ht:owner/repo", "git.sr.ht")]
+        [TestCase("https://gitlab.freedesktop.org/owner/repo.git", "gitlab.freedesktop.org")]
+        [TestCase("git@gitlab.freedesktop.org:owner/repo.git", "gitlab.freedesktop.org")]
+        public void TryExtractGitHubDataFromRemoteUrl(string url, string expectedGitHosting)
+        {
+            new GitHostingRemoteParser().TryExtractGitHostingDataFromRemoteUrl(url, out string? gitHosting, out string? owner, out string? repository).Should().BeTrue();
+            gitHosting.Should().Be(expectedGitHosting);
+            owner.Should().Be("owner");
+            repository.Should().Be("repo");
+        }
+
+        [Test]
+        public void Should_fail_in_parsing_invalid_url()
+        {
+            GitHostingRemoteParser gitHubRemoteParser = new();
+            string url = "https://owner@dev.bad.com/owner/project/_git/repo";
+            gitHubRemoteParser.TryExtractGitHostingDataFromRemoteUrl(url, out string? gitHosting, out string? owner, out string? repository).Should().BeFalse();
+            gitHosting.Should().BeNull();
+            owner.Should().BeNull();
+            repository.Should().BeNull();
+
+            gitHubRemoteParser.IsValidRemoteUrl(url).Should().BeFalse();
+        }
+    }
+}


### PR DESCRIPTION
Improve over https://github.com/gitextensions/gitextensions/pull/11559#discussion_r1474581069 and https://github.com/gitextensions/gitextensions/pull/11559#discussion_r1475190622

## Proposed changes

* A little more clever remote url completion (instead of relying on history of url remote that we know will **never** contains the desired url ): Use existing remotes to propose urls that has a lot higher probability to be suited.
* Do the opposite: extract remote name from URL if Url entered first.

Also:
* convert git hosting regex to compiled regex
* add a new more generic git hosting regex that cover more providers (but not Azure DevOps one 😞 because the format is different and I don't know how to parse it)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

When entering the url field, nothing happens and opening the dropdown just give an history of remotes:

![new_remote](https://github.com/gitextensions/gitextensions/assets/460196/b3a4f9cc-203d-4ede-aa94-95bb9103b400)

### After

Generate potential urls and put it at the top of a dropdown list (and auto select the 1st one):
![new_remote_smart](https://github.com/gitextensions/gitextensions/assets/460196/15eb913f-1990-41ac-b0dc-9209c8c7c97b)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 884d07e3558ea9b33e6a96f06fd60598b475f07b
- Git 2.44.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer **rebase**  merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
