### PR TITLE
perf(graph): Keep more lines in cache when scrolling forward

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/RevisionGraphColumnProvider.cs
@@ -101,15 +101,7 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                     return true;
                 }
 
-                if (Math.Abs(offsetToHead) >= _graphCache.Capacity)
-                {
-                    // Restart the cache with this line
-                    startRow = rowIndex;
-                    endRow = rowIndex + 1;
-                    _graphCache.HeadRow = startRow;
-                    _graphCache.Count = 1;
-                }
-                else if (offsetToHead < 0)
+                if (offsetToHead < 0 && -offsetToHead < _graphCache.Capacity)
                 {
                     // Scroll back, make the current row the head row
                     startRow = rowIndex;
@@ -119,17 +111,25 @@ namespace GitUI.UserControls.RevisionGrid.Columns
                     _graphCache.Head += _graphCache.Capacity + offsetToHead;
                     _graphCache.Head %= _graphCache.Capacity;
                 }
-                else
+                else if (offsetToHead > 0 && offsetToHead <= 2 * (_graphCache.Capacity - 1))
                 {
                     // Scroll forward
-                    startRow = _graphCache.HeadRow + _graphCache.Count;
+                    startRow = _graphCache.HeadRow + _graphCache.Count; // all rows before have already been rendered
                     endRow = rowIndex + 1;
-                    _graphCache.Count += endRow - startRow;
+                    _graphCache.Count += endRow - startRow; // Count = Count + (rowIndex + 1) - (HeadRow + Count) = rowIndex + 1 - HeadRow
                     int neededHeadAdjustment = Math.Max(0, _graphCache.Count - _graphCache.Capacity);
                     _graphCache.Count -= neededHeadAdjustment;
                     _graphCache.HeadRow += neededHeadAdjustment;
                     _graphCache.Head += neededHeadAdjustment;
                     _graphCache.Head %= _graphCache.Capacity;
+                }
+                else
+                {
+                    // Restart the cache with this line
+                    startRow = rowIndex;
+                    endRow = rowIndex + 1;
+                    _graphCache.HeadRow = startRow;
+                    _graphCache.Count = 1;
                 }
             }
 

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphColumnTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphColumnTests.cs
@@ -54,7 +54,7 @@ public class RevisionGraphColumnTests
     [Test]
     public void PaintGraphCell_should_fill_forward_then_restart()
     {
-        Setup(rowCount: 6, visibleRowCount: 2, out RevisionGraphColumnProvider.TestAccessor testAccessor, out Graphics graphics);
+        Setup(rowCount: 10, visibleRowCount: 2, out RevisionGraphColumnProvider.TestAccessor testAccessor, out Graphics graphics);
 
         int rowIndex = 0;
         testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
@@ -70,7 +70,7 @@ public class RevisionGraphColumnTests
         testAccessor.GraphCache.HeadRow.Should().Be(0);
         testAccessor.GraphCache.Count.Should().Be(2);
 
-        rowIndex = testAccessor.GraphCache.HeadRow + testAccessor.GraphCache.Capacity;
+        rowIndex = testAccessor.GraphCache.HeadRow + (2 * (testAccessor.GraphCache.Capacity - 1)) + 1;
         testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
             .Should().BeTrue();
         testAccessor.GraphCache.Head.Should().Be(0);
@@ -78,9 +78,10 @@ public class RevisionGraphColumnTests
         testAccessor.GraphCache.Count.Should().Be(1);
     }
 
+    [Test]
     public void PaintGraphCell_should_scroll_forward()
     {
-        Setup(rowCount: 3, visibleRowCount: 2, out RevisionGraphColumnProvider.TestAccessor testAccessor, out Graphics graphics);
+        Setup(rowCount: 10, visibleRowCount: 2, out RevisionGraphColumnProvider.TestAccessor testAccessor, out Graphics graphics);
 
         int rowIndex = 0;
         testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
@@ -99,9 +100,37 @@ public class RevisionGraphColumnTests
         ++rowIndex;
         testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
             .Should().BeTrue();
+        testAccessor.GraphCache.Head.Should().Be(0);
+        testAccessor.GraphCache.HeadRow.Should().Be(0);
+        testAccessor.GraphCache.Count.Should().Be(3);
+
+        ++rowIndex;
+        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
+            .Should().BeTrue();
+        testAccessor.GraphCache.Head.Should().Be(0);
+        testAccessor.GraphCache.HeadRow.Should().Be(0);
+        testAccessor.GraphCache.Count.Should().Be(4);
+
+        ++rowIndex;
+        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
+            .Should().BeTrue();
+        testAccessor.GraphCache.Head.Should().Be(0);
+        testAccessor.GraphCache.HeadRow.Should().Be(0);
+        testAccessor.GraphCache.Count.Should().Be(5);
+
+        ++rowIndex;
+        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
+            .Should().BeTrue();
         testAccessor.GraphCache.Head.Should().Be(1);
         testAccessor.GraphCache.HeadRow.Should().Be(1);
-        testAccessor.GraphCache.Count.Should().Be(2);
+        testAccessor.GraphCache.Count.Should().Be(5);
+
+        rowIndex = testAccessor.GraphCache.HeadRow + (2 * (testAccessor.GraphCache.Capacity - 1));
+        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
+            .Should().BeTrue();
+        testAccessor.GraphCache.Head.Should().Be(1 - 1);
+        testAccessor.GraphCache.HeadRow.Should().Be(rowIndex - (testAccessor.GraphCache.Capacity - 1));
+        testAccessor.GraphCache.Count.Should().Be(5);
     }
 
     [Test]


### PR DESCRIPTION
## Proposed changes

- `RevisionGraphColumnProvider.PaintGraphCell`: Keep more lines in cache when scrolling forward
  A different limit is needed for forward than for backward in order to not unnecessary throw away rendered lines.

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- extended unit tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).