### PR TITLE
Fix theme migration bug

### DIFF
--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -2104,8 +2104,11 @@ namespace GitCommands
         [Obsolete("AppSettings is no longer responsible for colors, ThemeModule is")]
         public static Color GetColor(AppColor name)
         {
-            return SettingsContainer.GetColor(name.ToString().ToLowerInvariant() + "color", AppColorDefaults.GetBy(name));
+            return SettingsContainer.GetColor(GetColorSettingName(name), AppColorDefaults.GetBy(name));
         }
+
+        [Obsolete("AppSettings is no longer responsible for colors, ThemeModule is")]
+        public static string GetColorSettingName(AppColor color) => color.ToString().ToLowerInvariant() + "color";
 
         // Enum
         public static T GetEnum<T>(string name, T defaultValue) where T : struct, Enum => SettingsContainer.GetEnum(name, defaultValue);

--- a/GitCommands/Settings/AppSettings.cs
+++ b/GitCommands/Settings/AppSettings.cs
@@ -2104,11 +2104,8 @@ namespace GitCommands
         [Obsolete("AppSettings is no longer responsible for colors, ThemeModule is")]
         public static Color GetColor(AppColor name)
         {
-            return SettingsContainer.GetColor(GetColorSettingName(name), AppColorDefaults.GetBy(name));
+            return SettingsContainer.GetColor(name.ToString().ToLowerInvariant() + "color", AppColorDefaults.GetBy(name));
         }
-
-        [Obsolete("AppSettings is no longer responsible for colors, ThemeModule is")]
-        public static string GetColorSettingName(AppColor color) => color.ToString().ToLowerInvariant() + "color";
 
         // Enum
         public static T GetEnum<T>(string name, T defaultValue) where T : struct, Enum => SettingsContainer.GetEnum(name, defaultValue);

--- a/Plugins/GitUIPluginInterfaces/SettingsSource.cs
+++ b/Plugins/GitUIPluginInterfaces/SettingsSource.cs
@@ -118,14 +118,23 @@ namespace GitUIPluginInterfaces
         {
             string? stringValue = GetValue(name);
 
-            try
+            if (!string.IsNullOrWhiteSpace(stringValue))
             {
-                return ColorTranslator.FromHtml(stringValue);
+                try
+                {
+                    Color result = ColorTranslator.FromHtml(stringValue);
+                    if (result != Color.Empty)
+                    {
+                        return result;
+                    }
+                }
+                catch
+                {
+                    // ignore invalid color values (return the default value)
+                }
             }
-            catch
-            {
-                return defaultValue;
-            }
+
+            return defaultValue;
         }
 
         public T GetEnum<T>(string name, T defaultValue) where T : struct, Enum

--- a/UnitTests/GitUI.Tests/Theming/AppColorDefaultsTests.cs
+++ b/UnitTests/GitUI.Tests/Theming/AppColorDefaultsTests.cs
@@ -45,7 +45,7 @@ namespace GitUITests.Theming
             MemorySettings emptySettings = new();
 
             Color defaultColor = AppColorDefaults.GetBy(name);
-            Color settingsColor = emptySettings.GetColor(AppSettings.GetColorSettingName(name), defaultColor);
+            Color settingsColor = emptySettings.GetColor(name.ToString(), defaultColor);
 
             settingsColor.Should().Be(defaultColor);
 #pragma warning restore CS0618

--- a/UnitTests/GitUI.Tests/Theming/AppColorDefaultsTests.cs
+++ b/UnitTests/GitUI.Tests/Theming/AppColorDefaultsTests.cs
@@ -35,6 +35,22 @@ namespace GitUITests.Theming
             }
         }
 
+        [Test]
+        public void Default_values_are_used_when_not_overridden_in_settings([Values]AppColor name)
+        {
+            // This only applies when migrating colors from AppSettings to a theme.
+            // Fixes https://github.com/gitextensions/gitextensions/issues/11629
+
+#pragma warning disable CS0618 // AppSettings.GetColorSettingName is obsolete, but still used by theme migration.
+            MemorySettings emptySettings = new();
+
+            Color defaultColor = AppColorDefaults.GetBy(name);
+            Color settingsColor = emptySettings.GetColor(AppSettings.GetColorSettingName(name), defaultColor);
+
+            settingsColor.Should().Be(defaultColor);
+#pragma warning restore CS0618
+        }
+
 #if SUPPORT_THEMES
         [Test]
         public void Default_values_are_specified_in_invariant_theme()

--- a/UnitTests/GitUI.Tests/Theming/AppColorDefaultsTests.cs
+++ b/UnitTests/GitUI.Tests/Theming/AppColorDefaultsTests.cs
@@ -41,14 +41,12 @@ namespace GitUITests.Theming
             // This only applies when migrating colors from AppSettings to a theme.
             // Fixes https://github.com/gitextensions/gitextensions/issues/11629
 
-#pragma warning disable CS0618 // AppSettings.GetColorSettingName is obsolete, but still used by theme migration.
             MemorySettings emptySettings = new();
 
             Color defaultColor = AppColorDefaults.GetBy(name);
             Color settingsColor = emptySettings.GetColor(name.ToString(), defaultColor);
 
             settingsColor.Should().Be(defaultColor);
-#pragma warning restore CS0618
         }
 
 #if SUPPORT_THEMES

--- a/contributors.txt
+++ b/contributors.txt
@@ -207,3 +207,4 @@ YYYY/MM/DD, github id, Full name, email
 2024/01/01, qgppl, Grzegorz Pachocki, g.pachocki(at)wp.pl
 2024/02/21, superhoang, Aymeric Nguyen, aymeric.nguyen(at)gmail.com
 2024/03/14, rstm-sf, Rustam rstm.sf(at)gmail.com
+2024/03/24, berrs, Per-Erik Stendahl, pererik.stendahl@gmail.com


### PR DESCRIPTION
Fixes #11629

There is a problem in SettingsSource.GetColor. If the settings do not contain a value for the requested color, GetColor will return Color.Empty rather than the provided default color (because of how ColorTranslator.FromHtml handles empty input).

This causes the theme migration to think the colors have been updated from the default to a very goth all-black.

## Proposed changes

Fix SettingsSource.GetColor to return the default color instead of Color.Empty

## Test methodology

- Added unit test for SettingsSource.GetColor

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 805cf4832e6e2ad5719c04bdc07607a87be4c7f5 (Dirty)
- Git 2.42.0.windows.2
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.3
- DPI 144dpi (150% scaling)
- Portable: False

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
