### PR TITLE
fix(RevisionDataGridView): Cancel outdated update

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -398,6 +398,7 @@ namespace GitUI.UserControls.RevisionGrid
         {
             ThreadHelper.AssertOnUIThread();
 
+            _updateVisibleRowRangeSequence.CancelCurrent();
             _backgroundScrollTo = -1;
             _forceRefresh = false;
             _visibleRowRange = new VisibleRowRange(fromIndex: 0, count: 0);


### PR DESCRIPTION
Might fix #11700

## Proposed changes

- `RevisionDataGridView.Clear`: Cancel outdated update by `RevisionDataGridView.UpdateVisibleRowRangeInternalAsync`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).