### PR TITLE
fix(RevisionReader): do not quote GetRevision() hash

### DIFF
--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -166,6 +166,7 @@ namespace GitCommands
             };
 
             // output can be cached if Git Notes is not included
+            // Artificial revision must not be called (empty commitHash, must not be cached
             if (!hasNotes && GitModule.GitCommandCache.TryGet(arguments.ToString(), out byte[]? commandOutput, out _) is true)
             {
                 // OK
@@ -184,7 +185,7 @@ namespace GitCommands
                 return null;
             }
 
-            if (!hasNotes && !string.IsNullOrWhiteSpace(commitHash) && !revision.IsArtificial)
+            if (!hasNotes && !string.IsNullOrWhiteSpace(commitHash))
             {
                 GitModule.GitCommandCache.Add(arguments.ToString(), commandOutput, commandOutput);
             }

--- a/GitCommands/RevisionReader.cs
+++ b/GitCommands/RevisionReader.cs
@@ -160,7 +160,9 @@ namespace GitCommands
                 "-z",
                 "-1",
                 $"--pretty=format:\"{GetLogFormat(hasNotes: hasNotes)}\"",
-                commitHash.QuoteNE()
+
+                // commit hash is either an ObjectId or empty, QuoteNE() should not be needed and may even fail
+                commitHash
             };
 
             // output can be cached if Git Notes is not included
@@ -182,7 +184,7 @@ namespace GitCommands
                 return null;
             }
 
-            if (!hasNotes)
+            if (!hasNotes && !string.IsNullOrWhiteSpace(commitHash) && !revision.IsArtificial)
             {
                 GitModule.GitCommandCache.Add(arguments.ToString(), commandOutput, commandOutput);
             }


### PR DESCRIPTION
Fixes #11732

## Proposed changes

Reviewed the code paths calling this and reverting the quoting added in #11570

Also make sure artificial commits are not cached

## Test methodology <!-- How did you ensure quality? -->

Manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
