### PR TITLE
fix(TranslationUtil): Suppress Trace output

### DIFF
--- a/ResourceManager/Xliff/TranslationUtil.cs
+++ b/ResourceManager/Xliff/TranslationUtil.cs
@@ -75,7 +75,7 @@ namespace ResourceManager.Xliff
                 if (field.IsPublic && !field.IsInitOnly)
                 {
                     // if public AND modifiable (NOT readonly)
-                    Trace.WriteLine(string.Format("Skip field {0}.{1} [{2}]", obj.GetType().Name, field.Name, field.GetValue(obj)), "Translation");
+                    Debug.WriteLine(string.Format("Skip field {0}.{1} [{2}]", obj.GetType().Name, field.Name, field.GetValue(obj)), "Translation");
                     continue;
                 }
 


### PR DESCRIPTION
## Proposed changes

- Suppress `Trace` output from `TranslationUtil` in release build

Though these traces might be a hint that something does not work properly. I think the number of such traces is not the same on every startup.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![hints from translation](https://github.com/gitextensions/gitextensions/assets/460196/b6eaa41b-1a14-4315-b083-3f648c715f02)

### After

no output

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).