### PR TITLE
Expose ScriptOptionsProvider to toolbar event scripts

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1157,11 +1157,12 @@ namespace GitUI.CommandsDialogs
         {
             if (fileTree.Visible)
             {
-                return fileTree.GetScriptOptionsProvider();
+                return fileTree.ScriptOptionsProvider;
             }
-            else if (revisionDiff.Visible)
+
+            if (revisionDiff.Visible)
             {
-                return revisionDiff.GetScriptOptionsProvider();
+                return revisionDiff.ScriptOptionsProvider;
             }
 
             return base.GetScriptOptionsProvider();

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1153,6 +1153,20 @@ namespace GitUI.CommandsDialogs
             }
         }
 
+        public override IScriptOptionsProvider? GetScriptOptionsProvider()
+        {
+            if (fileTree.Visible)
+            {
+                return fileTree.GetScriptOptionsProvider();
+            }
+            else if (revisionDiff.Visible)
+            {
+                return revisionDiff.GetScriptOptionsProvider();
+            }
+
+            return base.GetScriptOptionsProvider();
+        }
+
         #region Working directory combo box
 
         /// <summary>Updates the text shown on the combo button itself.</summary>

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -191,7 +191,9 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        public override IScriptOptionsProvider? GetScriptOptionsProvider()
+        internal IScriptOptionsProvider? ScriptOptionsProvider => GetScriptOptionsProvider();
+
+        protected override IScriptOptionsProvider? GetScriptOptionsProvider()
         {
             return new ScriptOptionsProvider(DiffFiles, () => BlameControl.Visible ? BlameControl.CurrentFileLine : DiffText.CurrentFileLine);
         }

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -191,7 +191,7 @@ namespace GitUI.CommandsDialogs
             }
         }
 
-        protected override IScriptOptionsProvider? GetScriptOptionsProvider()
+        public override IScriptOptionsProvider? GetScriptOptionsProvider()
         {
             return new ScriptOptionsProvider(DiffFiles, () => BlameControl.Visible ? BlameControl.CurrentFileLine : DiffText.CurrentFileLine);
         }

--- a/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -292,7 +292,7 @@ See the changes in the commit form.");
             return true;
         }
 
-        protected override IScriptOptionsProvider? GetScriptOptionsProvider()
+        public override IScriptOptionsProvider? GetScriptOptionsProvider()
         {
             return new ScriptOptionsProvider(() =>
                 {

--- a/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionFileTreeControl.cs
@@ -292,7 +292,9 @@ See the changes in the commit form.");
             return true;
         }
 
-        public override IScriptOptionsProvider? GetScriptOptionsProvider()
+        internal IScriptOptionsProvider? ScriptOptionsProvider => GetScriptOptionsProvider();
+
+        protected override IScriptOptionsProvider? GetScriptOptionsProvider()
         {
             return new ScriptOptionsProvider(() =>
                 {

--- a/src/app/GitUI/GitModuleControl.cs
+++ b/src/app/GitUI/GitModuleControl.cs
@@ -165,7 +165,7 @@ namespace GitUI
             }
         }
 
-        public virtual IScriptOptionsProvider? GetScriptOptionsProvider()
+        protected virtual IScriptOptionsProvider? GetScriptOptionsProvider()
         {
             return null;
         }

--- a/src/app/GitUI/GitModuleControl.cs
+++ b/src/app/GitUI/GitModuleControl.cs
@@ -165,7 +165,7 @@ namespace GitUI
             }
         }
 
-        protected virtual IScriptOptionsProvider? GetScriptOptionsProvider()
+        public virtual IScriptOptionsProvider? GetScriptOptionsProvider()
         {
             return null;
         }


### PR DESCRIPTION
<details>
  <summary>Previous PR description before it got "rebranded"</summary>

## Proposed changes

Once I've noticed this PR https://github.com/gitextensions/gitextensions/pull/11239 I wanted to use `{SelectedFiles}` in my script but it didn't work, I got literal value of `{SelectedFiles}` as a result.
Question: Is it a bug to leave `{SelectedFiles}` unreplaced into say an empty string?

- Since Toolbar Event Scripts go through `FormBrowse` when looking for a `IScriptOptionsProvider`, `FormBrowse` conveniently has two potential sources for it
- Override `GetScriptOptionsProvider()` in `FormBrowse` to forward this request to `RevisionDiffControl` or `RevisionFileTreeControl` depending on which one is visible

----

</details>

## Proposed changes

Currently scripts using `toolbar` event type do not have access to `IScriptOptionsProvider` thus are unable to make use of all variables provided by the scripting mechanism.

- Since Toolbar Event Scripts go through `FormBrowse` when looking for a `IScriptOptionsProvider`, `FormBrowse` conveniently has two potential sources for it
- Override `GetScriptOptionsProvider()` in `FormBrowse` to retrieve `IScriptOptionsProvider` from `RevisionDiffControl` or `RevisionFileTreeControl` depending on which one is visible/active

## Test methodology <!-- How did you ensure quality? -->

- Manually. I've been using this feature for ~2 weeks almost daily

<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
