### PR TITLE
Fix: Correct ProjectId retrieval in GitLab BuildServerIntegration due…

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -208,3 +208,4 @@ YYYY/MM/DD, github id, Full name, email
 2024/02/21, superhoang, Aymeric Nguyen, aymeric.nguyen(at)gmail.com
 2024/03/14, rstm-sf, Rustam rstm.sf(at)gmail.com
 2024/03/24, berrs, Per-Erik Stendahl, pererik.stendahl@gmail.com
+2024/05/27, redcatH, Yi Liu, i.hao.lin[at}outlook.com

--- a/src/plugins/BuildServerIntegration/GitlabIntegration/ApiClient/GitlabApiClient.cs
+++ b/src/plugins/BuildServerIntegration/GitlabIntegration/ApiClient/GitlabApiClient.cs
@@ -50,7 +50,7 @@ namespace GitExtensions.Plugins.GitlabIntegration.ApiClient
 
         public async Task<GitlabProject?> GetProjectAsync(string projectNamespace, string projectName)
         {
-            UriBuilder projectUriBuilder = new($"{InstanceUrl}/api/v4/projects/{projectNamespace}%2F{projectName}");
+            UriBuilder projectUriBuilder = new($"{InstanceUrl}/api/v4/projects/{Uri.EscapeDataString($"{projectNamespace}/{projectName}")}");
 
             return await LoadItemAsync<GitlabProject?>(projectUriBuilder.Uri);
         }

--- a/src/plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabRemoteParser.cs
+++ b/src/plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabRemoteParser.cs
@@ -9,7 +9,7 @@ namespace GitExtensions.Plugins.GitlabIntegration.Settings
         [GeneratedRegex(@"git(?:@|://)(?<host>[^/]+)[:/](?<owner>[^/]+)/(?<repo>[\w_\.\-]+)\.git")]
         private static partial Regex GitlabSshUrlRegex();
 
-        [GeneratedRegex(@"https?://(?<host>[^/@]+)/(?<owner>[^/].+)/(?<repo>[\w_\.\-]+)(?:.git)?")]
+        [GeneratedRegex(@"https?://(?<host>[^/@]+)/(?<owner>.+)/(?<repo>[\w_\.\-]+)(?:.git)?")]
         private static partial Regex GitlabHttpsUrlRegex();
 
         private static readonly Regex[] _gitLabRegexes = [GitlabHttpsUrlRegex(), GitlabSshUrlRegex()];

--- a/src/plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabRemoteParser.cs
+++ b/src/plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabRemoteParser.cs
@@ -9,7 +9,7 @@ namespace GitExtensions.Plugins.GitlabIntegration.Settings
         [GeneratedRegex(@"git(?:@|://)(?<host>[^/]+)[:/](?<owner>[^/]+)/(?<repo>[\w_\.\-]+)\.git")]
         private static partial Regex GitlabSshUrlRegex();
 
-        [GeneratedRegex(@"https?://(?<host>[^@]+)/(?<owner>[^/]+)/(?<repo>[\w_\.\-]+)(?:.git)?")]
+        [GeneratedRegex(@"https?://(?<host>[^/@]+)/(?<owner>[^/].+)/(?<repo>[\w_\.\-]+)(?:.git)?")]
         private static partial Regex GitlabHttpsUrlRegex();
 
         private static readonly Regex[] _gitLabRegexes = [GitlabHttpsUrlRegex(), GitlabSshUrlRegex()];

--- a/tests/plugins/UnitTests/BuildServerIntegration/GitlabIntegration.Tests/GitlabRemoteParserTests.cs
+++ b/tests/plugins/UnitTests/BuildServerIntegration/GitlabIntegration.Tests/GitlabRemoteParserTests.cs
@@ -43,5 +43,20 @@ namespace GitlabIntegrationTests
 
             gitlabRemoteParser.IsValidRemoteUrl(url).Should().BeFalse();
         }
+
+        [Test]
+        public void Should_Correct_in_parsing_repositoryNamespace()
+        {
+            GitlabRemoteParser gitlabRemoteParser = new();
+            string url = "https://dev.bad.com/groupname/groupname/repo.git";
+            gitlabRemoteParser.TryExtractGitlabDataFromRemoteUrl(url, out string? host, out string? owner, out string? repository).Should().BeTrue();
+            string? repositoryNamespace = owner;
+            repositoryNamespace.Should().NotBeNull();
+            repositoryNamespace.Should().BeEquivalentTo("groupname/groupname");
+            repositoryNamespace.Should().NotBeEquivalentTo("groupname");
+            repository.Should().BeEquivalentTo("repo");
+            host.Should().BeEquivalentTo("dev.bad.com");
+            gitlabRemoteParser.IsValidRemoteUrl(url).Should().BeTrue();
+        }
     }
 }

--- a/tests/plugins/UnitTests/BuildServerIntegration/GitlabIntegration.Tests/GitlabRemoteParserTests.cs
+++ b/tests/plugins/UnitTests/BuildServerIntegration/GitlabIntegration.Tests/GitlabRemoteParserTests.cs
@@ -51,11 +51,9 @@ namespace GitlabIntegrationTests
             string url = "https://dev.bad.com/groupname/groupname/repo.git";
             gitlabRemoteParser.TryExtractGitlabDataFromRemoteUrl(url, out string? host, out string? owner, out string? repository).Should().BeTrue();
             string? repositoryNamespace = owner;
-            repositoryNamespace.Should().NotBeNull();
-            repositoryNamespace.Should().BeEquivalentTo("groupname/groupname");
-            repositoryNamespace.Should().NotBeEquivalentTo("groupname");
-            repository.Should().BeEquivalentTo("repo");
             host.Should().BeEquivalentTo("dev.bad.com");
+            repositoryNamespace.Should().BeEquivalentTo("groupname/groupname");
+            repository.Should().BeEquivalentTo("repo");
             gitlabRemoteParser.IsValidRemoteUrl(url).Should().BeTrue();
         }
     }


### PR DESCRIPTION
… to improved group parsing in URLs

This commit addresses an issue where the BuildServerIntegration with GitLab was failing to correctly obtain ProjectIds.

An inconsistency was encountered in parsing GitLab project URLs, particularly those with nested namespaces (e.g., `https://git.xxx.ai/aot/xdtest/agv.git`). Previously, the namespace was incorrectly parsed as `xdtest`, and the host was mistakenly inclusive of the first part of the namespace (`git.xxx.ai/aot`), leading to failed Project ID retrievals.


Fixes 


## Test methodology <!-- How did you ensure quality? -->

Given a project URL `https://git.xxx.ai/aot/xdtest/agv.git`:
- Incorrect Namespace Parsing: `xdtest`
- Incorrect Host Interpretation: `git.xxx.ai/aot`

aot/xdtest/agv.git == [groupName]/[groupName]/[Project name].git

**Reproduction Steps:**

1. Configure the BuildServerIntegration with a GitLab instance containing projects
2.  Instance https://git.xxx.ai
3. Click on the "Get Project ID from server" button.
4. Observe that the system fails to retrieve the correct Project ID due to namespace parsing errors.