### PR TITLE
Combined diff error presentation

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2255,6 +2255,7 @@ namespace GitCommands
                 args,
                 cache: GitCommandCache,
                 outputEncoding: LosslessEncoding,
+                throwOnErrorExit: false,
                 cancellationToken: cancellationToken);
 
             return result;
@@ -3885,12 +3886,19 @@ namespace GitCommands
                 args,
                 cache: GitCommandCache,
                 outputEncoding: LosslessEncoding,
+                throwOnErrorExit: false,
                 cancellationToken: cancellationToken);
 
             if (!result.ExitedSuccessfully)
             {
-                diffOfConflict = "";
+                diffOfConflict = result.AllOutput;
                 return false;
+            }
+
+            if (string.IsNullOrEmpty(result.StandardOutput))
+            {
+                diffOfConflict = "";
+                return true;
             }
 
             List<Patch> patches = PatchProcessor.CreatePatchesFromString(result.StandardOutput, new Lazy<Encoding>(() => encoding)).ToList();

--- a/GitUI/GitUIExtensions.cs
+++ b/GitUI/GitUIExtensions.cs
@@ -140,12 +140,17 @@ namespace GitUI
 
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    return result switch
+                    if (!result)
                     {
-                        false => defaultText,
-                        true when string.IsNullOrWhiteSpace(diffOfConflict) => TranslatedStrings.UninterestingDiffOmitted,
-                        _ => diffOfConflict
-                    };
+                        return $"Git command exit code: {result}{Environment.NewLine}{diffOfConflict}";
+                    }
+
+                    if (string.IsNullOrWhiteSpace(diffOfConflict))
+                    {
+                        return TranslatedStrings.UninterestingDiffOmitted;
+                    }
+
+                    return diffOfConflict;
                 }
 
                 Task<GitSubmoduleStatus?> task = file.GetSubmoduleStatusAsync();


### PR DESCRIPTION
## Proposed changes

When combined diff or range-diff Git command fails, display the Git error message in the viewer, as for most other diff commands since #11535.

For combined diffs, "Uninteresting diff hunks are omitted." were no longer displayed.

Follow up to #11535, not fully handled.
"Uninteresting diff hunks" is a minor regression.

This is slightly refactored in #11590 , merge conflict and viewer has "combined" knowledge.
See tmp/git-coloring a53943ebed2e0263dd70a05d8eee0b7715a7a1b2

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Empty viewer

### After

Few merge commits in GE repo (good thing), an example from mstv's test branch that also have diffs with changes in 9da998f1439426a73034bc4ffed96dd691f0336b

![image](https://github.com/gitextensions/gitextensions/assets/6248932/a6918b84-7494-468a-afe0-ad811b184233)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
