### PR TITLE
feat(RevisionGrid): Column width adjustments

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/DateColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/DateColumnProvider.cs
@@ -15,13 +15,15 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         {
             _grid = grid;
 
+            int initialWidth = AppSettings.RelativeDate ? DpiUtil.Scale(130) : TextRenderer.MeasureText(DateTime.Now.ToString("G"), AppSettings.Font).Width;
+
             Column = new DataGridViewTextBoxColumn
             {
                 AutoSizeMode = DataGridViewAutoSizeColumnMode.None,
                 HeaderText = "Date",
                 ReadOnly = true,
                 SortMode = DataGridViewColumnSortMode.NotSortable,
-                Width = DpiUtil.Scale(130),
+                Width = initialWidth,
                 MinimumWidth = DpiUtil.Scale(25)
             };
         }


### PR DESCRIPTION
## Proposed changes

- Enforce HashColumn max width to hash length
- Adjust DateColumn width to exact content when date is displayed in "absolute date" (because the length is constant)

## Screenshots <!-- Remove this section if PR does not change UI -->

### Date column auto width

* Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/24791c26-c69d-4a15-8d17-7f06ccc0a535)

* After (no more lost space)
![image](https://github.com/gitextensions/gitextensions/assets/460196/74e61da0-d2cd-469f-996f-3a501d526a30)

### Hash column max width enforced to hash length

* Before (column could take a lot too much width):
![hash_column_width_not_enforced](https://github.com/gitextensions/gitextensions/assets/460196/9c782b6d-7e4c-4587-9cef-063045bac798)

* After (column took only required width to display whole hash):
![hash_column_width_enforced](https://github.com/gitextensions/gitextensions/assets/460196/ac0e5e6c-c9a0-4aba-b3b6-8e0e5127716b)



## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build d0b8ca8a5c59d1086b7e19a38ca0b94ac25c0cd5
- Git 2.44.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer **rebase** merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
