### PR TITLE
feat(FormCommit): Add Conventional Commit message support

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.cs
+++ b/GitUI/CommandsDialogs/FormCommit.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.InteropServices;
@@ -15,7 +16,6 @@ using GitUI.AutoCompletion;
 using GitUI.CommandsDialogs.CommitDialog;
 using GitUI.Editor;
 using GitUI.HelperDialogs;
-using GitUI.Hotkey;
 using GitUI.Properties;
 using GitUI.ScriptsEngine;
 using GitUI.SpellChecker;
@@ -24,6 +24,7 @@ using GitUIPluginInterfaces;
 using Microsoft;
 using Microsoft.VisualStudio.Threading;
 using ResourceManager;
+using ResourceManager.Hotkey;
 
 namespace GitUI.CommandsDialogs
 {
@@ -127,7 +128,9 @@ namespace GitUI.CommandsDialogs
 
         private readonly TranslationString _commitValidationCaption = new("Commit validation");
 
-        private readonly TranslationString _commitMessageSettings = new("Edit commit message templates and settings...");
+        private readonly TranslationString _commitMessageSettings = new("&Edit commit message templates and settings...");
+        private readonly TranslationString _conventionalCommit = new("Conven&tional Commits");
+        private readonly TranslationString _conventionalCommitDocumentation = new("Documentation...");
 
         private readonly TranslationString _commitAuthorInfo = new("Author");
         private readonly TranslationString _commitCommitterInfo = new("Committer");
@@ -167,6 +170,12 @@ namespace GitUI.CommandsDialogs
         private readonly IFullPathResolver _fullPathResolver;
         private readonly List<string> _formattedLines = [];
 
+        private const string _feat = "feat";
+
+        private static readonly string[] _headerCommitTypes = ["build", "chore", "ci", "docs", _feat, "fix", "perf", "refactor", "style", "test"];
+        private static readonly string[] _footerKeywords = ["BREAKING CHANGE", "Co-authored-by", "Reviewed-by"];
+
+        private bool _insertScopeParentheses;
         private CommitKind _commitKind;
         private FileStatusList _currentFilesList;
         private bool _skipUpdate;
@@ -183,6 +192,7 @@ namespace GitUI.CommandsDialogs
         private IReadOnlyList<GitItemStatus>? _currentSelection;
         private int _alreadyLoadedTemplatesCount = -1;
         private EventHandler? _branchNameLabelOnClick;
+        private ToolStripMenuItem _conventionalCommitItem;
 
         private CommitKind CommitKind
         {
@@ -684,6 +694,8 @@ namespace GitUI.CommandsDialogs
             SelectPrevious = 22, // Ctrl+P
             SelectPrevious_AlternativeHotkey1 = 23, // Alt+Up
             SelectPrevious_AlternativeHotkey2 = 24, // Alt+Left
+            ConventionalCommit_PrefixMessage = 25, // Ctrl+T
+            ConventionalCommit_PrefixMessageWithScope = 26, // Ctrl+Shift+T
         }
 
         private bool AddSelectionToCommitMessage()
@@ -847,6 +859,8 @@ namespace GitUI.CommandsDialogs
             switch ((Command)cmd)
             {
                 case Command.AddToGitIgnore: return AddToGitIgnore();
+                case Command.ConventionalCommit_PrefixMessage: OpenConventionalCommitMenu(insertScope: false); return true;
+                case Command.ConventionalCommit_PrefixMessageWithScope: OpenConventionalCommitMenu(insertScope: true); return true;
                 case Command.DeleteSelectedFiles: return DeleteSelectedFiles();
                 case Command.FocusStagedFiles: return FocusStagedFiles();
                 case Command.FocusUnstagedFiles: return FocusUnstagedFiles();
@@ -2757,6 +2771,14 @@ namespace GitUI.CommandsDialogs
             }
         }
 
+        private void OpenConventionalCommitMenu(bool insertScope)
+        {
+            commitTemplatesToolStripMenuItem.ShowDropDown();
+            _conventionalCommitItem.ShowDropDown();
+            _conventionalCommitItem.DropDownItems.Cast<ToolStripItem>().First(i => i.Text == _feat).Select();
+            _insertScopeParentheses = insertScope;
+        }
+
         private void Message_TextChanged(object sender, EventArgs e)
         {
             // Format text, except when doing an undo, because
@@ -3096,7 +3118,10 @@ namespace GitUI.CommandsDialogs
                     AddSeparator();
                 }
 
-                // Add a settings item
+                AddConventionalCommitsItems();
+
+                AddSeparator();
+
                 AddSettingsItem();
                 commitTemplatesToolStripMenuItem.DropDown.ResumeLayout();
 
@@ -3144,7 +3169,146 @@ namespace GitUI.CommandsDialogs
                     };
                     commitTemplatesToolStripMenuItem.DropDownItems.Add(settingsItem);
                 }
+
+                void AddConventionalCommitsItems()
+                {
+                    _conventionalCommitItem = new(_conventionalCommit.Text, Images.GitCommandLog);
+
+                    foreach (string conventionKeyword in _headerCommitTypes)
+                    {
+                        ToolStripMenuItem commitTypeMenuItem = new(conventionKeyword, null, (_, _) =>
+                        {
+                            (string title, int selectionStart) = PrefixOrReplaceKeyword(conventionKeyword);
+
+                            if (Message.Text.Length == 0)
+                            {
+                                Message.Text = title;
+                            }
+                            else
+                            {
+                                Message.ReplaceLine(0, title);
+                            }
+
+                            Message.SelectionStart = selectionStart;
+                            Message.Focus();
+                        });
+
+                        if (commitTypeMenuItem.Text == _feat)
+                        {
+                            string hotkey1 = GetShortcutKeyDisplayString(Command.ConventionalCommit_PrefixMessage);
+                            string hotkey2 = GetShortcutKeyDisplayString(Command.ConventionalCommit_PrefixMessageWithScope);
+
+                            commitTypeMenuItem.ShortcutKeyDisplayString = hotkey1;
+
+                            if (!string.IsNullOrEmpty(hotkey1) && !string.IsNullOrEmpty(hotkey2))
+                            {
+                                commitTypeMenuItem.ShortcutKeyDisplayString += ", ";
+                            }
+
+                            commitTypeMenuItem.ShortcutKeyDisplayString += hotkey2;
+                        }
+
+                        _conventionalCommitItem.DropDownItems.Add(commitTypeMenuItem);
+                    }
+
+                    _conventionalCommitItem.DropDownItems.Add(new ToolStripSeparator());
+
+                    foreach (string footerKeyword in _footerKeywords)
+                    {
+                        AddFooter(footerKeyword, $"{footerKeyword}: ");
+                    }
+
+                    AddFooter("[skip ci]", keepCursorPosition: true);
+
+                    void AddFooter(string itemText, string messageText = null, bool keepCursorPosition = false)
+                    {
+                        messageText ??= itemText;
+                        _conventionalCommitItem.DropDownItems.Add(itemText, null, (_, _) =>
+                        {
+                            int lineCount = Message.LineCount();
+                            if (lineCount == 0)
+                            {
+                                Message.Text = $"{Environment.NewLine}{messageText}";
+                            }
+                            else
+                            {
+                                int lastLine = lineCount - 1;
+                                string currentLastLine = Message.Line(lastLine);
+                                Message.ReplaceLine(lastLine, $"{currentLastLine}{Environment.NewLine}{messageText}");
+                            }
+
+                            if (!keepCursorPosition)
+                            {
+                                Message.SelectionStart = Message.Text.Length;
+                            }
+
+                            Message.Focus();
+                        });
+                    }
+
+                    _conventionalCommitItem.DropDownItems.Add(new ToolStripSeparator());
+
+                    _conventionalCommitItem.DropDownItems.Add(_conventionalCommitDocumentation.Text, Images.Information, (_, _)
+                        => OsShellUtil.OpenUrlInDefaultBrowser("https://www.conventionalcommits.org"));
+
+                    commitTemplatesToolStripMenuItem.DropDownItems.Add(_conventionalCommitItem);
+                }
             }
+        }
+
+        private (string message, int selectionStart) PrefixOrReplaceKeyword(string keyword)
+        {
+            int currentPosition = Message.SelectionStart;
+            string scope = _insertScopeParentheses ? "()" : "";
+            int scopePosition = keyword.Length + 1;
+            int titlePosition = keyword.Length + (scope.Length / 2) + 2;
+
+            string currentTitle = string.IsNullOrWhiteSpace(Message.Text) ? string.Empty : Message.Line(0);
+
+            // Replacing current keyword
+            foreach (string key in _headerCommitTypes)
+            {
+                if (!currentTitle.StartsWith(key))
+                {
+                    continue;
+                }
+
+                if (currentTitle.Length == key.Length)
+                {
+                    return ($"{keyword}{scope}: ", _insertScopeParentheses ? scopePosition : titlePosition);
+                }
+
+                char nextChar = currentTitle[key.Length];
+                if (!_insertScopeParentheses)
+                {
+                    if (nextChar == ':' || nextChar == '(' || nextChar == '!')
+                    {
+                        return ReplaceKeyword(_ => titlePosition);
+                    }
+                }
+                else
+                {
+                    if (nextChar == ':' || nextChar == '!')
+                    {
+                        return ($"{keyword}(){currentTitle.Substring(key.Length)}", scopePosition);
+                    }
+
+                    if (nextChar == '(')
+                    {
+                        return ReplaceKeyword(newTitle => 2 + Math.Max(newTitle.IndexOf(":"), newTitle.IndexOf("(")));
+                    }
+                }
+
+                (string message, int selectionStart) ReplaceKeyword(Func<string, int> maxPosition)
+                {
+                    string newTitle = $"{keyword}{currentTitle.Substring(key.Length)}";
+                    int newMessageLength = Message.Text.Length + newTitle.Length - currentTitle.Length;
+                    return (newTitle, Math.Min(newMessageLength, Math.Max(maxPosition(newTitle), currentPosition + keyword.Length - key.Length)));
+                }
+            }
+
+            // Append current keyword
+            return ($"{keyword}{scope}: {currentTitle}", _insertScopeParentheses ? scopePosition : titlePosition + currentPosition);
         }
 
         private void openContainingFolderToolStripMenuItem_Click(object sender, EventArgs e)
@@ -3352,6 +3516,16 @@ namespace GitUI.CommandsDialogs
             internal Button ResetSoft => _formCommit.ResetSoft;
 
             internal void RescanChanges() => _formCommit.RescanChanges();
+
+            internal (string message, int selectionStart) PrefixOrReplaceKeyword(string keyword)
+                => _formCommit.PrefixOrReplaceKeyword(keyword);
+
+            internal bool IncludeFeatureParentheses { set => _formCommit._insertScopeParentheses = value; }
+            internal void SetMessageState(string text, int position)
+            {
+                _formCommit.Message.Text = text;
+                _formCommit.Message.SelectionStart = position;
+            }
         }
     }
 

--- a/GitUI/Hotkey/HotkeySettingsManager.cs
+++ b/GitUI/Hotkey/HotkeySettingsManager.cs
@@ -195,6 +195,8 @@ namespace GitUI.Hotkey
                     FormCommit.HotkeySettingsName,
                     Hk(FormCommit.Command.AddSelectionToCommitMessage, Keys.C),
                     Hk(FormCommit.Command.AddToGitIgnore, Keys.None),
+                    Hk(FormCommit.Command.ConventionalCommit_PrefixMessage, Keys.Control | Keys.T),
+                    Hk(FormCommit.Command.ConventionalCommit_PrefixMessageWithScope, Keys.Control | Keys.Shift | Keys.T),
                     Hk(FormCommit.Command.CreateBranch, Keys.Control | Keys.B),
                     Hk(FormCommit.Command.DeleteSelectedFiles, Keys.Delete),
                     Hk(FormCommit.Command.EditFile, EditFileHotkey),

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3581,7 +3581,7 @@ Git will never check if the file has changed that will improve status check perf
         <target />
       </trans-unit>
       <trans-unit id="_commitMessageSettings.Text">
-        <source>Edit commit message templates and settings...</source>
+        <source>&amp;Edit commit message templates and settings...</source>
         <target />
       </trans-unit>
       <trans-unit id="_commitMsgFirstLineInvalid.Text">
@@ -3609,6 +3609,14 @@ Do you want to continue?</source>
       </trans-unit>
       <trans-unit id="_commitValidationCaption.Text">
         <source>Commit validation</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_conventionalCommit.Text">
+        <source>Conven&amp;tional Commits</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_conventionalCommitDocumentation.Text">
+        <source>Documentation...</source>
         <target />
       </trans-unit>
       <trans-unit id="_deleteFailed.Text">

--- a/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
+++ b/IntegrationTests/UI.IntegrationTests/CommandsDialogs/FormCommitTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.ComponentModel.Design;
+using System.Windows.Forms;
 using CommonTestUtils;
 using FluentAssertions;
 using GitCommands;
@@ -548,6 +549,72 @@ namespace GitExtensions.UITests.CommandsDialogs
             RunGeometryMemoryTest(
                 form => form.GetTestAccessor().SelectedDiff.Bounds,
                 (bounds1, bounds2) => bounds2.Should().Be(bounds1));
+        }
+
+        [TestCase("", 0, "feat: ", 6)]
+        [TestCase("text", 3, "feat: text", 9)]
+        public void ConventionalCommit_keyword_is_prefixed_when_none(string initialText, int initialPosition,
+            string expectedText, int expectedPosition)
+        {
+            RunFormTest(form =>
+            {
+                FormCommit.TestAccessor testForm = form.GetTestAccessor();
+                testForm.SetMessageState(initialText, initialPosition);
+                testForm.IncludeFeatureParentheses = false;
+                (string message, int selectionStart) = testForm.PrefixOrReplaceKeyword("feat");
+                Assert.AreEqual(expectedText, message);
+                Assert.AreEqual(expectedPosition, selectionStart);
+            });
+        }
+
+        [TestCase("", 0, "feat(): ", 5)]
+        [TestCase("text", 3, "feat(): text", 5)]
+        public void ConventionalCommit_keyword_is_prefixed_when_none_with_scope(string initialText, int initialPosition,
+            string expectedText, int expectedPosition)
+        {
+            RunFormTest(form =>
+            {
+                FormCommit.TestAccessor testForm = form.GetTestAccessor();
+                testForm.SetMessageState(initialText, initialPosition);
+                testForm.IncludeFeatureParentheses = true;
+                (string message, int selectionStart) = testForm.PrefixOrReplaceKeyword("feat");
+                Assert.AreEqual(expectedText, message);
+                Assert.AreEqual(expectedPosition, selectionStart);
+            });
+        }
+
+        [TestCase("fix: ", 0, "feat: ", 6)]
+        [TestCase("fix: text", 3, "feat: text", 6)]
+        public void ConventionalCommit_keyword_is_prefixed_when_already_typed(string initialText, int initialPosition,
+            string expectedText, int expectedPosition)
+        {
+            RunFormTest(form =>
+            {
+                FormCommit.TestAccessor testForm = form.GetTestAccessor();
+                testForm.SetMessageState(initialText, initialPosition);
+                testForm.IncludeFeatureParentheses = false;
+                (string message, int selectionStart) = testForm.PrefixOrReplaceKeyword("feat");
+                Assert.AreEqual(expectedText, message);
+                Assert.AreEqual(expectedPosition, selectionStart);
+            });
+        }
+
+        [TestCase("fix: ", 0, "feat(): ", 5)]
+        [TestCase("fix: text", 3, "feat(): text", 5)]
+        [TestCase("fix(scope): ", 0, "feat(scope): ", 13)]
+        [TestCase("fix(scope): text", 14, "feat(scope): text", 15)]
+        public void ConventionalCommit_keyword_is_prefixed_when_already_typed_with_scope(string initialText, int initialPosition,
+            string expectedText, int expectedPosition)
+        {
+            RunFormTest(form =>
+            {
+                FormCommit.TestAccessor testForm = form.GetTestAccessor();
+                testForm.SetMessageState(initialText, initialPosition);
+                testForm.IncludeFeatureParentheses = true;
+                (string message, int selectionStart) = testForm.PrefixOrReplaceKeyword("feat");
+                Assert.AreEqual(expectedText, message);
+                Assert.AreEqual(expectedPosition, selectionStart);
+            });
         }
 
         [Test]


### PR DESCRIPTION
accessible easily with `Ctrl+T` shortcut
Then first letter of keyword (like 'r' for 'refactor') allows quick selection
then followed by pressing ENTER key.

See https://www.conventionalcommits.org/

and some others useful git commit footers...

Contribute to #11662
Fixes #5903 (See https://github.com/gitextensions/gitextensions/issues/5903#issuecomment-1837623364 )

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/f3f06747-7e2e-4a0e-ac3f-1ad6ed8eb832)

<!-- [](![image](https://github.com/gitextensions/gitextensions/assets/460196/eb0b37d5-e8b8-4a62-beb5-e40fa6d63425)) -->

![conventional_commits](https://github.com/gitextensions/gitextensions/assets/460196/81064678-9976-4c01-b754-26c0a1dbfcaa)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 9c00de36289e762d91125edea26c9fcc95b866e6 (Dirty)
- Git 2.44.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
