### PR TITLE
Small refactoring or adjustments

### DIFF
--- a/GitUI/CommandsDialogs/FormBrowse.Designer.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.Designer.cs
@@ -976,7 +976,7 @@ namespace GitUI.CommandsDialogs
             repoSettingsToolStripMenuItem.Image = Properties.Images.Settings;
             repoSettingsToolStripMenuItem.Name = "repoSettingsToolStripMenuItem";
             repoSettingsToolStripMenuItem.Size = new Size(221, 22);
-            repoSettingsToolStripMenuItem.Text = "Rep&ository settings";
+            repoSettingsToolStripMenuItem.Text = "Rep&ository settings...";
             repoSettingsToolStripMenuItem.Click += RepoSettingsToolStripMenuItemClick;
             // 
             // toolStripSeparator13
@@ -1296,7 +1296,7 @@ namespace GitUI.CommandsDialogs
             pluginSettingsToolStripMenuItem.Image = Properties.Images.Settings;
             pluginSettingsToolStripMenuItem.Name = "pluginSettingsToolStripMenuItem";
             pluginSettingsToolStripMenuItem.Size = new Size(153, 22);
-            pluginSettingsToolStripMenuItem.Text = "Plugin &Settings";
+            pluginSettingsToolStripMenuItem.Text = "Plugins &settings...";
             pluginSettingsToolStripMenuItem.Click += PluginSettingsToolStripMenuItemClick;
             // 
             // helpToolStripMenuItem

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -181,7 +181,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _noReposHostPluginLoaded = new("No repository host plugin loaded.");
         private readonly TranslationString _noReposHostFound = new("Could not find any relevant repository hosts for the currently open repository.");
 
-        private readonly TranslationString _configureWorkingDirMenu = new("&Configure this menu");
+        private readonly TranslationString _configureWorkingDirMenu = new("&Configure this menu...");
 
         private readonly TranslationString _updateCurrentSubmodule = new("Update current submodule");
 

--- a/GitUI/CommandsDialogs/FormClone.Designer.cs
+++ b/GitUI/CommandsDialogs/FormClone.Designer.cs
@@ -52,13 +52,13 @@
             // MainPanel
             // 
             MainPanel.Controls.Add(tpnlMain);
-            MainPanel.Size = new Size(647, 310);
+            MainPanel.Size = new Size(647, 318);
             // 
             // ControlsPanel
             // 
             ControlsPanel.Controls.Add(Ok);
             ControlsPanel.Controls.Add(LoadSSHKey);
-            ControlsPanel.Location = new Point(0, 310);
+            ControlsPanel.Location = new Point(0, 318);
             ControlsPanel.Size = new Size(647, 41);
             // 
             // Central
@@ -151,6 +151,8 @@
             // FromBrowse
             // 
             FromBrowse.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            FromBrowse.Image = Properties.Images.BrowseFileExplorer;
+            FromBrowse.ImageAlign = ContentAlignment.MiddleLeft;
             FromBrowse.Location = new Point(526, 3);
             FromBrowse.Name = "FromBrowse";
             FromBrowse.Size = new Size(94, 24);
@@ -186,6 +188,8 @@
             // ToBrowse
             // 
             ToBrowse.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            ToBrowse.Image = Properties.Images.BrowseFileExplorer;
+            ToBrowse.ImageAlign = ContentAlignment.MiddleLeft;
             ToBrowse.Location = new Point(526, 34);
             ToBrowse.Name = "ToBrowse";
             ToBrowse.Size = new Size(94, 24);
@@ -345,7 +349,7 @@
             tpnlMain.RowStyles.Add(new RowStyle());
             tpnlMain.RowStyles.Add(new RowStyle());
             tpnlMain.RowStyles.Add(new RowStyle());
-            tpnlMain.Size = new Size(623, 286);
+            tpnlMain.Size = new Size(623, 294);
             tpnlMain.TabIndex = 0;
             // 
             // optionsPanel
@@ -365,7 +369,7 @@
             AcceptButton = Ok;
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
-            ClientSize = new Size(647, 351);
+            ClientSize = new Size(647, 359);
             HelpButton = true;
             ManualSectionAnchorName = "clone-repository";
             ManualSectionSubfolder = "getting_started";

--- a/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -179,6 +179,7 @@ namespace GitUI.CommandsDialogs
 
         private void FormResolveConflicts_Load(object sender, EventArgs e)
         {
+            InitMergetool();
             Initialize();
         }
 
@@ -239,8 +240,6 @@ namespace GitUI.CommandsDialogs
                         }
                     }
                 }
-
-                InitMergetool();
 
                 // Update UI after tool configuration is known
                 UpdateConflictedFilesMenu();

--- a/GitUI/CommandsDialogs/FormVerify.cs
+++ b/GitUI/CommandsDialogs/FormVerify.cs
@@ -46,10 +46,12 @@ namespace GitUI.CommandsDialogs
             columnDate.Width = DpiUtil.Scale(56);
             columnType.Width = DpiUtil.Scale(58);
             columnAuthor.Width = DpiUtil.Scale(150);
-            columnHash.Width = DpiUtil.Scale(280);
-            columnHash.MinimumWidth = DpiUtil.Scale(75);
-            columnParent.Width = DpiUtil.Scale(280);
-            columnParent.MinimumWidth = DpiUtil.Scale(75);
+            columnHash.Width = DpiUtil.Scale(60);
+            columnHash.MinimumWidth = DpiUtil.Scale(25);
+            columnHash.DefaultCellStyle.WrapMode = DataGridViewTriState.True;
+            columnParent.Width = DpiUtil.Scale(60);
+            columnParent.MinimumWidth = DpiUtil.Scale(25);
+            columnParent.DefaultCellStyle.WrapMode = DataGridViewTriState.True;
 
             _selectedItemsHeader.AttachTo(columnIsLostObjectSelected);
             fileViewer.ExtraDiffArgumentsChanged += Warnings_SelectionChanged;

--- a/GitUI/CommandsDialogs/Menus/ToolsToolStripMenuItem.Designer.cs
+++ b/GitUI/CommandsDialogs/Menus/ToolsToolStripMenuItem.Designer.cs
@@ -120,7 +120,7 @@
             settingsToolStripMenuItem.Image = Properties.Images.Settings;
             settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
             settingsToolStripMenuItem.Size = new Size(217, 22);
-            settingsToolStripMenuItem.Text = "&Settings";
+            settingsToolStripMenuItem.Text = "&Settings...";
             settingsToolStripMenuItem.Click += OnShowSettingsClick;
 
             DropDownItems.AddRange(new ToolStripItem[] {

--- a/GitUI/LeftPanel/BaseRevisionNode.cs
+++ b/GitUI/LeftPanel/BaseRevisionNode.cs
@@ -9,6 +9,7 @@ namespace GitUI.LeftPanel
     internal abstract class BaseRevisionNode : Node
     {
         protected const char PathSeparator = '/';
+        private static readonly Color _invisibleForeColor = Color.Silver.AdaptTextColor();
 
         protected BaseRevisionNode(Tree tree, string fullPath, bool visible)
             : base(tree)
@@ -56,7 +57,7 @@ namespace GitUI.LeftPanel
         {
             base.ApplyStyle();
 
-            TreeViewNode.ForeColor = Visible && TreeViewNode.TreeView is not null ? TreeViewNode.TreeView.ForeColor : Color.Silver.AdaptTextColor();
+            TreeViewNode.ForeColor = Visible && TreeViewNode.TreeView is not null ? TreeViewNode.TreeView.ForeColor : _invisibleForeColor;
             TreeViewNode.ImageKey = TreeViewNode.SelectedImageKey = Visible ? null : nameof(Images.EyeClosed);
         }
 

--- a/GitUI/Plugin/GitPluginSettingsContainer.cs
+++ b/GitUI/Plugin/GitPluginSettingsContainer.cs
@@ -1,67 +1,39 @@
 ﻿using GitCommands;
 using GitUIPluginInterfaces;
 
-namespace GitUI
+namespace GitUI;
+
+public class GitPluginSettingsContainer : SettingsSource, IGitPluginSettingsContainer
 {
-    public class GitPluginSettingsContainer : SettingsSource, IGitPluginSettingsContainer
+    private readonly string _pluginOldCompatibilityPrefix;
+    private readonly string _pluginPrefix;
+    private SettingsSource? _settingsSource;
+
+    public GitPluginSettingsContainer(Guid pluginId, string pluginName)
     {
-        private readonly Guid _pluginId;
-        private readonly string _pluginName;
-        private SettingsSource? _settingsSource;
-
-        public GitPluginSettingsContainer(Guid pluginId, string pluginName)
-        {
-            _pluginId = pluginId;
-            _pluginName = pluginName;
-        }
-
-        public SettingsSource GetSettingsSource()
-        {
-            return this;
-        }
-
-        public void SetSettingsSource(SettingsSource? settingsSource)
-        {
-            _settingsSource = settingsSource;
-        }
-
-        private SettingsSource ExternalSettings => _settingsSource ?? AppSettings.SettingsContainer;
-
-        public override SettingLevel SettingLevel
-        {
-            get => ExternalSettings.SettingLevel;
-            set => throw new InvalidOperationException(nameof(SettingLevel));
-        }
-
-        public override string? GetValue(string name)
-        {
-            // for old plugin setting processing
-            if (_pluginId == Guid.Empty)
-            {
-                return ExternalSettings.GetValue($"{_pluginName}{name}");
-            }
-
-            string value = ExternalSettings.GetValue($"{_pluginId}.{name}");
-
-            // for old plugin setting processing
-            if (value is null)
-            {
-                value = ExternalSettings.GetValue($"{_pluginName}{name}");
-            }
-
-            return value;
-        }
-
-        public override void SetValue(string name, string? value)
-        {
-            if (_pluginId == Guid.Empty)
-            {
-                ExternalSettings.SetValue($"{_pluginName}{name}", value);
-            }
-            else
-            {
-                ExternalSettings.SetValue($"{_pluginId}.{name}", value);
-            }
-        }
+        _pluginPrefix = pluginId == Guid.Empty ? pluginName : $"{pluginId}.";
+        _pluginOldCompatibilityPrefix = pluginName;
     }
+
+    public SettingsSource GetSettingsSource() => this;
+
+    public void SetSettingsSource(SettingsSource? settingsSource)
+    {
+        _settingsSource = settingsSource;
+    }
+
+    private SettingsSource ExternalSettings => _settingsSource ?? AppSettings.SettingsContainer;
+
+    public override SettingLevel SettingLevel
+    {
+        get => ExternalSettings.SettingLevel;
+        set => throw new InvalidOperationException(nameof(SettingLevel));
+    }
+
+    public override string? GetValue(string name)
+        => ExternalSettings.GetValue($"{_pluginPrefix}{name}")
+            ?? ExternalSettings.GetValue($"{_pluginOldCompatibilityPrefix}{name}");
+
+    public override void SetValue(string name, string? value)
+        => ExternalSettings.SetValue($"{_pluginPrefix}{name}", value);
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -2336,7 +2336,7 @@ compare with first:</source>
         <target />
       </trans-unit>
       <trans-unit id="_configureWorkingDirMenu.Text">
-        <source>&amp;Configure this menu</source>
+        <source>&amp;Configure this menu...</source>
         <target />
       </trans-unit>
       <trans-unit id="_consoleTabCaption.Text">
@@ -2702,7 +2702,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="pluginSettingsToolStripMenuItem.Text">
-        <source>Plugin &amp;Settings</source>
+        <source>Plugins &amp;settings...</source>
         <target />
       </trans-unit>
       <trans-unit id="pluginsLoadingToolStripMenuItem.Text">
@@ -2746,7 +2746,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="repoSettingsToolStripMenuItem.Text">
-        <source>Rep&amp;ository settings</source>
+        <source>Rep&amp;ository settings...</source>
         <target />
       </trans-unit>
       <trans-unit id="reportAnIssueToolStripMenuItem.Text">
@@ -2770,7 +2770,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="settingsToolStripMenuItem.Text">
-        <source>&amp;Settings</source>
+        <source>&amp;Settings...</source>
         <target />
       </trans-unit>
       <trans-unit id="startAuthenticationAgentToolStripMenuItem.Text">

--- a/GitUI/UserControls/PatchGrid.cs
+++ b/GitUI/UserControls/PatchGrid.cs
@@ -41,6 +41,7 @@ namespace GitUI
             CommitHash.Width = DpiUtil.Scale(55);
             authorDataGridViewTextBoxColumn.Width = DpiUtil.Scale(140);
             Patches.RowTemplate.MinimumHeight = Patches.ColumnHeadersHeight;
+            CommitHash.DefaultCellStyle.WrapMode = DataGridViewTriState.True;
 
             _commitDataManager = new CommitDataManager(() => Module);
         }


### PR DESCRIPTION
## Proposed changes

(better reviewed commit by commit)

- FormResolveConflicts: don't reinit merge tools after each file conflict resolved
- FormClone: Add Browse icons
- Menus: Add missing '...' to menu entries that will open a popup
- perf(LeftPanel): cache forecolor used for invisible refs
- refactor(GitPluginSettingsContainer): simplify logic
    - by putting the logic of backward compatibility when the container is created instead of every times a value is read
- perf(GitHub3Plugin): do less things
    - instantiate GitHubRemoteParser only once (instead for each remote parsed)
    - return an IEnumerable so that we could use a `.Any()` to stop earlier
- Hash column: remove ellipses

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

Browse icons added:

![image](https://github.com/gitextensions/gitextensions/assets/460196/ae2db307-7ac0-4333-8be3-5921ad93fee3)

Example of "..." added:

![image](https://github.com/gitextensions/gitextensions/assets/460196/310576a8-0e7e-41c2-9d66-97396784de25)

Hash columns: Remove "..."  and reduce size (as user need room to display subject or diff, could still have it in tooltip and is not really interested by this information) :
![image](https://github.com/gitextensions/gitextensions/assets/460196/d2062268-192e-4ae2-b5e1-d2fbd0c77423)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 08ed269e452d6b05e406a6182c5cd496c0bdf363
- Git 2.44.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer **rebase** merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
