### PR TITLE
Fix FormClone DPI issues

### DIFF
--- a/GitUI/CommandsDialogs/FormClone.Designer.cs
+++ b/GitUI/CommandsDialogs/FormClone.Designer.cs
@@ -51,6 +51,8 @@
             // 
             // MainPanel
             // 
+            MainPanel.AutoSize = true;
+            MainPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             MainPanel.Controls.Add(tpnlMain);
             MainPanel.Size = new Size(647, 318);
             // 
@@ -280,10 +282,13 @@
             // groupBox1
             // 
             groupBox1.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            groupBox1.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            groupBox1.AutoSize = true;
             groupBox1.Controls.Add(CentralRepository);
             groupBox1.Controls.Add(PersonalRepository);
             groupBox1.Location = new Point(3, 184);
             groupBox1.Margin = new Padding(3, 4, 3, 0);
+            groupBox1.MaximumSize = new Size(0, 78);
             groupBox1.Name = "groupBox1";
             groupBox1.Size = new Size(617, 78);
             groupBox1.TabIndex = 2;
@@ -370,12 +375,13 @@
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(647, 359);
+            AutoSize = true;
             HelpButton = true;
             ManualSectionAnchorName = "clone-repository";
             ManualSectionSubfolder = "getting_started";
             MaximizeBox = false;
-            MinimizeBox = false;
             MaximumSize = new Size(950, 398);
+            MinimizeBox = false;
             MinimumSize = new Size(450, 398);
             Name = "FormClone";
             StartPosition = FormStartPosition.CenterParent;


### PR DESCRIPTION
## Proposed changes

- Set relevant `AutoSize` / `AutoScale` properties for form/controls to fix Dpi issues
- Adjust `groupBox1` size related props to make it look good in all DPIs

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Notice how radio buttons are shifted down before resizing the form. Also... does anyone know why the heck the text is selected in the combo-boxes upon resize?

https://github.com/gitextensions/gitextensions/assets/483659/be7297fa-cf3d-43ac-bb7c-6dc0ebc242a3

### After

![image](https://github.com/gitextensions/gitextensions/assets/483659/c7e81c70-678b-43fe-8281-4dc8ed6482c1)

## Test methodology <!-- How did you ensure quality? -->

- Manually at 100% 150% and 200% scaling

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11
- 100% 150% 200% Scaling

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
