### PR TITLE
FormChooseCommit & Rebase onto: Display only potential commits

### DIFF
--- a/GitUI/CommandsDialogs/FormRebase.cs
+++ b/GitUI/CommandsDialogs/FormRebase.cs
@@ -1,5 +1,6 @@
 ﻿using GitCommands;
 using GitCommands.Git;
+using GitExtUtils;
 using GitExtUtils.GitUI.Theming;
 using GitUI.HelperDialogs;
 using GitUIPluginInterfaces;
@@ -408,7 +409,24 @@ namespace GitUI.CommandsDialogs
                 AppSettings.ShowStashes = false;
                 ObjectId firstParent = UICommands.Module.RevParse("HEAD~");
                 string preSelectedCommit = !string.IsNullOrWhiteSpace(txtFrom.Text) ? txtFrom.Text : firstParent?.ToString() ?? string.Empty;
-                using FormChooseCommit chooseForm = new(UICommands, preSelectedCommit, showCurrentBranchOnly: true);
+
+                string mergeBaseCommitId = null;
+
+                if (!string.IsNullOrWhiteSpace(cboBranches.Text))
+                {
+                    try
+                    {
+                        ObjectId commit1 = UICommands.Module.RevParse(cboBranches.Text);
+                        ObjectId commit2 = UICommands.Module.RevParse("HEAD");
+                        mergeBaseCommitId = UICommands.Module.GetMergeBase(commit1, commit2)?.ToString();
+                    }
+                    catch (Exception)
+                    {
+                        // if an exception occurs, display whole history
+                    }
+                }
+
+                using FormChooseCommit chooseForm = new(UICommands, preSelectedCommit, showCurrentBranchOnly: true, lastRevisionToDisplayHash: mergeBaseCommitId);
                 if (chooseForm.ShowDialog(this) == DialogResult.OK && chooseForm.SelectedRevision is not null)
                 {
                     txtFrom.Text = chooseForm.SelectedRevision.ObjectId.ToShortString();

--- a/GitUI/HelperDialogs/FormChooseCommit.cs
+++ b/GitUI/HelperDialogs/FormChooseCommit.cs
@@ -12,11 +12,16 @@ namespace GitUI.HelperDialogs
             InitializeComplete();
         }
 
-        public FormChooseCommit(GitUICommands commands, string? preselectCommit, bool showArtificial = false, bool showCurrentBranchOnly = false)
+        public FormChooseCommit(GitUICommands commands, string? preselectCommit, bool showArtificial = false, bool showCurrentBranchOnly = false, string? lastRevisionToDisplayHash = null)
             : this(commands)
         {
             revisionGrid.MultiSelect = false;
             revisionGrid.ShowUncommittedChangesIfPossible = showArtificial;
+            if (lastRevisionToDisplayHash is not null)
+            {
+                revisionGrid.SetLastRevisionToDisplayHash(lastRevisionToDisplayHash);
+            }
+
             if (showCurrentBranchOnly)
             {
                 revisionGrid.ShowCurrentBranchOnly();
@@ -83,7 +88,12 @@ namespace GitUI.HelperDialogs
         {
             IReadOnlyList<GitRevision> revisions = revisionGrid.GetSelectedRevisions();
 
-            if (revisions.Count != 1)
+            bool singleCommitSelected = revisions.Count == 1;
+            labelParents.Visible = singleCommitSelected;
+            linkLabelParent.Visible = singleCommitSelected;
+            linkLabelParent2.Visible = singleCommitSelected;
+
+            if (!singleCommitSelected)
             {
                 return;
             }

--- a/GitUI/UserControls/RevisionGrid/FilterInfo.cs
+++ b/GitUI/UserControls/RevisionGrid/FilterInfo.cs
@@ -195,6 +195,12 @@ namespace GitUI.UserControls.RevisionGrid
         }
 
         /// <summary>
+        /// The hash of the last revision to display (i.e. the oldest one displayed at the bottom).
+        /// This hash is used to query history only until this given commit.
+        /// </summary>
+        public string LastRevisionToDisplayHash { get; internal set; }
+
+        /// <summary>
         /// Disables all active filters.
         /// CurrentBranch and Reflog are not disabled.
         /// FullHistory and SimplifyMerges are considered settings and not reset.
@@ -481,6 +487,11 @@ namespace GitUI.UserControls.RevisionGrid
                 {
                     filter.Add("--boundary");
                 }
+            }
+
+            if (!string.IsNullOrWhiteSpace(LastRevisionToDisplayHash))
+            {
+                filter.Add($"...{LastRevisionToDisplayHash}");
             }
 
             return;

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1952,6 +1952,11 @@ namespace GitUI
             PerformRefreshRevisions();
         }
 
+        public void SetLastRevisionToDisplayHash(string hash)
+        {
+            _filterInfo.LastRevisionToDisplayHash = hash;
+        }
+
         public void ShowRevisionFilterDialog()
         {
             using FormRevisionFilter form = new(UICommands, _filterInfo);


### PR DESCRIPTION
so that choice is not overwhelming
and user has less data to process to find commit he wants

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

All the git history is displayed and user has to search for the commit to select:
![image](https://github.com/gitextensions/gitextensions/assets/460196/454e5f91-a157-4bcd-9920-12d379241ddc)

### After

Only the commit that could be rebased are displayed and it's easier for user to find the good low bound one of commits to rebase:
![image](https://github.com/gitextensions/gitextensions/assets/460196/43c29097-89b8-46ec-a9da-2258794bf173)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 754b034fbe97b7e7973e5b43bfed7fc87cff1a3e
- Git 2.44.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
