### PR TITLE
Fix HEAD ref arrow scaling

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionGridRefRenderer.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridRefRenderer.cs
@@ -144,8 +144,8 @@ namespace GitUI
         {
             ThreadHelper.AssertOnUIThread();
 
-            const float horShift = 4;
-            const float verShift = 3;
+            float horShift = DpiUtil.Scale(4f);
+            float verShift = DpiUtil.Scale(3f);
 
             float height = rowHeight - (verShift * 2);
             float width = height / 2;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Scale HEAD ref's Arrow "padding"

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/483659/809a6d3d-1f68-4f47-ae16-d58913e2aaac)

### After

![image](https://github.com/gitextensions/gitextensions/assets/483659/00599aa7-d8a3-422b-aef8-75b5f622fde6)

## Test methodology <!-- How did you ensure quality? -->

- Manually at 100%, 150% and 200% scaling

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11
- 100%, 150% and 200% scaling

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
