### PR TITLE
refactor: Factor out ExecutionResult.ThrowIfErrorExit

### DIFF
--- a/GitCommands/Git/ExecutableExtensions.cs
+++ b/GitCommands/Git/ExecutableExtensions.cs
@@ -201,6 +201,7 @@ namespace GitCommands
                 result = result is null
                     ? itemResult
                     : new ExecutionResult(
+                        item.Argument,
                         result?.StandardOutput + itemResult.StandardOutput,
                         result?.StandardError + itemResult.StandardError,
                         result?.ExitCode is (> 0 or < 0) ? result?.ExitCode : itemResult.ExitCode);
@@ -293,6 +294,7 @@ namespace GitCommands
             if (cache?.TryGet(arguments, out byte[]? cachedOutput, out byte[]? cachedError) is true)
             {
                 return new ExecutionResult(
+                    arguments,
                     CleanString(stripAnsiEscapeCodes, EncodingHelper.DecodeString(cachedOutput, error: null, ref outputEncoding)),
                     CleanString(stripAnsiEscapeCodes, EncodingHelper.DecodeString(output: null, cachedError, ref outputEncoding)),
                     exitCode: 0);
@@ -364,6 +366,7 @@ namespace GitCommands
             }
 
             return new ExecutionResult(
+                arguments,
                 CleanString(stripAnsiEscapeCodes, output),
                 CleanString(stripAnsiEscapeCodes, error),
                 exitCode);

--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -2125,12 +2125,14 @@ namespace GitCommands
 
             // Handle no value set, is error code 1: https://git-scm.com/docs/git-config#_description
             const int ConfigKeyInvalidOrNotSet = 1;
-            return result.ExitCode switch
+            if (result.ExitCode == ConfigKeyInvalidOrNotSet)
             {
-                ExecutionResult.Success => result.StandardOutput.Trim(),
-                ConfigKeyInvalidOrNotSet => null,
-                _ => throw new ExternalOperationException("git", args.ToString(), WorkingDir, result.ExitCode, new InvalidOperationException("Error getting config value"))
-            };
+                return null;
+            }
+
+            result.ThrowIfErrorExit(AppSettings.GitCommand, WorkingDir, "Error getting config value");
+
+            return result.StandardOutput.Trim();
         }
 
         public string? GetEffectiveGitSetting(string setting, bool cache = false)

--- a/Plugins/GitUIPluginInterfaces/ExecutionResult.cs
+++ b/Plugins/GitUIPluginInterfaces/ExecutionResult.cs
@@ -1,15 +1,19 @@
-﻿namespace GitUIPluginInterfaces
+﻿using GitExtUtils;
+
+namespace GitUIPluginInterfaces
 {
     public readonly struct ExecutionResult
     {
         public const int Success = 0;
 
+        public string Arguments { get; }
         public string StandardOutput { get; }
         public string StandardError { get; }
         public int? ExitCode { get; }
 
-        public ExecutionResult(string standardOutput, string standardError, int? exitCode)
+        public ExecutionResult(string arguments, string standardOutput, string standardError, int? exitCode)
         {
+            Arguments = arguments;
             StandardOutput = standardOutput;
             StandardError = standardError;
             ExitCode = exitCode;
@@ -18,5 +22,16 @@
         public bool ExitedSuccessfully => ExitCode == Success;
 
         public string AllOutput => string.Concat(StandardOutput, Environment.NewLine, StandardError);
+
+        public void ThrowIfErrorExit(string? command = null, string? workingDir = null, string? errorMessage = null)
+        {
+            if (ExitedSuccessfully)
+            {
+                return;
+            }
+
+            string output = string.Concat(errorMessage, Environment.NewLine, StandardError, Environment.NewLine, StandardOutput);
+            throw new ExternalOperationException(command, Arguments, workingDir, ExitCode, new Exception(output));
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Factor out `ExecutionResult.ThrowIfErrorExit`
  from `GitModuleGetGitSetting` in preparation of #11680

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).