### PR TITLE
Add TargetPlatform property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,8 +27,8 @@
 
     <IsPublishable>false</IsPublishable>
 
-    <!-- Set this manually whenever build ARM64-->
-    <Arm64Build>false</Arm64Build>
+    <!-- Set the target platform manually to be: x64 (default), x86, arm64 -->
+    <TargetPlatform Condition=" '$(TargetPlatform)' == '' ">x64</TargetPlatform>
 
     <!-- Opt in to build acceleration in VS (from 17.5 onwards): https://github.com/dotnet/project-system/blob/main/docs/build-acceleration.md -->
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>

--- a/setup/installer/Product.wxs
+++ b/setup/installer/Product.wxs
@@ -2,7 +2,14 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension" xmlns:VSExtension="http://schemas.microsoft.com/wix/VSExtension">
   <?include Config.wxi?>
   <Product Id="*" UpgradeCode="$(var.UpgradeCode)" Name="$(var.ProductName) $(var.Version)" Manufacturer="$(var.Manufacturer)" Version="$(var.NumericVersion)" Language="1033">
-    <Package InstallerVersion="200" Compressed="yes" Description="$(var.ProductName)" />
+    <?if $(var.Platform) = x64 ?>
+      <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+    <?elseif $(var.Platform) = arm64 ?>
+      <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+    <?else ?>
+      <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
+    <?endif ?>
+    <Package InstallerVersion="500" Compressed="yes" Description="$(var.ProductName)" />
     <Media Id="1" Cabinet="media1.cab" EmbedCab="yes" />
     <Property Id="ALLUSERS" Value="1" />
     <!--
@@ -21,7 +28,7 @@
     <WixVariable Id="WixUISupportPerUser" Value="1" Overridable="yes" />
     <WixVariable Id="WixUISupportPerMachine" Value="1" Overridable="yes" />
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
+      <Directory Id="$(var.PlatformProgramFilesFolder)">
         <Directory Id="INSTALLDIR" Name="$(var.InstallName)">
           <Directory Id="PluginsDir" Name="Plugins" />
           <Directory Id="DictionariesDir" Name="Dictionaries" />

--- a/src/app/GitExtensions/Project.Publish.targets
+++ b/src/app/GitExtensions/Project.Publish.targets
@@ -249,7 +249,7 @@
 
       <!-- This property comes from GitInfo package, but can be overriden on AppVeyor -->
       <_PublishPortableCommitHashSuffix Condition="'$(GitCommit)' != ''">-$(GitCommit)</_PublishPortableCommitHashSuffix>
-      <_PublishPortableFileName>GitExtensions-Portable$(_PublishPortableVersionSuffix)$(_PublishPortableCommitHashSuffix).zip</_PublishPortableFileName>
+      <_PublishPortableFileName>GitExtensions-Portable-$(TargetPlatform)$(_PublishPortableVersionSuffix)$(_PublishPortableCommitHashSuffix).zip</_PublishPortableFileName>
       <_PublishPortablePath>$([MSBuild]::NormalizePath('$(ArtifactsPublishDir)', '$(_PublishPortableFileName)'))</_PublishPortablePath>
 
       <!-- We want to archive the whole publish folder, so get one level up -->
@@ -285,14 +285,14 @@
     Creates an MSI.
     ============================================================
     -->
-  <Target Name="CreateMsi" Condition="'$(Arm64Build)' != 'true'" AfterTargets="CreatePortable">
+  <Target Name="CreateMsi" AfterTargets="CreatePortable">
     <PropertyGroup>
       <_AppVeyorSuffix>$(ARTIFACT_BUILD_SUFFIX)</_AppVeyorSuffix>
       <_PublishMsiVersionSuffix>-$(CurrentBuildVersion.ToString())$(_AppVeyorSuffix)</_PublishMsiVersionSuffix>
       <_PublishMsiCommitHashSuffix Condition="'$(GitCommit)' != ''">-$(GitCommit)</_PublishMsiCommitHashSuffix>
       <_PublishMsiCommitHashSuffix Condition="'$(env:APPVEYOR_REPO_COMMIT)' != ''">-$(env:APPVEYOR_REPO_COMMIT)</_PublishMsiCommitHashSuffix>
       <_PublishMsiCommitHashSuffix Condition="'$(env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)' != ''">-$(env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT)</_PublishMsiCommitHashSuffix>
-      <_PublishMsiFileName>GitExtensions$(_PublishMsiVersionSuffix)$(_PublishMsiCommitHashSuffix)</_PublishMsiFileName>
+      <_PublishMsiFileName>GitExtensions-$(TargetPlatform)$(_PublishMsiVersionSuffix)$(_PublishMsiCommitHashSuffix)</_PublishMsiFileName>
       <_PublishMsiPath>$([MSBuild]::NormalizePath('$(ArtifactsPublishDir)'))</_PublishMsiPath>
     </PropertyGroup>
 
@@ -322,7 +322,7 @@
 
     <PropertyGroup>
       <_MSBuildCurrentPath>$([MSBuild]::NormalizePath('$(_VSInstallPath)', 'MSBuild', 'Current', 'Bin'))</_MSBuildCurrentPath>
-      <_SetupArgs>/p:Configuration=$(Configuration);Platform=x86;WiXVersion=$(_WiXVersion);Version=$(CurrentBuildVersion);ArtifactsBinPath=$(ArtifactsBinDir);ArtifactsPublishPath=$(AppPublishDir);OutputPath=$(_PublishMsiPath.TrimEnd('\'));TargetName=$(_PublishMsiFileName)</_SetupArgs>
+      <_SetupArgs>/p:Configuration=$(Configuration);Platform=$(TargetPlatform);WiXVersion=$(_WiXVersion);Version=$(CurrentBuildVersion);ArtifactsBinPath=$(ArtifactsBinDir);ArtifactsPublishPath=$(AppPublishDir);OutputPath=$(_PublishMsiPath.TrimEnd('\'));TargetName=$(_PublishMsiFileName)</_SetupArgs>
     </PropertyGroup>
 
     <!-- WiX isn't yet compatible with .NET. See: https://github.com/wixtoolset/issues/issues/5627 
@@ -334,7 +334,7 @@
     <MSBuild 
         Projects="$(ProjectDir)\..\Setup\Setup.wixproj"
         Targets="Build"
-        Properties="Configuration=$(Configuration);Platform=x86;WiXVersion=$(_WiXVersion);Version=$(CurrentBuildVersion);ArtifactsBinPath=$(ArtifactsBinDir);ArtifactsPublishPath=$(AppPublishDir);OutputPath=$(_PublishMsiPath.TrimEnd('\'));TargetName=$(_PublishMsiFileName)"
+        Properties="Configuration=$(Configuration);Platform=$(TargetPlatform);WiXVersion=$(_WiXVersion);Version=$(CurrentBuildVersion);ArtifactsBinPath=$(ArtifactsBinDir);ArtifactsPublishPath=$(AppPublishDir);OutputPath=$(_PublishMsiPath.TrimEnd('\'));TargetName=$(_PublishMsiFileName)"
         StopOnFirstFailure="true"
         />
       -->

--- a/src/native/build.proj
+++ b/src/native/build.proj
@@ -44,7 +44,7 @@
 
     <!-- Build GitExtSshAskPass project, x86 -->
     <Exec
-        Condition="'$(Arm64Build)' != 'true'"
+        Condition="'$(TargetPlatform)' != 'arm64'"
         Command="msbuild.exe $(_GitExtSshAskPassPath) $(_ProjectArgs32) /p:OutDir=$(_OutputPath)GitExtSshAskPass\ /bl:$(_ArtifactsLogDir)\GitExtSshAskPass.binlog"
         WorkingDirectory="$(_MSBuildCurrentPath)"
         EchoOff="true"
@@ -53,7 +53,7 @@
     </Exec>
     <!-- Build GitExtSshAskPass project, ARM64 -->
     <Exec
-        Condition="'$(Arm64Build)' == 'true'"
+        Condition="'$(TargetPlatform)' == 'arm64'"
         Command="msbuild.exe $(_GitExtSshAskPassPath) $(_ProjectArgsARM64) /p:OutDir=$(_OutputPath)GitExtSshAskPass\ /bl:$(_ArtifactsLogDir)\GitExtSshAskPass.binlog"
         WorkingDirectory="$(_MSBuildCurrentPath)"
         EchoOff="true"
@@ -62,7 +62,7 @@
     </Exec>
     <!-- Build GitExtensionsShellEx project, x86 -->
     <Exec
-        Condition="'$(Arm64Build)' != 'true'"
+        Condition="'$(TargetPlatform)' != 'arm64'"
         Command="msbuild.exe $(_GitExtensionsShellExPath) $(_ProjectArgs32) /p:OutDir=$(_OutputPath)GitExtensionsShellEx\ /bl:$(_ArtifactsLogDir)\GitExtensionsShellEx32.binlog"
         WorkingDirectory="$(_MSBuildCurrentPath)"
         EchoOff="true"
@@ -71,7 +71,7 @@
     </Exec>
     <!-- Build GitExtensionsShellEx project, x64 -->
     <Exec
-        Condition="'$(Arm64Build)' != 'true'"
+        Condition="'$(TargetPlatform)' != 'arm64'"
         Command="msbuild.exe $(_GitExtensionsShellExPath) $(_ProjectArgs64) /p:OutDir=$(_OutputPath)GitExtensionsShellEx\ /bl:$(_ArtifactsLogDir)\GitExtensionsShellEx64.binlog"
         WorkingDirectory="$(_MSBuildCurrentPath)"
         EchoOff="true"
@@ -80,7 +80,7 @@
     </Exec>
     <!-- Build GitExtensionsShellEx project, ARM64 -->
     <Exec
-        Condition="'$(Arm64Build)' == 'true'"
+        Condition="'$(TargetPlatform)' == 'arm64'"
         Command="msbuild.exe $(_GitExtensionsShellExPath) $(_ProjectArgsARM64) /p:OutDir=$(_OutputPath)GitExtensionsShellEx\ /bl:$(_ArtifactsLogDir)\GitExtensionsShellEx64.binlog"
         WorkingDirectory="$(_MSBuildCurrentPath)"
         EchoOff="true"
@@ -89,7 +89,7 @@
     </Exec>
     <!-- Copy GitExtensionsShellEx64.dll file to GitExtensionsShellEx32.dll, ARM64 -->
     <Copy
-        Condition="'$(Arm64Build)' == 'true'"
+        Condition="'$(TargetPlatform)' == 'arm64'"
         SourceFiles="$(_OutputPath)GitExtensionsShellEx\GitExtensionsShellEx64.dll"
         DestinationFiles="$(_OutputPath)GitExtensionsShellEx\GitExtensionsShellEx32.dll">
     </Copy>


### PR DESCRIPTION
Add new `TargetPlatform` property, to control the specific platform for the GE installer (.msi) package.

Currently the GE installer package is hard-coded to be built for the `x86` platform, with `C:\Program Files (x86)` as the default installation folder.  This makes sense to install it on the `x86` (i.e. 32-bit) Windows platform, but a bit weird on `x64` (i.e. 64-bit) Windows platform (as discussed in #11554), and really feels weird when building an `Arm64-specific` installer package for Windows on Arm64 platform.

This commit defines a new `TargetPlatform` property which can take the following values: `x64` (default), `x86`, or `arm64` (must be lower-case values, as required by Wix). This property is passed on to the `Platform` parameter for WiX to create relevant installer package specific to that platform. Like any other property, this `TargetPlatform` property can be specified on the command line to build a platform-specific installer, rather than using the default `x64` platform value.

To build GE, the current build command series still work as before:
```
dotnet build -c Release
dotnet build -c Release scripts\native.proj
dotnet publish -c Release
```
and the following build artifacts are produced in the `artifacts\Release\publish` folder for the `x64` platform; for example:
```
GitExtensions-x64-33.33.33.0-0e12afbf1.msi
GitExtensions-Portable-x64-33.33.33.0-0e12afbf1.zip
```
The above `x64` installer (.msi) package will default to `C:\Program Files` as the installation folder, and will refuse to install on `x86` (i.e. 32-bit) Windows platform. It can be installed on Windows on Arm64 platform, as this platform contains translation layer for running `x64` program.

If the `TargetPlatform=x86` property value is specified in the `publish` command, like:
```
dotnet publish -c Release /p:TargetPlatform=x86
```
then the following files are produced:
```
GitExtensions-x86-33.33.33.0-0e12afbf1.msi
GitExtensions-Portable-x86-33.33.33.0-0e12afbf1.zip
```
The above `x86` installer (.msi) package will default to `C:\Program Files (x86)` as the installation folder, and can install on `x86` (i.e. 32-bit) Windows, `x64` Windows and Windows on Arm64 platforms.

Similarly, to produce an `Arm64-specific` installer package, the following build commands should be executed on a Windows on Arm64 box:
```
dotnet build -c Release
dotnet build -c Release scripts\native.proj /p:TargetPlatform=arm64
dotnet publish -c Release /p:TargetPlatform=arm64
```
and the following files will be produced for Arm64:
```
GitExtensions-arm64-33.33.33.0-0e12afbf1.msi
GitExtensions-Portable-arm64-33.33.33.0-0e12afbf1.zip
```
The above `arm64` installer (.msi) package will default to `C:\Program Files` as the installation folder, and will refuse to install on any Windows platform except the Windows on Arm64 platform.

Fixes #11554

## Test methodology

- default build GE installer for `x64` platform, and check that it installs to the default `C:\Program Files` folder and works properly on x64 and/or Arm64 Windows platforms. It should refuse to install on an x86 (i.e. 32-bit) Windows platform (but none are available to test.)
- build of `x86` platform GE installer, by specifying the `TargetPlatform=x86` property on the `publish` command, and check that it installs to the default `C:\Program Files (x86)` folder and works properly on x64 and/or Arm64 Windows platforms. It should work on an x86 (i.e. 32-bit) Windows platform too, but none are available to test.
- build GE installer for `Arm64` platform, by specifying the `TargetPlatform=arm64` property on the `publish` command, and check that it installs to the default `C:\Program Files` folder and works properly on Arm64 Windows platform. Check that it should refuse to install on `x64` Windows platform. It should refuse to install on an x86 (i.e. 32-bit) Windows platform too, but none are available to test.

## Test environment(s)

- Windows 10 & 11 on x64 platform
- Windows 11 on Arm64 platform

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
