### PR TITLE
Diff moved lines: Use dimmed-zebra algorithm

### DIFF
--- a/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
+++ b/GitUI/Editor/Diff/AnsiEscapeUtilities.cs
@@ -413,7 +413,7 @@ public partial class AnsiEscapeUtilities
             redId + _boldOffset => Color.FromArgb(255, 118, 118),
             redId + _dimOffset => Color.FromArgb(208, 142, 147),
 
-            greenId => Color.FromArgb(137, 190, 127),
+            greenId => Color.FromArgb(28, 168, 0),
             greenId + _boldOffset => Color.FromArgb(0, 242, 0),
             greenId + _dimOffset => Color.FromArgb(137, 190, 127),
 


### PR DESCRIPTION
Tweak to #11674

## Proposed changes

git-diff detects moved blocks (with at least 20 chars) and colors adjacent blocks with alternate colors.
The alternative color profile will use dimmed colors for lines that are moved without changes so changed lines stand out better.
Border lines close to changes are marked (not always done by Git though...)

A better description: https://stackoverflow.com/questions/57817642/whats-the-purpose-of-dimmed-zebra

This PR changes to use dimmed-zebra instead (zebra is git default).
A bonus is that the GE colors are hard to see in the terminal. (such theme colors are hard to tune)
After feedback, colors are changed to be dimmed colors for moved and normal colors (but not reverse video) for border lines.

Need to be updated in the GE doc PR too.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

block1 and block2 should have alternate colors

![image](https://github.com/gitextensions/gitextensions/assets/6248932/4014b719-9815-4bf0-94f5-a6b1f2742af1)

### After

Not sure why block2 added do not have alternate colors

![image](https://github.com/gitextensions/gitextensions/assets/6248932/561a82f5-a8b8-4b17-bc4e-17899b0f306a)

Slight update with some alternate blocks where border is seen

![image](https://github.com/gitextensions/gitextensions/assets/6248932/fb2767fc-5944-41e9-a1bb-bb9543504b9b)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
