### PR TITLE
Display "mixed" diff as red/green

### DIFF
--- a/GitUI/Editor/Diff/CombinedDiffHighlightService.cs
+++ b/GitUI/Editor/Diff/CombinedDiffHighlightService.cs
@@ -12,7 +12,6 @@ public class CombinedDiffHighlightService : DiffHighlightService
     private static readonly string[] _diffFullPrefixes = ["  ", "++", "+ ", " +", "--", "- ", " -"];
     private static readonly string[] _addedLinePrefixes = ["+", " +"];
     private static readonly string[] _removedLinePrefixes = ["-", " -"];
-    private static readonly string[] _diffSearchPrefixes = [.. _addedLinePrefixes, .. _removedLinePrefixes];
 
     public CombinedDiffHighlightService(ref string text, bool useGitColoring)
         : base(ref text, useGitColoring)
@@ -21,7 +20,7 @@ public class CombinedDiffHighlightService : DiffHighlightService
 
     public override void SetLineControl(DiffViewerLineNumberControl lineNumbersControl, TextEditorControl textEditor)
     {
-        DiffLinesInfo result = new DiffLineNumAnalyzer().Analyze(textEditor.Text, isCombinedDiff: true);
+        DiffLinesInfo result = DiffLineNumAnalyzer.Analyze(textEditor, isCombinedDiff: true);
         lineNumbersControl.DisplayLineNum(result, showLeftColumn: true);
     }
 
@@ -29,8 +28,6 @@ public class CombinedDiffHighlightService : DiffHighlightService
         => GetGitCommandConfiguration(module, useGitColoring, "diff-tree");
 
     public override string[] GetFullDiffPrefixes() => _diffFullPrefixes;
-
-    public override bool IsSearchMatch(string line) => line.StartsWithAny(_diffSearchPrefixes);
 
     protected override List<ISegment> GetAddedLines(IDocument document, ref int line, ref bool found)
         => LinePrefixHelper.GetLinesStartingWith(document, ref line, _addedLinePrefixes, ref found);

--- a/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -116,7 +116,7 @@ public abstract class DiffHighlightService : TextHighlightService
     }
 
     public override bool IsSearchMatch(DiffViewerLineNumberControl lineNumbersControl, int indexInText)
-        => lineNumbersControl.GetLineInfo(indexInText)?.LineType is (DiffLineType.Minus or DiffLineType.Plus or DiffLineType.Mixed or DiffLineType.Grep);
+        => lineNumbersControl.GetLineInfo(indexInText)?.LineType is (DiffLineType.Minus or DiffLineType.Plus or DiffLineType.MinusPlus or DiffLineType.Grep);
 
     public abstract string[] GetFullDiffPrefixes();
 

--- a/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -19,7 +19,6 @@ public abstract class DiffHighlightService : TextHighlightService
     public DiffHighlightService(ref string text, bool useGitColoring)
     {
         _useGitColoring = useGitColoring;
-
         SetText(ref text);
     }
 
@@ -116,9 +115,10 @@ public abstract class DiffHighlightService : TextHighlightService
         }
     }
 
-    public abstract string[] GetFullDiffPrefixes();
+    public override bool IsSearchMatch(DiffViewerLineNumberControl lineNumbersControl, int indexInText)
+        => lineNumbersControl.GetLineInfo(indexInText)?.LineType is (DiffLineType.Minus or DiffLineType.Plus or DiffLineType.Mixed or DiffLineType.Grep);
 
-    public abstract bool IsSearchMatch(string line);
+    public abstract string[] GetFullDiffPrefixes();
 
     protected readonly LinePrefixHelper LinePrefixHelper = new(new LineSegmentGetter());
 

--- a/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
+++ b/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
@@ -85,9 +85,9 @@ public partial class DiffLineNumAnalyzer
                 DiffLineInfo meta = new()
                 {
                     LineNumInDiff = lineNumInDiff,
-                    LeftLineNumber = isGitWordDiff ? DiffLineInfo.NotApplicableLineNum : leftLineNum,
-                    RightLineNumber = isGitWordDiff ? rightLineNum : DiffLineInfo.NotApplicableLineNum,
-                    LineType = DiffLineType.Minus
+                    LeftLineNumber = leftLineNum,
+                    RightLineNumber = DiffLineInfo.NotApplicableLineNum,
+                    LineType = isGitWordDiff ? DiffLineType.MinusLeft : DiffLineType.Minus
                 };
                 ret.Add(meta);
 
@@ -101,7 +101,7 @@ public partial class DiffLineNumAnalyzer
                     LineNumInDiff = lineNumInDiff,
                     LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
                     RightLineNumber = rightLineNum,
-                    LineType = DiffLineType.Plus,
+                    LineType = isGitWordDiff ? DiffLineType.PlusRight : DiffLineType.Plus,
                 };
                 ret.Add(meta);
                 rightLineNum++;
@@ -111,11 +111,12 @@ public partial class DiffLineNumAnalyzer
                 DiffLineInfo meta = new()
                 {
                     LineNumInDiff = lineNumInDiff,
-                    LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
+                    LeftLineNumber = leftLineNum,
                     RightLineNumber = rightLineNum,
-                    LineType = DiffLineType.Mixed,
+                    LineType = DiffLineType.MinusPlus,
                 };
                 ret.Add(meta);
+                leftLineNum++;
                 rightLineNum++;
             }
             else if (i == lines.Length - 1 && line.StartsWith(GitModule.NoNewLineAtTheEnd))
@@ -134,7 +135,7 @@ public partial class DiffLineNumAnalyzer
                 DiffLineInfo meta = new()
                 {
                     LineNumInDiff = lineNumInDiff,
-                    LeftLineNumber = isGitWordDiff ? DiffLineInfo.NotApplicableLineNum : leftLineNum,
+                    LeftLineNumber = leftLineNum,
                     RightLineNumber = rightLineNum,
                     LineType = DiffLineType.Context,
                 };

--- a/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
+++ b/GitUI/Editor/Diff/DiffLineNumAnalyzer.cs
@@ -1,5 +1,9 @@
 ﻿using System.Text.RegularExpressions;
 using GitCommands;
+using GitExtUtils.GitUI.Theming;
+using GitUI.Theming;
+using ICSharpCode.TextEditor;
+using ICSharpCode.TextEditor.Document;
 
 namespace GitUI.Editor.Diff;
 
@@ -8,14 +12,15 @@ public partial class DiffLineNumAnalyzer
     [GeneratedRegex(@"\-(?<leftStart>\d{1,})\,{0,}(?<leftCount>\d{0,})\s\+(?<rightStart>\d{1,})\,{0,}(?<rightCount>\d{0,})", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture)]
     private static partial Regex DiffRegex();
 
-    public DiffLinesInfo Analyze(string diffContent, bool isCombinedDiff)
+    public static DiffLinesInfo Analyze(TextEditorControl textEditor, bool isCombinedDiff, bool isGitWordDiff = false)
     {
         DiffLinesInfo ret = new();
         int lineNumInDiff = 0;
         int leftLineNum = DiffLineInfo.NotApplicableLineNum;
         int rightLineNum = DiffLineInfo.NotApplicableLineNum;
         bool isHeaderLineLocated = false;
-        string[] lines = diffContent.Split(Delimiters.LineFeed);
+        string[] lines = textEditor.Text.Split(Delimiters.LineFeed);
+        int textOffset = 0; // for git-diff-word
         for (int i = 0; i < lines.Length; i++)
         {
             string line = lines[i];
@@ -24,8 +29,10 @@ public partial class DiffLineNumAnalyzer
                 break;
             }
 
+            int textLength = lines[i].Length + 1;
+            Lazy<List<TextMarker>> textMarkers = new(() => textEditor.Document.MarkerStrategy.GetMarkers(textOffset, textLength));
             lineNumInDiff++;
-            if (line.StartsWith('@'))
+            if (line.StartsWith("@@"))
             {
                 DiffLineInfo meta = new()
                 {
@@ -70,20 +77,24 @@ public partial class DiffLineNumAnalyzer
 
                 ret.Add(meta);
             }
-            else if (isHeaderLineLocated && IsMinusLine(line))
+            else if (isHeaderLineLocated && ((!isGitWordDiff && IsMinusLine(line))
+
+                // Heuristics: For GitWordDiff AppSettings.UseGEThemeGitColoring is assumed, otherwise just DiffLineType.Mixed is detected
+                || (isGitWordDiff && textMarkers.Value.Count > 0 && textMarkers.Value.All(i => i.Color == AppColor.DiffRemoved.GetThemeColor()))))
             {
                 DiffLineInfo meta = new()
                 {
                     LineNumInDiff = lineNumInDiff,
-                    LeftLineNumber = leftLineNum,
-                    RightLineNumber = DiffLineInfo.NotApplicableLineNum,
+                    LeftLineNumber = isGitWordDiff ? DiffLineInfo.NotApplicableLineNum : leftLineNum,
+                    RightLineNumber = isGitWordDiff ? rightLineNum : DiffLineInfo.NotApplicableLineNum,
                     LineType = DiffLineType.Minus
                 };
                 ret.Add(meta);
 
                 leftLineNum++;
             }
-            else if (isHeaderLineLocated && IsPlusLine(line))
+            else if (isHeaderLineLocated && ((!isGitWordDiff && IsPlusLine(line))
+                || (isGitWordDiff && textMarkers.Value.Count > 0 && textMarkers.Value.All(i => i.Color == AppColor.DiffAdded.GetThemeColor()))))
             {
                 DiffLineInfo meta = new()
                 {
@@ -95,7 +106,19 @@ public partial class DiffLineNumAnalyzer
                 ret.Add(meta);
                 rightLineNum++;
             }
-            else if (line.StartsWith(GitModule.NoNewLineAtTheEnd))
+            else if (isHeaderLineLocated && isGitWordDiff && textMarkers.Value.Count > 0)
+            {
+                DiffLineInfo meta = new()
+                {
+                    LineNumInDiff = lineNumInDiff,
+                    LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
+                    RightLineNumber = rightLineNum,
+                    LineType = DiffLineType.Mixed,
+                };
+                ret.Add(meta);
+                rightLineNum++;
+            }
+            else if (i == lines.Length - 1 && line.StartsWith(GitModule.NoNewLineAtTheEnd))
             {
                 DiffLineInfo meta = new()
                 {
@@ -111,7 +134,7 @@ public partial class DiffLineNumAnalyzer
                 DiffLineInfo meta = new()
                 {
                     LineNumInDiff = lineNumInDiff,
-                    LeftLineNumber = leftLineNum,
+                    LeftLineNumber = isGitWordDiff ? DiffLineInfo.NotApplicableLineNum : leftLineNum,
                     RightLineNumber = rightLineNum,
                     LineType = DiffLineType.Context,
                 };
@@ -120,6 +143,8 @@ public partial class DiffLineNumAnalyzer
                 leftLineNum++;
                 rightLineNum++;
             }
+
+            textOffset += textLength;
         }
 
         return ret;

--- a/GitUI/Editor/Diff/DiffLineType.cs
+++ b/GitUI/Editor/Diff/DiffLineType.cs
@@ -6,5 +6,6 @@ public enum DiffLineType
     Plus,
     Minus,
     Context,
-    Grep
+    Mixed,
+    Grep,
 }

--- a/GitUI/Editor/Diff/DiffLineType.cs
+++ b/GitUI/Editor/Diff/DiffLineType.cs
@@ -6,6 +6,8 @@ public enum DiffLineType
     Plus,
     Minus,
     Context,
-    Mixed,
+    MinusLeft,
+    PlusRight,
+    MinusPlus,
     Grep,
 }

--- a/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
+++ b/GitUI/Editor/Diff/DiffViewerLineNumberControl.cs
@@ -78,13 +78,26 @@ public class DiffViewerLineNumberControl : AbstractMargin
                 continue;
             }
 
-            if (diffLine.LineType != DiffLineType.Context)
+            if (diffLine.LineType is DiffLineType.MinusPlus or DiffLineType.MinusLeft or DiffLineType.PlusRight)
+            {
+                if (diffLine.LineType is not DiffLineType.PlusRight)
+                {
+                    using Brush leftBrush = new SolidBrush(AppColor.DiffRemoved.GetThemeColor());
+                    g.FillRectangle(leftBrush, new Rectangle(0, backgroundRectangle.Top, backgroundRectangle.Width / 2, backgroundRectangle.Height));
+                }
+
+                if (diffLine.LineType is not DiffLineType.MinusLeft)
+                {
+                    using Brush rightBrush = new SolidBrush(AppColor.DiffAdded.GetThemeColor());
+                    g.FillRectangle(rightBrush, new Rectangle(backgroundRectangle.Width / 2, backgroundRectangle.Top, rightWidth, backgroundRectangle.Height));
+                }
+            }
+            else if (diffLine.LineType != DiffLineType.Context)
             {
                 using Brush brush = diffLine.LineType switch
                 {
                     DiffLineType.Plus => new SolidBrush(AppColor.DiffAdded.GetThemeColor()),
                     DiffLineType.Minus => new SolidBrush(AppColor.DiffRemoved.GetThemeColor()),
-                    DiffLineType.Mixed => new SolidBrush(Color.FromArgb(255, 0xc8, 0xc5, 0xff)),
                     DiffLineType.Header => new SolidBrush(AppColor.DiffSection.GetThemeColor()),
                     DiffLineType.Grep => new SolidBrush(AppColor.DiffRemoved.GetThemeColor()),
                     _ => default(Brush)

--- a/GitUI/Editor/Diff/GrepHighlightService.cs
+++ b/GitUI/Editor/Diff/GrepHighlightService.cs
@@ -27,7 +27,7 @@ public partial class GrepHighlightService : TextHighlightService
         => SetText(ref text, useGitColoring, grepString);
 
     public override bool IsSearchMatch(DiffViewerLineNumberControl lineNumbersControl, int indexInText)
-        => lineNumbersControl.GetLineInfo(indexInText)?.LineType is (DiffLineType.Minus or DiffLineType.Plus or DiffLineType.Mixed or DiffLineType.Grep);
+        => lineNumbersControl.GetLineInfo(indexInText)?.LineType is (DiffLineType.Minus or DiffLineType.Plus or DiffLineType.MinusPlus or DiffLineType.Grep);
 
     public override void SetLineControl(DiffViewerLineNumberControl lineNumbersControl, TextEditorControl textEditor)
         => lineNumbersControl.DisplayLineNum(_matchInfos, showLeftColumn: false);

--- a/GitUI/Editor/Diff/GrepHighlightService.cs
+++ b/GitUI/Editor/Diff/GrepHighlightService.cs
@@ -13,9 +13,8 @@ namespace GitUI.Editor.Diff;
 
 public partial class GrepHighlightService : TextHighlightService
 {
-    private readonly bool _useGitColoring;
     private readonly List<TextMarker> _textMarkers = [];
-    private List<(int lineno, bool match)> _matchInfos = [];
+    private DiffLinesInfo _matchInfos = new();
 
     [GeneratedRegex(@"-e\s*(((?<q>""|')(?<quote>.*?)\k<q>)|(?<noquote>[^\s]+))", RegexOptions.ExplicitCapture)]
     private static partial Regex GrepSearchStringRegex();
@@ -25,38 +24,36 @@ public partial class GrepHighlightService : TextHighlightService
     private static partial Regex GrepLineColumnRegex();
 
     public GrepHighlightService(ref string text, bool useGitColoring, string grepString)
-    {
-        _useGitColoring = useGitColoring;
-        SetText(ref text, useGitColoring, grepString);
-    }
+        => SetText(ref text, useGitColoring, grepString);
+
+    public override bool IsSearchMatch(DiffViewerLineNumberControl lineNumbersControl, int indexInText)
+        => lineNumbersControl.GetLineInfo(indexInText)?.LineType is (DiffLineType.Minus or DiffLineType.Plus or DiffLineType.Mixed or DiffLineType.Grep);
 
     public override void SetLineControl(DiffViewerLineNumberControl lineNumbersControl, TextEditorControl textEditor)
-    {
-        lineNumbersControl.DisplayLineNum(GetDiffLinesInfo(), showLeftColumn: false);
-    }
+        => lineNumbersControl.DisplayLineNum(_matchInfos, showLeftColumn: false);
 
     /// <summary>
     /// Get the next/previous line for the grep match.
     /// </summary>
     /// <param name="rowIndexInText">The row index (starting from 0) for the current position.</param>
     /// <param name="next"><c>true</c> if next position, <c>false</c> if previous.</param>
-    /// <returns>The next/previous line if found, -1 otherwise.</returns>
+    /// <returns>The next/previous index if found, -1 otherwise.</returns>
     public int GetGrepLineNum(int rowIndexInText, bool next)
     {
         int increase = next ? 1 : -1;
 
         // If start index is on a match, move to next
-        if (rowIndexInText >= 0 && rowIndexInText < _matchInfos.Count && _matchInfos[rowIndexInText].match)
+        if (_matchInfos.DiffLines.TryGetValue(rowIndexInText, out DiffLineInfo lineInfo) && lineInfo.LineType == DiffLineType.Grep)
         {
             rowIndexInText += increase;
         }
 
-        while (rowIndexInText >= 0 && rowIndexInText < _matchInfos.Count && !_matchInfos[rowIndexInText].match)
+        while (_matchInfos.DiffLines.TryGetValue(rowIndexInText, out lineInfo) && lineInfo.LineType != DiffLineType.Grep)
         {
             rowIndexInText += increase;
         }
 
-        return rowIndexInText >= 0 && rowIndexInText < _matchInfos.Count && _matchInfos[rowIndexInText].match ? rowIndexInText : -1;
+        return lineInfo?.LineType is DiffLineType.Grep ? rowIndexInText - increase : -1;
     }
 
     public static GitCommandConfiguration GetGitCommandConfiguration(IGitModule module, bool useGitColoring)
@@ -118,7 +115,7 @@ public partial class GrepHighlightService : TextHighlightService
             {
                 if (sb.Length > 0)
                 {
-                    _matchInfos.Add((DiffLineInfo.NotApplicableLineNum, false));
+                    _matchInfos.Add(GetDiffLineInfo(DiffLineInfo.NotApplicableLineNum, false));
                     sb.Append('\n');
                 }
 
@@ -144,7 +141,7 @@ public partial class GrepHighlightService : TextHighlightService
             }
 
             bool isMatch = match.Groups["kind"].Success && match.Groups["kind"].Value == ":";
-            _matchInfos.Add((lineNo, isMatch));
+            _matchInfos.Add(GetDiffLineInfo(lineNo, isMatch));
             string grepText = match.Groups["text"].Value;
 
             if (useGitColoring)
@@ -192,29 +189,16 @@ public partial class GrepHighlightService : TextHighlightService
     /// for git-diff this is parsed dynamically.
     /// </summary>
     /// <returns>The type of contents for all editor lines.</returns>
-    private DiffLinesInfo GetDiffLinesInfo()
-    {
-        DiffLinesInfo result = new();
-        for (int i = 0; i < _matchInfos.Count; ++i)
+    private DiffLineInfo GetDiffLineInfo(int lineno, bool match)
+        => new()
         {
-            int lineno = _matchInfos[i].lineno;
-            bool match = _matchInfos[i].match;
-
-            DiffLineInfo diffLineInfo = new()
-            {
-                LineNumInDiff = i + 1,
-                LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
-                RightLineNumber = lineno,
-                LineType = lineno == DiffLineInfo.NotApplicableLineNum
+            LineNumInDiff = _matchInfos.DiffLines.Count + 1,
+            LeftLineNumber = DiffLineInfo.NotApplicableLineNum,
+            RightLineNumber = lineno,
+            LineType = lineno == DiffLineInfo.NotApplicableLineNum
                     ? DiffLineType.Header
                     : match
                         ? DiffLineType.Grep
                         : DiffLineType.Context
-            };
-
-            result.Add(diffLineInfo);
-        }
-
-        return result;
-    }
+        };
 }

--- a/GitUI/Editor/Diff/ITextHighlightService.cs
+++ b/GitUI/Editor/Diff/ITextHighlightService.cs
@@ -15,6 +15,15 @@ public interface ITextHighlightService
     void AddTextHighlighting([NotNull] IDocument document);
 
     /// <summary>
+    /// Check if the index (line) in the text is a search match
+    /// for next/previous navigation, e.g. +/- for regular patches.
+    /// </summary>
+    /// <param name="lineNumbersControl">The line number control.</param>
+    /// <param name="indexInText">The index in the viewer text.</param>
+    /// <returns><see langword="true"/> if the line is a searchmatch; otherwise <see langword="false"/>.</returns>
+    bool IsSearchMatch(DiffViewerLineNumberControl lineNumbersControl, int indexInText);
+
+    /// <summary>
     /// Set info in line number control for e.g. Patch/Diff views
     /// where the line number is non sequential.
     /// Other views (like normal text) do not use this control.

--- a/GitUI/Editor/Diff/PatchHighlightService.cs
+++ b/GitUI/Editor/Diff/PatchHighlightService.cs
@@ -27,7 +27,7 @@ public class PatchHighlightService : DiffHighlightService
     {
         bool isGitWordDiff = _useGitColoring && AppSettings.ShowGitWordColoring.Value;
         DiffLinesInfo result = DiffLineNumAnalyzer.Analyze(textEditor, isCombinedDiff: false, isGitWordDiff);
-        lineNumbersControl.DisplayLineNum(result, showLeftColumn: !isGitWordDiff);
+        lineNumbersControl.DisplayLineNum(result, showLeftColumn: true);
     }
 
     public static GitCommandConfiguration GetGitCommandConfiguration(IGitModule module, bool useGitColoring)

--- a/GitUI/Editor/Diff/PatchHighlightService.cs
+++ b/GitUI/Editor/Diff/PatchHighlightService.cs
@@ -1,4 +1,5 @@
-﻿using GitExtUtils;
+﻿using GitCommands;
+using GitExtUtils;
 using GitExtUtils.GitUI.Theming;
 using GitUI.Theming;
 using GitUIPluginInterfaces;
@@ -16,7 +17,6 @@ public class PatchHighlightService : DiffHighlightService
     private const string _addedLinePrefix = "+";
     private const string _removedLinePrefix = "-";
     private static readonly string[] _diffFullPrefixes = [" ", _addedLinePrefix, _removedLinePrefix];
-    private static readonly string[] _diffSearchPrefixes = [_addedLinePrefix, _removedLinePrefix];
 
     public PatchHighlightService(ref string text, bool useGitColoring)
         : base(ref text, useGitColoring)
@@ -25,17 +25,15 @@ public class PatchHighlightService : DiffHighlightService
 
     public override void SetLineControl(DiffViewerLineNumberControl lineNumbersControl, TextEditorControl textEditor)
     {
-        // Note: This is the fourth time the text is parsed...
-        DiffLinesInfo result = new DiffLineNumAnalyzer().Analyze(textEditor.Text, isCombinedDiff: false);
-        lineNumbersControl.DisplayLineNum(result, showLeftColumn: true);
+        bool isGitWordDiff = _useGitColoring && AppSettings.ShowGitWordColoring.Value;
+        DiffLinesInfo result = DiffLineNumAnalyzer.Analyze(textEditor, isCombinedDiff: false, isGitWordDiff);
+        lineNumbersControl.DisplayLineNum(result, showLeftColumn: !isGitWordDiff);
     }
 
     public static GitCommandConfiguration GetGitCommandConfiguration(IGitModule module, bool useGitColoring)
         => GetGitCommandConfiguration(module, useGitColoring, "diff");
 
     public override string[] GetFullDiffPrefixes() => _diffFullPrefixes;
-
-    public override bool IsSearchMatch(string line) => line.StartsWithAny(_diffSearchPrefixes);
 
     protected override List<ISegment> GetAddedLines(IDocument document, ref int line, ref bool found)
         => LinePrefixHelper.GetLinesStartingWith(document, ref line, _addedLinePrefix, ref found);

--- a/GitUI/Editor/Diff/TextHighlightService.cs
+++ b/GitUI/Editor/Diff/TextHighlightService.cs
@@ -1,4 +1,5 @@
-﻿using ICSharpCode.TextEditor;
+﻿using GitExtUtils;
+using ICSharpCode.TextEditor;
 using ICSharpCode.TextEditor.Document;
 
 namespace GitUI.Editor.Diff;
@@ -14,11 +15,17 @@ public class TextHighlightService : ITextHighlightService
     {
     }
 
-    public virtual void SetLineControl(DiffViewerLineNumberControl lineNumbersControl, TextEditorControl textEditor)
+    public virtual void AddTextHighlighting(IDocument document)
     {
     }
 
-    public virtual void AddTextHighlighting(IDocument document)
+    public virtual bool IsSearchMatch(DiffViewerLineNumberControl lineNumbersControl, int indexInText)
+    {
+        DebugHelpers.Fail($"Unexpected highlight service {GetType()}, not a diff/grep type.");
+        return false;
+    }
+
+    public virtual void SetLineControl(DiffViewerLineNumberControl lineNumbersControl, TextEditorControl textEditor)
     {
     }
 }

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -524,7 +524,8 @@ namespace GitUI.Editor
                     }
                     else
                     {
-                        internalFileViewer.SetText(text, openWithDifftool);
+                        internalFileViewer.SetText(text, openWithDifftool, _viewMode, useGitColoring: false);
+
                         if (line is not null)
                         {
                             GoToLine(line.Value);
@@ -841,7 +842,7 @@ namespace GitUI.Editor
             treatAllFilesAsTextToolStripMenuItem.Visible = viewMode.IsPartialTextView();
 
             // toolbar
-            bool hasNextPreviousButton = viewMode.IsPartialTextView() && !ShowGitWordColoring;
+            bool hasNextPreviousButton = viewMode.IsPartialTextView();
             nextChangeButton.Visible = hasNextPreviousButton;
             previousChangeButton.Visible = hasNextPreviousButton;
 

--- a/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
@@ -163,18 +163,18 @@ public class DiffLineNumAnalyzerTests
 
         result.DiffLines[6].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
         result.DiffLines[6].RightLineNumber.Should().Be(1);
-        result.DiffLines[6].LineType.Should().Be(DiffLineType.Plus);
+        result.DiffLines[6].LineType.Should().Be(DiffLineType.PlusRight);
 
-        result.DiffLines[8].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[8].LeftLineNumber.Should().Be(1);
         result.DiffLines[8].RightLineNumber.Should().Be(3);
         result.DiffLines[8].LineType.Should().Be(DiffLineType.Context);
 
-        result.DiffLines[15].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
-        result.DiffLines[15].RightLineNumber.Should().Be(20);
-        result.DiffLines[15].LineType.Should().Be(DiffLineType.Minus);
+        result.DiffLines[15].LeftLineNumber.Should().Be(19);
+        result.DiffLines[15].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[15].LineType.Should().Be(DiffLineType.MinusLeft);
 
-        result.DiffLines[23].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[23].LeftLineNumber.Should().Be(28);
         result.DiffLines[23].RightLineNumber.Should().Be(28);
-        result.DiffLines[23].LineType.Should().Be(DiffLineType.Mixed);
+        result.DiffLines[23].LineType.Should().Be(DiffLineType.MinusPlus);
     }
 }

--- a/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/Diff/DiffLineNumAnalyzerTests.cs
@@ -1,37 +1,51 @@
 ﻿using FluentAssertions;
+using GitExtUtils.GitUI.Theming;
 using GitUI.Editor.Diff;
+using GitUI.Theming;
+using ICSharpCode.TextEditor;
 
 namespace GitUITests.Editor.Diff;
 
+[Apartment(ApartmentState.STA)]
 [TestFixture]
 public class DiffLineNumAnalyzerTests
 {
-    private static readonly string TestDataDir = Path.Combine(TestContext.CurrentContext.TestDirectory, "Editor", "Diff");
+    private static readonly string _testDataDir = Path.Combine(TestContext.CurrentContext.TestDirectory, "Editor", "Diff");
     private readonly string _sampleDiff;
     private readonly string _sampleCombinedDiff;
-    private DiffLineNumAnalyzer _lineNumAnalyzer;
+    private readonly string _sampleGitWordDiff;
+    private readonly TextEditorControl _textEditor;
 
     public DiffLineNumAnalyzerTests()
     {
         // File copied from https://github.com/libgit2/libgit2sharp/pull/1034/files
-        _sampleDiff = File.ReadAllText(Path.Combine(TestDataDir, "Sample.diff"));
+        _sampleDiff = File.ReadAllText(Path.Combine(_testDataDir, "Sample.diff"));
+        _sampleCombinedDiff = File.ReadAllText(Path.Combine(_testDataDir, "SampleCombined.diff"));
 
-        _sampleCombinedDiff = File.ReadAllText(Path.Combine(TestDataDir, "SampleCombined.diff"));
+        // Adjust the colors to match the current theme. (See code comments for limitations.)
+        Color added = AppColor.DiffAdded.GetThemeColor();
+        Color removed = AppColor.DiffRemoved.GetThemeColor();
+        _sampleGitWordDiff = File.ReadAllText(Path.Combine(_testDataDir, "SampleGitWord.diff"))
+            .Replace(@";200;255;200m", $";{added.R};{added.G};{added.B}m")
+            .Replace(@";255;200;200m", $";{removed.R};{removed.G};{removed.B}m");
+        _textEditor = new TextEditorControl();
     }
 
-    [SetUp]
-    public void SetUp()
+    [TearDown]
+    public void TearDown()
     {
-        _lineNumAnalyzer = new DiffLineNumAnalyzer();
+        _textEditor.Dispose();
     }
 
     [Test]
     public void CanGetHeaders()
     {
-        DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: true);
+        _textEditor.Text = _sampleDiff;
+        DiffLinesInfo result = DiffLineNumAnalyzer.Analyze(_textEditor, isCombinedDiff: true);
         List<int> headerLines = [5, 17];
         foreach (int header in headerLines)
         {
+            result.DiffLines[header].LineType.Should().Be(DiffLineType.Header);
             result.DiffLines[header].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
             result.DiffLines[header].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
         }
@@ -40,17 +54,26 @@ public class DiffLineNumAnalyzerTests
     [Test]
     public void CanGetContextLines()
     {
-        DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: false);
+        _textEditor.Text = _sampleDiff;
+        DiffLinesInfo result = DiffLineNumAnalyzer.Analyze(_textEditor, isCombinedDiff: false);
 
+        result.DiffLines[6].LineNumInDiff.Should().Be(6);
+        result.DiffLines[6].LineType.Should().Be(DiffLineType.Context);
         result.DiffLines[6].LeftLineNumber.Should().Be(9);
         result.DiffLines[6].RightLineNumber.Should().Be(9);
 
+        result.DiffLines[14].LineNumInDiff.Should().Be(14);
+        result.DiffLines[14].LineType.Should().Be(DiffLineType.Context);
         result.DiffLines[14].LeftLineNumber.Should().Be(15);
         result.DiffLines[14].RightLineNumber.Should().Be(16);
 
+        result.DiffLines[18].LineNumInDiff.Should().Be(18);
+        result.DiffLines[18].LineType.Should().Be(DiffLineType.Context);
         result.DiffLines[18].LeftLineNumber.Should().Be(33);
         result.DiffLines[18].RightLineNumber.Should().Be(34);
 
+        result.DiffLines[25].LineNumInDiff.Should().Be(25);
+        result.DiffLines[25].LineType.Should().Be(DiffLineType.Context);
         result.DiffLines[25].LeftLineNumber.Should().Be(39);
         result.DiffLines[25].RightLineNumber.Should().Be(40);
     }
@@ -58,11 +81,16 @@ public class DiffLineNumAnalyzerTests
     [Test]
     public void CanGetMinusLines()
     {
-        DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: false);
+        _textEditor.Text = _sampleDiff;
+        DiffLinesInfo result = DiffLineNumAnalyzer.Analyze(_textEditor, isCombinedDiff: false);
 
+        result.DiffLines[9].LineNumInDiff.Should().Be(9);
+        result.DiffLines[9].LineType.Should().Be(DiffLineType.Minus);
         result.DiffLines[9].LeftLineNumber.Should().Be(12);
         result.DiffLines[9].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
 
+        result.DiffLines[21].LineNumInDiff.Should().Be(21);
+        result.DiffLines[21].LineType.Should().Be(DiffLineType.Minus);
         result.DiffLines[21].LeftLineNumber.Should().Be(36);
         result.DiffLines[21].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
     }
@@ -70,14 +98,21 @@ public class DiffLineNumAnalyzerTests
     [Test]
     public void CanGetPlusLines()
     {
-        DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleDiff, isCombinedDiff: false);
+        _textEditor.Text = _sampleDiff;
+        DiffLinesInfo result = DiffLineNumAnalyzer.Analyze(_textEditor, isCombinedDiff: false);
 
+        result.DiffLines[12].LineNumInDiff.Should().Be(12);
+        result.DiffLines[12].LineType.Should().Be(DiffLineType.Plus);
         result.DiffLines[12].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
         result.DiffLines[12].RightLineNumber.Should().Be(14);
 
+        result.DiffLines[13].LineNumInDiff.Should().Be(13);
+        result.DiffLines[13].LineType.Should().Be(DiffLineType.Plus);
         result.DiffLines[13].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
         result.DiffLines[13].RightLineNumber.Should().Be(15);
 
+        result.DiffLines[22].LineNumInDiff.Should().Be(22);
+        result.DiffLines[22].LineType.Should().Be(DiffLineType.Plus);
         result.DiffLines[22].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
         result.DiffLines[22].RightLineNumber.Should().Be(37);
     }
@@ -85,7 +120,8 @@ public class DiffLineNumAnalyzerTests
     [Test]
     public void CanGetLineNumbersForCombinedDiff()
     {
-        DiffLinesInfo result = _lineNumAnalyzer.Analyze(_sampleCombinedDiff, isCombinedDiff: true);
+        _textEditor.Text = _sampleCombinedDiff;
+        DiffLinesInfo result = DiffLineNumAnalyzer.Analyze(_textEditor, isCombinedDiff: true);
 
         result.DiffLines[6].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
         result.DiffLines[6].RightLineNumber.Should().Be(70);
@@ -110,5 +146,35 @@ public class DiffLineNumAnalyzerTests
         result.DiffLines[38].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
         result.DiffLines[38].RightLineNumber.Should().Be(103);
         result.DiffLines[38].LineType.Should().Be(DiffLineType.Plus);
+    }
+
+    [Test]
+    public void CanGetGitWordDiffInfo()
+    {
+        string text = _sampleGitWordDiff;
+        DiffHighlightService diffHighlightService = new PatchHighlightService(ref text, useGitColoring: true);
+        _textEditor.Text = text;
+        diffHighlightService.AddTextHighlighting(_textEditor.Document);
+        DiffLinesInfo result = DiffLineNumAnalyzer.Analyze(_textEditor, isCombinedDiff: false, isGitWordDiff: true);
+
+        result.DiffLines[5].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[5].RightLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[5].LineType.Should().Be(DiffLineType.Header);
+
+        result.DiffLines[6].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[6].RightLineNumber.Should().Be(1);
+        result.DiffLines[6].LineType.Should().Be(DiffLineType.Plus);
+
+        result.DiffLines[8].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[8].RightLineNumber.Should().Be(3);
+        result.DiffLines[8].LineType.Should().Be(DiffLineType.Context);
+
+        result.DiffLines[15].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[15].RightLineNumber.Should().Be(20);
+        result.DiffLines[15].LineType.Should().Be(DiffLineType.Minus);
+
+        result.DiffLines[23].LeftLineNumber.Should().Be(DiffLineInfo.NotApplicableLineNum);
+        result.DiffLines[23].RightLineNumber.Should().Be(28);
+        result.DiffLines[23].LineType.Should().Be(DiffLineType.Mixed);
     }
 }

--- a/UnitTests/GitUI.Tests/Editor/Diff/SampleGitWord.diff
+++ b/UnitTests/GitUI.Tests/Editor/Diff/SampleGitWord.diff
@@ -1,0 +1,37 @@
+[1mdiff --git a/GitUI/Editor/Diff/PatchHighlightService.cs b/GitUI/Editor/Diff/PatchHighlightService.cs[m
+[1mindex 6e386..cad79 100644[m
+[1m--- a/GitUI/Editor/Diff/PatchHighlightService.cs[m
+[1m+++ b/GitUI/Editor/Diff/PatchHighlightService.cs[m
+[36m@@ -1,4 +1,5 @@[m
+﻿using [38;2;0;0;0;48;2;200;255;200mGitCommands;[m
+[38;2;0;0;0;48;2;200;255;200musing[m GitExtUtils;
+using GitExtUtils.GitUI.Theming;[m
+using GitUI.Theming;[m
+using GitUIPluginInterfaces;[m
+[36m@@ -16,7 +17,6 @@[m [mpublic class PatchHighlightService : DiffHighlightService[m
+    private const string _addedLinePrefix = "+";[m
+    private const string _removedLinePrefix = "-";[m
+    private static readonly string[] _diffFullPrefixes = [" ", _addedLinePrefix, _removedLinePrefix];[m
+[38;2;0;0;0;48;2;255;200;200m    private static readonly string[] _diffSearchPrefixes = [_addedLinePrefix, _removedLinePrefix];[m
+
+    public PatchHighlightService(ref string text, bool useGitColoring)[m
+        : base(ref text, useGitColoring)[m
+[36m@@ -25,9 +25,9 @@[m [mpublic PatchHighlightService(ref string text, bool useGitColoring)[m
+
+    public override void SetLineControl(DiffViewerLineNumberControl lineNumbersControl, TextEditorControl textEditor)[m
+    {[m
+        [38;2;0;0;0;48;2;255;200;200m// Note: This is the fourth time the text is parsed...[m[38;2;0;0;0;48;2;200;255;200mbool isGitWordDiff = _useGitColoring && AppSettings.ShowGitWordColoring.Value;[m
+        DiffLinesInfo result = new DiffLineNumAnalyzer().Analyze(textEditor[38;2;0;0;0;48;2;255;200;200m.Text[m, isCombinedDiff: false[38;2;0;0;0;48;2;200;255;200m, isGitWordDiff[m);
+        lineNumbersControl.DisplayLineNum(result, showLeftColumn: [38;2;0;0;0;48;2;255;200;200mtrue[m[38;2;0;0;0;48;2;200;255;200m!isGitWordDiff[m);
+    }[m
+
+    public static GitCommandConfiguration GetGitCommandConfiguration(IGitModule module, bool useGitColoring)[m
+[36m@@ -35,8 +35,6 @@[m [mpublic static GitCommandConfiguration GetGitCommandConfiguration(IGitModule modu[m
+
+    public override string[] GetFullDiffPrefixes() => _diffFullPrefixes;[m
+
+[38;2;0;0;0;48;2;255;200;200m    public override bool IsSearchMatch(string line) => line.StartsWithAny(_diffSearchPrefixes);[m
+
+    protected override List<ISegment> GetAddedLines(IDocument document, ref int line, ref bool found)[m
+        => LinePrefixHelper.GetLinesStartingWith(document, ref line, _addedLinePrefix, ref found);[m
+

--- a/UnitTests/GitUI.Tests/Editor/FileViewerInternal.CurrentViewPositionCacheTests.cs
+++ b/UnitTests/GitUI.Tests/Editor/FileViewerInternal.CurrentViewPositionCacheTests.cs
@@ -117,7 +117,7 @@ namespace GitUITests.Editor
             test.TextEditor.ActiveTextAreaControl.TextArea.ScrollToCaret();
             test.TextEditor.ActiveTextAreaControl.TextArea.TextView.FirstVisibleLine = 18;
             test.LineNumberControl = new DiffViewerLineNumberControl(test.TextEditor.ActiveTextAreaControl.TextArea);
-            DiffLinesInfo result = new DiffLineNumAnalyzer().Analyze(test.TextEditor.Text, isCombinedDiff: false);
+            DiffLinesInfo result = DiffLineNumAnalyzer.Analyze(test.TextEditor, isCombinedDiff: false);
             test.LineNumberControl.DisplayLineNum(result, showLeftColumn: true);
 
             _viewPositionCache.Capture();

--- a/UnitTests/GitUI.Tests/GitUI.Tests.csproj
+++ b/UnitTests/GitUI.Tests/GitUI.Tests.csproj
@@ -16,10 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="Editor\Diff\Sample.diff">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Editor\Diff\SampleCombined.diff">
+    <None Include="Editor\Diff\*.diff">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
Modification of #11628, approved but not yet merged.
First command is squash and rebase of the commit, not really to be reviewed

If this is approved, I plan to squash together wit the changes in #11628 as one commit.

## Proposed changes

Modification of the presentation in #11628 of GitWordDiff

- Show line number for removed, even if the info is unreliable
- Instead of the blueish line marker show removed line number (if changes detected) in red and new with green. Similar for when changes are only seen on one side, the other is then not colored. 

## Screenshots <!-- Remove this section if PR does not change UI -->

See #11628 also for the change in this PR

## Test methodology <!-- How did you ensure quality? -->

Tests are updated

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
