### PR TITLE
DeleteRemote: Add an option to delete a local tracking branch

### DIFF
--- a/GitUI/CommandsDialogs/FormDeleteRemoteBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormDeleteRemoteBranch.Designer.cs
@@ -30,9 +30,11 @@
         {
             Delete = new Button();
             labelSelectBranches = new Label();
-            Branches = new GitUI.BranchComboBox();
+            Branches = new BranchComboBox();
+            DeleteLocalTrackingBranch = new CheckBox();
             tlpnlMain = new TableLayoutPanel();
             DeleteRemote = new CheckBox();
+            _NO_TRANSLATE_labelLocalTrackingBranches = new Label();
             MainPanel.SuspendLayout();
             ControlsPanel.SuspendLayout();
             tlpnlMain.SuspendLayout();
@@ -40,15 +42,17 @@
             // 
             // MainPanel
             // 
+            MainPanel.AutoSize = true;
+            MainPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             MainPanel.Controls.Add(tlpnlMain);
             MainPanel.Padding = new Padding(9);
-            MainPanel.Size = new Size(394, 73);
+            MainPanel.Size = new Size(403, 145);
             // 
             // ControlsPanel
             // 
             ControlsPanel.Controls.Add(Delete);
-            ControlsPanel.Location = new Point(0, 73);
-            ControlsPanel.Size = new Size(394, 41);
+            ControlsPanel.Location = new Point(0, 145);
+            ControlsPanel.Size = new Size(403, 41);
             // 
             // Delete
             // 
@@ -57,7 +61,7 @@
             Delete.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             Delete.Enabled = false;
             Delete.ForeColor = SystemColors.ControlText;
-            Delete.Location = new Point(306, 8);
+            Delete.Location = new Point(315, 8);
             Delete.MinimumSize = new Size(75, 23);
             Delete.Name = "Delete";
             Delete.Size = new Size(75, 25);
@@ -80,31 +84,50 @@
             // 
             // Branches
             // 
+            Branches.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             Branches.BranchesToSelect = null;
-            Branches.Dock = DockStyle.Fill;
             Branches.Location = new Point(95, 0);
             Branches.Margin = new Padding(0);
             Branches.Name = "Branches";
-            Branches.Size = new Size(286, 28);
+            Branches.Size = new Size(290, 28);
             Branches.TabIndex = 1;
+            Branches.SelectedValueChanged += Branches_SelectedValueChanged;
+            // 
+            // DeleteLocalTrackingBranch
+            // 
+            DeleteLocalTrackingBranch.AutoSize = true;
+            DeleteLocalTrackingBranch.Dock = DockStyle.Fill;
+            DeleteLocalTrackingBranch.Location = new Point(98, 56);
+            DeleteLocalTrackingBranch.Name = "DeleteLocalTrackingBranch";
+            DeleteLocalTrackingBranch.Size = new Size(284, 19);
+            DeleteLocalTrackingBranch.TabIndex = 3;
+            DeleteLocalTrackingBranch.Text = "Delete local tracking branch (if available)";
+            DeleteLocalTrackingBranch.UseVisualStyleBackColor = true;
+            DeleteLocalTrackingBranch.CheckedChanged += DeleteRemote_CheckedChanged;
             // 
             // tlpnlMain
             // 
+            tlpnlMain.AutoSize = true;
+            tlpnlMain.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             tlpnlMain.ColumnCount = 2;
             tlpnlMain.ColumnStyles.Add(new ColumnStyle());
             tlpnlMain.ColumnStyles.Add(new ColumnStyle());
             tlpnlMain.Controls.Add(labelSelectBranches, 0, 0);
             tlpnlMain.Controls.Add(Branches, 1, 0);
             tlpnlMain.Controls.Add(DeleteRemote, 1, 1);
+            tlpnlMain.Controls.Add(DeleteLocalTrackingBranch, 1, 2);
+            tlpnlMain.Controls.Add(_NO_TRANSLATE_labelLocalTrackingBranches, 1, 3);
             tlpnlMain.Dock = DockStyle.Fill;
             tlpnlMain.Location = new Point(9, 9);
             tlpnlMain.Margin = new Padding(0);
             tlpnlMain.Name = "tlpnlMain";
-            tlpnlMain.RowCount = 3;
+            tlpnlMain.RowCount = 5;
             tlpnlMain.RowStyles.Add(new RowStyle());
             tlpnlMain.RowStyles.Add(new RowStyle());
             tlpnlMain.RowStyles.Add(new RowStyle());
-            tlpnlMain.Size = new Size(376, 55);
+            tlpnlMain.RowStyles.Add(new RowStyle());
+            tlpnlMain.RowStyles.Add(new RowStyle(SizeType.Absolute, 20F));
+            tlpnlMain.Size = new Size(385, 127);
             tlpnlMain.TabIndex = 0;
             // 
             // DeleteRemote
@@ -113,18 +136,28 @@
             DeleteRemote.Dock = DockStyle.Fill;
             DeleteRemote.Location = new Point(98, 31);
             DeleteRemote.Name = "DeleteRemote";
-            DeleteRemote.Size = new Size(280, 19);
-            DeleteRemote.TabIndex = 3;
+            DeleteRemote.Size = new Size(284, 19);
+            DeleteRemote.TabIndex = 2;
             DeleteRemote.Text = "Delete branch(es) from &remote repository";
             DeleteRemote.UseVisualStyleBackColor = true;
             DeleteRemote.CheckedChanged += DeleteRemote_CheckedChanged;
+            // 
+            // _NO_TRANSLATE_labelLocalTrackingBranches
+            // 
+            _NO_TRANSLATE_labelLocalTrackingBranches.AutoSize = true;
+            _NO_TRANSLATE_labelLocalTrackingBranches.Location = new Point(98, 78);
+            _NO_TRANSLATE_labelLocalTrackingBranches.Name = "_NO_TRANSLATE_labelLocalTrackingBranches";
+            _NO_TRANSLATE_labelLocalTrackingBranches.Size = new Size(184, 15);
+            _NO_TRANSLATE_labelLocalTrackingBranches.TabIndex = 4;
+            _NO_TRANSLATE_labelLocalTrackingBranches.Text = "local tracking deletion candidates";
             // 
             // FormDeleteRemoteBranch
             // 
             AcceptButton = Delete;
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
-            ClientSize = new Size(394, 114);
+            AutoSize = true;
+            ClientSize = new Size(403, 186);
             HelpButton = true;
             ManualSectionAnchorName = "delete-branch";
             ManualSectionSubfolder = "branches";
@@ -135,13 +168,13 @@
             StartPosition = FormStartPosition.CenterParent;
             Text = "Delete branch";
             MainPanel.ResumeLayout(false);
+            MainPanel.PerformLayout();
             ControlsPanel.ResumeLayout(false);
             ControlsPanel.PerformLayout();
             tlpnlMain.ResumeLayout(false);
             tlpnlMain.PerformLayout();
             ResumeLayout(false);
             PerformLayout();
-
         }
 
         #endregion
@@ -151,5 +184,7 @@
         private CheckBox DeleteRemote;
         private BranchComboBox Branches;
         private TableLayoutPanel tlpnlMain;
+        private CheckBox DeleteLocalTrackingBranch;
+        private Label _NO_TRANSLATE_labelLocalTrackingBranches;
     }
 }

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -4376,8 +4376,16 @@ Proceed?</source>
         <source>&amp;Delete</source>
         <target />
       </trans-unit>
+      <trans-unit id="DeleteLocalTrackingBranch.Text">
+        <source>Delete local tracking branch (if available)</source>
+        <target />
+      </trans-unit>
       <trans-unit id="DeleteRemote.Text">
         <source>Delete branch(es) from &amp;remote repository</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_andMore.Text">
+        <source>and {0} more...</source>
         <target />
       </trans-unit>
       <trans-unit id="_confirmDeleteUnmergedRemoteBranchMessage.Text">
@@ -4387,6 +4395,10 @@ Deleting a branch can cause commits to be deleted too!</source>
       </trans-unit>
       <trans-unit id="_deleteRemoteBranchesCaption.Text">
         <source>Delete remote branches</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_toDeleteCandidates.Text">
+        <source>Local tracking branche(s) candidate to deletion:</source>
         <target />
       </trans-unit>
       <trans-unit id="labelSelectBranches.Text">

--- a/GitUI/UserControls/BranchComboBox.Designer.cs
+++ b/GitUI/UserControls/BranchComboBox.Designer.cs
@@ -41,6 +41,8 @@
             branches.Location = new Point(0, 3);
             branches.Name = "branches";
             branches.Size = new Size(304, 23);
+            branches.TabIndex = 0;
+            branches.SelectedValueChanged += branches_SelectedValueChanged;
             // 
             // selectMultipleBranchesButton
             // 
@@ -49,6 +51,7 @@
             selectMultipleBranchesButton.Location = new Point(308, 1);
             selectMultipleBranchesButton.Margin = new Padding(0);
             selectMultipleBranchesButton.Name = "selectMultipleBranchesButton";
+            selectMultipleBranchesButton.TabIndex = 1;
             selectMultipleBranchesButton.Size = new Size(23, 23);
             selectMultipleBranchesButton.UseVisualStyleBackColor = true;
             selectMultipleBranchesButton.Click += selectMultipleBranchesButton_Click;

--- a/GitUI/UserControls/BranchComboBox.cs
+++ b/GitUI/UserControls/BranchComboBox.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands;
+﻿using System.ComponentModel;
+using GitCommands;
 using GitExtUtils;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
@@ -18,6 +19,14 @@ namespace GitUI
 
             branches.DisplayMember = nameof(IGitRef.Name);
         }
+
+        /// <summary>
+        /// Occurs whenever the branch selection has changed.
+        /// </summary>
+        [Browsable(true)]
+        [Category("Action")]
+        [Description("Occurs whenever the branch selection has changed.")]
+        public event EventHandler SelectedValueChanged;
 
         private IReadOnlyList<IGitRef>? _branchesToSelect;
         public IReadOnlyList<IGitRef>? BranchesToSelect
@@ -57,17 +66,11 @@ namespace GitUI
             }
         }
 
-        public string GetSelectedText()
-        {
-            return branches.Text;
-        }
+        public string GetSelectedText() => branches.Text;
 
         public void SetSelectedText(string text)
         {
-            if (text is null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
+            ArgumentNullException.ThrowIfNull(text);
 
             branches.Text = text;
         }
@@ -95,6 +98,13 @@ namespace GitUI
             }
 
             branches.Text = branchesText;
+
+            OnSelectedValueChanged();
         }
+
+        private void branches_SelectedValueChanged(object sender, EventArgs e)
+            => OnSelectedValueChanged();
+
+        private void OnSelectedValueChanged() => SelectedValueChanged?.Invoke(this, EventArgs.Empty);
     }
 }


### PR DESCRIPTION
 at the same time than a remote

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Part of #11640 ( Following discussion)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/5d5c4db6-4972-46e2-8549-ae651df94b5a)

<!-- ![image](https://github.com/gitextensions/gitextensions/assets/460196/ab8f5a86-06a8-4435-b8ee-0f88ea5cb9de) -->

When remote deleted successfully, local branch delete form opened automatically with good branch(es) selected:
![delete_local_with_remote](https://github.com/gitextensions/gitextensions/assets/460196/15e9c959-2b68-4284-b1e5-a81afe657707)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build fe059f5db67923fbb93efe2115223b97129e161d (Dirty)
- Git 2.44.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
