### PR TITLE
Always use Git coloring for word-diff

### DIFF
--- a/GitUI/Editor/Diff/DiffHighlightService.cs
+++ b/GitUI/Editor/Diff/DiffHighlightService.cs
@@ -122,11 +122,38 @@ public abstract class DiffHighlightService : TextHighlightService
 
     protected readonly LinePrefixHelper LinePrefixHelper = new(new LineSegmentGetter());
 
-    protected abstract List<ISegment> GetAddedLines(IDocument document, ref int line, ref bool found);
+    /// <summary>
+    /// Parse the text in the document from line and return the added lines directly following.
+    /// Overridden in the HighlightServices where GE coloring is used (AddTextHighlighting() for Patch and CombinedDiff).
+    /// </summary>
+    /// <param name="document">The document to analyze.</param>
+    /// <param name="line">The line number to start with, updated with the last line processed.</param>
+    /// <param name="found">Ref updated if any added lines were found.</param>
+    /// <returns>List with the segments of added lines.</returns>
+    protected virtual List<ISegment> GetAddedLines(IDocument document, ref int line, ref bool found)
+        => [];
 
-    protected abstract List<ISegment> GetRemovedLines(IDocument document, ref int line, ref bool found);
+    /// <summary>
+    /// Parse the text in the document from line and return the removed lines directly following.
+    /// Overridden in the HighlightServices where GE coloring is used (AddTextHighlighting() for Patch and CombinedDiff).
+    /// </summary>
+    /// <param name="document">The document to analyze.</param>
+    /// <param name="line">The line number to start with, updated with the last line processed.</param>
+    /// <param name="found">Ref updated if any removed lines were found.</param>
+    /// <returns>List with the segments of removed lines.</returns>
+    protected virtual List<ISegment> GetRemovedLines(IDocument document, ref int line, ref bool found)
+        => [];
 
-    protected abstract int TryHighlightAddedAndDeletedLines(IDocument document, int line, LineSegment lineSegment);
+    /// <summary>
+    /// Highlight the directly following lines.
+    /// Overridden in the HighlightServices where GE coloring is used (AddTextHighlighting() for Patch and CombinedDiff).
+    /// </summary>
+    /// <param name="document">The document to analyze.</param>
+    /// <param name="line">The line number to start with.</param>
+    /// <param name="lineSegment">The segment for the starting line.</param>
+    /// <returns>The last line number processed.</returns>
+    protected virtual int TryHighlightAddedAndDeletedLines(IDocument document, int line, LineSegment lineSegment)
+        => line;
 
     protected void ProcessLineSegment(IDocument document, ref int line,
         LineSegment lineSegment, string prefixStr, Color color, bool invertMatch = false)

--- a/GitUI/Editor/Diff/RangeDiffHighlightService.cs
+++ b/GitUI/Editor/Diff/RangeDiffHighlightService.cs
@@ -1,7 +1,5 @@
 using System.Text.RegularExpressions;
 using GitExtUtils;
-using GitExtUtils.GitUI.Theming;
-using GitUI.Theming;
 using GitUIPluginInterfaces;
 using ICSharpCode.TextEditor;
 using ICSharpCode.TextEditor.Document;
@@ -17,57 +15,15 @@ public partial class RangeDiffHighlightService : DiffHighlightService
     private static partial Regex RangeHeaderRegex();
 
     private static readonly string[] _diffFullPrefixes = ["      ", "    ++", "    + ", "     +", "    --", "    - ", "     -", "    +-", "    -+", "    "];
-    private static readonly string[] _addedLinePrefixes = ["+", " +"];
-    private static readonly string[] _removedLinePrefixes = ["-", " -"];
 
-    public RangeDiffHighlightService(ref string text, bool useGitColoring)
-        : base(ref text, useGitColoring)
+    public RangeDiffHighlightService(ref string text)
+        : base(ref text, useGitColoring: true)
     {
     }
 
     // git-range-diff has an extended subset of git-diff options, base is the same
-    public static GitCommandConfiguration GetGitCommandConfiguration(IGitModule module, bool useGitColoring)
-        => GetGitCommandConfiguration(module, useGitColoring, "range-diff");
-
-    public override void AddTextHighlighting(IDocument document)
-    {
-        if (_useGitColoring)
-        {
-            foreach (TextMarker tm in _textMarkers)
-            {
-                document.MarkerStrategy.AddMarker(tm);
-            }
-
-            return;
-        }
-
-        bool forceAbort = false;
-
-        for (int line = 0; line < document.TotalNumberOfLines && !forceAbort; line++)
-        {
-            LineSegment lineSegment = document.GetLineSegment(line);
-
-            if (lineSegment.TotalLength == 0)
-            {
-                continue;
-            }
-
-            if (line == document.TotalNumberOfLines - 1)
-            {
-                forceAbort = true;
-            }
-
-            line = TryHighlightAddedAndDeletedLines(document, line, lineSegment);
-
-            ProcessLineSegment(document, ref line, lineSegment, "    ", AppColor.AuthoredHighlight.GetThemeColor(), true);
-            ProcessLineSegment(document, ref line, lineSegment, "    @@", AppColor.DiffSection.GetThemeColor());
-            ProcessLineSegment(document, ref line, lineSegment, "     @@", AppColor.DiffSection.GetThemeColor());
-            ProcessLineSegment(document, ref line, lineSegment, "    -@@", AppColor.DiffSection.GetThemeColor());
-            ProcessLineSegment(document, ref line, lineSegment, "    +@@", AppColor.DiffSection.GetThemeColor());
-            ProcessLineSegment(document, ref line, lineSegment, "      ## ", AppColor.DiffSection.GetThemeColor());
-            ProcessLineSegment(document, ref line, lineSegment, "       ##", AppColor.DiffSection.GetThemeColor());
-        }
-    }
+    public static GitCommandConfiguration GetGitCommandConfiguration(IGitModule module)
+        => DiffHighlightService.GetGitCommandConfiguration(module, useGitColoring: true, "range-diff");
 
     public override bool IsSearchMatch(DiffViewerLineNumberControl lineNumbersControl, int indexInText)
         => lineNumbersControl.GetLineInfo(indexInText)?.LineType is DiffLineType.Header;
@@ -95,27 +51,11 @@ public partial class RangeDiffHighlightService : DiffHighlightService
 
     public override string[] GetFullDiffPrefixes() => _diffFullPrefixes;
 
-    protected override List<ISegment> GetAddedLines(IDocument document, ref int line, ref bool found)
-        => LinePrefixHelper.GetLinesStartingWith(document, ref line, _addedLinePrefixes, ref found);
-
-    protected override List<ISegment> GetRemovedLines(IDocument document, ref int line, ref bool found)
-        => LinePrefixHelper.GetLinesStartingWith(document, ref line, _removedLinePrefixes, ref found);
-
-    protected override int TryHighlightAddedAndDeletedLines(IDocument document, int line, LineSegment lineSegment)
+    public override void AddTextHighlighting(IDocument document)
     {
-        // part of range-diff dual-color
-
-        // Only changed in selected
-        ProcessLineSegment(document, ref line, lineSegment, "    ++", AppColor.DiffAddedExtra.GetThemeColor());
-        ProcessLineSegment(document, ref line, lineSegment, "    +-", AppColor.DiffRemovedExtra.GetThemeColor());
-
-        // Only changed in first or same change in both
-        ProcessLineSegment(document, ref line, lineSegment, "    -+", AppColor.DiffAdded.GetThemeColor());
-        ProcessLineSegment(document, ref line, lineSegment, "    --", AppColor.DiffRemoved.GetThemeColor());
-        ProcessLineSegment(document, ref line, lineSegment, "     -", AppColor.DiffRemoved.GetThemeColor());
-        ProcessLineSegment(document, ref line, lineSegment, "     +", AppColor.DiffAdded.GetThemeColor());
-
-        // No highlight for lines removed in both first/selected
-        return line;
+        foreach (TextMarker tm in _textMarkers)
+        {
+            document.MarkerStrategy.AddMarker(tm);
+        }
     }
 }

--- a/GitUI/Editor/FileViewerInternal.cs
+++ b/GitUI/Editor/FileViewerInternal.cs
@@ -243,7 +243,7 @@ namespace GitUI.Editor
         /// <param name="text">The text to set in the editor.</param>
         /// <param name="openWithDifftool">The command to open the difftool.</param>
         /// <param name="viewMode">the view viewMode in the file viewer, the kind of info shown</param>
-        public void SetText(string text, Action? openWithDifftool, ViewMode viewMode, bool useGitColoring, string? grepString = null)
+        public void SetText(string text, Action? openWithDifftool, ViewMode viewMode, bool useGitColoring)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
@@ -257,8 +257,8 @@ namespace GitUI.Editor
                 ViewMode.Text => TextHighlightService.Instance,
                 ViewMode.Diff or ViewMode.FixedDiff => new PatchHighlightService(ref text, useGitColoring),
                 ViewMode.CombinedDiff => new CombinedDiffHighlightService(ref text, useGitColoring),
-                ViewMode.RangeDiff => new RangeDiffHighlightService(ref text, useGitColoring),
-                ViewMode.Grep => new GrepHighlightService(ref text, useGitColoring, grepString),
+                ViewMode.RangeDiff => new RangeDiffHighlightService(ref text),
+                ViewMode.Grep => new GrepHighlightService(ref text),
                 _ => throw new ArgumentException($"Unexpected viewMode: {viewMode}", nameof(viewMode))
             };
 


### PR DESCRIPTION
## Proposed changes

as well as range-diff and git-grep.

Use of Git coloring of command output was added in #11590. The patch view (default) is configurable, setting to keep the current GE coloring.
git word-diff requires Git coloring and is not enabled if not Git coloring is enabled.

This removes the GE coloring for some commands ans the GE coloring is very limited and is adding complexity.
* git-word-diff (#11590)
* git-grep (#11359)
* git-range-diff (very limited GE coloring).

It is possible that a user want to keep the GE color engine for patches but use it for these commands.

Related to #11673 (and is a merge conflict), ther is a rebased commit in tmp/git-coloring but I want this reviewed in parallel.

## Screenshots <!-- Remove this section if PR does not change UI -->

No changes in the default configuration,  the first image is for without GE coloring.

git word-diff, only when git coloring is activated

![image](https://github.com/gitextensions/gitextensions/assets/6248932/76e2d382-358a-4380-920f-c7e51f42dfcb)

git-grep with regex (guess for length is incorrect)

![image](https://github.com/gitextensions/gitextensions/assets/6248932/b2db1255-7cfd-42d4-a5b3-c33eae78c921)

![image](https://github.com/gitextensions/gitextensions/assets/6248932/300bc177-974a-4608-b4c4-3586d572a47a)

range-diff

![image](https://github.com/gitextensions/gitextensions/assets/6248932/51cae703-b81e-4697-ad71-c7fce210ac25)

![image](https://github.com/gitextensions/gitextensions/assets/6248932/489d89a5-8a35-4d8f-b117-c5abcfadc29c)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
