### PR TITLE
Checkout *remote* branch: more helpful labels

### DIFF
--- a/GitUI/CommandsDialogs/FormCheckoutBranch.Designer.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.Designer.cs
@@ -342,7 +342,7 @@ namespace GitUI.CommandsDialogs
             rbDontCreate.Name = "rbDontCreate";
             rbDontCreate.Size = new Size(232, 19);
             rbDontCreate.TabIndex = 4;
-            rbDontCreate.Text = "Ch&eckout remote branch";
+            rbDontCreate.Text = "Ch&eckout the commit (in detached head)";
             rbDontCreate.UseVisualStyleBackColor = true;
             // 
             // txtCustomBranchName

--- a/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -16,7 +16,7 @@ namespace GitUI.CommandsDialogs
         private readonly TranslationString _customBranchNameIsNotValid =
             new("“{0}” is not valid branch name.\nEnter valid branch name or select predefined value.");
         private readonly TranslationString _createBranch =
-            new("Cr&eate local branch with the name:");
+            new("Cr&eate local branch with same name:");
         private readonly TranslationString _applyStashedItemsAgainCaption =
             new("Auto stash");
         private readonly TranslationString _applyStashedItemsAgain =

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3095,7 +3095,7 @@ Do you want to continue?</source>
         <target />
       </trans-unit>
       <trans-unit id="_createBranch.Text">
-        <source>Cr&amp;eate local branch with the name:</source>
+        <source>Cr&amp;eate local branch with same name:</source>
         <target />
       </trans-unit>
       <trans-unit id="_customBranchNameIsEmpty.Text">

--- a/GitUI/Translation/English.xlf
+++ b/GitUI/Translation/English.xlf
@@ -3143,7 +3143,7 @@ Are you sure?</source>
         <target />
       </trans-unit>
       <trans-unit id="rbDontCreate.Text">
-        <source>Ch&amp;eckout remote branch</source>
+        <source>Ch&amp;eckout the commit (in detached head)</source>
         <target />
       </trans-unit>
       <trans-unit id="rbMerge.Text">


### PR DESCRIPTION
## Proposed changes

Update labels to be clear that:
- a remote **can't** be checked out and that the commit will be checked out in fact (and user will be end up in 'detached head' state).
- local branch will be given the *same* branch name

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/98bad465-d01e-4899-9b9c-2dcd6a5f6de1)

### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/fee6d576-83c5-4b3b-8238-7cc8ae8ad0c4)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 453280d62575f353cd5d6b2d30a5e9cc08a21f2e
- Git 2.45.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
