### PR TITLE
Improve recovery form

### DIFF
--- a/src/app/GitUI/CommandsDialogs/FormVerify.Designer.cs
+++ b/src/app/GitUI/CommandsDialogs/FormVerify.Designer.cs
@@ -400,6 +400,7 @@
             // 
             saveAsToolStripMenuItem.Image = Properties.Images.SaveAs;
             saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
+            saveAsToolStripMenuItem.ShortcutKeys = ((Keys)((Keys.Control | Keys.S)));
             saveAsToolStripMenuItem.Size = new Size(189, 22);
             saveAsToolStripMenuItem.Text = "Save as...";
             saveAsToolStripMenuItem.Click += saveAsToolStripMenuItem_Click;

--- a/src/app/GitUI/CommandsDialogs/FormVerify.LostObject.cs
+++ b/src/app/GitUI/CommandsDialogs/FormVerify.LostObject.cs
@@ -59,7 +59,7 @@ namespace GitUI.CommandsDialogs
             /// <summary>
             /// Diagnostics and object type.
             /// </summary>
-            public string RawType { get; }
+            public string RawType { get; set; }
 
             public string? Author { get; private set; }
             public string? Subject { get; private set; }

--- a/src/app/GitUI/CommandsDialogs/FormVerify.LostObject.cs
+++ b/src/app/GitUI/CommandsDialogs/FormVerify.LostObject.cs
@@ -32,9 +32,9 @@ namespace GitUI.CommandsDialogs
             /// %s  - subject.
             /// %ct - committer date, UNIX timestamp (easy to parse format).
             /// </summary>
-            private static readonly string LogCommandArgumentsFormat = (ArgumentString)new GitArgumentBuilder("log")
+            private static readonly string ShowCommandArgumentsFormat = (ArgumentString)new GitArgumentBuilder("show")
             {
-                "-n1",
+                "--quiet",
                 "--pretty=format:\"%aN\u001F%s\u001F%ct\u001F%P\" {0}"
             };
 
@@ -78,6 +78,36 @@ namespace GitUI.CommandsDialogs
                 ObjectId = objectId ?? throw new ArgumentNullException(nameof(objectId));
             }
 
+            /// <summary>
+            /// Retrieve commits metadata for all the commits hashes provided.
+            /// </summary>
+            /// <param name="module">Git module to run the git command.</param>
+            /// <param name="commitIds">The collection of commits hashes.</param>
+            /// <returns>the metadata for all the commits.</returns>
+            public static string[] GetCommitsMetadata(IGitModule module, IEnumerable<string> commitIds)
+            {
+                return module.GitExecutable
+                    .GetOutput(string.Format(ShowCommandArgumentsFormat, string.Join(" ", commitIds)), outputEncoding: GitModule.LosslessEncoding)
+                    .Split('\n');
+            }
+
+            public void FillCommitData(IGitModule module, string commitLog)
+            {
+                Match logPatternMatch = LogRegex().Match(commitLog);
+                if (logPatternMatch.Success)
+                {
+                    // TODO: cache
+                    Author = module.ReEncodeStringFromLossless(logPatternMatch.Groups["author"].Value);
+                    Subject = module.ReEncodeCommitMessage(logPatternMatch.Groups["subject"].Value) ?? "";
+                    Date = DateTimeUtils.ParseUnixTime(logPatternMatch.Groups["date"].Value);
+                    string firstParent = logPatternMatch.Groups["first_parent"].Value;
+                    if (!string.IsNullOrEmpty(firstParent))
+                    {
+                        Parent = ObjectId.Parse(firstParent);
+                    }
+                }
+            }
+
             public static LostObject? TryParse(IGitModule module, string raw)
             {
                 if (string.IsNullOrEmpty(raw))
@@ -106,19 +136,7 @@ namespace GitUI.CommandsDialogs
 
                 if (objectType == LostObjectType.Commit)
                 {
-                    string commitLog = GetLostCommitLog();
-                    Match logPatternMatch = LogRegex().Match(commitLog);
-                    if (logPatternMatch.Success)
-                    {
-                        result.Author = module.ReEncodeStringFromLossless(logPatternMatch.Groups["author"].Value);
-                        result.Subject = module.ReEncodeCommitMessage(logPatternMatch.Groups["subject"].Value) ?? "";
-                        result.Date = DateTimeUtils.ParseUnixTime(logPatternMatch.Groups["date"].Value);
-                        string firstParent = logPatternMatch.Groups["first_parent"].Value;
-                        if (!string.IsNullOrEmpty(firstParent))
-                        {
-                            result.Parent = ObjectId.Parse(firstParent);
-                        }
-                    }
+                    // perf: Commit metadata will be fetched by batch
                 }
                 else if (objectType == LostObjectType.Tag)
                 {
@@ -142,7 +160,6 @@ namespace GitUI.CommandsDialogs
 
                 return result;
 
-                string GetLostCommitLog() => VerifyHashAndRunCommand(LogCommandArgumentsFormat);
                 string GetLostTagData() => VerifyHashAndRunCommand(TagCommandArgumentsFormat);
 
                 string VerifyHashAndRunCommand(ArgumentString commandFormat)

--- a/src/app/GitUI/CommandsDialogs/FormVerify.cs
+++ b/src/app/GitUI/CommandsDialogs/FormVerify.cs
@@ -27,8 +27,10 @@ namespace GitUI.CommandsDialogs
         private LostObject? _previewedItem;
         private string _defaultFilename = null;
 
+        // https://en.wikipedia.org/wiki/List_of_file_signatures
         private static readonly Dictionary<string, string> _languagesStartOfFile = new()
         {
+            { @"{\rtf", "rtf" },
             { "{", "json" },
             { "#include", "cpp" },
             { "import {", "js" },
@@ -43,18 +45,36 @@ namespace GitUI.CommandsDialogs
             { "[", "ini" },
             { "using ", "cs" },
             { "# ", "md" },
+            { "##", "md" },
             { "<!doctype html", "html" },
             { "<html", "html" },
             { "<?xml", "xml" },
             { "use ", "rs" },
-            { @"{\", "rtf" },
             { "%PDF", "pdf" },
             { "PK", "zip" },
             { "MZ", "exe" },
             { @"\document", "tex" },
             { "\u0089PNG", "png" },
-            { "ÿØÿà\0\x10JFIF", "jpg" },
+            { "ÿØÿQ", "jp2" },
+            { "ÿØÿ", "jpg" },
+            { "ÿ\x0A", "jxl" },
+            { "RIFF", "webp" },
             { "<svg", "svg" },
+            { "BM", "bmp" },
+            { "7z", "7z" },
+            { "GIF", "gif" },
+            { "ÐÏ\x11à¡±\x1Aá", "doc" },
+            { "qoif", "qoi" },
+            { "Rar!", "rar" },
+            { "%!PS", "ps" },
+            { "OggS", "ogg" },
+            { "8BPS", "psf" },
+            { "ID3", "mp3" },
+            { "CD001", "iso" },
+            { "fLaC", "flac" },
+            { "FLIF", "flif" },
+            { "␚Eß£", "mkv" },
+            { "<", "xml" },
         };
 
         private static readonly Dictionary<string, string[]> _fileTypesEquivalences = new()
@@ -63,8 +83,9 @@ namespace GitUI.CommandsDialogs
             { "html", ["php", "cshtml"] },
             { "cpp", ["c"] },
             { "xml", ["config", "settings", "csproj", "xlf", "props"] },
-            { "zip", ["docx", "xlsx", "odt", "ods"] },
+            { "zip", ["docx", "xlsx", "pptx", "odt", "ods", "odp", "epub", "jar", "msix"] },
             { "exe", ["dll"] },
+            { "doc", ["xls", "ppt", "msi"] },
             { "md", ["sh", "yml"] },
             { "txt", ["csv", "css", "md", "yml"] },
         };

--- a/src/app/GitUI/CommandsDialogs/FormVerify.cs
+++ b/src/app/GitUI/CommandsDialogs/FormVerify.cs
@@ -133,6 +133,7 @@ namespace GitUI.CommandsDialogs
         {
             UpdateLostObjects();
             Warnings.DataSource = _filteredLostObjects;
+            Warnings.Sort(columnDate, System.ComponentModel.ListSortDirection.Descending);
         }
 
         private void SaveObjectsClick(object sender, EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/FormVerify.cs
+++ b/src/app/GitUI/CommandsDialogs/FormVerify.cs
@@ -230,8 +230,10 @@ namespace GitUI.CommandsDialogs
             {
                 ShowOtherObjects.Checked = true;
             }
-
-            UpdateFilteredLostObjects();
+            else
+            {
+                UpdateFilteredLostObjects();
+            }
         }
 
         private void ShowOtherObjects_CheckedChanged(object sender, EventArgs e)
@@ -240,8 +242,10 @@ namespace GitUI.CommandsDialogs
             {
                 ShowCommitsAndTags.Checked = true;
             }
-
-            UpdateFilteredLostObjects();
+            else
+            {
+                UpdateFilteredLostObjects();
+            }
         }
 
         // NOTE: hack to select row under cursor on right click and context menu open

--- a/src/app/GitUI/CommandsDialogs/FormVerify.cs
+++ b/src/app/GitUI/CommandsDialogs/FormVerify.cs
@@ -585,5 +585,11 @@ namespace GitUI.CommandsDialogs
                 }
             }
         }
+
+        protected override bool ProcessKeyPreview(ref Message msg)
+        {
+            // Check if keyboard shortcut is one provided by the contextual menu
+            return mnuLostObjects.PreProcessMessage(ref msg) || base.ProcessKeyPreview(ref msg);
+        }
     }
 }

--- a/src/app/GitUI/HelperDialogs/FormEdit.cs
+++ b/src/app/GitUI/HelperDialogs/FormEdit.cs
@@ -4,12 +4,12 @@ namespace GitUI.HelperDialogs
 {
     public partial class FormEdit : GitModuleForm
     {
-        public FormEdit(IGitUICommands commands, string text)
+        public FormEdit(IGitUICommands commands, string text, string filename = "")
             : base(commands)
         {
             InitializeComponent();
             InitializeComplete();
-            Viewer.InvokeAndForget(() => Viewer.ViewTextAsync("", text));
+            Viewer.InvokeAndForget(() => Viewer.ViewTextAsync(filename, text));
             Viewer.IsReadOnly = false;
         }
 

--- a/src/app/GitUI/Translation/English.xlf
+++ b/src/app/GitUI/Translation/English.xlf
@@ -7591,6 +7591,10 @@ nodes.
         <source>Are you sure you want to delete all dangling objects?</source>
         <target />
       </trans-unit>
+      <trans-unit id="_seemingly.Text">
+        <source>seemingly</source>
+        <target />
+      </trans-unit>
       <trans-unit id="_selectLostObjectsToRestoreCaption.Text">
         <source>Restore lost objects</source>
         <target />


### PR DESCRIPTION
## Proposed changes

* display type of data for blob in grid
* perf: fetch ** dangling commit** metadata by batch (for my GE repo, for 1074 commits: 0.8s instead of 41.5s / only the long `git fsck` command --25s-- is now taking time. Overall: 1m5s before/ 25s after )
* syntax highlighting also when opening in popup viewer
* contextual shortcut are directly accessible (no need to open contextual menu first) & Ctrl-S added
* support more file types & magic numbers
* perf: don't do GUI costly processing twice

### Before

![image](https://github.com/gitextensions/gitextensions/assets/460196/03731d43-53f7-4ce7-a53e-6e61d83a7566)

![image](https://github.com/gitextensions/gitextensions/assets/460196/d003cb12-9f8b-4088-943e-536d9c25ba79)

![image](https://github.com/gitextensions/gitextensions/assets/460196/0edd7ebc-8d3e-4bd4-902e-2cd84051b3b9)

### After
![image](https://github.com/gitextensions/gitextensions/assets/460196/b8d2fa32-a5c0-4b94-9007-254ab775bc12)

![image](https://github.com/gitextensions/gitextensions/assets/460196/4362843d-c7c4-428f-8580-af5ec2a451d6)

![image](https://github.com/gitextensions/gitextensions/assets/460196/70741ce6-a97f-4757-8809-8780087c5c49)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- Git Extensions 33.33.33
- Build 3c8dd1972d260d7b0bcb613805a83e3988f96a87 (Dirty)
- Git 2.45.0.windows.1
- Microsoft Windows NT 10.0.22631.0
- .NET 8.0.1
- DPI 96dpi (no scaling)
- Portable: False


## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer **rebase** merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
