### PR TITLE
Improve stability of show stashes test

### DIFF
--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormBrowseTests.cs
@@ -1,12 +1,10 @@
-﻿using System.ComponentModel.Design;
+﻿using System.Runtime.CompilerServices;
 using CommonTestUtils;
 using FluentAssertions;
 using GitCommands;
 using GitUI;
 using GitUI.CommandsDialogs;
 using GitUIPluginInterfaces;
-using NSubstitute;
-using ResourceManager;
 
 namespace GitExtensions.UITests.CommandsDialogs
 {
@@ -137,8 +135,6 @@ namespace GitExtensions.UITests.CommandsDialogs
                         using ReferenceRepository repository = new();
                         form.SetWorkingDir(repository.Module.WorkingDir);
                         WaitForRevisionsToBeLoaded(form);
-                        form.RevisionGridControl.Invalidate();
-                        UITest.ProcessEventsFor(1000);
                         // Assert
                         AppSettings.BranchFilterEnabled.Value.Should().BeFalse();
                         AppSettings.ShowCurrentBranchOnly.Value.Should().BeTrue();
@@ -223,11 +219,9 @@ namespace GitExtensions.UITests.CommandsDialogs
                         form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(4);
 
                         // 2. Change ShowStashes to enabled
-                        Console.WriteLine("Scenario 1: change 'Show stashes' to enabled");
+                        Console.WriteLine("Scenario 2: change 'Show stashes' to enabled");
                         form.GetTestAccessor().RevisionGrid.ToggleShowStashes();
                         WaitForRevisionsToBeLoaded(form);
-                        form.RevisionGridControl.Invalidate();
-                        UITest.ProcessEventsFor(1000);
                         // Assert
                         AppSettings.ShowStashes.Should().BeTrue();
                         form.GetTestAccessor().RevisionGrid.GetTestAccessor().VisibleRevisionCount.Should().Be(7);
@@ -264,7 +258,7 @@ namespace GitExtensions.UITests.CommandsDialogs
                     try
                     {
                         // 1. Check with ShowStashes enabled
-                        Console.WriteLine("Scenario 2: set 'Show stash' to true");
+                        Console.WriteLine("Scenario 1: set 'Show stash' to true");
                         WaitForRevisionsToBeLoaded(form);
                         // Assert
                         AppSettings.ShowStashes.Should().BeTrue();
@@ -274,8 +268,6 @@ namespace GitExtensions.UITests.CommandsDialogs
                         Console.WriteLine("Scenario 2: change 'Show stash' to disabled");
                         form.GetTestAccessor().RevisionGrid.ToggleShowStashes();
                         WaitForRevisionsToBeLoaded(form);
-                        form.RevisionGridControl.Invalidate();
-                        UITest.ProcessEventsFor(1000);
                         // Assert
                         AppSettings.ShowStashes.Should().BeFalse();
 #if DEBUG
@@ -321,9 +313,9 @@ namespace GitExtensions.UITests.CommandsDialogs
                 testDriverAsync);
         }
 
-        private static void WaitForRevisionsToBeLoaded(FormBrowse form)
+        private static void WaitForRevisionsToBeLoaded(FormBrowse form, [CallerMemberName] string caller = "")
         {
-            UITest.ProcessUntil("Loading Revisions", () => form.GetTestAccessor().RevisionGrid.GetTestAccessor().IsDataLoadComplete);
+            UITest.ProcessUntil($"{caller} loading revisions", () => form.GetTestAccessor().RevisionGrid.GetTestAccessor().IsDataLoadComplete, maxMilliseconds: 10_000);
         }
     }
 }


### PR DESCRIPTION
Fixes https://ci.appveyor.com/project/gitextensions/gitextensions/builds/49461079#L339

## Proposed changes

- There is no need to invalidate RevisionGridControl
- Just be more patient until stashes are loaded

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).