### PR TITLE
Refresh less on author highlighting

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -592,6 +592,7 @@ namespace GitUI.UserControls.RevisionGrid
             finally
             {
                 UpdatingVisibleRows = false;
+                _backgroundUpdater.ScheduleExecution();
             }
         }
 

--- a/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -1023,7 +1023,7 @@ namespace GitUI
                     {
                         // Revision may be displayed already, explicit refresh needed
                         await this.SwitchToMainThreadAsync(cancellationToken);
-                        Refresh();
+                        _gridView.Invalidate();
                     }
                 });
 
@@ -1679,7 +1679,7 @@ namespace GitUI
                 !_gridView.UpdatingVisibleRows &&
                 _authorHighlighting.ProcessRevisionSelectionChange(Module, selectedRevisions))
             {
-                Refresh();
+                _gridView.Invalidate();
             }
         }
 


### PR DESCRIPTION
## Proposed changes

- Just invalidate `_gridView` on author highlight instead of refreshing the entire `RevisionGridControl`
- Always explicitly refresh the `RevisionGridControl` in `OnRevisionReadCompleted` in order to apply settings and column widths
- Trigger graph update from `RevisionDataGridView.SetRowCount`
  which fixes the regression from the improved author highlighting

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual
- existing tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).