### PR TITLE
fix(FormResetAnotherBranch): Do not open ComboBox drop down on Enter

### DIFF
--- a/GitUI/HelperDialogs/FormResetAnotherBranch.cs
+++ b/GitUI/HelperDialogs/FormResetAnotherBranch.cs
@@ -112,7 +112,7 @@ namespace GitUI.HelperDialogs
 
         private void Branches_KeyUp(object sender, KeyEventArgs e)
         {
-            if (!Branches.DroppedDown && e.KeyCode is not (Keys.Menu or Keys.Escape))
+            if (!Branches.DroppedDown && e.KeyCode is not (Keys.Menu or Keys.Enter or Keys.Escape))
             {
                 string text = Branches.Text;
                 int selectionStart = Branches.SelectionStart;


### PR DESCRIPTION
Fixes #11671
which is a regression in #11656

## Proposed changes

- Also ignore `Enter` in `Branches_KeyUp`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).