### PR TITLE
Fixup migration of color settings

### DIFF
--- a/GitUI/Theming/ThemeRepository.cs
+++ b/GitUI/Theming/ThemeRepository.cs
@@ -41,8 +41,11 @@ namespace GitUI.Theming
             return _persistence.Load(themePath, themeId, variations);
         }
 
-        public void Save(Theme theme) =>
+        public void Save(Theme theme)
+        {
+            Directory.CreateDirectory(_themePathProvider.UserThemesDirectory);
             _persistence.Save(theme, _themePathProvider.GetThemePath(theme.Id));
+        }
 
         public Theme GetInvariantTheme() =>
             GetTheme(new ThemeId(InvariantThemeName, isBuiltin: true), variations: Array.Empty<string>());


### PR DESCRIPTION
## Proposed changes

Fixup `MigrateColorSettings` by creating the user-themes directory in `ThemeRepository.Save`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

exception on every start

### After

`MigrateColorSettings` successfully executed once and not called any longer

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).