### PR TITLE
Render revision graph in the background

### DIFF
--- a/GitUI/UserControls/RevisionGrid/Columns/ColumnProvider.cs
+++ b/GitUI/UserControls/RevisionGrid/Columns/ColumnProvider.cs
@@ -46,10 +46,6 @@ namespace GitUI.UserControls.RevisionGrid.Columns
         {
         }
 
-        public virtual void OnVisibleRowsChanged(in VisibleRowRange visibleRowRange)
-        {
-        }
-
         /// <summary>Attempts to get custom tool tip text for a cell in this column.</summary>
         /// <remarks>Returning <c>false</c> here will not stop a tool tip being automatically displayed for truncated text.</remarks>
         public virtual bool TryGetToolTip(DataGridViewCellMouseEventArgs e, GitRevision revision, [NotNullWhen(returnValue: true)] out string? toolTip)

--- a/GitUI/UserControls/RevisionGrid/Graph/Rendering/GraphCache.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/Rendering/GraphCache.cs
@@ -64,6 +64,25 @@ internal sealed class GraphCache
         Reset();
     }
 
+    internal void CopyFrom(GraphCache source)
+    {
+        Capacity = source.Capacity;
+        Bitmap sourceBitmap = source.GraphBitmap;
+        Allocate(sourceBitmap.Width, sourceBitmap.Height);
+        GraphBitmapGraphics.CompositingMode = CompositingMode.SourceCopy;
+        GraphBitmapGraphics.DrawImage(sourceBitmap, 0, 0);
+        Count = source.Count;
+        Head = source.Head;
+        HeadRow = source.HeadRow;
+    }
+
+    /// <summary>
+    /// Maps a graph row to a cache row.
+    /// </summary>
+    /// <param name="rowIndex">The row index in the entire graph.</param>
+    /// <returns>The row index in the cache.</returns>
+    internal int GetCacheRow(int rowIndex) => (Head + rowIndex - HeadRow) % Capacity;
+
     internal void Reset()
     {
         Head = 0;

--- a/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -153,7 +153,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         /// <param name="lastToCacheRowIndex">
         /// The graph can be built per x rows. This defines the last row index that the graph will build cache to.
         /// </param>
-        public void CacheTo(int currentRowIndex, int lastToCacheRowIndex)
+        public void CacheTo(int currentRowIndex, int lastToCacheRowIndex, CancellationToken cancellationToken = default)
         {
             // Graph segments shall be straightened. For this, we need to look ahead some rows.
             // If lanes of a row are moved, go back the same number of rows as for the look-ahead
@@ -190,7 +190,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             }
 
             ImmutableArray<RevisionGraphRevision> orderedNodesCache = BuildOrderedNodesCache(currentRowIndex);
-            BuildOrderedRowCache(orderedNodesCache, lastToCacheRowIndex);
+            BuildOrderedRowCache(orderedNodesCache, lastToCacheRowIndex, cancellationToken);
         }
 
         public bool IsRowRelative(int row)
@@ -419,7 +419,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
                 || orderedRowCache[0].Revision != orderedNodesCache[0];
         }
 
-        private void BuildOrderedRowCache(ImmutableArray<RevisionGraphRevision> orderedNodesCache, int lastToCacheRowIndex)
+        private void BuildOrderedRowCache(ImmutableArray<RevisionGraphRevision> orderedNodesCache, int lastToCacheRowIndex, CancellationToken cancellationToken)
         {
             bool orderSegments = Config.ReduceGraphCrossings;
 
@@ -451,6 +451,7 @@ namespace GitUI.UserControls.RevisionGrid.Graph
 
             for (int nextIndex = startIndex; nextIndex <= lastToCacheRowIndex; ++nextIndex)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 RevisionGraphRevision revision = orderedNodesCache[nextIndex];
                 RevisionGraphSegment[] revisionStartSegments = revision.GetStartSegments();
                 if (orderSegments)

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -336,13 +336,6 @@ namespace GitUI.UserControls.RevisionGrid
             {
                 provider.OnCellPainting(e, _revision!, _rowHeight, _cellStyle.Value);
             }
-
-            if (!e.Handled)
-            {
-                e.Handled = true;
-
-                UpdateVisibleRowRange();
-            }
         }
 
         /// <summary>

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -769,7 +769,7 @@ namespace GitUI.UserControls.RevisionGrid
                 do
                 {
                     curCount = _revisionGraph.GetCachedCount();
-                    _revisionGraph.CacheTo(currentRowIndex: curCount, lastToCacheRowIndex: newBackgroundScrollTo);
+                    _revisionGraph.CacheTo(currentRowIndex: curCount, lastToCacheRowIndex: newBackgroundScrollTo, cancellationToken);
 
                     // Take changes to _backgroundScrollTo and IsDataLoadComplete by another thread into account
                     if (IsDataLoadComplete)

--- a/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphColumnTests.cs
+++ b/UnitTests/GitUI.Tests/UserControls/RevisionGrid/Graph/RevisionGraphColumnTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Drawing.Imaging;
-using FluentAssertions;
+﻿using FluentAssertions;
 using GitCommands;
 using GitUI.UserControls.RevisionGrid;
 using GitUI.UserControls.RevisionGrid.Columns;
@@ -13,158 +12,145 @@ namespace GitUITests.UserControls.RevisionGrid.Graph;
 public class RevisionGraphColumnTests
 {
     private const int _rowHeight = 42;
-    private const int _cellWidth = 1000;
-
-    private static readonly Rectangle _paintRectangle = new(0, 0, _cellWidth, _rowHeight);
 
     [Test]
-    public void PaintGraphCell_should_start_cache_with_single_line()
+    public void RenderGraphToCache_should_start_cache_with_single_line()
     {
         const int rowCount = 2;
-        Setup(rowCount, out RevisionGraphColumnProvider.TestAccessor testAccessor, out Graphics graphics);
+        Setup(rowCount, out RevisionGraphColumnProvider.TestAccessor testAccessor);
 
         const int rowIndex = 1;
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(0); // not really mandatory, but Head is reset in Clear()
         testAccessor.GraphCache.HeadRow.Should().Be(rowIndex);
         testAccessor.GraphCache.Count.Should().Be(1);
-        testAccessor.GraphCache.Capacity.Should().Be((2 * rowCount) + 1);
+        testAccessor.GraphCache.Capacity.Should().Be(3 * rowCount);
     }
 
     [Test]
-    public void PaintGraphCell_should_draw_from_cache()
+    public void RenderGraphToCache_should_draw_from_cache()
     {
-        Setup(rowCount: 2, out RevisionGraphColumnProvider.TestAccessor testAccessor, out Graphics graphics);
+        Setup(rowCount: 2, out RevisionGraphColumnProvider.TestAccessor testAccessor);
 
         const int rowIndex = 1;
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(0); // not really mandatory, but Head is reset in Clear()
         testAccessor.GraphCache.HeadRow.Should().Be(rowIndex);
         testAccessor.GraphCache.Count.Should().Be(1);
 
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(0); // not really mandatory, but Head is reset in Clear()
         testAccessor.GraphCache.HeadRow.Should().Be(rowIndex);
         testAccessor.GraphCache.Count.Should().Be(1);
     }
 
     [Test]
-    public void PaintGraphCell_should_fill_forward_then_restart()
+    public void RenderGraphToCache_should_fill_forward_then_restart()
     {
-        Setup(rowCount: 10, visibleRowCount: 2, out RevisionGraphColumnProvider.TestAccessor testAccessor, out Graphics graphics);
+        Setup(rowCount: 10, visibleRowCount: 2, out RevisionGraphColumnProvider.TestAccessor testAccessor);
 
         int rowIndex = 0;
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(0); // not really mandatory, but Head is reset in Clear()
         testAccessor.GraphCache.HeadRow.Should().Be(0);
         testAccessor.GraphCache.Count.Should().Be(1);
 
         ++rowIndex;
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(0);
         testAccessor.GraphCache.HeadRow.Should().Be(0);
         testAccessor.GraphCache.Count.Should().Be(2);
 
         rowIndex = testAccessor.GraphCache.HeadRow + (2 * (testAccessor.GraphCache.Capacity - 1)) + 1;
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(0);
         testAccessor.GraphCache.HeadRow.Should().Be(rowIndex);
         testAccessor.GraphCache.Count.Should().Be(1);
     }
 
     [Test]
-    public void PaintGraphCell_should_scroll_forward()
+    public void RenderGraphToCache_should_scroll_forward()
     {
-        Setup(rowCount: 10, visibleRowCount: 2, out RevisionGraphColumnProvider.TestAccessor testAccessor, out Graphics graphics);
+        Setup(rowCount: 10, visibleRowCount: 2, out RevisionGraphColumnProvider.TestAccessor testAccessor);
 
         int rowIndex = 0;
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(0); // not really mandatory, but Head is reset in Clear()
         testAccessor.GraphCache.HeadRow.Should().Be(0);
         testAccessor.GraphCache.Count.Should().Be(1);
 
         ++rowIndex;
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(0);
         testAccessor.GraphCache.HeadRow.Should().Be(0);
         testAccessor.GraphCache.Count.Should().Be(2);
 
         ++rowIndex;
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(0);
         testAccessor.GraphCache.HeadRow.Should().Be(0);
         testAccessor.GraphCache.Count.Should().Be(3);
 
         ++rowIndex;
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(0);
         testAccessor.GraphCache.HeadRow.Should().Be(0);
         testAccessor.GraphCache.Count.Should().Be(4);
 
         ++rowIndex;
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(0);
         testAccessor.GraphCache.HeadRow.Should().Be(0);
         testAccessor.GraphCache.Count.Should().Be(5);
 
         ++rowIndex;
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
+        testAccessor.GraphCache.Head.Should().Be(0);
+        testAccessor.GraphCache.HeadRow.Should().Be(0);
+        testAccessor.GraphCache.Count.Should().Be(6);
+
+        ++rowIndex;
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(1);
         testAccessor.GraphCache.HeadRow.Should().Be(1);
-        testAccessor.GraphCache.Count.Should().Be(5);
+        testAccessor.GraphCache.Count.Should().Be(6);
 
         rowIndex = testAccessor.GraphCache.HeadRow + (2 * (testAccessor.GraphCache.Capacity - 1));
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(1 - 1);
         testAccessor.GraphCache.HeadRow.Should().Be(rowIndex - (testAccessor.GraphCache.Capacity - 1));
-        testAccessor.GraphCache.Count.Should().Be(5);
+        testAccessor.GraphCache.Count.Should().Be(6);
     }
 
     [Test]
-    public void PaintGraphCell_should_scroll_backward_then_restart()
+    public void RenderGraphToCache_should_scroll_backward_then_restart()
     {
         const int rowCount = 10;
-        Setup(rowCount, visibleRowCount: 2, out RevisionGraphColumnProvider.TestAccessor testAccessor, out Graphics graphics);
+        Setup(rowCount, visibleRowCount: 2, out RevisionGraphColumnProvider.TestAccessor testAccessor);
 
         int rowIndex = rowCount - 1;
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(0); // not really mandatory, but Head is reset in Clear()
         testAccessor.GraphCache.HeadRow.Should().Be(rowIndex);
         testAccessor.GraphCache.Count.Should().Be(1);
 
         --rowIndex;
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(testAccessor.GraphCache.Capacity - 1);
         testAccessor.GraphCache.HeadRow.Should().Be(rowIndex);
         testAccessor.GraphCache.Count.Should().Be(2);
 
         rowIndex = testAccessor.GraphCache.HeadRow - testAccessor.GraphCache.Capacity;
-        testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-            .Should().BeTrue();
+        testAccessor.RenderRowToCache(rowIndex, _rowHeight);
         testAccessor.GraphCache.Head.Should().Be(testAccessor.GraphCache.Capacity - 1); // unchanged, does not really matter
         testAccessor.GraphCache.HeadRow.Should().Be(rowIndex);
         testAccessor.GraphCache.Count.Should().Be(1);
     }
 
-    private static void Setup(int rowCount, out RevisionGraphColumnProvider.TestAccessor testAccessor, out Graphics graphics)
-        => Setup(rowCount, rowCount, out testAccessor, out graphics);
+    private static void Setup(int rowCount, out RevisionGraphColumnProvider.TestAccessor testAccessor)
+        => Setup(rowCount, rowCount, out testAccessor);
 
-    private static void Setup(int rowCount, int visibleRowCount, out RevisionGraphColumnProvider.TestAccessor testAccessor, out Graphics graphics)
+    private static void Setup(int rowCount, int visibleRowCount, out RevisionGraphColumnProvider.TestAccessor testAccessor)
     {
         RevisionGraph revisionGraph = new();
         for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex)
@@ -179,18 +165,16 @@ public class RevisionGraphColumnTests
         RevisionGraphColumnProvider revisionGraphColumnProvider = new(revisionGraph, gitRevisionSummaryBuilder);
         testAccessor = revisionGraphColumnProvider.GetTestAccessor();
 
-        Bitmap destinationBitmap = new(width: _cellWidth, _rowHeight * rowCount, PixelFormat.Format32bppPArgb);
-        graphics = Graphics.FromImage(destinationBitmap);
         testAccessor.GraphCache.Capacity.Should().Be(0);
 
-        for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex)
-        {
-            testAccessor.PaintGraphCell(rowIndex, _rowHeight, _paintRectangle, graphics)
-                .Should().BeTrue();
-            testAccessor.GraphCache.Count.Should().Be(0);
-        }
+        VisibleRowRange range = new(fromIndex: 0, visibleRowCount);
+        testAccessor.RenderGraphToCache(range, rowCount - 1, _rowHeight);
+        int expectedCapacity = 3 * visibleRowCount;
+        testAccessor.GraphCache.Capacity.Should().Be(expectedCapacity);
+        testAccessor.GraphCache.Count.Should().Be(Math.Min(rowCount, expectedCapacity));
 
-        revisionGraphColumnProvider.OnVisibleRowsChanged(new VisibleRowRange(fromIndex: 0, visibleRowCount));
-        testAccessor.GraphCache.Capacity.Should().Be((2 * visibleRowCount) + 1);
+        testAccessor.GraphCache.Reset();
+        testAccessor.GraphCache.Capacity.Should().Be(expectedCapacity);
+        testAccessor.GraphCache.Count.Should().Be(0);
     }
 }


### PR DESCRIPTION
Fixes #11700

## Proposed changes

Have clear chains of revision grid updates (one for graph loading affecting RowCount, one for visible row range).
Get rid of several workarounds and of the mix-up of revision loading and graph-only operations.
Avoid unnecessary blocking the UI thread.

- Do not render the graph in the UI thread but in a background task with double buffering
  in order to avoid calling the potentially expensive `RevisionGraphRow.BuildSegmentLanes` from the UI thread
- Remove `RevisionDataGridView.UpdateGraphAsync`, just call `RevisionGraph.CacheTo` once with cancellation
  because `CacheTo` is needed for graph rendering only
- Remove `UpdateVisibleRowRange` call on unhandled `OnCellPainting`
  because there no need to for this additional trigger of graph update
- `RevisionDataGridView`: Remove special `OnScroll` handler which called `Update` from time to time
  because the revision graph rendering does not block the UI any longer

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual
- adapted tests

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

## Please do not squash merge!

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).