### PR TITLE
fix(RevisionReader): Load body in dependency on commit date

### DIFF
--- a/src/app/GitCommands/RevisionReader.cs
+++ b/src/app/GitCommands/RevisionReader.cs
@@ -486,7 +486,7 @@ namespace GitCommands
 
             // Keep a full multi-line message body within the last six months (by default).
             // Note also that if body and subject are identical (single line), the body never need to be stored
-            bool keepBody = authorUnixTime >= _oldestBody;
+            bool keepBody = commitUnixTime >= _oldestBody;
 
             // Subject can also be defined as the contents before empty line (%s for --pretty),
             // this uses the alternative definition of first line in body.


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11710

## Proposed changes

- RevisionReader: Load commit body in dependency on commit date instead of on author date

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/gitextensions/gitextensions/assets/36601201/4f57cf4d-4648-4760-971c-3a00063abd00)

### After

![image](https://github.com/gitextensions/gitextensions/assets/36601201/a3f75417-0040-4a6f-b660-57113f5bd1ba)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).