### PR TITLE
Turn on DoubleBuffered mode for the NativeTreeView control to prevent flickering

### DIFF
--- a/GitUI/LeftPanel/Node.cs
+++ b/GitUI/LeftPanel/Node.cs
@@ -106,7 +106,7 @@ namespace GitUI.LeftPanel
 
         public static void OnNode<T>(TreeNode? treeNode, Action<T> action) where T : class, INode
         {
-            T node = GetNodeSafe<T>(treeNode);
+            T? node = GetNodeSafe<T>(treeNode);
 
             if (node is not null)
             {

--- a/GitUI/LeftPanel/Node.cs
+++ b/GitUI/LeftPanel/Node.cs
@@ -104,7 +104,7 @@ namespace GitUI.LeftPanel
             return treeNode?.Tag as T;
         }
 
-        public static void OnNode<T>(TreeNode treeNode, Action<T> action) where T : class, INode
+        public static void OnNode<T>(TreeNode? treeNode, Action<T> action) where T : class, INode
         {
             T node = GetNodeSafe<T>(treeNode);
 

--- a/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -212,7 +212,7 @@ namespace GitUI.LeftPanel
 
             return;
 
-            bool IsOverride(MethodInfo m)
+            bool IsOverride(MethodInfo? m)
             {
                 return m is not null && m.GetBaseDefinition().DeclaringType != m.DeclaringType;
             }
@@ -608,7 +608,7 @@ namespace GitUI.LeftPanel
 
         private void OnNodeClick(object sender, TreeNodeMouseClickEventArgs e)
         {
-            NodeBase node = e.Node.Tag as NodeBase;
+            NodeBase node = (NodeBase)e.Node.Tag;
 
             if (e.Button == MouseButtons.Right && node.IsSelected)
             {
@@ -706,13 +706,13 @@ namespace GitUI.LeftPanel
                     nodes = node.Nodes.Cast<TreeNode>();
                 }
 
-                if (node.Tag.GetType() != typeof(TExpected))
+                if (node?.Tag.GetType() != typeof(TExpected))
                 {
-                    throw new ArgumentException($"The selected node is of type {node.Tag.GetType()} instead of the expected type {typeof(TExpected)}.", nameof(TExpected));
+                    throw new ArgumentException($"The selected node is of type {node?.Tag.GetType()} instead of the expected type {typeof(TExpected)}.", nameof(TExpected));
                 }
 
                 TreeView.SelectedNode = node; // simulates a node click well enough for UI tests
-                _repoObjectsTree.SelectNode(node.Tag as NodeBase, multiple, includingDescendants);
+                _repoObjectsTree.SelectNode((NodeBase)node.Tag, multiple, includingDescendants);
             }
 
             public void ReorderTreeNode(TreeNode node, bool up)

--- a/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -141,7 +141,7 @@ namespace GitUI.LeftPanel
 
             SearchControl<string> CreateSearchBox()
             {
-                SearchControl<string> search = new(SearchForBranch, _ => { })
+                SearchControl<string> search = new(SearchForBranch, onSizeChanged: size => { })
                 {
                     Anchor = AnchorStyles.Left | AnchorStyles.Right,
                     Name = "txtBranchCritierion",
@@ -497,7 +497,7 @@ namespace GitUI.LeftPanel
 
             TreeNode? GetNextSearchResult()
             {
-                if (_searchResult?.Count is not > 0 || _searchResult[0] is not { } first)
+                if (_searchResult?.Count is not > 0 || _searchResult[0] is not TreeNode first)
                 {
                     return null;
                 }
@@ -699,13 +699,13 @@ namespace GitUI.LeftPanel
             public void SelectNode<TExpected>(string[] nodeTexts, bool multiple = false, bool includingDescendants = false) where TExpected : Node
             {
                 IEnumerable<TreeNode> nodes = TreeView.Nodes.Cast<TreeNode>();
-                TreeNode node = null;
+                TreeNode? node = null;
 
                 foreach (string text in nodeTexts)
                 {
                     node = nodes.SingleOrDefault(n => n.Text == text);
 
-                    if (node == null)
+                    if (node is null)
                     {
                         throw new ArgumentException(
                             $"Node '{text}' not found. Available nodes on this level: " + nodes.Select(n => n.Text).Join(", "),

--- a/GitUI/LeftPanel/RepoObjectsTree.cs
+++ b/GitUI/LeftPanel/RepoObjectsTree.cs
@@ -81,7 +81,6 @@ namespace GitUI.LeftPanel
 
             treeMain.NodeMouseClick += OnNodeClick;
             treeMain.NodeMouseDoubleClick += OnNodeDoubleClick;
-            treeMain.DoubleBuffered = true;
 
             return;
 

--- a/GitUI/UserControls/NativeTreeView.cs
+++ b/GitUI/UserControls/NativeTreeView.cs
@@ -7,5 +7,11 @@
             base.CreateHandle();
             NativeMethods.SetWindowTheme(Handle, "explorer", null);
         }
+
+        public new bool DoubleBuffered
+        {
+            get => base.DoubleBuffered;
+            set => base.DoubleBuffered = value;
+        }
     }
 }

--- a/GitUI/UserControls/NativeTreeView.cs
+++ b/GitUI/UserControls/NativeTreeView.cs
@@ -2,16 +2,15 @@
 {
     public class NativeTreeView : TreeView
     {
+        public NativeTreeView()
+        {
+            DoubleBuffered = true;
+        }
+
         protected override void CreateHandle()
         {
             base.CreateHandle();
             NativeMethods.SetWindowTheme(Handle, "explorer", null);
-        }
-
-        public new bool DoubleBuffered
-        {
-            get => base.DoubleBuffered;
-            set => base.DoubleBuffered = value;
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Turn on `DoubleBuffered` in the `NativeTreeView` constructor to mitigate tree flicker during update

_I've also fixed some nullability and warnings/style issues around the code that I've explored while fixing this_

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Video is slowed down 3x, notice how the repo objects tree is flickering when different commits are selected

https://github.com/gitextensions/gitextensions/assets/483659/166d33d2-d219-43b5-b7bb-76b2c38d155c

### After

https://github.com/gitextensions/gitextensions/assets/483659/44f56a43-5731-4e7e-9863-5b9c23633394

## Test methodology <!-- How did you ensure quality? -->

- Manually over several months of GE usage

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11
- 200% Dpi

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
