### PR TITLE
fix(ReportDubiousOwnership): Replace single quotes

### DIFF
--- a/src/app/GitUI/NBugReports/BugReportInvoker.cs
+++ b/src/app/GitUI/NBugReports/BugReportInvoker.cs
@@ -5,6 +5,7 @@ using System.Text;
 using BugReporter;
 using BugReporter.Serialization;
 using GitCommands;
+using GitCommands.Utils;
 using GitExtensions.Extensibility;
 using GitExtensions.Extensibility.Settings;
 using GitUI.CommandsDialogs;
@@ -275,7 +276,7 @@ namespace GitUI.NBugReports
                 SizeToContent = true,
             };
             int startIndex = error.IndexOf(ExecutableExtensions.DubiousOwnershipSecurityConfigString);
-            string gitConfigTrustRepoCommand = error[startIndex..].Trim();
+            string gitConfigTrustRepoCommand = ReplaceQuotes(error[startIndex..].Trim());
             string folderPath = error[(startIndex + ExecutableExtensions.DubiousOwnershipSecurityConfigString.Length + 1)..];
 
             TaskDialogCommandLinkButton openExplorerButton = new(TranslatedStrings.GitDubiousOwnershipOpenRepositoryFolder, allowCloseDialog: false);
@@ -365,6 +366,17 @@ namespace GitUI.NBugReports
                             formBrowse.SetWorkingDir(workingDir);
                         });
                 }
+            }
+
+            static string ReplaceQuotes(string command)
+            {
+                if (!EnvUtils.RunningOnWindows() || !command.EndsWith('\''))
+                {
+                    return command;
+                }
+
+                int quoteIndex = command.IndexOf("'%(prefix)");
+                return quoteIndex < 0 ? command : @$"{command[..quoteIndex]}""{command[(quoteIndex + 1)..^1]}""";
             }
         }
 

--- a/src/app/GitUI/NBugReports/BugReportInvoker.cs
+++ b/src/app/GitUI/NBugReports/BugReportInvoker.cs
@@ -368,6 +368,9 @@ namespace GitUI.NBugReports
                 }
             }
 
+            // Turns single quotes to double quotes on Windows if there are any at all around the repo path.
+            // in : git config --global -add safe.directory '%(prefix)///unc_machine/folder/to/repo'
+            // out: git config --global -add safe.directory "%(prefix)///unc_machine/folder/to/repo"
             static string ReplaceQuotes(string command)
             {
                 if (!EnvUtils.RunningOnWindows() || !command.EndsWith('\''))

--- a/src/app/GitUI/NBugReports/BugReportInvoker.cs
+++ b/src/app/GitUI/NBugReports/BugReportInvoker.cs
@@ -276,7 +276,7 @@ namespace GitUI.NBugReports
                 SizeToContent = true,
             };
             int startIndex = error.IndexOf(ExecutableExtensions.DubiousOwnershipSecurityConfigString);
-            string gitConfigTrustRepoCommand = ReplaceQuotes(error[startIndex..].Trim());
+            string gitConfigTrustRepoCommand = ReplaceRepoPathQuotes(error[startIndex..].Trim());
             string folderPath = error[(startIndex + ExecutableExtensions.DubiousOwnershipSecurityConfigString.Length + 1)..];
 
             TaskDialogCommandLinkButton openExplorerButton = new(TranslatedStrings.GitDubiousOwnershipOpenRepositoryFolder, allowCloseDialog: false);
@@ -371,7 +371,7 @@ namespace GitUI.NBugReports
             // Turns single quotes to double quotes on Windows if there are any at all around the repo path.
             // in : git config --global -add safe.directory '%(prefix)///unc_machine/folder/to/repo'
             // out: git config --global -add safe.directory "%(prefix)///unc_machine/folder/to/repo"
-            static string ReplaceQuotes(string command)
+            static string ReplaceRepoPathQuotes(string command)
             {
                 if (!EnvUtils.RunningOnWindows() || !command.EndsWith('\''))
                 {


### PR DESCRIPTION
Fixes #11767

## Proposed changes

- `ReportDubiousOwnership`: Replace single quotes with double quotes in proposed git command

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

see issue

### After

![image](https://github.com/gitextensions/gitextensions/assets/36601201/777502d0-b14f-4c1a-827c-0a62b28d9062)

## Test methodology <!-- How did you ensure quality? -->

- manual

## Merge strategy

<!-- Change the following if the merge strategy should be changed:
- Squash merge (maintainer to decide merge message, PR submitter should cleanup commits/messages at PR approval).
- Rebase merge (PR submitter must change the commit message for the last commit).
- Merge commit. (PR submitter to rebase and squash before merges).
- To be decided later.
The maintainer may still request the contributor to squash and rebase, to make sure that merges and commit messages are clarified.
-->

I agree that the maintainer squash merge this PR (if the commit message is clear).

----

:black_nib: I contribute this code under [The Developer Certificate of Origin](../blob/master/contributors.txt).