### PR TITLE
fix(RevisionDataGridView): Update RowCount while loading

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.BackgroundUpdater.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.BackgroundUpdater.cs
@@ -48,10 +48,7 @@
                 }
                 finally
                 {
-                    if (_rerunRequested)
-                    {
-                        await Task.Delay(_cooldownMilliseconds);
-                    }
+                    await Task.Delay(_cooldownMilliseconds);
 
                     lock (_sync)
                     {


### PR DESCRIPTION
## Proposed changes

- `RevisionDataGridView`: (Asynchronously) update `RowCount` also if `DisplayedRowCount` returns 0 yet
- `BackgroundUpdater`: Always cool down after performing the `_operation`

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

revision grid may stay empty until "Loading" is hidden

### After

`RowCount` is updated every 300 milliseconds

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).