### PR TITLE
FormResolveConflicts: Avoid fragmented translation strings

### DIFF
--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -66,15 +66,18 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _button1Text = new("Open in");
 
         private readonly TranslationString _contextChooseLocalRebaseText = new("Choose local/current (theirs)");
-        private readonly TranslationString _takeOnly = new("Take only");
-        private readonly TranslationString _changesLocalRebaseTooltip = new("the changes from the branch you are rebasing onto");
+        private readonly TranslationString _changesTakeOnlyLocalRebaseTooltip = new("Take only the changes from the branch you are rebasing onto");
+        private readonly TranslationString _changesLocalRebaseTooltip = new("Changes from the branch you are rebasing onto");
         private readonly TranslationString _contextChooseRemoteRebaseText = new("Choose remote/incoming (ours)");
-        private readonly TranslationString _changesRemoteRebaseTooltip = new("the changes from the branch you are rebasing");
+        private readonly TranslationString _changesTakeOnlyRemoteRebaseTooltip = new("Take only the changes from the branch you are rebasing");
+        private readonly TranslationString _changesRemoteRebaseTooltip = new("Changes from the branch you are rebasing");
 
         private readonly TranslationString _contextChooseLocalMergeText = new("Choose local/current (ours)");
-        private readonly TranslationString _changesLocalMergeTooltip = new("the changes from the current branch");
+        private readonly TranslationString _changesTakeOnlyLocalMergeTooltip = new("Take only the changes from the current branch");
+        private readonly TranslationString _changesLocalMergeTooltip = new("Changes from the current branch");
         private readonly TranslationString _contextChooseRemoteMergeText = new("Choose remote/incoming (theirs)");
-        private readonly TranslationString _changesRemoteMergeTooltip = new("the changes from the branch you are merging");
+        private readonly TranslationString _changesTakeOnlyRemoteMergeTooltip = new("Take only the changes from the branch you are merging");
+        private readonly TranslationString _changesRemoteMergeTooltip = new("Changes from the branch you are merging");
 
         private readonly TranslationString _contextChooseBaseTooltip = new("Take no changes and revert to base content!");
 
@@ -249,24 +252,24 @@ namespace GitUI.CommandsDialogs
                 if (_inTheMiddleOfRebase)
                 {
                     ContextChooseLocal.Text = _contextChooseLocalRebaseText.Text;
-                    ContextChooseLocal.ToolTipText = _takeOnly.Text + " " + _changesLocalRebaseTooltip.Text;
+                    ContextChooseLocal.ToolTipText = _changesTakeOnlyLocalRebaseTooltip.Text;
                     labelLocalCurrent.Text = labelLocalCurrent.Text.UpdateSuffixWithinParenthesis(_theirs.Text);
                     toolTip.SetToolTip(labelLocalCurrent, _changesLocalRebaseTooltip.Text);
 
                     ContextChooseRemote.Text = _contextChooseRemoteRebaseText.Text;
-                    ContextChooseRemote.ToolTipText = _takeOnly.Text + " " + _changesRemoteRebaseTooltip.Text;
+                    ContextChooseRemote.ToolTipText = _changesTakeOnlyRemoteRebaseTooltip.Text;
                     labelRemoteIncoming.Text = labelRemoteIncoming.Text.UpdateSuffixWithinParenthesis(_ours.Text);
                     toolTip.SetToolTip(labelRemoteIncoming, _changesRemoteRebaseTooltip.Text);
                 }
                 else
                 {
                     ContextChooseLocal.Text = _contextChooseLocalMergeText.Text;
-                    ContextChooseLocal.ToolTipText = _takeOnly.Text + " " + _changesLocalMergeTooltip.Text;
+                    ContextChooseLocal.ToolTipText = _changesTakeOnlyLocalMergeTooltip.Text;
                     labelLocalCurrent.Text = labelLocalCurrent.Text.UpdateSuffixWithinParenthesis(_ours.Text);
                     toolTip.SetToolTip(labelLocalCurrent, _changesLocalMergeTooltip.Text);
 
                     ContextChooseRemote.Text = _contextChooseRemoteMergeText.Text;
-                    ContextChooseRemote.ToolTipText = _takeOnly.Text + " " + _changesRemoteMergeTooltip.Text;
+                    ContextChooseRemote.ToolTipText = _changesTakeOnlyRemoteMergeTooltip.Text;
                     labelRemoteIncoming.Text = labelRemoteIncoming.Text.UpdateSuffixWithinParenthesis(_theirs.Text);
                     toolTip.SetToolTip(labelRemoteIncoming, _changesRemoteMergeTooltip.Text);
                 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -6733,19 +6733,35 @@ Is the merge conflict solved?</source>
         <target />
       </trans-unit>
       <trans-unit id="_changesLocalMergeTooltip.Text">
-        <source>the changes from the current branch</source>
+        <source>Changes from the current branch</source>
         <target />
       </trans-unit>
       <trans-unit id="_changesLocalRebaseTooltip.Text">
-        <source>the changes from the branch you are rebasing onto</source>
+        <source>Changes from the branch you are rebasing onto</source>
         <target />
       </trans-unit>
       <trans-unit id="_changesRemoteMergeTooltip.Text">
-        <source>the changes from the branch you are merging</source>
+        <source>Changes from the branch you are merging</source>
         <target />
       </trans-unit>
       <trans-unit id="_changesRemoteRebaseTooltip.Text">
-        <source>the changes from the branch you are rebasing</source>
+        <source>Changes from the branch you are rebasing</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_changesTakeOnlyLocalMergeTooltip.Text">
+        <source>Take only the changes from the current branch</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_changesTakeOnlyLocalRebaseTooltip.Text">
+        <source>Take only the changes from the branch you are rebasing onto</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_changesTakeOnlyRemoteMergeTooltip.Text">
+        <source>Take only the changes from the branch you are merging</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_changesTakeOnlyRemoteRebaseTooltip.Text">
+        <source>Take only the changes from the branch you are rebasing</source>
         <target />
       </trans-unit>
       <trans-unit id="_chooseBaseFileFailedText.Text">
@@ -6950,10 +6966,6 @@ Please go to settings and configure the mergetool!</source>
       </trans-unit>
       <trans-unit id="_stageFilename.Text">
         <source>Stage {0}</source>
-        <target />
-      </trans-unit>
-      <trans-unit id="_takeOnly.Text">
-        <source>Take only</source>
         <target />
       </trans-unit>
       <trans-unit id="_theirs.Text">


### PR DESCRIPTION
fixes #11651

Introduced by 3a7e5d8bc16c2ba2f65eac3867e64ad89b9002e8 (#11619)


## Screenshots <!-- Remove this section if PR does not change UI -->

No changes for english version.

## Test methodology <!-- How did you ensure quality? -->

- Build and run

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 9c707d516b0fc5e42046550bba87cb0b2e49a1dd
- Git 2.44.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
