### PR TITLE
Generate P/Invoke code at compile time

### DIFF
--- a/src/app/GitCommands/Git/Extensions/ProcessExtensions.cs
+++ b/src/app/GitCommands/Git/Extensions/ProcessExtensions.cs
@@ -4,7 +4,7 @@ using GitCommands.Utils;
 
 namespace GitCommands.Git.Extensions
 {
-    public static class ProcessExtensions
+    public static partial class ProcessExtensions
     {
         public static void TerminateTree(this Process process)
         {
@@ -27,17 +27,19 @@ namespace GitCommands.Git.Extensions
             }
         }
 
-        private static class NativeMethods
+        private static partial class NativeMethods
         {
-            [DllImport("kernel32.dll")]
-            public static extern bool SetConsoleCtrlHandler(IntPtr handlerRoutine, bool add);
-
-            [DllImport("kernel32.dll", SetLastError = true)]
-            public static extern bool AttachConsole(int dwProcessId);
-
-            [DllImport("kernel32.dll", SetLastError = true)]
+            [LibraryImport("kernel32.dll")]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern bool GenerateConsoleCtrlEvent(uint dwCtrlEvent, int dwProcessGroupId);
+            public static partial bool SetConsoleCtrlHandler(IntPtr handlerRoutine, [MarshalAs(UnmanagedType.Bool)] bool add);
+
+            [LibraryImport("kernel32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static partial bool AttachConsole(int dwProcessId);
+
+            [LibraryImport("kernel32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static partial bool GenerateConsoleCtrlEvent(uint dwCtrlEvent, int dwProcessGroupId);
         }
     }
 }

--- a/src/app/GitExtUtils/GitExtUtils.csproj
+++ b/src/app/GitExtUtils/GitExtUtils.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- To be removed when NRT annotations are complete -->
     <Nullable>annotations</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/app/GitExtUtils/GitUI/DpiUtil.cs
+++ b/src/app/GitExtUtils/GitUI/DpiUtil.cs
@@ -8,7 +8,7 @@ namespace GitExtUtils.GitUI
     /// <summary>
     /// Utility class related to DPI settings, primarily used for scaling dimensions on high-DPI displays.
     /// </summary>
-    public static class DpiUtil
+    public static partial class DpiUtil
     {
         public static int DpiX { get; }
         public static int DpiY { get; }
@@ -187,14 +187,14 @@ namespace GitExtUtils.GitUI
             return bitmap;
         }
 
-        [DllImport("gdi32.dll")]
-        private static extern int GetDeviceCaps(DeviceContextSafeHandle hdc, int index);
+        [LibraryImport("gdi32.dll")]
+        private static partial int GetDeviceCaps(DeviceContextSafeHandle hdc, int index);
 
-        [DllImport("user32.dll")]
-        private static extern DeviceContextSafeHandle GetDC(IntPtr hwnd);
+        [LibraryImport("user32.dll")]
+        private static partial DeviceContextSafeHandle GetDC(IntPtr hwnd);
 
-        [DllImport("user32.dll")]
-        private static extern int ReleaseDC(IntPtr hwnd, IntPtr deviceContextHandle);
+        [LibraryImport("user32.dll")]
+        private static partial int ReleaseDC(IntPtr hwnd, IntPtr deviceContextHandle);
 
         [UsedImplicitly]
         private sealed class DeviceContextSafeHandle : SafeHandleZeroOrMinusOneIsInvalid

--- a/src/app/GitExtUtils/GitUI/HighDpiMouseCursors.cs
+++ b/src/app/GitExtUtils/GitUI/HighDpiMouseCursors.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace GitExtUtils.GitUI
 {
-    internal static class HighDpiMouseCursors
+    internal static partial class HighDpiMouseCursors
     {
         /// <summary>
         /// Replaces some .NET Framework 96-dpi .cur file mouse cursors with system cursors.
@@ -28,10 +28,10 @@ namespace GitExtUtils.GitUI
             }
         }
 
-        private static class NativeMethods
+        private static partial class NativeMethods
         {
-            [DllImport("user32.dll")]
-            public static extern IntPtr LoadCursor(IntPtr hInstance, IDC lpCursorName);
+            [LibraryImport("user32.dll")]
+            public static partial IntPtr LoadCursor(IntPtr hInstance, IDC lpCursorName);
         }
 
         private enum IDC

--- a/src/app/GitExtUtils/GitUI/Interops/ComCtl32/ImageListSetBkColor.cs
+++ b/src/app/GitExtUtils/GitUI/Interops/ComCtl32/ImageListSetBkColor.cs
@@ -2,10 +2,10 @@
 
 namespace System;
 
-internal static class NativeMethods
+internal static partial class NativeMethods
 {
     internal const int ComCtl32CLRNone = unchecked((int)0xFFFFFFFF);
 
-    [DllImport("comctl32.dll", EntryPoint = "ImageList_SetBkColor")]
-    internal static extern int ImageListSetBkColor(IntPtr himl, int clrBk);
+    [LibraryImport("comctl32.dll", EntryPoint = "ImageList_SetBkColor")]
+    internal static partial int ImageListSetBkColor(IntPtr himl, int clrBk);
 }

--- a/src/app/GitExtensions/Program.cs
+++ b/src/app/GitExtensions/Program.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.Design;
 using System.Configuration;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using GitCommands;
 using GitCommands.Utils;
 using GitExtUtils.GitUI;
@@ -15,12 +16,13 @@ using Microsoft.VisualStudio.Threading;
 
 namespace GitExtensions
 {
-    internal static class Program
+    internal static partial class Program
     {
         private static readonly ServiceContainer _serviceContainer = new();
 
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        private static extern bool SetProcessDPIAware();
+        [LibraryImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static partial bool SetProcessDPIAware();
 
         /// <summary>
         /// The main entry point for the application.

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -457,7 +457,7 @@ namespace GitUI.CommandsDialogs
             base.OnHandleCreated(e);
         }
 
-        [LibraryImport("user32.dll")]
+        [LibraryImport(Libraries.User32)]
         private static partial IntPtr SendMessageW(IntPtr hwnd, uint msg, IntPtr wp, IntPtr lp);
 
         protected override void OnApplicationActivated()

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -450,15 +450,15 @@ namespace GitUI.CommandsDialogs
 
         protected override void OnHandleCreated(EventArgs e)
         {
-            const int TVM_SETEXTENDEDSTYLE = 0x1100 + 44;
-            const int TVS_EX_DOUBLEBUFFER = 0x0004;
+            const uint TVM_SETEXTENDEDSTYLE = 0x1100 + 44;
+            const nint TVS_EX_DOUBLEBUFFER = 0x0004;
 
-            SendMessage(Handle, TVM_SETEXTENDEDSTYLE, (IntPtr)TVS_EX_DOUBLEBUFFER, (IntPtr)TVS_EX_DOUBLEBUFFER);
+            SendMessageW(Handle, TVM_SETEXTENDEDSTYLE, TVS_EX_DOUBLEBUFFER, TVS_EX_DOUBLEBUFFER);
             base.OnHandleCreated(e);
         }
 
-        [DllImport("user32.dll")]
-        private static extern IntPtr SendMessage(IntPtr hwnd, int msg, IntPtr wp, IntPtr lp);
+        [LibraryImport("user32.dll")]
+        private static partial IntPtr SendMessageW(IntPtr hwnd, uint msg, IntPtr wp, IntPtr lp);
 
         protected override void OnApplicationActivated()
         {

--- a/src/app/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
+++ b/src/app/GitUI/Editor/RichTextBoxXhtmlSupportExtension.cs
@@ -328,25 +328,25 @@ namespace GitUI.Editor.RichTextBoxExtension
 
             internal const int LF_FACESIZE = 32;
 
-            [DllImport("user32", CharSet = CharSet.Auto)]
+            [DllImport(Libraries.User32, CharSet = CharSet.Auto)]
             internal static extern IntPtr SendMessage(HandleRef hWnd,
                 int msg,
                 IntPtr wParam,
                 IntPtr lParam);
 
-            [DllImport("user32", CharSet = CharSet.Auto)]
+            [DllImport(Libraries.User32, CharSet = CharSet.Auto)]
             internal static extern IntPtr SendMessage(HandleRef hWnd,
                 int msg,
                 IntPtr wParam,
                 ref Point lParam);
 
-            [DllImport("user32", CharSet = CharSet.Auto)]
+            [DllImport(Libraries.User32, CharSet = CharSet.Auto)]
             internal static extern IntPtr SendMessage(HandleRef hWnd,
                 int msg,
                 IntPtr wParam,
                 ref PARAFORMAT lp);
 
-            [DllImport("user32", CharSet = CharSet.Auto)]
+            [DllImport(Libraries.User32, CharSet = CharSet.Auto)]
             internal static extern IntPtr SendMessage(HandleRef hWnd,
                 int msg,
                 IntPtr wParam,

--- a/src/app/GitUI/Interops/DwmApi/DwmApi.cs
+++ b/src/app/GitUI/Interops/DwmApi/DwmApi.cs
@@ -5,10 +5,10 @@ namespace GitUI.Interops.DwmApi
     /// <summary>
     /// Allow to set dark title bar on Win10. From: https://stackoverflow.com/questions/57124243/winforms-dark-title-bar-on-windows-10/62811758#62811758.
     /// </summary>
-    internal static class DwmApi
+    internal static partial class DwmApi
     {
-        [DllImport("dwmapi.dll", ExactSpelling = true)]
-        private static extern int DwmSetWindowAttribute(IntPtr hwnd, uint attr, ref int attrValue, int attrSize);
+        [LibraryImport("dwmapi.dll")]
+        private static partial int DwmSetWindowAttribute(IntPtr hwnd, uint attr, ref int attrValue, int attrSize);
 
         // Non-documented Windows constants
         private const uint DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 = 19;

--- a/src/app/GitUI/Interops/Gdi32/CreateSolidBrush.cs
+++ b/src/app/GitUI/Interops/Gdi32/CreateSolidBrush.cs
@@ -4,7 +4,7 @@ namespace System
 {
     internal static partial class NativeMethods
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true, SetLastError = true)]
-        public static extern IntPtr CreateSolidBrush(int crColor);
+        [LibraryImport(Libraries.Gdi32, SetLastError = true)]
+        public static partial IntPtr CreateSolidBrush(int crColor);
     }
 }

--- a/src/app/GitUI/Interops/Gdi32/DeleteObject.cs
+++ b/src/app/GitUI/Interops/Gdi32/DeleteObject.cs
@@ -5,7 +5,7 @@ namespace System
 {
     internal static partial class NativeMethods
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern BOOL DeleteObject(IntPtr hObject);
+        [LibraryImport(Libraries.Gdi32)]
+        public static partial BOOL DeleteObject(IntPtr hObject);
     }
 }

--- a/src/app/GitUI/Interops/User32/DestroyIcon.cs
+++ b/src/app/GitUI/Interops/User32/DestroyIcon.cs
@@ -5,7 +5,7 @@ namespace System
 {
     internal static partial class NativeMethods
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern BOOL DestroyIcon(IntPtr handle);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial BOOL DestroyIcon(IntPtr handle);
     }
 }

--- a/src/app/GitUI/Interops/User32/GetActiveWindow.cs
+++ b/src/app/GitUI/Interops/User32/GetActiveWindow.cs
@@ -4,7 +4,7 @@ namespace System
 {
     internal static partial class NativeMethods
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetActiveWindow();
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetActiveWindow();
     }
 }

--- a/src/app/GitUI/Interops/User32/GetScrollPos.cs
+++ b/src/app/GitUI/Interops/User32/GetScrollPos.cs
@@ -4,7 +4,7 @@ namespace System
 {
     internal static partial class NativeMethods
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern int GetScrollPos(IntPtr hWnd, SB nBar);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial int GetScrollPos(IntPtr hWnd, SB nBar);
     }
 }

--- a/src/app/GitUI/Interops/User32/GetWindowDC.cs
+++ b/src/app/GitUI/Interops/User32/GetWindowDC.cs
@@ -4,7 +4,7 @@ namespace System
 {
     internal static partial class NativeMethods
     {
-        [DllImport(Libraries.User32)]
-        public static extern IntPtr GetWindowDC(IntPtr hwnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetWindowDC(IntPtr hwnd);
     }
 }

--- a/src/app/GitUI/Interops/User32/PostMessageW.cs
+++ b/src/app/GitUI/Interops/User32/PostMessageW.cs
@@ -6,8 +6,8 @@ namespace System
     {
         public static IntPtr HWND_BROADCAST => (IntPtr)0xFFFF;
 
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr PostMessageW(
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr PostMessageW(
             IntPtr hWnd,
             uint Msg,
             IntPtr wParam = default,

--- a/src/app/GitUI/Interops/User32/RegisterWindowMessageW.cs
+++ b/src/app/GitUI/Interops/User32/RegisterWindowMessageW.cs
@@ -4,7 +4,7 @@ namespace System
 {
     internal static partial class NativeMethods
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern uint RegisterWindowMessageW(string name);
+        [LibraryImport(Libraries.User32, StringMarshalling = StringMarshalling.Utf16)]
+        public static partial uint RegisterWindowMessageW(string name);
     }
 }

--- a/src/app/GitUI/Interops/User32/ReleaseDC.cs
+++ b/src/app/GitUI/Interops/User32/ReleaseDC.cs
@@ -4,7 +4,7 @@ namespace System
 {
     internal static partial class NativeMethods
     {
-        [DllImport(Libraries.User32)]
-        public static extern void ReleaseDC(IntPtr hwnd, IntPtr dc);
+        [LibraryImport(Libraries.User32)]
+        public static partial void ReleaseDC(IntPtr hwnd, IntPtr dc);
     }
 }

--- a/src/app/GitUI/Interops/User32/SendMessageW.cs
+++ b/src/app/GitUI/Interops/User32/SendMessageW.cs
@@ -4,8 +4,8 @@ namespace System
 {
     internal static partial class NativeMethods
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr SendMessageW(
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr SendMessageW(
             IntPtr hWnd,
             uint Msg,
             IntPtr wParam = default,

--- a/src/app/GitUI/Interops/User32/ShowCaret.cs
+++ b/src/app/GitUI/Interops/User32/ShowCaret.cs
@@ -5,7 +5,7 @@ namespace System
 {
     internal static partial class NativeMethods
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL ShowCaret(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL ShowCaret(IntPtr hWnd);
     }
 }

--- a/src/app/GitUI/Interops/UxTheme/CloseThemeData.cs
+++ b/src/app/GitUI/Interops/UxTheme/CloseThemeData.cs
@@ -4,7 +4,7 @@ namespace System
 {
     internal static partial class NativeMethods
     {
-        [DllImport(Libraries.UxTheme, ExactSpelling = true)]
-        public static extern int CloseThemeData(IntPtr hTheme);
+        [LibraryImport(Libraries.UxTheme)]
+        public static partial int CloseThemeData(IntPtr hTheme);
     }
 }

--- a/src/app/GitUI/Interops/UxTheme/GetThemeColor.cs
+++ b/src/app/GitUI/Interops/UxTheme/GetThemeColor.cs
@@ -4,7 +4,7 @@ namespace System
 {
     internal static partial class NativeMethods
     {
-        [DllImport(Libraries.UxTheme, ExactSpelling = true)]
-        public static extern int GetThemeColor(IntPtr hTheme, int iPartId, int iStateId, int iPropId, out COLORREF pColor);
+        [LibraryImport(Libraries.UxTheme)]
+        public static partial int GetThemeColor(IntPtr hTheme, int iPartId, int iStateId, int iPropId, out COLORREF pColor);
     }
 }

--- a/src/app/GitUI/Interops/UxTheme/OpenThemeData.cs
+++ b/src/app/GitUI/Interops/UxTheme/OpenThemeData.cs
@@ -4,7 +4,7 @@ namespace System
 {
     internal static partial class NativeMethods
     {
-        [DllImport(Libraries.UxTheme, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern IntPtr OpenThemeData(IntPtr hWnd, string classList);
+        [LibraryImport(Libraries.UxTheme, StringMarshalling = StringMarshalling.Utf16)]
+        public static partial IntPtr OpenThemeData(IntPtr hWnd, string classList);
     }
 }

--- a/src/app/GitUI/Interops/UxTheme/SetWindowTheme.cs
+++ b/src/app/GitUI/Interops/UxTheme/SetWindowTheme.cs
@@ -4,8 +4,8 @@ namespace System
 {
     internal static partial class NativeMethods
     {
-        [DllImport(Libraries.UxTheme, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        private static unsafe extern int SetWindowTheme(IntPtr hWnd, char* pszSubAppName, char* pszSubIdList);
+        [LibraryImport(Libraries.UxTheme)]
+        private static unsafe partial int SetWindowTheme(IntPtr hWnd, char* pszSubAppName, char* pszSubIdList);
 
         public static unsafe int SetWindowTheme(IntPtr hWnd, string subAppName, string? subIdList)
         {

--- a/src/app/GitUI/Interops/WinInet/InternetGetConnectedState.cs
+++ b/src/app/GitUI/Interops/WinInet/InternetGetConnectedState.cs
@@ -4,7 +4,8 @@ namespace System
 {
     internal static partial class NativeMethods
     {
-        [DllImport(Libraries.WinInet)]
-        public static extern bool InternetGetConnectedState(out int description, int reservedValue);
+        [LibraryImport(Libraries.WinInet)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static partial bool InternetGetConnectedState(out int description, int reservedValue);
     }
 }

--- a/src/app/GitUI/MouseWheelRedirector.cs
+++ b/src/app/GitUI/MouseWheelRedirector.cs
@@ -3,7 +3,7 @@ using ResourceManager;
 
 namespace GitUI
 {
-    public sealed class MouseWheelRedirector : IMessageFilter
+    public sealed partial class MouseWheelRedirector : IMessageFilter
     {
         private static readonly MouseWheelRedirector instance = new();
 
@@ -75,20 +75,20 @@ namespace GitUI
                 return false;
             }
 
-            NativeMethods.SendMessage(hwnd, m.Msg, m.WParam, m.LParam);
+            NativeMethods.SendMessageW(hwnd, m.Msg, m.WParam, m.LParam);
             return true;
 
             static bool IsNonScrollableRichTextBox(Control c) => c is RichTextBox { ScrollBars: RichTextBoxScrollBars.None };
         }
 
-        private static class NativeMethods
+        private static partial class NativeMethods
         {
             // P/Invoke declarations
-            [DllImport("user32.dll")]
-            public static extern IntPtr WindowFromPoint(POINT pt);
+            [LibraryImport("user32.dll")]
+            public static partial IntPtr WindowFromPoint(POINT pt);
 
-            [DllImport("user32.dll")]
-            public static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wp, IntPtr lp);
+            [LibraryImport("user32.dll")]
+            public static partial IntPtr SendMessageW(IntPtr hWnd, int msg, IntPtr wp, IntPtr lp);
 
             [StructLayout(LayoutKind.Sequential)]
             public readonly struct POINT

--- a/src/app/GitUI/MouseWheelRedirector.cs
+++ b/src/app/GitUI/MouseWheelRedirector.cs
@@ -84,10 +84,10 @@ namespace GitUI
         private static partial class NativeMethods
         {
             // P/Invoke declarations
-            [LibraryImport("user32.dll")]
+            [LibraryImport(Libraries.User32)]
             public static partial IntPtr WindowFromPoint(POINT pt);
 
-            [LibraryImport("user32.dll")]
+            [LibraryImport(Libraries.User32)]
             public static partial IntPtr SendMessageW(IntPtr hWnd, int msg, IntPtr wp, IntPtr lp);
 
             [StructLayout(LayoutKind.Sequential)]

--- a/src/app/GitUI/VisualStudioIntegration.cs
+++ b/src/app/GitUI/VisualStudioIntegration.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Threading;
 
 namespace GitUI
 {
-    internal static class VisualStudioIntegration
+    internal static partial class VisualStudioIntegration
     {
         static VisualStudioIntegration()
         {
@@ -128,10 +128,11 @@ namespace GitUI
             }
         }
 
-        private static class NativeMethods
+        private static partial class NativeMethods
         {
-            [DllImport("user32.dll")]
-            public static extern bool SetForegroundWindow(IntPtr hwnd);
+            [LibraryImport("user32.dll")]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static partial bool SetForegroundWindow(IntPtr hwnd);
 
             [DllImport("ole32.dll")]
             public static extern void CreateBindCtx(int reserved, out IBindCtx ppbc);

--- a/src/app/GitUI/VisualStudioIntegration.cs
+++ b/src/app/GitUI/VisualStudioIntegration.cs
@@ -130,7 +130,7 @@ namespace GitUI
 
         private static partial class NativeMethods
         {
-            [LibraryImport("user32.dll")]
+            [LibraryImport(Libraries.User32)]
             [return: MarshalAs(UnmanagedType.Bool)]
             public static partial bool SetForegroundWindow(IntPtr hwnd);
 


### PR DESCRIPTION
## Proposed changes

`DllImport` causes binding code to be generated at run time, which can hurt startup performance. It also precludes use of NativeAOT compilation.

This change introduces the newer `LibraryImport` (.NET 7) which performs the binding at compile time via a source generator.

This fixes instances of diagnostic SYSLIB1054.

The changes here were made by a code fix, with a few exceptions:

- I had to roll a few automated changes back as they wouldn't compile.
- I had to explicitly specify string marshaling as UTF-16 in one instance.
- I had to rename a function from `SendMessage` to `SendMessageW` to avoid an exception when opening `FormCommit`.

As this last point suggests, this still uses late binding. It's just the code generation that's done up front.

There are also possible changes in `conemu` and `ICSharpCode.TextEditor`, but they would have to be filed separately.

More info on this at:

- https://learn.microsoft.com/en-us/dotnet/standard/native-interop/pinvoke-source-generation
- https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib1050-1069

## Test methodology <!-- How did you ensure quality? -->

Manual testing. It's possible that these changes fail at run time (as mentioned above) and most P/Invoke happens in the UI, so only using the UI will draw issues out. I'd avoid merging this right before a public release, just to give time for developers in the repo to hit any issues here. That said, I ran through a bunch of UI scenarios and didn't hit any problems.

## Test environment(s) <!-- Remove any that don't apply -->

- GIT N/A
- Windows 11

## Merge strategy

I don't mind. I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).
