### PR TITLE
Set ForceDesignerDpiUnaware prop for the GitUI project

### DIFF
--- a/GitUI/GitUI.csproj
+++ b/GitUI/GitUI.csproj
@@ -6,6 +6,8 @@
     <!-- To be removed when NRT annotations are complete -->
     <Nullable>annotations</Nullable>
 
+    <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
+
     <!--
     For debug purposes uncomment these lines:
 


### PR DESCRIPTION
## Proposed changes

- Enable `ForceDesignerDpiUnaware` for the `GitUI` project to prevents sizes getting recalculated based on how many pixels controls take when viewed with non-100% Dpi

The link from the informational "gold bar" in VS leads to: https://aka.ms/winforms/designer/unaware-mode which is a redirect to https://github.com/dotnet/winforms/blob/main/docs/designer/designer-high-dpi-mode.md

Prevents this upon save:
![image](https://github.com/gitextensions/gitextensions/assets/483659/e1f9893a-7e50-40d5-b0d5-7d16718c1040)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/483659/ec15023c-b5aa-4958-9ea3-191411aa5661)

### After

![image](https://github.com/gitextensions/gitextensions/assets/483659/382af4b0-7ee4-4fe9-a200-8276fd6d1be0)

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11 200% Dpi
- Visual Studio 2022

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
