### PR TITLE
perf(FileStatusList): Initialize ImageList data only once

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -62,12 +62,9 @@ namespace GitUI
         [DefaultValue(false)]
         public bool DisableSubmoduleMenuItemBold { get; set; }
 
-        private static readonly ImageListData _imageListData;
+        private record ImageListData(ImageList ImageList, FrozenDictionary<string, int> StateImageIndexMap);
 
-        static FileStatusList()
-        {
-            _imageListData = CreateImageListData();
-        }
+        private static readonly ImageListData _imageListData = CreateImageListData();
 
         public FileStatusList()
         {
@@ -155,8 +152,6 @@ namespace GitUI
                 return item;
             }
         }
-
-        private record ImageListData(ImageList ImageList, FrozenDictionary<string, int> StateImageIndexDict);
 
         private static ImageListData CreateImageListData()
         {
@@ -1206,12 +1201,12 @@ namespace GitUI
                     .Subscribe(_ => FileStatusListView_SelectedIndexChanged());
             }
 
-            int GetItemImageIndex(GitItemStatus gitItemStatus)
+            static int GetItemImageIndex(GitItemStatus gitItemStatus)
             {
                 string imageKey = GetItemImageKey(gitItemStatus);
-                return _imageListData.StateImageIndexDict.TryGetValue(imageKey, out int value)
+                return _imageListData.StateImageIndexMap.TryGetValue(imageKey, out int value)
                     ? value
-                    : _imageListData.StateImageIndexDict[nameof(Images.FileStatusUnknown)];
+                    : _imageListData.StateImageIndexMap[nameof(Images.FileStatusUnknown)];
             }
 
             static string GetItemImageKey(GitItemStatus gitItemStatus)


### PR DESCRIPTION
## Proposed changes / Background

While looking into `FormCommit` slow load times I've come across this inefficiency. Not only is it calculated twice per form open but it's done on every form open!

- Initialize `ImageList` with relevant data once and store the result in a static field

## Test methodology <!-- How did you ensure quality? -->

- Manually. In debug mode I think it shaved off `~40ms` for the first open and `~80ms` for subsequent opens

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
