### PR TITLE
Fixup hangs moving the RevisionGrid

### DIFF
--- a/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -83,9 +83,6 @@ namespace GitUI.UserControls.RevisionGrid.Graph
         /// </summary>
         private int _straightenLookAhead => 2 * (_straightenDiagonalsLookAhead + _straightenLanesLookAhead);
 
-        // When the cache is updated, this action can be used to invalidate the UI
-        public event Action? Updated;
-
         public void Clear()
         {
             _loadingCompleted = false;
@@ -563,8 +560,6 @@ namespace GitUI.UserControls.RevisionGrid.Graph
             }
 
             _orderedRowCache = localOrderedRowCache.ToImmutable();
-
-            Updated?.Invoke();
 
             return;
 

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -130,8 +130,6 @@ namespace GitUI.UserControls.RevisionGrid
                 }
             };
 
-            _revisionGraph.Updated += () => this.InvokeAndForget(Invalidate);
-
             VirtualMode = true;
             Clear();
 


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/discussions/11441#discussioncomment-7921050

## Proposed changes

- `RevisionDataGridView`: Remove double invalidate from `CacheTo`
- `RevisionGraph`: Save masses of pointer copies by switching to a permanent instance of `List<RevisionGraphRow>`
  `ImmutableArray` is not needed any longer as the `_orderedRowCache` is built and accessed from the same exclusive background task.
  `_orderedRowCache = localOrderedRowCache.ToImmutable();` is very expensive and seems to even block the UI thread although executed in a background task. 

## Screenshots <!-- Remove this section if PR does not change UI -->

N/A

## Test methodology <!-- How did you ensure quality? -->

- manual (scroll down the Linux repo)

## Please do not squash merge

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).