### PR TITLE
Scale PictureBox background images

### DIFF
--- a/GitExtUtils/GitUI/ControlDpiExtensions.cs
+++ b/GitExtUtils/GitUI/ControlDpiExtensions.cs
@@ -46,6 +46,11 @@ namespace GitUI
                             pictureBox.Image = DpiUtil.Scale(pictureBox.Image);
                         }
 
+                        if (isDpiScaled && pictureBox.BackgroundImage is not null)
+                        {
+                            pictureBox.BackgroundImage = DpiUtil.Scale(pictureBox.BackgroundImage);
+                        }
+
                         break;
                     }
 


### PR DESCRIPTION
## Proposed changes

- At the moment only the foreground image of the `PictureBox` is scaled but in some cases the image is set as background image and that has not been scaled up until now

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

(notice the tiny ℹ️ icon below the file list)
![image](https://github.com/gitextensions/gitextensions/assets/483659/84aa2159-b557-4d54-bd23-8d5c02b1cff6)

### After

<!-- TODO -->
![image](https://github.com/gitextensions/gitextensions/assets/483659/14099a67-b9fd-4f2f-be47-1dd67794ae18)


## Test methodology <!-- How did you ensure quality? -->

- Manually at 100% and 200% scaling

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11
- 100% and 200% scaling

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
