### PR TITLE
Support F# files

### DIFF
--- a/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
+++ b/Plugins/Statistics/GitStatistics/GitStatisticsPlugin.cs
@@ -11,7 +11,7 @@ namespace GitExtensions.Plugins.GitStatistics
     {
         private const string _defaultCodeFiles =
             "*.c;*.cpp;*.cc;*.cxx;*.h;*.hpp;*.hxx;*.inl;*.idl;*.asm;*.inc;*.cs;*.xsd;*.wsdl;*.xml;*.htm;*.html;*.css;" +
-            "*.vbs;*.vb;*.sql;*.aspx;*.asp;*.php;*.nav;*.pas;*.py;*.rb;*.js;*.jsm;*.ts;*.mk;*.java;*.os;*.bsl";
+            "*.vbs;*.vb;*.fs;*.fsx;*.sql;*.aspx;*.asp;*.php;*.nav;*.pas;*.py;*.rb;*.js;*.jsm;*.ts;*.mk;*.java;*.os;*.bsl";
 
         private readonly StringSetting _codeFiles = new("Code files", _defaultCodeFiles);
         private readonly StringSetting _ignoreDirectories = new("Directories to ignore (EndsWith)", @"\Debug;\Release;\obj;\bin;\lib");

--- a/contributors.txt
+++ b/contributors.txt
@@ -206,4 +206,4 @@ YYYY/MM/DD, github id, Full name, email
 2023/12/01, pmgiant, Pawel Marchewka, ppmmggiiaanntt(at)gmail.com
 2024/01/01, qgppl, Grzegorz Pachocki, g.pachocki(at)wp.pl
 2024/02/21, superhoang, Aymeric Nguyen, aymeric.nguyen(at)gmail.com
-
+2024/03/14, rstm-sf, Rustam rstm.sf(at)gmail.com


### PR DESCRIPTION


Add support F# files to the statistics plugin


## Screenshots 

### Before

![image](https://github.com/gitextensions/gitextensions/assets/2669927/7c766ba3-7d5f-4f75-a974-1a53c01d4aaf)


### After

![image](https://github.com/gitextensions/gitextensions/assets/2669927/703d1395-23f8-4fd4-aee1-e5b5ecd28947)


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
