### PR TITLE
Fix "Modify the commit message" button Dpi scaling

### DIFF
--- a/GitUI/CommandsDialogs/FormCommit.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCommit.Designer.cs
@@ -1028,10 +1028,12 @@ namespace GitUI.CommandsDialogs
             // modifyCommitMessageButton
             //
             modifyCommitMessageButton.AutoSize = true;
+            modifyCommitMessageButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             modifyCommitMessageButton.BackColor = SystemColors.ButtonFace;
             modifyCommitMessageButton.FlatStyle = FlatStyle.Flat;
             modifyCommitMessageButton.ForeColor = SystemColors.HotTrack;
             modifyCommitMessageButton.Location = new Point(185, 55);
+            modifyCommitMessageButton.MinimumSize = new Size(149, 25);
             modifyCommitMessageButton.Name = "modifyCommitMessageButton";
             modifyCommitMessageButton.Size = new Size(149, 25);
             modifyCommitMessageButton.TabIndex = 9;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Fix button scaling

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/483659/7280ea60-26fa-4e06-ab28-077516e15624)

### After

![image](https://github.com/gitextensions/gitextensions/assets/483659/4c95e8d6-a64e-4e42-918a-d3699202e7dd)

## Test methodology <!-- How did you ensure quality? -->

- Manually with 100% and 200% scaling

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11
- 100% and 200% scaling

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
