### PR TITLE
More meaningful and (I hope) pleasant default colors

### DIFF
--- a/GitExtUtils/GitUI/Theming/AppColorDefaults.cs
+++ b/GitExtUtils/GitUI/Theming/AppColorDefaults.cs
@@ -8,8 +8,8 @@
             new()
             {
                 { AppColor.OtherTag, Color.Gray },
-                { AppColor.AuthoredHighlight, Color.LightYellow },
-                { AppColor.HighlightAllOccurences, Color.LightYellow },
+                { AppColor.AuthoredHighlight, Color.FromArgb(0xea, 0xf1, 0xff) },
+                { AppColor.HighlightAllOccurences, Color.FromArgb(0xe8, 0xe8, 0xff) },
                 { AppColor.Tag, Color.DarkBlue },
                 { AppColor.Graph, Color.DarkRed },
                 { AppColor.Branch, Color.FromArgb(0x00, 0x80, 0x00) },

--- a/GitUI/Themes/invariant.css
+++ b/GitUI/Themes/invariant.css
@@ -35,8 +35,8 @@
 
 /* Application colors */
 .OtherTag                { color: #808080; }
-.AuthoredHighlight       { color: #ffffe0; }
-.HighlightAllOccurences  { color: #ffffe0; }
+.AuthoredHighlight       { color: #eaf1ff; }
+.HighlightAllOccurences  { color: #e8e8ff; }
 .Tag                     { color: #00008b; }
 .Graph                   { color: #8b0000; }
 .Branch                  { color: #008000; }


### PR DESCRIPTION
* Selected revision (blue) => Same author (**light** blue)
* Selected text (mauve) => Same text (**light** mauve)

Note: I know that colors is a sensible subject and that everyone has it's own tastes but I hope I will not open the pandora's box.
I personally prefer not seeing the kind of yellow.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/bee214f2-8368-4808-be85-1bb9070e88c0)

### After

![image](https://github.com/gitextensions/gitextensions/assets/460196/03ddabeb-1a7d-4240-8dfc-12016950e2d7)

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build dd7687981074b2c7cad97c5e2cfeb41dc5811749
- Git 2.45.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False
- Microsoft.WindowsDesktop.App Versions

```
    Microsoft.WindowsDesktop.App 6.0.26 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 7.0.15 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
    Microsoft.WindowsDesktop.App 8.0.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
```



## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
