### PR TITLE
Fix FormRemotes DPI scaling

### DIFF
--- a/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -106,9 +106,9 @@ namespace GitUI.CommandsDialogs
             flpnlRemoteManagement.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             flpnlRemoteManagement.ColumnCount = 1;
             flpnlRemoteManagement.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-            flpnlRemoteManagement.Controls.Add(flowLayoutPanel2, 0, 2);
-            flpnlRemoteManagement.Controls.Add(pnlMgtPuttySsh, 0, 1);
             flpnlRemoteManagement.Controls.Add(pnlMgtDetails, 0, 0);
+            flpnlRemoteManagement.Controls.Add(pnlMgtPuttySsh, 0, 1);
+            flpnlRemoteManagement.Controls.Add(flowLayoutPanel2, 0, 2);
             flpnlRemoteManagement.Dock = DockStyle.Fill;
             flpnlRemoteManagement.Location = new Point(3, 16);
             flpnlRemoteManagement.Name = "flpnlRemoteManagement";
@@ -169,21 +169,22 @@ namespace GitUI.CommandsDialogs
             tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle());
             tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
             tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle());
+            tableLayoutPanel1.Controls.Add(label3, 0, 0);
             tableLayoutPanel1.Controls.Add(PuttySshKey, 1, 0);
             tableLayoutPanel1.Controls.Add(SshBrowse, 2, 0);
-            tableLayoutPanel1.Controls.Add(label3, 0, 0);
             tableLayoutPanel1.Controls.Add(flowLayoutPanel3, 1, 1);
             tableLayoutPanel1.Location = new Point(16, 18);
             tableLayoutPanel1.Name = "tableLayoutPanel1";
             tableLayoutPanel1.RowCount = 2;
             tableLayoutPanel1.RowStyles.Add(new RowStyle());
             tableLayoutPanel1.RowStyles.Add(new RowStyle());
+            tableLayoutPanel1.SetColumnSpan(flowLayoutPanel3, 2);
             tableLayoutPanel1.Size = new Size(470, 60);
             tableLayoutPanel1.TabIndex = 12;
             // 
             // PuttySshKey
             // 
-            PuttySshKey.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            PuttySshKey.Anchor = AnchorStyles.Left | AnchorStyles.Right;
             PuttySshKey.Location = new Point(109, 3);
             PuttySshKey.Name = "PuttySshKey";
             PuttySshKey.Size = new Size(248, 20);
@@ -191,11 +192,14 @@ namespace GitUI.CommandsDialogs
             // 
             // SshBrowse
             // 
+            SshBrowse.Anchor = AnchorStyles.Right;
+            SshBrowse.AutoSize = true;
+            SshBrowse.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             SshBrowse.Dock = DockStyle.Fill;
             SshBrowse.Image = Properties.Images.FileNew;
             SshBrowse.ImageAlign = ContentAlignment.MiddleLeft;
             SshBrowse.Location = new Point(363, 3);
-            SshBrowse.MinimumSize = new Size(104, 0);
+            SshBrowse.MinimumSize = new Size(104, 25);
             SshBrowse.Name = "SshBrowse";
             SshBrowse.Size = new Size(104, 25);
             SshBrowse.TabIndex = 2;
@@ -206,6 +210,7 @@ namespace GitUI.CommandsDialogs
             // 
             // label3
             // 
+            label3.Anchor = AnchorStyles.Left;
             label3.AutoSize = true;
             label3.Dock = DockStyle.Fill;
             label3.Location = new Point(3, 0);
@@ -220,7 +225,6 @@ namespace GitUI.CommandsDialogs
             // 
             flowLayoutPanel3.AutoSize = true;
             flowLayoutPanel3.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            tableLayoutPanel1.SetColumnSpan(flowLayoutPanel3, 2);
             flowLayoutPanel3.Controls.Add(TestConnection);
             flowLayoutPanel3.Controls.Add(LoadSSHKey);
             flowLayoutPanel3.Dock = DockStyle.Fill;
@@ -234,11 +238,14 @@ namespace GitUI.CommandsDialogs
             // TestConnection
             // 
             TestConnection.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            TestConnection.AutoSize = true;
+            TestConnection.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             TestConnection.Image = Properties.Images.Putty;
             TestConnection.ImageAlign = ContentAlignment.MiddleLeft;
             TestConnection.Location = new Point(201, 3);
+            TestConnection.MinimumSize = new Size(160, 25);
             TestConnection.Name = "TestConnection";
-            TestConnection.Size = new Size(160, 23);
+            TestConnection.Size = new Size(160, 25);
             TestConnection.TabIndex = 1;
             TestConnection.Text = "Test connection";
             TestConnection.UseVisualStyleBackColor = true;
@@ -247,11 +254,14 @@ namespace GitUI.CommandsDialogs
             // LoadSSHKey
             // 
             LoadSSHKey.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            LoadSSHKey.AutoSize = true;
+            LoadSSHKey.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             LoadSSHKey.Image = Properties.Images.Putty;
             LoadSSHKey.ImageAlign = ContentAlignment.MiddleLeft;
             LoadSSHKey.Location = new Point(35, 3);
+            LoadSSHKey.MinimumSize = new Size(160, 25);
             LoadSSHKey.Name = "LoadSSHKey";
-            LoadSSHKey.Size = new Size(160, 23);
+            LoadSSHKey.Size = new Size(160, 25);
             LoadSSHKey.TabIndex = 0;
             LoadSSHKey.Text = "Load SSH key";
             LoadSSHKey.UseVisualStyleBackColor = true;
@@ -297,14 +307,14 @@ namespace GitUI.CommandsDialogs
             tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
             tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 110F));
             tblpnlMgtDetails.Controls.Add(label1, 0, 0);
-            tblpnlMgtDetails.Controls.Add(folderBrowserButtonPushUrl, 2, 3);
+            tblpnlMgtDetails.Controls.Add(RemoteName, 1, 0);
             tblpnlMgtDetails.Controls.Add(label2, 0, 1);
             tblpnlMgtDetails.Controls.Add(Url, 1, 1);
-            tblpnlMgtDetails.Controls.Add(comboBoxPushUrl, 1, 3);
-            tblpnlMgtDetails.Controls.Add(labelPushUrl, 0, 3);
             tblpnlMgtDetails.Controls.Add(folderBrowserButtonUrl, 2, 1);
             tblpnlMgtDetails.Controls.Add(checkBoxSepPushUrl, 0, 2);
-            tblpnlMgtDetails.Controls.Add(RemoteName, 1, 0);
+            tblpnlMgtDetails.Controls.Add(labelPushUrl, 0, 3);
+            tblpnlMgtDetails.Controls.Add(comboBoxPushUrl, 1, 3);
+            tblpnlMgtDetails.Controls.Add(folderBrowserButtonPushUrl, 2, 3);
             tblpnlMgtDetails.Location = new Point(16, 11);
             tblpnlMgtDetails.Name = "tblpnlMgtDetails";
             tblpnlMgtDetails.RowCount = 4;
@@ -312,11 +322,13 @@ namespace GitUI.CommandsDialogs
             tblpnlMgtDetails.RowStyles.Add(new RowStyle());
             tblpnlMgtDetails.RowStyles.Add(new RowStyle());
             tblpnlMgtDetails.RowStyles.Add(new RowStyle());
+            tblpnlMgtDetails.SetColumnSpan(checkBoxSepPushUrl, 2);
             tblpnlMgtDetails.Size = new Size(470, 114);
             tblpnlMgtDetails.TabIndex = 11;
             // 
             // label1
             // 
+            label1.Anchor = AnchorStyles.Left;
             label1.Dock = DockStyle.Fill;
             label1.Location = new Point(3, 0);
             label1.MinimumSize = new Size(100, 0);
@@ -328,8 +340,12 @@ namespace GitUI.CommandsDialogs
             // 
             // folderBrowserButtonPushUrl
             // 
+            folderBrowserButtonPushUrl.Anchor = AnchorStyles.Right;
+            folderBrowserButtonPushUrl.AutoSize = true;
+            folderBrowserButtonPushUrl.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             folderBrowserButtonPushUrl.Dock = DockStyle.Fill;
             folderBrowserButtonPushUrl.Location = new Point(363, 86);
+            folderBrowserButtonPushUrl.MinimumSize = new Size(104, 25);
             folderBrowserButtonPushUrl.Name = "folderBrowserButtonPushUrl";
             folderBrowserButtonPushUrl.PathShowingControl = comboBoxPushUrl;
             folderBrowserButtonPushUrl.Size = new Size(104, 25);
@@ -338,7 +354,7 @@ namespace GitUI.CommandsDialogs
             // 
             // comboBoxPushUrl
             // 
-            comboBoxPushUrl.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            comboBoxPushUrl.Anchor = AnchorStyles.Left | AnchorStyles.Right;
             comboBoxPushUrl.AutoCompleteMode = AutoCompleteMode.SuggestAppend;
             comboBoxPushUrl.AutoCompleteSource = AutoCompleteSource.ListItems;
             comboBoxPushUrl.FormattingEnabled = true;
@@ -351,6 +367,7 @@ namespace GitUI.CommandsDialogs
             // 
             // label2
             // 
+            label2.Anchor = AnchorStyles.Left;
             label2.Dock = DockStyle.Fill;
             label2.Location = new Point(3, 29);
             label2.Name = "label2";
@@ -361,7 +378,7 @@ namespace GitUI.CommandsDialogs
             // 
             // Url
             // 
-            Url.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            Url.Anchor = AnchorStyles.Left | AnchorStyles.Right;
             Url.AutoCompleteMode = AutoCompleteMode.SuggestAppend;
             Url.AutoCompleteSource = AutoCompleteSource.ListItems;
             Url.FormattingEnabled = true;
@@ -373,6 +390,7 @@ namespace GitUI.CommandsDialogs
             // 
             // labelPushUrl
             // 
+            labelPushUrl.Anchor = AnchorStyles.Left;
             labelPushUrl.Dock = DockStyle.Fill;
             labelPushUrl.Location = new Point(3, 83);
             labelPushUrl.Name = "labelPushUrl";
@@ -384,8 +402,12 @@ namespace GitUI.CommandsDialogs
             // 
             // folderBrowserButtonUrl
             // 
+            folderBrowserButtonUrl.Anchor = AnchorStyles.Right;
+            folderBrowserButtonUrl.AutoSize = true;
+            folderBrowserButtonUrl.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             folderBrowserButtonUrl.Dock = DockStyle.Fill;
             folderBrowserButtonUrl.Location = new Point(363, 32);
+            folderBrowserButtonUrl.MinimumSize = new Size(104, 25);
             folderBrowserButtonUrl.Name = "folderBrowserButtonUrl";
             folderBrowserButtonUrl.PathShowingControl = Url;
             folderBrowserButtonUrl.Size = new Size(104, 25);
@@ -394,7 +416,6 @@ namespace GitUI.CommandsDialogs
             // checkBoxSepPushUrl
             // 
             checkBoxSepPushUrl.AutoSize = true;
-            tblpnlMgtDetails.SetColumnSpan(checkBoxSepPushUrl, 2);
             checkBoxSepPushUrl.Dock = DockStyle.Fill;
             checkBoxSepPushUrl.Location = new Point(3, 63);
             checkBoxSepPushUrl.Name = "checkBoxSepPushUrl";
@@ -653,6 +674,7 @@ namespace GitUI.CommandsDialogs
             SaveDefaultPushPull.Image = Properties.Images.Save;
             SaveDefaultPushPull.ImageAlign = ContentAlignment.MiddleLeft;
             SaveDefaultPushPull.Location = new Point(541, 88);
+            SaveDefaultPushPull.MinimumSize = new Size(130, 25);
             SaveDefaultPushPull.Name = "SaveDefaultPushPull";
             SaveDefaultPushPull.Size = new Size(130, 25);
             SaveDefaultPushPull.TabIndex = 3;

--- a/GitUI/CommandsDialogs/FormRemotes.Designer.cs
+++ b/GitUI/CommandsDialogs/FormRemotes.Designer.cs
@@ -30,31 +30,31 @@ namespace GitUI.CommandsDialogs
         private void InitializeComponent()
         {
             components = new System.ComponentModel.Container();
-            ListViewGroup listViewGroup1 = new ListViewGroup("ListViewGroup", HorizontalAlignment.Left);
+            ListViewGroup listViewGroup2 = new ListViewGroup("ListViewGroup", HorizontalAlignment.Left);
             flpnlRemoteManagement = new TableLayoutPanel();
-            flowLayoutPanel2 = new FlowLayoutPanel();
-            Save = new Button();
+            pnlMgtDetails = new Panel();
+            tblpnlMgtDetails = new TableLayoutPanel();
+            label1 = new Label();
+            RemoteName = new TextBox();
+            label2 = new Label();
+            Url = new UserControls.CaseSensitiveComboBox();
+            folderBrowserButtonUrl = new UserControls.FolderBrowserButton();
+            checkBoxSepPushUrl = new CheckBox();
+            labelPushUrl = new Label();
+            comboBoxPushUrl = new UserControls.CaseSensitiveComboBox();
+            folderBrowserButtonPushUrl = new UserControls.FolderBrowserButton();
             pnlMgtPuttySsh = new Panel();
             tableLayoutPanel1 = new TableLayoutPanel();
+            label3 = new Label();
             PuttySshKey = new TextBox();
             SshBrowse = new Button();
-            label3 = new Label();
             flowLayoutPanel3 = new FlowLayoutPanel();
             TestConnection = new Button();
             LoadSSHKey = new Button();
             lblMgtPuttyPanelHeader = new Label();
             lblHeaderLine2 = new Label();
-            pnlMgtDetails = new Panel();
-            tblpnlMgtDetails = new TableLayoutPanel();
-            label1 = new Label();
-            folderBrowserButtonPushUrl = new GitUI.UserControls.FolderBrowserButton();
-            comboBoxPushUrl = new GitUI.UserControls.CaseSensitiveComboBox();
-            label2 = new Label();
-            Url = new GitUI.UserControls.CaseSensitiveComboBox();
-            labelPushUrl = new Label();
-            folderBrowserButtonUrl = new GitUI.UserControls.FolderBrowserButton();
-            checkBoxSepPushUrl = new CheckBox();
-            RemoteName = new TextBox();
+            flowLayoutPanel2 = new FlowLayoutPanel();
+            Save = new Button();
             pnlManagementContainer = new Panel();
             gbMgtPanel = new GroupBox();
             panelButtons = new FlowLayoutPanel();
@@ -64,8 +64,8 @@ namespace GitUI.CommandsDialogs
             tabControl1 = new TabControl();
             tabPage1 = new TabPage();
             panel1 = new Panel();
-            Remotes = new GitUI.UserControls.NativeListView();
-            columnHeader1 = ((ColumnHeader)(new ColumnHeader()));
+            Remotes = new UserControls.NativeListView();
+            columnHeader1 = new ColumnHeader();
             tabPage2 = new TabPage();
             tableLayoutPanel2 = new TableLayoutPanel();
             panelDetails = new Panel();
@@ -82,12 +82,12 @@ namespace GitUI.CommandsDialogs
             MergeWith = new DataGridViewTextBoxColumn();
             toolTip1 = new ToolTip(components);
             flpnlRemoteManagement.SuspendLayout();
-            flowLayoutPanel2.SuspendLayout();
+            pnlMgtDetails.SuspendLayout();
+            tblpnlMgtDetails.SuspendLayout();
             pnlMgtPuttySsh.SuspendLayout();
             tableLayoutPanel1.SuspendLayout();
             flowLayoutPanel3.SuspendLayout();
-            pnlMgtDetails.SuspendLayout();
-            tblpnlMgtDetails.SuspendLayout();
+            flowLayoutPanel2.SuspendLayout();
             pnlManagementContainer.SuspendLayout();
             gbMgtPanel.SuspendLayout();
             panelButtons.SuspendLayout();
@@ -97,7 +97,7 @@ namespace GitUI.CommandsDialogs
             tabPage2.SuspendLayout();
             tableLayoutPanel2.SuspendLayout();
             panelDetails.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(RemoteBranches)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)RemoteBranches).BeginInit();
             SuspendLayout();
             // 
             // flpnlRemoteManagement
@@ -110,40 +110,160 @@ namespace GitUI.CommandsDialogs
             flpnlRemoteManagement.Controls.Add(pnlMgtPuttySsh, 0, 1);
             flpnlRemoteManagement.Controls.Add(flowLayoutPanel2, 0, 2);
             flpnlRemoteManagement.Dock = DockStyle.Fill;
-            flpnlRemoteManagement.Location = new Point(3, 16);
+            flpnlRemoteManagement.Location = new Point(3, 19);
             flpnlRemoteManagement.Name = "flpnlRemoteManagement";
             flpnlRemoteManagement.RowCount = 3;
             flpnlRemoteManagement.RowStyles.Add(new RowStyle());
             flpnlRemoteManagement.RowStyles.Add(new RowStyle());
             flpnlRemoteManagement.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
-            flpnlRemoteManagement.Size = new Size(514, 274);
+            flpnlRemoteManagement.Size = new Size(514, 278);
             flpnlRemoteManagement.TabIndex = 0;
             // 
-            // flowLayoutPanel2
+            // pnlMgtDetails
             // 
-            flowLayoutPanel2.AutoSize = true;
-            flowLayoutPanel2.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            flowLayoutPanel2.Controls.Add(Save);
-            flowLayoutPanel2.Dock = DockStyle.Top;
-            flowLayoutPanel2.FlowDirection = FlowDirection.RightToLeft;
-            flowLayoutPanel2.Location = new Point(3, 240);
-            flowLayoutPanel2.Name = "flowLayoutPanel2";
-            flowLayoutPanel2.Padding = new Padding(0, 0, 20, 0);
-            flowLayoutPanel2.Size = new Size(508, 31);
-            flowLayoutPanel2.TabIndex = 2;
+            pnlMgtDetails.AutoSize = true;
+            pnlMgtDetails.Controls.Add(tblpnlMgtDetails);
+            pnlMgtDetails.Dock = DockStyle.Top;
+            pnlMgtDetails.Location = new Point(3, 3);
+            pnlMgtDetails.Name = "pnlMgtDetails";
+            pnlMgtDetails.Padding = new Padding(0, 0, 0, 8);
+            pnlMgtDetails.Size = new Size(508, 138);
+            pnlMgtDetails.TabIndex = 0;
+            pnlMgtDetails.Text = "Details";
             // 
-            // Save
+            // tblpnlMgtDetails
             // 
-            Save.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            Save.Image = Properties.Images.Save;
-            Save.ImageAlign = ContentAlignment.MiddleLeft;
-            Save.Location = new Point(355, 3);
-            Save.Name = "Save";
-            Save.Size = new Size(130, 25);
-            Save.TabIndex = 0;
-            Save.Text = "Save changes";
-            Save.UseVisualStyleBackColor = true;
-            Save.Click += SaveClick;
+            tblpnlMgtDetails.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            tblpnlMgtDetails.AutoSize = true;
+            tblpnlMgtDetails.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            tblpnlMgtDetails.ColumnCount = 3;
+            tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle());
+            tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 110F));
+            tblpnlMgtDetails.Controls.Add(label1, 0, 0);
+            tblpnlMgtDetails.Controls.Add(RemoteName, 1, 0);
+            tblpnlMgtDetails.Controls.Add(label2, 0, 1);
+            tblpnlMgtDetails.Controls.Add(Url, 1, 1);
+            tblpnlMgtDetails.Controls.Add(folderBrowserButtonUrl, 2, 1);
+            tblpnlMgtDetails.Controls.Add(checkBoxSepPushUrl, 0, 2);
+            tblpnlMgtDetails.Controls.Add(labelPushUrl, 0, 3);
+            tblpnlMgtDetails.Controls.Add(comboBoxPushUrl, 1, 3);
+            tblpnlMgtDetails.Controls.Add(folderBrowserButtonPushUrl, 2, 3);
+            tblpnlMgtDetails.Location = new Point(16, 11);
+            tblpnlMgtDetails.Name = "tblpnlMgtDetails";
+            tblpnlMgtDetails.RowCount = 4;
+            tblpnlMgtDetails.RowStyles.Add(new RowStyle());
+            tblpnlMgtDetails.RowStyles.Add(new RowStyle());
+            tblpnlMgtDetails.RowStyles.Add(new RowStyle());
+            tblpnlMgtDetails.RowStyles.Add(new RowStyle());
+            tblpnlMgtDetails.Size = new Size(470, 116);
+            tblpnlMgtDetails.TabIndex = 11;
+            // 
+            // label1
+            // 
+            label1.Dock = DockStyle.Fill;
+            label1.Location = new Point(3, 0);
+            label1.MinimumSize = new Size(100, 0);
+            label1.Name = "label1";
+            label1.Size = new Size(100, 29);
+            label1.TabIndex = 0;
+            label1.Text = "Name";
+            label1.TextAlign = ContentAlignment.MiddleLeft;
+            // 
+            // RemoteName
+            // 
+            RemoteName.Dock = DockStyle.Fill;
+            RemoteName.Location = new Point(109, 3);
+            RemoteName.Name = "RemoteName";
+            RemoteName.Size = new Size(248, 23);
+            RemoteName.TabIndex = 1;
+            RemoteName.TextChanged += RemoteName_TextChanged;
+            RemoteName.Enter += RemoteName_Enter;
+            // 
+            // label2
+            // 
+            label2.Dock = DockStyle.Fill;
+            label2.Location = new Point(3, 29);
+            label2.Name = "label2";
+            label2.Size = new Size(100, 31);
+            label2.TabIndex = 2;
+            label2.Text = "Url";
+            label2.TextAlign = ContentAlignment.MiddleLeft;
+            // 
+            // Url
+            // 
+            Url.Anchor = AnchorStyles.Left | AnchorStyles.Right;
+            Url.AutoCompleteMode = AutoCompleteMode.SuggestAppend;
+            Url.AutoCompleteSource = AutoCompleteSource.ListItems;
+            Url.FormattingEnabled = true;
+            Url.Location = new Point(109, 33);
+            Url.Name = "Url";
+            Url.Size = new Size(248, 23);
+            Url.TabIndex = 3;
+            Url.Enter += Url_Enter;
+            // 
+            // folderBrowserButtonUrl
+            // 
+            folderBrowserButtonUrl.AutoSize = true;
+            folderBrowserButtonUrl.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            folderBrowserButtonUrl.Dock = DockStyle.Fill;
+            folderBrowserButtonUrl.Location = new Point(363, 32);
+            folderBrowserButtonUrl.MinimumSize = new Size(104, 25);
+            folderBrowserButtonUrl.Name = "folderBrowserButtonUrl";
+            folderBrowserButtonUrl.PathShowingControl = Url;
+            folderBrowserButtonUrl.Size = new Size(104, 25);
+            folderBrowserButtonUrl.TabIndex = 4;
+            // 
+            // checkBoxSepPushUrl
+            // 
+            checkBoxSepPushUrl.AutoSize = true;
+            tblpnlMgtDetails.SetColumnSpan(checkBoxSepPushUrl, 2);
+            checkBoxSepPushUrl.Dock = DockStyle.Fill;
+            checkBoxSepPushUrl.Location = new Point(3, 63);
+            checkBoxSepPushUrl.Name = "checkBoxSepPushUrl";
+            checkBoxSepPushUrl.Padding = new Padding(24, 0, 0, 0);
+            checkBoxSepPushUrl.Size = new Size(354, 19);
+            checkBoxSepPushUrl.TabIndex = 5;
+            checkBoxSepPushUrl.Text = "Separate Push Url";
+            checkBoxSepPushUrl.UseVisualStyleBackColor = true;
+            checkBoxSepPushUrl.CheckedChanged += checkBoxSepPushUrl_CheckedChanged;
+            // 
+            // labelPushUrl
+            // 
+            labelPushUrl.Dock = DockStyle.Fill;
+            labelPushUrl.Location = new Point(3, 85);
+            labelPushUrl.Name = "labelPushUrl";
+            labelPushUrl.Size = new Size(100, 31);
+            labelPushUrl.TabIndex = 6;
+            labelPushUrl.Text = "Push Url";
+            labelPushUrl.TextAlign = ContentAlignment.MiddleLeft;
+            labelPushUrl.Visible = false;
+            // 
+            // comboBoxPushUrl
+            // 
+            comboBoxPushUrl.Anchor = AnchorStyles.Left | AnchorStyles.Right;
+            comboBoxPushUrl.AutoCompleteMode = AutoCompleteMode.SuggestAppend;
+            comboBoxPushUrl.AutoCompleteSource = AutoCompleteSource.ListItems;
+            comboBoxPushUrl.FormattingEnabled = true;
+            comboBoxPushUrl.Location = new Point(109, 89);
+            comboBoxPushUrl.Name = "comboBoxPushUrl";
+            comboBoxPushUrl.Size = new Size(248, 23);
+            comboBoxPushUrl.TabIndex = 7;
+            comboBoxPushUrl.Visible = false;
+            comboBoxPushUrl.Enter += ComboBoxPushUrl_Enter;
+            // 
+            // folderBrowserButtonPushUrl
+            // 
+            folderBrowserButtonPushUrl.AutoSize = true;
+            folderBrowserButtonPushUrl.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            folderBrowserButtonPushUrl.Dock = DockStyle.Fill;
+            folderBrowserButtonPushUrl.Location = new Point(363, 88);
+            folderBrowserButtonPushUrl.MinimumSize = new Size(104, 25);
+            folderBrowserButtonPushUrl.Name = "folderBrowserButtonPushUrl";
+            folderBrowserButtonPushUrl.PathShowingControl = comboBoxPushUrl;
+            folderBrowserButtonPushUrl.Size = new Size(104, 25);
+            folderBrowserButtonPushUrl.TabIndex = 8;
+            folderBrowserButtonPushUrl.Visible = false;
             // 
             // pnlMgtPuttySsh
             // 
@@ -153,10 +273,10 @@ namespace GitUI.CommandsDialogs
             pnlMgtPuttySsh.Controls.Add(lblMgtPuttyPanelHeader);
             pnlMgtPuttySsh.Controls.Add(lblHeaderLine2);
             pnlMgtPuttySsh.Dock = DockStyle.Top;
-            pnlMgtPuttySsh.Location = new Point(3, 145);
+            pnlMgtPuttySsh.Location = new Point(3, 147);
             pnlMgtPuttySsh.Name = "pnlMgtPuttySsh";
             pnlMgtPuttySsh.Padding = new Padding(0, 0, 0, 8);
-            pnlMgtPuttySsh.Size = new Size(508, 89);
+            pnlMgtPuttySsh.Size = new Size(508, 91);
             pnlMgtPuttySsh.TabIndex = 1;
             pnlMgtPuttySsh.Text = "PuTTY SSH";
             // 
@@ -178,21 +298,31 @@ namespace GitUI.CommandsDialogs
             tableLayoutPanel1.RowCount = 2;
             tableLayoutPanel1.RowStyles.Add(new RowStyle());
             tableLayoutPanel1.RowStyles.Add(new RowStyle());
-            tableLayoutPanel1.SetColumnSpan(flowLayoutPanel3, 2);
-            tableLayoutPanel1.Size = new Size(470, 60);
+            tableLayoutPanel1.Size = new Size(470, 62);
             tableLayoutPanel1.TabIndex = 12;
+            // 
+            // label3
+            // 
+            label3.AutoSize = true;
+            label3.Dock = DockStyle.Fill;
+            label3.Location = new Point(3, 0);
+            label3.MinimumSize = new Size(100, 0);
+            label3.Name = "label3";
+            label3.Size = new Size(100, 31);
+            label3.TabIndex = 0;
+            label3.Text = "Private key file";
+            label3.TextAlign = ContentAlignment.MiddleLeft;
             // 
             // PuttySshKey
             // 
             PuttySshKey.Anchor = AnchorStyles.Left | AnchorStyles.Right;
-            PuttySshKey.Location = new Point(109, 3);
+            PuttySshKey.Location = new Point(109, 4);
             PuttySshKey.Name = "PuttySshKey";
-            PuttySshKey.Size = new Size(248, 20);
+            PuttySshKey.Size = new Size(248, 23);
             PuttySshKey.TabIndex = 1;
             // 
             // SshBrowse
             // 
-            SshBrowse.Anchor = AnchorStyles.Right;
             SshBrowse.AutoSize = true;
             SshBrowse.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             SshBrowse.Dock = DockStyle.Fill;
@@ -208,23 +338,11 @@ namespace GitUI.CommandsDialogs
             SshBrowse.UseVisualStyleBackColor = true;
             SshBrowse.Click += SshBrowseClick;
             // 
-            // label3
-            // 
-            label3.Anchor = AnchorStyles.Left;
-            label3.AutoSize = true;
-            label3.Dock = DockStyle.Fill;
-            label3.Location = new Point(3, 0);
-            label3.MinimumSize = new Size(100, 0);
-            label3.Name = "label3";
-            label3.Size = new Size(100, 31);
-            label3.TabIndex = 0;
-            label3.Text = "Private key file";
-            label3.TextAlign = ContentAlignment.MiddleLeft;
-            // 
             // flowLayoutPanel3
             // 
             flowLayoutPanel3.AutoSize = true;
             flowLayoutPanel3.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            tableLayoutPanel1.SetColumnSpan(flowLayoutPanel3, 2);
             flowLayoutPanel3.Controls.Add(TestConnection);
             flowLayoutPanel3.Controls.Add(LoadSSHKey);
             flowLayoutPanel3.Dock = DockStyle.Fill;
@@ -232,7 +350,7 @@ namespace GitUI.CommandsDialogs
             flowLayoutPanel3.Location = new Point(106, 31);
             flowLayoutPanel3.Margin = new Padding(0);
             flowLayoutPanel3.Name = "flowLayoutPanel3";
-            flowLayoutPanel3.Size = new Size(364, 29);
+            flowLayoutPanel3.Size = new Size(364, 31);
             flowLayoutPanel3.TabIndex = 3;
             // 
             // TestConnection
@@ -272,7 +390,7 @@ namespace GitUI.CommandsDialogs
             lblMgtPuttyPanelHeader.AutoSize = true;
             lblMgtPuttyPanelHeader.Location = new Point(8, 0);
             lblMgtPuttyPanelHeader.Name = "lblMgtPuttyPanelHeader";
-            lblMgtPuttyPanelHeader.Size = new Size(66, 13);
+            lblMgtPuttyPanelHeader.Size = new Size(64, 15);
             lblMgtPuttyPanelHeader.TabIndex = 0;
             lblMgtPuttyPanelHeader.Text = "PuTTY SSH";
             // 
@@ -285,156 +403,31 @@ namespace GitUI.CommandsDialogs
             lblHeaderLine2.Size = new Size(481, 3);
             lblHeaderLine2.TabIndex = 1;
             // 
-            // pnlMgtDetails
+            // flowLayoutPanel2
             // 
-            pnlMgtDetails.AutoSize = true;
-            pnlMgtDetails.Controls.Add(tblpnlMgtDetails);
-            pnlMgtDetails.Dock = DockStyle.Top;
-            pnlMgtDetails.Location = new Point(3, 3);
-            pnlMgtDetails.Name = "pnlMgtDetails";
-            pnlMgtDetails.Padding = new Padding(0, 0, 0, 8);
-            pnlMgtDetails.Size = new Size(508, 136);
-            pnlMgtDetails.TabIndex = 0;
-            pnlMgtDetails.Text = "Details";
+            flowLayoutPanel2.AutoSize = true;
+            flowLayoutPanel2.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            flowLayoutPanel2.Controls.Add(Save);
+            flowLayoutPanel2.Dock = DockStyle.Top;
+            flowLayoutPanel2.FlowDirection = FlowDirection.RightToLeft;
+            flowLayoutPanel2.Location = new Point(3, 244);
+            flowLayoutPanel2.Name = "flowLayoutPanel2";
+            flowLayoutPanel2.Padding = new Padding(0, 0, 20, 0);
+            flowLayoutPanel2.Size = new Size(508, 31);
+            flowLayoutPanel2.TabIndex = 2;
             // 
-            // tblpnlMgtDetails
+            // Save
             // 
-            tblpnlMgtDetails.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
-            tblpnlMgtDetails.AutoSize = true;
-            tblpnlMgtDetails.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            tblpnlMgtDetails.ColumnCount = 3;
-            tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle());
-            tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-            tblpnlMgtDetails.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 110F));
-            tblpnlMgtDetails.Controls.Add(label1, 0, 0);
-            tblpnlMgtDetails.Controls.Add(RemoteName, 1, 0);
-            tblpnlMgtDetails.Controls.Add(label2, 0, 1);
-            tblpnlMgtDetails.Controls.Add(Url, 1, 1);
-            tblpnlMgtDetails.Controls.Add(folderBrowserButtonUrl, 2, 1);
-            tblpnlMgtDetails.Controls.Add(checkBoxSepPushUrl, 0, 2);
-            tblpnlMgtDetails.Controls.Add(labelPushUrl, 0, 3);
-            tblpnlMgtDetails.Controls.Add(comboBoxPushUrl, 1, 3);
-            tblpnlMgtDetails.Controls.Add(folderBrowserButtonPushUrl, 2, 3);
-            tblpnlMgtDetails.Location = new Point(16, 11);
-            tblpnlMgtDetails.Name = "tblpnlMgtDetails";
-            tblpnlMgtDetails.RowCount = 4;
-            tblpnlMgtDetails.RowStyles.Add(new RowStyle());
-            tblpnlMgtDetails.RowStyles.Add(new RowStyle());
-            tblpnlMgtDetails.RowStyles.Add(new RowStyle());
-            tblpnlMgtDetails.RowStyles.Add(new RowStyle());
-            tblpnlMgtDetails.SetColumnSpan(checkBoxSepPushUrl, 2);
-            tblpnlMgtDetails.Size = new Size(470, 114);
-            tblpnlMgtDetails.TabIndex = 11;
-            // 
-            // label1
-            // 
-            label1.Anchor = AnchorStyles.Left;
-            label1.Dock = DockStyle.Fill;
-            label1.Location = new Point(3, 0);
-            label1.MinimumSize = new Size(100, 0);
-            label1.Name = "label1";
-            label1.Size = new Size(100, 29);
-            label1.TabIndex = 0;
-            label1.Text = "Name";
-            label1.TextAlign = ContentAlignment.MiddleLeft;
-            // 
-            // folderBrowserButtonPushUrl
-            // 
-            folderBrowserButtonPushUrl.Anchor = AnchorStyles.Right;
-            folderBrowserButtonPushUrl.AutoSize = true;
-            folderBrowserButtonPushUrl.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            folderBrowserButtonPushUrl.Dock = DockStyle.Fill;
-            folderBrowserButtonPushUrl.Location = new Point(363, 86);
-            folderBrowserButtonPushUrl.MinimumSize = new Size(104, 25);
-            folderBrowserButtonPushUrl.Name = "folderBrowserButtonPushUrl";
-            folderBrowserButtonPushUrl.PathShowingControl = comboBoxPushUrl;
-            folderBrowserButtonPushUrl.Size = new Size(104, 25);
-            folderBrowserButtonPushUrl.TabIndex = 8;
-            folderBrowserButtonPushUrl.Visible = false;
-            // 
-            // comboBoxPushUrl
-            // 
-            comboBoxPushUrl.Anchor = AnchorStyles.Left | AnchorStyles.Right;
-            comboBoxPushUrl.AutoCompleteMode = AutoCompleteMode.SuggestAppend;
-            comboBoxPushUrl.AutoCompleteSource = AutoCompleteSource.ListItems;
-            comboBoxPushUrl.FormattingEnabled = true;
-            comboBoxPushUrl.Location = new Point(109, 86);
-            comboBoxPushUrl.Name = "comboBoxPushUrl";
-            comboBoxPushUrl.Size = new Size(248, 21);
-            comboBoxPushUrl.TabIndex = 7;
-            comboBoxPushUrl.Visible = false;
-            comboBoxPushUrl.Enter += ComboBoxPushUrl_Enter;
-            // 
-            // label2
-            // 
-            label2.Anchor = AnchorStyles.Left;
-            label2.Dock = DockStyle.Fill;
-            label2.Location = new Point(3, 29);
-            label2.Name = "label2";
-            label2.Size = new Size(100, 31);
-            label2.TabIndex = 2;
-            label2.Text = "Url";
-            label2.TextAlign = ContentAlignment.MiddleLeft;
-            // 
-            // Url
-            // 
-            Url.Anchor = AnchorStyles.Left | AnchorStyles.Right;
-            Url.AutoCompleteMode = AutoCompleteMode.SuggestAppend;
-            Url.AutoCompleteSource = AutoCompleteSource.ListItems;
-            Url.FormattingEnabled = true;
-            Url.Location = new Point(109, 32);
-            Url.Name = "Url";
-            Url.Size = new Size(248, 21);
-            Url.TabIndex = 3;
-            Url.Enter += Url_Enter;
-            // 
-            // labelPushUrl
-            // 
-            labelPushUrl.Anchor = AnchorStyles.Left;
-            labelPushUrl.Dock = DockStyle.Fill;
-            labelPushUrl.Location = new Point(3, 83);
-            labelPushUrl.Name = "labelPushUrl";
-            labelPushUrl.Size = new Size(100, 31);
-            labelPushUrl.TabIndex = 6;
-            labelPushUrl.Text = "Push Url";
-            labelPushUrl.TextAlign = ContentAlignment.MiddleLeft;
-            labelPushUrl.Visible = false;
-            // 
-            // folderBrowserButtonUrl
-            // 
-            folderBrowserButtonUrl.Anchor = AnchorStyles.Right;
-            folderBrowserButtonUrl.AutoSize = true;
-            folderBrowserButtonUrl.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            folderBrowserButtonUrl.Dock = DockStyle.Fill;
-            folderBrowserButtonUrl.Location = new Point(363, 32);
-            folderBrowserButtonUrl.MinimumSize = new Size(104, 25);
-            folderBrowserButtonUrl.Name = "folderBrowserButtonUrl";
-            folderBrowserButtonUrl.PathShowingControl = Url;
-            folderBrowserButtonUrl.Size = new Size(104, 25);
-            folderBrowserButtonUrl.TabIndex = 4;
-            // 
-            // checkBoxSepPushUrl
-            // 
-            checkBoxSepPushUrl.AutoSize = true;
-            checkBoxSepPushUrl.Dock = DockStyle.Fill;
-            checkBoxSepPushUrl.Location = new Point(3, 63);
-            checkBoxSepPushUrl.Name = "checkBoxSepPushUrl";
-            checkBoxSepPushUrl.Padding = new Padding(24, 0, 0, 0);
-            checkBoxSepPushUrl.Size = new Size(354, 17);
-            checkBoxSepPushUrl.TabIndex = 5;
-            checkBoxSepPushUrl.Text = "Separate Push Url";
-            checkBoxSepPushUrl.UseVisualStyleBackColor = true;
-            checkBoxSepPushUrl.CheckedChanged += checkBoxSepPushUrl_CheckedChanged;
-            // 
-            // RemoteName
-            // 
-            RemoteName.Dock = DockStyle.Fill;
-            RemoteName.Location = new Point(109, 3);
-            RemoteName.Name = "RemoteName";
-            RemoteName.Size = new Size(248, 20);
-            RemoteName.TabIndex = 1;
-            RemoteName.TextChanged += RemoteName_TextChanged;
-            RemoteName.Enter += RemoteName_Enter;
+            Save.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            Save.Image = Properties.Images.Save;
+            Save.ImageAlign = ContentAlignment.MiddleLeft;
+            Save.Location = new Point(355, 3);
+            Save.Name = "Save";
+            Save.Size = new Size(130, 25);
+            Save.TabIndex = 0;
+            Save.Text = "Save changes";
+            Save.UseVisualStyleBackColor = true;
+            Save.Click += SaveClick;
             // 
             // pnlManagementContainer
             // 
@@ -443,7 +436,7 @@ namespace GitUI.CommandsDialogs
             pnlManagementContainer.Location = new Point(197, 3);
             pnlManagementContainer.Name = "pnlManagementContainer";
             pnlManagementContainer.Padding = new Padding(8, 4, 8, 8);
-            pnlManagementContainer.Size = new Size(536, 299);
+            pnlManagementContainer.Size = new Size(536, 297);
             pnlManagementContainer.TabIndex = 0;
             // 
             // gbMgtPanel
@@ -454,7 +447,7 @@ namespace GitUI.CommandsDialogs
             gbMgtPanel.Dock = DockStyle.Top;
             gbMgtPanel.Location = new Point(8, 4);
             gbMgtPanel.Name = "gbMgtPanel";
-            gbMgtPanel.Size = new Size(520, 293);
+            gbMgtPanel.Size = new Size(520, 300);
             gbMgtPanel.TabIndex = 0;
             gbMgtPanel.TabStop = false;
             gbMgtPanel.Text = "Create New Remote";
@@ -471,7 +464,7 @@ namespace GitUI.CommandsDialogs
             panelButtons.Margin = new Padding(8);
             panelButtons.Name = "panelButtons";
             panelButtons.Padding = new Padding(4, 0, 0, 0);
-            panelButtons.Size = new Size(36, 283);
+            panelButtons.Size = new Size(36, 281);
             panelButtons.TabIndex = 1;
             // 
             // New
@@ -522,10 +515,10 @@ namespace GitUI.CommandsDialogs
             // 
             tabPage1.Controls.Add(pnlManagementContainer);
             tabPage1.Controls.Add(panel1);
-            tabPage1.Location = new Point(4, 22);
+            tabPage1.Location = new Point(4, 24);
             tabPage1.Name = "tabPage1";
             tabPage1.Padding = new Padding(3);
-            tabPage1.Size = new Size(736, 305);
+            tabPage1.Size = new Size(736, 303);
             tabPage1.TabIndex = 0;
             tabPage1.Text = "Remote repositories";
             tabPage1.UseVisualStyleBackColor = true;
@@ -538,27 +531,24 @@ namespace GitUI.CommandsDialogs
             panel1.Location = new Point(3, 3);
             panel1.Name = "panel1";
             panel1.Padding = new Padding(8);
-            panel1.Size = new Size(194, 299);
+            panel1.Size = new Size(194, 297);
             panel1.TabIndex = 0;
             // 
             // Remotes
             // 
             Remotes.Activation = ItemActivation.OneClick;
-            Remotes.Columns.AddRange(new ColumnHeader[] {
-            columnHeader1});
+            Remotes.Columns.AddRange(new ColumnHeader[] { columnHeader1 });
             Remotes.Dock = DockStyle.Fill;
             Remotes.FullRowSelect = true;
-            listViewGroup1.Header = "ListViewGroup";
-            listViewGroup1.Name = "listViewGroup1";
-            Remotes.Groups.AddRange(new ListViewGroup[] {
-            listViewGroup1});
+            listViewGroup2.Header = "ListViewGroup";
+            listViewGroup2.Name = "listViewGroup1";
+            Remotes.Groups.AddRange(new ListViewGroup[] { listViewGroup2 });
             Remotes.HeaderStyle = ColumnHeaderStyle.None;
-            Remotes.HideSelection = false;
             Remotes.LabelWrap = false;
             Remotes.Location = new Point(8, 8);
             Remotes.MultiSelect = false;
             Remotes.Name = "Remotes";
-            Remotes.Size = new Size(142, 283);
+            Remotes.Size = new Size(142, 281);
             Remotes.TabIndex = 1;
             Remotes.TileSize = new Size(136, 18);
             Remotes.UseCompatibleStateImageBehavior = false;
@@ -573,10 +563,10 @@ namespace GitUI.CommandsDialogs
             // tabPage2
             // 
             tabPage2.Controls.Add(tableLayoutPanel2);
-            tabPage2.Location = new Point(4, 22);
+            tabPage2.Location = new Point(4, 24);
             tabPage2.Name = "tabPage2";
             tabPage2.Padding = new Padding(3);
-            tabPage2.Size = new Size(736, 305);
+            tabPage2.Size = new Size(736, 303);
             tabPage2.TabIndex = 1;
             tabPage2.Text = "Default pull behavior (fetch & merge)";
             tabPage2.UseVisualStyleBackColor = true;
@@ -594,7 +584,7 @@ namespace GitUI.CommandsDialogs
             tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
             tableLayoutPanel2.RowStyles.Add(new RowStyle());
             tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Absolute, 20F));
-            tableLayoutPanel2.Size = new Size(730, 299);
+            tableLayoutPanel2.Size = new Size(730, 297);
             tableLayoutPanel2.TabIndex = 12;
             // 
             // panelDetails
@@ -607,7 +597,7 @@ namespace GitUI.CommandsDialogs
             panelDetails.Controls.Add(RemoteRepositoryCombo);
             panelDetails.Controls.Add(LocalBranchNameEdit);
             panelDetails.Controls.Add(SaveDefaultPushPull);
-            panelDetails.Location = new Point(3, 175);
+            panelDetails.Location = new Point(3, 173);
             panelDetails.Name = "panelDetails";
             panelDetails.Size = new Size(724, 121);
             panelDetails.TabIndex = 0;
@@ -617,7 +607,7 @@ namespace GitUI.CommandsDialogs
             label4.AutoSize = true;
             label4.Location = new Point(36, 11);
             label4.Name = "label4";
-            label4.Size = new Size(98, 13);
+            label4.Size = new Size(108, 15);
             label4.TabIndex = 0;
             label4.Text = "Local branch name";
             // 
@@ -626,7 +616,7 @@ namespace GitUI.CommandsDialogs
             label5.AutoSize = true;
             label5.Location = new Point(36, 37);
             label5.Name = "label5";
-            label5.Size = new Size(92, 13);
+            label5.Size = new Size(104, 15);
             label5.TabIndex = 1;
             label5.Text = "Remote repository";
             // 
@@ -635,7 +625,7 @@ namespace GitUI.CommandsDialogs
             label6.AutoSize = true;
             label6.Location = new Point(36, 64);
             label6.Name = "label6";
-            label6.Size = new Size(95, 13);
+            label6.Size = new Size(108, 15);
             label6.TabIndex = 2;
             label6.Text = "Default merge with";
             // 
@@ -645,7 +635,7 @@ namespace GitUI.CommandsDialogs
             DefaultMergeWithCombo.FormattingEnabled = true;
             DefaultMergeWithCombo.Location = new Point(158, 61);
             DefaultMergeWithCombo.Name = "DefaultMergeWithCombo";
-            DefaultMergeWithCombo.Size = new Size(513, 21);
+            DefaultMergeWithCombo.Size = new Size(513, 23);
             DefaultMergeWithCombo.TabIndex = 2;
             DefaultMergeWithCombo.DropDown += DefaultMergeWithComboDropDown;
             DefaultMergeWithCombo.Validated += DefaultMergeWithComboValidated;
@@ -656,7 +646,7 @@ namespace GitUI.CommandsDialogs
             RemoteRepositoryCombo.FormattingEnabled = true;
             RemoteRepositoryCombo.Location = new Point(158, 34);
             RemoteRepositoryCombo.Name = "RemoteRepositoryCombo";
-            RemoteRepositoryCombo.Size = new Size(513, 21);
+            RemoteRepositoryCombo.Size = new Size(513, 23);
             RemoteRepositoryCombo.TabIndex = 1;
             RemoteRepositoryCombo.Validated += RemoteRepositoryComboValidated;
             // 
@@ -665,7 +655,7 @@ namespace GitUI.CommandsDialogs
             LocalBranchNameEdit.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             LocalBranchNameEdit.Location = new Point(158, 8);
             LocalBranchNameEdit.Name = "LocalBranchNameEdit";
-            LocalBranchNameEdit.Size = new Size(513, 20);
+            LocalBranchNameEdit.Size = new Size(513, 23);
             LocalBranchNameEdit.TabIndex = 0;
             // 
             // SaveDefaultPushPull
@@ -692,10 +682,7 @@ namespace GitUI.CommandsDialogs
             RemoteBranches.BackgroundColor = SystemColors.Window;
             RemoteBranches.BorderStyle = BorderStyle.None;
             RemoteBranches.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            RemoteBranches.Columns.AddRange(new DataGridViewColumn[] {
-            BranchName,
-            RemoteCombo,
-            MergeWith});
+            RemoteBranches.Columns.AddRange(new DataGridViewColumn[] { BranchName, RemoteCombo, MergeWith });
             RemoteBranches.Dock = DockStyle.Fill;
             RemoteBranches.GridColor = SystemColors.ControlLight;
             RemoteBranches.Location = new Point(3, 3);
@@ -704,7 +691,7 @@ namespace GitUI.CommandsDialogs
             RemoteBranches.ReadOnly = true;
             RemoteBranches.RowHeadersVisible = false;
             RemoteBranches.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
-            RemoteBranches.Size = new Size(724, 166);
+            RemoteBranches.Size = new Size(724, 164);
             RemoteBranches.TabIndex = 0;
             RemoteBranches.DataError += RemoteBranchesDataError;
             // 
@@ -741,16 +728,17 @@ namespace GitUI.CommandsDialogs
             Text = "Remote repositories";
             flpnlRemoteManagement.ResumeLayout(false);
             flpnlRemoteManagement.PerformLayout();
-            flowLayoutPanel2.ResumeLayout(false);
+            pnlMgtDetails.ResumeLayout(false);
+            pnlMgtDetails.PerformLayout();
+            tblpnlMgtDetails.ResumeLayout(false);
+            tblpnlMgtDetails.PerformLayout();
             pnlMgtPuttySsh.ResumeLayout(false);
             pnlMgtPuttySsh.PerformLayout();
             tableLayoutPanel1.ResumeLayout(false);
             tableLayoutPanel1.PerformLayout();
             flowLayoutPanel3.ResumeLayout(false);
-            pnlMgtDetails.ResumeLayout(false);
-            pnlMgtDetails.PerformLayout();
-            tblpnlMgtDetails.ResumeLayout(false);
-            tblpnlMgtDetails.PerformLayout();
+            flowLayoutPanel3.PerformLayout();
+            flowLayoutPanel2.ResumeLayout(false);
             pnlManagementContainer.ResumeLayout(false);
             pnlManagementContainer.PerformLayout();
             gbMgtPanel.ResumeLayout(false);
@@ -764,9 +752,8 @@ namespace GitUI.CommandsDialogs
             tableLayoutPanel2.ResumeLayout(false);
             panelDetails.ResumeLayout(false);
             panelDetails.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(RemoteBranches)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)RemoteBranches).EndInit();
             ResumeLayout(false);
-
         }
 
         #endregion

--- a/GitUI/CommandsDialogs/FormRemotes.resx
+++ b/GitUI/CommandsDialogs/FormRemotes.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -128,5 +128,17 @@
   </metadata>
   <metadata name="MergeWith.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
+  </metadata>
+  <metadata name="BranchName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="RemoteCombo.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="MergeWith.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
 </root>


### PR DESCRIPTION
## Proposed changes

- Fix `FormRemotes` DPI scaling
- Adjust alignment/anchoring for more even layout

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

100% scaling
![image](https://github.com/gitextensions/gitextensions/assets/483659/d8851e42-6b4c-4eaf-9c24-7f18f181ef97)

200% scaling (notice huge buttons)
![image](https://github.com/gitextensions/gitextensions/assets/483659/86543bfc-defb-4ef1-a958-116598e50227)

### After

100% scaling
![image](https://github.com/gitextensions/gitextensions/assets/483659/bad115db-bd4e-4118-b8b5-5a89d614a186)

200% scaling
![image](https://github.com/gitextensions/gitextensions/assets/483659/02cf0398-0cb9-4688-ad8e-42c1bddcb55f)

## Test methodology <!-- How did you ensure quality? -->

- Manually at 100% and 200% scaling

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
