### PR TITLE
fix: label "No changes" no more hiding first file of the list

### DIFF
--- a/GitUI/UserControls/FileStatusList.cs
+++ b/GitUI/UserControls/FileStatusList.cs
@@ -357,9 +357,12 @@ namespace GitUI
         private void SetFileStatusListVisibility(bool filesPresent)
         {
             LoadingFiles.Visible = false;
-            FilterComboBox.Visible = filesPresent || (SearchComboBox.Visible && !string.IsNullOrEmpty(SearchComboBox.Text));
-            NoFiles.Visible = !FilterComboBox.Visible;
-            if (NoFiles.Visible)
+
+            // Use variable to prevent bad value retrieved from `Visible` property
+            bool filesToFilter = filesPresent || (SearchComboBox.Visible && !string.IsNullOrEmpty(SearchComboBox.Text));
+            FilterComboBox.Visible = filesToFilter;
+            NoFiles.Visible = !filesToFilter;
+            if (!filesToFilter)
             {
                 // Workaround for startup issue if set in EnableSearchForList()
                 NoFiles.Top = FilterComboBox.Top;


### PR DESCRIPTION
when opening "FormLog"
even if it was set as not visible.

Fixes #11679

Reproduce step: double click on a revision in the revision grid

Regression introduced by f8c035302bba1351d88b5159e5ec93bfbbc5933d

/!\ Technical reason of the bug:
Previous code was:

            FilterComboBox.Visible = filesPresent || (SearchComboBox.Visible && !string.IsNullOrEmpty(SearchComboBox.Text));
            NoFiles.Visible = !FilterComboBox.Visible;

But as `FilterComboBox.Visible` is not just a property storing the value directly to a backed field
(it has a complex WinFoms internal logic),
 the value retrieved by the getter ( to after set `NoFiles.Visible`) is sometimes wrong and not the one set to the property :(
The value is not "well" set due to complex internal logic and so a wrong value is used after.

Using a temporary variable fix the issue because the set of the 2 properties has no more impact on each others!
## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/ccd4b5c1-31bf-4495-854b-ae5c43ffcb7a)

### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/07b479f0-df00-4fb0-8365-ca2322809d83)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 10b42c51f9bf9285b4a064e2a3d2547ea215f87a
- Git 2.45.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
