### PR TITLE
Open GitHub release page for portable apps instead of downloading msi

### DIFF
--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.Designer.cs
@@ -33,33 +33,49 @@
             linkChangeLog = new LinkLabel();
             btnUpdateNow = new Button();
             linkDirectDownload = new LinkLabel();
-            flowLayoutPanel1 = new FlowLayoutPanel();
-            flowLayoutPanel1.SuspendLayout();
+            tlpnlContent = new TableLayoutPanel();
+            MainPanel.SuspendLayout();
+            ControlsPanel.SuspendLayout();
+            tlpnlContent.SuspendLayout();
             SuspendLayout();
+            // 
+            // MainPanel
+            // 
+            MainPanel.Controls.Add(tlpnlContent);
+            MainPanel.Size = new Size(456, 73);
+            // 
+            // ControlsPanel
+            // 
+            ControlsPanel.Controls.Add(linkDirectDownload);
+            ControlsPanel.Controls.Add(btnUpdateNow);
             // 
             // UpdateLabel
             // 
             UpdateLabel.AutoSize = true;
-            UpdateLabel.Location = new Point(13, 13);
+            UpdateLabel.Dock = DockStyle.Fill;
+            UpdateLabel.Location = new Point(3, 0);
             UpdateLabel.Name = "UpdateLabel";
-            UpdateLabel.Size = new Size(111, 13);
+            UpdateLabel.Size = new Size(426, 15);
             UpdateLabel.TabIndex = 0;
             UpdateLabel.Text = "Searching for updates";
             // 
             // progressBar1
             // 
-            progressBar1.Location = new Point(16, 35);
+            progressBar1.Dock = DockStyle.Fill;
+            progressBar1.Location = new Point(3, 18);
+            progressBar1.MinimumSize = new Size(0, 20);
             progressBar1.Name = "progressBar1";
-            progressBar1.Size = new Size(424, 23);
+            progressBar1.Size = new Size(426, 20);
             progressBar1.Style = ProgressBarStyle.Continuous;
             progressBar1.TabIndex = 1;
             // 
             // linkChangeLog
             // 
             linkChangeLog.AutoSize = true;
-            linkChangeLog.Location = new Point(13, 35);
+            linkChangeLog.Dock = DockStyle.Fill;
+            linkChangeLog.Location = new Point(3, 41);
             linkChangeLog.Name = "linkChangeLog";
-            linkChangeLog.Size = new Size(92, 13);
+            linkChangeLog.Size = new Size(426, 15);
             linkChangeLog.TabIndex = 2;
             linkChangeLog.TabStop = true;
             linkChangeLog.Text = "Show Change&Log";
@@ -70,23 +86,23 @@
             // 
             btnUpdateNow.AutoSize = true;
             btnUpdateNow.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            btnUpdateNow.Location = new Point(253, 3);
+            btnUpdateNow.Location = new Point(242, 8);
             btnUpdateNow.MinimumSize = new Size(100, 0);
             btnUpdateNow.Name = "btnUpdateNow";
-            btnUpdateNow.Size = new Size(100, 23);
+            btnUpdateNow.Size = new Size(100, 25);
             btnUpdateNow.TabIndex = 0;
             btnUpdateNow.Text = "&Update Now";
-            btnUpdateNow.Visible = false;
             btnUpdateNow.UseVisualStyleBackColor = true;
+            btnUpdateNow.Visible = false;
             btnUpdateNow.Click += btnUpdateNow_Click;
             // 
             // linkDirectDownload
             // 
             linkDirectDownload.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left;
             linkDirectDownload.AutoSize = true;
-            linkDirectDownload.Location = new Point(359, 0);
+            linkDirectDownload.Location = new Point(348, 5);
             linkDirectDownload.Name = "linkDirectDownload";
-            linkDirectDownload.Size = new Size(86, 29);
+            linkDirectDownload.Size = new Size(95, 31);
             linkDirectDownload.TabIndex = 1;
             linkDirectDownload.TabStop = true;
             linkDirectDownload.Text = "&Direct Download";
@@ -94,40 +110,44 @@
             linkDirectDownload.Visible = false;
             linkDirectDownload.LinkClicked += linkDirectDownload_LinkClicked;
             // 
-            // flowLayoutPanel1
+            // tlpnlContent
             // 
-            flowLayoutPanel1.AutoSize = true;
-            flowLayoutPanel1.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            flowLayoutPanel1.Controls.Add(linkDirectDownload);
-            flowLayoutPanel1.Controls.Add(btnUpdateNow);
-            flowLayoutPanel1.Dock = DockStyle.Bottom;
-            flowLayoutPanel1.FlowDirection = FlowDirection.RightToLeft;
-            flowLayoutPanel1.Location = new Point(0, 69);
-            flowLayoutPanel1.Name = "flowLayoutPanel1";
-            flowLayoutPanel1.Padding = new Padding(0, 0, 4, 2);
-            flowLayoutPanel1.Size = new Size(452, 31);
-            flowLayoutPanel1.TabIndex = 3;
+            tlpnlContent.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            tlpnlContent.ColumnStyles.Add(new ColumnStyle());
+            tlpnlContent.Controls.Add(UpdateLabel, 0, 0);
+            tlpnlContent.Controls.Add(progressBar1, 0, 1);
+            tlpnlContent.Controls.Add(linkChangeLog, 0, 2);
+            tlpnlContent.Dock = DockStyle.Fill;
+            tlpnlContent.Location = new Point(12, 12);
+            tlpnlContent.Margin = new Padding(0);
+            tlpnlContent.Name = "tlpnlContent";
+            tlpnlContent.RowCount = 4;
+            tlpnlContent.RowStyles.Add(new RowStyle());
+            tlpnlContent.RowStyles.Add(new RowStyle());
+            tlpnlContent.RowStyles.Add(new RowStyle());
+            tlpnlContent.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+            tlpnlContent.Size = new Size(432, 49);
+            tlpnlContent.TabIndex = 3;
             // 
             // FormUpdates
             // 
             AutoScaleDimensions = new SizeF(96F, 96F);
             AutoScaleMode = AutoScaleMode.Dpi;
-            ClientSize = new Size(452, 100);
-            Controls.Add(flowLayoutPanel1);
-            Controls.Add(linkChangeLog);
-            Controls.Add(UpdateLabel);
-            Controls.Add(progressBar1);
+            ClientSize = new Size(456, 114);
             FormBorderStyle = FormBorderStyle.FixedToolWindow;
             MaximizeBox = false;
             MinimizeBox = false;
             Name = "FormUpdates";
             StartPosition = FormStartPosition.CenterParent;
             Text = "Check for update";
-            flowLayoutPanel1.ResumeLayout(false);
-            flowLayoutPanel1.PerformLayout();
+            MainPanel.ResumeLayout(false);
+            MainPanel.PerformLayout();
+            ControlsPanel.ResumeLayout(false);
+            ControlsPanel.PerformLayout();
+            tlpnlContent.ResumeLayout(false);
+            tlpnlContent.PerformLayout();
             ResumeLayout(false);
             PerformLayout();
-
         }
 
         #endregion
@@ -137,6 +157,6 @@
         private LinkLabel linkChangeLog;
         private Button btnUpdateNow;
         private LinkLabel linkDirectDownload;
-        private FlowLayoutPanel flowLayoutPanel1;
+        private TableLayoutPanel tlpnlContent;
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -3,291 +3,226 @@ using System.Diagnostics;
 using System.Net;
 using Git.hub;
 using GitCommands;
-using GitCommands.Config;
-using GitExtensions.Extensibility.Configurations;
 using ResourceManager;
 
-namespace GitUI.CommandsDialogs.BrowseDialog
+namespace GitUI.CommandsDialogs.BrowseDialog;
+
+public partial class FormUpdates : GitExtensionsDialog
 {
-    public partial class FormUpdates : GitExtensionsDialog
+    #region Translation
+    private readonly TranslationString _newVersionAvailable = new("There is a new version {0} of Git Extensions available");
+    private readonly TranslationString _noUpdatesFound = new("No updates found");
+    private readonly TranslationString _downloadingUpdate = new("Downloading update...");
+    private readonly TranslationString _errorHeading = new("Download Failed");
+    private readonly TranslationString _errorMessage = new("Failed to download an update.");
+    #endregion
+
+    public IWin32Window? OwnerWindow;
+    public Version CurrentVersion { get; }
+    public bool UpdateFound;
+    public string UpdateUrl = "";
+    public string NewVersion = "";
+
+    public FormUpdates(Version currentVersion)
+        : base(commands: null, enablePositionRestore: false)
     {
-        #region Translation
-        private readonly TranslationString _newVersionAvailable = new("There is a new version {0} of Git Extensions available");
-        private readonly TranslationString _noUpdatesFound = new("No updates found");
-        private readonly TranslationString _downloadingUpdate = new("Downloading update...");
-        private readonly TranslationString _errorHeading = new("Download Failed");
-        private readonly TranslationString _errorMessage = new("Failed to download an update.");
-        #endregion
+        CurrentVersion = currentVersion;
 
-        public IWin32Window? OwnerWindow;
-        public Version CurrentVersion { get; }
-        public bool UpdateFound;
-        public string UpdateUrl = "";
-        public string NewVersion = "";
+        InitializeComponent();
+        InitializeComplete();
 
-        public FormUpdates(Version currentVersion)
-            : base(commands: null, enablePositionRestore: false)
+        progressBar1.Visible = true;
+        progressBar1.Style = ProgressBarStyle.Marquee;
+    }
+
+    public void SearchForUpdatesAndShow(IWin32Window ownerWindow, bool alwaysShow)
+    {
+        OwnerWindow = ownerWindow;
+        new Thread(SearchForUpdates).Start();
+        if (alwaysShow)
         {
-            CurrentVersion = currentVersion;
-
-            InitializeComponent();
-            InitializeComplete();
-
-            progressBar1.Visible = true;
-            progressBar1.Style = ProgressBarStyle.Marquee;
+            ShowDialog(ownerWindow);
         }
+    }
 
-        public void SearchForUpdatesAndShow(IWin32Window ownerWindow, bool alwaysShow)
-        {
-            OwnerWindow = ownerWindow;
-            new Thread(SearchForUpdates).Start();
-            if (alwaysShow)
-            {
-                ShowDialog(ownerWindow);
-            }
-        }
-
-        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
-        {
-            // We need to override ProcessCmdKey as mnemonics on labels do not behave the same as buttons
-            if (keyData == (Keys.Alt | Keys.L))
-            {
-                LaunchUrl(LaunchType.ChangeLog);
-            }
-            else if (keyData == (Keys.Alt | Keys.D))
-            {
-                LaunchUrl(LaunchType.DirectDownload);
-            }
-
-            return base.ProcessCmdKey(ref msg, keyData);
-        }
-
-        private void SearchForUpdates()
-        {
-            try
-            {
-                Client github = new();
-                Repository gitExtRepo = github.getRepository("gitextensions", "gitextensions");
-
-                GitHubReference configData = gitExtRepo?.GetRef("heads/configdata");
-
-                GitHubTree tree = configData?.GetTree();
-                if (tree is null)
-                {
-                    return;
-                }
-
-                GitHubTreeEntry releases = tree.Tree.FirstOrDefault(entry => "GitExtensions.releases".Equals(entry.Path, StringComparison.InvariantCultureIgnoreCase));
-
-                if (releases?.Blob.Value is not null)
-                {
-                    CheckForNewerVersion(releases.Blob.Value.GetContent());
-                }
-            }
-            catch (InvalidAsynchronousStateException)
-            {
-                // InvalidAsynchronousStateException (The destination thread no longer exists) is thrown
-                // if a UI component gets disposed or the UI thread EXITs while a 'check for updates' thread
-                // is in the middle of its run... Ignore it, likely the user has closed the app
-            }
-            catch (NullReferenceException)
-            {
-                // We had a number of NRE reports.
-                // Most likely scenario is that GitHub is API rate limiting unauthenticated requests that lead to failures in Git.hub library.
-                // Nothing we can do here, ignore it.
-            }
-            catch (Exception ex)
-            {
-                ThreadHelper.JoinableTaskFactory.Run(async () =>
-                    {
-                        await this.SwitchToMainThreadAsync();
-                        if (Visible)
-                        {
-                            ExceptionUtils.ShowException(this, ex, string.Empty, true);
-                        }
-                    });
-                Done();
-            }
-        }
-
-        private void CheckForNewerVersion(string releases)
-        {
-            IEnumerable<ReleaseVersion> versions = ReleaseVersion.Parse(releases);
-            IEnumerable<ReleaseVersion> updates = ReleaseVersion.GetNewerVersions(CurrentVersion, AppSettings.CheckForReleaseCandidates, versions);
-
-            ReleaseVersion update = updates.OrderBy(version => version.Version).LastOrDefault();
-            if (update is not null)
-            {
-                UpdateFound = true;
-                UpdateUrl = update.DownloadPage;
-                NewVersion = update.Version.ToString();
-                Done();
-                return;
-            }
-
-            UpdateUrl = "";
-            UpdateFound = false;
-            Done();
-        }
-
-        private void Done()
-        {
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
-            {
-                await this.SwitchToMainThreadAsync();
-
-                progressBar1.Visible = false;
-
-                if (UpdateFound)
-                {
-                    btnUpdateNow.Visible = true;
-                    UpdateLabel.Text = string.Format(_newVersionAvailable.Text, NewVersion);
-                    linkChangeLog.Visible = true;
-                    linkDirectDownload.Visible = true;
-
-                    if (!Visible)
-                    {
-                        ShowDialog(OwnerWindow);
-                    }
-                }
-                else
-                {
-                    UpdateLabel.Text = _noUpdatesFound.Text;
-                }
-            });
-        }
-
-        private void LaunchUrl(LaunchType launchType)
-        {
-            switch (launchType)
-            {
-                case LaunchType.ChangeLog:
-                    OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/blob/master/GitUI/Resources/ChangeLog.md");
-                    break;
-                case LaunchType.DirectDownload:
-                    OsShellUtil.OpenUrlInDefaultBrowser(UpdateUrl);
-                    break;
-            }
-        }
-
-        private void linkChangeLog_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+    protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+    {
+        // We need to override ProcessCmdKey as mnemonics on labels do not behave the same as buttons
+        if (keyData == (Keys.Alt | Keys.L))
         {
             LaunchUrl(LaunchType.ChangeLog);
         }
-
-        private void btnUpdateNow_Click(object sender, EventArgs e)
-        {
-            linkChangeLog.Visible = false;
-            progressBar1.Visible = true;
-            btnUpdateNow.Enabled = false;
-            UpdateLabel.Text = _downloadingUpdate.Text;
-
-            ThreadHelper.FileAndForget(async () =>
-            {
-                string fileName = Path.GetFileName(UpdateUrl);
-                try
-                {
-#pragma warning disable SYSLIB0014 // 'WebClient' is obsolete
-                    using WebClient webClient = new();
-#pragma warning restore SYSLIB0014 // 'WebClient' is obsolete
-                    await webClient.DownloadFileTaskAsync(new Uri(UpdateUrl), Environment.GetEnvironmentVariable("TEMP") + "\\" + fileName);
-                }
-                catch (Exception ex)
-                {
-                    MessageBox.Show(this, _errorMessage.Text + Environment.NewLine + ex.Message, _errorHeading.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                    return;
-                }
-
-                try
-                {
-                    Process process = new();
-                    process.StartInfo.UseShellExecute = false;
-                    process.StartInfo.FileName = "msiexec.exe";
-                    process.StartInfo.Arguments = string.Format("/i \"{0}\\{1}\" /qb LAUNCH=1", Environment.GetEnvironmentVariable("TEMP"), fileName);
-                    process.Start();
-
-                    await this.SwitchToMainThreadAsync();
-                    progressBar1.Visible = false;
-                    Close();
-                    Application.Exit();
-                }
-                catch (Win32Exception)
-                {
-                }
-            });
-        }
-
-        private void linkDirectDownload_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        else if (keyData == (Keys.Alt | Keys.D))
         {
             LaunchUrl(LaunchType.DirectDownload);
         }
+
+        return base.ProcessCmdKey(ref msg, keyData);
     }
 
-    internal enum LaunchType
+    private void SearchForUpdates()
+    {
+        try
+        {
+            Client github = new();
+            Repository gitExtRepo = github.getRepository("gitextensions", "gitextensions");
+
+            GitHubReference configData = gitExtRepo?.GetRef("heads/configdata");
+
+            GitHubTree tree = configData?.GetTree();
+            if (tree is null)
+            {
+                return;
+            }
+
+            GitHubTreeEntry releases = tree.Tree.FirstOrDefault(entry => "GitExtensions.releases".Equals(entry.Path, StringComparison.InvariantCultureIgnoreCase));
+
+            if (releases?.Blob.Value is not null)
+            {
+                CheckForNewerVersion(releases.Blob.Value.GetContent());
+            }
+        }
+        catch (InvalidAsynchronousStateException)
+        {
+            // InvalidAsynchronousStateException (The destination thread no longer exists) is thrown
+            // if a UI component gets disposed or the UI thread EXITs while a 'check for updates' thread
+            // is in the middle of its run... Ignore it, likely the user has closed the app
+        }
+        catch (NullReferenceException)
+        {
+            // We had a number of NRE reports.
+            // Most likely scenario is that GitHub is API rate limiting unauthenticated requests that lead to failures in Git.hub library.
+            // Nothing we can do here, ignore it.
+        }
+        catch (Exception ex)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    await this.SwitchToMainThreadAsync();
+                    if (Visible)
+                    {
+                        ExceptionUtils.ShowException(this, ex, string.Empty, true);
+                    }
+                });
+            Done();
+        }
+    }
+
+    private void CheckForNewerVersion(string releases)
+    {
+        IEnumerable<ReleaseVersion> versions = ReleaseVersion.Parse(releases);
+        IEnumerable<ReleaseVersion> updates = ReleaseVersion.GetNewerVersions(CurrentVersion, AppSettings.CheckForReleaseCandidates, versions);
+
+        ReleaseVersion update = updates.OrderBy(version => version.Version).LastOrDefault();
+        if (update is not null)
+        {
+            UpdateFound = true;
+            UpdateUrl = update.DownloadPage;
+            NewVersion = update.Version.ToString();
+            Done();
+            return;
+        }
+
+        UpdateUrl = "";
+        UpdateFound = false;
+        Done();
+    }
+
+    private void Done()
+    {
+        ThreadHelper.JoinableTaskFactory.Run(async () =>
+        {
+            await this.SwitchToMainThreadAsync();
+
+            progressBar1.Visible = false;
+
+            if (UpdateFound)
+            {
+                btnUpdateNow.Visible = true;
+                UpdateLabel.Text = string.Format(_newVersionAvailable.Text, NewVersion);
+                linkChangeLog.Visible = true;
+                linkDirectDownload.Visible = true;
+
+                if (!Visible)
+                {
+                    ShowDialog(OwnerWindow);
+                }
+            }
+            else
+            {
+                UpdateLabel.Text = _noUpdatesFound.Text;
+            }
+        });
+    }
+
+    private void LaunchUrl(LaunchType launchType)
+    {
+        switch (launchType)
+        {
+            case LaunchType.ChangeLog:
+                OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/blob/master/GitUI/Resources/ChangeLog.md");
+                break;
+            case LaunchType.DirectDownload:
+                OsShellUtil.OpenUrlInDefaultBrowser(UpdateUrl);
+                break;
+        }
+    }
+
+    private void linkChangeLog_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+    {
+        LaunchUrl(LaunchType.ChangeLog);
+    }
+
+    private void btnUpdateNow_Click(object sender, EventArgs e)
+    {
+        linkChangeLog.Visible = false;
+        progressBar1.Visible = true;
+        btnUpdateNow.Enabled = false;
+        UpdateLabel.Text = _downloadingUpdate.Text;
+
+        ThreadHelper.FileAndForget(async () =>
+        {
+            string fileName = Path.GetFileName(UpdateUrl);
+            try
+            {
+#pragma warning disable SYSLIB0014 // 'WebClient' is obsolete
+                using WebClient webClient = new();
+#pragma warning restore SYSLIB0014 // 'WebClient' is obsolete
+                await webClient.DownloadFileTaskAsync(new Uri(UpdateUrl), Environment.GetEnvironmentVariable("TEMP") + "\\" + fileName);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, _errorMessage.Text + Environment.NewLine + ex.Message, _errorHeading.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            try
+            {
+                Process process = new();
+                process.StartInfo.UseShellExecute = false;
+                process.StartInfo.FileName = "msiexec.exe";
+                process.StartInfo.Arguments = string.Format("/i \"{0}\\{1}\" /qb LAUNCH=1", Environment.GetEnvironmentVariable("TEMP"), fileName);
+                process.Start();
+
+                await this.SwitchToMainThreadAsync();
+                progressBar1.Visible = false;
+                Close();
+                Application.Exit();
+            }
+            catch (Win32Exception)
+            {
+            }
+        });
+    }
+
+    private void linkDirectDownload_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+    {
+        LaunchUrl(LaunchType.DirectDownload);
+    }
+
+    private enum LaunchType
     {
         ChangeLog,
         DirectDownload
-    }
-
-    public enum ReleaseType
-    {
-        Major,
-        HotFix,
-        ReleaseCandidate
-    }
-
-    public class ReleaseVersion
-    {
-        public Version Version { get; }
-        public ReleaseType ReleaseType { get; }
-        public string DownloadPage { get; }
-
-        public ReleaseVersion(Version version, ReleaseType releaseType, string downloadPage)
-        {
-            Version = version;
-            ReleaseType = releaseType;
-            DownloadPage = downloadPage;
-        }
-
-        public static ReleaseVersion? FromSection(IConfigSection section)
-        {
-            Version ver;
-            try
-            {
-                ver = new Version(section.SubSection);
-            }
-            catch (Exception e)
-            {
-                Debug.WriteLine(e);
-                return null;
-            }
-
-            Enum.TryParse(section.GetValue("ReleaseType"), true, out ReleaseType releaseType);
-
-            return new ReleaseVersion(ver, releaseType, section.GetValue("DownloadPage"));
-        }
-
-        public static IEnumerable<ReleaseVersion> Parse(string versionsStr)
-        {
-            ConfigFile cfg = new(fileName: "");
-            cfg.LoadFromString(versionsStr);
-            IEnumerable<IConfigSection> sections = cfg.GetConfigSections("Version");
-            sections = sections.Concat(cfg.GetConfigSections("RCVersion"));
-
-            return sections.Select(FromSection).WhereNotNull();
-        }
-
-        public static IEnumerable<ReleaseVersion> GetNewerVersions(
-            Version currentVersion,
-            bool checkForReleaseCandidates,
-            IEnumerable<ReleaseVersion> availableVersions)
-        {
-            IEnumerable<ReleaseVersion> versions = availableVersions.Where(version =>
-                    version.ReleaseType == ReleaseType.Major ||
-                    version.ReleaseType == ReleaseType.HotFix ||
-                    (checkForReleaseCandidates && version.ReleaseType == ReleaseType.ReleaseCandidate));
-
-            return versions.Where(version => version.Version.CompareTo(currentVersion) > 0);
-        }
     }
 }

--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -9,7 +9,7 @@ using ResourceManager;
 
 namespace GitUI.CommandsDialogs.BrowseDialog
 {
-    public partial class FormUpdates : GitExtensionsForm
+    public partial class FormUpdates : GitExtensionsDialog
     {
         #region Translation
         private readonly TranslationString _newVersionAvailable = new("There is a new version {0} of Git Extensions available");
@@ -26,6 +26,7 @@ namespace GitUI.CommandsDialogs.BrowseDialog
         public string NewVersion = "";
 
         public FormUpdates(Version currentVersion)
+            : base(commands: null, enablePositionRestore: false)
         {
             CurrentVersion = currentVersion;
 

--- a/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/FormUpdates.cs
@@ -53,9 +53,9 @@ public partial class FormUpdates : GitExtensionsDialog
             LaunchUrl(LaunchType.ChangeLog);
         }
         else if (keyData == (Keys.Alt | Keys.D))
-        {
-            LaunchUrl(LaunchType.DirectDownload);
-        }
+            {
+                LaunchUrl(LaunchType.DirectDownload);
+            }
 
         return base.ProcessCmdKey(ref msg, keyData);
     }
@@ -138,7 +138,7 @@ public partial class FormUpdates : GitExtensionsDialog
 
             if (UpdateFound)
             {
-                btnUpdateNow.Visible = true;
+                btnUpdateNow.Visible = !AppSettings.IsPortable();
                 UpdateLabel.Text = string.Format(_newVersionAvailable.Text, NewVersion);
                 linkChangeLog.Visible = true;
                 linkDirectDownload.Visible = true;
@@ -162,8 +162,17 @@ public partial class FormUpdates : GitExtensionsDialog
             case LaunchType.ChangeLog:
                 OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/blob/master/GitUI/Resources/ChangeLog.md");
                 break;
+
             case LaunchType.DirectDownload:
-                OsShellUtil.OpenUrlInDefaultBrowser(UpdateUrl);
+                if (AppSettings.IsPortable())
+                {
+                    OsShellUtil.OpenUrlInDefaultBrowser(@"https://github.com/gitextensions/gitextensions/releases");
+                }
+                else
+                {
+                    OsShellUtil.OpenUrlInDefaultBrowser(UpdateUrl);
+                }
+
                 break;
         }
     }

--- a/GitUI/CommandsDialogs/BrowseDialog/ReleaseType.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/ReleaseType.cs
@@ -1,0 +1,8 @@
+﻿namespace GitUI.CommandsDialogs.BrowseDialog;
+
+internal enum ReleaseType
+{
+    Major,
+    HotFix,
+    ReleaseCandidate
+}

--- a/GitUI/CommandsDialogs/BrowseDialog/ReleaseVersion.cs
+++ b/GitUI/CommandsDialogs/BrowseDialog/ReleaseVersion.cs
@@ -1,0 +1,60 @@
+﻿using System.Diagnostics;
+using GitCommands.Config;
+using GitExtensions.Extensibility.Configurations;
+
+namespace GitUI.CommandsDialogs.BrowseDialog;
+
+internal class ReleaseVersion
+{
+    public Version Version { get; }
+    public ReleaseType ReleaseType { get; }
+    public string DownloadPage { get; }
+
+    public ReleaseVersion(Version version, ReleaseType releaseType, string downloadPage)
+    {
+        Version = version;
+        ReleaseType = releaseType;
+        DownloadPage = downloadPage;
+    }
+
+    public static ReleaseVersion? FromSection(IConfigSection section)
+    {
+        Version ver;
+        try
+        {
+            ver = new Version(section.SubSection);
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine(e);
+            return null;
+        }
+
+        Enum.TryParse(section.GetValue("ReleaseType"), true, out ReleaseType releaseType);
+
+        return new ReleaseVersion(ver, releaseType, section.GetValue("DownloadPage"));
+    }
+
+    public static IEnumerable<ReleaseVersion> Parse(string versionsStr)
+    {
+        ConfigFile cfg = new(fileName: "");
+        cfg.LoadFromString(versionsStr);
+        IEnumerable<IConfigSection> sections = cfg.GetConfigSections("Version");
+        sections = sections.Concat(cfg.GetConfigSections("RCVersion"));
+
+        return sections.Select(FromSection).WhereNotNull();
+    }
+
+    public static IEnumerable<ReleaseVersion> GetNewerVersions(
+        Version currentVersion,
+        bool checkForReleaseCandidates,
+        IEnumerable<ReleaseVersion> availableVersions)
+    {
+        IEnumerable<ReleaseVersion> versions = availableVersions.Where(version =>
+                version.ReleaseType == ReleaseType.Major ||
+                version.ReleaseType == ReleaseType.HotFix ||
+                (checkForReleaseCandidates && version.ReleaseType == ReleaseType.ReleaseCandidate));
+
+        return versions.Where(version => version.Version.CompareTo(currentVersion) > 0);
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->


Fixes #11742

## Proposed changes

- Open GitHub release page for portable apps instead of downloading msi
- Convert FormUpdates to use GitExtensionsDialog

## Screenshots <!-- Remove this section if PR does not change UI -->



### After

* Installed
![image](https://github.com/gitextensions/gitextensions/assets/4403806/63f690f9-ecdc-476b-af51-6fdffa87d577)
![image](https://github.com/gitextensions/gitextensions/assets/4403806/2389e8a7-29f2-40e7-857b-d662b239ed5e)
![image](https://github.com/gitextensions/gitextensions/assets/4403806/b847b5d8-22bc-4537-8776-0b3ae3e11b4d)


* Portable
![image](https://github.com/gitextensions/gitextensions/assets/4403806/17967835-295c-4ed4-91ee-9e07aeee989d)
![image](https://github.com/gitextensions/gitextensions/assets/4403806/de03208b-4bd7-4542-9710-9cb95c538efc)


<!-- Mention language, UI scaling, or anything else that might be relevant -->

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
