### PR TITLE
Handle `RevisionReader.GetRevision` returning `null`

### DIFF
--- a/src/app/GitCommands/CommitDataManager.cs
+++ b/src/app/GitCommands/CommitDataManager.cs
@@ -73,7 +73,7 @@ namespace GitCommands
         /// <inheritdoc />
         public CommitData? GetCommitData(string commitId, bool includeNotes = false)
         {
-            GitRevision revision = new RevisionReader(GetModule(), allBodies: true).GetRevision(commitId, hasNotes: includeNotes, cancellationToken: default);
+            GitRevision? revision = new RevisionReader(GetModule(), allBodies: true).GetRevision(commitId, hasNotes: includeNotes, throwOnError: false, cancellationToken: default);
             return revision is not null
                 ? CreateFromRevision(revision, null)
                 : null;

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -977,7 +977,7 @@ namespace GitCommands
 
         public GitRevision GetRevision(ObjectId? objectId = null, bool shortFormat = false, bool loadRefs = false)
         {
-            GitRevision revision = new RevisionReader(this, allBodies: true).GetRevision(objectId?.ToString(), hasNotes: !shortFormat, cancellationToken: default);
+            GitRevision revision = new RevisionReader(this, allBodies: true).GetRevision(objectId?.ToString(), hasNotes: !shortFormat, throwOnError: true, cancellationToken: default)!;
 
             if (loadRefs)
             {

--- a/src/app/GitCommands/RevisionReader.cs
+++ b/src/app/GitCommands/RevisionReader.cs
@@ -149,13 +149,14 @@ namespace GitCommands
         }
 
         /// <summary>
-        /// Retrieves the GitRevision.
+        ///  Retrieves the <see cref="GitRevision"/> for a real commit.
         /// </summary>
         /// <param name="commitHash">The Git commit hash.</param>
-        /// <param name="hasNotes">A cancellation token.</param>
+        /// <param name="hasNotes">Specifies whether Git Notes should be retrieved.</param>
+        /// <param name="throwOnError">Specifies whether an <see cref="ExternalOperationException"/> shall be thrown if the revision does not exist.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>The retrieved git history.</returns>
-        public GitRevision GetRevision(string commitHash, bool hasNotes, CancellationToken cancellationToken)
+        /// <returns>The retrieved git revision or <see langword="null"/> if it does not exist.</returns>
+        public GitRevision? GetRevision(string commitHash, bool hasNotes, bool throwOnError, CancellationToken cancellationToken)
         {
             GitArgumentBuilder arguments = new("log")
             {
@@ -167,9 +168,9 @@ namespace GitCommands
                 commitHash
             };
 
-            // output can be cached if Git Notes is not included
-            // Artificial revision must not be called (empty commitHash, must not be cached
-            if (!hasNotes && GitModule.GitCommandCache.TryGet(arguments.ToString(), out byte[]? commandOutput, out _) is true)
+            // output can be cached if Git Notes is not included and hash is valid
+            bool canCache = !hasNotes && !string.IsNullOrWhiteSpace(commitHash);
+            if (canCache && GitModule.GitCommandCache.TryGet(arguments.ToString(), out byte[]? commandOutput, out _) is true)
             {
                 // OK
             }
@@ -180,16 +181,27 @@ namespace GitCommands
 #endif
                 using IProcess process = _module.GitCommandRunner.RunDetached(cancellationToken, arguments, redirectOutput: true, outputEncoding: null);
                 commandOutput = process.StandardOutput.BaseStream.SplitLogOutput().SingleOrDefault().ToArray();
+                string errorOutput = process.StandardError.ReadToEnd();
+                if (!string.IsNullOrWhiteSpace(errorOutput) && throwOnError)
+                {
+                    throw new ExternalOperationException(AppSettings.GitCommand, arguments.ToString(), innerException: new Exception(errorOutput));
+                }
             }
 
             if (!TryParseRevision(commandOutput, out GitRevision? revision))
             {
+                if (throwOnError)
+                {
+                    throw new ExternalOperationException(AppSettings.GitCommand, arguments.ToString(),
+                        innerException: new Exception($"invalid revision{Environment.NewLine}{commandOutput}"));
+                }
+
                 return null;
             }
 
-            if (!hasNotes && !string.IsNullOrWhiteSpace(commitHash))
+            if (canCache)
             {
-                GitModule.GitCommandCache.Add(arguments.ToString(), commandOutput, commandOutput);
+                GitModule.GitCommandCache.Add(arguments.ToString(), output: commandOutput, error: []);
             }
 
             return revision;

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.cs
@@ -29,6 +29,23 @@ namespace GitCommandsTests
         }
 
         [Test]
+        public void GetRevision_should_return_null_if_revision_does_not_exist()
+        {
+            RevisionReader reader = RevisionReader.TestAccessor.RevisionReader(new GitModule(""), _logOutputEncoding, _sixMonths);
+            GitRevision? revision = reader.GetRevision(GitRevision.WorkTreeGuid, hasNotes: false, throwOnError: false, cancellationToken: default);
+
+            revision.Should().BeNull();
+        }
+
+        [Test]
+        public void GetRevision_should_throw_if_revision_does_not_exist()
+        {
+            RevisionReader reader = RevisionReader.TestAccessor.RevisionReader(new GitModule(""), _logOutputEncoding, _sixMonths);
+            Assert.Throws<ExternalOperationException>(() =>
+                reader.GetRevision(GitRevision.WorkTreeGuid, hasNotes: false, throwOnError: true, cancellationToken: default));
+        }
+
+        [Test]
         public void TryParseRevisionshould_return_false_if_argument_is_invalid()
         {
             ArraySegment<byte> chunk = null;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes NRE after calling `RevisionReader.GetRevision`

## Proposed changes

- Indicate that `RevisionReader.GetRevision` can return `null` and handle it
  optionally by throwing an `ExternalOperationException`

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- additional testcases

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).