### PR TITLE
Improve hotkey display and handling

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.InitMenusAndToolbars.cs
@@ -141,7 +141,7 @@ namespace GitUI.CommandsDialogs
             => UpdateTooltipWithShortcut(button, GetShortcutKeys(command));
 
         private static void UpdateTooltipWithShortcut(ToolStripItem button, Keys keys)
-            => button.ToolTipText = button.ToolTipText.UpdateTooltipWithShortcut(keys.ToShortcutKeyToolTipString());
+            => button.ToolTipText = button.ToolTipText.UpdateSuffix(keys.ToShortcutKeyToolTipString());
 
         private void InsertFetchPullShortcuts()
         {
@@ -163,7 +163,7 @@ namespace GitUI.CommandsDialogs
                     Name = FetchPullToolbarShortcutsPrefix + toolStripMenuItem.Name,
                     Size = toolStripMenuItem.Size,
                     Text = toolTipText,
-                    ToolTipText = toolTipText.UpdateTooltipWithShortcut(command.HasValue ? GetShortcutKeyTooltipString(command.Value) : null),
+                    ToolTipText = toolTipText.UpdateSuffix(command.HasValue ? GetShortcutKeyTooltipString(command.Value) : null),
                     DisplayStyle = ToolStripItemDisplayStyle.Image,
                 };
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -1356,8 +1356,7 @@ namespace GitUI.CommandsDialogs
         {
             return base.ProcessHotkey(keyData) // generic handling of this controls's hotkeys (upstream)
                 || (!GitExtensionsControl.IsTextEditKey(keyData) // downstream (without keys for quick search and filter)
-                    && ((DiffFiles.Visible && DiffFiles.ProcessHotkey(keyData))
-                        || (DiffText.Visible && DiffText.ProcessHotkey(keyData))
+                    && ((DiffText.Visible && DiffText.ProcessHotkey(keyData))
                         || (BlameControl.Visible && BlameControl.ProcessHotkey(keyData))));
         }
 

--- a/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -11,7 +11,6 @@ using GitUIPluginInterfaces;
 using Microsoft;
 using Microsoft.VisualStudio.Threading;
 using ResourceManager;
-using ResourceManager.Hotkey;
 
 namespace GitUI.CommandsDialogs
 {
@@ -226,11 +225,6 @@ namespace GitUI.CommandsDialogs
         public void CancelLoadCustomDifftools()
         {
             _customDiffToolsSequence.CancelCurrent();
-        }
-
-        private string GetShortcutKeyDisplayString(Command cmd)
-        {
-            return GetShortcutKeys((int)cmd).ToShortcutKeyDisplayString();
         }
 
         #endregion

--- a/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -11,7 +11,6 @@ using GitUI.UserControls;
 using GitUIPluginInterfaces;
 using Microsoft;
 using ResourceManager;
-using ResourceManager.Hotkey;
 
 namespace GitUI.CommandsDialogs
 {
@@ -312,11 +311,6 @@ See the changes in the commit form.");
             filterFileInGridToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.FilterFileInGrid);
             findToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.FindFile);
             FileText.ReloadHotkeys();
-        }
-
-        private string GetShortcutKeyDisplayString(Command cmd)
-        {
-            return GetShortcutKeys((int)cmd).ToShortcutKeyDisplayString();
         }
 
         #endregion

--- a/GitUI/CommandsDialogs/ToolStripPushButton.cs
+++ b/GitUI/CommandsDialogs/ToolStripPushButton.cs
@@ -1,5 +1,6 @@
 ﻿using GitCommands;
 using GitCommands.Git;
+using GitExtUtils;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Properties;
 using ResourceManager;
@@ -24,7 +25,7 @@ namespace GitUI.CommandsDialogs
                 || aheadBehindData?.TryGetValue(branchName, out AheadBehindData data) is not true)
             {
                 ResetToDefaultState();
-                ToolTipText = ToolTipText.UpdateTooltipWithShortcut(shortcut);
+                ToolTipText = ToolTipText.UpdateSuffix(shortcut);
                 return;
             }
 
@@ -32,7 +33,7 @@ namespace GitUI.CommandsDialogs
             AutoSize = true;
             Text = data.ToDisplay();
             DisplayStyle = ToolStripItemDisplayStyle.ImageAndText;
-            ToolTipText = GetToolTipText(data).UpdateTooltipWithShortcut(shortcut);
+            ToolTipText = GetToolTipText(data).UpdateSuffix(shortcut);
 
             if (!string.IsNullOrEmpty(data.BehindCount))
             {

--- a/GitUI/CommitInfo/CommitInfo.cs
+++ b/GitUI/CommitInfo/CommitInfo.cs
@@ -21,7 +21,6 @@ using Microsoft;
 using Microsoft.VisualStudio.Threading;
 using ResourceManager;
 using ResourceManager.CommitDataRenders;
-using ResourceManager.Hotkey;
 
 namespace GitUI.CommitInfo
 {
@@ -106,7 +105,7 @@ namespace GitUI.CommitInfo
 
             rtbxCommitMessage.Font = AppSettings.CommitFont;
             RevisionInfo.Font = AppSettings.Font;
-            addNoteToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeys((int)FormBrowse.Command.AddNotes).ToShortcutKeyDisplayString();
+            addNoteToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(FormBrowse.Command.AddNotes);
 
             _commitMessageResizedSubscription = subscribeToContentsResized(rtbxCommitMessage, CommitMessage_ContentsResized);
             _revisionInfoResizedSubscription = subscribeToContentsResized(RevisionInfo, RevisionInfo_ContentsResized);

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -17,7 +17,6 @@ using GitUI.UserControls;
 using GitUIPluginInterfaces;
 using Microsoft;
 using ResourceManager;
-using ResourceManager.Hotkey;
 
 namespace GitUI.Editor
 {
@@ -1882,11 +1881,6 @@ namespace GitUI.Editor
                 // Don't handle the hotkey to let the control handle it if an action is bound to it
                 return false;
             }
-        }
-
-        private string GetShortcutKeyDisplayString(Command cmd)
-        {
-            return GetShortcutKeys((int)cmd).ToShortcutKeyDisplayString();
         }
 
         #endregion

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -335,6 +335,14 @@ namespace GitUI.Editor
             findToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.Find);
             replaceToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.Replace);
             goToLineToolStripMenuItem.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(Command.GoToLine);
+
+            UpdateTooltipWithShortcut(nextChangeButton, Command.NextChange);
+            UpdateTooltipWithShortcut(previousChangeButton, Command.PreviousChange);
+            UpdateTooltipWithShortcut(increaseNumberOfLines, Command.IncreaseNumberOfVisibleLines);
+            UpdateTooltipWithShortcut(decreaseNumberOfLines, Command.DecreaseNumberOfVisibleLines);
+            UpdateTooltipWithShortcut(showEntireFileButton, Command.ShowEntireFile);
+            UpdateTooltipWithShortcut(showSyntaxHighlighting, Command.ShowSyntaxHighlighting);
+            UpdateTooltipWithShortcut(ignoreAllWhitespaces, Command.IgnoreAllWhitespace);
         }
 
         public ToolStripSeparator AddContextMenuSeparator()

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -332,7 +332,7 @@ namespace GitUI.Hotkey
                     Hk(FileViewer.Command.PreviousChange, Keys.Alt | Keys.Up),
                     Hk(FileViewer.Command.ShowEntireFile, Keys.Control | Keys.E),
                     Hk(FileViewer.Command.ShowSyntaxHighlighting, Keys.X),
-                    Hk(FileViewer.Command.ShowGitWordColoring, Keys.Control | Keys.Shift | Keys.D),
+                    Hk(FileViewer.Command.ShowGitWordColoring, Keys.Control | Keys.D),
                     Hk(FileViewer.Command.TreatFileAsText, Keys.None),
                     Hk(FileViewer.Command.NextOccurrence, Keys.Alt | Keys.Right),
                     Hk(FileViewer.Command.PreviousOccurrence, Keys.Alt | Keys.Left),

--- a/GitUI/UserControls/FilterToolBar.cs
+++ b/GitUI/UserControls/FilterToolBar.cs
@@ -486,13 +486,13 @@ namespace GitUI.UserControls
         {
             _tslblRevisionFilterToolTip ??= tslblRevisionFilter.ToolTipText;
 
-            tslblRevisionFilter.ToolTipText = _tslblRevisionFilterToolTip.UpdateTooltipWithShortcut(hotkeys.GetShortcutToolTip(FormBrowse.Command.FocusFilter));
+            tslblRevisionFilter.ToolTipText = _tslblRevisionFilterToolTip.UpdateSuffix(hotkeys.GetShortcutToolTip(FormBrowse.Command.FocusFilter));
         }
 
         internal void RefreshRevisionGridShortcutKeys(IReadOnlyList<HotkeyCommand> hotkeys)
         {
-            tsbShowReflog.ToolTipText = TranslatedStrings.ShowReflogTooltip.UpdateTooltipWithShortcut(hotkeys.GetShortcutToolTip(RevisionGridControl.Command.ShowReflogReferences));
-            tsmiShowOnlyFirstParent.ToolTipText = TranslatedStrings.ShowOnlyFirstParent.UpdateTooltipWithShortcut(hotkeys.GetShortcutToolTip(RevisionGridControl.Command.ShowCurrentBranchOnly));
+            tsbShowReflog.ToolTipText = TranslatedStrings.ShowReflogTooltip.UpdateSuffix(hotkeys.GetShortcutToolTip(RevisionGridControl.Command.ShowReflogReferences));
+            tsmiShowOnlyFirstParent.ToolTipText = TranslatedStrings.ShowOnlyFirstParent.UpdateSuffix(hotkeys.GetShortcutToolTip(RevisionGridControl.Command.ShowCurrentBranchOnly));
 
             tsmiShowBranchesAll.ShortcutKeyDisplayString = hotkeys.GetShortcutDisplay(RevisionGridControl.Command.ShowAllBranches);
             tsmiShowBranchesFiltered.ShortcutKeyDisplayString = hotkeys.GetShortcutDisplay(RevisionGridControl.Command.ShowFilteredBranches);

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2893,13 +2893,7 @@ namespace GitUI
 
         private void SetShortcutString(ToolStripMenuItem item, Command command)
         {
-            item.ShortcutKeyDisplayString = GetShortcutKeys(command)
-                .ToShortcutKeyDisplayString();
-        }
-
-        internal Keys GetShortcutKeys(Command cmd)
-        {
-            return GetShortcutKeys((int)cmd);
+            item.ShortcutKeyDisplayString = GetShortcutKeyDisplayString(command);
         }
 
         private void CompareToBranchToolStripMenuItem_Click(object sender, EventArgs e)

--- a/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -5,7 +5,6 @@ using GitUI.CommandsDialogs.BrowseDialog;
 using GitUI.Properties;
 using GitUIPluginInterfaces;
 using ResourceManager;
-using ResourceManager.Hotkey;
 
 namespace GitUI.UserControls.RevisionGrid
 {
@@ -462,16 +461,10 @@ namespace GitUI.UserControls.RevisionGrid
             };
         }
 
-        public string? GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command revGridCommands)
+        public string? GetShortcutKeyDisplayStringFromRevisionGridIfAvailable(RevisionGridControl.Command revisionGridCommand)
         {
             // _revisionGrid is null when TranslationApp is called
-            return _revisionGrid?.GetShortcutKeys(revGridCommands).ToShortcutKeyDisplayString();
-        }
-
-        public string? GetShortcutKeyTooltipStringFromRevisionGridIfAvailable(RevisionGridControl.Command revGridCommands)
-        {
-            // _revisionGrid is null when TranslationApp is called
-            return _revisionGrid?.GetShortcutKeys(revGridCommands).ToShortcutKeyToolTipString();
+            return _revisionGrid?.GetShortcutKeyDisplayString(revisionGridCommand);
         }
 
         protected override IEnumerable<MenuCommand> GetMenuCommandsForTranslation()

--- a/ResourceManager/GitExtensionsControl.cs
+++ b/ResourceManager/GitExtensionsControl.cs
@@ -1,5 +1,6 @@
 using GitExtUtils;
 using GitUIPluginInterfaces;
+using ResourceManager.Hotkey;
 
 namespace ResourceManager
 {
@@ -94,14 +95,10 @@ namespace ResourceManager
         }
 
         protected Keys GetShortcutKeys(int commandCode)
-        {
-            return GetHotkeyCommand(commandCode)?.KeyData ?? Keys.None;
-        }
+            => _hotkeys.GetShortcutKey(commandCode);
 
-        private HotkeyCommand? GetHotkeyCommand(int commandCode)
-        {
-            return _hotkeys?.FirstOrDefault(h => h.CommandCode == commandCode);
-        }
+        public string GetShortcutKeyDisplayString<T>(T commandCode) where T : struct, Enum
+            => _hotkeys.GetShortcutDisplay(commandCode);
 
         /// <summary>
         /// Override this method to handle form-specific Hotkey commands.

--- a/ResourceManager/GitExtensionsControl.cs
+++ b/ResourceManager/GitExtensionsControl.cs
@@ -100,6 +100,11 @@ namespace ResourceManager
         public string GetShortcutKeyDisplayString<T>(T commandCode) where T : struct, Enum
             => _hotkeys.GetShortcutDisplay(commandCode);
 
+        protected void UpdateTooltipWithShortcut<T>(ToolStripItem button, T commandCode) where T : struct, Enum
+        {
+            button.ToolTipText = button.ToolTipText.UpdateSuffix(_hotkeys.GetShortcutToolTip(commandCode));
+        }
+
         /// <summary>
         /// Override this method to handle form-specific Hotkey commands.
         /// <remarks>This base method does nothing and returns <see langword="false"/>.</remarks>

--- a/ResourceManager/Hotkey/KeysExtensions.cs
+++ b/ResourceManager/Hotkey/KeysExtensions.cs
@@ -82,9 +82,6 @@ namespace ResourceManager.Hotkey
         public static string ToShortcutKeyToolTipString(this Keys key)
             => key == Keys.None ? "" : $"({key.ToShortcutKeyDisplayString()})";
 
-        public static string UpdateTooltipWithShortcut(this string currentTooltipText, string shortcut)
-            => currentTooltipText.UpdateSuffix(shortcut);
-
         private static string? ToCultureSpecificString(this Keys key)
         {
             if (key == Keys.None)

--- a/ResourceManager/Hotkey/ShortcutHelper.cs
+++ b/ResourceManager/Hotkey/ShortcutHelper.cs
@@ -1,32 +1,31 @@
-﻿namespace ResourceManager.Hotkey
+﻿namespace ResourceManager.Hotkey;
+
+public static class ShortcutHelper
 {
-    public static class ShortcutHelper
-    {
-        /// <summary>
-        ///  Returns the string representation of <paramref name="commandCode"/> if it exists in <paramref name="hotkeys"/> collection.
-        /// </summary>
-        /// <param name="hotkeys">The collection of configured shortcut keys.</param>
-        /// <param name="commandCode">The required shortcut identifier.</param>
-        /// <returns>The string representation of the shortcut, if exists; otherwise, the string representation of <see cref="Keys.None"/>.</returns>
-        public static string GetShortcutToolTip<T>(this IEnumerable<HotkeyCommand>? hotkeys, T commandCode) where T : struct, Enum
-            => hotkeys.GetShortcutKey(commandCode).ToShortcutKeyToolTipString();
+    /// <summary>
+    ///  Returns the assigned shortcut key of <paramref name="commandCode"/> if it exists in <paramref name="hotkeys"/> collection.
+    /// </summary>
+    /// <param name="hotkeys">The collection of configured shortcut keys.</param>
+    /// <param name="commandCode">The required shortcut identifier.</param>
+    /// <returns>The shortcut key code, if exists; otherwise, <see cref="Keys.None"/>.</returns>
+    public static Keys GetShortcutKey<T>(this IEnumerable<HotkeyCommand>? hotkeys, T commandCode) where T : notnull
+        => hotkeys?.FirstOrDefault(h => h.CommandCode == (int)(object)commandCode)?.KeyData ?? Keys.None;
 
-        /// <summary>
-        ///  Returns the string representation of <paramref name="commandCode"/> if it exists in <paramref name="hotkeys"/> collection.
-        /// </summary>
-        /// <param name="hotkeys">The collection of configured shortcut keys.</param>
-        /// <param name="commandCode">The required shortcut identifier.</param>
-        /// <returns>The string representation of the shortcut, if exists; otherwise, the string representation of <see cref="Keys.None"/>.</returns>
-        public static string GetShortcutDisplay<T>(this IEnumerable<HotkeyCommand>? hotkeys, T commandCode) where T : struct, Enum
-            => hotkeys.GetShortcutKey(commandCode).ToShortcutKeyDisplayString();
+    /// <summary>
+    ///  Returns the menu string representation of <paramref name="commandCode"/> if it exists in <paramref name="hotkeys"/> collection.
+    /// </summary>
+    /// <param name="hotkeys">The collection of configured shortcut keys.</param>
+    /// <param name="commandCode">The required shortcut identifier.</param>
+    /// <returns>The string representation of the shortcut, if exists; otherwise, the string representation of <see cref="Keys.None"/>, which is empty.</returns>
+    public static string GetShortcutDisplay<T>(this IEnumerable<HotkeyCommand>? hotkeys, T commandCode) where T : struct, Enum
+        => hotkeys.GetShortcutKey(commandCode).ToShortcutKeyDisplayString();
 
-        /// <summary>
-        ///  Returns the string representation of <paramref name="commandCode"/> if it exists in <paramref name="hotkeys"/> collection.
-        /// </summary>
-        /// <param name="hotkeys">The collection of configured shortcut keys.</param>
-        /// <param name="commandCode">The required shortcut identifier.</param>
-        /// <returns>The string representation of the shortcut, if exists; otherwise, the string representation of <see cref="Keys.None"/>.</returns>
-        public static Keys GetShortcutKey<T>(this IEnumerable<HotkeyCommand>? hotkeys, T commandCode) where T : struct, Enum
-            => hotkeys?.FirstOrDefault(h => h.CommandCode == (int)(object)commandCode)?.KeyData ?? Keys.None;
-    }
+    /// <summary>
+    ///  Returns the tooltip string representation of <paramref name="commandCode"/> if it exists in <paramref name="hotkeys"/> collection.
+    /// </summary>
+    /// <param name="hotkeys">The collection of configured shortcut keys.</param>
+    /// <param name="commandCode">The required shortcut identifier.</param>
+    /// <returns>The string representation of the shortcut, if exists; otherwise, the string representation of <see cref="Keys.None"/>, which is empty.</returns>
+    public static string GetShortcutToolTip<T>(this IEnumerable<HotkeyCommand>? hotkeys, T commandCode) where T : struct, Enum
+        => hotkeys.GetShortcutKey(commandCode).ToShortcutKeyToolTipString();
 }


### PR DESCRIPTION
Follow-up to #11620

## Proposed changes

- Display shortcuts in tooltips of FileViewer toolbar
- Fixup xmldoc of `ShortcutHelper`
- Change default hotkey for `ShowGitWordColoring` to `Ctrl+D`
  - less modifiers
  - works from FileStatusList
  - similar to "Show entire file (Ctrl+E)"
- Remove pointless call to `DiffFiles.ProcessHotkey` because FileStatusList does not support hotkeys at all
- Add `GitExtensionsControl.GetShortcutKeyDisplayString`
- Replace `KeysExtensions.UpdateTooltipWithShortcut` with direct call of `DisplayWithSuffixUpdater.UpdateSuffix`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/36601201/182caf1f-dced-44db-b8a3-14226669b9fc)

### After

![image](https://github.com/gitextensions/gitextensions/assets/36601201/b7ec5de0-91f4-449a-8079-0eb02a76a0a7)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Please do not squash!

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).