### PR TITLE
GE internal revision links: Match PR starting with number

### DIFF
--- a/GitExtensions.settings
+++ b/GitExtensions.settings
@@ -91,7 +91,7 @@
       &lt;RevisionPart&gt;LocalBranches&lt;/RevisionPart&gt;
       &lt;RevisionPart&gt;RemoteBranches&lt;/RevisionPart&gt;
     &lt;/SearchInParts&gt;
-    &lt;SearchPattern&gt;(?i)(pull request |pr[ _]?)#?\d+&lt;/SearchPattern&gt;
+    &lt;SearchPattern&gt;(?i)(^|pull request |pr[ _]?)#?\d+&lt;/SearchPattern&gt;
     &lt;UseOnlyFirstRemote&gt;false&lt;/UseOnlyFirstRemote&gt;
   &lt;/GitExtLinkDef&gt;
 &lt;/ArrayOfGitExtLinkDef&gt;</string>


### PR DESCRIPTION
# Proposed changes

- Provide revision link for the PR if the branch name starts with the PR number
  e.g. created by `git fetch upstream pull/{UserInput}/head:{UserInput}`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

no link

### After

![image](https://github.com/gitextensions/gitextensions/assets/36601201/408498dd-db32-457c-bfa1-14e54bcee1e7)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).