### PR TITLE
fix(diff): Script separator only if items

### DIFF
--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -756,7 +756,7 @@ namespace GitUI.CommandsDialogs
                 blameToolStripMenuItem.Checked = false;
             }
 
-            DiffContextMenu.AddUserScripts(runScriptToolStripMenuItem, ExecuteCommand, script => script.OnEvent == ScriptEvent.ShowInFileList, UICommands);
+            toolStripSeparatorScript.Visible = DiffContextMenu.AddUserScripts(runScriptToolStripMenuItem, ExecuteCommand, script => script.OnEvent == ScriptEvent.ShowInFileList, UICommands);
         }
 
         private void DiffContextMenu_Opening(object sender, CancelEventArgs e)

--- a/src/app/GitUI/CommandsDialogs/UserScriptContextMenuExtensions.cs
+++ b/src/app/GitUI/CommandsDialogs/UserScriptContextMenuExtensions.cs
@@ -18,7 +18,8 @@ namespace GitUI.CommandsDialogs
         /// <param name="hostMenuItem">The menu item user scripts not marked as <see cref="ScriptInfo.AddToRevisionGridContextMenu"/> are added to.</param>
         /// <param name="scriptInvoker">The handler that handles user script invocation.</param>
         /// <param name="serviceProvider">The DI service provider.</param>
-        public static void AddUserScripts(this ContextMenuStrip contextMenu, ToolStripMenuItem hostMenuItem, Func<int, bool> scriptInvoker, Func<ScriptInfo, bool> scriptFilterAddDirect, IServiceProvider serviceProvider)
+        /// <returns><see langword="true"/> if any scripts were added to menus; otherwise <see langword="false"/>.</returns>
+        public static bool AddUserScripts(this ContextMenuStrip contextMenu, ToolStripMenuItem hostMenuItem, Func<int, bool> scriptInvoker, Func<ScriptInfo, bool> scriptFilterAddDirect, IServiceProvider serviceProvider)
         {
             ArgumentNullException.ThrowIfNull(contextMenu);
             ArgumentNullException.ThrowIfNull(hostMenuItem);
@@ -34,6 +35,7 @@ namespace GitUI.CommandsDialogs
 
             IHotkeySettingsLoader hotkeySettingsLoader = serviceProvider.GetRequiredService<IHotkeySettingsLoader>();
             IReadOnlyList<HotkeyCommand> hotkeys = hotkeySettingsLoader.LoadHotkeys(FormSettings.HotkeySettingsName);
+            bool itemsAdded = false;
 
             foreach (ScriptInfo script in scripts)
             {
@@ -61,7 +63,11 @@ namespace GitUI.CommandsDialogs
                     hostMenuItem.DropDown.Items.Add(item);
                     hostMenuItem.Enable(true);
                 }
+
+                itemsAdded = true;
             }
+
+            return itemsAdded;
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed changes

Only show the script separator if there are items

## Screenshots <!-- Remove this section if PR does not change UI -->

diff tab context menu
### Before

![image](https://github.com/gitextensions/gitextensions/assets/6248932/b373705b-3d43-4cf3-8299-f7109cda7880)

### After

![image](https://github.com/gitextensions/gitextensions/assets/6248932/d203e96d-3cb3-4516-8f12-df4d1044daf0)

## Test methodology <!-- How did you ensure quality? -->

manual

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
