### PR TITLE
fix(revgrid): SuperprojectModule has no workingdir

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -1069,7 +1069,7 @@ namespace GitCommands
 
         public async Task<(char code, ObjectId? commitId)> GetSuperprojectCurrentCheckoutAsync()
         {
-            if (SuperprojectModule is null)
+            if (string.IsNullOrEmpty(SuperprojectModule?.WorkingDir))
             {
                 return (' ', null);
             }


### PR DESCRIPTION
Fixes #11730

## Proposed changes

The superproject workingdir is occasionally null at least for WSL when restoring minimized windows and the command to add branches for the super project in the submodule cannot run.

## Screenshots <!-- Remove this section if PR does not change UI -->

No GUI change, just example of the superproject info
![image](https://github.com/gitextensions/gitextensions/assets/6248932/24252432-44a0-42fd-afbf-be39cd437699)

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
