### PR TITLE
fix finding merge base when unrelated history

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -2835,10 +2835,22 @@ namespace GitUI
                 revisions
             };
 
-            string mergeBaseCommitId = UICommands.Module.GitExecutable.GetOutput(args).TrimEnd('\n');
+            ExecutionResult result = UICommands.Module.GitExecutable.Execute(args, throwOnErrorExit: false);
+
+            // Not related histories: https://git-scm.com/docs/git-merge-base#Documentation/git-merge-base.txt---is-ancestor
+            const int NoCommonAncestorsExitCode = 1;
+            if (result.ExitCode == NoCommonAncestorsExitCode)
+            {
+                MessageBoxes.ShowError(this, _noMergeBaseCommit.Text);
+                return;
+            }
+
+            result.ThrowIfErrorExit();
+
+            string mergeBaseCommitId = result.StandardOutput.TrimEnd();
             if (string.IsNullOrWhiteSpace(mergeBaseCommitId))
             {
-                MessageBox.Show(_noMergeBaseCommit.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBoxes.ShowError(this, _noMergeBaseCommit.Text);
                 return;
             }
 


### PR DESCRIPTION
i.e there is no common ancestors.
"merge-base" command exit code is 1
which is not an error but more a "nothing found".

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/d6963665-e97d-4776-bdd1-831ff7520a01)

### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/fc2759ea-7d41-4152-9254-31c1422e7ea7)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build e8497aecf376488273c1ffc6293f9ac3b6318814
- Git 2.44.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
