### PR TITLE
Allow selecting custom icons for user defined scripts

### DIFF
--- a/GitExtUtils/GitUI/PropertyGridExtensions.cs
+++ b/GitExtUtils/GitUI/PropertyGridExtensions.cs
@@ -4,11 +4,15 @@ namespace GitExtUtils.GitUI;
 
 public static class PropertyGridExtensions
 {
+    private static readonly FieldInfo? _gridViewField = typeof(PropertyGrid).GetField("_gridView", BindingFlags.Instance | BindingFlags.NonPublic);
+
+    private static readonly MethodInfo? _moveSplitterToMethod =
+        typeof(PropertyGrid).Assembly.GetType("System.Windows.Forms.PropertyGridInternal.PropertyGridView")
+        ?.GetMethod("MoveSplitterTo", BindingFlags.Instance | BindingFlags.NonPublic);
+
     public static void SetLabelColumnWidth(this PropertyGrid grid, int width)
     {
-        FieldInfo fi = grid.GetType().GetField("_gridView", BindingFlags.Instance | BindingFlags.NonPublic);
-        Control view = fi?.GetValue(grid) as Control;
-        MethodInfo mi = view?.GetType().GetMethod("MoveSplitterTo", BindingFlags.Instance | BindingFlags.NonPublic);
-        mi?.Invoke(view, [width]);
+        object view = _gridViewField?.GetValue(grid);
+        _moveSplitterToMethod?.Invoke(view, [width]);
     }
 }

--- a/GitExtUtils/GitUI/PropertyGridExtensions.cs
+++ b/GitExtUtils/GitUI/PropertyGridExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Reflection;
+
+namespace GitExtUtils.GitUI;
+
+public static class PropertyGridExtensions
+{
+    public static void SetLabelColumnWidth(this PropertyGrid grid, int width)
+    {
+        FieldInfo fi = grid.GetType().GetField("_gridView", BindingFlags.Instance | BindingFlags.NonPublic);
+        Control view = fi?.GetValue(grid) as Control;
+        MethodInfo mi = view?.GetType().GetMethod("MoveSplitterTo", BindingFlags.Instance | BindingFlags.NonPublic);
+        mi?.Invoke(view, [width]);
+    }
+}

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.ScriptInfoProxy.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.ScriptInfoProxy.cs
@@ -97,14 +97,14 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 ImageList = images;
             }
 
-            internal string? GetIconImageKey()
+            public string GetIconImageKey()
             {
                 if (File.Exists(IconPathName))
                 {
                     return IconPathName;
                 }
 
-                return Icon;
+                return Icon ?? string.Empty;
             }
 
             [return: NotNullIfNotNull(nameof(script))]

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.ScriptInfoProxy.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.ScriptInfoProxy.cs
@@ -60,7 +60,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             [DisplayName("Icon or associated file path")]
             [Description("This can either be a path to an .ico file or to any other file in which case its \"associated icon\" is used.")]
             [Editor(typeof(System.Windows.Forms.Design.FileNameEditor), typeof(UITypeEditor))]
-            public string? IconPathName { get; set; }
+            public string? IconFilePath { get; set; }
 
             [Category(ScriptBehaviourCategory)]
             [DisplayName("Ask confirmation")]
@@ -84,13 +84,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             internal void SetImages(ImageList images)
             {
-                if (IconPathName is not null)
+                if (IconFilePath is not null)
                 {
                     ScriptInfo scriptInfo = this;
                     Bitmap? icon = scriptInfo.GetIcon();
-                    if (icon is not null && !images.Images.ContainsKey(IconPathName))
+                    if (icon is not null && !images.Images.ContainsKey(IconFilePath))
                     {
-                        images.Images.Add(IconPathName, icon.AdaptLightness());
+                        images.Images.Add(IconFilePath, icon.AdaptLightness());
                     }
                 }
 
@@ -99,9 +99,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             public string GetIconImageKey()
             {
-                if (File.Exists(IconPathName))
+                if (File.Exists(IconFilePath))
                 {
-                    return IconPathName;
+                    return IconFilePath;
                 }
 
                 return Icon ?? string.Empty;
@@ -128,7 +128,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     AddToRevisionGridContextMenu = script.AddToRevisionGridContextMenu,
                     RunInBackground = script.RunInBackground,
                     Icon = script.Icon,
-                    IconPathName = script.IconPathName
+                    IconFilePath = script.IconFilePath
                 };
             }
 
@@ -153,7 +153,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     AddToRevisionGridContextMenu = proxy.AddToRevisionGridContextMenu,
                     RunInBackground = proxy.RunInBackground,
                     Icon = proxy.Icon,
-                    IconPathName = proxy.IconPathName
+                    IconFilePath = proxy.IconFilePath
                 };
             }
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.ScriptInfoProxy.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.ScriptInfoProxy.cs
@@ -88,12 +88,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                 {
                     ScriptInfo scriptInfo = this;
                     Bitmap? icon = scriptInfo.GetIcon();
-                    if (icon is not null)
+                    if (icon is not null && !images.Images.ContainsKey(IconPath))
                     {
-                        if (!images.Images.ContainsKey(IconPath))
-                        {
-                            images.Images.Add(IconPath, icon.AdaptLightness());
-                        }
+                        images.Images.Add(IconPath, icon.AdaptLightness());
                     }
                 }
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.ScriptInfoProxy.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.ScriptInfoProxy.cs
@@ -60,7 +60,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             [DisplayName("Icon or associated file path")]
             [Description("This can either be a path to an .ico file or to any other file in which case its \"associated icon\" is used.")]
             [Editor(typeof(System.Windows.Forms.Design.FileNameEditor), typeof(UITypeEditor))]
-            public string? IconPath { get; set; }
+            public string? IconPathName { get; set; }
 
             [Category(ScriptBehaviourCategory)]
             [DisplayName("Ask confirmation")]
@@ -84,13 +84,13 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             internal void SetImages(ImageList images)
             {
-                if (IconPath is not null)
+                if (IconPathName is not null)
                 {
                     ScriptInfo scriptInfo = this;
                     Bitmap? icon = scriptInfo.GetIcon();
-                    if (icon is not null && !images.Images.ContainsKey(IconPath))
+                    if (icon is not null && !images.Images.ContainsKey(IconPathName))
                     {
-                        images.Images.Add(IconPath, icon.AdaptLightness());
+                        images.Images.Add(IconPathName, icon.AdaptLightness());
                     }
                 }
 
@@ -99,9 +99,9 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             internal string? GetIconImageKey()
             {
-                if (File.Exists(IconPath))
+                if (File.Exists(IconPathName))
                 {
-                    return IconPath;
+                    return IconPathName;
                 }
 
                 return Icon;
@@ -128,7 +128,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     AddToRevisionGridContextMenu = script.AddToRevisionGridContextMenu,
                     RunInBackground = script.RunInBackground,
                     Icon = script.Icon,
-                    IconPath = script.IconPath
+                    IconPathName = script.IconPathName
                 };
             }
 
@@ -153,7 +153,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
                     AddToRevisionGridContextMenu = proxy.AddToRevisionGridContextMenu,
                     RunInBackground = proxy.RunInBackground,
                     Icon = proxy.Icon,
-                    IconPath = proxy.IconPath
+                    IconPathName = proxy.IconPathName
                 };
             }
         }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -86,7 +86,7 @@ File(s):
         private static readonly string[] WatchedProxyPropertiesOnValueChanged =
         [
             nameof(ScriptInfoProxy.Icon),
-            nameof(ScriptInfoProxy.IconPath),
+            nameof(ScriptInfoProxy.IconPathName),
         ];
 
         private static readonly ImageList EmbeddedIcons = new()

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -245,7 +245,7 @@ File(s):
                         ToolTipText = $"{script.Command} {script.Arguments}",
                         Tag = script,
                         ForeColor = color,
-                        ImageKey = script.GetIconImageKey() ?? string.Empty,
+                        ImageKey = script.GetIconImageKey(),
                         Checked = script.Enabled
                     };
                     lvScripts.Items.Add(lvitem);

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -86,7 +86,7 @@ File(s):
         private static readonly string[] WatchedProxyPropertiesOnValueChanged =
         [
             nameof(ScriptInfoProxy.Icon),
-            nameof(ScriptInfoProxy.IconPathName),
+            nameof(ScriptInfoProxy.IconFilePath),
         ];
 
         private static readonly ImageList EmbeddedIcons = new()

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections;
 using System.ComponentModel;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using GitCommands;
 using GitCommands.Utils;
@@ -9,6 +8,7 @@ using GitExtUtils.GitUI;
 using GitExtUtils.GitUI.Theming;
 using GitUI.ScriptsEngine;
 using GitUIPluginInterfaces;
+using Microsoft;
 using ResourceManager;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
@@ -166,7 +166,8 @@ File(s):
             // dummy request; for some strange reason the ResourceSets are not loaded until after the first object request... bug?
             rm.GetObject("dummy");
 
-            using System.Resources.ResourceSet resourceSet = rm.GetResourceSet(CultureInfo.CurrentUICulture, true, true)!;
+            using System.Resources.ResourceSet resourceSet = rm.GetResourceSet(CultureInfo.CurrentUICulture, true, true);
+            Validates.NotNull(resourceSet);
             foreach (DictionaryEntry icon in resourceSet.Cast<DictionaryEntry>().OrderBy(icon => icon.Key))
             {
                 if (icon.Value is Bitmap bitmap)
@@ -244,7 +245,7 @@ File(s):
                         ToolTipText = $"{script.Command} {script.Arguments}",
                         Tag = script,
                         ForeColor = color,
-                        ImageKey = script.GetIconImageKey(),
+                        ImageKey = script.GetIconImageKey() ?? string.Empty,
                         Checked = script.Enabled
                     };
                     lvScripts.Items.Add(lvitem);
@@ -293,7 +294,7 @@ File(s):
 
         private void btnAdd_Click(object sender, EventArgs e)
         {
-            ScriptInfoProxy script = _scripts.AddNew()!;
+            ScriptInfoProxy script = _scripts.AddNew();
             script.HotkeyCommandIdentifier = Math.Max(ScriptsManager.MinimumUserScriptID, _scripts.Max(s => s.HotkeyCommandIdentifier)) + 1;
             script.Name = "<New Script>";
             script.Enabled = true;

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -282,6 +282,8 @@ File(s):
                 {
                     chdrCommand.Width = -1;
                 }
+
+                SetPropertyGridWidthOnce();
             }
             finally
             {
@@ -388,6 +390,18 @@ File(s):
             int index = _scripts.IndexOf(script);
             btnMoveUp.Enabled = index > 0;
             btnMoveDown.Enabled = index < _scripts.Count - 1;
+        }
+
+        private void SetPropertyGridWidthOnce()
+        {
+            const string widthSetTag = "width_set";
+
+            string? tag = propertyGrid1.GetTag<string?>();
+            if (tag != widthSetTag)
+            {
+                propertyGrid1.SetLabelColumnWidth(DpiUtil.Scale(240));
+                propertyGrid1.SetTag(widthSetTag);
+            }
         }
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/ScriptsSettingsPage.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.ComponentModel;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using GitCommands;
 using GitCommands.Utils;
@@ -73,18 +74,25 @@ File(s):
 {SelectedFiles}
 {LineNumber}");
 
-        private static readonly string[] WatchedProxyProperties = new string[]
-        {
+        private static readonly string[] WatchedProxyPropertiesOnFocusChanged =
+        [
             nameof(ScriptInfoProxy.Name),
             nameof(ScriptInfoProxy.Enabled),
-            nameof(ScriptInfoProxy.Icon),
             nameof(ScriptInfoProxy.OnEvent),
             nameof(ScriptInfoProxy.Command),
             nameof(ScriptInfoProxy.Arguments),
-        };
+        ];
+
+        private static readonly string[] WatchedProxyPropertiesOnValueChanged =
+        [
+            nameof(ScriptInfoProxy.Icon),
+            nameof(ScriptInfoProxy.IconPath),
+        ];
+
         private static readonly ImageList EmbeddedIcons = new()
         {
-            ColorDepth = ColorDepth.Depth32Bit
+            ColorDepth = ColorDepth.Depth32Bit,
+            ImageSize = DpiUtil.Scale(new Size(16, 16))
         };
 
         private readonly BindingList<ScriptInfoProxy> _scripts = [];
@@ -94,7 +102,7 @@ File(s):
 
         // settings maybe loaded before page is shown or after
         // we need to track that so we load images before we bind the list
-        private bool _imagsLoaded;
+        private bool _imagesLoaded;
 
         public ScriptsSettingsPage(IServiceProvider serviceProvider)
             : base(serviceProvider)
@@ -117,14 +125,21 @@ File(s):
             int margin = propertyGrid1.Margin.Left;
             propertyGrid1.Margin = new Padding(margin, margin, panelButtons.Width, margin);
 
-            propertyGrid1.SelectedGridItemChanged += (s, e) =>
+            propertyGrid1.SelectedGridItemChanged += (_, e) =>
+                UpdateScripts(WatchedProxyPropertiesOnFocusChanged, e.OldSelection?.PropertyDescriptor?.Name ?? "");
+
+            propertyGrid1.PropertyValueChanged += (_, e) =>
+                UpdateScripts(WatchedProxyPropertiesOnValueChanged, e.ChangedItem?.PropertyDescriptor?.Name ?? "");
+
+            void UpdateScripts(string[] watchedProperties, string changedItem)
             {
-                if (WatchedProxyProperties.Contains(e.OldSelection?.PropertyDescriptor?.Name ?? ""))
+                if (watchedProperties.Contains(changedItem))
                 {
+                    SelectedScript?.SetImages(EmbeddedIcons);
                     BindScripts(_scripts, SelectedScript);
                     propertyGrid1.Focus();
                 }
-            };
+            }
         }
 
         private ScriptInfoProxy? SelectedScript { get; set; }
@@ -151,12 +166,12 @@ File(s):
             // dummy request; for some strange reason the ResourceSets are not loaded until after the first object request... bug?
             rm.GetObject("dummy");
 
-            using System.Resources.ResourceSet resourceSet = rm.GetResourceSet(CultureInfo.CurrentUICulture, true, true);
+            using System.Resources.ResourceSet resourceSet = rm.GetResourceSet(CultureInfo.CurrentUICulture, true, true)!;
             foreach (DictionaryEntry icon in resourceSet.Cast<DictionaryEntry>().OrderBy(icon => icon.Key))
             {
                 if (icon.Value is Bitmap bitmap)
                 {
-                    EmbeddedIcons.Images.Add(icon.Key.ToString(), bitmap.AdaptLightness());
+                    EmbeddedIcons.Images.Add(icon.Key.ToString()!, bitmap.AdaptLightness());
                 }
             }
 
@@ -164,7 +179,7 @@ File(s):
             rm.ReleaseAllResources();
 
             lvScripts.LargeImageList = lvScripts.SmallImageList = EmbeddedIcons;
-            _imagsLoaded = true;
+            _imagesLoaded = true;
 
             BindScripts(_scripts, null);
         }
@@ -175,10 +190,12 @@ File(s):
 
             foreach (ScriptInfo script in _scriptsManager.GetScripts())
             {
-                _scripts.Add(script);
+                ScriptInfoProxy scriptProxy = script;
+                scriptProxy.SetImages(EmbeddedIcons);
+                _scripts.Add(scriptProxy);
             }
 
-            if (_imagsLoaded)
+            if (_imagesLoaded)
             {
                 BindScripts(_scripts, null);
             }
@@ -227,7 +244,7 @@ File(s):
                         ToolTipText = $"{script.Command} {script.Arguments}",
                         Tag = script,
                         ForeColor = color,
-                        ImageKey = script.Icon,
+                        ImageKey = script.GetIconImageKey(),
                         Checked = script.Enabled
                     };
                     lvScripts.Items.Add(lvitem);
@@ -242,7 +259,7 @@ File(s):
 
                 SelectedScript = selectedScript;
 
-                if (selectedScript is object)
+                if (selectedScript is not null)
                 {
                     ListViewItem lvi = lvScripts.Items.Cast<ListViewItem>().FirstOrDefault(x => x.Tag == selectedScript);
                     if (lvi is not null)
@@ -274,8 +291,8 @@ File(s):
 
         private void btnAdd_Click(object sender, EventArgs e)
         {
-            ScriptInfoProxy script = _scripts.AddNew();
-            script.HotkeyCommandIdentifier = Math.Max(GitUI.ScriptsEngine.ScriptsManager.MinimumUserScriptID, _scripts.Max(s => s.HotkeyCommandIdentifier)) + 1;
+            ScriptInfoProxy script = _scripts.AddNew()!;
+            script.HotkeyCommandIdentifier = Math.Max(ScriptsManager.MinimumUserScriptID, _scripts.Max(s => s.HotkeyCommandIdentifier)) + 1;
             script.Name = "<New Script>";
             script.Enabled = true;
 
@@ -366,8 +383,6 @@ File(s):
             }
 
             SelectedScript = script;
-            script.SetImages(EmbeddedIcons);
-
             propertyGrid1.SelectedObject = script;
 
             int index = _scripts.IndexOf(script);

--- a/GitUI/Design/PropertySorter.cs
+++ b/GitUI/Design/PropertySorter.cs
@@ -12,7 +12,7 @@ namespace GitUI.Design
         public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
         {
             PropertyDescriptorCollection pdc = TypeDescriptor.GetProperties(value, attributes);
-            List<(string, int)> orderedProperties = [];
+            List<(string name, int order)> orderedProperties = [];
             foreach (PropertyDescriptor pd in pdc)
             {
                 Attribute attribute = pd.Attributes[typeof(PropertyOrderAttribute)];
@@ -27,7 +27,7 @@ namespace GitUI.Design
                 }
             }
 
-            return pdc.Sort(orderedProperties.OrderBy(p => p.Item2).Select(p => p.Item1).ToArray());
+            return pdc.Sort(orderedProperties.OrderBy(p => p.order).Select(p => p.name).ToArray());
         }
     }
 }

--- a/GitUI/ScriptsEngine/ScriptInfo.cs
+++ b/GitUI/ScriptsEngine/ScriptInfo.cs
@@ -35,11 +35,34 @@
         public string? Icon { get; set; }
 
         /// <summary>
+        /// Gets or sets the Icon or associated file path
+        /// </summary>
+        public string? IconPath { get; set; }
+
+        /// <summary>
         /// Gets the associated bitmap.
         /// </summary>
         /// <returns>Bitmap image.</returns>
         public Bitmap? GetIcon()
         {
+            if (File.Exists(IconPath))
+            {
+                if (IconPath.EndsWith(".ico", StringComparison.OrdinalIgnoreCase))
+                {
+                    System.Drawing.Icon icon = new(IconPath);
+                    return icon.ToBitmap();
+                }
+
+                try
+                {
+                    System.Drawing.Icon associatedIcon = System.Drawing.Icon.ExtractAssociatedIcon(IconPath);
+                    return associatedIcon.ToBitmap();
+                }
+                catch
+                {
+                }
+            }
+
             if (string.IsNullOrWhiteSpace(Icon))
             {
                 return null;

--- a/GitUI/ScriptsEngine/ScriptInfo.cs
+++ b/GitUI/ScriptsEngine/ScriptInfo.cs
@@ -37,7 +37,7 @@
         /// <summary>
         /// Gets or sets the path to the file containing the icon.
         /// </summary>
-        public string? IconPathName { get; set; }
+        public string? IconFilePath { get; set; }
 
         /// <summary>
         /// Gets the associated bitmap.
@@ -45,17 +45,17 @@
         /// <returns>Bitmap image.</returns>
         public Bitmap? GetIcon()
         {
-            if (File.Exists(IconPathName))
+            if (File.Exists(IconFilePath))
             {
-                if (IconPathName.EndsWith(".ico", StringComparison.OrdinalIgnoreCase))
+                if (IconFilePath.EndsWith(".ico", StringComparison.OrdinalIgnoreCase))
                 {
-                    using Icon icon = new(IconPathName);
+                    using Icon icon = new(IconFilePath);
                     return icon.ToBitmap();
                 }
 
                 try
                 {
-                    using Icon? associatedIcon = System.Drawing.Icon.ExtractAssociatedIcon(IconPathName);
+                    using Icon? associatedIcon = System.Drawing.Icon.ExtractAssociatedIcon(IconFilePath);
                     if (associatedIcon is not null)
                     {
                         return associatedIcon.ToBitmap();

--- a/GitUI/ScriptsEngine/ScriptInfo.cs
+++ b/GitUI/ScriptsEngine/ScriptInfo.cs
@@ -49,14 +49,17 @@
             {
                 if (IconPathName.EndsWith(".ico", StringComparison.OrdinalIgnoreCase))
                 {
-                    System.Drawing.Icon icon = new(IconPathName);
+                    using Icon icon = new(IconPathName);
                     return icon.ToBitmap();
                 }
 
                 try
                 {
-                    System.Drawing.Icon associatedIcon = System.Drawing.Icon.ExtractAssociatedIcon(IconPathName);
-                    return associatedIcon.ToBitmap();
+                    using Icon? associatedIcon = System.Drawing.Icon.ExtractAssociatedIcon(IconPathName);
+                    if (associatedIcon is not null)
+                    {
+                        return associatedIcon.ToBitmap();
+                    }
                 }
                 catch
                 {

--- a/GitUI/ScriptsEngine/ScriptInfo.cs
+++ b/GitUI/ScriptsEngine/ScriptInfo.cs
@@ -37,7 +37,7 @@
         /// <summary>
         /// Gets or sets the Icon or associated file path
         /// </summary>
-        public string? IconPath { get; set; }
+        public string? IconPathName { get; set; }
 
         /// <summary>
         /// Gets the associated bitmap.
@@ -45,17 +45,17 @@
         /// <returns>Bitmap image.</returns>
         public Bitmap? GetIcon()
         {
-            if (File.Exists(IconPath))
+            if (File.Exists(IconPathName))
             {
-                if (IconPath.EndsWith(".ico", StringComparison.OrdinalIgnoreCase))
+                if (IconPathName.EndsWith(".ico", StringComparison.OrdinalIgnoreCase))
                 {
-                    System.Drawing.Icon icon = new(IconPath);
+                    System.Drawing.Icon icon = new(IconPathName);
                     return icon.ToBitmap();
                 }
 
                 try
                 {
-                    System.Drawing.Icon associatedIcon = System.Drawing.Icon.ExtractAssociatedIcon(IconPath);
+                    System.Drawing.Icon associatedIcon = System.Drawing.Icon.ExtractAssociatedIcon(IconPathName);
                     return associatedIcon.ToBitmap();
                 }
                 catch

--- a/GitUI/ScriptsEngine/ScriptInfo.cs
+++ b/GitUI/ScriptsEngine/ScriptInfo.cs
@@ -35,7 +35,7 @@
         public string? Icon { get; set; }
 
         /// <summary>
-        /// Gets or sets the Icon or associated file path
+        /// Gets or sets the path to the file containing the icon.
         /// </summary>
         public string? IconPathName { get; set; }
 


### PR DESCRIPTION
## Proposed changes

- In `Scripts` in addition to `Icon` property, add `IconPathName` in the property grid
  - First, this will allow to pick any icon the user wishes for
  - Second, this will allow picking high quality icons (built in ones are blurry)
- Change icon related property handling such that their values are reflected in the scripts list immediately on-value-change
- Fix DPI issues with script icons (see "before 200% scaling" screenshot)
- Default position of `PropertyGrid` is ridonculous. StackOverflow listed the only option of using reflection to read into internal control and adjusting its splitter position.. not pretty but no downsides even if underling API changes **and** it looks much better.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

100% scaling
![image](https://github.com/gitextensions/gitextensions/assets/483659/50d4bd57-da37-4075-8f33-b4819b6ce3a0)

200% scaling
![image](https://github.com/gitextensions/gitextensions/assets/483659/b2253036-9800-4c16-8900-a7b4dcf3d0fa)


### After

100% scaling
![image](https://github.com/gitextensions/gitextensions/assets/483659/258ececc-2c8c-4df1-8c25-ff10ab3c3a5b)

200% scaling
![image](https://github.com/gitextensions/gitextensions/assets/483659/40ee82d0-7e55-47c8-80b3-8af5af15d01b)

## Test methodology <!-- How did you ensure quality? -->

- Manually by adding empty paths, incorrect paths, setting both `Icon` and `IconPathName`, etc.

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11 200% scaling

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
