### PR TITLE
fix(diff): Don't fail if user customized git `diff.*Prefix` settings

### DIFF
--- a/GitCommands/Git/SubmoduleHelpers.cs
+++ b/GitCommands/Git/SubmoduleHelpers.cs
@@ -7,7 +7,7 @@ namespace GitCommands.Git
 {
     public static partial class SubmoduleHelpers
     {
-        [GeneratedRegex(@"diff --git [abic]/(?<filenamea>.+)\s[abwi]/(?<filenameb>.+)", RegexOptions.ExplicitCapture)]
+        [GeneratedRegex(@"diff --git [^/\s]+/(?<filenamea>.+)\s[^/\s]+/(?<filenameb>.+)", RegexOptions.ExplicitCapture)]
         private static partial Regex DiffCommandRegex();
         [GeneratedRegex(@"diff --cc (?<filenamea>.+)", RegexOptions.ExplicitCapture)]
         private static partial Regex CombinedDiffCommandRegex();

--- a/GitCommands/Patches/PatchProcessor.cs
+++ b/GitCommands/Patches/PatchProcessor.cs
@@ -30,13 +30,13 @@ namespace GitCommands.Patches
         // diff --git a/GitCommands/CommitInformationTest.cs b/GitCommands/CommitInformationTest.cs
         // diff --git b/Benchmarks/App.config a/Benchmarks/App.config
         // diff --cc config-enumerator
-        [GeneratedRegex(@$"^diff --(?<type>git|cc|combined)\s[""]?([abiwco12]/)?(?<filenamea>.*?)[""]?( [""]?[abiwco12]/(?<filenameb>.*?)[""]?)?\s*$", RegexOptions.ExplicitCapture)]
+        [GeneratedRegex(@$"^diff --(?<type>git|cc|combined)\s[""]?([^/\s]+/)?(?<filenamea>.*?)[""]?( [""]?[^/\s]+/(?<filenameb>.*?)[""]?)?\s*$", RegexOptions.ExplicitCapture)]
         private static partial Regex PatchHeaderFileNameRegex();
 
         [GeneratedRegex(@$"^({_escapeSequenceRegex})?diff --(?<type>git|cc|combined)\s", RegexOptions.ExplicitCapture)]
         private static partial Regex PatchHeaderRegex();
 
-        [GeneratedRegex(@$"(---|\+\+\+) [""]?[abiwco12]/(?<filename>.*)[""]?", RegexOptions.ExplicitCapture)]
+        [GeneratedRegex(@$"(---|\+\+\+) [""]?[^/\s]+/(?<filename>.*)[""]?", RegexOptions.ExplicitCapture)]
         private static partial Regex FileNameRegex();
 
         [GeneratedRegex(@$"^({_escapeSequenceRegex})?[ -+@]", RegexOptions.ExplicitCapture)]

--- a/UnitTests/GitCommands.Tests/Git/SubmoduleHelpersTest.cs
+++ b/UnitTests/GitCommands.Tests/Git/SubmoduleHelpersTest.cs
@@ -67,6 +67,18 @@ namespace GitCommandsTests.Git
             Assert.IsNull(status.OldCommit);
             Assert.AreEqual("Externals/ICSharpCode.TextEditor", status.OldName);
 
+            // With user customized `diff.srcPrefix` and `diff.dstPrefix` settings: Submodule name with spaces in the name
+
+            text = "diff --git before:/Assets/Core/Vehicle Physics core assets after:/Assets/Core/Vehicle Physics core assets\nindex 2fb8851..0cc457d 160000\n--- before:/Assets/Core/Vehicle Physics core assets\t\n+++ after:/Assets/Core/Vehicle Physics core assets\t\n@@ -1 +1 @@\n-Subproject commit 2fb88514cfdc37a2708c24f71eca71c424b8d402\n+Subproject commit 0cc457d030e92f804569407c7cd39893320f9740\n";
+            fileName = "Assets/Core/Vehicle Physics core assets";
+
+            status = SubmoduleHelpers.ParseSubmoduleStatus(text, testModule, fileName);
+
+            Assert.AreEqual(ObjectId.Parse("0cc457d030e92f804569407c7cd39893320f9740"), status.Commit);
+            Assert.AreEqual(fileName, status.Name);
+            Assert.AreEqual(ObjectId.Parse("2fb88514cfdc37a2708c24f71eca71c424b8d402"), status.OldCommit);
+            Assert.AreEqual(fileName, status.OldName);
+
             try
             {
                 // Clean up temporary folders

--- a/UnitTests/GitCommands.Tests/GitCommands.Tests.csproj
+++ b/UnitTests/GitCommands.Tests/GitCommands.Tests.csproj
@@ -41,6 +41,9 @@
     <None Include="Patches\testdata\color-binary.diff">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Patches\testdata\color-prefix.diff">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="TestData\RevisionReader\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/UnitTests/GitCommands.Tests/Patches/testdata/color-prefix.diff
+++ b/UnitTests/GitCommands.Tests/Patches/testdata/color-prefix.diff
@@ -1,0 +1,325 @@
+[1mdiff --git [PLACEHOLDER_PREFIX_SRC]GitCommands/Patches/PatchProcessor.cs [PLACEHOLDER_PREFIX_DST]GitCommands/Patches/PatchProcessor.cs[m
+[1mindex 70b40..c1e6c 100644[m
+[1m--- [PLACEHOLDER_PREFIX_SRC]GitCommands/Patches/PatchProcessor.cs[m
+[1m+++ [PLACEHOLDER_PREFIX_DST]GitCommands/Patches/PatchProcessor.cs[m
+[36m@@ -15,19 +15,29 @@[m [mprivate enum PatchProcessorState[m
+             OutsidePatch[m
+         }[m
+ [m
+[32m+[m[32m        private const string _escapeSequenceRegex = @"(\u001b\[.*?m)?";[m
+[32m+[m[32m        [GeneratedRegex(@$"^{_escapeSequenceRegex}", RegexOptions.ExplicitCapture)][m
+[32m+[m[32m        private static partial Regex StartEscapeSequenceRegex();[m
+[32m+[m[32m        [GeneratedRegex(@$"{_escapeSequenceRegex}$", RegexOptions.ExplicitCapture)][m
+[32m+[m[32m        private static partial Regex EndEscapeSequenceRegex();[m
+[32m+[m[32m        [GeneratedRegex(@$"^{_escapeSequenceRegex}diff --(?<type>git|cc|combined)\s", RegexOptions.ExplicitCapture)][m
+         private static partial Regex PatchHeaderRegex();[m
+[31m-        [GeneratedRegex(@$"{_escapeSequenceRegex}diff --git [""]?[abiwco12]/(?<filenamea>.*)[""]? [""]?[abiwco12]/(?<filenameb>.*?)[""]?{_escapeSequenceRegex}$", RegexOptions.ExplicitCapture)][m
+[31m-        private static partial Regex DiffCommandRegex();[m
+[31m-        [GeneratedRegex(@$"^{_escapeSequenceRegex}diff --(cc|combined) [""]?(?<filenamea>.*?)[""]?{_escapeSequenceRegex}$", RegexOptions.ExplicitCapture)][m
+[31m-        private static partial Regex CombinedDiffCommandRegex();[m
+[31m-        [GeneratedRegex(@$"{_escapeSequenceRegex}[-+]{{3}} [""]?[abiwco12]/(?<filename>.*)[""]?{_escapeSequenceRegex}", RegexOptions.ExplicitCapture)][m
+[32m+[m
+[32m+[m[32m        // diff --git a/GitCommands/CommitInformationTest.cs b/GitCommands/CommitInformationTest.cs[m
+[32m+[m[32m        // diff --git b/Benchmarks/App.config a/Benchmarks/App.config[m
+[32m+[m[32m        // diff --cc config-enumerator[m
+[32m+[m[32m        [GeneratedRegex(@$"^diff --(?<type>git|cc|combined)\s[""]?([abiwco12]/)?(?<filenamea>.*?)[""]?( [""]?[abiwco12]/(?<filenameb>.*?)[""]?)?$", RegexOptions.ExplicitCapture)][m
+[32m+[m[32m        private static partial Regex PatchHeaderFileNameRegex();[m
+[32m+[m[32m        ////[GeneratedRegex(@$"diff --git [""]?[abiwco12]/(?<filenamea>.*)[""]? [""]?[abiwco12]/(?<filenameb>.*?)[""]?$", RegexOptions.ExplicitCapture)][m
+[32m+[m[32m        ////private static partial Regex DiffCommandRegex();[m
+[32m+[m[32m        ////[GeneratedRegex(@$"^diff --(cc|combined) [""]?(?<filenamea>.*?)[""]?$", RegexOptions.ExplicitCapture)][m
+[32m+[m[32m        ////private static partial Regex CombinedDiffCommandRegex();[m
+[32m+[m[32m        [GeneratedRegex(@$"[-+]{{3}} [""]?[abiwco12]/(?<filename>.*)[""]?", RegexOptions.ExplicitCapture)][m
+         private static partial Regex FileNameRegex();[m
+[31m-        [GeneratedRegex(@$"^{_escapeSequenceRegex}(?<line>,*)", RegexOptions.ExplicitCapture)][m
+[31m-        private static partial Regex StartOfLineRegex();[m
+[32m+[m[32m        [GeneratedRegex(@$"^@@", RegexOptions.ExplicitCapture)][m
+[32m+[m[32m        private static partial Regex StartOfChunkRegex();[m
+         [GeneratedRegex(@$"^{_escapeSequenceRegex}?[ -+@]", RegexOptions.ExplicitCapture)][m
+         private static partial Regex StartOfContentsRegex();[m
+[31m-        [GeneratedRegex(@$"^{_escapeSequenceRegex}?@@", RegexOptions.ExplicitCapture)][m
+[31m-        private static partial Regex StartOfChunkRegex();[m
+ [m
+         /// <summary>[m
+         /// Parses a patch file into individual <see cref="Patch"/> objects.[m
+[36m@@ -53,7 +63,7 @@[m [mpublic static IEnumerable<Patch> CreatePatchesFromString(string patchText, Lazy<[m
+             // skip email header[m
+             for (; i < lines.Length; i++)[m
+             {[m
+[31m-                if (IsStartOfANewPatch(lines[i]))[m
+[32m+[m[32m                if (PatchHeaderRegex().IsMatch(lines[i]))[m
+                 {[m
+                     break;[m
+                 }[m
+[36m@@ -76,56 +86,38 @@[m [mpublic static IEnumerable<Patch> CreatePatchesFromString(string patchText, Lazy<[m
+                 return null;[m
+             }[m
+ [m
+[31m-            string header = lines[lineIndex];[m
+[31m-[m
+[31m-            Match headerMatch = PatchHeaderRegex().Match(header);[m
+[32m+[m[32m            string rawHeader = lines[lineIndex];[m
+[32m+[m[32m            Match startEscape = StartEscapeSequenceRegex().Match(rawHeader);[m
+[32m+[m[32m            Match endEscape = EndEscapeSequenceRegex().Match(rawHeader);[m
+[32m+[m[32m            ReadOnlySpan<char> header = rawHeader.AsSpan(startEscape.Length, rawHeader.Length - startEscape.Length - endEscape.Length);[m
+ [m
+[32m+[m[32m            Match headerMatch = PatchHeaderFileNameRegex().Match(header.ToString());[m
+             if (!headerMatch.Success)[m
+             {[m
+                 return null;[m
+             }[m
+ [m
+[31m-            header = GitModule.ReEncodeFileNameFromLossless(header);[m
+[31m-[m
+[31m-            PatchProcessorState state = PatchProcessorState.InHeader;[m
+[31m-[m
+[31m-            string? fileNameA, fileNameB;[m
+[31m-[m
+[32m+[m[32m            header = GitModule.ReEncodeFileNameFromLossless(header.ToString());[m
+             bool isCombinedDiff = headerMatch.Groups["type"].Value != "git";[m
+ [m
+[31m-            if (!isCombinedDiff)[m
+[32m+[m[32m            // Match match = (isCombinedDiff ? CombinedDiffCommandRegex() : DiffCommandRegex())[m
+[32m+[m[32m            //     .Match(header.ToString());[m
+[32m+[m[32m            if (!headerMatch.Success || (!isCombinedDiff && !headerMatch.Groups["filenameb"].Success))[m
+             {[m
+[31m-                // diff --git a/GitCommands/CommitInformationTest.cs b/GitCommands/CommitInformationTest.cs[m
+[31m-                // diff --git b/Benchmarks/App.config a/Benchmarks/App.config[m
+[31m-                Match match = DiffCommandRegex().Match(header);[m
+[31m-[m
+[31m-                if (!match.Success)[m
+[31m-                {[m
+[31m-                    throw new FormatException("Invalid patch header: " + header);[m
+[31m-                }[m
+[31m-[m
+[31m-                fileNameA = match.Groups["filenamea"].Value.Trim();[m
+[31m-                fileNameB = match.Groups["filenameb"].Value.Trim();[m
+[31m-            }[m
+[31m-            else[m
+[31m-            {[m
+[31m-                Match match = CombinedDiffCommandRegex().Match(header);[m
+[31m-[m
+[31m-                if (!match.Success)[m
+[31m-                {[m
+[31m-                    throw new FormatException("Invalid patch header: " + header);[m
+[31m-                }[m
+[31m-[m
+[31m-                fileNameA = match.Groups["filenamea"].Value.Trim();[m
+[31m-                fileNameB = null;[m
+[32m+[m[32m                throw new FormatException($"Invalid patch header: {header}");[m
+             }[m
+ [m
+[31m-            string? index = null;[m
+[32m+[m[32m            string fileNameA = headerMatch.Groups["filenamea"].Value.Trim();[m
+[32m+[m[32m            string? fileNameB = isCombinedDiff ? null : headerMatch.Groups["filenameb"].Value.Trim();[m
+[32m+[m
+[32m+[m[32m            PatchProcessorState state = PatchProcessorState.InHeader;[m
+             PatchChangeType changeType = PatchChangeType.ChangeFile;[m
+             PatchFileType fileType = PatchFileType.Text;[m
+[32m+[m
+[32m+[m[32m            ReadOnlySpan<char> index = null;[m
+             StringBuilder patchText = new();[m
+ [m
+[31m-            patchText.Append(header);[m
+[32m+[m[32m            patchText.Append($"{startEscape.Value}{header}{endEscape.Value}");[m
+             if (lineIndex < lines.Length - 1)[m
+             {[m
+                 patchText.Append('\n');[m
+[36m@@ -133,12 +125,14 @@[m [mpublic static IEnumerable<Patch> CreatePatchesFromString(string patchText, Lazy<[m
+ [m
+             bool done = false;[m
+             int i = lineIndex + 1;[m
+[31m-[m
+             for (; i < lines.Length; i++)[m
+             {[m
+[31m-                string line = lines[i];[m
+[32m+[m[32m                string rawLine = lines[i];[m
+[32m+[m[32m                startEscape = StartEscapeSequenceRegex().Match(rawLine);[m
+[32m+[m[32m                endEscape = EndEscapeSequenceRegex().Match(rawLine);[m
+[32m+[m[32m                ReadOnlySpan<char> line = rawLine.AsSpan(startEscape.Length, rawLine.Length - startEscape.Length - endEscape.Length);[m
+ [m
+[31m-                if (IsStartOfANewPatch(line))[m
+[32m+[m[32m                if (PatchHeaderRegex().IsMatch(line))[m
+                 {[m
+                     done = true;[m
+                     break;[m
+[36m@@ -152,84 +146,69 @@[m [mpublic static IEnumerable<Patch> CreatePatchesFromString(string patchText, Lazy<[m
+                 }[m
+ [m
+                 // header lines are encoded in GitModule.SystemEncoding[m
+[31m-                line = GitModule.ReEncodeStringFromLossless(line, GitModule.SystemEncoding);[m
+[32m+[m[32m                line = GitModule.ReEncodeStringFromLossless(line.ToString(), GitModule.SystemEncoding);[m
+ [m
+[31m-                Match startOfLineMatch = StartOfLineRegex().Match(line);[m
+[31m-                if (!startOfLineMatch.Success)[m
+[31m-                {[m
+[31m-                    throw new FormatException("Invalid patch line: " + line);[m
+[31m-                }[m
+[31m-[m
+[31m-                string startOfLine = startOfLineMatch.Groups["line"].Value;[m
+[31m-                if (startOfLine.StartsWith("index "))[m
+[32m+[m[32m                if (line.StartsWith("index "))[m
+                 {[m
+                     // Index line[m
+                     index = line;[m
+[31m-                    patchText.Append(line);[m
+[31m-                    if (i < lines.Length - 1)[m
+[31m-                    {[m
+[31m-                        patchText.Append('\n');[m
+[31m-                    }[m
+[31m-[m
+[31m-                    continue;[m
+                 }[m
+[31m-[m
+[31m-                if (startOfLine.StartsWith("new file mode "))[m
+[32m+[m[32m                else if (line.StartsWith("new file mode "))[m
+                 {[m
+                     changeType = PatchChangeType.NewFile;[m
+                 }[m
+[31m-                else if (startOfLine.StartsWith("deleted file mode "))[m
+[32m+[m[32m                else if (line.StartsWith("deleted file mode "))[m
+                 {[m
+                     changeType = PatchChangeType.DeleteFile;[m
+                 }[m
+[31m-                else if (startOfLine.StartsWith("old mode "))[m
+[32m+[m[32m                else if (line.StartsWith("old mode "))[m
+                 {[m
+                     changeType = PatchChangeType.ChangeFileMode;[m
+                 }[m
+[31m-                else if (startOfLine.StartsWith("Binary files a/") && line.EndsWith(" and /dev/null differ"))[m
+[32m+[m[32m                else if (line.StartsWith("Binary files a/") && line.EndsWith(" and /dev/null differ"))[m
+                 {[m
+                     // Unlisted binary file deletion[m
+                     if (changeType != PatchChangeType.DeleteFile)[m
+                     {[m
+[31m-                        throw new FormatException("Change not parsed correctly: " + line);[m
+[32m+[m[32m                        throw new FormatException($"Invalid patch header: {line}");[m
+                     }[m
+ [m
+                     fileType = PatchFileType.Binary;[m
+                     state = PatchProcessorState.OutsidePatch;[m
+                     break;[m
+                 }[m
+[31m-                else if (startOfLine.StartsWith("Binary files /dev/null and b/") && line.EndsWith(" differ"))[m
+[32m+[m[32m                else if (line.StartsWith("Binary files /dev/null and b/") && line.EndsWith(" differ"))[m
+                 {[m
+                     // Unlisted binary file addition[m
+                     if (changeType != PatchChangeType.NewFile)[m
+                     {[m
+[31m-                        throw new FormatException("Change not parsed correctly: " + line);[m
+[32m+[m[32m                        throw new FormatException($"Invalid patch header: {line}");[m
+                     }[m
+ [m
+                     fileType = PatchFileType.Binary;[m
+                     state = PatchProcessorState.OutsidePatch;[m
+                     break;[m
+                 }[m
+[31m-                else if (startOfLine.StartsWith("GIT binary patch"))[m
+[32m+[m[32m                else if (line.StartsWith("GIT binary patch"))[m
+                 {[m
+                     fileType = PatchFileType.Binary;[m
+                     state = PatchProcessorState.OutsidePatch;[m
+                     break;[m
+                 }[m
+ [m
+[31m-                if (startOfLine.StartsWith("--- /dev/null"))[m
+[32m+[m[32m                if (line.StartsWith("--- /dev/null"))[m
+                 {[m
+                     // there is no old file, so this should be a new file[m
+                     if (changeType != PatchChangeType.NewFile)[m
+                     {[m
+[31m-                        throw new FormatException("Change not parsed correctly: " + line);[m
+[32m+[m[32m                        throw new FormatException($"Invalid patch header: {line}");[m
+                     }[m
+                 }[m
+[31m-                else if (startOfLine.StartsWith("--- "))[m
+[32m+[m[32m                else if (line.StartsWith("--- "))[m
+                 {[m
+                     // old file name[m
+[31m-                    line = GitModule.UnescapeOctalCodePoints(line);[m
+[31m-                    Match regexMatch = FileNameRegex().Match(line);[m
+[32m+[m[32m                    line = GitModule.UnescapeOctalCodePoints(line.ToString());[m
+[32m+[m[32m                    Match regexMatch = FileNameRegex().Match(line.ToString());[m
+ [m
+                     if (regexMatch.Success)[m
+                     {[m
+[36m@@ -237,22 +216,22 @@[m [mpublic static IEnumerable<Patch> CreatePatchesFromString(string patchText, Lazy<[m
+                     }[m
+                     else[m
+                     {[m
+[31m-                        throw new FormatException("Old filename not parsed correctly: " + line);[m
+[32m+[m[32m                        throw new FormatException($"Invalid patch header: {line}");[m
+                     }[m
+                 }[m
+[31m-                else if (startOfLine.StartsWith("+++ /dev/null"))[m
+[32m+[m[32m                else if (line.StartsWith("+++ /dev/null"))[m
+                 {[m
+                     // there is no new file, so this should be a deleted file[m
+                     if (changeType != PatchChangeType.DeleteFile)[m
+                     {[m
+[31m-                        throw new FormatException("Change not parsed correctly: " + line);[m
+[32m+[m[32m                        throw new FormatException($"Invalid patch header: {line}");[m
+                     }[m
+                 }[m
+[31m-                else if (startOfLine.StartsWith("+++ "))[m
+[32m+[m[32m                else if (line.StartsWith("+++ "))[m
+                 {[m
+                     // new file name[m
+[31m-                    line = GitModule.UnescapeOctalCodePoints(line);[m
+[31m-                    Match regexMatch = FileNameRegex().Match(line);[m
+[32m+[m[32m                    line = GitModule.UnescapeOctalCodePoints(line.ToString());[m
+[32m+[m[32m                    Match regexMatch = FileNameRegex().Match(line.ToString());[m
+ [m
+                     if (regexMatch.Success)[m
+                     {[m
+[36m@@ -260,12 +239,11 @@[m [mpublic static IEnumerable<Patch> CreatePatchesFromString(string patchText, Lazy<[m
+                     }[m
+                     else[m
+                     {[m
+[31m-                        throw new FormatException("New filename not parsed correctly: " + line);[m
+[32m+[m[32m                        throw new FormatException($"Invalid patch header: {line}");[m
+                     }[m
+                 }[m
+ [m
+[31m-                patchText.Append(line);[m
+[31m-[m
+[32m+[m[32m                patchText.Append($"{startEscape.Value}{line}{endEscape.Value}");[m
+                 if (i < lines.Length - 1)[m
+                 {[m
+                     patchText.Append('\n');[m
+[36m@@ -276,8 +254,7 @@[m [mpublic static IEnumerable<Patch> CreatePatchesFromString(string patchText, Lazy<[m
+             for (; !done && i < lines.Length; i++)[m
+             {[m
+                 string line = lines[i];[m
+[31m-[m
+[31m-                if (IsStartOfANewPatch(line))[m
+[32m+[m[32m                if (PatchHeaderRegex().IsMatch(line))[m
+                 {[m
+                     break;[m
+                 }[m
+[36m@@ -287,23 +264,16 @@[m [mpublic static IEnumerable<Patch> CreatePatchesFromString(string patchText, Lazy<[m
+                     : GitModule.SystemEncoding; // warnings, messages ...[m
+ [m
+                 line = GitModule.ReEncodeStringFromLossless(line, encoding);[m
+[32m+[m[32m                patchText.Append(line);[m
+                 if (i < lines.Length - 1)[m
+                 {[m
+[31m-                    line += "\n";[m
+[32m+[m[32m                    patchText.Append('\n');[m
+                 }[m
+[31m-[m
+[31m-                patchText.Append(line);[m
+             }[m
+ [m
+             lineIndex = i - 1;[m
+ [m
+[31m-            return new Patch(header, index, fileType, fileNameA, fileNameB, changeType, patchText.ToString());[m
+[31m-        }[m
+[31m-[m
+[31m-        [Pure][m
+[31m-        private static bool IsStartOfANewPatch(string input)[m
+[31m-        {[m
+[31m-            return PatchHeaderRegex().IsMatch(input);[m
+[32m+[m[32m            return new Patch(header.ToString(), index.ToString(), fileType, fileNameA, fileNameB, changeType, patchText.ToString());[m
+         }[m
+     }[m
+ }[m


### PR DESCRIPTION
i.e. `diff.srcPrefix` and `diff.dstPrefix` settings introduced with git v2.45 https://git-scm.com/docs/git-diff/2.45.0#Documentation/git-diff.txt---default-prefix

Only (remaining) constraint is that the prefix end with '/' and doesn't contain a space.

Allowing something like (for terminals supporting hyperlinking to paths):
 git config --global diff.srcPrefix "before:./"
 git config --global diff.dstPrefix "after:./"

https://github.blog/2024-04-29-highlights-from-git-2-45/

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/da66bac6-bfce-4d9b-87b2-c3c13c861528)

### After

No error diff displayed:

![image](https://github.com/gitextensions/gitextensions/assets/460196/37a05d12-7501-4746-a9fc-ef0386520931)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 9dd1ea113a519b0c40036d35f66c4d2f01b26423
- Git 2.45.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
