### PR TITLE
Restore splitter positions early in the layout process for FormCommit

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1552,8 +1552,8 @@ namespace GitUI.CommandsDialogs
             commitStatusStrip.ResumeLayout(false);
             commitStatusStrip.PerformLayout();
             ResumeLayout(false);
+            RestoreSplitters();
             PerformLayout();
-
         }
 
         #endregion

--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1552,6 +1552,8 @@ namespace GitUI.CommandsDialogs
             commitStatusStrip.ResumeLayout(false);
             commitStatusStrip.PerformLayout();
             ResumeLayout(false);
+            // Restoring splitter distance is deliberatly done here, early in the process.
+            // This prevents additional re-drawing of the form as it's done before the initial layout.
             RestoreSplitters();
             PerformLayout();
         }

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -3325,6 +3325,8 @@ namespace GitUI.CommandsDialogs
 
             internal FileViewer SelectedDiff => _formCommit.SelectedDiff;
 
+            internal SplitContainer MainSplitter => _formCommit.splitMain;
+
             internal ToolStripDropDownButton CommitMessageToolStripMenuItem => _formCommit.commitMessageToolStripMenuItem;
 
             internal ToolStripStatusLabel CommitAuthorStatusToolStripStatusLabel => _formCommit.commitAuthorStatus;

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -484,7 +484,10 @@ namespace GitUI.CommandsDialogs
             LoadCustomDifftools();
 
             base.OnLoad(e);
+        }
 
+        private void RestoreSplitters()
+        {
             _splitterManager.AddSplitter(splitMain, nameof(splitMain));
             _splitterManager.AddSplitter(splitRight, nameof(splitRight));
             _splitterManager.AddSplitter(splitLeft, nameof(splitLeft));

--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -492,13 +492,6 @@ namespace GitUI.CommandsDialogs
             _splitterManager.AddSplitter(splitRight, nameof(splitRight));
             _splitterManager.AddSplitter(splitLeft, nameof(splitLeft));
             _splitterManager.RestoreSplitters();
-
-            // Since #8849 and #8557 we have a geometry bug, which pushes the splitter up by 6px.
-            // Account for this shift. This is a workaround at best.
-            //
-            // The problem is likely caused by 'splitRight.FixedPanel = FixedPanel.Panel2' fact, but other forms
-            // have the same setting, and don't appear to suffer from the same bug.
-            splitRight.SplitterDistance -= DpiUtil.Scale(6);
         }
 
         protected override void OnShown(EventArgs e)

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -550,6 +550,24 @@ namespace GitExtensions.UITests.CommandsDialogs
                 (bounds1, bounds2) => bounds2.Should().Be(bounds1));
         }
 
+        [Test]
+        public void MainSplitter_Remembers_Distance()
+        {
+            bool splitterMoved = false;
+            RunGeometryMemoryTest(
+                form =>
+                {
+                    if (!splitterMoved)
+                    {
+                        form.GetTestAccessor().MainSplitter.SplitterDistance += 100;
+                        splitterMoved = true;
+                    }
+
+                    return form.GetTestAccessor().UnstagedList.Bounds;
+                },
+                (bounds1, bounds2) => bounds2.Should().Be(bounds1));
+        }
+
         private void TestAddSelectionToCommitMessage(
             bool focusSelectedDiff,
             string selectedText,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Splitters in `FormCommit` are restored after layout is already done causing quite some visible re-drawing
- Since all controls are ready early in the layout cycle, restore splitters before performing initial form layout
- Remove the **splitter-drift** hack as it became unnecessary and the tests caught that! (haven't looked at who wrote these tests, but my hat is off to you! 🙇)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Notice the unstaged/staged controls getting resized during the loading of the form (video is slowed down 3x)

https://github.com/gitextensions/gitextensions/assets/483659/245e63e7-7eb3-479e-8f81-0579fc87ae4b

### After

https://github.com/gitextensions/gitextensions/assets/483659/b069b8d5-da8c-4d4c-991d-a93b5c869745

## Test methodology <!-- How did you ensure quality? -->

- Manually for several days

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11
- DPI 200%

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
