### PR TITLE
feat(GitHub): Add commit message issue helper feature

### DIFF
--- a/src/app/GitUI/Translation/English.Plugins.xlf
+++ b/src/app/GitUI/Translation/English.Plugins.xlf
@@ -731,12 +731,28 @@ Are you sure you want to continue?</source>
         <source>Personal Access Token</source>
         <target />
       </trans-unit>
+      <trans-unit id="_error.Text">
+        <source>Error</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_generateToken.Text">
         <source>Generate a GitHub personal access token</source>
         <target />
       </trans-unit>
+      <trans-unit id="_issueCommitMessageHelperEnabled.Caption">
+        <source>Enable commit message issue helper</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_manageToken.Text">
         <source>Manage GitHub personal access token</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_noAssignedIssues.Text">
+        <source>No assigned GitHub issues found</source>
+        <target />
+      </trans-unit>
+      <trans-unit id="_noTokenError.Text">
+        <source>No GitHub personal access token (PAT) defined</source>
         <target />
       </trans-unit>
       <trans-unit id="_noteRestartNeeded.Text">

--- a/src/app/GitUI/Translation/English.Plugins.xlf
+++ b/src/app/GitUI/Translation/English.Plugins.xlf
@@ -743,6 +743,10 @@ Are you sure you want to continue?</source>
         <source>Enable commit message issue helper</source>
         <target />
       </trans-unit>
+      <trans-unit id="_issueCommitMessageHelperMaxCount.Caption">
+        <source>Maximum number of issues retrieved</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_manageToken.Text">
         <source>Manage GitHub personal access token</source>
         <target />

--- a/src/plugins/Github3/GitHub3Plugin.cs
+++ b/src/plugins/Github3/GitHub3Plugin.cs
@@ -7,6 +7,8 @@ using GitExtensions.Extensibility.Git;
 using GitExtensions.Extensibility.Plugins;
 using GitExtensions.Extensibility.Settings;
 using GitExtensions.Plugins.GitHub3.Properties;
+using GitUI;
+using GitUIPluginInterfaces;
 using GitUIPluginInterfaces.RepositoryHosts;
 using Microsoft;
 using ResourceManager;
@@ -67,19 +69,26 @@ namespace GitExtensions.Plugins.GitHub3
 
     [Export(typeof(IGitPlugin))]
     [Export(typeof(IRepositoryHostPlugin))]
-    public class GitHub3Plugin : GitPluginBase, IRepositoryHostPlugin
+    [Export(typeof(IGitPluginForCommit))]
+    public class GitHub3Plugin : GitPluginBase, IRepositoryHostPlugin, IGitPluginForCommit
     {
+        private const int MaxMostRecentIssuesDisplayed = 10;
+
         private readonly TranslationString _viewInWebSite = new("View in {0}");
         private readonly TranslationString _tokenAlreadyExist = new("You already have an personal access token. To get a new one, delete your old one in Plugins > Plugin Settings first.");
         private readonly TranslationString _generateToken = new("Generate a GitHub personal access token");
         private readonly TranslationString _manageToken = new("Manage GitHub personal access token");
         private readonly TranslationString _openLinkFailed = new("Fail to open the link. Reason: ");
         private readonly TranslationString _noteRestartNeeded = new("Note: Git Extensions need to be restarted so that the token is taken into account.");
+        private readonly TranslationString _noTokenError = new("No GitHub personal access token (PAT) defined");
+        private readonly TranslationString _noAssignedIssues = new("No assigned GitHub issues found");
+        private readonly TranslationString _error = new("Error");
 
         public static string GitHubAuthorizationRelativeUrl = "authorizations";
         public static string UpstreamConventionName = "upstream";
         public readonly StringSetting GitHubHost = new("GitHub (Enterprise) hostname", "github.com");
         public readonly StringSetting PersonalAccessToken = new("OAuth Token", "Personal Access Token", "");
+        private readonly BoolSetting _issueCommitMessageHelperEnabled = new("IssueCommitMessageHelperEnabled", "Enable commit message issue helper", true);
         public string GitHubApiEndpoint => $"https://api.{GitHubHost.ValueOrDefault(Settings)}";
         public string GitHubEndpoint => $"https://{GitHubHost.ValueOrDefault(Settings)}";
 
@@ -90,6 +99,7 @@ namespace GitExtensions.Plugins.GitHub3
 
         private IGitUICommands? _currentGitUiCommands;
         private IReadOnlyList<IHostedRemote>? _hostedRemotesForModule;
+        private List<string> _currentMessages = new(MaxMostRecentIssuesDisplayed);
 
         public GitHub3Plugin() : base(true)
         {
@@ -115,6 +125,8 @@ namespace GitExtensions.Plugins.GitHub3
             yield return new PseudoSetting(manageTokenLink);
 
             yield return new PseudoSetting(_noteRestartNeeded.Text);
+
+            yield return _issueCommitMessageHelperEnabled;
         }
 
         private void GenerateTokenLink_Click(object sender, EventArgs e)
@@ -146,6 +158,80 @@ namespace GitExtensions.Plugins.GitHub3
             {
                 GitHub.setOAuth2Token(GitHubLoginInfo.OAuthToken);
             }
+
+            gitUiCommands.PreCommit += GitUiCommands_PreCommit;
+            gitUiCommands.PostCommit += GitUiCommands_PostCommit;
+        }
+
+        private void GitUiCommands_PreCommit(object? sender, GitUIEventArgs e)
+        {
+            if (!_issueCommitMessageHelperEnabled.ValueOrDefault(Settings))
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(GitHubLoginInfo.OAuthToken))
+            {
+                e.GitUICommands.AddCommitTemplate(_noTokenError.Text, () => string.Empty, Icon);
+                return;
+            }
+
+            ThreadHelper.FileAndForget(async () =>
+            {
+                IHostedRemote[] hostedRemotes = GetHostedRemotes().ToArray();
+                if (hostedRemotes.Length == 0)
+                {
+                    return;
+                }
+
+                IReadOnlyList<Issue> issues = _gitHub.GetAssignedIssues();
+
+                if (issues?.All(i => i.Number == 0) ?? true)
+                {
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    e.GitUICommands.AddCommitTemplate(_noAssignedIssues.Text, () => string.Empty, Icon);
+                    return;
+                }
+
+                Issue[] recentUserIssues = issues.Where(i => i.Number != 0 && hostedRemotes.Any(r => r.Owner == i.Repository.Owner.Login && r.RemoteRepositoryName == i.Repository.Name))
+                                                            .OrderByDescending(i => i.UpdatedAt)
+                                                            .Take(MaxMostRecentIssuesDisplayed)
+                                                            .ToArray();
+
+                bool multipleRemotes = hostedRemotes.Length > 1;
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                foreach (Issue issue in recentUserIssues)
+                {
+                    string remoteData = multipleRemotes ? $" ({issue.Repository.Owner.Login}/{issue.Repository.Name})" : string.Empty;
+                    string key = $"{issue.Number}: {issue.Title}{remoteData}";
+                    _currentMessages.Add(key);
+                    e.GitUICommands.AddCommitTemplate(key, () => GetIssueDescription(issue), Icon);
+                }
+
+                string GetIssueDescription(Issue issue)
+                    => $"""
+
+                        Fixes #{issue.Number} : {issue.Title}
+
+                        {issue.Body}
+
+                        """;
+            });
+        }
+
+        private void GitUiCommands_PostCommit(object sender, GitUIEventArgs e)
+        {
+            if (_currentMessages.Count == 0)
+            {
+                return;
+            }
+
+            foreach (string key in _currentMessages)
+            {
+                e.GitUICommands.RemoveCommitTemplate(key);
+            }
+
+            _currentMessages.Clear();
         }
 
         public override bool Execute(GitUIEventArgs args)
@@ -156,7 +242,7 @@ namespace GitExtensions.Plugins.GitHub3
             }
             else
             {
-                MessageBox.Show(args.OwnerForm, _tokenAlreadyExist.Text, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(args.OwnerForm, _tokenAlreadyExist.Text, _error.Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             return false;

--- a/src/plugins/Github3/GitHub3Plugin.cs
+++ b/src/plugins/Github3/GitHub3Plugin.cs
@@ -87,7 +87,7 @@ namespace GitExtensions.Plugins.GitHub3
         public readonly StringSetting GitHubHost = new("GitHub (Enterprise) hostname", "github.com");
         public readonly StringSetting PersonalAccessToken = new("OAuth Token", "Personal Access Token", "");
         private readonly BoolSetting _issueCommitMessageHelperEnabled = new("IssueCommitMessageHelperEnabled", "Enable commit message issue helper", true);
-        private readonly NumberSetting<int> _issueCommitMessageHelperMaxCount = new("IssueCommitMessageHelperMaxCount", "Maximum number of issue retrieved", 10);
+        private readonly NumberSetting<int> _issueCommitMessageHelperMaxCount = new("IssueCommitMessageHelperMaxCount", "Maximum number of issues retrieved", 10);
         public string GitHubApiEndpoint => $"https://api.{GitHubHost.ValueOrDefault(Settings)}";
         public string GitHubEndpoint => $"https://{GitHubHost.ValueOrDefault(Settings)}";
 

--- a/src/plugins/Github3/GitHubHostedRemote.cs
+++ b/src/plugins/Github3/GitHubHostedRemote.cs
@@ -1,7 +1,9 @@
-﻿using GitUIPluginInterfaces.RepositoryHosts;
+﻿using System.Diagnostics;
+using GitUIPluginInterfaces.RepositoryHosts;
 
 namespace GitExtensions.Plugins.GitHub3
 {
+    [DebuggerDisplay("{Data}")]
     internal class GitHubHostedRemote : IHostedRemote
     {
         private GitHubRepo? _repo;

--- a/src/plugins/Github3/GitHubRepo.cs
+++ b/src/plugins/Github3/GitHubRepo.cs
@@ -89,7 +89,7 @@ namespace GitExtensions.Plugins.GitHub3
 
         public IReadOnlyList<IPullRequestInformation> GetPullRequests()
         {
-            IList<PullRequest> pullRequests = _repo?.GetPullRequests();
+            IReadOnlyList<PullRequest> pullRequests = _repo?.GetPullRequests();
 
             if (pullRequests is not null)
             {


### PR DESCRIPTION

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

no git issue menu item

### After

Need to be enabled:
![image](https://github.com/gitextensions/gitextensions/assets/460196/91667560-be47-4d1d-9735-a380dd1fdff2)

Issue template from GitHub assigned issues:
![image](https://github.com/gitextensions/gitextensions/assets/460196/c5233d9e-622f-49e7-9dbf-0a4f623f9fa1)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build a32c590c1f00a2e918f68d0fe5b70d86bc54db48
- Git 2.45.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
